### PR TITLE
Use AndroidX in new projects by default

### DIFF
--- a/dev/integration_tests/android_host_app/app/build.gradle
+++ b/dev/integration_tests/android_host_app/app/build.gradle
@@ -14,11 +14,11 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 }
 
 dependencies {
     implementation project(':flutter')
-    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
 }

--- a/dev/integration_tests/android_host_app/app/src/main/java/io/flutter/add2app/MainActivity.java
+++ b/dev/integration_tests/android_host_app/app/src/main/java/io/flutter/add2app/MainActivity.java
@@ -1,7 +1,7 @@
 package io.flutter.add2app;
 
-import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import androidx.appcompat.app.AppCompatActivity;
 import io.flutter.facade.Flutter;
 
 public class MainActivity extends AppCompatActivity {

--- a/dev/integration_tests/android_host_app/gradle.properties
+++ b/dev/integration_tests/android_host_app/gradle.properties
@@ -1,1 +1,4 @@
 org.gradle.jvmargs=-Xmx1536m
+
+android.useAndroidX=true
+android.enableJetifier=true

--- a/dev/integration_tests/module_host_with_custom_build/app/build.gradle
+++ b/dev/integration_tests/module_host_with_custom_build/app/build.gradle
@@ -39,5 +39,5 @@ android {
 
 dependencies {
     implementation project(':flutter')
-    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
 }

--- a/dev/integration_tests/module_host_with_custom_build/app/src/main/java/io/flutter/addtoapp/MainActivity.java
+++ b/dev/integration_tests/module_host_with_custom_build/app/src/main/java/io/flutter/addtoapp/MainActivity.java
@@ -1,7 +1,7 @@
 package io.flutter.addtoapp;
 
-import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import androidx.appcompat.app.AppCompatActivity;
 import io.flutter.facade.Flutter;
 
 public class MainActivity extends AppCompatActivity {

--- a/dev/integration_tests/module_host_with_custom_build/gradle.properties
+++ b/dev/integration_tests/module_host_with_custom_build/gradle.properties
@@ -1,1 +1,4 @@
 org.gradle.jvmargs=-Xmx1536m
+
+android.useAndroidX=true
+android.enableJetifier=true

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -141,7 +141,7 @@ class CreateCommand extends FlutterCommand {
     argParser.addFlag(
       'androidx',
       negatable: true,
-      defaultsTo: false,
+      defaultsTo: true,
       help: 'Generate a project using the AndroidX support libraries',
     );
     // Deprecated

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -389,7 +389,7 @@ class CreateCommand extends FlutterCommand {
 
     final String relativeDirPath = fs.path.relative(projectDirPath);
     if (!projectDir.existsSync() || projectDir.listSync().isEmpty) {
-      printStatus('Creating project $relativeDirPath...');
+      printStatus('Creating project $relativeDirPath... androidx: ${argResults['androidx']}');
     } else {
       if (sampleCode != null && !argResults['overwrite']) {
         throwToolExit('Will not overwrite existing project in $relativeDirPath: '

--- a/packages/flutter_tools/test/general.shard/commands/create_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/create_test.dart
@@ -410,7 +410,7 @@ void main() {
   }, timeout: allowForRemotePubInvocation);
 
 
-  testUsingContext('androidx app project', () async {
+  testUsingContext('androidx is used by default in an app project', () async {
     Cache.flutterRoot = '../..';
     when(mockFlutterVersion.frameworkRevision).thenReturn(frameworkRevision);
     when(mockFlutterVersion.channel).thenReturn(frameworkChannel);
@@ -418,7 +418,7 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
-    await runner.run(<String>['create', '--no-pub', '--androidx', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', projectDir.path]);
 
     void expectExists(String relPath) {
       expect(fs.isFileSync('${projectDir.path}/$relPath'), true);
@@ -452,7 +452,7 @@ void main() {
     expect(actualContents.contains('useAndroidX'), false);
   }, timeout: allowForCreateFlutterProject);
 
-  testUsingContext('androidx app module', () async {
+  testUsingContext('androidx is used by default in a module project', () async {
     Cache.flutterRoot = '../..';
     when(mockFlutterVersion.frameworkRevision).thenReturn(frameworkRevision);
     when(mockFlutterVersion.channel).thenReturn(frameworkChannel);
@@ -460,7 +460,7 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
-    await runner.run(<String>['create', '--template=module', '--no-pub', '--androidx', projectDir.path]);
+    await runner.run(<String>['create', '--template=module', '--no-pub', projectDir.path]);
 
     final FlutterProject project = FlutterProject.fromDirectory(projectDir);
     expect(
@@ -469,7 +469,7 @@ void main() {
     );
   }, timeout: allowForCreateFlutterProject);
 
-  testUsingContext('non androidx app module', () async {
+  testUsingContext('non androidx module', () async {
     Cache.flutterRoot = '../..';
     when(mockFlutterVersion.frameworkRevision).thenReturn(frameworkRevision);
     when(mockFlutterVersion.channel).thenReturn(frameworkChannel);
@@ -486,7 +486,7 @@ void main() {
     );
   }, timeout: allowForCreateFlutterProject);
 
-  testUsingContext('androidx plugin project', () async {
+  testUsingContext('androidx is used by default in a plugin project', () async {
     Cache.flutterRoot = '../..';
     when(mockFlutterVersion.frameworkRevision).thenReturn(frameworkRevision);
     when(mockFlutterVersion.channel).thenReturn(frameworkChannel);
@@ -494,7 +494,7 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--androidx', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
 
     void expectExists(String relPath) {
       expect(fs.isFileSync('${projectDir.path}/$relPath'), true);


### PR DESCRIPTION
## Description

Create new AndroidX projects by default.
This can be merged after https://github.com/flutter/flutter/pull/40810

## Related Issues

https://flutter.dev/go/androidx-transition

## Tests

I added the following tests: ensure that Flutter creates an AndroidX project by default.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
