### PR TITLE
Make module pod headers public

### DIFF
--- a/packages/flutter_tools/templates/module/ios/host_app_ephemeral_cocoapods/Podfile.copy.tmpl
+++ b/packages/flutter_tools/templates/module/ios/host_app_ephemeral_cocoapods/Podfile.copy.tmpl
@@ -3,9 +3,23 @@ platform :ios, '8.0'
 flutter_application_path = '../'
 load File.join(flutter_application_path, '.ios', 'Flutter', 'podhelper.rb')
 
+use_frameworks!
+
 target 'Runner' do
   install_flutter_engine_pod
   install_flutter_plugin_pods flutter_application_path
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    # Aggregate targets do not have a headers build phase.
+    if target.respond_to?('headers_build_phase')
+      target.headers_build_phase.files.each do |file|
+        # Make headers public so they can be imported by the host application.
+        file.settings = { 'ATTRIBUTES' => ['Public'] }
+      end
+    end
+  end
 end
 
 # Prevent Cocoapods from embedding a second Flutter framework and causing an error with the new Xcode build system.


### PR DESCRIPTION
## Description

Another attempt at a subset of https://github.com/flutter/flutter/pull/39275.  I wanted to document a script people can use before https://github.com/flutter/flutter/issues/36968 is complete, but the headers must be public in the ephemeral Podfile.  I don't want people to edit it directly since it will be regenerated on `flutter clean`.  I still don't have any tests for it, but I've tested it manually.

Building iOS frameworks to be embedded in another existing app without CocoaPods requires that the plugin frameworks be built on a machine with CocoaPods to get transitive dependencies.

In the _module_ Podfile make headers Public instead of Project so plugin headers/modules can be imported by the host app.

With this change, from working directory `<path/to/module>/.ios/Pods`:
```
$ xcrun xcodebuild -alltargets -sdk iphoneos -configuration "Debug" ONLY_ACTIVE_ARCH=NO
$ xcrun xcodebuild -alltargets -sdk iphoneos -configuration "Profile" ONLY_ACTIVE_ARCH=NO
$ xcrun xcodebuild -alltargets -sdk iphoneos -configuration "Release" ONLY_ACTIVE_ARCH=NO
```
will produce frameworks for all plugins, CocoaPod transitive dependencies, and FlutterPluginRegistrant in the SYMROOT for every valid architecture.  They can then be embedded into an existing app since all headers are public.

## Related Issues

A step in making https://github.com/flutter/flutter/issues/36968 actually work.

## Tests

Made sure module_test_ios still passes.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

This change updates the _module_ Podfile, not the _host_ Podfile.  This will therefore impact the module Runner workspace, but not in any way how the host project/workspace currently embeds these frameworks as described in [Add-Flutter-to-existing-apps#add-your-flutter-app-to-your-podfile](https://github.com/flutter/flutter/wiki/Add-Flutter-to-existing-apps#add-your-flutter-app-to-your-podfile).