### PR TITLE
Address previous comments, fix Intent.doNothing.

### DIFF
--- a/dev/manual_tests/lib/actions.dart
+++ b/dev/manual_tests/lib/actions.dart
@@ -235,9 +235,9 @@ abstract class UndoableAction extends Action {
 
   @override
   @mustCallSuper
-  void invoke(FocusNode node, Intent tag) {
+  void invoke(FocusNode node, Intent intent) {
     invocationNode = node;
-    invocationIntent = tag;
+    invocationIntent = intent;
   }
 
   @override
@@ -253,8 +253,8 @@ class SetFocusActionBase extends UndoableAction {
   FocusNode _previousFocus;
 
   @override
-  void invoke(FocusNode node, Intent tag) {
-    super.invoke(node, tag);
+  void invoke(FocusNode node, Intent intent) {
+    super.invoke(node, intent);
     _previousFocus = WidgetsBinding.instance.focusManager.primaryFocus;
     node.requestFocus();
   }
@@ -292,8 +292,8 @@ class SetFocusAction extends SetFocusActionBase {
   static const LocalKey key = ValueKey<Type>(SetFocusAction);
 
   @override
-  void invoke(FocusNode node, Intent tag) {
-    super.invoke(node, tag);
+  void invoke(FocusNode node, Intent intent) {
+    super.invoke(node, intent);
     node.requestFocus();
   }
 }
@@ -305,8 +305,8 @@ class NextFocusAction extends SetFocusActionBase {
   static const LocalKey key = ValueKey<Type>(NextFocusAction);
 
   @override
-  void invoke(FocusNode node, Intent tag) {
-    super.invoke(node, tag);
+  void invoke(FocusNode node, Intent intent) {
+    super.invoke(node, intent);
     node.nextFocus();
   }
 }
@@ -317,8 +317,8 @@ class PreviousFocusAction extends SetFocusActionBase {
   static const LocalKey key = ValueKey<Type>(PreviousFocusAction);
 
   @override
-  void invoke(FocusNode node, Intent tag) {
-    super.invoke(node, tag);
+  void invoke(FocusNode node, Intent intent) {
+    super.invoke(node, intent);
     node.previousFocus();
   }
 }
@@ -337,9 +337,9 @@ class DirectionalFocusAction extends SetFocusActionBase {
   TraversalDirection direction;
 
   @override
-  void invoke(FocusNode node, DirectionalFocusIntent tag) {
-    super.invoke(node, tag);
-    final DirectionalFocusIntent args = tag;
+  void invoke(FocusNode node, DirectionalFocusIntent intent) {
+    super.invoke(node, intent);
+    final DirectionalFocusIntent args = intent;
     node.focusInDirection(args.direction);
   }
 }

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -94,7 +94,7 @@ abstract class Action extends Diagnosticable {
   /// needed in the action, use [ActionDispatcher.invokeFocusedAction] instead.
   @protected
   @mustCallSuper
-  void invoke(FocusNode node, covariant Intent tag);
+  void invoke(FocusNode node, covariant Intent intent);
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -133,7 +133,7 @@ class CallbackAction extends Action {
   final OnInvokeCallback onInvoke;
 
   @override
-  void invoke(FocusNode node, Intent tag) => onInvoke.call(node, tag);
+  void invoke(FocusNode node, Intent intent) => onInvoke.call(node, intent);
 }
 
 /// An action manager that simply invokes the actions given to it.
@@ -366,7 +366,7 @@ class DoNothingAction extends Action {
   static const LocalKey key = ValueKey<Type>(DoNothingAction);
 
   @override
-  void invoke(FocusNode node, Intent invocation) { }
+  void invoke(FocusNode node, Intent intent) { }
 }
 
 /// An [Intent] that can be used to disable [Shortcuts] key bindings defined

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -151,6 +151,9 @@ class ActionDispatcher extends Diagnosticable {
   /// The `action` and `intent` arguments must not be null.
   ///
   /// Returns true if the action was successfully invoked.
+  ///
+  /// If the `intent` argument is [Intent.doNothing], then this function will
+  /// return true, without invoking the action.
   bool invokeAction(Action action, Intent intent, {FocusNode focusNode}) {
     assert(action != null);
     assert(intent != null);

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -154,6 +154,11 @@ class ActionDispatcher extends Diagnosticable {
   bool invokeAction(Action action, Intent intent, {FocusNode focusNode}) {
     assert(action != null);
     assert(intent != null);
+
+    if (identical(intent, Intent.doNothing)) {
+      return true;
+    }
+
     focusNode ??= WidgetsBinding.instance.focusManager.primaryFocus;
     if (action != null && intent.isEnabled(focusNode.context)) {
       action.invoke(focusNode, intent);
@@ -280,7 +285,7 @@ class Actions extends InheritedWidget {
   /// found, then this method will return false instead of throwing.
   ///
   /// If the `intent` argument is [Intent.doNothing], then this function will
-  /// return false, without looking for a matching action.
+  /// return true, without looking for a matching action.
   static bool invoke(
     BuildContext context,
     Intent intent, {
@@ -293,7 +298,7 @@ class Actions extends InheritedWidget {
     Action action;
 
     if (identical(intent, Intent.doNothing)) {
-      return false;
+      return true;
     }
 
     bool visitAncestorElement(Element element) {

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -8,6 +8,7 @@ import 'dart:collection' show HashMap;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 
+import 'actions.dart';
 import 'banner.dart';
 import 'basic.dart';
 import 'binding.dart';
@@ -1194,14 +1195,19 @@ class _WidgetsAppState extends State<WidgetsApp> implements WidgetsBindingObserv
 
     assert(_debugCheckLocalizations(appLocale));
 
-    return DefaultFocusTraversal(
-      policy: ReadingOrderTraversalPolicy(),
-      child: MediaQuery(
-        data: MediaQueryData.fromWindow(WidgetsBinding.instance.window),
-        child: Localizations(
-          locale: appLocale,
-          delegates: _localizationsDelegates.toList(),
-          child: title,
+    return Actions(
+      actions: <LocalKey, ActionFactory>{
+        DoNothingAction.key: () => const DoNothingAction(),
+      },
+      child: DefaultFocusTraversal(
+        policy: ReadingOrderTraversalPolicy(),
+        child: MediaQuery(
+          data: MediaQueryData.fromWindow(WidgetsBinding.instance.window),
+          child: Localizations(
+            locale: appLocale,
+            delegates: _localizationsDelegates.toList(),
+            child: title,
+          ),
         ),
       ),
     );

--- a/packages/flutter/test/widgets/actions_test.dart
+++ b/packages/flutter/test/widgets/actions_test.dart
@@ -71,6 +71,22 @@ void main() {
       expect(result, isTrue);
       expect(invoked, isTrue);
     });
+    test('$ActionDispatcher does nothing if Intent.doNothing is the intent.', () {
+      bool invoked = false;
+      const ActionDispatcher dispatcher = ActionDispatcher();
+      final FocusNode testNode = FocusNode(debugLabel: 'Test Node');
+      final bool result = dispatcher.invokeAction(
+        TestAction(
+          onInvoke: (FocusNode node, Intent invocation) {
+            invoked = true;
+          },
+        ),
+        Intent.doNothing,
+        focusNode: testNode,
+      );
+      expect(result, isTrue);
+      expect(invoked, isFalse);
+    });
   });
   group(Actions, () {
     Intent invokedIntent;
@@ -302,11 +318,11 @@ void main() {
       ).debugFillProperties(builder);
 
       final List<String> description = builder.properties
-          .where((DiagnosticsNode node) {
-            return !node.isFiltered(DiagnosticLevel.info);
-          })
-          .map((DiagnosticsNode node) => node.toString())
-          .toList();
+        .where((DiagnosticsNode node) {
+          return !node.isFiltered(DiagnosticLevel.info);
+        })
+        .map((DiagnosticsNode node) => node.toString())
+        .toList();
 
       expect(description[0], equalsIgnoringHashCodes('dispatcher: ActionDispatcher#00000'));
       expect(description[1], equals('actions: {}'));

--- a/packages/flutter/test/widgets/actions_test.dart
+++ b/packages/flutter/test/widgets/actions_test.dart
@@ -71,22 +71,6 @@ void main() {
       expect(result, isTrue);
       expect(invoked, isTrue);
     });
-    test('$ActionDispatcher does nothing if Intent.doNothing is the intent.', () {
-      bool invoked = false;
-      const ActionDispatcher dispatcher = ActionDispatcher();
-      final FocusNode testNode = FocusNode(debugLabel: 'Test Node');
-      final bool result = dispatcher.invokeAction(
-        TestAction(
-          onInvoke: (FocusNode node, Intent invocation) {
-            invoked = true;
-          },
-        ),
-        Intent.doNothing,
-        focusNode: testNode,
-      );
-      expect(result, isTrue);
-      expect(invoked, isFalse);
-    });
   });
   group(Actions, () {
     Intent invokedIntent;

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -37,18 +37,6 @@ class TestIntent extends Intent {
   const TestIntent() : super(TestAction.key);
 }
 
-class DoNothingAction extends Action {
-  const DoNothingAction({
-    @required OnInvokeCallback onInvoke,
-  })  : assert(onInvoke != null),
-        super(key);
-
-  static const LocalKey key = ValueKey<Type>(DoNothingAction);
-
-  @override
-  void invoke(FocusNode node, Intent invocation) {}
-}
-
 class TestShortcutManager extends ShortcutManager {
   TestShortcutManager(this.keys);
 

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -49,10 +49,6 @@ class DoNothingAction extends Action {
   void invoke(FocusNode node, Intent invocation) {}
 }
 
-class DoNothingIntent extends Intent {
-  const DoNothingIntent() : super(DoNothingAction.key);
-}
-
 class TestShortcutManager extends ShortcutManager {
   TestShortcutManager(this.keys);
 
@@ -143,8 +139,8 @@ void main() {
         LogicalKeyboardKey.keyD,
         LogicalKeyboardKey.keyC,
         LogicalKeyboardKey.keyB,
-        LogicalKeyboardKey.keyA,}
-      );
+        LogicalKeyboardKey.keyA,
+      });
       final Map<LogicalKeySet, String> map = <LogicalKeySet, String>{set1: 'one'};
       expect(set2 == set3, isTrue);
       expect(set2 == set4, isTrue);
@@ -192,10 +188,12 @@ void main() {
       await tester.pumpWidget(
         Actions(
           actions: <LocalKey, ActionFactory>{
-            TestAction.key: () => TestAction(onInvoke: (FocusNode node, Intent intent) {
-              invoked = true;
-              return true;
-            }),
+            TestAction.key: () => TestAction(
+              onInvoke: (FocusNode node, Intent intent) {
+                invoked = true;
+                return true;
+              },
+            ),
           },
           child: Shortcuts(
             manager: testManager,
@@ -228,14 +226,16 @@ void main() {
           },
           child: Actions(
             actions: <LocalKey, ActionFactory>{
-              TestAction.key: () => TestAction(onInvoke: (FocusNode node, Intent intent) {
-                invoked = true;
-                return true;
-              }),
+              TestAction.key: () => TestAction(
+                onInvoke: (FocusNode node, Intent intent) {
+                  invoked = true;
+                  return true;
+                },
+              ),
             },
             child: Shortcuts(
               shortcuts: <LogicalKeySet, Intent>{
-                LogicalKeySet(LogicalKeyboardKey.keyA): const DoNothingIntent(),
+                LogicalKeySet(LogicalKeyboardKey.keyA): Intent.doNothing,
               },
               child: Focus(
                 autofocus: true,
@@ -250,6 +250,44 @@ void main() {
       await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
       expect(invoked, isTrue);
       expect(pressedKeys, equals(<LogicalKeyboardKey>[LogicalKeyboardKey.shiftLeft]));
+    });
+    testWidgets('$Shortcuts can disable a shortcut with Intent.doNothing', (WidgetTester tester) async {
+      final GlobalKey containerKey = GlobalKey();
+      final List<LogicalKeyboardKey> pressedKeys = <LogicalKeyboardKey>[];
+      final TestShortcutManager testManager = TestShortcutManager(pressedKeys);
+      bool invoked = false;
+      await tester.pumpWidget(
+        Shortcuts(
+          manager: testManager,
+          shortcuts: <LogicalKeySet, Intent>{
+            LogicalKeySet(LogicalKeyboardKey.shift): const TestIntent(),
+          },
+          child: Actions(
+            actions: <LocalKey, ActionFactory>{
+              TestAction.key: () => TestAction(
+                onInvoke: (FocusNode node, Intent intent) {
+                  invoked = true;
+                  return true;
+                },
+              ),
+            },
+            child: Shortcuts(
+              shortcuts: <LogicalKeySet, Intent>{
+                LogicalKeySet(LogicalKeyboardKey.shift): Intent.doNothing,
+              },
+              child: Focus(
+                autofocus: true,
+                child: Container(key: containerKey, width: 100, height: 100),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(Shortcuts.of(containerKey.currentContext), isNotNull);
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+      expect(invoked, isFalse);
+      expect(pressedKeys, isEmpty);
     });
   });
 }

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -245,27 +245,29 @@ void main() {
       final TestShortcutManager testManager = TestShortcutManager(pressedKeys);
       bool invoked = false;
       await tester.pumpWidget(
-        Shortcuts(
-          manager: testManager,
-          shortcuts: <LogicalKeySet, Intent>{
-            LogicalKeySet(LogicalKeyboardKey.shift): const TestIntent(),
-          },
-          child: Actions(
-            actions: <LocalKey, ActionFactory>{
-              TestAction.key: () => TestAction(
-                onInvoke: (FocusNode node, Intent intent) {
-                  invoked = true;
-                  return true;
-                },
-              ),
+        MaterialApp(
+          home: Shortcuts(
+            manager: testManager,
+            shortcuts: <LogicalKeySet, Intent>{
+              LogicalKeySet(LogicalKeyboardKey.shift): const TestIntent(),
             },
-            child: Shortcuts(
-              shortcuts: <LogicalKeySet, Intent>{
-                LogicalKeySet(LogicalKeyboardKey.shift): Intent.doNothing,
+            child: Actions(
+              actions: <LocalKey, ActionFactory>{
+                TestAction.key: () => TestAction(
+                  onInvoke: (FocusNode node, Intent intent) {
+                    invoked = true;
+                    return true;
+                  },
+                ),
               },
-              child: Focus(
-                autofocus: true,
-                child: Container(key: containerKey, width: 100, height: 100),
+              child: Shortcuts(
+                shortcuts: <LogicalKeySet, Intent>{
+                  LogicalKeySet(LogicalKeyboardKey.shift): Intent.doNothing,
+                },
+                child: Focus(
+                  autofocus: true,
+                  child: Container(key: containerKey, width: 100, height: 100),
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
## Description

This addresses comments in the original PR (https://github.com/flutter/flutter/pull/41245) that introduced `Intent.doNothing`, adds tests, and fixes an issue with it.

## Related Issues

## Tests

- Added tests for `Intent.doNothing`. 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.
- [X] I checked all the boxes!

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes