### PR TITLE
Rename Server/web to Headless Server/headless-server

### DIFF
--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -190,7 +190,7 @@ String parseVersionForWindows(String input) {
 /// A special device type to allow serving for arbitrary browsers.
 class WebServerDevice extends Device {
   WebServerDevice() : super(
-    'web',
+    'headless-server',
     platformType: PlatformType.web,
     category: Category.web,
     ephemeral: false,
@@ -228,7 +228,7 @@ class WebServerDevice extends Device {
   }
 
   @override
-  String get name => 'Server';
+  String get name => 'Headless Server';
 
   @override
   DevicePortForwarder get portForwarder => const NoOpDevicePortForwarder();

--- a/packages/flutter_tools/test/general.shard/web/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devices_test.dart
@@ -48,8 +48,8 @@ void main() {
   test('Server defaults', () async {
     final WebServerDevice device = WebServerDevice();
 
-    expect(device.name, 'Server');
-    expect(device.id, 'web');
+    expect(device.name, 'Headless Server');
+    expect(device.id, 'headless-server');
     expect(device.supportsHotReload, true);
     expect(device.supportsHotRestart, true);
     expect(device.supportsStartPaused, true);


### PR DESCRIPTION
## Description

Per previous offline discussion, this name better captures the device kind