### PR TITLE
Reland changes to Intent.doNothing to avoid analyzer issue

### DIFF
--- a/dev/manual_tests/lib/actions.dart
+++ b/dev/manual_tests/lib/actions.dart
@@ -235,9 +235,9 @@ abstract class UndoableAction extends Action {
 
   @override
   @mustCallSuper
-  void invoke(FocusNode node, Intent tag) {
+  void invoke(FocusNode node, Intent intent) {
     invocationNode = node;
-    invocationIntent = tag;
+    invocationIntent = intent;
   }
 
   @override
@@ -253,8 +253,8 @@ class SetFocusActionBase extends UndoableAction {
   FocusNode _previousFocus;
 
   @override
-  void invoke(FocusNode node, Intent tag) {
-    super.invoke(node, tag);
+  void invoke(FocusNode node, Intent intent) {
+    super.invoke(node, intent);
     _previousFocus = WidgetsBinding.instance.focusManager.primaryFocus;
     node.requestFocus();
   }
@@ -292,8 +292,8 @@ class SetFocusAction extends SetFocusActionBase {
   static const LocalKey key = ValueKey<Type>(SetFocusAction);
 
   @override
-  void invoke(FocusNode node, Intent tag) {
-    super.invoke(node, tag);
+  void invoke(FocusNode node, Intent intent) {
+    super.invoke(node, intent);
     node.requestFocus();
   }
 }
@@ -305,8 +305,8 @@ class NextFocusAction extends SetFocusActionBase {
   static const LocalKey key = ValueKey<Type>(NextFocusAction);
 
   @override
-  void invoke(FocusNode node, Intent tag) {
-    super.invoke(node, tag);
+  void invoke(FocusNode node, Intent intent) {
+    super.invoke(node, intent);
     node.nextFocus();
   }
 }
@@ -317,8 +317,8 @@ class PreviousFocusAction extends SetFocusActionBase {
   static const LocalKey key = ValueKey<Type>(PreviousFocusAction);
 
   @override
-  void invoke(FocusNode node, Intent tag) {
-    super.invoke(node, tag);
+  void invoke(FocusNode node, Intent intent) {
+    super.invoke(node, intent);
     node.previousFocus();
   }
 }
@@ -337,9 +337,9 @@ class DirectionalFocusAction extends SetFocusActionBase {
   TraversalDirection direction;
 
   @override
-  void invoke(FocusNode node, DirectionalFocusIntent tag) {
-    super.invoke(node, tag);
-    final DirectionalFocusIntent args = tag;
+  void invoke(FocusNode node, DirectionalFocusIntent intent) {
+    super.invoke(node, intent);
+    final DirectionalFocusIntent args = intent;
     node.focusInDirection(args.direction);
   }
 }

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -29,11 +29,10 @@ class Intent extends Diagnosticable {
 
   /// An intent that can't be mapped to an action.
   ///
-  /// This Intent is prevented from being mapped to an action in the
-  /// [ActionDispatcher], and as such can be used to indicate that a shortcut
-  /// should not do anything, allowing a shortcut defined at a higher level to
-  /// be disabled at a deeper level in the widget hierarchy.
-  static const Intent doNothing = Intent(ValueKey<Type>(Intent));
+  /// This Intent is mapped to an action in the [WidgetsApp] that does nothing,
+  /// so that it can be bound to a key in a [Shortcuts] widget in order to
+  /// disable a key binding made above it in the hierarchy.
+  static const Intent doNothing = DoNothingIntent();
 
   /// The key for the action this intent is associated with.
   final LocalKey key;
@@ -95,7 +94,7 @@ abstract class Action extends Diagnosticable {
   /// needed in the action, use [ActionDispatcher.invokeFocusedAction] instead.
   @protected
   @mustCallSuper
-  void invoke(FocusNode node, covariant Intent tag);
+  void invoke(FocusNode node, covariant Intent intent);
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -134,7 +133,7 @@ class CallbackAction extends Action {
   final OnInvokeCallback onInvoke;
 
   @override
-  void invoke(FocusNode node, Intent tag) => onInvoke.call(node, tag);
+  void invoke(FocusNode node, Intent intent) => onInvoke.call(node, intent);
 }
 
 /// An action manager that simply invokes the actions given to it.
@@ -224,6 +223,7 @@ class Actions extends InheritedWidget {
         // Stop visiting.
         return false;
       }
+
       element.visitAncestorElements(visitAncestorElement);
     }
     return dispatcher ?? const ActionDispatcher();
@@ -278,9 +278,6 @@ class Actions extends InheritedWidget {
   ///
   /// Setting `nullOk` to true means that if no ambient [Actions] widget is
   /// found, then this method will return false instead of throwing.
-  ///
-  /// If the `intent` argument is [Intent.doNothing], then this function will
-  /// return false, without looking for a matching action.
   static bool invoke(
     BuildContext context,
     Intent intent, {
@@ -291,10 +288,6 @@ class Actions extends InheritedWidget {
     assert(intent != null);
     Element actionsElement;
     Action action;
-
-    if (identical(intent, Intent.doNothing)) {
-      return false;
-    }
 
     bool visitAncestorElement(Element element) {
       if (element.widget is! Actions) {
@@ -357,4 +350,30 @@ class Actions extends InheritedWidget {
     properties.add(DiagnosticsProperty<ActionDispatcher>('dispatcher', dispatcher));
     properties.add(DiagnosticsProperty<Map<LocalKey, ActionFactory>>('actions', actions));
   }
+}
+
+/// An [Action], that, as the name implies, does nothing.
+///
+/// This action is bound to the [Intent.doNothing] intent inside of
+/// [WidgetsApp.build] so that a [Shortcuts] widget can bind a key to it to
+/// override another shortcut binding defined above it in the hierarchy.
+class DoNothingAction extends Action {
+  /// Const constructor for [DoNothingAction].
+  const DoNothingAction() : super(key);
+
+  /// The Key used for the [DoNothingIntent] intent, and registered at the top
+  /// level actions in [WidgetsApp.build].
+  static const LocalKey key = ValueKey<Type>(DoNothingAction);
+
+  @override
+  void invoke(FocusNode node, Intent intent) { }
+}
+
+/// An [Intent] that can be used to disable [Shortcuts] key bindings defined
+/// above a widget in the hierarchy.
+///
+/// The [Intent.doNothing] intent is of this type.
+class DoNothingIntent extends Intent {
+  /// Const constructor for [DoNothingIntent].
+  const DoNothingIntent() : super(DoNothingAction.key);
 }

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -32,7 +32,7 @@ class Intent extends Diagnosticable {
   /// This Intent is mapped to an action in the [WidgetsApp] that does nothing,
   /// so that it can be bound to a key in a [Shortcuts] widget in order to
   /// disable a key binding made above it in the hierarchy.
-  static const Intent doNothing = DoNothingIntent();
+  static const Intent doNothing = Intent(DoNothingAction.key);
 
   /// The key for the action this intent is associated with.
   final LocalKey key;
@@ -367,13 +367,4 @@ class DoNothingAction extends Action {
 
   @override
   void invoke(FocusNode node, Intent intent) { }
-}
-
-/// An [Intent] that can be used to disable [Shortcuts] key bindings defined
-/// above a widget in the hierarchy.
-///
-/// The [Intent.doNothing] intent is of this type.
-class DoNothingIntent extends Intent {
-  /// Const constructor for [DoNothingIntent].
-  const DoNothingIntent() : super(DoNothingAction.key);
 }

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -8,6 +8,7 @@ import 'dart:collection' show HashMap;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 
+import 'actions.dart';
 import 'banner.dart';
 import 'basic.dart';
 import 'binding.dart';
@@ -1194,14 +1195,19 @@ class _WidgetsAppState extends State<WidgetsApp> implements WidgetsBindingObserv
 
     assert(_debugCheckLocalizations(appLocale));
 
-    return DefaultFocusTraversal(
-      policy: ReadingOrderTraversalPolicy(),
-      child: MediaQuery(
-        data: MediaQueryData.fromWindow(WidgetsBinding.instance.window),
-        child: Localizations(
-          locale: appLocale,
-          delegates: _localizationsDelegates.toList(),
-          child: title,
+    return Actions(
+      actions: <LocalKey, ActionFactory>{
+        DoNothingAction.key: () => const DoNothingAction(),
+      },
+      child: DefaultFocusTraversal(
+        policy: ReadingOrderTraversalPolicy(),
+        child: MediaQuery(
+          data: MediaQueryData.fromWindow(WidgetsBinding.instance.window),
+          child: Localizations(
+            locale: appLocale,
+            delegates: _localizationsDelegates.toList(),
+            child: title,
+          ),
         ),
       ),
     );

--- a/packages/flutter/test/widgets/actions_test.dart
+++ b/packages/flutter/test/widgets/actions_test.dart
@@ -302,11 +302,11 @@ void main() {
       ).debugFillProperties(builder);
 
       final List<String> description = builder.properties
-          .where((DiagnosticsNode node) {
-            return !node.isFiltered(DiagnosticLevel.info);
-          })
-          .map((DiagnosticsNode node) => node.toString())
-          .toList();
+        .where((DiagnosticsNode node) {
+          return !node.isFiltered(DiagnosticLevel.info);
+        })
+        .map((DiagnosticsNode node) => node.toString())
+        .toList();
 
       expect(description[0], equalsIgnoringHashCodes('dispatcher: ActionDispatcher#00000'));
       expect(description[1], equals('actions: {}'));


### PR DESCRIPTION
## Description

This re-lands https://github.com/flutter/flutter/pull/41417 with a slight change that will hopefully not tickle the analyzer as it did before.  The last time I tried to land this, the analyzer succeeded for the analyze step in Cirrus, and locally, but failed in an integration test.

## Breaking Change

- [X] No, this is *not* a breaking change.