### PR TITLE
Use EdgeInsetsGeometry instead of EdgeInsets

### DIFF
--- a/packages/flutter/lib/src/painting/shape_decoration.dart
+++ b/packages/flutter/lib/src/painting/shape_decoration.dart
@@ -178,7 +178,7 @@ class ShapeDecoration extends Decoration {
   ///
   /// This value may be misleading. See the discussion at [ShapeBorder.dimensions].
   @override
-  EdgeInsets get padding => shape.dimensions;
+  EdgeInsetsGeometry get padding => shape.dimensions;
 
   @override
   bool get isComplex => shadows != null;

--- a/packages/flutter/test/widgets/shape_decoration_test.dart
+++ b/packages/flutter/test/widgets/shape_decoration_test.dart
@@ -61,6 +61,14 @@ Future<void> main() async {
     );
   }, skip: isBrowser);
 
+  test('ShapeDecoration with BorderDirectional', () {
+    var decoration = ShapeDecoration(
+      shape: BorderDirectional(start: BorderSide(color: Colors.red, width: 3)),
+    );
+
+    expect(decoration.padding, isInstanceOf<EdgeInsetsDirectional>());
+  });
+
   testWidgets('TestBorder and Directionality - 1', (WidgetTester tester) async {
     final List<String> log = <String>[];
     await tester.pumpWidget(

--- a/packages/flutter/test/widgets/shape_decoration_test.dart
+++ b/packages/flutter/test/widgets/shape_decoration_test.dart
@@ -62,7 +62,7 @@ Future<void> main() async {
   }, skip: isBrowser);
 
   test('ShapeDecoration with BorderDirectional', () {
-    var decoration = ShapeDecoration(
+    final ShapeDecoration decoration = ShapeDecoration(
       shape: BorderDirectional(start: BorderSide(color: Colors.red, width: 3)),
     );
 

--- a/packages/flutter/test/widgets/shape_decoration_test.dart
+++ b/packages/flutter/test/widgets/shape_decoration_test.dart
@@ -62,7 +62,7 @@ Future<void> main() async {
   }, skip: isBrowser);
 
   test('ShapeDecoration with BorderDirectional', () {
-    final ShapeDecoration decoration = ShapeDecoration(
+    const ShapeDecoration decoration = ShapeDecoration(
       shape: BorderDirectional(start: BorderSide(color: Colors.red, width: 3)),
     );
 


### PR DESCRIPTION
Should accommodate both `EdgeInsetsDirectional` and `EdgeInsets`.

## Description
Use the common superclass instead of just `EdgeInsets`

Before this PR, the following code will fail with `type 'EdgeInsetsDirectional' is not a subtype of type 'EdgeInsets'`:

```dart
  Widget build(BuildContext context) {
    return Container(
        child: Text("Hi"),
        padding: EdgeInsetsDirectional.only(start: 3),
        decoration: ShapeDecoration(
          shape: BorderDirectional(start: BorderSide(color: Colors.red, width: 3)),
        ));
  }
```

The getter delegates to 

https://github.com/flutter/flutter/blob/0b24a5a2ff9eccfba77bb68a0abcf1b7f0ae5b37/packages/flutter/lib/src/painting/borders.dart#L307

## Related Issues
Similar to #19305