### PR TITLE
Fixing a text editing bug happening when text field changes.

### DIFF
--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -642,8 +642,11 @@ abstract class TextInputClient {
 ///  * [TextInput.attach]
 class TextInputConnection {
   TextInputConnection._(this._client)
-    : assert(_client != null),
-      _id = _nextId++;
+      : assert(_client != null),
+        _id = _nextId++;
+
+  Size _cachedSize;
+  Matrix4 _cachedTransform;
 
   static int _nextId = 1;
   final int _id;
@@ -678,14 +681,18 @@ class TextInputConnection {
   /// 2. [transform]: a matrix that maps the local paint coordinate system
   ///                 to the [PipelineOwner.rootNode].
   void setEditableSizeAndTransform(Size editableBoxSize, Matrix4 transform) {
-    SystemChannels.textInput.invokeMethod<void>(
-      'TextInput.setEditableSizeAndTransform',
-      <String, dynamic>{
-        'width': editableBoxSize.width,
-        'height': editableBoxSize.height,
-        'transform': transform.storage,
-      },
-    );
+    if (editableBoxSize != _cachedSize || transform != _cachedTransform) {
+      _cachedSize = editableBoxSize;
+      _cachedTransform = transform;
+      SystemChannels.textInput.invokeMethod<void>(
+        'TextInput.setEditableSizeAndTransform',
+        <String, dynamic>{
+          'width': editableBoxSize.width,
+          'height': editableBoxSize.height,
+          'transform': transform.storage,
+        },
+      );
+    }
   }
 
   /// Send text styling information.

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1703,9 +1703,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     updateKeepAlive();
   }
 
-  Size _lastSize;
-  Matrix4 _lastTransform;
-
   void _updateSizeAndTransform() {
     if (_hasInputConnection) {
       final Size size = renderEditable.size;

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1710,11 +1710,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     if (_hasInputConnection) {
       final Size size = renderEditable.size;
       final Matrix4 transform = renderEditable.getTransformTo(null);
-      if (size != _lastSize || transform != _lastTransform) {
-        _lastSize = size;
-        _lastTransform = transform;
-        _textInputConnection.setEditableSizeAndTransform(size, transform);
-      }
+      _textInputConnection.setEditableSizeAndTransform(size, transform);
       SchedulerBinding.instance
           .addPostFrameCallback((Duration _) => _updateSizeAndTransform());
     }


### PR DESCRIPTION
During text editing, if one changes between text fields, sometimes the size/transform was not being updated. 

## Description

This was due to the check in this editable text:

if (size != _lastSize || transform != _lastTransform) 

When there is a new connection lastSize and lastTransform was not being cleared.

By carrying lastSize,lastTransform to TextInputConnection we are making sure that when there is a new connection, the old values won't be cached.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
