### PR TITLE
Serve every html file under web

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/web_fs.dart
+++ b/packages/flutter_tools/lib/src/build_runner/web_fs.dart
@@ -265,7 +265,16 @@ class AssetServer {
   Directory partFiles;
 
   Future<Response> handle(Request request) async {
-    if (request.url.path.contains('stack_trace_mapper')) {
+    if (request.url.path.endsWith('.html')) {
+      final Uri htmlUri = flutterProject.web.directory.uri.resolveUri(request.url);
+      final File htmlFile = fs.file(htmlUri);
+      if (htmlFile.existsSync()) {
+        return Response.ok(htmlFile.readAsBytesSync(), headers: <String, String>{
+          'Content-Type': 'text/html',
+        });
+      }
+      return Response.notFound('');
+    } else if (request.url.path.contains('stack_trace_mapper')) {
       final File file = fs.file(fs.path.join(
         artifacts.getArtifactPath(Artifact.engineDartSdkPath),
         'lib',

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -636,6 +636,9 @@ class WebProject {
   /// The 'lib' directory for the application.
   Directory get libDirectory => parent.directory.childDirectory('lib');
 
+  /// The directory containing additional html files for the application,
+  Directory get directory => parent.directory.childDirectory('web');
+
   /// The html file used to host the flutter web application.
   File get indexFile => parent.directory
       .childDirectory('web')

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -636,7 +636,7 @@ class WebProject {
   /// The 'lib' directory for the application.
   Directory get libDirectory => parent.directory.childDirectory('lib');
 
-  /// The directory containing additional html files for the application,
+  /// The directory containing additional files for the application.
   Directory get directory => parent.directory.childDirectory('web');
 
   /// The html file used to host the flutter web application.

--- a/packages/flutter_tools/test/general.shard/web/asset_server_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/asset_server_test.dart
@@ -1,4 +1,6 @@
-
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/build_runner/web_fs.dart';

--- a/packages/flutter_tools/test/general.shard/web/asset_server_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/asset_server_test.dart
@@ -1,0 +1,45 @@
+
+
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/build_runner/web_fs.dart';
+import 'package:flutter_tools/src/project.dart';
+import 'package:shelf/shelf.dart';
+
+import '../../src/common.dart';
+import '../../src/testbed.dart';
+
+void main() {
+  Testbed testbed;
+  AssetServer assetServer;
+
+  setUp(() {
+    testbed = Testbed(
+      setup: () {
+        fs.file(fs.path.join('lib', 'main.dart'))
+          .createSync(recursive: true);
+        fs.file(fs.path.join('web', 'index.html'))
+          ..createSync(recursive: true)
+          ..writeAsStringSync('hello');
+        assetServer = AssetServer(FlutterProject.current(), fs.path.join('main'));
+      }
+    );
+  });
+
+  test('can serve an html file from the web directory', () => testbed.run(() async {
+    final Response response = await assetServer
+      .handle(Request('GET', Uri.parse('http://localhost:8080/index.html')));
+
+    expect(response.headers, <String, String>{
+      'Content-Type': 'text/html',
+      'content-length': '5'
+    });
+    expect(await response.readAsString(), 'hello');
+  }));
+
+  test('handles a missing html file from the web directory', () => testbed.run(() async {
+    final Response response = await assetServer
+        .handle(Request('GET', Uri.parse('http://localhost:8080/foobar.html')));
+
+    expect(response.statusCode, 404);
+  }));
+}


### PR DESCRIPTION
## Description

Resolve any .html files to something under `web/`. This allows using multiple different html files besides index.html. Also adds a test case for serving and failing to serve one of these files.

