### PR TITLE
Skip pod initialization if version >= 1.8.0.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -414,7 +414,7 @@ task:
   print_date_script:
     - date
   install_cocoapods_script:
-    - sudo gem install cocoapods -v 1.7.5 --no-document
+    - sudo gem install cocoapods --no-document
   git_fetch_script:
     - git clean -xfd
     - git fetch origin
@@ -486,7 +486,7 @@ task:
   print_date_script:
     - date
   install_cocoapods_script:
-    - sudo gem install cocoapods -v 1.7.5 --no-document
+    - sudo gem install cocoapods --no-document
   git_fetch_script:
     - git clean -xfd
     - git fetch origin

--- a/dev/integration_tests/release_smoke_test/ios/Podfile
+++ b/dev/integration_tests/release_smoke_test/ios/Podfile
@@ -1,6 +1,3 @@
-# Using a CDN with CocoaPods 1.7.2 or later can save a lot of time on pod installation, but it's experimental rather than the default.
-# source 'https://cdn.cocoapods.org/'
-
 # Uncomment this line to define a global platform for your project
 # platform :ios, '9.0'
 

--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -35,12 +35,10 @@ const String brokenCocoaPodsConsequence = '''
   This can usually be fixed by re-installing CocoaPods. For more info, see https://github.com/flutter/flutter/issues/14293.''';
 
 const String cocoaPodsInstallInstructions = '''
-  sudo gem install cocoapods
-  pod setup''';
+  sudo gem install cocoapods''';
 
 const String cocoaPodsUpgradeInstructions = '''
-  sudo gem install cocoapods
-  pod setup''';
+  sudo gem install cocoapods''';
 
 CocoaPods get cocoaPods => context.get<CocoaPods>();
 
@@ -104,13 +102,21 @@ class CocoaPods {
 
   /// Whether CocoaPods ran 'pod setup' once where the costly pods' specs are
   /// cloned.
+  /// 
+  /// Versions >= 1.8.0 do not require 'pod setup' and default to a CDN instead
+  /// of a locally cloned repository.
+  /// See http://blog.cocoapods.org/CocoaPods-1.8.0-beta/
   ///
   /// A user can override the default location via the CP_REPOS_DIR environment
   /// variable.
   ///
   /// See https://github.com/CocoaPods/CocoaPods/blob/master/lib/cocoapods/config.rb#L138
   /// for details of this variable.
-  Future<bool> get isCocoaPodsInitialized {
+  Future<bool> get isCocoaPodsInitialized async {
+    final Version installedVersion = Version.parse(await cocoaPodsVersionText);
+    if (installedVersion != null && installedVersion >= Version.parse('1.8.0')) {
+      return true;
+    }
     final String cocoapodsReposDir = platform.environment['CP_REPOS_DIR'] ?? fs.path.join(homeDirPath, '.cocoapods', 'repos');
     return fs.isDirectory(fs.path.join(cocoapodsReposDir, 'master'));
   }

--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -102,7 +102,7 @@ class CocoaPods {
 
   /// Whether CocoaPods ran 'pod setup' once where the costly pods' specs are
   /// cloned.
-  /// 
+  ///
   /// Versions >= 1.8.0 do not require 'pod setup' and default to a CDN instead
   /// of a locally cloned repository.
   /// See http://blog.cocoapods.org/CocoaPods-1.8.0-beta/

--- a/packages/flutter_tools/templates/cocoapods/Podfile-ios-objc
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-ios-objc
@@ -1,6 +1,3 @@
-# Using a CDN with CocoaPods 1.7.2 or later can save a lot of time on pod installation, but it's experimental rather than the default.
-# source 'https://cdn.cocoapods.org/'
-
 # Uncomment this line to define a global platform for your project
 # platform :ios, '9.0'
 

--- a/packages/flutter_tools/templates/cocoapods/Podfile-ios-swift
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-ios-swift
@@ -1,6 +1,3 @@
-# Using a CDN with CocoaPods 1.7.2 or later can save a lot of time on pod installation, but it's experimental rather than the default.
-# source 'https://cdn.cocoapods.org/'
-
 # Uncomment this line to define a global platform for your project
 # platform :ios, '9.0'
 

--- a/packages/flutter_tools/templates/cocoapods/Podfile-macos
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-macos
@@ -1,6 +1,3 @@
-# Using a CDN with CocoaPods 1.7.2 or later can save a lot of time on pod installation, but it's experimental rather than the default.
-# source 'https://cdn.cocoapods.org/'
-
 platform :osx, '10.11'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -160,6 +160,16 @@ void main() {
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
     });
+
+    testUsingContext('detects initialized over 1.8.0', () async {
+      pretendPodIsInstalled();
+      pretendPodVersionIs('1.8.0');
+      expect(await cocoaPodsUnderTest.isCocoaPodsInitialized, isTrue);
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+      Platform: () => FakePlatform(),
+      FileSystem: () => fs,
+    });
   });
 
   group('Setup Podfile', () {


### PR DESCRIPTION
## Description

CocoaPods 1.8.0 no longer requires `pod setup` to be run since it doesn't need the local specs repository set up.

Also remove hard-coded 1.7.5 device lab version since 1.8.1 has fixed the gem issue introduced in 1.8.0.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/41253.
Fixes https://github.com/flutter/flutter/issues/41221.

## Tests

Added cocoapods_test.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.