### PR TITLE
Added attribute to DropdownButton for separate style on expanded

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -610,6 +610,7 @@ class DropdownButton<T> extends StatefulWidget {
     @required this.onChanged,
     this.elevation = 8,
     this.style,
+    this.menuItemStyle,
     this.underline,
     this.icon,
     this.iconDisabledColor,
@@ -708,11 +709,19 @@ class DropdownButton<T> extends StatefulWidget {
   final int elevation;
 
   /// The text style to use for text in the dropdown button and the dropdown
-  /// menu that appears when you tap the button.
+  /// menu that appears when you tap the button. If you want to have a separate
+  /// text style for drop down menu when you tap the button then add
+  /// the [menuItemStyle] property.
   ///
   /// Defaults to the [TextTheme.subhead] value of the current
   /// [ThemeData.textTheme] of the current [Theme].
   final TextStyle style;
+
+  /// The text style to use for text in the dropdown menu that appears
+  /// when you tap the button.
+  ///
+  /// Defaults to the [style] value.
+  final TextStyle menuItemStyle;
 
   /// The widget to use for drawing the drop-down button's underline.
   ///
@@ -834,7 +843,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
       selectedIndex: _selectedIndex ?? 0,
       elevation: widget.elevation,
       theme: Theme.of(context, shadowThemeOnly: true),
-      style: _textStyle,
+      style: widget.menuItemStyle ?? _textStyle,
       barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
     );
 


### PR DESCRIPTION


## Description

In short, suppose the background of my container in `body` is blue and there is a `DropdownButton` in the center. Now, I set the `style` attribute of the `DropdownButton` to a `TextStyle` with color white. Now, since the background color is blue, text in dropdown is properly visible as white. But when I expand the dropdown on tap the text is not visible since the background of expanded menu item is white and also the text is white. A code example of the scenario I just described can be found [here](https://gist.github.com/shabab477/a4234951652221a38e39e3c8322b3292)

I solved this problem by adding a new attribute which lets developers have a different text style when drop down is expanded.

## Related Issues

- Issue: #17414

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
