### PR TITLE
Give benchmark output dill path

### DIFF
--- a/dev/devicelab/lib/tasks/hot_mode_tests.dart
+++ b/dev/devicelab/lib/tasks/hot_mode_tests.dart
@@ -23,7 +23,7 @@ TaskFunction createHotModeTest() {
     final File benchmarkFile = file(path.join(_editedFlutterGalleryDir.path, 'hot_benchmark.json'));
     rm(benchmarkFile);
     final List<String> options = <String>[
-      '--hot', '-d', device.deviceId, '--benchmark', '--verbose', '--resident',
+      '--hot', '-d', device.deviceId, '--benchmark', '--verbose', '--resident', '--output-dill', path.join('build', 'app.dill')
     ];
     int hotReloadCount = 0;
     Map<String, dynamic> twoReloadsData;


### PR DESCRIPTION
## Description

This allows us to measure initialize from dill performance, will still benefiting from the fix in https://github.com/flutter/flutter/pull/40171 normally.