### PR TITLE
ensure debug builds are only accessible through run

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_web.dart
+++ b/packages/flutter_tools/lib/src/commands/build_web.dart
@@ -17,7 +17,7 @@ class BuildWebCommand extends BuildSubCommand {
   BuildWebCommand() {
     usesTargetOption();
     usesPubOption();
-    addBuildModeFlags();
+    addBuildModeFlags(excludeDebug: true);
     argParser.addFlag('web-initialize-platform',
         defaultsTo: true,
         negatable: true,
@@ -50,6 +50,9 @@ class BuildWebCommand extends BuildSubCommand {
     final FlutterProject flutterProject = FlutterProject.current();
     final String target = argResults['target'];
     final BuildInfo buildInfo = getBuildInfo();
+    if (buildInfo.isDebug) {
+      throwToolExit('debug builds cannot be built directly for the web. Try using "flutter run"');
+    }
     await buildWeb(flutterProject, target, buildInfo, argResults['web-initialize-platform']);
     return null;
   }

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -125,6 +125,8 @@ abstract class FlutterCommand extends Command<void> {
   bool get shouldRunPub => _usesPubOption && argResults['pub'];
 
   bool get shouldUpdateCache => true;
+  
+  bool _excludeDebug = false;
 
   BuildMode _defaultBuildMode;
 
@@ -266,6 +268,7 @@ abstract class FlutterCommand extends Command<void> {
   void addBuildModeFlags({ bool defaultToRelease = true, bool verboseHelp = false, bool excludeDebug = false }) {
     // A release build must be the default if a debug build is not possible.
     assert(defaultToRelease || !excludeDebug);
+    _excludeDebug = excludeDebug;
     defaultBuildMode = defaultToRelease ? BuildMode.release : BuildMode.debug;
 
     if (!excludeDebug) {
@@ -316,9 +319,7 @@ abstract class FlutterCommand extends Command<void> {
   }
 
   BuildMode getBuildMode() {
-    final bool debugResult = argResults.wasParsed('debug')
-      ? argResults['debug']
-      : false;
+    final bool debugResult = _excludeDebug ? false : argResults['debug']
     final List<bool> modeFlags = <bool>[debugResult, argResults['profile'], argResults['release']];
     if (modeFlags.where((bool flag) => flag).length > 1) {
       throw UsageException('Only one of --debug, --profile, or --release can be specified.', null);

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -321,11 +321,14 @@ abstract class FlutterCommand extends Command<void> {
   }
 
   BuildMode getBuildMode() {
-    final List<bool> modeFlags = <bool>[argResults['debug'], argResults['profile'], argResults['release']];
+    final bool debugResult = argResults.wasParsed('debug')
+      ? argResults['debug']
+      : false;
+    final List<bool> modeFlags = <bool>[debugResult, argResults['profile'], argResults['release']];
     if (modeFlags.where((bool flag) => flag).length > 1) {
       throw UsageException('Only one of --debug, --profile, or --release can be specified.', null);
     }
-    if (argResults['debug']) {
+    if (debugResult) {
       return BuildMode.debug;
     }
     if (argResults['profile']) {

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -319,7 +319,7 @@ abstract class FlutterCommand extends Command<void> {
   }
 
   BuildMode getBuildMode() {
-    final bool debugResult = _excludeDebug ? false : argResults['debug']
+    final bool debugResult = _excludeDebug ? false : argResults['debug'];
     final List<bool> modeFlags = <bool>[debugResult, argResults['profile'], argResults['release']];
     if (modeFlags.where((bool flag) => flag).length > 1) {
       throw UsageException('Only one of --debug, --profile, or --release can be specified.', null);

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -125,7 +125,7 @@ abstract class FlutterCommand extends Command<void> {
   bool get shouldRunPub => _usesPubOption && argResults['pub'];
 
   bool get shouldUpdateCache => true;
-  
+
   bool _excludeDebug = false;
 
   BuildMode _defaultBuildMode;

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -264,13 +264,8 @@ abstract class FlutterCommand extends Command<void> {
   }
 
   void addBuildModeFlags({ bool defaultToRelease = true, bool verboseHelp = false, bool excludeDebug = false }) {
-    assert(() {
-      // If we don't default to release, ensure that we support debug mode.
-      if (!defaultToRelease && excludeDebug) {
-        return false;
-      }
-      return true;
-    }());
+    // A release build must be the default if a debug build is not possible.
+    assert(defaultToRelease || !excludeDebug);
     defaultBuildMode = defaultToRelease ? BuildMode.release : BuildMode.debug;
 
     if (!excludeDebug) {

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -263,12 +263,21 @@ abstract class FlutterCommand extends Command<void> {
             'Normally there\'s only one, but when adding Flutter to a pre-existing app it\'s possible to create multiple.');
   }
 
-  void addBuildModeFlags({ bool defaultToRelease = true, bool verboseHelp = false }) {
+  void addBuildModeFlags({ bool defaultToRelease = true, bool verboseHelp = false, bool excludeDebug = false }) {
+    assert(() {
+      // If we don't default to release, ensure that we support debug mode.
+      if (!defaultToRelease && excludeDebug) {
+        return false;
+      }
+      return true;
+    }());
     defaultBuildMode = defaultToRelease ? BuildMode.release : BuildMode.debug;
 
-    argParser.addFlag('debug',
-      negatable: false,
-      help: 'Build a debug version of your app${defaultToRelease ? '' : ' (default mode)'}.');
+    if (!excludeDebug) {
+      argParser.addFlag('debug',
+        negatable: false,
+        help: 'Build a debug version of your app${defaultToRelease ? '' : ' (default mode)'}.');
+    }
     argParser.addFlag('profile',
       negatable: false,
       help: 'Build a version of your app specialized for performance profiling.');

--- a/packages/flutter_tools/test/general.shard/commands/build_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_web_test.dart
@@ -92,6 +92,15 @@ void main() {
     );
   }));
 
+  test('Refuses to build a debug build for web', () => testbed.run(() async {
+    final CommandRunner<void> runner = createTestCommandRunner(BuildCommand());
+
+    expect(() => runner.run(<String>['build', 'web', '--debug']),
+        throwsA(isInstanceOf<UsageException>()));
+  }, overrides: <Type, Generator>{
+    FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
+  }));
+
   test('Refuses to build for web when feature is disabled', () => testbed.run(() async {
     final CommandRunner<void> runner = createTestCommandRunner(BuildCommand());
 


### PR DESCRIPTION
## Description

We don't actually allow debug builds to be "built" for flutter for web, because it requires an asset server to work correctly today. Remove the option to reduce confusion.

Fixes https://github.com/flutter/flutter/issues/40772