### PR TITLE
Test that flutter assets are contained in the APK

### DIFF
--- a/dev/devicelab/bin/tasks/module_host_with_custom_build_test.dart
+++ b/dev/devicelab/bin/tasks/module_host_with_custom_build_test.dart
@@ -100,6 +100,7 @@ Future<void> main() async {
 
       final Iterable<String> demoDebugFiles = await getFilesInApk(demoDebugApk);
       checkItContains<String>(<String>[
+        ...flutterAssets,
         'assets/flutter_assets/isolate_snapshot_data',
         'assets/flutter_assets/kernel_blob.bin',
         'assets/flutter_assets/vm_snapshot_data',
@@ -149,6 +150,7 @@ Future<void> main() async {
 
       final Iterable<String> demoStagingFiles = await getFilesInApk(demoStagingApk);
       checkItContains<String>(<String>[
+        ...flutterAssets,
         'assets/flutter_assets/isolate_snapshot_data',
         'assets/flutter_assets/kernel_blob.bin',
         'assets/flutter_assets/vm_snapshot_data',
@@ -200,6 +202,7 @@ Future<void> main() async {
 
       final Iterable<String> demoReleaseFiles = await getFilesInApk(demoReleaseApk);
       checkItContains<String>(<String>[
+        ...flutterAssets,
         'lib/arm64-v8a/libapp.so',
         'lib/arm64-v8a/libflutter.so',
         'lib/armeabi-v7a/libapp.so',
@@ -250,6 +253,7 @@ Future<void> main() async {
 
       final Iterable<String> demoProdFiles = await getFilesInApk(demoProdApk);
       checkItContains<String>(<String>[
+          ...flutterAssets,
           'lib/arm64-v8a/libapp.so',
           'lib/arm64-v8a/libflutter.so',
           'lib/armeabi-v7a/libapp.so',

--- a/dev/devicelab/bin/tasks/module_test.dart
+++ b/dev/devicelab/bin/tasks/module_test.dart
@@ -190,6 +190,7 @@ Future<void> main() async {
       section('Check files in debug APK');
 
       checkItContains<String>(<String>[
+        ...flutterAssets,
         'AndroidManifest.xml',
         'assets/flutter_assets/isolate_snapshot_data',
         'assets/flutter_assets/kernel_blob.bin',
@@ -246,6 +247,7 @@ Future<void> main() async {
       section('Check files in release APK');
 
       checkItContains<String>(<String>[
+        ...flutterAssets,
         'AndroidManifest.xml',
         'lib/arm64-v8a/libapp.so',
         'lib/arm64-v8a/libflutter.so',

--- a/dev/devicelab/lib/framework/apk_utils.dart
+++ b/dev/devicelab/lib/framework/apk_utils.dart
@@ -10,6 +10,13 @@ import 'package:path/path.dart' as path;
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
 
+final List<String> flutterAssets = <String>[
+  'assets/flutter_assets/AssetManifest.json',
+  'assets/flutter_assets/LICENSE',
+  'assets/flutter_assets/fonts/MaterialIcons-Regular.ttf',
+  'assets/flutter_assets/packages/cupertino_icons/assets/CupertinoIcons.ttf',
+];
+
 /// Runs the given [testFunction] on a freshly generated Flutter project.
 Future<void> runProjectTest(Future<void> testFunction(FlutterProject project)) async {
   final Directory tempDir = Directory.systemTemp.createTempSync('flutter_devicelab_gradle_plugin_test.');


### PR DESCRIPTION
In add2app scenarios, flutter assets must be present in the final APK. 
This PR updates the test to ensure that the assets are contained in the final APK.