### PR TITLE
Pass Linux build mode on command line

### DIFF
--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
+++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
@@ -17,11 +17,9 @@ import '../reporting/reporting.dart';
 
 /// Builds the Linux project through the Makefile.
 Future<void> buildLinux(LinuxProject linuxProject, BuildInfo buildInfo, {String target = 'lib/main.dart'}) async {
-  final String buildFlag = buildInfo?.isDebug == true ? 'debug' : 'release';
   final StringBuffer buffer = StringBuffer('''
 # Generated code do not commit.
 export FLUTTER_ROOT=${Cache.flutterRoot}
-export BUILD=$buildFlag
 export TRACK_WIDGET_CREATION=${buildInfo?.trackWidgetCreation == true}
 export FLUTTER_TARGET=$target
 export PROJECT_DIR=${linuxProject.project.directory.path}
@@ -48,12 +46,14 @@ export PROJECT_DIR=${linuxProject.project.directory.path}
   }
 
   // Invoke make.
+  final String buildFlag = getNameForBuildMode(buildInfo.mode ?? BuildMode.release);
   final Stopwatch sw = Stopwatch()..start();
   final Process process = await processManager.start(<String>[
     'make',
     '-C',
     linuxProject.makeFile.parent.path,
-  ], runInShell: true);
+    'BUILD=$buildFlag'
+  ]);
   final Status status = logger.startProgress(
     'Building Linux application...',
     timeout: null,

--- a/packages/flutter_tools/test/general.shard/commands/build_linux_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_linux_test.dart
@@ -52,6 +52,26 @@ void main() {
     when(notLinuxPlatform.isLinux).thenReturn(false);
   });
 
+  // Creates the mock files necessary to run a build.
+  void setUpMockProjectFilesForBuild() {
+    fs.file('linux/build.sh').createSync(recursive: true);
+    fs.file('pubspec.yaml').createSync();
+    fs.file('.packages').createSync();
+    fs.file(fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+  }
+
+  // Sets up mock expectation for running 'make'.
+  void expectMakeInvocationWithMode(String buildModeName) {
+    when(mockProcessManager.start(<String>[
+      'make',
+      '-C',
+      '/linux',
+      'BUILD=$buildModeName',
+    ])).thenAnswer((Invocation invocation) async {
+      return mockProcess;
+    });
+  }
+
   testUsingContext('Linux build fails when there is no linux project', () async {
     final BuildCommand command = BuildCommand();
     applyMocksToCommand(command);
@@ -67,10 +87,7 @@ void main() {
   testUsingContext('Linux build fails on non-linux platform', () async {
     final BuildCommand command = BuildCommand();
     applyMocksToCommand(command);
-    fs.file('linux/build.sh').createSync(recursive: true);
-    fs.file('pubspec.yaml').createSync();
-    fs.file('.packages').createSync();
-    fs.file(fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    setUpMockProjectFilesForBuild();
 
     expect(createTestCommandRunner(command).run(
       const <String>['build', 'linux']
@@ -84,23 +101,45 @@ void main() {
   testUsingContext('Linux build invokes make and writes temporary files', () async {
     final BuildCommand command = BuildCommand();
     applyMocksToCommand(command);
-    fs.file('linux/build.sh').createSync(recursive: true);
-    fs.file('pubspec.yaml').createSync();
-    fs.file('.packages').createSync();
-    fs.file(fs.path.join('lib', 'main.dart')).createSync(recursive: true);
-
-    when(mockProcessManager.start(<String>[
-      'make',
-      '-C',
-      '/linux',
-    ], runInShell: true)).thenAnswer((Invocation invocation) async {
-      return mockProcess;
-    });
+    setUpMockProjectFilesForBuild();
+    expectMakeInvocationWithMode('release');
 
     await createTestCommandRunner(command).run(
       const <String>['build', 'linux']
     );
     expect(fs.file('linux/flutter/ephemeral/generated_config.mk').existsSync(), true);
+  }, overrides: <Type, Generator>{
+    FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => mockProcessManager,
+    Platform: () => linuxPlatform,
+    FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
+  });
+
+  testUsingContext('Linux build --debug passes debug mode to make', () async {
+    final BuildCommand command = BuildCommand();
+    applyMocksToCommand(command);
+    setUpMockProjectFilesForBuild();
+    expectMakeInvocationWithMode('debug');
+
+    await createTestCommandRunner(command).run(
+      const <String>['build', 'linux', '--debug']
+    );
+  }, overrides: <Type, Generator>{
+    FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => mockProcessManager,
+    Platform: () => linuxPlatform,
+    FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
+  });
+
+  testUsingContext('Linux build --profile passes profile mode to make', () async {
+    final BuildCommand command = BuildCommand();
+    applyMocksToCommand(command);
+    setUpMockProjectFilesForBuild();
+    expectMakeInvocationWithMode('profile');
+
+    await createTestCommandRunner(command).run(
+      const <String>['build', 'linux', '--profile']
+    );
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(),
     ProcessManager: () => mockProcessManager,
@@ -138,18 +177,8 @@ BINARY_NAME=fizz_bar
   testUsingContext('Release build prints an under-construction warning', () async {
     final BuildCommand command = BuildCommand();
     applyMocksToCommand(command);
-    fs.file('linux/build.sh').createSync(recursive: true);
-    fs.file('pubspec.yaml').createSync();
-    fs.file('.packages').createSync();
-    fs.file(fs.path.join('lib', 'main.dart')).createSync(recursive: true);
-
-    when(mockProcessManager.start(<String>[
-      'make',
-      '-C',
-      '/linux',
-    ], runInShell: true)).thenAnswer((Invocation invocation) async {
-      return mockProcess;
-    });
+    setUpMockProjectFilesForBuild();
+    expectMakeInvocationWithMode('release');
 
     await createTestCommandRunner(command).run(
       const <String>['build', 'linux']


### PR DESCRIPTION
## Description

Currently Linux builds override the default BUILD mode by putting it in
the generated config. That makes it sticky for manual runs of make,
which is inconsistent with how other platforms work.

Instead, pass the build mode as a command-line override, the same way
someone would if building directly with make. This makes the flow of
controlling the mode less confusing.

Minor incidental cleanup:
- Removes `runInShell: true` from the `make` call, as it's not needed, and running through the shell is generally more error-prone.
- Passes `profile` for Profile builds, rather than `release`. It currently won't build differently, but it's one less place that there's a hard-coded bypass of profile mode to clean up later.

## Related Issues

Fixes #41528

## Tests

I added the following tests: verify that release, profile, and debug all pass the correct override.

Also pulled some common test setup for the Linux build tests into helper functions.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
