### PR TITLE
[Material] Remove the wrong elevation (#387)

### DIFF
--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -773,7 +773,7 @@ class _MaterialInteriorState extends AnimatedWidgetBaseState<_MaterialInterior> 
         textDirection: Directionality.of(context),
       ),
       clipBehavior: widget.clipBehavior,
-      elevation: elevation,
+      elevation: 0,
       color: _elevationOverlayColor(context, widget.color, elevation),
       shadowColor: _shadowColor.evaluate(animation),
     );


### PR DESCRIPTION
## Description

* With elevation: elevation and color: _elevationOverlayColor(context, widget.color, elevation), the final color will mix twice.
The expected color has no relationship with shadowColor, so we need to remove the elevation value.

* Before :  see https://github.com/flutter/flutter/issues/387#issuecomment-455474221
* After 
![after_code](https://user-images.githubusercontent.com/3965102/65830395-a7aa8500-e2e1-11e9-907c-039518a1310b.gif)

* Reproduce code : see https://github.com/flutter/flutter/issues/387#issuecomment-455474221

## Related Issues

#387

## Tests

N/A

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
