### PR TITLE
Fix ReorderableListView's use of child keys (#41334)

### DIFF
--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -344,7 +344,7 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
   // Handles up the logic for dragging and reordering items in the list.
   Widget _wrap(Widget toWrap, int index, BoxConstraints constraints) {
     assert(toWrap.key != null);
-    final _ScopedValueKey keyIndexGlobalKey = _ScopedValueKey(
+    final _ScopedValueGlobalKey keyIndexGlobalKey = _ScopedValueGlobalKey(
       scope: this,
       value: toWrap.key,
     );
@@ -583,8 +583,8 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
 /// The scope is compared using [identical], while the value is compared
 /// using [operator ==]. This allows a locally scoped value to be turned
 /// into a globally unique key.
-class _ScopedValueKey extends GlobalKey {
-  const _ScopedValueKey({this.scope, this.value}) : super.constructor();
+class _ScopedValueGlobalKey extends GlobalKey {
+  const _ScopedValueGlobalKey({this.scope, this.value}) : super.constructor();
 
   final Object scope;
   final Object value;
@@ -597,7 +597,7 @@ class _ScopedValueKey extends GlobalKey {
     if (other.runtimeType != runtimeType) {
       return false;
     }
-    final _ScopedValueKey typedOther = other;
+    final _ScopedValueGlobalKey typedOther = other;
     return identical(scope, typedOther.scope) && value == typedOther.value;
   }
 }

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -4,8 +4,9 @@
 
 import 'dart:math';
 
-import 'package:flutter/widgets.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
 
 import 'debug.dart';
 import 'material.dart';
@@ -344,7 +345,8 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
   // Handles up the logic for dragging and reordering items in the list.
   Widget _wrap(Widget toWrap, int index, BoxConstraints constraints) {
     assert(toWrap.key != null);
-    final _ScopedValueGlobalKey keyIndexGlobalKey = _ScopedValueGlobalKey(
+    final _ScopedValueGlobalKey<_ReorderableListContentState> keyIndexGlobalKey =
+        _ScopedValueGlobalKey<_ReorderableListContentState>(
       scope: this,
       value: toWrap.key,
     );
@@ -583,7 +585,7 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
 /// The scope is compared using [identical], while the value is compared
 /// using [operator ==]. This allows a locally scoped value to be turned
 /// into a globally unique key.
-class _ScopedValueGlobalKey extends GlobalKey {
+class _ScopedValueGlobalKey<T extends State<StatefulWidget>> extends GlobalKey<T> {
   const _ScopedValueGlobalKey({this.scope, this.value}) : super.constructor();
 
   final Object scope;
@@ -597,7 +599,12 @@ class _ScopedValueGlobalKey extends GlobalKey {
     if (other.runtimeType != runtimeType) {
       return false;
     }
-    final _ScopedValueGlobalKey typedOther = other;
+    final _ScopedValueGlobalKey<T> typedOther = other;
     return identical(scope, typedOther.scope) && value == typedOther.value;
+  }
+
+  @override
+  String toString() {
+    return '[$runtimeType ${describeIdentity(scope)} ${describeIdentity(value)}]';
   }
 }

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -584,7 +584,7 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
 /// using [operator ==]. This allows a locally scoped value to be turned
 /// into a globally unique key.
 class _ScopedValueKey extends GlobalKey {
-  _ScopedValueKey({this.scope, this.value}) : super.constructor();
+  const _ScopedValueKey({this.scope, this.value}) : super.constructor();
 
   final Object scope;
   final Object value;
@@ -593,11 +593,11 @@ class _ScopedValueKey extends GlobalKey {
   int get hashCode => hashValues(identityHashCode(scope), value.hashCode);
 
   @override
-  operator ==(other) {
+  bool operator ==(dynamic other) {
     if (other.runtimeType != runtimeType) {
       return false;
     }
-    _ScopedValueKey typedOther = other;
+    final _ScopedValueKey typedOther = other;
     return identical(scope, typedOther.scope) && value == typedOther.value;
   }
 }

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -344,7 +344,10 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
   // Handles up the logic for dragging and reordering items in the list.
   Widget _wrap(Widget toWrap, int index, BoxConstraints constraints) {
     assert(toWrap.key != null);
-    final GlobalObjectKey keyIndexGlobalKey = GlobalObjectKey(toWrap.key);
+    final _ScopedValueKey keyIndexGlobalKey = _ScopedValueKey(
+      scope: this,
+      value: toWrap.key,
+    );
     // We pass the toWrapWithGlobalKey into the Draggable so that when a list
     // item gets dragged, the accessibility framework can preserve the selected
     // state of the dragging item.
@@ -572,5 +575,29 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
         ),
       );
     });
+  }
+}
+
+/// A [GlobalKey] that uses a scope and a value to determine equality.
+///
+/// The scope is compared using [identical], while the value is compared
+/// using [operator ==]. This allows a locally scoped value to be turned
+/// into a globally unique key.
+class _ScopedValueKey extends GlobalKey {
+  _ScopedValueKey({this.scope, this.value}) : super.constructor();
+
+  final Object scope;
+  final Object value;
+
+  @override
+  int get hashCode => hashValues(identityHashCode(scope), value.hashCode);
+
+  @override
+  operator ==(other) {
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    _ScopedValueKey typedOther = other;
+    return identical(scope, typedOther.scope) && value == typedOther.value;
   }
 }

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -684,6 +684,8 @@ void main() {
         await tester.pumpWidget(MaterialApp(
           home: ReorderableListView(
             children: <Widget>[
+              // Deliberately avoid the const constructor below to ensure keys are
+              // distinct objects.
               _Stateful(key: ObjectKey('B')), // ignore:prefer_const_constructors
               _Stateful(key: ObjectKey('C')), // ignore:prefer_const_constructors
               _Stateful(key: ObjectKey('A')), // ignore:prefer_const_constructors

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -665,36 +665,37 @@ void main() {
         await tester.pumpWidget(MaterialApp(
           home: ReorderableListView(
             children: <Widget>[
-              _Stateful(key: ObjectKey('A')),
-              _Stateful(key: ObjectKey('B')),
-              _Stateful(key: ObjectKey('C')),
+              _Stateful(key: const ObjectKey('A')),
+              _Stateful(key: const ObjectKey('B')),
+              _Stateful(key: const ObjectKey('C')),
             ],
             onReorder: (int oldIndex, int newIndex) { },
             scrollDirection: Axis.horizontal,
           ),
         ));
-        await tester.tap(find.byKey(ObjectKey('A')));
+        await tester.tap(find.byKey(const ObjectKey('A')));
         await tester.pumpAndSettle();
         // Only the 'A' widget should be checked.
-        expect(findState(ObjectKey('A')).checked, true);
-        expect(findState(ObjectKey('B')).checked, false);
-        expect(findState(ObjectKey('C')).checked, false);
+        expect(findState(const ObjectKey('A')).checked, true);
+        expect(findState(const ObjectKey('B')).checked, false);
+        expect(findState(const ObjectKey('C')).checked, false);
 
+        // Rebuild with distinct key objects.
         await tester.pumpWidget(MaterialApp(
           home: ReorderableListView(
             children: <Widget>[
-              _Stateful(key: ObjectKey('B')),
-              _Stateful(key: ObjectKey('C')),
-              _Stateful(key: ObjectKey('A')),
+              _Stateful(key: ObjectKey('B')), // ignore:prefer_const_constructors
+              _Stateful(key: ObjectKey('C')), // ignore:prefer_const_constructors
+              _Stateful(key: ObjectKey('A')), // ignore:prefer_const_constructors
             ],
             onReorder: (int oldIndex, int newIndex) { },
             scrollDirection: Axis.horizontal,
           ),
         ));
         // Only the 'A' widget should be checked.
-        expect(findState(ObjectKey('B')).checked, false);
-        expect(findState(ObjectKey('C')).checked, false);
-        expect(findState(ObjectKey('A')).checked, true);
+        expect(findState(const ObjectKey('B')).checked, false);
+        expect(findState(const ObjectKey('C')).checked, false);
+        expect(findState(const ObjectKey('A')).checked, true);
       });
 
       group('Accessibility (a11y/Semantics)', () {


### PR DESCRIPTION
## Description

ReorderableListView was constructing a GlobalObjectKey using the child key as the value. This only had the intended behavior if the child key was identical across build method invocations.

The new strategy is to scope the child key's value to the State object's identity, allowing child keys to have value compare semantics while disambiguating among different list view instances.

## Related Issues

#41334 - fixed

## Tests

Updated test/material/reorderable_list_test.dart to add 'Preserves children states across reorder when keys are not identical'.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
