### PR TITLE
fix flutter error report correct local widget

### DIFF
--- a/dev/automated_tests/flutter_test/print_correct_local_widget_expectation.txt
+++ b/dev/automated_tests/flutter_test/print_correct_local_widget_expectation.txt
@@ -3,7 +3,7 @@
 The following assertion was thrown during layout:
 A RenderFlex overflowed by 2844 pixels on the right\.
 
-User-created ancestor of the error-causing widget was:
+The relevant error-causing widget was:
   Row
   file:\/\/\/.+print_correct_local_widget_test\.dart:[0-9]+:[0-9]+
 

--- a/dev/automated_tests/flutter_test/print_correct_local_widget_expectation.txt
+++ b/dev/automated_tests/flutter_test/print_correct_local_widget_expectation.txt
@@ -1,0 +1,10 @@
+<<skip until matching line>>
+══╡ EXCEPTION CAUGHT BY RENDERING LIBRARY ╞═════════════════════════════════════════════════════════
+The following assertion was thrown during layout:
+A RenderFlex overflowed by 2844 pixels on the right\.
+
+User-created ancestor of the error-causing widget was:
+  Row
+  file:\/\/\/.+print_correct_local_widget_test\.dart:[0-9]+:[0-9]+
+
+The overflowing RenderFlex has an orientation of Axis.horizontal\.

--- a/dev/automated_tests/flutter_test/print_correct_local_widget_test.dart
+++ b/dev/automated_tests/flutter_test/print_correct_local_widget_test.dart
@@ -1,0 +1,44 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Rendering Error', (WidgetTester tester) async {
+    // this should fail
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(
+            title: const Text('RenderFlex OverFlow 2'),
+          ),
+          body: Container(
+            width: 400.0,
+            child: Row(
+              children: <Widget>[
+                Icon(Icons.message),
+                Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: const <Widget>[
+                    Text('Title'),
+                    Text(
+                      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed'
+                      'do eiusmod tempor incididunt ut labore et dolore magna '
+                      'aliqua. Ut enim ad minim veniam, quis nostrud '
+                      'exercitation ullamco laboris nisi ut aliquip ex ea '
+                      'commodo consequat.'
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      )
+    );
+  });
+}

--- a/dev/automated_tests/flutter_test/print_correct_local_widget_test.dart
+++ b/dev/automated_tests/flutter_test/print_correct_local_widget_test.dart
@@ -13,7 +13,7 @@ void main() {
       MaterialApp(
         home: Scaffold(
           appBar: AppBar(
-            title: const Text('RenderFlex OverFlow 2'),
+            title: const Text('RenderFlex OverFlow'),
           ),
           body: Container(
             width: 400.0,

--- a/dev/automated_tests/flutter_test/print_correct_local_widget_test.dart
+++ b/dev/automated_tests/flutter_test/print_correct_local_widget_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('Rendering Error', (WidgetTester tester) async {
-    // this should fail
+    // This should fail with user created widget = Row.
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(

--- a/dev/automated_tests/flutter_test/print_user_created_ancestor_expectation.txt
+++ b/dev/automated_tests/flutter_test/print_user_created_ancestor_expectation.txt
@@ -9,7 +9,7 @@ more information in this error message to help you determine and fix the underly
 In either case, please report this assertion by filing a bug on GitHub:
   https:\/\/github\.com\/flutter\/flutter\/issues\/new\?template=BUG\.md
 
-User-created ancestor of the error-causing widget was:
+The relevant error-causing widget was:
   CustomScrollView
   file:\/\/\/.+print_user_created_ancestor_test\.dart:[0-9]+:7
 

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -2798,7 +2798,7 @@ Iterable<DiagnosticsNode> _describeRelevantUserCode(Element element) {
     ];
   }
   final List<DiagnosticsNode> nodes = <DiagnosticsNode>[];
-  element.visitAncestorElements((Element ancestor) {
+  bool processElement(Element ancestor) {
     // TODO(chunhtai): should print out all the widgets that are about to cross
     // package boundaries.
     if (_isLocalCreationLocation(ancestor)) {
@@ -2814,7 +2814,9 @@ Iterable<DiagnosticsNode> _describeRelevantUserCode(Element element) {
       return false;
     }
     return true;
-  });
+  }
+  if (processElement(element))
+    element.visitAncestorElements(processElement);
   return nodes;
 }
 

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -2798,15 +2798,15 @@ Iterable<DiagnosticsNode> _describeRelevantUserCode(Element element) {
     ];
   }
   final List<DiagnosticsNode> nodes = <DiagnosticsNode>[];
-  bool processElement(Element currentElement) {
+  bool processElement(Element target) {
     // TODO(chunhtai): should print out all the widgets that are about to cross
     // package boundaries.
-    if (_isLocalCreationLocation(currentElement)) {
+    if (_isLocalCreationLocation(target)) {
       nodes.add(
         DiagnosticsBlock(
-          name: 'User-created ancestor of the error-causing widget was',
+          name: 'The relevant error-causing widget was',
           children: <DiagnosticsNode>[
-            ErrorDescription('${currentElement.widget.toStringShort()} ${_describeCreationLocation(currentElement)}'),
+            ErrorDescription('${target.widget.toStringShort()} ${_describeCreationLocation(target)}'),
           ],
         ),
       );

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -2798,15 +2798,15 @@ Iterable<DiagnosticsNode> _describeRelevantUserCode(Element element) {
     ];
   }
   final List<DiagnosticsNode> nodes = <DiagnosticsNode>[];
-  bool processElement(Element ancestor) {
+  bool processElement(Element currentElement) {
     // TODO(chunhtai): should print out all the widgets that are about to cross
     // package boundaries.
-    if (_isLocalCreationLocation(ancestor)) {
+    if (_isLocalCreationLocation(currentElement)) {
       nodes.add(
         DiagnosticsBlock(
           name: 'User-created ancestor of the error-causing widget was',
           children: <DiagnosticsNode>[
-            ErrorDescription('${ancestor.widget.toStringShort()} ${_describeCreationLocation(ancestor)}'),
+            ErrorDescription('${currentElement.widget.toStringShort()} ${_describeCreationLocation(currentElement)}'),
           ],
         ),
       );

--- a/packages/flutter_tools/test/commands.shard/permeable/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/test_test.dart
@@ -65,6 +65,12 @@ void main() {
       return _testFile('print_user_created_ancestor_no_flag', automatedTestsDirectory, flutterTestDirectory);
     }, skip: io.Platform.isWindows); // TODO(chunhtai): Dart on Windows has trouble with unicode characters in output (#35425).
 
+    testUsingContext('report correct created widget caused the error', () async {
+      Cache.flutterRoot = '../..';
+      return _testFile('print_correct_local_widget', automatedTestsDirectory, flutterTestDirectory,
+        extraArguments: const <String>['--track-widget-creation']);
+    }, skip: io.Platform.isWindows); // TODO(chunhtai): Dart on Windows has trouble with unicode characters in output (#35425).
+
     testUsingContext('can load assets within its own package', () async {
       Cache.flutterRoot = '../..';
       return _testFile('package_assets', automatedTestsDirectory, flutterTestDirectory, exitCode: isZero);


### PR DESCRIPTION
## Description

The checking first user creating widget logic in flutter error reporting starts with ancestor widget. This pr fixes it.

## Related Issues

https://github.com/flutter/flutter/issues/41149

## Tests

I added the following tests:
"report correct created widget caused the error"

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
