### PR TITLE
Fix integration test results to match new paradigm.

### DIFF
--- a/dev/integration_tests/android_semantics_testing/lib/src/matcher.dart
+++ b/dev/integration_tests/android_semantics_testing/lib/src/matcher.dart
@@ -135,8 +135,13 @@ class _AndroidSemanticsMatcher extends Matcher {
       return _failWithMessage('Expected size: $size', matchState);
     if (actions != null) {
       final List<AndroidSemanticsAction> itemActions = item.getActions();
-      if (!unorderedEquals(actions).matches(itemActions, matchState))
-        return _failWithMessage('Expected actions: $actions', matchState);
+      if (!unorderedEquals(actions).matches(itemActions, matchState)) {
+        final List<String> actionsString = actions.map<String>((AndroidSemanticsAction action) => action.toString()).toList()..sort();
+        final List<String> itemActionsString = itemActions.map<String>((AndroidSemanticsAction action) => action.toString()).toList()..sort();
+        final Set<String> unexpected = itemActionsString.toSet().difference(actionsString.toSet());
+        final Set<String> missing = actionsString.toSet().difference(itemActionsString.toSet());
+        return _failWithMessage('Expected actions: $actionsString\nActual actions: $itemActionsString\nUnexpected: $unexpected\nMissing: $missing', matchState);
+      }
     }
     if (isChecked != null && isChecked != item.isChecked)
       return _failWithMessage('Expected isChecked: $isChecked', matchState);

--- a/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
+++ b/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
@@ -76,8 +76,9 @@ void main() {
           isFocused: false,
           isPassword: false,
           actions: <AndroidSemanticsAction>[
-            AndroidSemanticsAction.click,
             AndroidSemanticsAction.accessibilityFocus,
+            AndroidSemanticsAction.click,
+            AndroidSemanticsAction.focus,
           ],
         ));
 
@@ -90,10 +91,11 @@ void main() {
           isEditable: true,
           isPassword: false,
           actions: <AndroidSemanticsAction>[
+            AndroidSemanticsAction.clearAccessibilityFocus,
             AndroidSemanticsAction.click,
-            AndroidSemanticsAction.accessibilityFocus,
-            AndroidSemanticsAction.setSelection,
             AndroidSemanticsAction.copy,
+            AndroidSemanticsAction.focus,
+            AndroidSemanticsAction.setSelection,
           ],
         ));
 
@@ -107,10 +109,11 @@ void main() {
           isEditable: true,
           isPassword: false,
           actions: <AndroidSemanticsAction>[
+            AndroidSemanticsAction.clearAccessibilityFocus,
             AndroidSemanticsAction.click,
-            AndroidSemanticsAction.accessibilityFocus,
-            AndroidSemanticsAction.setSelection,
             AndroidSemanticsAction.copy,
+            AndroidSemanticsAction.focus,
+            AndroidSemanticsAction.setSelection,
           ],
         ));
       });
@@ -128,8 +131,9 @@ void main() {
           isFocused: false,
           isPassword: true,
           actions: <AndroidSemanticsAction>[
-            AndroidSemanticsAction.click,
             AndroidSemanticsAction.accessibilityFocus,
+            AndroidSemanticsAction.click,
+            AndroidSemanticsAction.focus,
           ],
         ));
 
@@ -142,10 +146,11 @@ void main() {
           isEditable: true,
           isPassword: true,
           actions: <AndroidSemanticsAction>[
+            AndroidSemanticsAction.clearAccessibilityFocus,
             AndroidSemanticsAction.click,
-            AndroidSemanticsAction.accessibilityFocus,
-            AndroidSemanticsAction.setSelection,
             AndroidSemanticsAction.copy,
+            AndroidSemanticsAction.focus,
+            AndroidSemanticsAction.setSelection,
           ],
         ));
 
@@ -159,10 +164,11 @@ void main() {
           isEditable: true,
           isPassword: true,
           actions: <AndroidSemanticsAction>[
+            AndroidSemanticsAction.clearAccessibilityFocus,
             AndroidSemanticsAction.click,
-            AndroidSemanticsAction.accessibilityFocus,
-            AndroidSemanticsAction.setSelection,
             AndroidSemanticsAction.copy,
+            AndroidSemanticsAction.focus,
+            AndroidSemanticsAction.setSelection,
           ],
         ));
       });
