### PR TITLE
Fix mouse hover to not schedule a frame for every mouse move.

### DIFF
--- a/packages/flutter/lib/src/gestures/mouse_tracking.dart
+++ b/packages/flutter/lib/src/gestures/mouse_tracking.dart
@@ -155,7 +155,7 @@ class MouseTracker extends ChangeNotifier {
     if (_trackedAnnotations.isNotEmpty && !_scheduledPostFramePositionCheck) {
       _scheduledPostFramePositionCheck = true;
       SchedulerBinding.instance.addPostFrameCallback((Duration duration) {
-        sendMouseNotifications(_lastMouseEvent.keys.toSet());
+        sendMouseNotifications(_lastMouseEvent.keys);
         _scheduledPostFramePositionCheck = false;
       });
     }

--- a/packages/flutter/lib/src/gestures/mouse_tracking.dart
+++ b/packages/flutter/lib/src/gestures/mouse_tracking.dart
@@ -92,11 +92,20 @@ class MouseTracker extends ChangeNotifier {
   /// Creates a mouse tracker to keep track of mouse locations.
   ///
   /// All of the parameters must not be null.
-  MouseTracker(PointerRouter router, this.annotationFinder)
-      : assert(router != null),
+  MouseTracker(this._router, this.annotationFinder)
+      : assert(_router != null),
         assert(annotationFinder != null) {
-    router.addGlobalRoute(_handleEvent);
+    _router.addGlobalRoute(_handleEvent);
   }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _router.removeGlobalRoute(_handleEvent);
+  }
+
+  // The pointer router that the mouse tracker listens to for events.
+  final PointerRouter _router;
 
   /// Used to find annotations at a given logical coordinate.
   final MouseDetectorAnnotationFinder annotationFinder;
@@ -111,16 +120,19 @@ class MouseTracker extends ChangeNotifier {
   /// annotation has been added to the layer tree.
   void attachAnnotation(MouseTrackerAnnotation annotation) {
     _trackedAnnotations[annotation] = _TrackedAnnotation(annotation);
-    // Schedule a check so that we test this new annotation to see if the mouse
-    // is currently inside its region.
-    _scheduleMousePositionCheck();
+    // Schedule a check so that we test this new annotation to see if any mouse
+    // is currently inside its region. It has to happen after the frame is
+    // complete so that the annotation layer has been added before the check.
+    if (mouseIsConnected) {
+      _scheduleMousePositionCheck();
+    }
   }
 
   /// Stops tracking an annotation, indicating that it has been removed from the
   /// layer tree.
   ///
   /// If the associated layer is not removed, and receives a hit, then
-  /// [collectMousePositions] will assert the next time it is called.
+  /// [sendMouseNotifications] will assert the next time it is called.
   void detachAnnotation(MouseTrackerAnnotation annotation) {
     final _TrackedAnnotation trackedAnnotation = _findAnnotation(annotation);
     for (int deviceId in trackedAnnotation.activeDevices) {
@@ -133,18 +145,19 @@ class MouseTracker extends ChangeNotifier {
     _trackedAnnotations.remove(annotation);
   }
 
-  bool _postFrameCheckScheduled = false;
+  bool _scheduledPostFramePositionCheck = false;
+  // Schedules a position check at the end of this frame for those annotations
+  // that have been added.
   void _scheduleMousePositionCheck() {
     // If we're not tracking anything, then there is no point in registering a
     // frame callback or scheduling a frame. By definition there are no active
     // annotations that need exiting, either.
-    if (_trackedAnnotations.isNotEmpty && !_postFrameCheckScheduled) {
-      _postFrameCheckScheduled = true;
-      SchedulerBinding.instance.addPostFrameCallback((Duration _) {
-        _postFrameCheckScheduled = false;
-        collectMousePositions();
+    if (_trackedAnnotations.isNotEmpty && !_scheduledPostFramePositionCheck) {
+      _scheduledPostFramePositionCheck = true;
+      SchedulerBinding.instance.addPostFrameCallback((Duration duration) {
+        sendMouseNotifications(_lastMouseEvent.keys.toSet());
+        _scheduledPostFramePositionCheck = false;
       });
-      SchedulerBinding.instance.scheduleFrame();
     }
   }
 
@@ -158,21 +171,24 @@ class MouseTracker extends ChangeNotifier {
       // If we are adding the device again, then we're not removing it anymore.
       _pendingRemovals.remove(deviceId);
       _addMouseEvent(deviceId, event);
+      sendMouseNotifications(<int>{deviceId});
       return;
     }
     if (event is PointerRemovedEvent) {
       _removeMouseEvent(deviceId, event);
       // If the mouse was removed, then we need to schedule one more check to
       // exit any annotations that were active.
-      _scheduleMousePositionCheck();
+      sendMouseNotifications(<int>{deviceId});
     } else {
       if (event is PointerMoveEvent || event is PointerHoverEvent || event is PointerDownEvent) {
-        if (!_lastMouseEvent.containsKey(deviceId) || _lastMouseEvent[deviceId].position != event.position) {
+        final PointerEvent lastEvent = _lastMouseEvent[deviceId];
+        _addMouseEvent(deviceId, event);
+        if (lastEvent == null ||
+            lastEvent is PointerAddedEvent || lastEvent.position != event.position) {
           // Only schedule a frame if we have our first event, or if the
           // location of the mouse has changed, and only if there are tracked annotations.
-          _scheduleMousePositionCheck();
+          sendMouseNotifications(<int>{deviceId});
         }
-        _addMouseEvent(deviceId, event);
       }
     }
   }
@@ -206,14 +222,18 @@ class MouseTracker extends ChangeNotifier {
   /// This function is only public to allow for proper testing of the
   /// MouseTracker. Do not call in other contexts.
   @visibleForTesting
-  void collectMousePositions() {
+  void sendMouseNotifications(Iterable<int> deviceIds) {
+    if (_trackedAnnotations.isEmpty) {
+      return;
+    }
+
     void exitAnnotation(_TrackedAnnotation trackedAnnotation, int deviceId) {
       if (trackedAnnotation.annotation?.onExit != null && trackedAnnotation.activeDevices.contains(deviceId)) {
         final PointerEvent event = _lastMouseEvent[deviceId] ?? _pendingRemovals[deviceId];
         assert(event != null);
         trackedAnnotation.annotation.onExit(PointerExitEvent.fromMouseEvent(event));
-        trackedAnnotation.activeDevices.remove(deviceId);
       }
+      trackedAnnotation.activeDevices.remove(deviceId);
     }
 
     void exitAllDevices(_TrackedAnnotation trackedAnnotation) {
@@ -234,8 +254,9 @@ class MouseTracker extends ChangeNotifier {
         return;
       }
 
-      for (int deviceId in _lastMouseEvent.keys) {
+      for (int deviceId in deviceIds) {
         final PointerEvent lastEvent = _lastMouseEvent[deviceId];
+        assert(lastEvent != null);
         final Iterable<MouseTrackerAnnotation> hits = annotationFinder(lastEvent.position);
 
         // No annotations were found at this position for this deviceId, so send an
@@ -311,7 +332,6 @@ class MouseTracker extends ChangeNotifier {
   /// The most recent mouse event observed for each mouse device ID observed.
   ///
   /// May be null if no mouse is connected, or hasn't produced an event yet.
-  /// Will not be updated unless there is at least one tracked annotation.
   final Map<int, PointerEvent> _lastMouseEvent = <int, PointerEvent>{};
 
   /// Whether or not a mouse is connected and has produced events.

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -43,7 +43,7 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
     _handleSemanticsEnabledChanged();
     assert(renderView != null);
     addPersistentFrameCallback(_handlePersistentFrameCallback);
-    _mouseTracker = _createMouseTracker();
+    initMouseTracker();
   }
 
   /// The current [RendererBinding], if one has been created.
@@ -238,10 +238,14 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
 
   SemanticsHandle _semanticsHandle;
 
-  // Creates a [MouseTracker] which manages state about currently connected
-  // mice, for hover notification.
-  MouseTracker _createMouseTracker() {
-    return MouseTracker(pointerRouter, renderView.hitTestMouseTrackers);
+  /// Creates a [MouseTracker] which manages state about currently connected
+  /// mice, for hover notification.
+  ///
+  /// Used by testing framework to reinitialize the mouse tracker between tests.
+  @visibleForTesting
+  void initMouseTracker([MouseTracker tracker]) {
+    _mouseTracker?.dispose();
+    _mouseTracker = tracker ?? MouseTracker(pointerRouter, renderView.hitTestMouseTrackers);
   }
 
   void _handleSemanticsEnabledChanged() {

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2614,9 +2614,9 @@ class RenderMouseRegion extends RenderProxyBox {
        _annotationIsActive = false,
        super(child) {
     _hoverAnnotation = MouseTrackerAnnotation(
-      onEnter: _handleEnter,
-      onHover: _handleHover,
-      onExit: _handleExit,
+      onEnter: _onEnter,
+      onHover: _onHover,
+      onExit: _onExit,
     );
   }
 
@@ -2632,10 +2632,6 @@ class RenderMouseRegion extends RenderProxyBox {
     }
   }
   PointerEnterEventListener _onEnter;
-  void _handleEnter(PointerEnterEvent event) {
-    if (_onEnter != null)
-      _onEnter(event);
-  }
 
   /// Called when a pointer that has not triggered an [onPointerDown] changes
   /// position.
@@ -2649,10 +2645,6 @@ class RenderMouseRegion extends RenderProxyBox {
     }
   }
   PointerHoverEventListener _onHover;
-  void _handleHover(PointerHoverEvent event) {
-    if (_onHover != null)
-      _onHover(event);
-  }
 
   /// Called when a hovering pointer leaves the region for this widget.
   ///
@@ -2666,10 +2658,6 @@ class RenderMouseRegion extends RenderProxyBox {
     }
   }
   PointerExitEventListener _onExit;
-  void _handleExit(PointerExitEvent event) {
-    if (_onExit != null)
-      _onExit(event);
-  }
 
   // Object used for annotation of the layer used for hover hit detection.
   MouseTrackerAnnotation _hoverAnnotation;

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2614,9 +2614,9 @@ class RenderMouseRegion extends RenderProxyBox {
        _annotationIsActive = false,
        super(child) {
     _hoverAnnotation = MouseTrackerAnnotation(
-      onEnter: _onEnter,
-      onHover: _onHover,
-      onExit: _onExit,
+      onEnter: _handleEnter,
+      onHover: _handleHover,
+      onExit: _handleExit,
     );
   }
 
@@ -2632,6 +2632,10 @@ class RenderMouseRegion extends RenderProxyBox {
     }
   }
   PointerEnterEventListener _onEnter;
+  void _handleEnter(PointerEnterEvent event) {
+    if (_onEnter != null)
+      _onEnter(event);
+  }
 
   /// Called when a pointer that has not triggered an [onPointerDown] changes
   /// position.
@@ -2645,6 +2649,10 @@ class RenderMouseRegion extends RenderProxyBox {
     }
   }
   PointerHoverEventListener _onHover;
+  void _handleHover(PointerHoverEvent event) {
+    if (_onHover != null)
+      _onHover(event);
+  }
 
   /// Called when a hovering pointer leaves the region for this widget.
   ///
@@ -2658,6 +2666,10 @@ class RenderMouseRegion extends RenderProxyBox {
     }
   }
   PointerExitEventListener _onExit;
+  void _handleExit(PointerExitEvent event) {
+    if (_onExit != null)
+      _onExit(event);
+  }
 
   // Object used for annotation of the layer used for hover hit detection.
   MouseTrackerAnnotation _hoverAnnotation;

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -5833,7 +5833,7 @@ class MouseRegion extends SingleChildRenderObjectWidget {
   final PointerExitEventListener onExit;
 
   @override
-  _ListenerElement createElement() => _ListenerElement(this);
+  _MouseRegionElement createElement() => _MouseRegionElement(this);
 
   @override
   RenderMouseRegion createRenderObject(BuildContext context) {
@@ -5866,20 +5866,20 @@ class MouseRegion extends SingleChildRenderObjectWidget {
   }
 }
 
-class _ListenerElement extends SingleChildRenderObjectElement {
-  _ListenerElement(SingleChildRenderObjectWidget widget) : super(widget);
+class _MouseRegionElement extends SingleChildRenderObjectElement {
+  _MouseRegionElement(SingleChildRenderObjectWidget widget) : super(widget);
 
   @override
   void activate() {
     super.activate();
-    final RenderMouseRegion renderMouseListener = renderObject;
-    renderMouseListener.postActivate();
+    final RenderMouseRegion renderMouseRegion = renderObject;
+    renderMouseRegion.postActivate();
   }
 
   @override
   void deactivate() {
-    final RenderMouseRegion renderMouseListener = renderObject;
-    renderMouseListener.preDeactivate();
+    final RenderMouseRegion renderMouseRegion = renderObject;
+    renderMouseRegion.preDeactivate();
     super.deactivate();
   }
 }

--- a/packages/flutter/test/gestures/mouse_tracking_test.dart
+++ b/packages/flutter/test/gestures/mouse_tracking_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:ui' as ui;
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/gestures.dart';
@@ -36,334 +37,335 @@ void ensureTestGestureBinding() {
 void main() {
   setUp(ensureTestGestureBinding);
 
-  group(MouseTracker, () {
-    final List<PointerEnterEvent> enter = <PointerEnterEvent>[];
-    final List<PointerHoverEvent> move = <PointerHoverEvent>[];
-    final List<PointerExitEvent> exit = <PointerExitEvent>[];
-    final MouseTrackerAnnotation annotation = MouseTrackerAnnotation(
-      onEnter: (PointerEnterEvent event) => enter.add(event),
-      onHover: (PointerHoverEvent event) => move.add(event),
-      onExit: (PointerExitEvent event) => exit.add(event),
+  final List<PointerEnterEvent> enter = <PointerEnterEvent>[];
+  final List<PointerHoverEvent> move = <PointerHoverEvent>[];
+  final List<PointerExitEvent> exit = <PointerExitEvent>[];
+  final MouseTrackerAnnotation annotation = MouseTrackerAnnotation(
+    onEnter: (PointerEnterEvent event) => enter.add(event),
+    onHover: (PointerHoverEvent event) => move.add(event),
+    onExit: (PointerExitEvent event) => exit.add(event),
+  );
+  // Only respond to some mouse events.
+  final MouseTrackerAnnotation partialAnnotation = MouseTrackerAnnotation(
+    onEnter: (PointerEnterEvent event) => enter.add(event),
+    onHover: (PointerHoverEvent event) => move.add(event),
+  );
+  bool isInHitRegionOne;
+  bool isInHitRegionTwo;
+
+  void clear() {
+    enter.clear();
+    exit.clear();
+    move.clear();
+  }
+
+  setUp(() {
+    clear();
+    isInHitRegionOne = true;
+    isInHitRegionTwo = false;
+    RendererBinding.instance.initMouseTracker(
+      MouseTracker(
+        GestureBinding.instance.pointerRouter,
+        (Offset position) sync* {
+          if (isInHitRegionOne)
+            yield annotation;
+          else if (isInHitRegionTwo) {
+            yield partialAnnotation;
+          }
+        },
+      ),
     );
-    // Only respond to some mouse events.
-    final MouseTrackerAnnotation partialAnnotation = MouseTrackerAnnotation(
-      onEnter: (PointerEnterEvent event) => enter.add(event),
-      onHover: (PointerHoverEvent event) => move.add(event),
-    );
-    bool isInHitRegionOne;
-    bool isInHitRegionTwo;
+    PointerEventConverter.clearPointers();
+  });
 
-    void clear() {
-      enter.clear();
-      exit.clear();
-      move.clear();
-    }
+  test('receives and processes mouse hover events', () {
+    final ui.PointerDataPacket packet1 = ui.PointerDataPacket(data: <ui.PointerData>[
+      ui.PointerData(
+        change: ui.PointerChange.hover, // Will implicitly also add a PointerAdded event.
+        physicalX: 0.0 * ui.window.devicePixelRatio,
+        physicalY: 0.0 * ui.window.devicePixelRatio,
+        kind: PointerDeviceKind.mouse,
+      ),
+    ]);
+    final ui.PointerDataPacket packet2 = ui.PointerDataPacket(data: <ui.PointerData>[
+      ui.PointerData(
+        change: ui.PointerChange.hover,
+        physicalX: 1.0 * ui.window.devicePixelRatio,
+        physicalY: 101.0 * ui.window.devicePixelRatio,
+        kind: PointerDeviceKind.mouse,
+      ),
+    ]);
+    final ui.PointerDataPacket packet3 = ui.PointerDataPacket(data: <ui.PointerData>[
+      ui.PointerData(
+        change: ui.PointerChange.remove,
+        physicalX: 1.0 * ui.window.devicePixelRatio,
+        physicalY: 201.0 * ui.window.devicePixelRatio,
+        kind: PointerDeviceKind.mouse,
+      ),
+    ]);
+    final ui.PointerDataPacket packet4 = ui.PointerDataPacket(data: <ui.PointerData>[
+      ui.PointerData(
+        change: ui.PointerChange.hover,
+        physicalX: 1.0 * ui.window.devicePixelRatio,
+        physicalY: 301.0 * ui.window.devicePixelRatio,
+        kind: PointerDeviceKind.mouse,
+      ),
+    ]);
+    final ui.PointerDataPacket packet5 = ui.PointerDataPacket(data: <ui.PointerData>[
+      ui.PointerData(
+        change: ui.PointerChange.hover,
+        physicalX: 1.0 * ui.window.devicePixelRatio,
+        physicalY: 401.0 * ui.window.devicePixelRatio,
+        kind: PointerDeviceKind.mouse,
+        device: 1,
+      ),
+    ]);
+    RendererBinding.instance.mouseTracker.attachAnnotation(annotation);
+    RendererBinding.instance.mouseTracker.sendMouseNotifications(<int>{0});
+    isInHitRegionOne = true;
+    ui.window.onPointerDataPacket(packet1);
+    expect(enter.length, equals(1), reason: 'enter contains $enter');
+    expect(enter.first.position, equals(const Offset(0.0, 0.0)));
+    expect(enter.first.device, equals(0));
+    expect(enter.first.runtimeType, equals(PointerEnterEvent));
+    expect(exit.length, equals(0), reason: 'exit contains $exit');
+    expect(move.length, equals(1), reason: 'move contains $move');
+    expect(move.first.position, equals(const Offset(0.0, 0.0)));
+    expect(move.first.device, equals(0));
+    expect(move.first.runtimeType, equals(PointerHoverEvent));
+    clear();
 
-    setUp(() {
-      clear();
-      isInHitRegionOne = true;
-      isInHitRegionTwo = false;
-      RendererBinding.instance.initMouseTracker(
-        MouseTracker(
-          GestureBinding.instance.pointerRouter,
-          (Offset position) sync* {
-            if (isInHitRegionOne)
-              yield annotation;
-            else if (isInHitRegionTwo) {
-              yield partialAnnotation;
-            }
-          },
-        ),
-      );
-      PointerEventConverter.clearPointers();
-    });
+    ui.window.onPointerDataPacket(packet2);
+    expect(enter.length, equals(0), reason: 'enter contains $enter');
+    expect(exit.length, equals(0), reason: 'exit contains $exit');
+    expect(move.length, equals(1), reason: 'move contains $move');
+    expect(move.first.position, equals(const Offset(1.0, 101.0)));
+    expect(move.first.device, equals(0));
+    expect(move.first.runtimeType, equals(PointerHoverEvent));
+    clear();
 
-    test('receives and processes mouse hover events', () {
-      final ui.PointerDataPacket packet1 = ui.PointerDataPacket(data: <ui.PointerData>[
-        ui.PointerData(
-          change: ui.PointerChange.hover, // Will implicitly also add a PointerAdded event.
-          physicalX: 0.0 * ui.window.devicePixelRatio,
-          physicalY: 0.0 * ui.window.devicePixelRatio,
-          kind: PointerDeviceKind.mouse,
-        ),
-      ]);
-      final ui.PointerDataPacket packet2 = ui.PointerDataPacket(data: <ui.PointerData>[
-        ui.PointerData(
-          change: ui.PointerChange.hover,
-          physicalX: 1.0 * ui.window.devicePixelRatio,
-          physicalY: 101.0 * ui.window.devicePixelRatio,
-          kind: PointerDeviceKind.mouse,
-        ),
-      ]);
-      final ui.PointerDataPacket packet3 = ui.PointerDataPacket(data: <ui.PointerData>[
-        ui.PointerData(
-          change: ui.PointerChange.remove,
-          physicalX: 1.0 * ui.window.devicePixelRatio,
-          physicalY: 201.0 * ui.window.devicePixelRatio,
-          kind: PointerDeviceKind.mouse,
-        ),
-      ]);
-      final ui.PointerDataPacket packet4 = ui.PointerDataPacket(data: <ui.PointerData>[
-        ui.PointerData(
-          change: ui.PointerChange.hover,
-          physicalX: 1.0 * ui.window.devicePixelRatio,
-          physicalY: 301.0 * ui.window.devicePixelRatio,
-          kind: PointerDeviceKind.mouse,
-        ),
-      ]);
-      final ui.PointerDataPacket packet5 = ui.PointerDataPacket(data: <ui.PointerData>[
-        ui.PointerData(
-          change: ui.PointerChange.hover,
-          physicalX: 1.0 * ui.window.devicePixelRatio,
-          physicalY: 401.0 * ui.window.devicePixelRatio,
-          kind: PointerDeviceKind.mouse,
-          device: 1,
-        ),
-      ]);
-      RendererBinding.instance.mouseTracker.attachAnnotation(annotation);
-      RendererBinding.instance.mouseTracker.sendMouseNotifications(<int>{0});
-      isInHitRegionOne = true;
-      ui.window.onPointerDataPacket(packet1);
-      expect(enter.length, equals(1), reason: 'enter contains $enter');
-      expect(enter.first.position, equals(const Offset(0.0, 0.0)));
-      expect(enter.first.device, equals(0));
-      expect(enter.first.runtimeType, equals(PointerEnterEvent));
-      expect(exit.length, equals(0), reason: 'exit contains $exit');
-      expect(move.length, equals(1), reason: 'move contains $move');
-      expect(move.first.position, equals(const Offset(0.0, 0.0)));
-      expect(move.first.device, equals(0));
-      expect(move.first.runtimeType, equals(PointerHoverEvent));
-      clear();
+    ui.window.onPointerDataPacket(packet3);
+    expect(enter.length, equals(0), reason: 'enter contains $enter');
+    expect(move.length, equals(1), reason: 'move contains $move');
+    expect(move.first.position, equals(const Offset(1.0, 201.0)));
+    expect(move.first.device, equals(0));
+    expect(move.first.runtimeType, equals(PointerHoverEvent));
+    expect(exit.length, equals(1), reason: 'exit contains $exit');
+    expect(exit.first.position, equals(const Offset(1.0, 201.0)));
+    expect(exit.first.device, equals(0));
+    expect(exit.first.runtimeType, equals(PointerExitEvent));
 
-      ui.window.onPointerDataPacket(packet2);
-      expect(enter.length, equals(0), reason: 'enter contains $enter');
-      expect(exit.length, equals(0), reason: 'exit contains $exit');
-      expect(move.length, equals(1), reason: 'move contains $move');
-      expect(move.first.position, equals(const Offset(1.0, 101.0)));
-      expect(move.first.device, equals(0));
-      expect(move.first.runtimeType, equals(PointerHoverEvent));
-      clear();
+    clear();
+    ui.window.onPointerDataPacket(packet4);
+    expect(enter.length, equals(1), reason: 'enter contains $enter');
+    expect(enter.first.position, equals(const Offset(1.0, 301.0)));
+    expect(enter.first.device, equals(0));
+    expect(enter.first.runtimeType, equals(PointerEnterEvent));
+    expect(exit.length, equals(0), reason: 'exit contains $exit');
+    expect(move.length, equals(1), reason: 'move contains $move');
+    expect(move.first.position, equals(const Offset(1.0, 301.0)));
+    expect(move.first.device, equals(0));
+    expect(move.first.runtimeType, equals(PointerHoverEvent));
 
-      ui.window.onPointerDataPacket(packet3);
-      expect(enter.length, equals(0), reason: 'enter contains $enter');
-      expect(move.length, equals(1), reason: 'move contains $move');
-      expect(move.first.position, equals(const Offset(1.0, 201.0)));
-      expect(move.first.device, equals(0));
-      expect(move.first.runtimeType, equals(PointerHoverEvent));
-      expect(exit.length, equals(1), reason: 'exit contains $exit');
-      expect(exit.first.position, equals(const Offset(1.0, 201.0)));
-      expect(exit.first.device, equals(0));
-      expect(exit.first.runtimeType, equals(PointerExitEvent));
+    // add in a second mouse simultaneously.
+    clear();
+    ui.window.onPointerDataPacket(packet5);
+    RendererBinding.instance.mouseTracker.sendMouseNotifications(<int>{1});
+    expect(enter.length, equals(1), reason: 'enter contains $enter');
+    expect(enter.first.position, equals(const Offset(1.0, 401.0)));
+    expect(enter.first.device, equals(1));
+    expect(enter.first.runtimeType, equals(PointerEnterEvent));
+    expect(exit.length, equals(0), reason: 'exit contains $exit');
+    expect(move.length, equals(2), reason: 'move contains $move');
+    expect(move.first.position, equals(const Offset(1.0, 401.0)));
+    expect(move.first.device, equals(1));
+    expect(move.first.runtimeType, equals(PointerHoverEvent));
+    expect(move.last.position, equals(const Offset(1.0, 401.0)));
+    expect(move.last.device, equals(1));
+    expect(move.last.runtimeType, equals(PointerHoverEvent));
+  });
 
-      clear();
-      ui.window.onPointerDataPacket(packet4);
-      expect(enter.length, equals(1), reason: 'enter contains $enter');
-      expect(enter.first.position, equals(const Offset(1.0, 301.0)));
-      expect(enter.first.device, equals(0));
-      expect(enter.first.runtimeType, equals(PointerEnterEvent));
-      expect(exit.length, equals(0), reason: 'exit contains $exit');
-      expect(move.length, equals(1), reason: 'move contains $move');
-      expect(move.first.position, equals(const Offset(1.0, 301.0)));
-      expect(move.first.device, equals(0));
-      expect(move.first.runtimeType, equals(PointerHoverEvent));
+  test('detects exit when annotated layer no longer hit', () {
+    final ui.PointerDataPacket packet1 = ui.PointerDataPacket(data: <ui.PointerData>[
+      ui.PointerData(
+        change: ui.PointerChange.hover,
+        physicalX: 0.0 * ui.window.devicePixelRatio,
+        physicalY: 0.0 * ui.window.devicePixelRatio,
+        kind: PointerDeviceKind.mouse,
+      ),
+      ui.PointerData(
+        change: ui.PointerChange.hover,
+        physicalX: 1.0 * ui.window.devicePixelRatio,
+        physicalY: 101.0 * ui.window.devicePixelRatio,
+        kind: PointerDeviceKind.mouse,
+      ),
+    ]);
+    final ui.PointerDataPacket packet2 = ui.PointerDataPacket(data: <ui.PointerData>[
+      ui.PointerData(
+        change: ui.PointerChange.hover,
+        physicalX: 1.0 * ui.window.devicePixelRatio,
+        physicalY: 201.0 * ui.window.devicePixelRatio,
+        kind: PointerDeviceKind.mouse,
+      ),
+    ]);
+    isInHitRegionOne = true;
+    RendererBinding.instance.mouseTracker.attachAnnotation(annotation);
+    RendererBinding.instance.mouseTracker.sendMouseNotifications(<int>{0});
 
-      // add in a second mouse simultaneously.
-      clear();
-      ui.window.onPointerDataPacket(packet5);
-      RendererBinding.instance.mouseTracker.sendMouseNotifications(<int>{1});
-      expect(enter.length, equals(1), reason: 'enter contains $enter');
-      expect(enter.first.position, equals(const Offset(1.0, 401.0)));
-      expect(enter.first.device, equals(1));
-      expect(enter.first.runtimeType, equals(PointerEnterEvent));
-      expect(exit.length, equals(0), reason: 'exit contains $exit');
-      expect(move.length, equals(2), reason: 'move contains $move');
-      expect(move.first.position, equals(const Offset(1.0, 401.0)));
-      expect(move.first.device, equals(1));
-      expect(move.first.runtimeType, equals(PointerHoverEvent));
-      expect(move.last.position, equals(const Offset(1.0, 401.0)));
-      expect(move.last.device, equals(1));
-      expect(move.last.runtimeType, equals(PointerHoverEvent));
-    });
-    test('detects exit when annotated layer no longer hit', () {
-      final ui.PointerDataPacket packet1 = ui.PointerDataPacket(data: <ui.PointerData>[
-        ui.PointerData(
-          change: ui.PointerChange.hover,
-          physicalX: 0.0 * ui.window.devicePixelRatio,
-          physicalY: 0.0 * ui.window.devicePixelRatio,
-          kind: PointerDeviceKind.mouse,
-        ),
-        ui.PointerData(
-          change: ui.PointerChange.hover,
-          physicalX: 1.0 * ui.window.devicePixelRatio,
-          physicalY: 101.0 * ui.window.devicePixelRatio,
-          kind: PointerDeviceKind.mouse,
-        ),
-      ]);
-      final ui.PointerDataPacket packet2 = ui.PointerDataPacket(data: <ui.PointerData>[
-        ui.PointerData(
-          change: ui.PointerChange.hover,
-          physicalX: 1.0 * ui.window.devicePixelRatio,
-          physicalY: 201.0 * ui.window.devicePixelRatio,
-          kind: PointerDeviceKind.mouse,
-        ),
-      ]);
-      isInHitRegionOne = true;
-      RendererBinding.instance.mouseTracker.attachAnnotation(annotation);
-      RendererBinding.instance.mouseTracker.sendMouseNotifications(<int>{0});
+    ui.window.onPointerDataPacket(packet1);
 
-      ui.window.onPointerDataPacket(packet1);
+    expect(enter.length, equals(1), reason: 'enter contains $enter');
+    expect(enter.first.position, equals(const Offset(0.0, 0.0)));
+    expect(enter.first.device, equals(0));
+    expect(enter.first.runtimeType, equals(PointerEnterEvent));
+    expect(move.length, equals(2), reason: 'move contains $move');
+    expect(move.first.position, equals(const Offset(0.0, 0.0)));
+    expect(move.first.device, equals(0));
+    expect(move.first.runtimeType, equals(PointerHoverEvent));
+    expect(move.last.position, equals(const Offset(1.0, 101.0)));
+    expect(move.last.device, equals(0));
+    expect(move.last.runtimeType, equals(PointerHoverEvent));
+    expect(exit.length, equals(0), reason: 'exit contains $exit');
+    // Simulate layer going away by detaching it.
+    clear();
+    isInHitRegionOne = false;
 
-      expect(enter.length, equals(1), reason: 'enter contains $enter');
-      expect(enter.first.position, equals(const Offset(0.0, 0.0)));
-      expect(enter.first.device, equals(0));
-      expect(enter.first.runtimeType, equals(PointerEnterEvent));
-      expect(move.length, equals(2), reason: 'move contains $move');
-      expect(move.first.position, equals(const Offset(0.0, 0.0)));
-      expect(move.first.device, equals(0));
-      expect(move.first.runtimeType, equals(PointerHoverEvent));
-      expect(move.last.position, equals(const Offset(1.0, 101.0)));
-      expect(move.last.device, equals(0));
-      expect(move.last.runtimeType, equals(PointerHoverEvent));
-      expect(exit.length, equals(0), reason: 'exit contains $exit');
-      // Simulate layer going away by detaching it.
-      clear();
-      isInHitRegionOne = false;
+    ui.window.onPointerDataPacket(packet2);
+    expect(enter.length, equals(0), reason: 'enter contains $enter');
+    expect(move.length, equals(0), reason: 'enter contains $move');
+    expect(exit.length, equals(1), reason: 'enter contains $exit');
+    expect(exit.first.position, const Offset(1.0, 201.0));
+    expect(exit.first.device, equals(0));
+    expect(exit.first.runtimeType, equals(PointerExitEvent));
 
-      ui.window.onPointerDataPacket(packet2);
-      expect(enter.length, equals(0), reason: 'enter contains $enter');
-      expect(move.length, equals(0), reason: 'enter contains $move');
-      expect(exit.length, equals(1), reason: 'enter contains $exit');
-      expect(exit.first.position, const Offset(1.0, 201.0));
-      expect(exit.first.device, equals(0));
-      expect(exit.first.runtimeType, equals(PointerExitEvent));
+    // Actually detach annotation. Shouldn't receive hit.
+    RendererBinding.instance.mouseTracker.detachAnnotation(annotation);
+    clear();
+    isInHitRegionOne = false;
 
-      // Actually detach annotation. Shouldn't receive hit.
-      RendererBinding.instance.mouseTracker.detachAnnotation(annotation);
-      clear();
-      isInHitRegionOne = false;
+    ui.window.onPointerDataPacket(packet2);
+    expect(enter.length, equals(0), reason: 'enter contains $enter');
+    expect(move.length, equals(0), reason: 'enter contains $move');
+    expect(exit.length, equals(0), reason: 'enter contains $exit');
+  });
 
-      ui.window.onPointerDataPacket(packet2);
-      expect(enter.length, equals(0), reason: 'enter contains $enter');
-      expect(move.length, equals(0), reason: 'enter contains $move');
-      expect(exit.length, equals(0), reason: 'enter contains $exit');
-    });
+  test("don't flip out if not all mouse events are listened to", () {
+    final ui.PointerDataPacket packet = ui.PointerDataPacket(data: <ui.PointerData>[
+      ui.PointerData(
+        change: ui.PointerChange.hover,
+        physicalX: 1.0 * ui.window.devicePixelRatio,
+        physicalY: 101.0 * ui.window.devicePixelRatio,
+        kind: PointerDeviceKind.mouse,
+      ),
+    ]);
 
-    test("don't flip out if not all mouse events are listened to", () {
-      final ui.PointerDataPacket packet = ui.PointerDataPacket(data: <ui.PointerData>[
-        ui.PointerData(
-          change: ui.PointerChange.hover,
-          physicalX: 1.0 * ui.window.devicePixelRatio,
-          physicalY: 101.0 * ui.window.devicePixelRatio,
-          kind: PointerDeviceKind.mouse,
-        ),
-      ]);
+    isInHitRegionOne = false;
+    isInHitRegionTwo = true;
+    RendererBinding.instance.mouseTracker.attachAnnotation(partialAnnotation);
 
-      isInHitRegionOne = false;
-      isInHitRegionTwo = true;
-      RendererBinding.instance.mouseTracker.attachAnnotation(partialAnnotation);
+    ui.window.onPointerDataPacket(packet);
+    RendererBinding.instance.mouseTracker.detachAnnotation(partialAnnotation);
+    isInHitRegionTwo = false;
+  });
 
-      ui.window.onPointerDataPacket(packet);
-      RendererBinding.instance.mouseTracker.detachAnnotation(partialAnnotation);
-      isInHitRegionTwo = false;
-    });
-    test('detects exit when mouse goes away', () {
-      final ui.PointerDataPacket packet1 = ui.PointerDataPacket(data: <ui.PointerData>[
-        ui.PointerData(
-          change: ui.PointerChange.hover,
-          physicalX: 0.0 * ui.window.devicePixelRatio,
-          physicalY: 0.0 * ui.window.devicePixelRatio,
-          kind: PointerDeviceKind.mouse,
-        ),
-        ui.PointerData(
-          change: ui.PointerChange.hover,
-          physicalX: 1.0 * ui.window.devicePixelRatio,
-          physicalY: 101.0 * ui.window.devicePixelRatio,
-          kind: PointerDeviceKind.mouse,
-        ),
-      ]);
-      final ui.PointerDataPacket packet2 = ui.PointerDataPacket(data: <ui.PointerData>[
-        ui.PointerData(
-          change: ui.PointerChange.remove,
-          physicalX: 1.0 * ui.window.devicePixelRatio,
-          physicalY: 201.0 * ui.window.devicePixelRatio,
-          kind: PointerDeviceKind.mouse,
-        ),
-      ]);
-      isInHitRegionOne = true;
-      RendererBinding.instance.mouseTracker.attachAnnotation(annotation);
-      RendererBinding.instance.mouseTracker.sendMouseNotifications(<int>{0});
-      ui.window.onPointerDataPacket(packet1);
-      ui.window.onPointerDataPacket(packet2);
-      expect(enter.length, equals(1), reason: 'enter contains $enter');
-      expect(enter.first.position, equals(const Offset(0.0, 0.0)));
-      expect(enter.first.delta, equals(const Offset(0.0, 0.0)));
-      expect(enter.first.device, equals(0));
-      expect(enter.first.runtimeType, equals(PointerEnterEvent));
-      expect(move.length, equals(3), reason: 'move contains $move');
-      expect(move[0].position, equals(const Offset(0.0, 0.0)));
-      expect(move[0].delta, equals(const Offset(0.0, 0.0)));
-      expect(move[0].device, equals(0));
-      expect(move[0].runtimeType, equals(PointerHoverEvent));
-      expect(move[1].position, equals(const Offset(1.0, 101.0)));
-      expect(move[1].delta, equals(const Offset(1.0, 101.0)));
-      expect(move[1].device, equals(0));
-      expect(move[1].runtimeType, equals(PointerHoverEvent));
-      expect(move[2].position, equals(const Offset(1.0, 201.0)));
-      expect(move[2].delta, equals(const Offset(0.0, 100.0)));
-      expect(move[2].device, equals(0));
-      expect(move[2].runtimeType, equals(PointerHoverEvent));
-      expect(exit.length, equals(1), reason: 'exit contains $exit');
-      expect(exit.first.position, equals(const Offset(1.0, 201.0)));
-      expect(exit.first.delta, equals(const Offset(0.0, 0.0)));
-      expect(exit.first.device, equals(0));
-      expect(exit.first.runtimeType, equals(PointerExitEvent));
-    });
-    test('handles mouse down and move', () {
-      final ui.PointerDataPacket packet1 = ui.PointerDataPacket(data: <ui.PointerData>[
-        ui.PointerData(
-          change: ui.PointerChange.hover,
-          physicalX: 0.0 * ui.window.devicePixelRatio,
-          physicalY: 0.0 * ui.window.devicePixelRatio,
-          kind: PointerDeviceKind.mouse,
-        ),
-        ui.PointerData(
-          change: ui.PointerChange.hover,
-          physicalX: 1.0 * ui.window.devicePixelRatio,
-          physicalY: 101.0 * ui.window.devicePixelRatio,
-          kind: PointerDeviceKind.mouse,
-        ),
-      ]);
-      final ui.PointerDataPacket packet2 = ui.PointerDataPacket(data: <ui.PointerData>[
-        ui.PointerData(
-          change: ui.PointerChange.down,
-          physicalX: 1.0 * ui.window.devicePixelRatio,
-          physicalY: 101.0 * ui.window.devicePixelRatio,
-          kind: PointerDeviceKind.mouse,
-        ),
-        ui.PointerData(
-          change: ui.PointerChange.move,
-          physicalX: 1.0 * ui.window.devicePixelRatio,
-          physicalY: 201.0 * ui.window.devicePixelRatio,
-          kind: PointerDeviceKind.mouse,
-        ),
-      ]);
-      isInHitRegionOne = true;
-      RendererBinding.instance.mouseTracker.attachAnnotation(annotation);
-      RendererBinding.instance.mouseTracker.sendMouseNotifications(<int>{0});
-      ui.window.onPointerDataPacket(packet1);
-      ui.window.onPointerDataPacket(packet2);
-      expect(enter.length, equals(1), reason: 'enter contains $enter');
-      expect(enter.first.position, equals(const Offset(0.0, 0.0)));
-      expect(enter.first.device, equals(0));
-      expect(enter.first.runtimeType, equals(PointerEnterEvent));
-      expect(move.length, equals(2), reason: 'move contains $move');
-      expect(move[0].position, equals(const Offset(0.0, 0.0)));
-      expect(move[0].device, equals(0));
-      expect(move[0].runtimeType, equals(PointerHoverEvent));
-      expect(move[1].position, equals(const Offset(1.0, 101.0)));
-      expect(move[1].device, equals(0));
-      expect(move[1].runtimeType, equals(PointerHoverEvent));
-      expect(exit.length, equals(0), reason: 'exit contains $exit');
-    });
+  test('detects exit when mouse goes away', () {
+    final ui.PointerDataPacket packet1 = ui.PointerDataPacket(data: <ui.PointerData>[
+      ui.PointerData(
+        change: ui.PointerChange.hover,
+        physicalX: 0.0 * ui.window.devicePixelRatio,
+        physicalY: 0.0 * ui.window.devicePixelRatio,
+        kind: PointerDeviceKind.mouse,
+      ),
+      ui.PointerData(
+        change: ui.PointerChange.hover,
+        physicalX: 1.0 * ui.window.devicePixelRatio,
+        physicalY: 101.0 * ui.window.devicePixelRatio,
+        kind: PointerDeviceKind.mouse,
+      ),
+    ]);
+    final ui.PointerDataPacket packet2 = ui.PointerDataPacket(data: <ui.PointerData>[
+      ui.PointerData(
+        change: ui.PointerChange.remove,
+        physicalX: 1.0 * ui.window.devicePixelRatio,
+        physicalY: 201.0 * ui.window.devicePixelRatio,
+        kind: PointerDeviceKind.mouse,
+      ),
+    ]);
+    isInHitRegionOne = true;
+    RendererBinding.instance.mouseTracker.attachAnnotation(annotation);
+    RendererBinding.instance.mouseTracker.sendMouseNotifications(<int>{0});
+    ui.window.onPointerDataPacket(packet1);
+    ui.window.onPointerDataPacket(packet2);
+    expect(enter.length, equals(1), reason: 'enter contains $enter');
+    expect(enter.first.position, equals(const Offset(0.0, 0.0)));
+    expect(enter.first.delta, equals(const Offset(0.0, 0.0)));
+    expect(enter.first.device, equals(0));
+    expect(enter.first.runtimeType, equals(PointerEnterEvent));
+    expect(move.length, equals(3), reason: 'move contains $move');
+    expect(move[0].position, equals(const Offset(0.0, 0.0)));
+    expect(move[0].delta, equals(const Offset(0.0, 0.0)));
+    expect(move[0].device, equals(0));
+    expect(move[0].runtimeType, equals(PointerHoverEvent));
+    expect(move[1].position, equals(const Offset(1.0, 101.0)));
+    expect(move[1].delta, equals(const Offset(1.0, 101.0)));
+    expect(move[1].device, equals(0));
+    expect(move[1].runtimeType, equals(PointerHoverEvent));
+    expect(move[2].position, equals(const Offset(1.0, 201.0)));
+    expect(move[2].delta, equals(const Offset(0.0, 100.0)));
+    expect(move[2].device, equals(0));
+    expect(move[2].runtimeType, equals(PointerHoverEvent));
+    expect(exit.length, equals(1), reason: 'exit contains $exit');
+    expect(exit.first.position, equals(const Offset(1.0, 201.0)));
+    expect(exit.first.delta, equals(const Offset(0.0, 0.0)));
+    expect(exit.first.device, equals(0));
+    expect(exit.first.runtimeType, equals(PointerExitEvent));
+  });
+
+  test('handles mouse down and move', () {
+    final ui.PointerDataPacket packet1 = ui.PointerDataPacket(data: <ui.PointerData>[
+      ui.PointerData(
+        change: ui.PointerChange.hover,
+        physicalX: 0.0 * ui.window.devicePixelRatio,
+        physicalY: 0.0 * ui.window.devicePixelRatio,
+        kind: PointerDeviceKind.mouse,
+      ),
+      ui.PointerData(
+        change: ui.PointerChange.hover,
+        physicalX: 1.0 * ui.window.devicePixelRatio,
+        physicalY: 101.0 * ui.window.devicePixelRatio,
+        kind: PointerDeviceKind.mouse,
+      ),
+    ]);
+    final ui.PointerDataPacket packet2 = ui.PointerDataPacket(data: <ui.PointerData>[
+      ui.PointerData(
+        change: ui.PointerChange.down,
+        physicalX: 1.0 * ui.window.devicePixelRatio,
+        physicalY: 101.0 * ui.window.devicePixelRatio,
+        kind: PointerDeviceKind.mouse,
+      ),
+      ui.PointerData(
+        change: ui.PointerChange.move,
+        physicalX: 1.0 * ui.window.devicePixelRatio,
+        physicalY: 201.0 * ui.window.devicePixelRatio,
+        kind: PointerDeviceKind.mouse,
+      ),
+    ]);
+    isInHitRegionOne = true;
+    RendererBinding.instance.mouseTracker.attachAnnotation(annotation);
+    RendererBinding.instance.mouseTracker.sendMouseNotifications(<int>{0});
+    ui.window.onPointerDataPacket(packet1);
+    ui.window.onPointerDataPacket(packet2);
+    expect(enter.length, equals(1), reason: 'enter contains $enter');
+    expect(enter.first.position, equals(const Offset(0.0, 0.0)));
+    expect(enter.first.device, equals(0));
+    expect(enter.first.runtimeType, equals(PointerEnterEvent));
+    expect(move.length, equals(2), reason: 'move contains $move');
+    expect(move[0].position, equals(const Offset(0.0, 0.0)));
+    expect(move[0].device, equals(0));
+    expect(move[0].runtimeType, equals(PointerHoverEvent));
+    expect(move[1].position, equals(const Offset(1.0, 101.0)));
+    expect(move[1].device, equals(0));
+    expect(move[1].runtimeType, equals(PointerHoverEvent));
+    expect(exit.length, equals(0), reason: 'exit contains $exit');
   });
 }

--- a/packages/flutter/test/gestures/mouse_tracking_test.dart
+++ b/packages/flutter/test/gestures/mouse_tracking_test.dart
@@ -176,13 +176,10 @@ void main() {
       expect(enter.first.device, equals(1));
       expect(enter.first.runtimeType, equals(PointerEnterEvent));
       expect(exit.length, equals(0), reason: 'exit contains $exit');
-      expect(move.length, equals(3), reason: 'move contains $move');
+      expect(move.length, equals(2), reason: 'move contains $move');
       expect(move.first.position, equals(const Offset(1.0, 401.0)));
       expect(move.first.device, equals(1));
       expect(move.first.runtimeType, equals(PointerHoverEvent));
-      expect(move[1].position, equals(const Offset(1.0, 301.0)));
-      expect(move[1].device, equals(0));
-      expect(move[1].runtimeType, equals(PointerHoverEvent));
       expect(move.last.position, equals(const Offset(1.0, 401.0)));
       expect(move.last.device, equals(1));
       expect(move.last.runtimeType, equals(PointerHoverEvent));
@@ -215,9 +212,7 @@ void main() {
       RendererBinding.instance.mouseTracker.sendMouseNotifications(<int>{0});
 
       ui.window.onPointerDataPacket(packet1);
-      RendererBinding.instance.mouseTracker.collectMousePositions(<int>{0});
 
-      ui.window.onPointerDataPacket(packet1);
       expect(enter.length, equals(1), reason: 'enter contains $enter');
       expect(enter.first.position, equals(const Offset(0.0, 0.0)));
       expect(enter.first.device, equals(0));
@@ -297,8 +292,6 @@ void main() {
       isInHitRegionOne = true;
       RendererBinding.instance.mouseTracker.attachAnnotation(annotation);
       RendererBinding.instance.mouseTracker.sendMouseNotifications(<int>{0});
-      ui.window.onPointerDataPacket(packet1);
-      RendererBinding.instance.mouseTracker.collectMousePositions(<int>{0});
       ui.window.onPointerDataPacket(packet1);
       ui.window.onPointerDataPacket(packet2);
       expect(enter.length, equals(1), reason: 'enter contains $enter');

--- a/packages/flutter/test/material/button_theme_test.dart
+++ b/packages/flutter/test/material/button_theme_test.dart
@@ -388,7 +388,7 @@ void main() {
     final TestGesture gesture = await tester.createGesture(
       kind: PointerDeviceKind.mouse,
     );
-    await gesture.addPointer();
+    await gesture.addPointer(location: Offset.zero);
     addTearDown(gesture.removePointer);
     await gesture.moveTo(center);
     await tester.pumpAndSettle();

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -110,7 +110,6 @@ void main() {
     TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await gesture.addPointer();
     addTearDown(() => gesture?.removePointer());
-    await tester.pumpAndSettle();
     await gesture.moveTo(tester.getCenter(find.byType(FloatingActionButton)));
     await tester.pumpAndSettle();
 
@@ -118,8 +117,8 @@ void main() {
 
     await gesture.moveTo(Offset.zero);
     await gesture.removePointer();
-    await tester.pumpAndSettle();
     gesture = null;
+    await tester.pumpAndSettle();
 
     expect(find.text('Add'), findsNothing);
 

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -110,6 +110,7 @@ void main() {
     TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await gesture.addPointer();
     addTearDown(() => gesture?.removePointer());
+    await tester.pumpAndSettle();
     await gesture.moveTo(tester.getCenter(find.byType(FloatingActionButton)));
     await tester.pumpAndSettle();
 
@@ -117,8 +118,8 @@ void main() {
 
     await gesture.moveTo(Offset.zero);
     await gesture.removePointer();
-    gesture = null;
     await tester.pumpAndSettle();
+    gesture = null;
 
     expect(find.text('Add'), findsNothing);
 
@@ -147,6 +148,7 @@ void main() {
     TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await gesture.addPointer();
     addTearDown(() => gesture?.removePointer());
+    await tester.pumpAndSettle();
     await gesture.moveTo(tester.getCenter(find.byType(FloatingActionButton)));
     await tester.pumpAndSettle();
 

--- a/packages/flutter/test/widgets/listener_deprecated_test.dart
+++ b/packages/flutter/test/widgets/listener_deprecated_test.dart
@@ -8,7 +8,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/gestures.dart';
 
-
 // The tests in this file are moved from listener_test.dart, which tests several
 // deprecated APIs. The file should be removed once these parameters are.
 
@@ -82,7 +81,7 @@ void main() {
     // onPointer{Enter,Hover,Exit} are removed. They were kept for compatibility,
     // and the tests have been copied to mouse_region_test.
     // https://github.com/flutter/flutter/issues/36085
-    setUp((){
+    setUp(() {
       HoverClientState.numExits = 0;
       HoverClientState.numEntries = 0;
     });
@@ -91,19 +90,22 @@ void main() {
       PointerEnterEvent enter;
       PointerHoverEvent move;
       PointerExitEvent exit;
-      await tester.pumpWidget(Center(
-        child: Listener(
-          child: Container(
-            color: const Color.fromARGB(0xff, 0xff, 0x00, 0x00),
-            width: 100.0,
-            height: 100.0,
+      await tester.pumpWidget(
+        Center(
+          child: Listener(
+            child: Container(
+              color: const Color.fromARGB(0xff, 0xff, 0x00, 0x00),
+              width: 100.0,
+              height: 100.0,
+            ),
+            onPointerEnter: (PointerEnterEvent details) => enter = details,
+            onPointerHover: (PointerHoverEvent details) => move = details,
+            onPointerExit: (PointerExitEvent details) => exit = details,
           ),
-          onPointerEnter: (PointerEnterEvent details) => enter = details,
-          onPointerHover: (PointerHoverEvent details) => move = details,
-          onPointerExit: (PointerExitEvent details) => exit = details,
         ),
-      ));
+      );
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer(location: Offset.zero);
       addTearDown(gesture.removePointer);
       await gesture.moveTo(const Offset(400.0, 300.0));
       await tester.pump();
@@ -117,18 +119,21 @@ void main() {
       PointerEnterEvent enter;
       PointerHoverEvent move;
       PointerExitEvent exit;
-      await tester.pumpWidget(Center(
-        child: Listener(
-          child: Container(
-            width: 100.0,
-            height: 100.0,
+      await tester.pumpWidget(
+        Center(
+          child: Listener(
+            child: Container(
+              width: 100.0,
+              height: 100.0,
+            ),
+            onPointerEnter: (PointerEnterEvent details) => enter = details,
+            onPointerHover: (PointerHoverEvent details) => move = details,
+            onPointerExit: (PointerExitEvent details) => exit = details,
           ),
-          onPointerEnter: (PointerEnterEvent details) => enter = details,
-          onPointerHover: (PointerHoverEvent details) => move = details,
-          onPointerExit: (PointerExitEvent details) => exit = details,
         ),
-      ));
+      );
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer(location: Offset.zero);
       addTearDown(gesture.removePointer);
       await gesture.moveTo(const Offset(400.0, 300.0));
       await tester.pump();
@@ -145,19 +150,22 @@ void main() {
       PointerEnterEvent enter;
       PointerHoverEvent move;
       PointerExitEvent exit;
-      await tester.pumpWidget(Center(
-        child: Listener(
-          child: Container(
-            width: 100.0,
-            height: 100.0,
+      await tester.pumpWidget(
+        Center(
+          child: Listener(
+            child: Container(
+              width: 100.0,
+              height: 100.0,
+            ),
+            onPointerEnter: (PointerEnterEvent details) => enter = details,
+            onPointerHover: (PointerHoverEvent details) => move = details,
+            onPointerExit: (PointerExitEvent details) => exit = details,
           ),
-          onPointerEnter: (PointerEnterEvent details) => enter = details,
-          onPointerHover: (PointerHoverEvent details) => move = details,
-          onPointerExit: (PointerExitEvent details) => exit = details,
         ),
-      ));
+      );
       final RenderMouseRegion renderListener = tester.renderObject(find.byType(MouseRegion));
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer(location: Offset.zero);
       addTearDown(gesture.removePointer);
       await gesture.moveTo(const Offset(400.0, 300.0));
       await tester.pump();
@@ -430,8 +438,8 @@ void main() {
       expect(bottomLeft.dy - topLeft.dy, scaleFactor * localHeight);
 
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      await gesture.addPointer();
       addTearDown(gesture.removePointer);
+      await gesture.addPointer(location: Offset.zero);
       await gesture.moveTo(topLeft - const Offset(1, 1));
       await tester.pump();
       expect(events, isEmpty);
@@ -458,8 +466,8 @@ void main() {
     testWidgets('needsCompositing updates correctly and is respected', (WidgetTester tester) async {
       // Pretend that we have a mouse connected.
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      await gesture.addPointer();
       addTearDown(gesture.removePointer);
+      await gesture.addPointer(location: Offset.zero);
 
       await tester.pumpWidget(
         Transform.scale(
@@ -507,8 +515,8 @@ void main() {
 
     testWidgets("Callbacks aren't called during build", (WidgetTester tester) async {
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      await gesture.addPointer();
       addTearDown(gesture.removePointer);
+      await gesture.addPointer(location: Offset.zero);
 
       await tester.pumpWidget(
         const Center(child: HoverFeedback()),
@@ -587,10 +595,7 @@ void main() {
       // Plug-in a mouse and move it to the center of the container.
       TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
       await gesture.addPointer();
-      addTearDown(() async {
-        if (gesture != null)
-          return gesture.removePointer();
-      });
+      addTearDown(() => gesture?.removePointer());
       await gesture.moveTo(tester.getCenter(find.byType(Container)));
       await tester.pumpAndSettle();
 
@@ -613,7 +618,7 @@ void main() {
       expect(hover.length, 0);
       expect(exit.length, 1);
       expect(exit.single.position, const Offset(400.0, 300.0));
-      expect(exit.single.delta, const Offset(0.0, 0.0));
+      expect(exit.single.delta, Offset.zero);
     });
   });
 }

--- a/packages/flutter/test/widgets/listener_deprecated_test.dart
+++ b/packages/flutter/test/widgets/listener_deprecated_test.dart
@@ -133,9 +133,8 @@ void main() {
         ),
       );
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      await gesture.addPointer(location: Offset.zero);
+      await gesture.addPointer(location: const Offset(400.0, 300.0));
       addTearDown(gesture.removePointer);
-      await gesture.moveTo(const Offset(400.0, 300.0));
       await tester.pump();
       move = null;
       enter = null;
@@ -165,12 +164,10 @@ void main() {
       );
       final RenderMouseRegion renderListener = tester.renderObject(find.byType(MouseRegion));
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      await gesture.addPointer(location: Offset.zero);
+      await gesture.addPointer(location: const Offset(400.0, 300.0));
       addTearDown(gesture.removePointer);
-      await gesture.moveTo(const Offset(400.0, 300.0));
       await tester.pump();
-      expect(move, isNotNull);
-      expect(move.position, equals(const Offset(400.0, 300.0)));
+      expect(move, isNull);
       expect(enter, isNotNull);
       expect(enter.position, equals(const Offset(400.0, 300.0)));
       expect(exit, isNull);
@@ -205,7 +202,7 @@ void main() {
       await tester.pumpWidget(Container());
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
       addTearDown(gesture.removePointer);
-      await gesture.moveTo(const Offset(400.0, 0.0));
+      await gesture.addPointer(location: const Offset(400.0, 0.0));
       await tester.pump();
       await tester.pumpWidget(
         Column(
@@ -438,9 +435,8 @@ void main() {
       expect(bottomLeft.dy - topLeft.dy, scaleFactor * localHeight);
 
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      await gesture.addPointer(location: Offset.zero);
+      await gesture.addPointer(location: topLeft - const Offset(1, 1));
       addTearDown(gesture.removePointer);
-      await gesture.moveTo(topLeft - const Offset(1, 1));
       await tester.pump();
       expect(events, isEmpty);
 
@@ -546,7 +542,7 @@ void main() {
     testWidgets("Listener activate/deactivate don't duplicate annotations", (WidgetTester tester) async {
       final GlobalKey feedbackKey = GlobalKey();
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      await gesture.addPointer();
+      await gesture.addPointer(location: Offset.zero);
       addTearDown(gesture.removePointer);
 
       await tester.pumpWidget(
@@ -594,7 +590,7 @@ void main() {
 
       // Plug-in a mouse and move it to the center of the container.
       TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      await gesture.addPointer();
+      await gesture.addPointer(location: Offset.zero);
       addTearDown(() => gesture?.removePointer());
       await gesture.moveTo(tester.getCenter(find.byType(Container)));
       await tester.pumpAndSettle();

--- a/packages/flutter/test/widgets/listener_deprecated_test.dart
+++ b/packages/flutter/test/widgets/listener_deprecated_test.dart
@@ -438,8 +438,8 @@ void main() {
       expect(bottomLeft.dy - topLeft.dy, scaleFactor * localHeight);
 
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      addTearDown(gesture.removePointer);
       await gesture.addPointer(location: Offset.zero);
+      addTearDown(gesture.removePointer);
       await gesture.moveTo(topLeft - const Offset(1, 1));
       await tester.pump();
       expect(events, isEmpty);
@@ -466,8 +466,8 @@ void main() {
     testWidgets('needsCompositing updates correctly and is respected', (WidgetTester tester) async {
       // Pretend that we have a mouse connected.
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      addTearDown(gesture.removePointer);
       await gesture.addPointer(location: Offset.zero);
+      addTearDown(gesture.removePointer);
 
       await tester.pumpWidget(
         Transform.scale(
@@ -515,8 +515,8 @@ void main() {
 
     testWidgets("Callbacks aren't called during build", (WidgetTester tester) async {
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      addTearDown(gesture.removePointer);
       await gesture.addPointer(location: Offset.zero);
+      addTearDown(gesture.removePointer);
 
       await tester.pumpWidget(
         const Center(child: HoverFeedback()),

--- a/packages/flutter/test/widgets/mouse_region_test.dart
+++ b/packages/flutter/test/widgets/mouse_region_test.dart
@@ -7,7 +7,6 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/gestures.dart';
 
-
 class HoverClient extends StatefulWidget {
   const HoverClient({
     Key key,
@@ -100,6 +99,7 @@ void main() {
         ),
       ));
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer(location: Offset.zero);
       addTearDown(gesture.removePointer);
       await gesture.moveTo(const Offset(400.0, 300.0));
       await tester.pump();
@@ -125,6 +125,7 @@ void main() {
         ),
       ));
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer(location: Offset.zero);
       addTearDown(gesture.removePointer);
       await gesture.moveTo(const Offset(400.0, 300.0));
       await tester.pump();
@@ -154,6 +155,7 @@ void main() {
       ));
       final RenderMouseRegion renderListener = tester.renderObject(find.byType(MouseRegion));
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer(location: Offset.zero);
       addTearDown(gesture.removePointer);
       await gesture.moveTo(const Offset(400.0, 300.0));
       await tester.pump();
@@ -276,7 +278,6 @@ void main() {
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
       addTearDown(gesture.removePointer);
       await gesture.moveTo(const Offset(400.0, 0.0));
-      addTearDown(gesture.removePointer);
       await tester.pump();
       await tester.pumpWidget(
         Column(
@@ -501,8 +502,7 @@ void main() {
     testWidgets("Callbacks aren't called during build", (WidgetTester tester) async {
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
       addTearDown(gesture.removePointer);
-      await gesture.addPointer();
-      addTearDown(gesture.removePointer);
+      await gesture.addPointer(location: Offset.zero);
 
       int numEntries = 0;
       int numExits = 0;
@@ -601,7 +601,7 @@ void main() {
 
       // Plug-in a mouse and move it to the center of the container.
       TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      await gesture.addPointer();
+      await gesture.addPointer(location: Offset.zero);
       addTearDown(() => gesture?.removePointer());
       await gesture.moveTo(tester.getCenter(find.byType(Container)));
       await tester.pumpAndSettle();
@@ -625,7 +625,7 @@ void main() {
       expect(hover.length, 0);
       expect(exit.length, 1);
       expect(exit.single.position, const Offset(400.0, 300.0));
-      expect(exit.single.delta, const Offset(0.0, 0.0));
+      expect(exit.single.delta, Offset.zero);
     });
 
     testWidgets('detects pointer enter with closure arguments', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/mouse_region_test.dart
+++ b/packages/flutter/test/widgets/mouse_region_test.dart
@@ -27,14 +27,18 @@ class HoverClient extends StatefulWidget {
 
 class HoverClientState extends State<HoverClient> {
   void _onExit(PointerExitEvent details) {
-    if (widget.onExit != null) widget.onExit();
+    if (widget.onExit != null) {
+      widget.onExit();
+    }
     if (widget.onHover != null) {
       widget.onHover(false);
     }
   }
 
   void _onEnter(PointerEnterEvent details) {
-    if (widget.onEnter != null) widget.onEnter();
+    if (widget.onEnter != null) {
+      widget.onEnter();
+    }
     if (widget.onHover != null) {
       widget.onHover(true);
     }
@@ -853,7 +857,9 @@ class _PaintCallbackObject extends RenderProxyBox {
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    if (onPaint != null) onPaint();
+    if (onPaint != null) {
+      onPaint();
+    }
     super.paint(context, offset);
   }
 }

--- a/packages/flutter/test/widgets/mouse_region_test.dart
+++ b/packages/flutter/test/widgets/mouse_region_test.dart
@@ -26,18 +26,15 @@ class HoverClient extends StatefulWidget {
 }
 
 class HoverClientState extends State<HoverClient> {
-
   void _onExit(PointerExitEvent details) {
-    if (widget.onExit != null)
-      widget.onExit();
+    if (widget.onExit != null) widget.onExit();
     if (widget.onHover != null) {
       widget.onHover(false);
     }
   }
 
   void _onEnter(PointerEnterEvent details) {
-    if (widget.onEnter != null)
-      widget.onEnter();
+    if (widget.onEnter != null) widget.onEnter();
     if (widget.onHover != null) {
       widget.onHover(true);
     }
@@ -81,652 +78,287 @@ class _HoverFeedbackState extends State<HoverFeedback> {
 }
 
 void main() {
-  group('MouseRegion hover detection', () {
-    testWidgets('detects pointer enter', (WidgetTester tester) async {
-      PointerEnterEvent enter;
-      PointerHoverEvent move;
-      PointerExitEvent exit;
-      await tester.pumpWidget(Center(
-        child: MouseRegion(
-          child: Container(
-            color: const Color.fromARGB(0xff, 0xff, 0x00, 0x00),
-            width: 100.0,
-            height: 100.0,
-          ),
-          onEnter: (PointerEnterEvent details) => enter = details,
-          onHover: (PointerHoverEvent details) => move = details,
-          onExit: (PointerExitEvent details) => exit = details,
+  testWidgets('detects pointer enter', (WidgetTester tester) async {
+    PointerEnterEvent enter;
+    PointerHoverEvent move;
+    PointerExitEvent exit;
+    await tester.pumpWidget(Center(
+      child: MouseRegion(
+        child: Container(
+          color: const Color.fromARGB(0xff, 0xff, 0x00, 0x00),
+          width: 100.0,
+          height: 100.0,
         ),
-      ));
-      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      await gesture.addPointer(location: Offset.zero);
-      addTearDown(gesture.removePointer);
-      await gesture.moveTo(const Offset(400.0, 300.0));
-      await tester.pump();
-      expect(move, isNotNull);
-      expect(move.position, equals(const Offset(400.0, 300.0)));
-      expect(enter, isNotNull);
-      expect(enter.position, equals(const Offset(400.0, 300.0)));
-      expect(exit, isNull);
-    });
-    testWidgets('detects pointer exiting', (WidgetTester tester) async {
-      PointerEnterEvent enter;
-      PointerHoverEvent move;
-      PointerExitEvent exit;
-      await tester.pumpWidget(Center(
-        child: MouseRegion(
-          child: Container(
-            width: 100.0,
-            height: 100.0,
-          ),
-          onEnter: (PointerEnterEvent details) => enter = details,
-          onHover: (PointerHoverEvent details) => move = details,
-          onExit: (PointerExitEvent details) => exit = details,
-        ),
-      ));
-      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      await gesture.addPointer(location: Offset.zero);
-      addTearDown(gesture.removePointer);
-      await gesture.moveTo(const Offset(400.0, 300.0));
-      await tester.pump();
-      move = null;
-      enter = null;
-      await gesture.moveTo(const Offset(1.0, 1.0));
-      await tester.pump();
-      expect(move, isNull);
-      expect(enter, isNull);
-      expect(exit, isNotNull);
-      expect(exit.position, equals(const Offset(1.0, 1.0)));
-    });
-    testWidgets('detects pointer exit when widget disappears', (WidgetTester tester) async {
-      PointerEnterEvent enter;
-      PointerHoverEvent move;
-      PointerExitEvent exit;
-      await tester.pumpWidget(Center(
-        child: MouseRegion(
-          child: Container(
-            width: 100.0,
-            height: 100.0,
-          ),
-          onEnter: (PointerEnterEvent details) => enter = details,
-          onHover: (PointerHoverEvent details) => move = details,
-          onExit: (PointerExitEvent details) => exit = details,
-        ),
-      ));
-      final RenderMouseRegion renderListener = tester.renderObject(find.byType(MouseRegion));
-      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      await gesture.addPointer(location: Offset.zero);
-      addTearDown(gesture.removePointer);
-      await gesture.moveTo(const Offset(400.0, 300.0));
-      await tester.pump();
-      expect(move, isNotNull);
-      expect(move.position, equals(const Offset(400.0, 300.0)));
-      expect(enter, isNotNull);
-      expect(enter.position, equals(const Offset(400.0, 300.0)));
-      expect(exit, isNull);
-      await tester.pumpWidget(Center(
+        onEnter: (PointerEnterEvent details) => enter = details,
+        onHover: (PointerHoverEvent details) => move = details,
+        onExit: (PointerExitEvent details) => exit = details,
+      ),
+    ));
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: Offset.zero);
+    addTearDown(gesture.removePointer);
+    await gesture.moveTo(const Offset(400.0, 300.0));
+    await tester.pump();
+    expect(move, isNotNull);
+    expect(move.position, equals(const Offset(400.0, 300.0)));
+    expect(enter, isNotNull);
+    expect(enter.position, equals(const Offset(400.0, 300.0)));
+    expect(exit, isNull);
+  });
+
+  testWidgets('detects pointer exiting', (WidgetTester tester) async {
+    PointerEnterEvent enter;
+    PointerHoverEvent move;
+    PointerExitEvent exit;
+    await tester.pumpWidget(Center(
+      child: MouseRegion(
         child: Container(
           width: 100.0,
           height: 100.0,
         ),
-      ));
-      expect(exit, isNotNull);
-      expect(exit.position, equals(const Offset(400.0, 300.0)));
-      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener.hoverAnnotation), isFalse);
-    });
-    testWidgets('Hover works with nested listeners', (WidgetTester tester) async {
-      final UniqueKey key1 = UniqueKey();
-      final UniqueKey key2 = UniqueKey();
-      final List<PointerEnterEvent> enter1 = <PointerEnterEvent>[];
-      final List<PointerHoverEvent> move1 = <PointerHoverEvent>[];
-      final List<PointerExitEvent> exit1 = <PointerExitEvent>[];
-      final List<PointerEnterEvent> enter2 = <PointerEnterEvent>[];
-      final List<PointerHoverEvent> move2 = <PointerHoverEvent>[];
-      final List<PointerExitEvent> exit2 = <PointerExitEvent>[];
-      void clearLists() {
-        enter1.clear();
-        move1.clear();
-        exit1.clear();
-        enter2.clear();
-        move2.clear();
-        exit2.clear();
-      }
+        onEnter: (PointerEnterEvent details) => enter = details,
+        onHover: (PointerHoverEvent details) => move = details,
+        onExit: (PointerExitEvent details) => exit = details,
+      ),
+    ));
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: Offset.zero);
+    addTearDown(gesture.removePointer);
+    await gesture.moveTo(const Offset(400.0, 300.0));
+    await tester.pump();
+    move = null;
+    enter = null;
+    await gesture.moveTo(const Offset(1.0, 1.0));
+    await tester.pump();
+    expect(move, isNull);
+    expect(enter, isNull);
+    expect(exit, isNotNull);
+    expect(exit.position, equals(const Offset(1.0, 1.0)));
+  });
 
-      await tester.pumpWidget(Container());
-      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      addTearDown(gesture.removePointer);
-      await gesture.moveTo(const Offset(400.0, 0.0));
-      await tester.pump();
-      await tester.pumpWidget(
-        Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: <Widget>[
-            MouseRegion(
-              onEnter: (PointerEnterEvent details) => enter1.add(details),
-              onHover: (PointerHoverEvent details) => move1.add(details),
-              onExit: (PointerExitEvent details) => exit1.add(details),
-              key: key1,
-              child: Container(
-                width: 200,
-                height: 200,
-                padding: const EdgeInsets.all(50.0),
-                child: MouseRegion(
-                  key: key2,
-                  onEnter: (PointerEnterEvent details) => enter2.add(details),
-                  onHover: (PointerHoverEvent details) => move2.add(details),
-                  onExit: (PointerExitEvent details) => exit2.add(details),
-                  child: Container(),
-                ),
-              ),
-            ),
-          ],
+  testWidgets('detects pointer exit when widget disappears', (WidgetTester tester) async {
+    PointerEnterEvent enter;
+    PointerHoverEvent move;
+    PointerExitEvent exit;
+    await tester.pumpWidget(Center(
+      child: MouseRegion(
+        child: Container(
+          width: 100.0,
+          height: 100.0,
         ),
-      );
-      final RenderMouseRegion renderListener1 = tester.renderObject(find.byKey(key1));
-      final RenderMouseRegion renderListener2 = tester.renderObject(find.byKey(key2));
-      Offset center = tester.getCenter(find.byKey(key2));
-      await gesture.moveTo(center);
-      await tester.pump();
-      expect(move2, isNotEmpty);
-      expect(enter2, isNotEmpty);
-      expect(exit2, isEmpty);
-      expect(move1, isNotEmpty);
-      expect(move1.last.position, equals(center));
-      expect(enter1, isNotEmpty);
-      expect(enter1.last.position, equals(center));
-      expect(exit1, isEmpty);
-      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener1.hoverAnnotation), isTrue);
-      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener2.hoverAnnotation), isTrue);
-      clearLists();
+        onEnter: (PointerEnterEvent details) => enter = details,
+        onHover: (PointerHoverEvent details) => move = details,
+        onExit: (PointerExitEvent details) => exit = details,
+      ),
+    ));
+    final RenderMouseRegion renderListener = tester.renderObject(find.byType(MouseRegion));
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: Offset.zero);
+    addTearDown(gesture.removePointer);
+    await gesture.moveTo(const Offset(400.0, 300.0));
+    await tester.pump();
+    expect(move, isNotNull);
+    expect(move.position, equals(const Offset(400.0, 300.0)));
+    expect(enter, isNotNull);
+    expect(enter.position, equals(const Offset(400.0, 300.0)));
+    expect(exit, isNull);
+    await tester.pumpWidget(Center(
+      child: Container(
+        width: 100.0,
+        height: 100.0,
+      ),
+    ));
+    expect(exit, isNotNull);
+    expect(exit.position, equals(const Offset(400.0, 300.0)));
+    expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener.hoverAnnotation), isFalse);
+  });
 
-      // Now make sure that exiting the child only triggers the child exit, not
-      // the parent too.
-      center = center - const Offset(75.0, 0.0);
-      await gesture.moveTo(center);
-      await tester.pumpAndSettle();
-      expect(move2, isEmpty);
-      expect(enter2, isEmpty);
-      expect(exit2, isNotEmpty);
-      expect(move1, isNotEmpty);
-      expect(move1.last.position, equals(center));
-      expect(enter1, isEmpty);
-      expect(exit1, isEmpty);
-      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener1.hoverAnnotation), isTrue);
-      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener2.hoverAnnotation), isTrue);
-      clearLists();
-    });
-    testWidgets('Hover transfers between two listeners', (WidgetTester tester) async {
-      final UniqueKey key1 = UniqueKey();
-      final UniqueKey key2 = UniqueKey();
-      final List<PointerEnterEvent> enter1 = <PointerEnterEvent>[];
-      final List<PointerHoverEvent> move1 = <PointerHoverEvent>[];
-      final List<PointerExitEvent> exit1 = <PointerExitEvent>[];
-      final List<PointerEnterEvent> enter2 = <PointerEnterEvent>[];
-      final List<PointerHoverEvent> move2 = <PointerHoverEvent>[];
-      final List<PointerExitEvent> exit2 = <PointerExitEvent>[];
-      void clearLists() {
-        enter1.clear();
-        move1.clear();
-        exit1.clear();
-        enter2.clear();
-        move2.clear();
-        exit2.clear();
-      }
+  testWidgets('Hover works with nested listeners', (WidgetTester tester) async {
+    final UniqueKey key1 = UniqueKey();
+    final UniqueKey key2 = UniqueKey();
+    final List<PointerEnterEvent> enter1 = <PointerEnterEvent>[];
+    final List<PointerHoverEvent> move1 = <PointerHoverEvent>[];
+    final List<PointerExitEvent> exit1 = <PointerExitEvent>[];
+    final List<PointerEnterEvent> enter2 = <PointerEnterEvent>[];
+    final List<PointerHoverEvent> move2 = <PointerHoverEvent>[];
+    final List<PointerExitEvent> exit2 = <PointerExitEvent>[];
+    void clearLists() {
+      enter1.clear();
+      move1.clear();
+      exit1.clear();
+      enter2.clear();
+      move2.clear();
+      exit2.clear();
+    }
 
-      await tester.pumpWidget(Container());
-      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      addTearDown(gesture.removePointer);
-      await gesture.moveTo(const Offset(400.0, 0.0));
-      await tester.pump();
-      await tester.pumpWidget(
-        Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: <Widget>[
-            MouseRegion(
-              key: key1,
-              child: Container(
-                width: 100.0,
-                height: 100.0,
-              ),
-              onEnter: (PointerEnterEvent details) => enter1.add(details),
-              onHover: (PointerHoverEvent details) => move1.add(details),
-              onExit: (PointerExitEvent details) => exit1.add(details),
-            ),
-            MouseRegion(
-              key: key2,
-              child: Container(
-                width: 100.0,
-                height: 100.0,
-              ),
-              onEnter: (PointerEnterEvent details) => enter2.add(details),
-              onHover: (PointerHoverEvent details) => move2.add(details),
-              onExit: (PointerExitEvent details) => exit2.add(details),
-            ),
-          ],
-        ),
-      );
-      final RenderMouseRegion renderListener1 = tester.renderObject(find.byKey(key1));
-      final RenderMouseRegion renderListener2 = tester.renderObject(find.byKey(key2));
-      final Offset center1 = tester.getCenter(find.byKey(key1));
-      final Offset center2 = tester.getCenter(find.byKey(key2));
-      await gesture.moveTo(center1);
-      await tester.pump();
-      expect(move1, isNotEmpty);
-      expect(move1.last.position, equals(center1));
-      expect(enter1, isNotEmpty);
-      expect(enter1.last.position, equals(center1));
-      expect(exit1, isEmpty);
-      expect(move2, isEmpty);
-      expect(enter2, isEmpty);
-      expect(exit2, isEmpty);
-      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener1.hoverAnnotation), isTrue);
-      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener2.hoverAnnotation), isTrue);
-      clearLists();
-      await gesture.moveTo(center2);
-      await tester.pump();
-      expect(move1, isEmpty);
-      expect(enter1, isEmpty);
-      expect(exit1, isNotEmpty);
-      expect(exit1.last.position, equals(center2));
-      expect(move2, isNotEmpty);
-      expect(move2.last.position, equals(center2));
-      expect(enter2, isNotEmpty);
-      expect(enter2.last.position, equals(center2));
-      expect(exit2, isEmpty);
-      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener1.hoverAnnotation), isTrue);
-      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener2.hoverAnnotation), isTrue);
-      clearLists();
-      await gesture.moveTo(const Offset(400.0, 450.0));
-      await tester.pump();
-      expect(move1, isEmpty);
-      expect(enter1, isEmpty);
-      expect(exit1, isEmpty);
-      expect(move2, isEmpty);
-      expect(enter2, isEmpty);
-      expect(exit2, isNotEmpty);
-      expect(exit2.last.position, equals(const Offset(400.0, 450.0)));
-      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener1.hoverAnnotation), isTrue);
-      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener2.hoverAnnotation), isTrue);
-      clearLists();
-      await tester.pumpWidget(Container());
-      expect(move1, isEmpty);
-      expect(enter1, isEmpty);
-      expect(exit1, isEmpty);
-      expect(move2, isEmpty);
-      expect(enter2, isEmpty);
-      expect(exit2, isEmpty);
-      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener1.hoverAnnotation), isFalse);
-      expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener2.hoverAnnotation), isFalse);
-    });
-
-    testWidgets('needsCompositing set when parent class needsCompositing is set', (WidgetTester tester) async {
-      await tester.pumpWidget(
-        MouseRegion(
-          onEnter: (PointerEnterEvent _) {},
-          child: const Opacity(opacity: 0.5, child: Placeholder()),
-        ),
-      );
-
-      RenderMouseRegion listener = tester.renderObject(find.byType(MouseRegion).first);
-      expect(listener.needsCompositing, isTrue);
-
-      await tester.pumpWidget(
-        MouseRegion(
-          onEnter: (PointerEnterEvent _) {},
-          child: const Placeholder(),
-        ),
-      );
-
-      listener = tester.renderObject(find.byType(MouseRegion).first);
-      expect(listener.needsCompositing, isFalse);
-    });
-
-    testWidgets('works with transform', (WidgetTester tester) async {
-      // Regression test for https://github.com/flutter/flutter/issues/31986.
-      final Key key = UniqueKey();
-      const double scaleFactor = 2.0;
-      const double localWidth = 150.0;
-      const double localHeight = 100.0;
-      final List<PointerEvent> events = <PointerEvent>[];
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Center(
-            child: Transform.scale(
-              scale: scaleFactor,
-              child: MouseRegion(
-                onEnter: (PointerEnterEvent event) {
-                  events.add(event);
-                },
-                onHover: (PointerHoverEvent event) {
-                  events.add(event);
-                },
-                onExit: (PointerExitEvent event) {
-                  events.add(event);
-                },
-                child: Container(
-                  key: key,
-                  color: Colors.blue,
-                  height: localHeight,
-                  width: localWidth,
-                  child: const Text('Hi'),
-                ),
-              ),
-            ),
-          ),
-        ),
-      );
-
-      final Offset topLeft = tester.getTopLeft(find.byKey(key));
-      final Offset topRight = tester.getTopRight(find.byKey(key));
-      final Offset bottomLeft = tester.getBottomLeft(find.byKey(key));
-      expect(topRight.dx - topLeft.dx, scaleFactor * localWidth);
-      expect(bottomLeft.dy - topLeft.dy, scaleFactor * localHeight);
-
-      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      addTearDown(gesture.removePointer);
-      await gesture.addPointer();
-      addTearDown(gesture.removePointer);
-      await gesture.moveTo(topLeft - const Offset(1, 1));
-      await tester.pump();
-      expect(events, isEmpty);
-
-      await gesture.moveTo(topLeft + const Offset(1, 1));
-      await tester.pump();
-      expect(events, hasLength(2));
-      expect(events.first, isA<PointerEnterEvent>());
-      expect(events.last, isA<PointerHoverEvent>());
-      events.clear();
-
-      await gesture.moveTo(bottomLeft + const Offset(1, -1));
-      await tester.pump();
-      expect(events.single, isA<PointerHoverEvent>());
-      expect(events.single.delta, const Offset(0.0, scaleFactor * localHeight - 2));
-      events.clear();
-
-      await gesture.moveTo(bottomLeft + const Offset(1, 1));
-      await tester.pump();
-      expect(events.single, isA<PointerExitEvent>());
-      events.clear();
-    });
-
-    testWidgets('needsCompositing updates correctly and is respected', (WidgetTester tester) async {
-      // Pretend that we have a mouse connected.
-      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      addTearDown(gesture.removePointer);
-      await gesture.addPointer();
-      addTearDown(gesture.removePointer);
-
-      await tester.pumpWidget(
-        Transform.scale(
-          scale: 2.0,
-          child: const MouseRegion(),
-        ),
-      );
-      final RenderMouseRegion listener = tester.renderObject(find.byType(MouseRegion));
-      expect(listener.needsCompositing, isFalse);
-      // No TransformLayer for `Transform.scale` is added because composting is
-      // not required and therefore the transform is executed on the canvas
-      // directly. (One TransformLayer is always present for the root
-      // transform.)
-      expect(tester.layers.whereType<TransformLayer>(), hasLength(1));
-
-      await tester.pumpWidget(
-        Transform.scale(
-          scale: 2.0,
-          child: MouseRegion(
-            onHover: (PointerHoverEvent _) { },
-          ),
-        ),
-      );
-      expect(listener.needsCompositing, isTrue);
-      // Compositing is required, therefore a dedicated TransformLayer for
-      // `Transform.scale` is added.
-      expect(tester.layers.whereType<TransformLayer>(), hasLength(2));
-
-      await tester.pumpWidget(
-        Transform.scale(
-          scale: 2.0,
-          child: const MouseRegion(
-          ),
-        ),
-      );
-      expect(listener.needsCompositing, isFalse);
-      // TransformLayer for `Transform.scale` is removed again as transform is
-      // executed directly on the canvas.
-      expect(tester.layers.whereType<TransformLayer>(), hasLength(1));
-    });
-
-    testWidgets("Callbacks aren't called during build", (WidgetTester tester) async {
-      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      addTearDown(gesture.removePointer);
-      await gesture.addPointer(location: Offset.zero);
-
-      int numEntries = 0;
-      int numExits = 0;
-
-      await tester.pumpWidget(
-        Center(child: HoverFeedback(
-          onEnter: () => numEntries++,
-          onExit: () => numExits++,
-        )),
-      );
-
-      await gesture.moveTo(tester.getCenter(find.byType(Text)));
-      await tester.pumpAndSettle();
-      expect(numEntries, equals(1));
-      expect(numExits, equals(0));
-      expect(find.text('HOVERING'), findsOneWidget);
-
-      await tester.pumpWidget(
-        Container(),
-      );
-      await tester.pump();
-      expect(numEntries, equals(1));
-      expect(numExits, equals(1));
-
-      await tester.pumpWidget(
-        Center(child: HoverFeedback(
-          onEnter: () => numEntries++,
-          onExit: () => numExits++,
-        )),
-      );
-      await tester.pump();
-      expect(numEntries, equals(2));
-      expect(numExits, equals(1));
-    });
-
-    testWidgets("MouseRegion activate/deactivate don't duplicate annotations", (WidgetTester tester) async {
-      final GlobalKey feedbackKey = GlobalKey();
-      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      addTearDown(gesture.removePointer);
-      await gesture.addPointer();
-      addTearDown(gesture.removePointer);
-
-      int numEntries = 0;
-      int numExits = 0;
-
-      await tester.pumpWidget(
-        Center(child: HoverFeedback(
-          key: feedbackKey,
-          onEnter: () => numEntries++,
-          onExit: () => numExits++,
-        )),
-      );
-
-      await gesture.moveTo(tester.getCenter(find.byType(Text)));
-      await tester.pumpAndSettle();
-      expect(numEntries, equals(1));
-      expect(numExits, equals(0));
-      expect(find.text('HOVERING'), findsOneWidget);
-
-      await tester.pumpWidget(
-        Center(child: Container(child: HoverFeedback(
-          key: feedbackKey,
-          onEnter: () => numEntries++,
-          onExit: () => numExits++,
-        ))),
-      );
-      await tester.pump();
-      expect(numEntries, equals(2));
-      expect(numExits, equals(1));
-      await tester.pumpWidget(
-        Container(),
-      );
-      await tester.pump();
-      expect(numEntries, equals(2));
-      expect(numExits, equals(2));
-    });
-
-    testWidgets('Exit event when unplugging mouse should have a position', (WidgetTester tester) async {
-      final List<PointerEnterEvent> enter = <PointerEnterEvent>[];
-      final List<PointerHoverEvent> hover = <PointerHoverEvent>[];
-      final List<PointerExitEvent> exit = <PointerExitEvent>[];
-
-      await tester.pumpWidget(
-        Center(
-          child: MouseRegion(
-            onEnter: (PointerEnterEvent e) => enter.add(e),
-            onHover: (PointerHoverEvent e) => hover.add(e),
-            onExit: (PointerExitEvent e) => exit.add(e),
+    await tester.pumpWidget(Container());
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(gesture.removePointer);
+    await gesture.moveTo(const Offset(400.0, 0.0));
+    await tester.pump();
+    await tester.pumpWidget(
+      Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: <Widget>[
+          MouseRegion(
+            onEnter: (PointerEnterEvent details) => enter1.add(details),
+            onHover: (PointerHoverEvent details) => move1.add(details),
+            onExit: (PointerExitEvent details) => exit1.add(details),
+            key: key1,
             child: Container(
-              height: 100.0,
+              width: 200,
+              height: 200,
+              padding: const EdgeInsets.all(50.0),
+              child: MouseRegion(
+                key: key2,
+                onEnter: (PointerEnterEvent details) => enter2.add(details),
+                onHover: (PointerHoverEvent details) => move2.add(details),
+                onExit: (PointerExitEvent details) => exit2.add(details),
+                child: Container(),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+    final RenderMouseRegion renderListener1 = tester.renderObject(find.byKey(key1));
+    final RenderMouseRegion renderListener2 = tester.renderObject(find.byKey(key2));
+    Offset center = tester.getCenter(find.byKey(key2));
+    await gesture.moveTo(center);
+    await tester.pump();
+    expect(move2, isNotEmpty);
+    expect(enter2, isNotEmpty);
+    expect(exit2, isEmpty);
+    expect(move1, isNotEmpty);
+    expect(move1.last.position, equals(center));
+    expect(enter1, isNotEmpty);
+    expect(enter1.last.position, equals(center));
+    expect(exit1, isEmpty);
+    expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener1.hoverAnnotation), isTrue);
+    expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener2.hoverAnnotation), isTrue);
+    clearLists();
+
+    // Now make sure that exiting the child only triggers the child exit, not
+    // the parent too.
+    center = center - const Offset(75.0, 0.0);
+    await gesture.moveTo(center);
+    await tester.pumpAndSettle();
+    expect(move2, isEmpty);
+    expect(enter2, isEmpty);
+    expect(exit2, isNotEmpty);
+    expect(move1, isNotEmpty);
+    expect(move1.last.position, equals(center));
+    expect(enter1, isEmpty);
+    expect(exit1, isEmpty);
+    expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener1.hoverAnnotation), isTrue);
+    expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener2.hoverAnnotation), isTrue);
+    clearLists();
+  });
+
+  testWidgets('Hover transfers between two listeners', (WidgetTester tester) async {
+    final UniqueKey key1 = UniqueKey();
+    final UniqueKey key2 = UniqueKey();
+    final List<PointerEnterEvent> enter1 = <PointerEnterEvent>[];
+    final List<PointerHoverEvent> move1 = <PointerHoverEvent>[];
+    final List<PointerExitEvent> exit1 = <PointerExitEvent>[];
+    final List<PointerEnterEvent> enter2 = <PointerEnterEvent>[];
+    final List<PointerHoverEvent> move2 = <PointerHoverEvent>[];
+    final List<PointerExitEvent> exit2 = <PointerExitEvent>[];
+    void clearLists() {
+      enter1.clear();
+      move1.clear();
+      exit1.clear();
+      enter2.clear();
+      move2.clear();
+      exit2.clear();
+    }
+
+    await tester.pumpWidget(Container());
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(gesture.removePointer);
+    await gesture.moveTo(const Offset(400.0, 0.0));
+    await tester.pump();
+    await tester.pumpWidget(
+      Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: <Widget>[
+          MouseRegion(
+            key: key1,
+            child: Container(
               width: 100.0,
+              height: 100.0,
             ),
+            onEnter: (PointerEnterEvent details) => enter1.add(details),
+            onHover: (PointerHoverEvent details) => move1.add(details),
+            onExit: (PointerExitEvent details) => exit1.add(details),
           ),
-        ),
-      );
-
-      // Plug-in a mouse and move it to the center of the container.
-      TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      await gesture.addPointer(location: Offset.zero);
-      addTearDown(() => gesture?.removePointer());
-      await gesture.moveTo(tester.getCenter(find.byType(Container)));
-      await tester.pumpAndSettle();
-
-      expect(enter.length, 1);
-      expect(enter.single.position, const Offset(400.0, 300.0));
-      expect(hover.length, 1);
-      expect(hover.single.position, const Offset(400.0, 300.0));
-      expect(exit.length, 0);
-
-      enter.clear();
-      hover.clear();
-      exit.clear();
-
-      // Unplug the mouse.
-      await gesture.removePointer();
-      gesture = null;
-      await tester.pumpAndSettle();
-
-      expect(enter.length, 0);
-      expect(hover.length, 0);
-      expect(exit.length, 1);
-      expect(exit.single.position, const Offset(400.0, 300.0));
-      expect(exit.single.delta, Offset.zero);
-    });
-
-    testWidgets('detects pointer enter with closure arguments', (WidgetTester tester) async {
-      await tester.pumpWidget(_HoverClientWithClosures());
-      expect(find.text('not hovering'), findsOneWidget);
-
-      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      addTearDown(gesture.removePointer);
-      await gesture.addPointer();
-      // Move to a position out of MouseRegion
-      await gesture.moveTo(tester.getBottomRight(find.byType(MouseRegion)) + const Offset(10, -10));
-      await tester.pumpAndSettle();
-      expect(find.text('not hovering'), findsOneWidget);
-
-      // Move into MouseRegion
-      await gesture.moveBy(const Offset(-20, 0));
-      await tester.pumpAndSettle();
-      expect(find.text('HOVERING'), findsOneWidget);
-    });
-  });
-
-  group('MouseRegion paints child once and only once', () {
-    testWidgets('When MouseRegion is inactive', (WidgetTester tester) async {
-      int paintCount = 0;
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: MouseRegion(
-            onEnter: (PointerEnterEvent e) {},
-            child: _PaintDelegateWidget(
-              onPaint: _VoidDelegate(() => paintCount++),
-              child: const Text('123'),
+          MouseRegion(
+            key: key2,
+            child: Container(
+              width: 100.0,
+              height: 100.0,
             ),
+            onEnter: (PointerEnterEvent details) => enter2.add(details),
+            onHover: (PointerHoverEvent details) => move2.add(details),
+            onExit: (PointerExitEvent details) => exit2.add(details),
           ),
-        ),
-      );
-
-      expect(paintCount, 1);
-    });
-
-    testWidgets('When MouseRegion is active', (WidgetTester tester) async {
-      int paintCount = 0;
-
-      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      await gesture.addPointer();
-
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: MouseRegion(
-            onEnter: (PointerEnterEvent e) {},
-            child: _PaintDelegateWidget(
-              onPaint: _VoidDelegate(() => paintCount++),
-              child: const Text('123'),
-            ),
-          ),
-        ),
-      );
-
-      expect(paintCount, 1);
-      await gesture.removePointer();
-    });
-  });
-
-  testWidgets('RenderMouseRegion\'s debugFillProperties when default', (WidgetTester tester) async {
-    final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
-    RenderMouseRegion().debugFillProperties(builder);
-
-    final List<String> description = builder.properties
-      .where((DiagnosticsNode node) => !node.isFiltered(DiagnosticLevel.info))
-      .map((DiagnosticsNode node) => node.toString())
-      .toList();
-
-    expect(description, <String>[
-      'parentData: MISSING',
-      'constraints: MISSING',
-      'size: MISSING',
-      'listeners: <none>',
-    ]);
-  });
-
-  testWidgets('RenderMouseRegion\'s debugFillProperties when full', (WidgetTester tester) async {
-    final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
-    RenderMouseRegion(
-      onEnter: (PointerEnterEvent event) {},
-      onExit: (PointerExitEvent event) {},
-      onHover: (PointerHoverEvent event) {},
-      child: RenderErrorBox(),
-    ).debugFillProperties(builder);
-
-    final List<String> description = builder.properties
-      .where((DiagnosticsNode node) => !node.isFiltered(DiagnosticLevel.info))
-      .map((DiagnosticsNode node) => node.toString())
-      .toList();
-
-    expect(description, <String>[
-      'parentData: MISSING',
-      'constraints: MISSING',
-      'size: MISSING',
-      'listeners: enter, hover, exit',
-    ]);
+        ],
+      ),
+    );
+    final RenderMouseRegion renderListener1 = tester.renderObject(find.byKey(key1));
+    final RenderMouseRegion renderListener2 = tester.renderObject(find.byKey(key2));
+    final Offset center1 = tester.getCenter(find.byKey(key1));
+    final Offset center2 = tester.getCenter(find.byKey(key2));
+    await gesture.moveTo(center1);
+    await tester.pump();
+    expect(move1, isNotEmpty);
+    expect(move1.last.position, equals(center1));
+    expect(enter1, isNotEmpty);
+    expect(enter1.last.position, equals(center1));
+    expect(exit1, isEmpty);
+    expect(move2, isEmpty);
+    expect(enter2, isEmpty);
+    expect(exit2, isEmpty);
+    expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener1.hoverAnnotation), isTrue);
+    expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener2.hoverAnnotation), isTrue);
+    clearLists();
+    await gesture.moveTo(center2);
+    await tester.pump();
+    expect(move1, isEmpty);
+    expect(enter1, isEmpty);
+    expect(exit1, isNotEmpty);
+    expect(exit1.last.position, equals(center2));
+    expect(move2, isNotEmpty);
+    expect(move2.last.position, equals(center2));
+    expect(enter2, isNotEmpty);
+    expect(enter2.last.position, equals(center2));
+    expect(exit2, isEmpty);
+    expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener1.hoverAnnotation), isTrue);
+    expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener2.hoverAnnotation), isTrue);
+    clearLists();
+    await gesture.moveTo(const Offset(400.0, 450.0));
+    await tester.pump();
+    expect(move1, isEmpty);
+    expect(enter1, isEmpty);
+    expect(exit1, isEmpty);
+    expect(move2, isEmpty);
+    expect(enter2, isEmpty);
+    expect(exit2, isNotEmpty);
+    expect(exit2.last.position, equals(const Offset(400.0, 450.0)));
+    expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener1.hoverAnnotation), isTrue);
+    expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener2.hoverAnnotation), isTrue);
+    clearLists();
+    await tester.pumpWidget(Container());
+    expect(move1, isEmpty);
+    expect(enter1, isEmpty);
+    expect(exit1, isEmpty);
+    expect(move2, isEmpty);
+    expect(enter2, isEmpty);
+    expect(exit2, isEmpty);
+    expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener1.hoverAnnotation), isFalse);
+    expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener2.hoverAnnotation), isFalse);
   });
 
   testWidgets('MouseRegion uses updated callbacks', (WidgetTester tester) async {
@@ -785,6 +417,402 @@ void main() {
     await tester.pump();
     expect(logs, <String>['enter2', 'hover2', 'exit2']);
   });
+
+  testWidgets('needsCompositing set when parent class needsCompositing is set', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MouseRegion(
+        onEnter: (PointerEnterEvent _) {},
+        child: const Opacity(opacity: 0.5, child: Placeholder()),
+      ),
+    );
+
+    RenderMouseRegion listener = tester.renderObject(find.byType(MouseRegion).first);
+    expect(listener.needsCompositing, isTrue);
+
+    await tester.pumpWidget(
+      MouseRegion(
+        onEnter: (PointerEnterEvent _) {},
+        child: const Placeholder(),
+      ),
+    );
+
+    listener = tester.renderObject(find.byType(MouseRegion).first);
+    expect(listener.needsCompositing, isFalse);
+  });
+
+  testWidgets('works with transform', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/31986.
+    final Key key = UniqueKey();
+    const double scaleFactor = 2.0;
+    const double localWidth = 150.0;
+    const double localHeight = 100.0;
+    final List<PointerEvent> events = <PointerEvent>[];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: Transform.scale(
+            scale: scaleFactor,
+            child: MouseRegion(
+              onEnter: (PointerEnterEvent event) {
+                events.add(event);
+              },
+              onHover: (PointerHoverEvent event) {
+                events.add(event);
+              },
+              onExit: (PointerExitEvent event) {
+                events.add(event);
+              },
+              child: Container(
+                key: key,
+                color: Colors.blue,
+                height: localHeight,
+                width: localWidth,
+                child: const Text('Hi'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Offset topLeft = tester.getTopLeft(find.byKey(key));
+    final Offset topRight = tester.getTopRight(find.byKey(key));
+    final Offset bottomLeft = tester.getBottomLeft(find.byKey(key));
+    expect(topRight.dx - topLeft.dx, scaleFactor * localWidth);
+    expect(bottomLeft.dy - topLeft.dy, scaleFactor * localHeight);
+
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(gesture.removePointer);
+    await gesture.addPointer();
+    addTearDown(gesture.removePointer);
+    await gesture.moveTo(topLeft - const Offset(1, 1));
+    await tester.pump();
+    expect(events, isEmpty);
+
+    await gesture.moveTo(topLeft + const Offset(1, 1));
+    await tester.pump();
+    expect(events, hasLength(2));
+    expect(events.first, isA<PointerEnterEvent>());
+    expect(events.last, isA<PointerHoverEvent>());
+    events.clear();
+
+    await gesture.moveTo(bottomLeft + const Offset(1, -1));
+    await tester.pump();
+    expect(events.single, isA<PointerHoverEvent>());
+    expect(events.single.delta, const Offset(0.0, scaleFactor * localHeight - 2));
+    events.clear();
+
+    await gesture.moveTo(bottomLeft + const Offset(1, 1));
+    await tester.pump();
+    expect(events.single, isA<PointerExitEvent>());
+    events.clear();
+  });
+
+  testWidgets('needsCompositing updates correctly and is respected', (WidgetTester tester) async {
+    // Pretend that we have a mouse connected.
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(gesture.removePointer);
+    await gesture.addPointer();
+    addTearDown(gesture.removePointer);
+
+    await tester.pumpWidget(
+      Transform.scale(
+        scale: 2.0,
+        child: const MouseRegion(),
+      ),
+    );
+    final RenderMouseRegion listener = tester.renderObject(find.byType(MouseRegion));
+    expect(listener.needsCompositing, isFalse);
+    // No TransformLayer for `Transform.scale` is added because composting is
+    // not required and therefore the transform is executed on the canvas
+    // directly. (One TransformLayer is always present for the root
+    // transform.)
+    expect(tester.layers.whereType<TransformLayer>(), hasLength(1));
+
+    await tester.pumpWidget(
+      Transform.scale(
+        scale: 2.0,
+        child: MouseRegion(
+          onHover: (PointerHoverEvent _) {},
+        ),
+      ),
+    );
+    expect(listener.needsCompositing, isTrue);
+    // Compositing is required, therefore a dedicated TransformLayer for
+    // `Transform.scale` is added.
+    expect(tester.layers.whereType<TransformLayer>(), hasLength(2));
+
+    await tester.pumpWidget(
+      Transform.scale(
+        scale: 2.0,
+        child: const MouseRegion(),
+      ),
+    );
+    expect(listener.needsCompositing, isFalse);
+    // TransformLayer for `Transform.scale` is removed again as transform is
+    // executed directly on the canvas.
+    expect(tester.layers.whereType<TransformLayer>(), hasLength(1));
+  });
+
+  testWidgets("Callbacks aren't called during build", (WidgetTester tester) async {
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(gesture.removePointer);
+    await gesture.addPointer(location: Offset.zero);
+
+    int numEntries = 0;
+    int numExits = 0;
+
+    await tester.pumpWidget(
+      Center(
+          child: HoverFeedback(
+        onEnter: () => numEntries++,
+        onExit: () => numExits++,
+      )),
+    );
+
+    await gesture.moveTo(tester.getCenter(find.byType(Text)));
+    await tester.pumpAndSettle();
+    expect(numEntries, equals(1));
+    expect(numExits, equals(0));
+    expect(find.text('HOVERING'), findsOneWidget);
+
+    await tester.pumpWidget(
+      Container(),
+    );
+    await tester.pump();
+    expect(numEntries, equals(1));
+    expect(numExits, equals(1));
+
+    await tester.pumpWidget(
+      Center(
+          child: HoverFeedback(
+        onEnter: () => numEntries++,
+        onExit: () => numExits++,
+      )),
+    );
+    await tester.pump();
+    expect(numEntries, equals(2));
+    expect(numExits, equals(1));
+  });
+
+  testWidgets("MouseRegion activate/deactivate don't duplicate annotations", (WidgetTester tester) async {
+    final GlobalKey feedbackKey = GlobalKey();
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(gesture.removePointer);
+    await gesture.addPointer();
+    addTearDown(gesture.removePointer);
+
+    int numEntries = 0;
+    int numExits = 0;
+
+    await tester.pumpWidget(
+      Center(
+          child: HoverFeedback(
+        key: feedbackKey,
+        onEnter: () => numEntries++,
+        onExit: () => numExits++,
+      )),
+    );
+
+    await gesture.moveTo(tester.getCenter(find.byType(Text)));
+    await tester.pumpAndSettle();
+    expect(numEntries, equals(1));
+    expect(numExits, equals(0));
+    expect(find.text('HOVERING'), findsOneWidget);
+
+    await tester.pumpWidget(
+      Center(
+          child: Container(
+              child: HoverFeedback(
+        key: feedbackKey,
+        onEnter: () => numEntries++,
+        onExit: () => numExits++,
+      ))),
+    );
+    await tester.pump();
+    expect(numEntries, equals(2));
+    expect(numExits, equals(1));
+    await tester.pumpWidget(
+      Container(),
+    );
+    await tester.pump();
+    expect(numEntries, equals(2));
+    expect(numExits, equals(2));
+  });
+
+  testWidgets('Exit event when unplugging mouse should have a position', (WidgetTester tester) async {
+    final List<PointerEnterEvent> enter = <PointerEnterEvent>[];
+    final List<PointerHoverEvent> hover = <PointerHoverEvent>[];
+    final List<PointerExitEvent> exit = <PointerExitEvent>[];
+
+    await tester.pumpWidget(
+      Center(
+        child: MouseRegion(
+          onEnter: (PointerEnterEvent e) => enter.add(e),
+          onHover: (PointerHoverEvent e) => hover.add(e),
+          onExit: (PointerExitEvent e) => exit.add(e),
+          child: Container(
+            height: 100.0,
+            width: 100.0,
+          ),
+        ),
+      ),
+    );
+
+    // Plug-in a mouse and move it to the center of the container.
+    TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: Offset.zero);
+    addTearDown(() => gesture?.removePointer());
+    await gesture.moveTo(tester.getCenter(find.byType(Container)));
+    await tester.pumpAndSettle();
+
+    expect(enter.length, 1);
+    expect(enter.single.position, const Offset(400.0, 300.0));
+    expect(hover.length, 1);
+    expect(hover.single.position, const Offset(400.0, 300.0));
+    expect(exit.length, 0);
+
+    enter.clear();
+    hover.clear();
+    exit.clear();
+
+    // Unplug the mouse.
+    await gesture.removePointer();
+    gesture = null;
+    await tester.pumpAndSettle();
+
+    expect(enter.length, 0);
+    expect(hover.length, 0);
+    expect(exit.length, 1);
+    expect(exit.single.position, const Offset(400.0, 300.0));
+    expect(exit.single.delta, Offset.zero);
+  });
+
+  testWidgets('detects pointer enter with closure arguments', (WidgetTester tester) async {
+    await tester.pumpWidget(_HoverClientWithClosures());
+    expect(find.text('not hovering'), findsOneWidget);
+
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(gesture.removePointer);
+    await gesture.addPointer();
+    // Move to a position out of MouseRegion
+    await gesture.moveTo(tester.getBottomRight(find.byType(MouseRegion)) + const Offset(10, -10));
+    await tester.pumpAndSettle();
+    expect(find.text('not hovering'), findsOneWidget);
+
+    // Move into MouseRegion
+    await gesture.moveBy(const Offset(-20, 0));
+    await tester.pumpAndSettle();
+    expect(find.text('HOVERING'), findsOneWidget);
+  });
+
+  testWidgets('MouseRegion paints child once and only once when MouseRegion is inactive', (WidgetTester tester) async {
+    int paintCount = 0;
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: MouseRegion(
+          onEnter: (PointerEnterEvent e) {},
+          child: _PaintDelegateWidget(
+            onPaint: _VoidDelegate(() => paintCount++),
+            child: const Text('123'),
+          ),
+        ),
+      ),
+    );
+
+    expect(paintCount, 1);
+  });
+
+  testWidgets('MouseRegion paints child once and only once when MouseRegion is active', (WidgetTester tester) async {
+    int paintCount = 0;
+
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer();
+    addTearDown(gesture.removePointer);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: MouseRegion(
+          onEnter: (PointerEnterEvent e) {},
+          child: _PaintDelegateWidget(
+            onPaint: _VoidDelegate(() => paintCount++),
+            child: const Text('123'),
+          ),
+        ),
+      ),
+    );
+
+    expect(paintCount, 1);
+  });
+
+  testWidgets('RenderMouseRegion\'s debugFillProperties when default', (WidgetTester tester) async {
+    final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
+    RenderMouseRegion().debugFillProperties(builder);
+
+    final List<String> description = builder.properties.where((DiagnosticsNode node) => !node.isFiltered(DiagnosticLevel.info)).map((DiagnosticsNode node) => node.toString()).toList();
+
+    expect(description, <String>[
+      'parentData: MISSING',
+      'constraints: MISSING',
+      'size: MISSING',
+      'listeners: <none>',
+    ]);
+  });
+
+  testWidgets('RenderMouseRegion\'s debugFillProperties when full', (WidgetTester tester) async {
+    final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
+    RenderMouseRegion(
+      onEnter: (PointerEnterEvent event) {},
+      onExit: (PointerExitEvent event) {},
+      onHover: (PointerHoverEvent event) {},
+      child: RenderErrorBox(),
+    ).debugFillProperties(builder);
+
+    final List<String> description = builder.properties.where((DiagnosticsNode node) => !node.isFiltered(DiagnosticLevel.info)).map((DiagnosticsNode node) => node.toString()).toList();
+
+    expect(description, <String>[
+      'parentData: MISSING',
+      'constraints: MISSING',
+      'size: MISSING',
+      'listeners: enter, hover, exit',
+    ]);
+  });
+
+  testWidgets('No new frames are scheduled when mouse moves without triggering callbacks', (WidgetTester tester) async {
+    await tester.pumpWidget(Center(
+      child: MouseRegion(
+        child: Container(
+          width: 100.0,
+          height: 100.0,
+        ),
+        onEnter: (PointerEnterEvent details) {},
+        onHover: (PointerHoverEvent details) {},
+        onExit: (PointerExitEvent details) {},
+      ),
+    ));
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: const Offset(400.0, 300.0));
+    addTearDown(gesture.removePointer);
+    await tester.pumpAndSettle();
+    await gesture.moveBy(const Offset(10.0, 10.0));
+    expect(tester.binding.hasScheduledFrame, isFalse);
+  });
+
+  testWidgets("MouseTracker's attachAnnotation doesn't schedule any frames", (WidgetTester tester) async {
+    // This test is here because MouseTracker can't use testWidgets.
+    final MouseTrackerAnnotation annotation = MouseTrackerAnnotation(
+      onEnter: (PointerEnterEvent event) {},
+      onHover: (PointerHoverEvent event) {},
+      onExit: (PointerExitEvent event) {},
+    );
+    RendererBinding.instance.mouseTracker.attachAnnotation(annotation);
+    expect(tester.binding.hasScheduledFrame, isFalse);
+    expect(RendererBinding.instance.mouseTracker.isAnnotationAttached(annotation), isTrue);
+    RendererBinding.instance.mouseTracker.detachAnnotation(annotation);
+  });
 }
 
 // This widget allows you to send a callback that is called during `onPaint.
@@ -805,8 +833,7 @@ class _PaintDelegateWidget extends SingleChildRenderObjectWidget {
 
   @override
   void updateRenderObject(BuildContext context, _PaintCallbackObject renderObject) {
-    renderObject
-      ..onPaint = onPaint?.callback;
+    renderObject..onPaint = onPaint?.callback;
   }
 }
 
@@ -826,8 +853,7 @@ class _PaintCallbackObject extends RenderProxyBox {
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    if (onPaint != null)
-      onPaint();
+    if (onPaint != null) onPaint();
     super.paint(context, offset);
   }
 }
@@ -838,7 +864,6 @@ class _HoverClientWithClosures extends StatefulWidget {
 }
 
 class _HoverClientWithClosuresState extends State<_HoverClientWithClosures> {
-
   bool _hovering = false;
 
   @override
@@ -846,8 +871,16 @@ class _HoverClientWithClosuresState extends State<_HoverClientWithClosures> {
     return Directionality(
       textDirection: TextDirection.ltr,
       child: MouseRegion(
-        onEnter: (PointerEnterEvent _) { setState(() { _hovering = true; }); },
-        onExit: (PointerExitEvent _) { setState(() { _hovering = false; }); },
+        onEnter: (PointerEnterEvent _) {
+          setState(() {
+            _hovering = true;
+          });
+        },
+        onExit: (PointerExitEvent _) {
+          setState(() {
+            _hovering = false;
+          });
+        },
         child: Text(_hovering ? 'HOVERING' : 'not hovering'),
       ),
     );

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -805,6 +805,10 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
         'The MouseTracker thinks that there is still a mouse connected, which indicates that a '
         'test has not removed the mouse pointer which it added. Call removePointer on the '
         'active mouse gesture to remove the mouse pointer.');
+    // ignore: invalid_use_of_visible_for_testing_member
+    RendererBinding.instance.initMouseTracker();
+    // ignore: invalid_use_of_visible_for_testing_member
+    PointerEventConverter.clearPointers();
   }
 }
 

--- a/packages/flutter_test/lib/src/test_pointer.dart
+++ b/packages/flutter_test/lib/src/test_pointer.dart
@@ -373,14 +373,14 @@ class TestGesture {
   }
 
   /// In a test, send a pointer add event for this pointer.
-  Future<void> addPointer({ Duration timeStamp = Duration.zero, Offset location}) {
+  Future<void> addPointer({ Duration timeStamp = Duration.zero, Offset location }) {
     return TestAsyncUtils.guard<void>(() {
       return _dispatcher(_pointer.addPointer(timeStamp: timeStamp, location: location ?? _pointer.location), null);
     });
   }
 
   /// In a test, send a pointer remove event for this pointer.
-  Future<void> removePointer({ Duration timeStamp = Duration.zero, Offset location}) {
+  Future<void> removePointer({ Duration timeStamp = Duration.zero, Offset location }) {
     return TestAsyncUtils.guard<void>(() {
       return _dispatcher(_pointer.removePointer(timeStamp: timeStamp, location: location ?? _pointer.location), null);
     });

--- a/packages/flutter_test/lib/src/test_pointer.dart
+++ b/packages/flutter_test/lib/src/test_pointer.dart
@@ -373,16 +373,16 @@ class TestGesture {
   }
 
   /// In a test, send a pointer add event for this pointer.
-  Future<void> addPointer({ Duration timeStamp = Duration.zero }) {
+  Future<void> addPointer({ Duration timeStamp = Duration.zero, Offset location}) {
     return TestAsyncUtils.guard<void>(() {
-      return _dispatcher(_pointer.addPointer(timeStamp: timeStamp, location: _pointer.location), null);
+      return _dispatcher(_pointer.addPointer(timeStamp: timeStamp, location: location ?? _pointer.location), null);
     });
   }
 
   /// In a test, send a pointer remove event for this pointer.
-  Future<void> removePointer({ Duration timeStamp = Duration.zero}) {
+  Future<void> removePointer({ Duration timeStamp = Duration.zero, Offset location}) {
     return TestAsyncUtils.guard<void>(() {
-      return _dispatcher(_pointer.removePointer(timeStamp: timeStamp, location: _pointer.location), null);
+      return _dispatcher(_pointer.removePointer(timeStamp: timeStamp, location: location ?? _pointer.location), null);
     });
   }
 


### PR DESCRIPTION
## Description

This fixes the mouse hover code to not schedule frames with every mouse move.

Before this, it would schedule a post frame callback, and then schedule a frame immediately, even if there was nothing that needed to be updated. Now it will schedule checks for mouse position updates synchronously, unless there's a new annotation, and skip scheduling a new frame in all cases. It has to be async in the case of a new annotation (i.e. a new `MouseRegion` is added), since when the annotation is added, it hasn't yet painted, and it can't hit test against the new layer until after the paint, so in that case it schedules a post frame callback, but since it's already building a frame when it does that, it doesn't need to schedule a frame.

The code also used to do mouse position checks for all mice if only one mouse changed position.  I fixed this part too, so that it will only check position for the mouse that changed.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/40600

## Tests

- I updated tests for MouseRegion and MouseTracker to match new behavior, and in the process found that those tests weren't actually expecting the right output (and so fixed that).
- Also added some pump() calls to a couple of tests that were relying on the mouse tracker to schedule frames.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.
- [X] I checked all the boxes!

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes