### PR TITLE
[flutter_tool] Report to analytics when the tool is killed by a signal

### DIFF
--- a/packages/flutter_tools/lib/src/base/signals.dart
+++ b/packages/flutter_tools/lib/src/base/signals.dart
@@ -12,11 +12,20 @@ typedef SignalHandler = FutureOr<void> Function(ProcessSignal signal);
 
 Signals get signals => Signals.instance;
 
+// The default list of signals that should cause the process to exit.
+const List<ProcessSignal> _defaultExitSignals = <ProcessSignal>[
+  ProcessSignal.SIGTERM,
+  ProcessSignal.SIGINT,
+  ProcessSignal.SIGKILL,
+];
+
 /// A class that manages signal handlers
 ///
 /// Signal handlers are run in the order that they were added.
 abstract class Signals {
-  factory Signals() => _DefaultSignals._();
+  factory Signals({
+    List<ProcessSignal> exitSignals = _defaultExitSignals,
+  }) => _DefaultSignals._(exitSignals);
 
   static Signals get instance => context.get<Signals>();
 
@@ -40,7 +49,9 @@ abstract class Signals {
 }
 
 class _DefaultSignals implements Signals {
-  _DefaultSignals._();
+  _DefaultSignals._(this.exitSignals);
+
+  final List<ProcessSignal> exitSignals;
 
   // A table mapping (signal, token) -> signal handler.
   final Map<ProcessSignal, Map<Object, SignalHandler>> _handlersTable =
@@ -119,12 +130,5 @@ class _DefaultSignals implements Signals {
     }
   }
 
-  // The list of signals that should cause the process to exit.
-  static const List<ProcessSignal> _exitingSignals = <ProcessSignal>[
-    ProcessSignal.SIGTERM,
-    ProcessSignal.SIGINT,
-    ProcessSignal.SIGKILL,
-  ];
-
-  bool _shouldExitFor(ProcessSignal signal) => _exitingSignals.contains(signal);
+  bool _shouldExitFor(ProcessSignal signal) => exitSignals.contains(signal);
 }

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -14,6 +14,7 @@ import '../base/common.dart';
 import '../base/context.dart';
 import '../base/file_system.dart';
 import '../base/io.dart' as io;
+import '../base/signals.dart';
 import '../base/terminal.dart';
 import '../base/time.dart';
 import '../base/user_messages.dart';
@@ -37,6 +38,7 @@ enum ExitStatus {
   success,
   warning,
   fail,
+  killed,
 }
 
 /// [FlutterCommand]s' subclasses' [FlutterCommand.runCommand] can optionally
@@ -73,6 +75,8 @@ class FlutterCommandResult {
         return 'warning';
       case ExitStatus.fail:
         return 'fail';
+      case ExitStatus.killed:
+        return 'killed';
       default:
         assert(false);
         return null;
@@ -447,6 +451,7 @@ abstract class FlutterCommand extends Command<void> {
           flutterUsage.printWelcome();
         }
         final String commandPath = await usagePath;
+        _registerSignalHandlers(commandPath, startTime);
         FlutterCommandResult commandResult;
         try {
           commandResult = await verifyThenRunCommand(commandPath);
@@ -460,6 +465,19 @@ abstract class FlutterCommand extends Command<void> {
         }
       },
     );
+  }
+
+  void _registerSignalHandlers(String commandPath, DateTime startTime) {
+    final SignalHandler handler = (io.ProcessSignal s) {
+      _sendPostUsage(
+        commandPath,
+        const FlutterCommandResult(ExitStatus.killed),
+        startTime,
+        systemClock.now(),
+      );
+    };
+    signals.addHandler(io.ProcessSignal.SIGTERM, handler);
+    signals.addHandler(io.ProcessSignal.SIGINT, handler);
   }
 
   /// Logs data about this command.

