### PR TITLE
change logging in mDNS discovery to verbose-mode only

### DIFF
--- a/packages/flutter_tools/lib/src/mdns_discovery.dart
+++ b/packages/flutter_tools/lib/src/mdns_discovery.dart
@@ -51,7 +51,7 @@ class MDnsObservatoryDiscovery {
   /// it will return that instance's information regardless of what application
   /// the Observatory instance is for.
   Future<MDnsObservatoryDiscoveryResult> query({String applicationId}) async {
-    printStatus('Checking for advertised Dart observatories...');
+    printTrace('Checking for advertised Dart observatories...');
     try {
       await client.start();
       final List<PtrResourceRecord> pointerRecords = await client
@@ -92,7 +92,7 @@ class MDnsObservatoryDiscovery {
       } else {
         domainName = pointerRecords[0].domainName;
       }
-      printStatus('Checking for available port on $domainName');
+      printTrace('Checking for available port on $domainName');
       // Here, if we get more than one, it should just be a duplicate.
       final List<SrvResourceRecord> srv = await client
           .lookup<SrvResourceRecord>(
@@ -106,7 +106,7 @@ class MDnsObservatoryDiscovery {
         printError('Unexpectedly found more than one observatory report for $domainName '
                    '- using first one (${srv.first.port}).');
       }
-      printStatus('Checking for authentication code for $domainName');
+      printTrace('Checking for authentication code for $domainName');
       final List<TxtResourceRecord> txt = await client
         .lookup<TxtResourceRecord>(
             ResourceRecordQuery.text(domainName),


### PR DESCRIPTION
This change brings the non verbose `flutter run` to be the same as it was prior to my mDNS refactor in https://github.com/flutter/flutter/pull/40447.