### PR TITLE
Devicelab run.dart: Fixed check for path equality

### DIFF
--- a/dev/devicelab/bin/run.dart
+++ b/dev/devicelab/bin/run.dart
@@ -123,7 +123,7 @@ final ArgParser _argParser = ArgParser()
         if (fragments.length == 1 && !isDartFile) {
           // Not a path
           _taskNames.add(nameOrPath);
-        } else if (!isDartFile || fragments.length != 3 || !_listsEqual(<String>['bin', 'tasks'], fragments.take(2).toList())) {
+        } else if (!isDartFile || !path.equals(path.dirname(nameOrPath), path.join('bin', 'tasks'))) {
           // Unsupported executable location
           throw FormatException('Invalid value for option -t (--task): $nameOrPath');
         } else {

--- a/dev/devicelab/bin/run.dart
+++ b/dev/devicelab/bin/run.dart
@@ -197,15 +197,3 @@ final ArgParser _argParser = ArgParser()
       }
     },
   );
-
-bool _listsEqual(List<dynamic> a, List<dynamic> b) {
-  if (a.length != b.length)
-    return false;
-
-  for (int i = 0; i < a.length; i++) {
-    if (a[i] != b[i])
-      return false;
-  }
-
-  return true;
-}


### PR DESCRIPTION
## Description

Before this PR `../../bin/cache/dart-sdk/bin/dart bin/run.dart -s devicelab_ios -t ./bin/tasks/smoke_catalina_hot_mode_dev_cycle_ios__benchmark.dart` would fail but `../../bin/cache/dart-sdk/bin/dart bin/run.dart -s devicelab_ios -t ./bin/tasks/smoke_catalina_hot_mode_dev_cycle_ios__benchmark.dart` would work.

## Related Issues

## Tests

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
