### PR TITLE
[flutter_tools] Report iOS mDNS lookup failures to analytics

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -373,13 +373,15 @@ class IOSDevice extends Device {
           debuggingOptions.observatoryPort,
         );
         if (localUri != null) {
+          UsageEvent('ios-mdns', 'success').send();
           return LaunchResult.succeeded(observatoryUri: localUri);
         }
       } catch (error) {
         printError('Failed to establish a debug connection with $id: $error');
       }
 
-      // Fallback to manual protocol discovery
+      // Fallback to manual protocol discovery.
+      UsageEvent('ios-mdns', 'failure').send();
       printTrace('mDNS lookup failed, attempting fallback to reading device log.');
       try {
         printTrace('Waiting for observatory port.');


### PR DESCRIPTION
## Description

We're getting reports that mDNS lookups are failing on iOS. This PR adds some analytics events to get a better idea of the severity of the issue.

## Related Issues

https://github.com/flutter/flutter/issues/41085

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