--- a/packages/flutter_tools/test/general.shard/commands/build_fuchsia_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_fuchsia_test.dart
@@ -39,6 +39,7 @@ void main() {
     fuchsiaArtifactsNoCompiler = MockFuchsiaArtifacts();
 
     when(linuxPlatform.isLinux).thenReturn(true);
+    when(linuxPlatform.isWindows).thenReturn(false);
     when(windowsPlatform.isWindows).thenReturn(true);
     when(windowsPlatform.isLinux).thenReturn(false);
     when(windowsPlatform.isMacOS).thenReturn(false);

--- a/packages/flutter_tools/test/general.shard/commands/build_linux_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_linux_test.dart
@@ -49,7 +49,9 @@ void main() {
       return const Stream<List<int>>.empty();
     });
     when(linuxPlatform.isLinux).thenReturn(true);
+    when(linuxPlatform.isWindows).thenReturn(false);
     when(notLinuxPlatform.isLinux).thenReturn(false);
+    when(notLinuxPlatform.isWindows).thenReturn(false);
   });
 
   testUsingContext('Linux build fails when there is no linux project', () async {

--- a/packages/flutter_tools/test/general.shard/commands/build_macos_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_macos_test.dart
@@ -61,7 +61,9 @@ void main() {
       return const Stream<List<int>>.empty();
     });
     when(macosPlatform.isMacOS).thenReturn(true);
+    when(macosPlatform.isWindows).thenReturn(false);
     when(notMacosPlatform.isMacOS).thenReturn(false);
+    when(notMacosPlatform.isWindows).thenReturn(false);
   });
 
   // Sets up the minimal mock project files necessary for macOS builds to succeed.

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -402,5 +402,5 @@ class FakeSignals implements Signals {
   }
 
   @override
-  Stream<Object> get errors => Stream<Object>.empty();
+  Stream<Object> get errors => const Stream<Object>.empty();
 }

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -12,6 +12,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
+import 'package:flutter_tools/src/base/signals.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/base/time.dart';
 import 'package:flutter_tools/src/cache.dart';
@@ -90,6 +91,7 @@ void testUsingContext(
           FileSystem: () => const LocalFileSystemBlockingSetCurrentDirectory(),
           TimeoutConfiguration: () => const TimeoutConfiguration(),
           PlistParser: () => FakePlistParser(),
+          Signals: () => FakeSignals(),
         },
         body: () {
           final String flutterRoot = getFlutterRoot();
@@ -386,4 +388,19 @@ class LocalFileSystemBlockingSetCurrentDirectory extends LocalFileSystem {
           'Consider using a MemoryFileSystem for testing if possible or refactor '
           'code to not require setting fs.currentDirectory.';
   }
+}
+
+class FakeSignals implements Signals {
+  @override
+  Object addHandler(ProcessSignal signal, SignalHandler handler) {
+    return null;
+  }
+
+  @override
+  Future<bool> removeHandler(ProcessSignal signal, Object token) async {
+    return true;
+  }
+
+  @override
+  Stream<Object> get errors => Stream<Object>.empty();
 }

--- a/packages/flutter_tools/test/src/testbed.dart
+++ b/packages/flutter_tools/test/src/testbed.dart
@@ -14,6 +14,7 @@ import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/signals.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/context_runner.dart';
@@ -35,6 +36,7 @@ final Map<Type, Generator> _testbedDefaults = <Type, Generator>{
   OutputPreferences: () => OutputPreferences(showColor: false), // configures BufferLogger to avoid color codes.
   Usage: () => NoOpUsage(), // prevent addition of analytics from burdening test mocks
   FlutterVersion: () => FakeFlutterVersion(), // prevent requirement to mock git for test runner.
+  Signals: () => FakeSignals(),  // prevent registering actual signal handlers.
 };
 
 /// Manages interaction with the tool injection and runner system.


### PR DESCRIPTION
## Description

This PR adds signal handlers such that the tool will report a command result event and command timing when the tool is killed by a signal (SIGINT, SIGTERM).

## Tests

I added the following tests:

Tests in signals_test.dart and flutter_command_test.dart.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
