### PR TITLE
[flutter_tool] Add analytics events for ios-mdns fallback success/failure

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -377,7 +377,7 @@ class IOSDevice extends Device {
           return LaunchResult.succeeded(observatoryUri: localUri);
         }
       } catch (error) {
-        printError('Failed to establish a debug connection with $id: $error');
+        printError('Failed to establish a debug connection with $id using mdns: $error');
       }
 
       // Fallback to manual protocol discovery.
@@ -387,13 +387,15 @@ class IOSDevice extends Device {
         printTrace('Waiting for observatory port.');
         localUri = await observatoryDiscovery.uri;
         if (localUri != null) {
+          UsageEvent('ios-mdns', 'fallback-success').send();
           return LaunchResult.succeeded(observatoryUri: localUri);
         }
       } catch (error) {
-        printError('Failed to establish a debug connection with $id: $error');
+        printError('Failed to establish a debug connection with $id using logs: $error');
       } finally {
         await observatoryDiscovery?.cancel();
       }
+      UsageEvent('ios-mdns', 'fallback-failure').send();
       return LaunchResult.failed();
     } finally {
       installStatus.stop();

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -219,6 +219,7 @@ void main() {
           platformArgs: <String, dynamic>{},
         );
         verify(mockUsage.sendEvent('ios-mdns', 'failure')).called(1);
+        verify(mockUsage.sendEvent('ios-mdns', 'fallback-success')).called(1);
         expect(launchResult.started, isTrue);
         expect(launchResult.hasObservatory, isTrue);
         expect(await device.stopApp(mockApp), isFalse);
@@ -250,6 +251,8 @@ void main() {
             debuggingOptions: DebuggingOptions.enabled(const BuildInfo(BuildMode.debug, null)),
             platformArgs: <String, dynamic>{},
         );
+        verify(mockUsage.sendEvent('ios-mdns', 'failure')).called(1);
+        verify(mockUsage.sendEvent('ios-mdns', 'fallback-failure')).called(1);
         expect(launchResult.started, isFalse);
         expect(launchResult.hasObservatory, isFalse);
       }, overrides: <Type, Generator>{
@@ -259,6 +262,7 @@ void main() {
         MDnsObservatoryDiscovery: () => mockMDnsObservatoryDiscovery,
         Platform: () => macPlatform,
         ProcessManager: () => mockProcessManager,
+        Usage: () => mockUsage,
       });
 
       testUsingContext(' succeeds in release mode', () async {


### PR DESCRIPTION
## Description

Adds success/failure events for observatory discovery after an mdns failure on iOS.

## Related Issues

https://github.com/flutter/flutter/issues/41085

## Tests

I added the following tests:

Tests in devices_test.dart

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
