### PR TITLE
Flutter build bundle without --precompiled should always perform a debug build.

### DIFF
--- a/packages/flutter_tools/bin/tool_backend.dart
+++ b/packages/flutter_tools/bin/tool_backend.dart
@@ -73,6 +73,7 @@ or
       'bundle',
       '--target=$flutterTarget',
       '--target-platform=$targetPlatform',
+      '--debug',
       if (trackWidgetCreation) '--track-widget-creation',
       if (flutterEngine != null) '--local-engine-src-path=$flutterEngine',
       if (localEngine != null) '--local-engine=$localEngine',

--- a/packages/flutter_tools/bin/tool_backend.dart
+++ b/packages/flutter_tools/bin/tool_backend.dart
@@ -73,7 +73,6 @@ or
       'bundle',
       '--target=$flutterTarget',
       '--target-platform=$targetPlatform',
-      '--debug',
       if (trackWidgetCreation) '--track-widget-creation',
       if (flutterEngine != null) '--local-engine-src-path=$flutterEngine',
       if (localEngine != null) '--local-engine=$localEngine',

--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -89,6 +89,7 @@ class BundleBuilder {
         flutterProject: flutterProject,
         outputDir: assetDirPath,
         depfilePath: depfilePath,
+        precompiled: precompiledSnapshot,
       );
       return;
     }
@@ -150,7 +151,10 @@ Future<void> buildWithAssemble({
   @required String mainPath,
   @required String outputDir,
   @required String depfilePath,
+  @required bool precompiled,
 }) async {
+  // If the precompiled flag was not passed, force us into debug mode.
+  buildMode = precompiled ? buildMode : BuildMode.debug;
   final Environment environment = Environment(
     projectDir: flutterProject.directory,
     outputDir: fs.directory(outputDir),

--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
@@ -21,7 +21,10 @@ class BuildBundleCommand extends BuildSubCommand {
     usesBuildNumberOption();
     addBuildModeFlags(verboseHelp: verboseHelp);
     argParser
-      ..addFlag('precompiled', negatable: false)
+      ..addFlag('precompiled', negatable: false, help: 'If not provided, then '
+        'a debug build is always provided, regardless of build mode. If provided '
+        'then release is the default mode.'
+      )
       // This option is still referenced by the iOS build scripts. We should
       // remove it once we've updated those build scripts.
       ..addOption('asset-base', help: 'Ignored. Will be removed.', hide: !verboseHelp)

--- a/packages/flutter_tools/test/general.shard/bundle_shim_test.dart
+++ b/packages/flutter_tools/test/general.shard/bundle_shim_test.dart
@@ -39,6 +39,7 @@ void main() {
       outputDir: 'example',
       targetPlatform: TargetPlatform.ios,
       depfilePath: 'example.d',
+      precompiled: false,
     );
     expect(fs.file(fs.path.join('example', 'kernel_blob.bin')).existsSync(), true);
     expect(fs.file(fs.path.join('example', 'LICENSE')).existsSync(), true);
@@ -60,6 +61,7 @@ void main() {
       outputDir: 'example',
       targetPlatform: TargetPlatform.linux_x64,
       depfilePath: 'example.d',
+      precompiled: false,
     ), throwsA(isInstanceOf<ToolExit>()));
   }));
 }


### PR DESCRIPTION
## Description

If not provided this defaults to release. In release mode, we no longer copy out the dill or precompiled snapshots.

Fixes https://github.com/flutter/flutter/issues/41352