### PR TITLE
track unused inputs in build_runner

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/build_script.dart
+++ b/packages/flutter_tools/lib/src/build_runner/build_script.dart
@@ -148,9 +148,11 @@ final List<core.BuilderApplication> builders = <core.BuilderApplication>[
               librariesPath: path.absolute(path.join(builderOptions.config['flutterWebSdk'], 'libraries.json')),
               kernelTargetName: 'ddc',
               useIncrementalCompiler: true,
+              trackUnusedInputs: true,
             ),
         (BuilderOptions builderOptions) => DevCompilerBuilder(
               useIncrementalCompiler: true,
+              trackUnusedInputs: true,
               platform: flutterWebPlatform,
               platformSdk: builderOptions.config['flutterWebSdk'],
               sdkKernelPath: path.url.join('kernel', 'flutter_ddc_sdk.dill'),


### PR DESCRIPTION
Enables dependency tracking for ddc/kernel which tracks actual used deps for each action.

This makes api edits invalidate fewer actions.