### PR TITLE
Allow test beds to override defaultTestTimeout

### DIFF
--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -834,8 +834,11 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   @override
   bool get checkIntrinsicSizes => true;
 
+  /// The value of [defaultTestTimeout] can be set to `None` to enable debugging flutter tests where
+  /// we would not want to timeout the test. This is expected to be used by test tooling which
+  /// can detect debug mode.
   @override
-  test_package.Timeout get defaultTestTimeout => const test_package.Timeout(Duration(minutes: 10));
+  test_package.Timeout defaultTestTimeout = const test_package.Timeout(Duration(minutes: 10));
 
   @override
   bool get inTest => _currentFakeAsync != null;

--- a/packages/flutter_test/test/bindings_test.dart
+++ b/packages/flutter_test/test/bindings_test.dart
@@ -18,7 +18,7 @@ void main() {
   group(AutomatedTestWidgetsFlutterBinding, () {
     test('allows setting defaultTestTimeout to 5 minutes', () {
       final AutomatedTestWidgetsFlutterBinding binding = AutomatedTestWidgetsFlutterBinding();
-      binding.defaultTestTimeout = test_package.Timeout(Duration(minutes: 5));
+      binding.defaultTestTimeout = const test_package.Timeout(Duration(minutes: 5));
       expect(binding.defaultTestTimeout.duration, const Duration(minutes: 5));
     });
   });

--- a/packages/flutter_test/test/bindings_test.dart
+++ b/packages/flutter_test/test/bindings_test.dart
@@ -15,7 +15,7 @@ void main() {
     });
   });
 
-  group('AutomatedWidgetsBinding ', () {
+  group(AutomatedTestWidgetsFlutterBinding, () {
     test('allows setting defaultTestTimeout to 5 minutes', () {
       final AutomatedTestWidgetsFlutterBinding binding = AutomatedTestWidgetsFlutterBinding();
       binding.defaultTestTimeout = test_package.Timeout(Duration(minutes: 5));

--- a/packages/flutter_test/test/bindings_test.dart
+++ b/packages/flutter_test/test/bindings_test.dart
@@ -5,13 +5,21 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-
+import 'package:test_api/test_api.dart' as test_package;
 
 void main() {
   group(TestViewConfiguration, () {
     test('is initialized with top-level window if one is not provided', () {
       // The code below will throw without the default.
       TestViewConfiguration(size: const Size(1280.0, 800.0));
+    });
+  });
+
+  group('AutomatedWidgetsBinding ', () {
+    test('allows setting defaultTestTimeout to 5 minutes', () {
+      final AutomatedTestWidgetsFlutterBinding binding = AutomatedTestWidgetsFlutterBinding();
+      binding.defaultTestTimeout = test_package.Timeout(Duration(minutes: 5));
+      expect(binding.defaultTestTimeout.duration, const Duration(minutes: 5));
     });
   });
 }


### PR DESCRIPTION
- Not a breaking change.
- An alternative to this would be to create another property for AutomatedTestWidgets binding for debugging specifically. I feel like that's too much of a narrow use case.