### PR TITLE
Fix timing issues in initialization of web resident runner

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -74,7 +74,7 @@ class ResidentWebRunner extends ResidentRunner {
   StreamSubscription<vmservice.Event> _stdOutSub;
   bool _exited = false;
 
-  vmservice.VmService get _vmService => _connectionResult.debugConnection.vmService;
+  vmservice.VmService get _vmService => _connectionResult?.debugConnection?.vmService;
 
   @override
   bool get canHotRestart {
@@ -231,12 +231,12 @@ class ResidentWebRunner extends ResidentRunner {
       });
       unawaited(_vmService.registerService('reloadSources', 'FlutterTools'));
       websocketUri = Uri.parse(_connectionResult.debugConnection.uri);
+      // Always run main after connecting because start paused doesn't work yet.
+      _connectionResult.appConnection.runMain();
     }
     if (websocketUri != null) {
       printStatus('Debug service listening on $websocketUri');
     }
-    // Always run main after connecting because start paused doesn't work yet.
-    _connectionResult.appConnection.runMain();
     connectionInfoCompleter?.complete(
       DebugConnectionInfo(wsUri: websocketUri)
     );

--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import 'package:dwds/dwds.dart';
 import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart' as vmservice;
 
@@ -71,11 +70,11 @@ class ResidentWebRunner extends ResidentRunner {
   bool get debuggingEnabled => isRunningDebug && device is! WebServerDevice;
 
   WebFs _webFs;
-  DebugConnection _debugConnection;
+  ConnectionResult _connectionResult;
   StreamSubscription<vmservice.Event> _stdOutSub;
   bool _exited = false;
 
-  vmservice.VmService get _vmService => _debugConnection.vmService;
+  vmservice.VmService get _vmService => _connectionResult.debugConnection.vmService;
 
   @override
   bool get canHotRestart {
@@ -105,7 +104,7 @@ class ResidentWebRunner extends ResidentRunner {
     if (_exited) {
       return;
     }
-    await _debugConnection?.close();
+    await _connectionResult?.debugConnection?.close();
     await _stdOutSub?.cancel();
     await _webFs?.stop();
     await device.stopApp(null);
@@ -173,12 +172,25 @@ class ResidentWebRunner extends ResidentRunner {
         port: debuggingOptions.port,
         skipDwds: device is WebServerDevice,
       );
-      await device.startApp(package, mainPath: target, debuggingOptions: debuggingOptions, platformArgs: <String, Object>{
-        'uri': _webFs.uri
-      });
+      // When connecting to a browser, update the message with a seemsSlow notification
+      // to handle the case where we fail to connect.
+      if (debuggingOptions.browserLaunch) {
+        buildStatus.stop();
+        buildStatus = logger.startProgress(
+          'Attempting to connect to browser instance..',
+          timeout: const Duration(seconds: 30),
+        );
+      }
+      await device.startApp(package,
+        mainPath: target,
+        debuggingOptions: debuggingOptions,
+        platformArgs: <String, Object>{
+          'uri': _webFs.uri
+        },
+      );
       if (supportsServiceProtocol) {
-        _debugConnection = await _webFs.runAndDebug(debuggingOptions);
-        unawaited(_debugConnection.onDone.whenComplete(exit));
+        _connectionResult = await _webFs.connect(debuggingOptions);
+        unawaited(_connectionResult.debugConnection.onDone.whenComplete(exit));
       }
     } catch (err, stackTrace) {
       printError(err.toString());
@@ -202,27 +214,29 @@ class ResidentWebRunner extends ResidentRunner {
     // Cleanup old subscriptions. These will throw if there isn't anything
     // listening, which is fine because that is what we want to ensure.
     try {
-      await _debugConnection?.vmService?.streamCancel('Stdout');
+      await _vmService?.streamCancel('Stdout');
     } on vmservice.RPCError {
       // Ignore this specific error.
     }
     try {
-      await _debugConnection?.vmService?.streamListen('Stdout');
+      await _vmService?.streamListen('Stdout');
     } on vmservice.RPCError  {
       // Ignore this specific error.
     }
     Uri websocketUri;
     if (supportsServiceProtocol) {
-      _stdOutSub = _debugConnection.vmService.onStdoutEvent.listen((vmservice.Event log) {
+      _stdOutSub = _vmService.onStdoutEvent.listen((vmservice.Event log) {
         final String message = utf8.decode(base64.decode(log.bytes)).trim();
         printStatus(message);
       });
-      unawaited(_debugConnection.vmService.registerService('reloadSources', 'FlutterTools'));
-      websocketUri = Uri.parse(_debugConnection.uri);
+      unawaited(_vmService.registerService('reloadSources', 'FlutterTools'));
+      websocketUri = Uri.parse(_connectionResult.debugConnection.uri);
     }
     if (websocketUri != null) {
       printStatus('Debug service listening on $websocketUri');
     }
+    // Always run main after connecting because start paused doesn't work yet.
+    _connectionResult.appConnection.runMain();
     connectionInfoCompleter?.complete(
       DebugConnectionInfo(wsUri: websocketUri)
     );

--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -211,20 +211,20 @@ class ResidentWebRunner extends ResidentRunner {
     Completer<DebugConnectionInfo> connectionInfoCompleter,
     Completer<void> appStartedCompleter,
   }) async {
-    // Cleanup old subscriptions. These will throw if there isn't anything
-    // listening, which is fine because that is what we want to ensure.
-    try {
-      await _vmService?.streamCancel('Stdout');
-    } on vmservice.RPCError {
-      // Ignore this specific error.
-    }
-    try {
-      await _vmService?.streamListen('Stdout');
-    } on vmservice.RPCError  {
-      // Ignore this specific error.
-    }
     Uri websocketUri;
     if (supportsServiceProtocol) {
+      // Cleanup old subscriptions. These will throw if there isn't anything
+      // listening, which is fine because that is what we want to ensure.
+      try {
+        await _vmService.streamCancel('Stdout');
+      } on vmservice.RPCError {
+        // Ignore this specific error.
+      }
+      try {
+        await _vmService.streamListen('Stdout');
+      } on vmservice.RPCError  {
+        // Ignore this specific error.
+      }
       _stdOutSub = _vmService.onStdoutEvent.listen((vmservice.Event log) {
         final String message = utf8.decode(base64.decode(log.bytes)).trim();
         printStatus(message);

--- a/packages/flutter_tools/lib/src/build_runner/web_fs.dart
+++ b/packages/flutter_tools/lib/src/build_runner/web_fs.dart
@@ -112,17 +112,20 @@ class WebFs {
 
   Future<DebugConnection> _cachedExtensionFuture;
 
-  /// Retrieve the [DebugConnection] for the current application
-  Future<DebugConnection> runAndDebug(DebuggingOptions debuggingOptions) {
-    final Completer<DebugConnection> firstConnection = Completer<DebugConnection>();
+  /// Connect and retrieve the [DebugConnection] for the current application.
+  ///
+  /// Only calls [AppConnection.runMain] on the subsequent connections.
+  Future<ConnectionResult> connect(DebuggingOptions debuggingOptions) {
+    final Completer<ConnectionResult> firstConnection = Completer<ConnectionResult>();
     _connectedApps = _dwds.connectedApps.listen((AppConnection appConnection) async {
       final DebugConnection debugConnection = debuggingOptions.browserLaunch
         ? await _dwds.debugConnection(appConnection)
         : await (_cachedExtensionFuture ??= _dwds.extensionDebugConnections.stream.first);
       if (!firstConnection.isCompleted) {
-        firstConnection.complete(debugConnection);
+        firstConnection.complete(ConnectionResult(appConnection, debugConnection));
+      } else {
+        appConnection.runMain();
       }
-      appConnection.runMain();
     });
     return firstConnection.future;
   }
@@ -382,6 +385,13 @@ class AssetServer {
   void dispose() {
     partFiles?.deleteSync(recursive: true);
   }
+}
+
+class ConnectionResult {
+  ConnectionResult(this.appConnection, this.debugConnection);
+
+  final AppConnection appConnection;
+  final DebugConnection debugConnection;
 }
 
 /// A testable interface for starting a build daemon.

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
@@ -56,7 +56,7 @@ void main() {
     fs.file('pubspec.yaml').createSync();
     fs.file(fs.path.join('lib', 'main.dart')).createSync(recursive: true);
     fs.file(fs.path.join('web', 'index.html')).createSync(recursive: true);
-    when(mockWebFs.runAndDebug(any)).thenThrow(StateError('debugging not supported'));
+    when(mockWebFs.connect(any)).thenThrow(StateError('debugging not supported'));
   }
 
   test('Can successfully run and connect without vmservice', () => testbed.run(() async {


### PR DESCRIPTION
## Description

Don't claim to be building an application while we're actually trying to connect to it. Ensure that we register stdout listeners before calling main, so that we catch all print statements.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/40115
Makes failure easier to understand in https://github.com/flutter/flutter/issues/41336