### PR TITLE
Make innerController of NestedScrollView publicly accessible

### DIFF
--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -267,8 +267,9 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
   }
 
   bool _handleGlowNotification(OverscrollIndicatorNotification notification) {
-    if (notification.depth != 0) return false;
-    if (_mode == _RefreshIndicatorMode.drag || _mode == _RefreshIndicatorMode.armed) {
+    if (notification.depth != 0 || !notification.leading)
+      return false;
+    if (_mode == _RefreshIndicatorMode.drag) {
       notification.disallowGlow();
       return true;
     }

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -267,9 +267,8 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
   }
 
   bool _handleGlowNotification(OverscrollIndicatorNotification notification) {
-    if (notification.depth != 0 || !notification.leading)
-      return false;
-    if (_mode == _RefreshIndicatorMode.drag) {
+    if (notification.depth != 0) return false;
+    if (_mode == _RefreshIndicatorMode.drag || _mode == _RefreshIndicatorMode.armed) {
       notification.disallowGlow();
       return true;
     }

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -181,7 +181,7 @@ class NestedScrollView extends StatefulWidget {
   ///
   /// The [reverse], [headerSliverBuilder], and [body] arguments must not be
   /// null.
-  const NestedScrollView({
+  NestedScrollView({
     Key key,
     this.controller,
     this.scrollDirection = Axis.vertical,
@@ -190,7 +190,8 @@ class NestedScrollView extends StatefulWidget {
     @required this.headerSliverBuilder,
     @required this.body,
     this.dragStartBehavior = DragStartBehavior.start,
-  }) : assert(scrollDirection != null),
+  }) : coordinator = NestedScrollCoordinator(),
+        assert(scrollDirection != null),
        assert(reverse != null),
        assert(headerSliverBuilder != null),
        assert(body != null),
@@ -256,6 +257,13 @@ class NestedScrollView extends StatefulWidget {
 
   /// {@macro flutter.widgets.scrollable.dragStartBehavior}
   final DragStartBehavior dragStartBehavior;
+  
+  /// This contains the [ScrollController]s for the outer and inner parts
+  /// of the [NestedScrollView] and will be populated once the state has
+  /// been created.
+  /// The property allows you to access the scroll positions of the
+  /// inner and outer [ScrollController]s individually.
+  final NestedScrollCoordinator coordinator;
 
   /// Returns the [SliverOverlapAbsorberHandle] of the nearest ancestor
   /// [NestedScrollView].
@@ -290,31 +298,34 @@ class NestedScrollView extends StatefulWidget {
 class _NestedScrollViewState extends State<NestedScrollView> {
   final SliverOverlapAbsorberHandle _absorberHandle = SliverOverlapAbsorberHandle();
 
-  _NestedScrollCoordinator _coordinator;
-
   @override
   void initState() {
+    print('_NestedScrollViewState.initState');
+    widget.coordinator.assign(this, widget.controller, _handleHasScrolledBodyChanged);
     super.initState();
-    _coordinator = _NestedScrollCoordinator(this, widget.controller, _handleHasScrolledBodyChanged);
   }
 
   @override
   void didChangeDependencies() {
+    print('_NestedScrollViewState.didChangeDependencies');
+    widget.coordinator.setParent(widget.controller);
     super.didChangeDependencies();
-    _coordinator.setParent(widget.controller);
   }
 
   @override
   void didUpdateWidget(NestedScrollView oldWidget) {
-    super.didUpdateWidget(oldWidget);
+    print('_NestedScrollViewState.didUpdateWidget');
+    if (oldWidget.coordinator != widget.coordinator)
+      widget.coordinator.copy(oldWidget.coordinator);
     if (oldWidget.controller != widget.controller)
-      _coordinator.setParent(widget.controller);
+      widget.coordinator.setParent(widget.controller);
+    super.didUpdateWidget(oldWidget);
   }
 
   @override
   void dispose() {
-    _coordinator.dispose();
-    _coordinator = null;
+    print('_NestedScrollViewState.dispose');
+    widget.coordinator.dispose();
     super.dispose();
   }
 
@@ -323,10 +334,10 @@ class _NestedScrollViewState extends State<NestedScrollView> {
   void _handleHasScrolledBodyChanged() {
     if (!mounted)
       return;
-    final bool newHasScrolledBody = _coordinator.hasScrolledBody;
+    final bool newHasScrolledBody = widget.coordinator.hasScrolledBody;
     if (_lastHasScrolledBody != newHasScrolledBody) {
       setState(() {
-        // _coordinator.hasScrolledBody changed (we use it in the build method)
+        // widget.coordinator.hasScrolledBody changed (we use it in the build method)
         // (We record _lastHasScrolledBody in the build() method, rather than in
         // this setState call, because the build() method may be called more
         // often than just from here, and we want to only call setState when the
@@ -337,11 +348,12 @@ class _NestedScrollViewState extends State<NestedScrollView> {
 
   @override
   Widget build(BuildContext context) {
+    print('_NestedScrollViewState.build ${widget.coordinator.innerController}');
     return _InheritedNestedScrollView(
       state: this,
       child: Builder(
         builder: (BuildContext context) {
-          _lastHasScrolledBody = _coordinator.hasScrolledBody;
+          _lastHasScrolledBody = widget.coordinator.hasScrolledBody;
           return _NestedScrollViewCustomScrollView(
             dragStartBehavior: widget.dragStartBehavior,
             scrollDirection: widget.scrollDirection,
@@ -349,10 +361,10 @@ class _NestedScrollViewState extends State<NestedScrollView> {
             physics: widget.physics != null
                 ? widget.physics.applyTo(const ClampingScrollPhysics())
                 : const ClampingScrollPhysics(),
-            controller: _coordinator._outerController,
+            controller: widget.coordinator.outerController,
             slivers: widget._buildSlivers(
               context,
-              _coordinator._innerController,
+              widget.coordinator.innerController,
               _lastHasScrolledBody,
             ),
             handle: _absorberHandle,
@@ -465,28 +477,41 @@ class _NestedScrollMetrics extends FixedScrollMetrics {
 
 typedef _NestedScrollActivityGetter = ScrollActivity Function(_NestedScrollPosition position);
 
-class _NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldController {
-  _NestedScrollCoordinator(this._state, this._parent, this._onHasScrolledBodyChanged) {
+class NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldController {
+  _NestedScrollViewState _state;
+  ScrollController _parent;
+  VoidCallback _onHasScrolledBodyChanged;
+
+  _NestedScrollController outerController;
+  _NestedScrollController innerController;
+  
+  void assign(_NestedScrollViewState state, ScrollController parent, VoidCallback onHasScrolledBodyChanged) {
+    this._state = state;
+    this._parent = parent;
+    this._onHasScrolledBodyChanged = onHasScrolledBodyChanged;
+
     final double initialScrollOffset = _parent?.initialScrollOffset ?? 0.0;
-    _outerController = _NestedScrollController(this, initialScrollOffset: initialScrollOffset, debugLabel: 'outer');
-    _innerController = _NestedScrollController(this, initialScrollOffset: 0.0, debugLabel: 'inner');
+    outerController = _NestedScrollController(this, initialScrollOffset: initialScrollOffset, debugLabel: 'outer');
+    innerController = _NestedScrollController(this, initialScrollOffset: 0.0, debugLabel: 'inner');
+    print('NestedScrollCoordinator.assign $innerController');
   }
 
-  final _NestedScrollViewState _state;
-  ScrollController _parent;
-  final VoidCallback _onHasScrolledBodyChanged;
-
-  _NestedScrollController _outerController;
-  _NestedScrollController _innerController;
+  void copy(NestedScrollCoordinator coordinator) {
+    _state = coordinator._state;
+    _parent = coordinator._parent;
+    _onHasScrolledBodyChanged = coordinator._onHasScrolledBodyChanged;
+    outerController = coordinator.outerController;
+    innerController = coordinator.innerController;
+  }
 
   _NestedScrollPosition get _outerPosition {
-    if (!_outerController.hasClients)
+    if (!outerController.hasClients)
       return null;
-    return _outerController.nestedPositions.single;
+    return outerController.nestedPositions.single;
   }
 
   Iterable<_NestedScrollPosition> get _innerPositions {
-    return _innerController.nestedPositions;
+    return innerController.nestedPositions;
   }
 
   bool get canScrollBody {
@@ -837,12 +862,12 @@ class _NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldCont
   void dispose() {
     _currentDrag?.dispose();
     _currentDrag = null;
-    _outerController.dispose();
-    _innerController.dispose();
+    outerController.dispose();
+    innerController.dispose();
   }
 
   @override
-  String toString() => '$runtimeType(outer=$_outerController; inner=$_innerController)';
+  String toString() => '$runtimeType(outer=$outerController; inner=$innerController)';
 }
 
 class _NestedScrollController extends ScrollController {
@@ -852,7 +877,7 @@ class _NestedScrollController extends ScrollController {
     String debugLabel,
   }) : super(initialScrollOffset: initialScrollOffset, debugLabel: debugLabel);
 
-  final _NestedScrollCoordinator coordinator;
+  final NestedScrollCoordinator coordinator;
 
   @override
   ScrollPosition createScrollPosition(
@@ -909,7 +934,7 @@ class _NestedScrollController extends ScrollController {
 
 // The _NestedScrollPosition is used by both the inner and outer viewports of a
 // NestedScrollView. It tracks the offset to use for those viewports, and knows
-// about the _NestedScrollCoordinator, so that when activities are triggered on
+// about the NestedScrollCoordinator, so that when activities are triggered on
 // this class, they can defer, or be influenced by, the coordinator.
 class _NestedScrollPosition extends ScrollPosition implements ScrollActivityDelegate {
   _NestedScrollPosition({
@@ -933,7 +958,7 @@ class _NestedScrollPosition extends ScrollPosition implements ScrollActivityDele
     saveScrollOffset(); // in case we didn't restore but could, so that we don't restore it later
   }
 
-  final _NestedScrollCoordinator coordinator;
+  final NestedScrollCoordinator coordinator;
 
   TickerProvider get vsync => context.vsync;
 
@@ -1149,7 +1174,7 @@ class _NestedInnerBallisticScrollActivity extends BallisticScrollActivity {
     TickerProvider vsync,
   ) : super(position, simulation, vsync);
 
-  final _NestedScrollCoordinator coordinator;
+  final NestedScrollCoordinator coordinator;
 
   @override
   _NestedScrollPosition get delegate => super.delegate;
@@ -1181,7 +1206,7 @@ class _NestedOuterBallisticScrollActivity extends BallisticScrollActivity {
       assert(metrics.maxRange > metrics.minRange),
       super(position, simulation, vsync);
 
-  final _NestedScrollCoordinator coordinator;
+  final NestedScrollCoordinator coordinator;
   final _NestedScrollMetrics metrics;
 
   @override

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -300,15 +300,14 @@ class NestedScrollView extends StatefulWidget {
 ///
 /// {@tool sample}
 ///
-/// You would store your [GlobalKey] outside of your `build` method and return
-/// your [NestedScrollView] to your build method.
+/// You would access the [NestedScrollViewState] using a [GlobalKey].
 ///
 /// ```dart
-/// // In your state or widget but outside of the build method.
-/// final GlobalKey<NestedScrollViewState> globalKey = GlobalKey();
-///
 /// @override
 /// Widget build(BuildContext context) {
+///   // You probably want to declare your GlobalKey outside of your build method.
+///   final GlobalKey<NestedScrollViewState> globalKey = GlobalKey();
+///
 ///   return NestedScrollView(
 ///     key: globalKey,
 ///     headerSliverBuilder: (context, _) => const [SliverAppBar()],

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -317,10 +317,9 @@ class NestedScrollView extends StatefulWidget {
 ///     ),
 ///   );
 /// }
-///
-/// double get innerScrollPosition =>
-///     globalKey.currentState.innerController.position.pixels;
 /// ```
+///
+/// Now, you can access the inner scroll controller using `globalKey.currentState.innerController`.
 /// {@end-tool}
 ///
 /// Alternatively, you could also visit child elements of your parent widget to obtain

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -337,7 +337,7 @@ class NestedScrollViewState extends State<NestedScrollView> {
   /// The [ScrollController] provided to the [ScrollView] in [NestedScrollView.body].
   ///
   /// Manipulating the [ScrollPosition] of this controller fully pushes the header sliver up,
-  /// i.e. the position of the [outerController] will be set to [ScrollPosition.minScrollExtent],
+  /// i.e. the position of the [outerController] will be set to [ScrollPosition.maxScrollExtent],
   /// unless you use [ScrollPosition.setPixels].
   /// Visually, the header sliver will be not be visible, i.e. it is "pushed" up out of view.
   ///

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -296,7 +296,32 @@ class NestedScrollView extends StatefulWidget {
 ///
 /// If you want to access the inner scroll controller of your nested scroll view,
 /// you can get its [NestedScrollViewState] by supplying a `GlobalKey<NestedScrollViewState>`
-/// to your [NestedScrollView] widget (the `key` parameter). See [GlobalKey].
+/// to your [NestedScrollView] widget (the `key` parameter).
+///
+/// {@tool sample}
+///
+/// You would store your [GlobalKey] outside of your `build` method and return
+/// your [NestedScrollView] to your build method.
+///
+/// ```dart
+/// // In your state or widget but outside of the build method.
+/// final GlobalKey<NestedScrollViewState> globalKey = GlobalKey();
+///
+/// @override
+/// Widget build(BuildContext context) {
+///   return NestedScrollView(
+///     key: globalKey,
+///     headerSliverBuilder: (context, _) => const [SliverAppBar()],
+///     body: const CustomScrollView(
+///       // ...
+///     ),
+///   );
+/// }
+///
+/// double get innerScrollPosition =>
+///     globalKey.currentState.innerController.position.pixels;
+/// ```
+/// {@end-tool}
 ///
 /// Alternatively, you could also visit child elements of your parent widget to obtain
 /// the state if you know exactly that the widget is a direct descendant.

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -191,7 +191,7 @@ class NestedScrollView extends StatefulWidget {
     @required this.body,
     this.dragStartBehavior = DragStartBehavior.start,
   }) : coordinator = NestedScrollCoordinator(),
-        assert(scrollDirection != null),
+       assert(scrollDirection != null),
        assert(reverse != null),
        assert(headerSliverBuilder != null),
        assert(body != null),

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -335,23 +335,10 @@ class NestedScrollViewState extends State<NestedScrollView> {
 
   /// The [ScrollController] provided to the [ScrollView] in [NestedScrollView.body].
   ///
-  /// Manipulating this scroll controller will affect the [ScrollPosition]
-  /// of [outerController] in the following manner:
-  ///
-  ///  * If the scroll position of the header sliver is greater than zero
-  ///    (which means that the header is fully or partially pushed up),
-  ///    decreasing the [ScrollPosition] of this controller
-  ///    (using e.g. [ScrollController.jumpTo]/[ScrollPosition.jumpTo])
-  ///    will decrease the [ScrollController.position] of the [outerController]
-  ///    by the same amount until it reaches zero.
-  ///    Visually, this means pulling the header sliver downwards into view.
-  ///  * If the scroll position is smaller than [ScrollPosition.maxScrollExtent]
-  ///    (which is equivalent to the height of the header sliver),
-  ///    increasing the [ScrollPosition] of this controller
-  ///    (using e.g. [ScrollController.jumpTo]/[ScrollPosition.jumpTo])
-  ///    will increase the [ScrollController.position] of the [outerController]
-  ///    by the same amount until it reaches [ScrollPosition.maxScrollExtent].
-  ///    Visually, this means pushing the header sliver upwards out of view.
+  /// Manipulating the [ScrollPosition] of this controller fully pushes the header sliver down,
+  /// i.e. the position of the [outerController] will be set to [ScrollPosition.maxScrollExtent],
+  /// unless you use [ScrollPosition.setPixels].
+  /// Visually, the header sliver will be completely expanded afterwards.
   ///
   /// See also:
   ///
@@ -364,11 +351,10 @@ class NestedScrollViewState extends State<NestedScrollView> {
   ///
   /// This is equivalent to [NestedScrollView.controller] if provided.
   ///
-  /// Manipulating this scroll controller will not alter the [ScrollPosition]
-  /// of [innerController] as the header sliver sits above the body,
-  /// which means that changing the position will visually move the body,
-  /// i.e. push it downwards or pull it upwards with the header sliver,
-  /// however, it will not affect the scroll position of the body.
+  /// Manipulating the [ScrollPosition] of this controller fully pulls back the inner body,
+  /// i.e. the position of the [innerController] will be set to [ScrollPosition.minScrollExtent],
+  /// unless you use [ScrollPosition.setPixels].
+  /// Visually, the inner body will be scrolled to its beginning.
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -257,7 +257,7 @@ class NestedScrollView extends StatefulWidget {
 
   /// {@macro flutter.widgets.scrollable.dragStartBehavior}
   final DragStartBehavior dragStartBehavior;
-  
+
   /// This contains the [ScrollController]s for the outer and inner parts
   /// of the [NestedScrollView] and will be populated once the state has
   /// been created.
@@ -489,7 +489,7 @@ class NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldContr
 
   /// Controls the scroll of the [Scrollable] passed to [NestedScrollView.body].
   _NestedScrollController innerController;
-  
+
   void _assign(_NestedScrollViewState state, ScrollController parent, VoidCallback onHasScrolledBodyChanged) {
     _state = state;
     _parent = parent;

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -296,27 +296,7 @@ class NestedScrollView extends StatefulWidget {
 ///
 /// If you want to access the inner scroll controller of your nested scroll view,
 /// you can get its [NestedScrollViewState] by supplying a `GlobalKey<NestedScrollViewState>`
-/// to your [NestedScrollView] widget (the `key` parameter).
-///
-/// {@tool sample}
-///
-/// You would store your [GlobalKey] outside of your `build` method and return
-/// your [NestedScrollView] to your build method.
-///
-/// ```dart
-/// // In your state or widget but outside of the build method.
-/// final GlobalKey<NestedScrollViewState> globalKey = GlobalKey();
-///
-/// // In your build method.
-/// NestedScrollView(
-///   key: globalKey,
-///   // ...
-/// );
-///
-/// // When you want to access the inner scroll position.
-/// globalKey.currentState.innerController;
-/// ```
-/// {@end-tool}
+/// to your [NestedScrollView] widget (the `key` parameter). See [GlobalKey].
 ///
 /// Alternatively, you could also visit child elements of your parent widget to obtain
 /// the state if you know exactly that the widget is a direct descendant.

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -284,11 +284,50 @@ class NestedScrollView extends StatefulWidget {
   }
 
   @override
-  _NestedScrollViewState createState() => _NestedScrollViewState();
+  NestedScrollViewState createState() => NestedScrollViewState();
 }
 
-class _NestedScrollViewState extends State<NestedScrollView> {
+/// This is the [State] for [NestedScrollView]. It allows you to obtain the scroll
+/// position of the children of your nested scroll view.
+///
+/// You can access the inner scroll controller via [innerController] and the outer
+/// controller with [outerController], however, notice that the outer scroll position
+/// can also be obtained using [NestedScrollView.controller].
+///
+/// If you want to access the inner scroll controller of your nested scroll view,
+/// you can get its [NestedScrollViewState] by supplying a `GlobalKey<NestedScrollViewState>`
+/// to your [NestedScrollView] widget (the `key` parameter).
+///
+/// {@tool sample}
+///
+/// You would store your [GlobalKey] outside of your `build` method and return
+/// your [NestedScrollView] to your build method.
+///
+/// ```dart
+/// // In your state or widget but outside of the build method.
+/// final GlobalKey<NestedScrollViewState> globalKey = GlobalKey();
+///
+/// // In your build method.
+/// NestedScrollView(
+///   key: globalKey,
+///   // ...
+/// );
+///
+/// // When you want to access the inner scroll position.
+/// globalKey.currentState.innerController;
+/// ```
+/// {@end-tool}
+///
+/// Alternatively, you could also visit child elements of your parent widget to obtain
+/// the state if you know exactly that the widget is a direct descendant.
+class NestedScrollViewState extends State<NestedScrollView> {
   final SliverOverlapAbsorberHandle _absorberHandle = SliverOverlapAbsorberHandle();
+
+  /// This controls the scroll of the scroll view in [NestedScrollView.body].
+  ScrollController get innerController => _coordinator._innerController;
+
+  /// This controls the scroll of the scroll view in [NestedScrollView.headerSliverBuilder].
+  ScrollController get outerController => _coordinator._outerController;
 
   _NestedScrollCoordinator _coordinator;
 
@@ -409,7 +448,7 @@ class _InheritedNestedScrollView extends InheritedWidget {
        assert(child != null),
        super(key: key, child: child);
 
-  final _NestedScrollViewState state;
+  final NestedScrollViewState state;
 
   @override
   bool updateShouldNotify(_InheritedNestedScrollView old) => state != old.state;
@@ -472,7 +511,7 @@ class _NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldCont
     _innerController = _NestedScrollController(this, initialScrollOffset: 0.0, debugLabel: 'inner');
   }
 
-  final _NestedScrollViewState _state;
+  final NestedScrollViewState _state;
   ScrollController _parent;
   final VoidCallback _onHasScrolledBodyChanged;
 

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -191,7 +191,7 @@ class NestedScrollView extends StatefulWidget {
     @required this.body,
     this.dragStartBehavior = DragStartBehavior.start,
   }) : coordinator = NestedScrollCoordinator(),
-       assert(scrollDirection != null),
+        assert(scrollDirection != null),
        assert(reverse != null),
        assert(headerSliverBuilder != null),
        assert(body != null),

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -300,18 +300,21 @@ class _NestedScrollViewState extends State<NestedScrollView> {
 
   @override
   void initState() {
+    print('_NestedScrollViewState.initState');
     widget.coordinator.assign(this, widget.controller, _handleHasScrolledBodyChanged);
     super.initState();
   }
 
   @override
   void didChangeDependencies() {
+    print('_NestedScrollViewState.didChangeDependencies');
     widget.coordinator.setParent(widget.controller);
     super.didChangeDependencies();
   }
 
   @override
   void didUpdateWidget(NestedScrollView oldWidget) {
+    print('_NestedScrollViewState.didUpdateWidget');
     if (oldWidget.coordinator != widget.coordinator)
       widget.coordinator.copy(oldWidget.coordinator);
     if (oldWidget.controller != widget.controller)
@@ -321,6 +324,7 @@ class _NestedScrollViewState extends State<NestedScrollView> {
 
   @override
   void dispose() {
+    print('_NestedScrollViewState.dispose');
     widget.coordinator.dispose();
     super.dispose();
   }
@@ -344,6 +348,7 @@ class _NestedScrollViewState extends State<NestedScrollView> {
 
   @override
   Widget build(BuildContext context) {
+    print('_NestedScrollViewState.build ${widget.coordinator.innerController}');
     return _InheritedNestedScrollView(
       state: this,
       child: Builder(
@@ -488,6 +493,7 @@ class NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldContr
     final double initialScrollOffset = _parent?.initialScrollOffset ?? 0.0;
     outerController = _NestedScrollController(this, initialScrollOffset: initialScrollOffset, debugLabel: 'outer');
     innerController = _NestedScrollController(this, initialScrollOffset: 0.0, debugLabel: 'inner');
+    print('NestedScrollCoordinator.assign $innerController');
   }
 
   void copy(NestedScrollCoordinator coordinator) {

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -329,16 +329,17 @@ class NestedScrollView extends StatefulWidget {
 /// {@end-tool}
 ///
 /// Alternatively, you could also visit child elements of your parent widget to obtain
-/// the state if you know exactly that the widget is a direct descendant.
+/// the state if you know exactly that the widget is a direct descendant
+/// (see [BuildContext.visitChildElements] or [Element.visitChildren]).
 class NestedScrollViewState extends State<NestedScrollView> {
   final SliverOverlapAbsorberHandle _absorberHandle = SliverOverlapAbsorberHandle();
 
   /// The [ScrollController] provided to the [ScrollView] in [NestedScrollView.body].
   ///
-  /// Manipulating the [ScrollPosition] of this controller fully pushes the header sliver down,
-  /// i.e. the position of the [outerController] will be set to [ScrollPosition.maxScrollExtent],
+  /// Manipulating the [ScrollPosition] of this controller fully pushes the header sliver up,
+  /// i.e. the position of the [outerController] will be set to [ScrollPosition.minScrollExtent],
   /// unless you use [ScrollPosition.setPixels].
-  /// Visually, the header sliver will be completely expanded afterwards.
+  /// Visually, the header sliver will be not be visible, i.e. it is "pushed" up out of view.
   ///
   /// See also:
   ///
@@ -354,7 +355,7 @@ class NestedScrollViewState extends State<NestedScrollView> {
   /// Manipulating the [ScrollPosition] of this controller fully pulls back the inner body,
   /// i.e. the position of the [innerController] will be set to [ScrollPosition.minScrollExtent],
   /// unless you use [ScrollPosition.setPixels].
-  /// Visually, the inner body will be scrolled to its beginning.
+  /// Visually, the inner body will be scrolled to its beginning, i.e. it is "pulled" back.
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -257,7 +257,7 @@ class NestedScrollView extends StatefulWidget {
 
   /// {@macro flutter.widgets.scrollable.dragStartBehavior}
   final DragStartBehavior dragStartBehavior;
-
+  
   /// This contains the [ScrollController]s for the outer and inner parts
   /// of the [NestedScrollView] and will be populated once the state has
   /// been created.
@@ -489,7 +489,7 @@ class NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldContr
 
   /// Controls the scroll of the [Scrollable] passed to [NestedScrollView.body].
   _NestedScrollController innerController;
-
+  
   void _assign(_NestedScrollViewState state, ScrollController parent, VoidCallback onHasScrolledBodyChanged) {
     _state = state;
     _parent = parent;

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -300,21 +300,18 @@ class _NestedScrollViewState extends State<NestedScrollView> {
 
   @override
   void initState() {
-    print('_NestedScrollViewState.initState');
     widget.coordinator.assign(this, widget.controller, _handleHasScrolledBodyChanged);
     super.initState();
   }
 
   @override
   void didChangeDependencies() {
-    print('_NestedScrollViewState.didChangeDependencies');
     widget.coordinator.setParent(widget.controller);
     super.didChangeDependencies();
   }
 
   @override
   void didUpdateWidget(NestedScrollView oldWidget) {
-    print('_NestedScrollViewState.didUpdateWidget');
     if (oldWidget.coordinator != widget.coordinator)
       widget.coordinator.copy(oldWidget.coordinator);
     if (oldWidget.controller != widget.controller)
@@ -324,7 +321,6 @@ class _NestedScrollViewState extends State<NestedScrollView> {
 
   @override
   void dispose() {
-    print('_NestedScrollViewState.dispose');
     widget.coordinator.dispose();
     super.dispose();
   }
@@ -348,7 +344,6 @@ class _NestedScrollViewState extends State<NestedScrollView> {
 
   @override
   Widget build(BuildContext context) {
-    print('_NestedScrollViewState.build ${widget.coordinator.innerController}');
     return _InheritedNestedScrollView(
       state: this,
       child: Builder(
@@ -493,7 +488,6 @@ class NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldContr
     final double initialScrollOffset = _parent?.initialScrollOffset ?? 0.0;
     outerController = _NestedScrollController(this, initialScrollOffset: initialScrollOffset, debugLabel: 'outer');
     innerController = _NestedScrollController(this, initialScrollOffset: 0.0, debugLabel: 'inner');
-    print('NestedScrollCoordinator.assign $innerController');
   }
 
   void copy(NestedScrollCoordinator coordinator) {

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -327,10 +327,6 @@ class NestedScrollView extends StatefulWidget {
 /// ```
 ///
 /// {@end-tool}
-///
-/// Alternatively, you could also visit child elements of your parent widget to obtain
-/// the state if you know exactly that the widget is a direct descendant
-/// (see [BuildContext.visitChildElements] or [Element.visitChildren]).
 class NestedScrollViewState extends State<NestedScrollView> {
   final SliverOverlapAbsorberHandle _absorberHandle = SliverOverlapAbsorberHandle();
 
@@ -339,7 +335,7 @@ class NestedScrollViewState extends State<NestedScrollView> {
   /// Manipulating the [ScrollPosition] of this controller fully pushes the header sliver up,
   /// i.e. the position of the [outerController] will be set to [ScrollPosition.maxScrollExtent],
   /// unless you use [ScrollPosition.setPixels].
-  /// Visually, the header sliver will be not be visible, i.e. it is "pushed" up out of view.
+  /// Visually, the header sliver will not be visible, i.e. it is "pushed" up out of view.
   ///
   /// See also:
   ///

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -676,27 +676,10 @@ void main() {
     await gesture.up();
     debugDefaultTargetPlatformOverride = null;
   });
-
-  testWidgets('NestedScrollView exposed scroll controllers',
-          (WidgetTester tester) async {
-    final NestedScrollView widget = NestedScrollView(
-      body: Container(),
-      headerSliverBuilder: (_, __) => <Widget>[const SliverAppBar()],
-    );
-    await tester.pumpWidget(Directionality(
-      textDirection: TextDirection.ltr,
-      child: Localizations(
-        locale: const Locale('en', 'US'),
-        delegates: const <LocalizationsDelegate<dynamic>>[
-          DefaultMaterialLocalizations.delegate,
-          DefaultWidgetsLocalizations.delegate,
-        ],
-        child: MediaQuery(
-          data: const MediaQueryData(),
-          child: widget,
-        ),
-      ),
-    ));
+  
+  testWidgets('NestedScrollView exposed scroll controllers', (WidgetTester tester) async {
+    final NestedScrollView widget = NestedScrollView(body: Container(), headerSliverBuilder: (_, __) => <Widget>[Container()],);
+    await tester.pumpWidget(widget);
     expect(widget.coordinator.innerController, isNotNull);
     expect(widget.coordinator.outerController, isNotNull);
   });

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -676,10 +676,27 @@ void main() {
     await gesture.up();
     debugDefaultTargetPlatformOverride = null;
   });
-  
-  testWidgets('NestedScrollView exposed scroll controllers', (WidgetTester tester) async {
-    final NestedScrollView widget = NestedScrollView(body: Container(), headerSliverBuilder: (_, __) => <Widget>[Container()],);
-    await tester.pumpWidget(widget);
+
+  testWidgets('NestedScrollView exposed scroll controllers',
+          (WidgetTester tester) async {
+    final NestedScrollView widget = NestedScrollView(
+      body: Container(),
+      headerSliverBuilder: (_, __) => <Widget>[const SliverAppBar()],
+    );
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: Localizations(
+        locale: const Locale('en', 'US'),
+        delegates: const <LocalizationsDelegate<dynamic>>[
+          DefaultMaterialLocalizations.delegate,
+          DefaultWidgetsLocalizations.delegate,
+        ],
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: widget,
+        ),
+      ),
+    ));
     expect(widget.coordinator.innerController, isNotNull);
     expect(widget.coordinator.outerController, isNotNull);
   });

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -711,7 +711,7 @@ void main() {
   for (final double scrollExtent in const <double>[
     kToolbarHeight - 9,
     4.2e2,
-    3e3,
+    1e3,
     1e4
   ]) {
     testWidgets(
@@ -743,7 +743,16 @@ void main() {
             ),
           ));
 
-          const double scrollExtent = 4.2e2;
+          // The scroll gesture should be taken where in the inner body, so the whole scroll view is scrolled.
+          final TestGesture gesture =
+          await tester.startGesture(const Offset(0, kToolbarHeight + 1));
+          await gesture.moveBy(Offset(0, -scrollExtent));
+
+          await tester.pump();
+
+          // The scrollController should be equal to the outerController defined in the state.
+          expect(scrollController.position,
+              globalKey.currentState.outerController.position);
 
           expect(
               globalKey.currentState.innerController.position.pixels +

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -676,6 +676,13 @@ void main() {
     await gesture.up();
     debugDefaultTargetPlatformOverride = null;
   });
+  
+  testWidgets('NestedScrollView exposed scroll controllers', (WidgetTester tester) async {
+    final NestedScrollView widget = NestedScrollView(body: Container(), headerSliverBuilder: (_, __) => <Widget>[Container()],);
+    await tester.pumpWidget(widget);
+    expect(widget.coordinator.innerController, isNotNull);
+    expect(widget.coordinator.outerController, isNotNull);
+  });
 }
 
 class TestHeader extends SliverPersistentHeaderDelegate {

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -676,6 +676,33 @@ void main() {
     await gesture.up();
     debugDefaultTargetPlatformOverride = null;
   });
+
+  testWidgets('NestedScrollView exposes scroll controllers',
+          (WidgetTester tester) async {
+    final GlobalKey<NestedScrollViewState> globalKey = GlobalKey();
+
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: Localizations(
+        locale: const Locale('en', 'US'),
+        delegates: const <LocalizationsDelegate<dynamic>>[
+          DefaultMaterialLocalizations.delegate,
+          DefaultWidgetsLocalizations.delegate,
+        ],
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: NestedScrollView(
+            key: globalKey,
+            body: Container(),
+            headerSliverBuilder: (_, __) => <Widget>[const SliverAppBar()],
+          ),
+        ),
+      ),
+    ));
+
+    expect(globalKey.currentState.innerController, isNotNull);
+    expect(globalKey.currentState.outerController, isNotNull);
+  });
 }
 
 class TestHeader extends SliverPersistentHeaderDelegate {

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -676,13 +676,6 @@ void main() {
     await gesture.up();
     debugDefaultTargetPlatformOverride = null;
   });
-  
-  testWidgets('NestedScrollView exposed scroll controllers', (WidgetTester tester) async {
-    final NestedScrollView widget = NestedScrollView(body: Container(), headerSliverBuilder: (_, __) => <Widget>[Container()],);
-    await tester.pumpWidget(widget);
-    expect(widget.coordinator.innerController, isNotNull);
-    expect(widget.coordinator.outerController, isNotNull);
-  });
 }
 
 class TestHeader extends SliverPersistentHeaderDelegate {

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -734,8 +734,9 @@ void main() {
                   controller: scrollController,
                   key: globalKey,
                   body: ListView.builder(
-                    itemBuilder: (BuildContext context, int index) =>
-                        Text('$index'),
+                    itemBuilder: (BuildContext context, int index) {
+                      return Text('$index');
+                    },
                   ),
                   headerSliverBuilder: (_, __) => <Widget>[const SliverAppBar()],
                 ),
@@ -744,24 +745,28 @@ void main() {
           ));
 
           // The scroll gesture should be taken where in the inner body, so the whole scroll view is scrolled.
-          final TestGesture gesture =
-          await tester.startGesture(const Offset(0, kToolbarHeight + 1));
+          final TestGesture gesture = await tester.startGesture(const Offset(0, kToolbarHeight + 1));
           await gesture.moveBy(Offset(0, -scrollExtent));
 
           await tester.pump();
 
           expect(
-              globalKey.currentState.innerController.position.pixels +
-                  globalKey.currentState.outerController.position.pixels,
-              scrollExtent);
+            globalKey.currentState.innerController.position.pixels +
+                globalKey.currentState.outerController.position.pixels,
+            scrollExtent,
+          );
 
           // The outer scroll view cannot scroll past its height, which should be kToolbarHeight as a SliverAppBar represents the outer body.
-          expect(globalKey.currentState.outerController.position.pixels,
-              min(kToolbarHeight, scrollExtent));
+          expect(
+            globalKey.currentState.outerController.position.pixels,
+            min(kToolbarHeight, scrollExtent),
+          );
 
           // The inner controller should only start scrolling once the outer controller has been scrolled to its full extent.
-          expect(globalKey.currentState.innerController.position.pixels,
-              max(0, scrollExtent - kToolbarHeight));
+          expect(
+            globalKey.currentState.innerController.position.pixels,
+            max(0, scrollExtent - kToolbarHeight),
+          );
         });
   }
 
@@ -783,8 +788,9 @@ void main() {
             controller: scrollController,
             key: globalKey,
             body: ListView.builder(
-              itemBuilder: (BuildContext context, int index) =>
-                  Text('$index'),
+              itemBuilder: (BuildContext context, int index) {
+                return Text('$index');
+              },
             ),
             headerSliverBuilder: (_, __) => <Widget>[const SliverAppBar()],
           ),
@@ -793,8 +799,10 @@ void main() {
     ));
 
     // The scrollController should be equal to the outerController defined in the state.
-    expect(scrollController.position,
-        globalKey.currentState.outerController.position);
+    expect(
+      scrollController.position,
+      globalKey.currentState.outerController.position,
+    );
   });
 
   testWidgets('Manipulating NestedScrollViewState.innerController should manipulate NestedScrollViewState.outerController', (WidgetTester tester) async {
@@ -813,8 +821,9 @@ void main() {
           child: NestedScrollView(
             key: globalKey,
             body: ListView.builder(
-              itemBuilder: (BuildContext context, int index) =>
-                  Text('$index'),
+              itemBuilder: (BuildContext context, int index) {
+                return Text('$index');
+              },
             ),
             headerSliverBuilder: (_, __) => <Widget>[const SliverAppBar()],
           ),
@@ -848,8 +857,9 @@ void main() {
           child: NestedScrollView(
             key: globalKey,
             body: ListView.builder(
-              itemBuilder: (BuildContext context, int index) =>
-                  Text('$index'),
+              itemBuilder: (BuildContext context, int index) {
+                return Text('$index');
+              },
             ),
             headerSliverBuilder: (_, __) => <Widget>[const SliverAppBar()],
           ),

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -708,8 +708,8 @@ void main() {
   // to ensure that the inner scroll controller is not scrolled in that case.
   for (final double scrollExtent in const <double>[
     kToolbarHeight - 9,
-    4.2e2,
-    1e3,
+    420,
+    1000,
     1e4
   ]) {
     testWidgets(
@@ -814,7 +814,8 @@ void main() {
       expect(globalKey.currentState.outerController.position.pixels, 0);
       expect(globalKey.currentState.innerController.position.pixels, 0);
 
-      const double innerPosition = 0e0, outerPosition = kToolbarHeight;
+      const double innerPosition = 0;
+      const double outerPosition = kToolbarHeight;
 
       testModifyingInnerController(globalKey, innerPosition, outerPosition);
       testModifyingOuterController(globalKey, innerPosition, outerPosition);
@@ -828,7 +829,8 @@ void main() {
       expect(globalKey.currentState.outerController.position.pixels, 0);
       expect(globalKey.currentState.innerController.position.pixels, 0);
 
-      const double innerPosition = 1e3, outerPosition = kToolbarHeight;
+      const double innerPosition = 1000;
+      const double outerPosition = kToolbarHeight;
 
       testModifyingInnerController(globalKey, innerPosition, outerPosition);
       testModifyingOuterController(globalKey, innerPosition, outerPosition);
@@ -842,7 +844,8 @@ void main() {
       expect(globalKey.currentState.outerController.position.pixels, 0);
       expect(globalKey.currentState.innerController.position.pixels, 0);
 
-      const double innerPosition = 0e0, outerPosition = 0e0;
+      const double innerPosition = 0;
+      const double outerPosition = 0;
 
       testModifyingInnerController(globalKey, innerPosition, outerPosition);
       testModifyingOuterController(globalKey, innerPosition, outerPosition);
@@ -856,7 +859,8 @@ void main() {
       expect(globalKey.currentState.outerController.position.pixels, 0);
       expect(globalKey.currentState.innerController.position.pixels, 0);
 
-      const double innerPosition = 1e3, outerPosition = 0e0;
+      const double innerPosition = 1000;
+      const double outerPosition = 0;
 
       testModifyingInnerController(globalKey, innerPosition, outerPosition);
       testModifyingOuterController(globalKey, innerPosition, outerPosition);
@@ -870,7 +874,8 @@ void main() {
       expect(globalKey.currentState.outerController.position.pixels, 0);
       expect(globalKey.currentState.innerController.position.pixels, 0);
 
-      const double innerPosition = 0e3, outerPosition = kToolbarHeight / 3;
+      const double innerPosition = 0;
+      const double outerPosition = kToolbarHeight / 3;
 
       testModifyingInnerController(globalKey, innerPosition, outerPosition);
       testModifyingOuterController(globalKey, innerPosition, outerPosition);
@@ -884,7 +889,8 @@ void main() {
       expect(globalKey.currentState.outerController.position.pixels, 0);
       expect(globalKey.currentState.innerController.position.pixels, 0);
 
-      const double innerPosition = 1e3, outerPosition = kToolbarHeight / 3;
+      const double innerPosition = 1000;
+      const double outerPosition = kToolbarHeight / 3;
 
       testModifyingInnerController(globalKey, innerPosition, outerPosition);
       testModifyingOuterController(globalKey, innerPosition, outerPosition);

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -710,7 +710,7 @@ void main() {
     kToolbarHeight - 9,
     420,
     1000,
-    1e4
+    1e4,
   ]) {
     testWidgets(
         'NestedScrollViewState exposed scroll controllers work properly with a scroll extent of $scrollExtent',


### PR DESCRIPTION
## Description

This is supposed to offer a solution to the problem [mentioned here](https://stackoverflow.com/q/55307231/6509751) by exposing the inner (and outer) `ScrollController` of `NestedScrollView`.

## Tests

I added the following tests:

 * Ensuring that the exposed properties are accessible

Everything else should be tested already.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.