### PR TITLE
Rebuild modal routes when the value of userGestureInProgress changes

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -2239,8 +2239,8 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
     route.dispose();
   }
 
-  int _userGesturesInProgressCount = 0;
   int get _userGesturesInProgress => _userGesturesInProgressCount;
+  int _userGesturesInProgressCount = 0;
   set _userGesturesInProgress(int value) {
     _userGesturesInProgressCount = value;
     userGestureInProgressNotifier.value = _userGesturesInProgress > 0;

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -2239,10 +2239,25 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
     route.dispose();
   }
 
+  int _userGesturesInProgressCount = 0;
+  int get _userGesturesInProgress => _userGesturesInProgressCount;
+  set _userGesturesInProgress(int value) {
+    _userGesturesInProgressCount = value;
+    userGestureInProgressNotifier.value = _userGesturesInProgress > 0;
+  }
+
   /// Whether a route is currently being manipulated by the user, e.g.
   /// as during an iOS back gesture.
-  bool get userGestureInProgress => _userGesturesInProgress > 0;
-  int _userGesturesInProgress = 0;
+  ///
+  /// See also:
+  ///
+  ///  * [userGestureInProgressNotifier], which notifies its listeners if
+  ///    the value of [userGestureInProgress] changes.
+  bool get userGestureInProgress => userGestureInProgressNotifier.value;
+
+  /// Notifies its listeners if the value of [userGestureInProgress] changes.
+  final ValueNotifier<bool> userGestureInProgressNotifier = ValueNotifier<bool>(false);
+
 
   /// The navigator is being controlled by a user gesture.
   ///

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -652,9 +652,18 @@ class _ModalScopeState<T> extends State<_ModalScope<T>> {
                     context,
                     widget.route.animation,
                     widget.route.secondaryAnimation,
-                    IgnorePointer(
-                      ignoring: widget.route.navigator.userGestureInProgress
-                        || widget.route.animation?.status == AnimationStatus.reverse,
+                    // This additional AnimatedBuilder is include because if the
+                    // value of the userGestureInProgressNotifier changes, it's
+                    // only necessary to rebuild the IgnorePointer widget.
+                    AnimatedBuilder(
+                      animation: widget.route.navigator.userGestureInProgressNotifier,
+                      builder: (BuildContext context, Widget child) {
+                        return IgnorePointer(
+                          ignoring: widget.route.navigator.userGestureInProgress
+                            || widget.route.animation?.status == AnimationStatus.reverse,
+                          child: child,
+                        );
+                      },
                       child: child,
                     ),
                   );


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/41024

The build has been red all day. So It might be possible to just land this PR  instead of reverting https://github.com/flutter/flutter/pull/41141 (and then relanding https://github.com/flutter/flutter/pull/40466 with the changes included here).