### PR TITLE
Merge Flutter assets in add to app

### DIFF
--- a/dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart
@@ -20,7 +20,7 @@ Future<void> main() async {
         final Iterable<String> apkFiles = await getFilesInApk(pluginProject.debugApkPath);
 
         checkItContains<String>(<String>[
-          'AndroidManifest.xml',
+          ...flutterAssets,
           'classes.dex',
           'assets/flutter_assets/isolate_snapshot_data',
           'assets/flutter_assets/kernel_blob.bin',
@@ -47,7 +47,7 @@ Future<void> main() async {
         final Iterable<String> apkFiles = await getFilesInApk(pluginProject.releaseApkPath);
 
         checkItContains<String>(<String>[
-          'AndroidManifest.xml',
+          ...flutterAssets,
           'classes.dex',
           'lib/arm64-v8a/libflutter.so',
           'lib/arm64-v8a/libapp.so',
@@ -70,7 +70,7 @@ Future<void> main() async {
         final Iterable<String> apkFiles = await getFilesInApk(pluginProject.releaseApkPath);
 
         checkItContains<String>(<String>[
-          'AndroidManifest.xml',
+          ...flutterAssets,
           'classes.dex',
           'lib/armeabi-v7a/libflutter.so',
           'lib/armeabi-v7a/libapp.so',
@@ -94,7 +94,7 @@ Future<void> main() async {
         final Iterable<String> armApkFiles = await getFilesInApk(pluginProject.releaseArmApkPath);
 
         checkItContains<String>(<String>[
-          'AndroidManifest.xml',
+          ...flutterAssets,
           'classes.dex',
           'lib/armeabi-v7a/libflutter.so',
           'lib/armeabi-v7a/libapp.so',
@@ -109,7 +109,7 @@ Future<void> main() async {
         final Iterable<String> arm64ApkFiles = await getFilesInApk(pluginProject.releaseArm64ApkPath);
 
         checkItContains<String>(<String>[
-          'AndroidManifest.xml',
+          ...flutterAssets,
           'classes.dex',
           'lib/arm64-v8a/libflutter.so',
           'lib/arm64-v8a/libapp.so',
@@ -134,13 +134,14 @@ Future<void> main() async {
         ];
         for (final String targetPlatform in targetPlatforms) {
           final String androidArmSnapshotPath = path.join(
-              project.rootPath,
-              'build',
-              'app',
-              'intermediates',
-              'flutter',
-              'release',
-              targetPlatform);
+            project.rootPath,
+            'build',
+            'app',
+            'intermediates',
+            'flutter',
+            'release',
+            targetPlatform,
+          );
 
           final String sharedLibrary = path.join(androidArmSnapshotPath, 'app.so');
           if (!File(sharedLibrary).existsSync()) {

--- a/dev/devicelab/bin/tasks/gradle_plugin_light_apk_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_light_apk_test.dart
@@ -20,7 +20,7 @@ Future<void> main() async {
         final Iterable<String> apkFiles = await getFilesInApk(pluginProject.debugApkPath);
 
         checkItContains<String>(<String>[
-          'AndroidManifest.xml',
+          ...flutterAssets,
           'classes.dex',
           'assets/flutter_assets/isolate_snapshot_data',
           'assets/flutter_assets/kernel_blob.bin',
@@ -47,7 +47,7 @@ Future<void> main() async {
         final Iterable<String> apkFiles = await getFilesInApk(pluginProject.debugApkPath);
 
         checkItContains<String>(<String>[
-          'AndroidManifest.xml',
+          ...flutterAssets,
           'classes.dex',
           'assets/flutter_assets/isolate_snapshot_data',
           'assets/flutter_assets/kernel_blob.bin',
@@ -73,7 +73,7 @@ Future<void> main() async {
         final Iterable<String> apkFiles = await getFilesInApk(pluginProject.debugApkPath);
 
         checkItContains<String>(<String>[
-          'AndroidManifest.xml',
+          ...flutterAssets,
           'classes.dex',
           'assets/flutter_assets/isolate_snapshot_data',
           'assets/flutter_assets/kernel_blob.bin',
@@ -98,7 +98,7 @@ Future<void> main() async {
         final Iterable<String> apkFiles = await getFilesInApk(pluginProject.releaseApkPath);
 
         checkItContains<String>(<String>[
-          'AndroidManifest.xml',
+          ...flutterAssets,
           'classes.dex',
           'lib/armeabi-v7a/libflutter.so',
           'lib/armeabi-v7a/libapp.so',
@@ -121,7 +121,7 @@ Future<void> main() async {
         final Iterable<String> apkFiles = await getFilesInApk(pluginProject.releaseApkPath);
 
         checkItContains<String>(<String>[
-          'AndroidManifest.xml',
+          ...flutterAssets,
           'classes.dex',
           'lib/arm64-v8a/libflutter.so',
           'lib/arm64-v8a/libapp.so',

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -576,12 +576,13 @@ class FlutterPlugin implements Plugin<Project> {
                     }
                 }
             }
-            def compileTasks = targetPlatforms.collect { targetArch ->
+            String variantBuildMode = buildModeFor(variant.buildType)
+            List<FlutterTask> compileTasks = targetPlatforms.collect { targetArch ->
                 String taskName = toCammelCase(["compile", FLUTTER_BUILD_PREFIX, variant.name, targetArch.replace('android-', '')])
                 project.tasks.create(name: taskName, type: FlutterTask) {
                     flutterRoot this.flutterRoot
                     flutterExecutable this.flutterExecutable
-                    buildMode buildModeFor(variant.buildType)
+                    buildMode variantBuildMode
                     localEngine this.localEngine
                     localEngineSrcPath this.localEngineSrcPath
                     abi PLATFORM_ARCH_MAP[targetArch]
@@ -601,7 +602,7 @@ class FlutterPlugin implements Plugin<Project> {
                     extraGenSnapshotOptions extraGenSnapshotOptionsValue
                 }
             }
-            def libJar = project.file("${project.buildDir}/${AndroidProject.FD_INTERMEDIATES}/flutter/${variant.name}/libs.jar")
+            File libJar = project.file("${project.buildDir}/${AndroidProject.FD_INTERMEDIATES}/flutter/${variant.name}/libs.jar")
             Task packFlutterAppAotTask = project.tasks.create(name: "packLibs${FLUTTER_BUILD_PREFIX}${variant.name.capitalize()}", type: Jar) {
                 destinationDir libJar.parentFile
                 archiveName libJar.name
@@ -619,33 +620,70 @@ class FlutterPlugin implements Plugin<Project> {
             addApiDependencies(project, variant.name, project.files {
                 packFlutterAppAotTask
             })
-            // We know that the flutter app is a subproject in another Android app when these tasks exist.
             Task packageAssets = project.tasks.findByPath(":flutter:package${variant.name.capitalize()}Assets")
             Task cleanPackageAssets = project.tasks.findByPath(":flutter:cleanPackage${variant.name.capitalize()}Assets")
+            // In add to app scenarios, :flutter is a subproject of another Android app.
+            // We know that :flutter is used as a subproject when these tasks exist.
+            boolean isUsedAsSubproject = packageAssets && cleanPackageAssets
             Task copyFlutterAssetsTask = project.tasks.create(name: "copyFlutterAssets${variant.name.capitalize()}", type: Copy) {
                 dependsOn compileTasks
-                if (packageAssets && cleanPackageAssets) {
+                compileTasks.each { flutterTask ->
+                    // Add flutter_assets.
+                    with flutterTask.assets
+                }
+                if (isUsedAsSubproject) {
                     dependsOn packageAssets
                     dependsOn cleanPackageAssets
                     into packageAssets.outputDir
-                } else {
-                    // `variant.mergeAssets` will be removed at the end of 2019.
-                    def mergeAssets = variant.hasProperty("mergeAssetsProvider") ?
-                        variant.mergeAssetsProvider.get() : variant.mergeAssets
-                    dependsOn mergeAssets
-                    dependsOn "clean${mergeAssets.name.capitalize()}"
-                    mergeAssets.mustRunAfter("clean${mergeAssets.name.capitalize()}")
-                    into mergeAssets.outputDir
+                    return
                 }
-                compileTasks.each { flutterTask ->
-                    with flutterTask.assets
+                // `variant.mergeAssets` will be removed at the end of 2019.
+                def mergeAssets = variant.hasProperty("mergeAssetsProvider") ?
+                    variant.mergeAssetsProvider.get() : variant.mergeAssets
+                dependsOn mergeAssets
+                dependsOn "clean${mergeAssets.name.capitalize()}"
+                mergeAssets.mustRunAfter("clean${mergeAssets.name.capitalize()}")
+                into mergeAssets.outputDir
+            }
+            if (!isUsedAsSubproject) {
+                variant.mergeResources.dependsOn(copyFlutterAssetsTask)
+                return
+            }
+            // Flutter module included as a subproject in add to app.
+            Project appProject = project.rootProject.findProject(':app')
+            assert appProject != null
+            appProject.afterEvaluate {
+                assert appProject.android != null
+                appProject.android.applicationVariants.all { appProjectVariant ->
+                    // Find a compatible application variant in the host app.
+                    //
+                    // For example, consider a host app that defines the following variants:
+                    // | ----------------- | ----------------------------- |
+                    // |   Build Variant   |   Flutter Equivalent Variant  |
+                    // | ----------------- | ----------------------------- |
+                    // |   freeRelease     |   relese                      |
+                    // |   freeDebug       |   debug                       |
+                    // |   freeDevelop     |   debug                       |
+                    // |   profile         |   profile                     |
+                    // | ----------------- | ----------------------------- |
+                    //
+                    // This mapping is based on the following rules:
+                    // 1. If the host app build variant name is `profile` then the equivalent
+                    //    Flutter variant is `profile`.
+                    // 2. If the host app build variant is debuggable
+                    //    (e.g. `buildType.debuggable = true`), then the equivalent Flutter
+                    //    variant is `debug`.
+                    // 3. Otherwise, the equivalent Flutter variant is `release`.
+                    if (buildModeFor(appProjectVariant.buildType) != variantBuildMode) {
+                        return
+                    }
+                    Task mergeAssets = project
+                        .tasks
+                        .findByPath(":app:merge${appProjectVariant.name.capitalize()}Assets")
+                    assert mergeAssets
+                    mergeAssets.dependsOn(copyFlutterAssetsTask)
                 }
             }
-            def variantOutput = variant.outputs.first()
-            // `variantOutput.processResources` will be removed at the end of 2019.
-            def processResources = variantOutput.hasProperty("processResourcesProvider") ?
-                variantOutput.processResourcesProvider.get() : variantOutput.processResources
-            processResources.dependsOn(copyFlutterAssetsTask)
         }
         if (project.android.hasProperty("applicationVariants")) {
             project.android.applicationVariants.all addFlutterDeps


### PR DESCRIPTION
## Description

PR https://github.com/flutter/flutter/pull/36805 broke add to app: `flutter_assets` ins't in the APK if the `mergeAssets` tasks runs before `processManifest`. This is the case if the host app uses the https://fabric.io Gradle plugin.

PR https://github.com/flutter/flutter/pull/38542 tried to fix this issue, but it didn't add a minimal reproduction / test.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/38286

## Tests

Integration test.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
