### PR TITLE
Make flutter load only the specified flavor resource to reduce the si…

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -267,6 +267,8 @@ BuildApp() {
     --target-platform=ios                                                   \
     --target="${target_path}"                                               \
     --${build_mode}                                                         \
+    --flavor=${FLUTTER_FLAVOR}                                              \
+    --flavor-assets-dir=${FLUTTER_FLAVOR_ASSETS_DIR}                        \
     --depfile="${build_dir}/snapshot_blob.bin.d"                            \
     --asset-dir="${derived_dir}/App.framework/${assets_path}"               \
     ${precompilation_flag}                                                  \

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -583,6 +583,8 @@ class FlutterPlugin implements Plugin<Project> {
                     flutterRoot this.flutterRoot
                     flutterExecutable this.flutterExecutable
                     buildMode variantBuildMode
+                    flavor resolveProperty("flutter.flavor", null)
+                    flavorAssetsDir resolveProperty("flutter.flavor-assets-dir", null)
                     localEngine this.localEngine
                     localEngineSrcPath this.localEngineSrcPath
                     abi PLATFORM_ARCH_MAP[targetArch]
@@ -703,6 +705,8 @@ abstract class BaseFlutterTask extends DefaultTask {
     File flutterRoot
     File flutterExecutable
     String buildMode
+    String flavor
+    String flavorAssetsDir
     String localEngine
     String localEngineSrcPath
     @Input
@@ -797,6 +801,12 @@ abstract class BaseFlutterTask extends DefaultTask {
             args "--target-platform", "${targetPlatform}"
             if (verbose) {
                 args "--verbose"
+            }
+            if (flavor != null) {
+                args "--flavor", flavor
+            }
+            if (flavorAssetsDir != null) {
+                args "--flavor-assets-dir", flavorAssetsDir
             }
             if (fileSystemRoots != null) {
                 for (root in fileSystemRoots) {

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -519,6 +519,8 @@ void updateLocalProperties({
 
   if (buildInfo != null) {
     changeIfNecessary('flutter.buildMode', buildInfo.modeName);
+    changeIfNecessary('flutter.flavor', buildInfo.flavor);
+    changeIfNecessary('flutter.flavor-assets-dir', buildInfo.flavorAssetsDir);
     final String buildName = validatedBuildNameForPlatform(TargetPlatform.android_arm, buildInfo.buildName ?? manifest.buildName);
     changeIfNecessary('flutter.versionName', buildName);
     final String buildNumber = validatedBuildNumberForPlatform(TargetPlatform.android_arm, buildInfo.buildNumber ?? manifest.buildNumber);

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -13,6 +13,7 @@ class BuildInfo {
   const BuildInfo(
     this.mode,
     this.flavor, {
+    this.flavorAssetsDir,
     this.trackWidgetCreation = false,
     this.extraFrontEndOptions,
     this.extraGenSnapshotOptions,
@@ -31,6 +32,22 @@ class BuildInfo {
   /// `assemblePaidRelease`), and the Xcode build configuration will be
   /// Mode-Flavor (e.g. Release-Paid).
   final String flavor;
+
+  /// Directory for storing different flavors assets. when parse assets
+  /// only the flavor specified in the flavorAssetsDir will be parsed.
+  /// The flavorAssetsDir should only contain directories with the name
+  /// of the flavors.
+  ///
+  /// If there are three flavors of var1, var2, var3, and set
+  /// --flavor-assets-dir equals assets_flavor, directory structure should like this:
+  ///
+  /// assets_flavor/var1/
+  /// assets_flavor/var2/
+  /// assets_flavor/var3/
+  ///
+  /// when assign --flavor equals var1, the final product only contains
+  /// the assets in the var1 directory.
+  final String flavorAssetsDir;
 
   final List<String> fileSystemRoots;
   final String fileSystemScheme;

--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -58,6 +58,8 @@ class BundleBuilder {
   Future<void> build({
     TargetPlatform platform,
     BuildMode buildMode,
+    String flavor,
+    String flavorAssetsDir,
     String mainPath,
     String manifestPath = defaultManifestPath,
     String applicationKernelFilePath,
@@ -122,6 +124,8 @@ class BundleBuilder {
     }
 
     final AssetBundle assets = await buildAssets(
+      flavor: flavor,
+      flavorAssetsDir: flavorAssetsDir,
       manifestPath: manifestPath,
       assetDirPath: assetDirPath,
       packagesPath: packagesPath,
@@ -205,6 +209,8 @@ void _writeFilesToBuffer(List<File> files, StringBuffer buffer) {
 }
 
 Future<AssetBundle> buildAssets({
+  String flavor,
+  String flavorAssetsDir,
   String manifestPath,
   String assetDirPath,
   String packagesPath,
@@ -217,6 +223,8 @@ Future<AssetBundle> buildAssets({
   // Build the asset bundle.
   final AssetBundle assetBundle = AssetBundleFactory.instance.createBundle();
   final int result = await assetBundle.build(
+    flavor: flavor,
+    flavorAssetsDir: flavorAssetsDir,
     manifestPath: manifestPath,
     assetDirPath: assetDirPath,
     packagesPath: packagesPath,

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -18,6 +18,7 @@ class BuildApkCommand extends BuildSubCommand {
     usesTargetOption();
     addBuildModeFlags(verboseHelp: verboseHelp);
     usesFlavorOption();
+    usesFlavorAssetsDirOption();
     usesPubOption();
     usesBuildNumberOption();
     usesBuildNameOption();

--- a/packages/flutter_tools/lib/src/commands/build_appbundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_appbundle.dart
@@ -16,6 +16,7 @@ class BuildAppBundleCommand extends BuildSubCommand {
     usesTargetOption();
     addBuildModeFlags();
     usesFlavorOption();
+    usesFlavorAssetsDirOption();
     usesPubOption();
     usesBuildNumberOption();
     usesBuildNameOption();

--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
@@ -17,6 +17,8 @@ import 'build.dart';
 class BuildBundleCommand extends BuildSubCommand {
   BuildBundleCommand({bool verboseHelp = false, this.bundleBuilder}) {
     usesTargetOption();
+    usesFlavorOption();
+    usesFlavorAssetsDirOption();
     usesFilesystemOptions(hide: !verboseHelp);
     usesBuildNumberOption();
     addBuildModeFlags(verboseHelp: verboseHelp);
@@ -122,6 +124,8 @@ class BuildBundleCommand extends BuildSubCommand {
     await bundleBuilder.build(
       platform: platform,
       buildMode: buildMode,
+      flavor: argResults['flavor'],
+      flavorAssetsDir: argResults['flavor-assets-dir'],
       mainPath: targetFile,
       manifestPath: argResults['manifest'],
       depfilePath: argResults['depfile'],

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -17,6 +17,7 @@ class BuildIOSCommand extends BuildSubCommand {
   BuildIOSCommand() {
     usesTargetOption();
     usesFlavorOption();
+    usesFlavorAssetsDirOption();
     usesPubOption();
     usesBuildNumberOption();
     usesBuildNameOption();

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -32,6 +32,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
   RunCommandBase({ bool verboseHelp = false }) {
     addBuildModeFlags(defaultToRelease: false, verboseHelp: verboseHelp);
     usesFlavorOption();
+    usesFlavorAssetsDirOption();
     argParser
       ..addFlag('trace-startup',
         negatable: false,

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -215,6 +215,15 @@ List<String> _xcodeBuildSettingsLines({
     xcodeBuildSettings.add('TRACK_WIDGET_CREATION=true');
   }
 
+  if (buildInfo.flavor != null) {
+    xcodeBuildSettings.add('FLUTTER_FLAVOR=${buildInfo.flavor}');
+  }
+
+  if (buildInfo.flavorAssetsDir != null) {
+    xcodeBuildSettings.add(
+        'FLUTTER_FLAVOR_ASSETS_DIR=${buildInfo.flavorAssetsDir}');
+  }
+
   return xcodeBuildSettings;
 }
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -353,6 +353,15 @@ abstract class FlutterCommand extends Command<void> {
     );
   }
 
+  void usesFlavorAssetsDirOption() {
+    argParser.addOption(
+        'flavor-assets-dir',
+        help: 'Directory for storing different flavor\'s assets.\n'
+            'When compiling, only the specified flavor directory '
+            'will be loaded from this directory.'
+    );
+  }
+
   void usesTrackWidgetCreation({ bool hasEffect = true, @required bool verboseHelp }) {
     argParser.addFlag(
       'track-widget-creation',
@@ -392,6 +401,9 @@ abstract class FlutterCommand extends Command<void> {
       argParser.options.containsKey('flavor')
         ? argResults['flavor']
         : null,
+      flavorAssetsDir: argParser.options.containsKey('flavor-assets-dir')
+          ? argResults['flavor-assets-dir']
+          : null,
       trackWidgetCreation: trackWidgetCreation,
       extraFrontEndOptions: extraFrontEndOptions,
       extraGenSnapshotOptions: argParser.options.containsKey(FlutterOptions.kExtraGenSnapshotOptions)


### PR DESCRIPTION
add --flavor-assets-dir parameter. Directory for storing different flavor's assets. When compiling, only the specified flavor directory will be loaded from this directory. --flavor-assets-dir and --flavor are used in combination.