### PR TITLE
Move build info checks from generating files to the xcode build

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -20,6 +20,7 @@ import '../base/process_manager.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
 import '../convert.dart';
+import '../flutter_manifest.dart';
 import '../globals.dart';
 import '../macos/cocoapod_utils.dart';
 import '../macos/xcode.dart';
@@ -321,6 +322,25 @@ Future<XcodeBuildResult> buildXcodeProject({
     printError('');
     printError('4. If you are not using completely custom build configurations, name the newly created configuration ${buildInfo.modeName}.');
     return XcodeBuildResult(success: false);
+  }
+
+  final FlutterManifest manifest = app.project.parent.manifest;
+  final String buildName = parsedBuildName(manifest: manifest, buildInfo: buildInfo);
+  final bool buildNameIsMissing = buildName == null || buildName.isEmpty;
+
+  if (buildNameIsMissing) {
+    printStatus('Warning: Missing build name (CFBundleShortVersionString).');
+  }
+
+  final String buildNumber = parsedBuildNumber(manifest: manifest, buildInfo: buildInfo);
+  final bool buildNumberIsMissing = buildNumber == null || buildNumber.isEmpty;
+
+  if (buildNumberIsMissing) {
+    printStatus('Warning: Missing build number (CFBundleVersion).');
+  }
+  if (buildNameIsMissing || buildNumberIsMissing) {
+    printError('Action Required: You must set a build name and number in the pubspec.yaml '
+      'file version field before submitting to the App Store.');
   }
 
   Map<String, String> autoSigningConfigs;

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -646,24 +646,6 @@ flutter:
         expectedBuildNumber: '1',
       );
     });
-
-    testUsingOsxContext('fail when build name cannot be parsed', () async {
-      const String manifest = '''
-name: test
-dependencies:
-  flutter:
-    sdk: flutter
-flutter:
-''';
-      const BuildInfo buildInfo = BuildInfo(BuildMode.release, null, buildName: 'abc', buildNumber: '1');
-
-      const String stderr = 'Cannot parse build name abc, check pubspec.yaml version.';
-      expect(() async => await checkBuildVersion(
-        manifestString: manifest,
-        buildInfo: buildInfo
-      ),
-      throwsToolExit(message: stderr));
-    });
   });
 }
 


### PR DESCRIPTION
## Description

Move the build number and build name checks from where the build settings files are generated and to where the Xcode project is actually built.
Remove the tool exit since that's a bit aggressive and it was harder to move to the right place.

I see the warnings on `flutter build ios` and `flutter run -d iPhone` but no longer on a web build.

## Related Issues

Regressed with https://github.com/flutter/flutter/pull/40611.
Fixes https://github.com/flutter/flutter/issues/40782.

## Tests

I removed the tool throw test.  Other tests from https://github.com/flutter/flutter/pull/40611 still pass.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.