### PR TITLE
Marking flutter_gold_triage benchmark flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -660,6 +660,7 @@ tasks:
       Checks the number of un-triaged image digests from Flutter Gold.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
+    flaky: true
 
   # run_without_leak_linux:
   #   description: >


### PR DESCRIPTION
Marking new triage benchmark flaky to unblock the tree. 
Change introduced in: #40634 