@@ -185,8 +191,9 @@ void main() {
           isEnabled: true,
           isFocusable: true,
           actions: <AndroidSemanticsAction>[
-            AndroidSemanticsAction.click,
             AndroidSemanticsAction.accessibilityFocus,
+            AndroidSemanticsAction.click,
+            AndroidSemanticsAction.focus,
           ],
         ));
 
@@ -199,8 +206,9 @@ void main() {
           isEnabled: true,
           isFocusable: true,
           actions: <AndroidSemanticsAction>[
-            AndroidSemanticsAction.click,
             AndroidSemanticsAction.accessibilityFocus,
+            AndroidSemanticsAction.click,
+            AndroidSemanticsAction.focus,
           ],
         ));
         expect(await getSemantics(find.byValueKey(disabledCheckboxKeyValue)), hasAndroidSemantics(
@@ -209,6 +217,7 @@ void main() {
           isEnabled: false,
           actions: const <AndroidSemanticsAction>[
             AndroidSemanticsAction.accessibilityFocus,
+            AndroidSemanticsAction.focus,
           ],
         ));
       });
@@ -220,8 +229,9 @@ void main() {
           isEnabled: true,
           isFocusable: true,
           actions: <AndroidSemanticsAction>[
-            AndroidSemanticsAction.click,
             AndroidSemanticsAction.accessibilityFocus,
+            AndroidSemanticsAction.click,
+            AndroidSemanticsAction.focus,
           ],
         ));
 
@@ -234,8 +244,9 @@ void main() {
           isEnabled: true,
           isFocusable: true,
           actions: <AndroidSemanticsAction>[
-            AndroidSemanticsAction.click,
             AndroidSemanticsAction.accessibilityFocus,
+            AndroidSemanticsAction.click,
+            AndroidSemanticsAction.focus,
           ],
         ));
       });
@@ -247,8 +258,9 @@ void main() {
           isEnabled: true,
           isFocusable: true,
           actions: <AndroidSemanticsAction>[
-            AndroidSemanticsAction.click,
             AndroidSemanticsAction.accessibilityFocus,
+            AndroidSemanticsAction.click,
+            AndroidSemanticsAction.focus,
           ],
         ));
 
@@ -261,8 +273,9 @@ void main() {
           isEnabled: true,
           isFocusable: true,
           actions: <AndroidSemanticsAction>[
-            AndroidSemanticsAction.click,
             AndroidSemanticsAction.accessibilityFocus,
+            AndroidSemanticsAction.click,
+            AndroidSemanticsAction.focus,
           ],
         ));
       });
@@ -277,8 +290,9 @@ void main() {
           isFocusable: true,
           contentDescription: switchLabel,
           actions: <AndroidSemanticsAction>[
-            AndroidSemanticsAction.click,
             AndroidSemanticsAction.accessibilityFocus,
+            AndroidSemanticsAction.click,
+            AndroidSemanticsAction.focus,
           ],
         ));
       });

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -3488,6 +3488,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
     bool header,
     bool textField,
     bool readOnly,
+    bool focusable,
     bool focused,
     bool inMutuallyExclusiveGroup,
     bool obscured,
@@ -3539,6 +3540,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
        _header = header,
        _textField = textField,
        _readOnly = readOnly,
+       _focusable = focusable,
        _focused = focused,
        _inMutuallyExclusiveGroup = inMutuallyExclusiveGroup,
        _obscured = obscured,
@@ -3705,6 +3707,16 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
     if (readOnly == value)
       return;
     _readOnly = value;
+    markNeedsSemanticsUpdate();
+  }
+
+  /// If non-null, sets the [SemanticsNode.isFocusable] semantic to the given value.
+  bool get focusable => _focusable;
+  bool _focusable;
+  set focusable(bool value) {
+    if (focusable == value)
+      return;
+    _focusable = value;
     markNeedsSemanticsUpdate();
   }
 
@@ -4366,6 +4378,8 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
       config.isTextField = textField;
     if (readOnly != null)
       config.isReadOnly = readOnly;
