### PR TITLE
Exception when selecting in TextField

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection.dart
@@ -164,15 +164,13 @@ class _ToolbarRenderBox extends RenderShiftedBox {
     child.layout(heightConstraint.enforce(enforcedConstraint), parentUsesSize: true,);
     final _ToolbarParentData childParentData = child.parentData;
 
-    final Offset topCenter = Offset(_arrowTipX, _barTopY);
-
     // The local x-coordinate of the center of the toolbar.
     final double lowerBound = child.size.width/2 + _kToolbarScreenPadding;
     final double upperBound = size.width - child.size.width/2 - _kToolbarScreenPadding;
-    final double adjustedCenterX = topCenter.dx.clamp(lowerBound, upperBound);
+    final double adjustedCenterX = _arrowTipX.clamp(lowerBound, upperBound);
 
-    childParentData.offset = Offset(adjustedCenterX - child.size.width / 2, topCenter.dy);
-    childParentData.arrowXOffsetFromCenter = topCenter.dx - adjustedCenterX;
+    childParentData.offset = Offset(adjustedCenterX - child.size.width / 2, _barTopY);
+    childParentData.arrowXOffsetFromCenter = _arrowTipX - adjustedCenterX;
   }
 
   // The path is described in the toolbar's coordinate system.

--- a/packages/flutter/lib/src/cupertino/text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection.dart
@@ -164,15 +164,15 @@ class _ToolbarRenderBox extends RenderShiftedBox {
     child.layout(heightConstraint.enforce(enforcedConstraint), parentUsesSize: true,);
     final _ToolbarParentData childParentData = child.parentData;
 
-    final Offset localTopCenter = globalToLocal(Offset(_arrowTipX, _barTopY));
+    final Offset topCenter = Offset(_arrowTipX, _barTopY);
 
     // The local x-coordinate of the center of the toolbar.
     final double lowerBound = child.size.width/2 + _kToolbarScreenPadding;
     final double upperBound = size.width - child.size.width/2 - _kToolbarScreenPadding;
-    final double adjustedCenterX = localTopCenter.dx.clamp(lowerBound, upperBound);
+    final double adjustedCenterX = topCenter.dx.clamp(lowerBound, upperBound);
 
-    childParentData.offset = Offset(adjustedCenterX - child.size.width / 2, localTopCenter.dy);
-    childParentData.arrowXOffsetFromCenter = localTopCenter.dx - adjustedCenterX;
+    childParentData.offset = Offset(adjustedCenterX - child.size.width / 2, topCenter.dy);
+    childParentData.arrowXOffsetFromCenter = topCenter.dx - adjustedCenterX;
   }
 
   // The path is described in the toolbar's coordinate system.

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -3280,6 +3280,10 @@ void main() {
     // This is a regression test for
     // https://github.com/flutter/flutter/issues/37046.
     testWidgets('No exceptions when showing selection menu inside of nested Navigators', (WidgetTester tester) async {
+      const String testValue = '123456';
+      final TextEditingController controller = TextEditingController(
+        text: testValue,
+      );
       await tester.pumpWidget(
         CupertinoApp(
           home: CupertinoPageScaffold(
@@ -3293,8 +3297,10 @@ void main() {
                   Expanded(
                     child: Navigator(
                       onGenerateRoute: (_) =>
-                        CupertinoPageRoute(builder: (_) => Container(
-                          child: const CupertinoTextField(),
+                        CupertinoPageRoute<void>(builder: (_) => Container(
+                          child: CupertinoTextField(
+                            controller: controller,
+                          ),
                         )),
                     ),
                   ),
@@ -3308,12 +3314,10 @@ void main() {
       // No text selection toolbar.
       expect(find.byType(CupertinoTextSelectionToolbar), findsNothing);
 
-      // Type a string and double tap on it.
-      const String testValue = '123456';
-      await tester.enterText(find.byType(CupertinoTextField), testValue);
+      // Double tap on the text in the input.
       await tester.pumpAndSettle();
       await tester.tapAt(textOffsetToPosition(tester, testValue.length ~/ 2));
-      await tester.pump(Duration(milliseconds: 100));
+      await tester.pump(const Duration(milliseconds: 100));
       await tester.tapAt(textOffsetToPosition(tester, testValue.length ~/ 2));
       await tester.pumpAndSettle();
 

--- a/packages/flutter/test/cupertino/text_selection_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_test.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/widgets.dart';
 
 void main() {
   group('canSelectAll', () {


### PR DESCRIPTION
## Description

In an app with nested Navigators, selecting text in a TextField caused an exception to be logged.  

This PR fixes it by removing the offending call to `globalToLocal`, which turns out to be unnecessary.  The coordinates relative to the selection menu are always equivalent to global coordinates, because the selection menu is in an Overlay covering the entire screen.  Even in situations where the containing Navigator does not cover the full screen, the Overlay still does.

## Related Issues

Closes https://github.com/flutter/flutter/issues/37046

## Tests

I added the following tests:

  * A test that renders an app with nested Navigators, shows the selection menu, and verifies that there were no exceptions.
