### PR TITLE
Ensure we find dart.exe on local engines

### DIFF
--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -158,6 +158,19 @@ abstract class Artifacts {
   String getEngineType(TargetPlatform platform, [ BuildMode mode ]);
 }
 
+TargetPlatform get _currentHostPlatform {
+  if (platform.isMacOS) {
+    return TargetPlatform.darwin_x64;
+  }
+  if (platform.isLinux) {
+    return TargetPlatform.linux_x64;
+  }
+  if (platform.isWindows) {
+    return TargetPlatform.windows_x64;
+  }
+  throw UnimplementedError('Host OS not supported.');
+}
+
 /// Manages the engine artifacts downloaded to the local cache.
 class CachedArtifacts extends Artifacts {
 
@@ -337,19 +350,6 @@ class CachedArtifacts extends Artifacts {
     assert(false, 'Invalid platform $platform.');
     return null;
   }
-
-  TargetPlatform get _currentHostPlatform {
-    if (platform.isMacOS) {
-      return TargetPlatform.darwin_x64;
-    }
-    if (platform.isLinux) {
-      return TargetPlatform.linux_x64;
-    }
-    if (platform.isWindows) {
-      return TargetPlatform.windows_x64;
-    }
-    throw UnimplementedError('Host OS not supported.');
-  }
 }
 
 /// Manages the artifacts of a locally built engine.
@@ -362,7 +362,8 @@ class LocalEngineArtifacts extends Artifacts {
 
   @override
   String getArtifactPath(Artifact artifact, { TargetPlatform platform, BuildMode mode }) {
-    final String artifactFileName = _artifactToFileName(artifact);
+    platform ??= _currentHostPlatform;
+    final String artifactFileName = _artifactToFileName(artifact, platform);
     switch (artifact) {
       case Artifact.snapshotDart:
         return fs.path.join(_engineSrcPath, 'flutter', 'lib', 'snapshot', artifactFileName);

--- a/packages/flutter_tools/test/general.shard/artifacts_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifacts_test.dart
@@ -113,6 +113,20 @@ void main() {
         FileSystem: () => memoryFileSystem,
         Platform: () => FakePlatform(operatingSystem: 'linux'),
       });
+
+      testUsingContext('Looks up dart.exe on windows platforms', () async {
+        expect(artifacts.getArtifactPath(Artifact.engineDartBinary), contains('.exe'));
+      }, overrides: <Type, Generator>{
+        FileSystem: () => memoryFileSystem,
+        Platform: () => FakePlatform(operatingSystem: 'windows'),
+      });
+
+      testUsingContext('Looks up dart on linux platforms', () async {
+        expect(artifacts.getArtifactPath(Artifact.engineDartBinary), isNot(contains('.exe')));
+      }, overrides: <Type, Generator>{
+        FileSystem: () => memoryFileSystem,
+        Platform: () => FakePlatform(operatingSystem: 'linux'),
+      });
     });
   });
 }


### PR DESCRIPTION
## Description

When performing a build with assemble we take the hash of the dart executable as an input. On windows, the executable is called `dart.exe` and not `dart`. While the cache engine artifacts were updated to account for this, the local engine artifacts never were.