### PR TITLE
Revert "Use separate isolate for image loading. (#34188)"

### DIFF
--- a/packages/flutter/lib/src/painting/_network_image_io.dart
+++ b/packages/flutter/lib/src/painting/_network_image_io.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:io';
-import 'dart:isolate';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
@@ -15,7 +14,7 @@ import 'debug.dart';
 import 'image_provider.dart' as image_provider;
 import 'image_stream.dart';
 
-/// The dart:io implementation of [image_provider.NetworkImage].
+/// The dart:io implemenation of [image_provider.NetworkImage].
 class NetworkImage extends image_provider.ImageProvider<image_provider.NetworkImage> implements image_provider.NetworkImage {
   /// Creates an object that fetches the image at the given URL.
   ///
@@ -40,9 +39,9 @@ class NetworkImage extends image_provider.ImageProvider<image_provider.NetworkIm
 
   @override
   ImageStreamCompleter load(image_provider.NetworkImage key) {
-    // Ownership of this controller is handed off to [_loadAsync];
-    // it is that method's responsibility to close the controller's stream when
-    // the image has been loaded or an error is thrown.
+    // Ownership of this controller is handed off to [_loadAsync]; it is that
+    // method's responsibility to close the controller's stream when the image
+    // has been loaded or an error is thrown.
     final StreamController<ImageChunkEvent> chunkEvents = StreamController<ImageChunkEvent>();
 
     return MultiFrameImageStreamCompleter(
@@ -58,130 +57,54 @@ class NetworkImage extends image_provider.ImageProvider<image_provider.NetworkIm
     );
   }
 
-  // For [_pendingLoader] we don't need the value(worker isolate), just the future
-  // itself that is used as an indicator that successive load requests should be
-  // added to the list of pending load requests [_pendingLoadRequests].
-  static Future<void> _pendingLoader;
-  static RawReceivePort _loaderErrorHandler;
-  static List<_DownloadRequest> _pendingLoadRequests;
-  static SendPort _requestPort;
+  // Do not access this field directly; use [_httpClient] instead.
+  // We set `autoUncompress` to false to ensure that we can trust the value of
+  // the `Content-Length` HTTP header. We automatically uncompress the content
+  // in our call to [consolidateHttpClientResponseBytes].
+  static final HttpClient _sharedHttpClient = HttpClient()..autoUncompress = false;
+
+  static HttpClient get _httpClient {
+    HttpClient client = _sharedHttpClient;
+    assert(() {
+      if (debugNetworkImageHttpClientProvider != null)
+        client = debugNetworkImageHttpClientProvider();
+      return true;
+    }());
+    return client;
+  }
 
   Future<ui.Codec> _loadAsync(
     NetworkImage key,
     StreamController<ImageChunkEvent> chunkEvents,
   ) async {
-    RawReceivePort downloadResponseHandler;
     try {
       assert(key == this);
 
       final Uri resolved = Uri.base.resolve(key.url);
-
-      final Completer<TransferableTypedData> bytesCompleter = Completer<TransferableTypedData>();
-      downloadResponseHandler = RawReceivePort((_DownloadResponse response) {
-        if (response.bytes != null) {
-          if (bytesCompleter.isCompleted) {
-            // If an uncaught error occurred in the worker isolate, we'll have
-            // already completed our bytes completer.
-            return;
-          }
-          bytesCompleter.complete(response.bytes);
-        } else if (response.chunkEvent != null) {
-          chunkEvents.add(response.chunkEvent);
-        } else if (response.error != null) {
-          bytesCompleter.completeError(response.error);
-        } else {
-          assert(false);
-        }
+      final HttpClientRequest request = await _httpClient.getUrl(resolved);
+      headers?.forEach((String name, String value) {
+        request.headers.add(name, value);
       });
+      final HttpClientResponse response = await request.close();
+      if (response.statusCode != HttpStatus.ok)
+        throw image_provider.NetworkImageLoadException(statusCode: response.statusCode, uri: resolved);
 
-      // This will keep references to [debugNetworkImageHttpClientProvider] tree-shaken
-      // out of release builds.
-      HttpClientProvider httpClientProvider;
-      assert(() { httpClientProvider = debugNetworkImageHttpClientProvider; return true; }());
-
-      final _DownloadRequest downloadRequest = _DownloadRequest(
-        downloadResponseHandler.sendPort,
-        resolved,
-        headers,
-        httpClientProvider,
+      final Uint8List bytes = await consolidateHttpClientResponseBytes(
+        response,
+        onBytesReceived: (int cumulative, int total) {
+          chunkEvents.add(ImageChunkEvent(
+            cumulativeBytesLoaded: cumulative,
+            expectedTotalBytes: total,
+          ));
+        },
       );
-      if (_requestPort != null) {
-        // If worker isolate is properly set up ([_requestPort] is holding
-        // initialized [SendPort]), then just send download request down to it.
-        _requestPort.send(downloadRequest);
-      } else {
-        if (_pendingLoader == null) {
-          // If worker isolate creation was not started, start creation now.
-          _spawnAndSetupIsolate();
-        }
-        // Record download request so it can either send a request when isolate is ready or handle errors.
-        _pendingLoadRequests.add(downloadRequest);
-      }
-
-      final TransferableTypedData transferable = await bytesCompleter.future;
-
-      final Uint8List bytes = transferable.materialize().asUint8List();
-      if (bytes.isEmpty)
+      if (bytes.lengthInBytes == 0)
         throw Exception('NetworkImage is an empty file: $resolved');
 
       return PaintingBinding.instance.instantiateImageCodec(bytes);
     } finally {
       chunkEvents.close();
-      downloadResponseHandler?.close();
     }
-  }
-
-  void _spawnAndSetupIsolate() {
-    assert(_pendingLoadRequests == null);
-    assert(_loaderErrorHandler == null);
-    assert(_pendingLoader == null);
-    _pendingLoadRequests = <_DownloadRequest>[];
-    _pendingLoader = _spawnIsolate()..then((Isolate isolate) {
-      _loaderErrorHandler = RawReceivePort((List<dynamic> errorAndStackTrace) {
-        _cleanupDueToError(errorAndStackTrace[0]);
-      });
-      isolate.addErrorListener(_loaderErrorHandler.sendPort);
-      isolate.resume(isolate.pauseCapability);
-    }).catchError((dynamic error, StackTrace stackTrace) {
-      _cleanupDueToError(error);
-    });
-  }
-
-  void _cleanupDueToError(dynamic error) {
-    for (_DownloadRequest request in _pendingLoadRequests) {
-      request.handleError(error);
-    }
-    _pendingLoadRequests = null;
-    _pendingLoader = null;
-    _loaderErrorHandler.close();
-    _loaderErrorHandler = null;
-  }
-
-  Future<Isolate> _spawnIsolate() {
-    // Once worker isolate is up and running it sends it's [sendPort] over
-    // [communicationBootstrapHandler] receive port.
-    // If [sendPort] is [null], it indicates that worker isolate exited after
-    // being idle.
-    final RawReceivePort communicationBootstrapHandler = RawReceivePort((SendPort sendPort) {
-      _requestPort = sendPort;
-      if (sendPort == null) {
-        assert(_pendingLoadRequests.isEmpty);
-        _pendingLoader = null;
-        _pendingLoadRequests = null;
-        _loaderErrorHandler.close();
-        _loaderErrorHandler = null;
-        return;
-      }
-
-      // When we received [SendPort] for the worker isolate, we send all
-      // pending requests that were accumulated before worker isolate provided
-      // it's port (before [_requestPort] was populated).
-      _pendingLoadRequests.forEach(sendPort.send);
-      _pendingLoadRequests.clear();
-    });
-
-    return Isolate.spawn<SendPort>(_initializeWorkerIsolate,
-      communicationBootstrapHandler.sendPort, paused: true);
   }
 
   @override
@@ -189,7 +112,8 @@ class NetworkImage extends image_provider.ImageProvider<image_provider.NetworkIm
     if (other.runtimeType != runtimeType)
       return false;
     final NetworkImage typedOther = other;
-    return url == typedOther.url && scale == typedOther.scale;
+    return url == typedOther.url
+        && scale == typedOther.scale;
   }
 
   @override
@@ -197,96 +121,4 @@ class NetworkImage extends image_provider.ImageProvider<image_provider.NetworkIm
 
   @override
   String toString() => '$runtimeType("$url", scale: $scale)';
-}
-
-@immutable
-class _DownloadResponse {
-  const _DownloadResponse.bytes(this.bytes) : assert(bytes != null), chunkEvent = null, error = null;
-  const _DownloadResponse.chunkEvent(this.chunkEvent) : assert(chunkEvent != null), bytes = null, error = null;
-  const _DownloadResponse.error(this.error) : assert(error != null), bytes = null, chunkEvent = null;
-
-  final TransferableTypedData bytes;
-  final ImageChunkEvent chunkEvent;
-  final dynamic error;
-}
-
-@immutable
-class _DownloadRequest {
-  const _DownloadRequest(this.sendPort, this.uri, this.headers, this.httpClientProvider) :
-      assert(sendPort != null), assert(uri != null);
-
-  final SendPort sendPort;
-  final Uri uri;
-  final Map<String, String> headers;
-  final HttpClientProvider httpClientProvider;
-
-  void handleError(dynamic error) { sendPort.send(_DownloadResponse.error(error)); }
-}
-
-// We set `autoUncompress` to false to ensure that we can trust the value of
-// the `Content-Length` HTTP header. We automatically uncompress the content
-// in our call to [getHttpClientResponseBytes].
-final HttpClient _sharedHttpClient = HttpClient()..autoUncompress = false;
-const Duration _idleDuration = Duration(seconds: 60);
-
-/// Sets up the worker isolate to listen for incoming [_DownloadRequest]s from
-/// the main isolate.
-///
-/// This method runs on a worker isolate.
-///
-/// The `handshakeSendPort` argument is this worker isolate's communications
-/// link back to the main isolate. It is used to set-up the channel with which
-/// the main isolate sends download requests to the worker isolate.
-void _initializeWorkerIsolate(SendPort handshakeSendPort) {
-  int ongoingRequests = 0;
-  Timer idleTimer;
-  RawReceivePort downloadRequestHandler;
-
-  // Sets up a handler that processes download requests messages.
-  downloadRequestHandler = RawReceivePort((_DownloadRequest downloadRequest) async {
-    ongoingRequests++;
-    idleTimer?.cancel();
-    final HttpClient httpClient = downloadRequest.httpClientProvider != null
-        ? downloadRequest.httpClientProvider()
-        : _sharedHttpClient;
-
-    try {
-      final HttpClientRequest request = await httpClient.getUrl(downloadRequest.uri);
-      downloadRequest.headers?.forEach((String name, String value) {
-        request.headers.add(name, value);
-      });
-      final HttpClientResponse response = await request.close();
-      if (response.statusCode != HttpStatus.ok) {
-        throw image_provider.NetworkImageLoadException(
-          statusCode: response?.statusCode,
-          uri: downloadRequest.uri,
-        );
-      }
-      final TransferableTypedData transferable = await getHttpClientResponseBytes(
-        response,
-        onBytesReceived: (int cumulative, int total) {
-          downloadRequest.sendPort.send(_DownloadResponse.chunkEvent(
-            ImageChunkEvent(
-              cumulativeBytesLoaded: cumulative,
-              expectedTotalBytes: total,
-            ),
-          ));
-        },
-      );
-      downloadRequest.sendPort.send(_DownloadResponse.bytes(transferable));
-    } catch (error) {
-      downloadRequest.sendPort.send(_DownloadResponse.error(error));
-    }
-    ongoingRequests--;
-    if (ongoingRequests == 0) {
-      idleTimer = Timer(_idleDuration, () {
-        assert(ongoingRequests == 0);
-        // [null] indicates that worker is going down.
-        handshakeSendPort.send(null);
-        downloadRequestHandler.close();
-      });
-    }
-  });
-
-  handshakeSendPort.send(downloadRequestHandler.sendPort);
 }

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'dart:isolate';
 import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
@@ -121,8 +120,8 @@ class NetworkAssetBundle extends AssetBundle {
         'Unable to load asset: $key\n'
         'HTTP status code: ${response.statusCode}'
       );
-    final TransferableTypedData transferable = await getHttpClientResponseBytes(response);
-    return transferable.materialize().asByteData();
+    final Uint8List bytes = await consolidateHttpClientResponseBytes(response);
+    return bytes.buffer.asByteData();
   }
 
   /// Retrieve a string from the asset bundle, parse it with the given function,

--- a/packages/flutter/test/foundation/consolidate_response_test.dart
+++ b/packages/flutter/test/foundation/consolidate_response_test.dart
@@ -6,7 +6,6 @@
 
 import 'dart:async';
 import 'dart:io';
-import 'dart:isolate';
 import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
@@ -15,7 +14,7 @@ import 'package:mockito/mockito.dart';
 import '../flutter_test_alternative.dart';
 
 void main() {
-  group(getHttpClientResponseBytes, () {
+  group(consolidateHttpClientResponseBytes, () {
     final Uint8List chunkOne = Uint8List.fromList(<int>[0, 1, 2, 3, 4, 5]);
     final Uint8List chunkTwo = Uint8List.fromList(<int>[6, 7, 8, 9, 10]);
     MockHttpClientResponse response;
@@ -47,24 +46,24 @@ void main() {
     test('Converts an HttpClientResponse with contentLength to bytes', () async {
       when(response.contentLength)
           .thenReturn(chunkOne.length + chunkTwo.length);
-      final List<int> bytes = (await getHttpClientResponseBytes(response))
-          .materialize().asUint8List();
+      final List<int> bytes =
+          await consolidateHttpClientResponseBytes(response);
 
       expect(bytes, <int>[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     });
 
     test('Converts a compressed HttpClientResponse with contentLength to bytes', () async {
       when(response.contentLength).thenReturn(chunkOne.length);
-      final List<int> bytes = (await getHttpClientResponseBytes(response))
-          .materialize().asUint8List();
+      final List<int> bytes =
+          await consolidateHttpClientResponseBytes(response);
 
       expect(bytes, <int>[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     });
 
     test('Converts an HttpClientResponse without contentLength to bytes', () async {
       when(response.contentLength).thenReturn(-1);
-      final List<int> bytes = (await getHttpClientResponseBytes(response))
-          .materialize().asUint8List();
+      final List<int> bytes =
+          await consolidateHttpClientResponseBytes(response);
 
       expect(bytes, <int>[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     });
@@ -73,7 +72,7 @@ void main() {
       final int syntheticTotal = (chunkOne.length + chunkTwo.length) * 2;
       when(response.contentLength).thenReturn(syntheticTotal);
       final List<int> records = <int>[];
-      await getHttpClientResponseBytes(
+      await consolidateHttpClientResponseBytes(
         response,
         onBytesReceived: (int cumulative, int total) {
           records.addAll(<int>[cumulative, total]);
@@ -111,13 +110,13 @@ void main() {
       });
       when(response.contentLength).thenReturn(-1);
 
-      expect(getHttpClientResponseBytes(response),
+      expect(consolidateHttpClientResponseBytes(response),
           throwsA(isInstanceOf<Exception>()));
     });
 
     test('Propagates error to Future return value if onBytesReceived throws', () async {
       when(response.contentLength).thenReturn(-1);
-      final Future<TransferableTypedData> result = getHttpClientResponseBytes(
+      final Future<List<int>> result = consolidateHttpClientResponseBytes(
         response,
         onBytesReceived: (int cumulative, int total) {
           throw 'misbehaving callback';
@@ -158,14 +157,14 @@ void main() {
       test('Uncompresses GZIP bytes if autoUncompress is true and response.compressionState is compressed', () async {
         when(response.compressionState).thenReturn(HttpClientResponseCompressionState.compressed);
         when(response.contentLength).thenReturn(gzipped.length);
-        final List<int> bytes = (await getHttpClientResponseBytes(response)).materialize().asUint8List();
+        final List<int> bytes = await consolidateHttpClientResponseBytes(response);
         expect(bytes, <int>[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
       });
 
       test('returns gzipped bytes if autoUncompress is false and response.compressionState is compressed', () async {
         when(response.compressionState).thenReturn(HttpClientResponseCompressionState.compressed);
         when(response.contentLength).thenReturn(gzipped.length);
-        final List<int> bytes = (await getHttpClientResponseBytes(response, autoUncompress: false)).materialize().asUint8List();
+        final List<int> bytes = await consolidateHttpClientResponseBytes(response, autoUncompress: false);
         expect(bytes, gzipped);
       });
 
@@ -173,7 +172,7 @@ void main() {
         when(response.compressionState).thenReturn(HttpClientResponseCompressionState.compressed);
         when(response.contentLength).thenReturn(gzipped.length);
         final List<int> records = <int>[];
-        await getHttpClientResponseBytes(
+        await consolidateHttpClientResponseBytes(
           response,
           onBytesReceived: (int cumulative, int total) {
             records.addAll(<int>[cumulative, total]);
@@ -193,7 +192,7 @@ void main() {
         when(response.compressionState).thenReturn(HttpClientResponseCompressionState.decompressed);
         when(response.contentLength).thenReturn(syntheticTotal);
         final List<int> records = <int>[];
-        await getHttpClientResponseBytes(
+        await consolidateHttpClientResponseBytes(
           response,
           onBytesReceived: (int cumulative, int total) {
             records.addAll(<int>[cumulative, total]);

--- a/packages/flutter/test/widgets/image_headers_test.dart
+++ b/packages/flutter/test/widgets/image_headers_test.dart
@@ -1,0 +1,53 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../painting/image_data.dart';
+
+void main() {
+  final MockHttpClient client = MockHttpClient();
+  final MockHttpClientRequest request = MockHttpClientRequest();
+  final MockHttpClientResponse response = MockHttpClientResponse();
+  final MockHttpHeaders headers = MockHttpHeaders();
+
+  testWidgets('Headers', (WidgetTester tester) async {
+    HttpOverrides.runZoned<Future<void>>(() async {
+      await tester.pumpWidget(Image.network(
+        'https://www.example.com/images/frame.png',
+        headers: const <String, String>{'flutter': 'flutter'},
+      ));
+
+      verify(headers.add('flutter', 'flutter')).called(1);
+
+    }, createHttpClient: (SecurityContext _) {
+      when(client.getUrl(any)).thenAnswer((_) => Future<HttpClientRequest>.value(request));
+      when(request.headers).thenReturn(headers);
+      when(request.close()).thenAnswer((_) => Future<HttpClientResponse>.value(response));
+      when(response.contentLength).thenReturn(kTransparentImage.length);
+      when(response.statusCode).thenReturn(HttpStatus.ok);
+      when(response.listen(any)).thenAnswer((Invocation invocation) {
+        final void Function(List<int>) onData = invocation.positionalArguments[0];
+        final void Function() onDone = invocation.namedArguments[#onDone];
+        final void Function(Object, [ StackTrace ]) onError = invocation.namedArguments[#onError];
+        final bool cancelOnError = invocation.namedArguments[#cancelOnError];
+        return Stream<List<int>>.fromIterable(<List<int>>[kTransparentImage]).listen(onData, onDone: onDone, onError: onError, cancelOnError: cancelOnError);
+      });
+      return client;
+    });
+  }, skip: isBrowser);
+}
+
+class MockHttpClient extends Mock implements HttpClient {}
+
+class MockHttpClientRequest extends Mock implements HttpClientRequest {}
+
+class MockHttpClientResponse extends Mock implements HttpClientResponse {}
+
+class MockHttpHeaders extends Mock implements HttpHeaders {}


### PR DESCRIPTION
This reverts commit b12bdd0ea13619903b9a56164c69e7e62410b723 as it
breaks existing tests that expect image loaded after certaing number of
pupms. With image loading done on separate isolate pumping is not
guaranteed to get image loaded.

## Description

*Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change. If you're changing visual properties, consider including before/after screenshots (and runnable code snippets to reproduce them).*

## Related Issues

*Replace this paragraph with a list of issues related to this PR from our [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behaviour with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
