### PR TITLE
Focus semantics

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1815,6 +1815,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
             onCopy: _semanticsOnCopy(controls),
             onCut: _semanticsOnCut(controls),
             onPaste: _semanticsOnPaste(controls),
+            focused: _hasFocus,
             child: _Editable(
               key: _editableKey,
               startHandleLayerLink: _startHandleLayerLink,

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1815,7 +1815,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
             onCopy: _semanticsOnCopy(controls),
             onCut: _semanticsOnCut(controls),
             onPaste: _semanticsOnPaste(controls),
-            focused: _hasFocus,
             child: _Editable(
               key: _editableKey,
               startHandleLayerLink: _startHandleLayerLink,

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -431,9 +431,12 @@ class _FocusState extends State<Focus> {
   @override
   Widget build(BuildContext context) {
     _focusAttachment.reparent();
-    return _FocusMarker(
-      node: focusNode,
-      child: widget.child,
+    return Semantics(
+      focused: focusNode.hasPrimaryFocus,
+      child: _FocusMarker(
+        node: focusNode,
+        child: widget.child,
+      ),
     );
   }
 }

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -434,6 +434,7 @@ class _FocusState extends State<Focus> {
     return _FocusMarker(
       node: focusNode,
       child: Semantics(
+        focusable: focusNode.canRequestFocus,
         focused: focusNode.hasFocus,
         child: widget.child,
       ),

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -431,10 +431,10 @@ class _FocusState extends State<Focus> {
   @override
   Widget build(BuildContext context) {
     _focusAttachment.reparent();
-    return Semantics(
-      focused: focusNode.hasPrimaryFocus,
-      child: _FocusMarker(
-        node: focusNode,
+    return _FocusMarker(
+      node: focusNode,
+      child: Semantics(
+        focused: focusNode.hasFocus,
         child: widget.child,
       ),
     );

--- a/packages/flutter/test/widgets/focus_scope_test.dart
+++ b/packages/flutter/test/widgets/focus_scope_test.dart
@@ -2,8 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter/semantics.dart';
 
 class TestFocus extends StatefulWidget {
   const TestFocus({
@@ -1289,5 +1292,23 @@ void main() {
     await tester.pumpWidget(Container());
 
     expect(WidgetsBinding.instance.focusManager.rootScope.descendants, isEmpty);
+  });
+  testWidgets('Focus widgets set Semantics information about focus', (WidgetTester tester) async {
+    final GlobalKey<TestFocusState> key = GlobalKey();
+
+    await tester.pumpWidget(
+      TestFocus(key: key, name: 'a'),
+    );
+
+    final SemanticsNode semantics = tester.getSemantics(find.byKey(key));
+
+    expect(key.currentState.focusNode.hasFocus, isFalse);
+    expect(semantics.hasFlag(SemanticsFlag.isFocused), isFalse);
+
+    FocusScope.of(key.currentContext).requestFocus(key.currentState.focusNode);
+    await tester.pumpAndSettle();
+
+    expect(key.currentState.focusNode.hasFocus, isTrue);
+    expect(semantics.hasFlag(SemanticsFlag.isFocused), isTrue);
   });
 }

--- a/packages/flutter/test/widgets/focus_scope_test.dart
+++ b/packages/flutter/test/widgets/focus_scope_test.dart
@@ -1304,11 +1304,20 @@ void main() {
 
     expect(key.currentState.focusNode.hasFocus, isFalse);
     expect(semantics.hasFlag(SemanticsFlag.isFocused), isFalse);
+    expect(semantics.hasFlag(SemanticsFlag.isFocusable), isTrue);
 
     FocusScope.of(key.currentContext).requestFocus(key.currentState.focusNode);
     await tester.pumpAndSettle();
 
     expect(key.currentState.focusNode.hasFocus, isTrue);
     expect(semantics.hasFlag(SemanticsFlag.isFocused), isTrue);
+    expect(semantics.hasFlag(SemanticsFlag.isFocusable), isTrue);
+
+    key.currentState.focusNode.canRequestFocus = false;
+    await tester.pumpAndSettle();
+
+    expect(key.currentState.focusNode.hasFocus, isFalse);
+    expect(semantics.hasFlag(SemanticsFlag.isFocused), isFalse);
+    expect(semantics.hasFlag(SemanticsFlag.isFocusable), isFalse);
   });
 }

--- a/packages/flutter/test/widgets/platform_view_test.dart
+++ b/packages/flutter/test/widgets/platform_view_test.dart
@@ -836,7 +836,15 @@ void main() {
         ),
       );
 
-      final SemanticsNode semantics =  tester.getSemantics(find.byType(AndroidView));
+      // Find the first _AndroidPlatformView widget inside of the AndroidView so
+      // that it finds the right RenderObject when looking for semantics.
+      final Finder semanticsFinder = find.byWidgetPredicate(
+        (Widget widget) {
+          return widget.runtimeType.toString() == '_AndroidPlatformView';
+        },
+        description: '_AndroidPlatformView widget inside AndroidView',
+      );
+      final SemanticsNode semantics = tester.getSemantics(semanticsFinder.first);
 
       // Platform view has not been created yet, no platformViewId.
       expect(semantics.platformViewId, null);


### PR DESCRIPTION
## Description

This adds a `Semantics` widget to each `Focus` widget so that the semantics information will include correct information about what is focused.

## Tests

- Modified a test so that it found the right render object, since sometimes our semantics finder in the test framework is inconsistent. The structure of the semantics tree didn't change.
- Added a test to make sure that focus nodes introduce `isFocused` for semantics.

## Breaking Change

- [X] No, this is *not* a breaking change.