+    if (focusable != null)
+      config.isFocusable = focusable;
     if (focused != null)
       config.isFocused = focused;
     if (inMutuallyExclusiveGroup != null)

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -594,6 +594,7 @@ class SemanticsProperties extends DiagnosticableTree {
     this.header,
     this.textField,
     this.readOnly,
+    this.focusable,
     this.focused,
     this.inMutuallyExclusiveGroup,
     this.hidden,
@@ -690,14 +691,25 @@ class SemanticsProperties extends DiagnosticableTree {
   /// TalkBack/VoiceOver will treat it as non-editable text field.
   final bool readOnly;
 
-  /// If non-null, whether the node currently holds input focus.
+  /// If non-null, whether the node currently is able to hold input focus.
   ///
-  /// At most one node in the tree should hold input focus at any point in time.
+  /// If [focusable] is set to false, then [focused] must not be true.
   ///
   /// Input focus (indicates that the node will receive keyboard events) is not
   /// to be confused with accessibility focus. Accessibility focus is the
-  /// green/black rectangular that TalkBack/VoiceOver on the screen and is
-  /// separate from input focus.
+  /// green/black rectangular highlight that TalkBack/VoiceOver draws around the
+  /// element it is reading, and is separate from input focus.
+  final bool focusable;
+
+  /// If non-null, whether the node currently holds input focus.
+  ///
+  /// At most one node in the tree should hold input focus at any point in time,
+  /// and it should not be set to true if [focusable] is false.
+  ///
+  /// Input focus (indicates that the node will receive keyboard events) is not
+  /// to be confused with accessibility focus. Accessibility focus is the
+  /// green/black rectangular highlight that TalkBack/VoiceOver draws around the
+  /// element it is reading, and is separate from input focus.
   final bool focused;
 
   /// If non-null, whether a semantic node is in a mutually exclusive group.
@@ -3601,6 +3613,12 @@ class SemanticsConfiguration {
   bool get isInMutuallyExclusiveGroup => _hasFlag(SemanticsFlag.isInMutuallyExclusiveGroup);
   set isInMutuallyExclusiveGroup(bool value) {
     _setFlag(SemanticsFlag.isInMutuallyExclusiveGroup, value);
+  }
+
+  /// Whether the owning [RenderObject] currently holds the user's focus.
+  bool get isFocusable => _hasFlag(SemanticsFlag.isFocusable);
+  set isFocusable(bool value) {
+    _setFlag(SemanticsFlag.isFocusable, value);
   }
 
   /// Whether the owning [RenderObject] currently holds the user's focus.

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -6187,6 +6187,7 @@ class Semantics extends SingleChildRenderObjectWidget {
     bool header,
     bool textField,
     bool readOnly,
+    bool focusable,
     bool focused,
     bool inMutuallyExclusiveGroup,
     bool obscured,
@@ -6240,6 +6241,7 @@ class Semantics extends SingleChildRenderObjectWidget {
       header: header,
       textField: textField,
       readOnly: readOnly,
+      focusable: focusable,
       focused: focused,
       inMutuallyExclusiveGroup: inMutuallyExclusiveGroup,
       obscured: obscured,
@@ -6352,6 +6354,7 @@ class Semantics extends SingleChildRenderObjectWidget {
       header: properties.header,
       textField: properties.textField,
       readOnly: properties.readOnly,
+      focusable: properties.focusable,
       focused: properties.focused,
       liveRegion: properties.liveRegion,
       maxValueLength: properties.maxValueLength,
@@ -6421,6 +6424,7 @@ class Semantics extends SingleChildRenderObjectWidget {
       ..header = properties.header
       ..textField = properties.textField
       ..readOnly = properties.readOnly
+      ..focusable = properties.focusable
       ..focused = properties.focused
       ..inMutuallyExclusiveGroup = properties.inMutuallyExclusiveGroup
       ..obscured = properties.obscured

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -433,7 +433,11 @@ class _FocusState extends State<Focus> {
     _focusAttachment.reparent();
     return _FocusMarker(
       node: focusNode,
-      child: widget.child,
+      child: Semantics(
+
+        focused: _hasFocus,
+        child: widget.child
+      ),
     );
   }
 }


### PR DESCRIPTION
## Description

This changes the expected accessibility actions/flags for Flutter controls in the `android_semantics_testing` integration test.

I also enhanced the fail message so that it includes a diff of the expected actions in a readable form.

It will be used to land a manual engine roll that includes the engine-side changes in https://github.com/flutter/engine/pull/12599, once the engine build has completed.

**This PR won't land until we have a new ref from the engine repo to include in the `engine.version` file.**

## Related Issues

- https://github.com/flutter/flutter/issues/40101

## Tests

- This is a test.

## Breaking Change

- [X] No, this is *not* a breaking change.