### PR TITLE
Update DefaultTabController to allow for zero tabs

### DIFF
--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -313,7 +313,7 @@ class DefaultTabController extends StatefulWidget {
     @required this.child,
   }) : assert(initialIndex != null),
        assert(length >= 0),
-       assert(initialIndex >= 0 && initialIndex < length),
+       assert(length == 0 || (initialIndex >= 0 && initialIndex < length)),
        super(key: key);
 
   /// The total number of tabs.

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2394,7 +2394,7 @@ void main() {
                         },
                       ),
                       IconButton(
-                        key: const Key('Del tab'),
+                        key: const Key('Delete tab'),
                         icon: const Icon(Icons.delete),
                         onPressed: () {
                           setState(() {
@@ -2418,7 +2418,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Tab 1'), findsOneWidget);
     expect(find.text('Tab 1\'s view'), findsOneWidget);
-    await tester.tap(find.byKey(const Key('Del tab')));
+    await tester.tap(find.byKey(const Key('Delete tab')));
     await tester.pumpAndSettle();
     expect(find.text('No tabs'), findsOneWidget);
   });

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2350,4 +2350,76 @@ void main() {
     expect(find.text('Tab1'), findsOneWidget);
     expect(find.text('Tab2'), findsOneWidget);
   });
+
+  testWidgets('DefaultTabController should allow for a length of zero', (WidgetTester tester) async {
+    List<String> tabTextContent = <String>[];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return DefaultTabController(
+              length: tabTextContent.length,
+              child: Scaffold(
+                appBar: AppBar(
+                  title: const Text('Default TabBar Preview'),
+                  bottom: tabTextContent.isNotEmpty
+                    ? TabBar(
+                      isScrollable: true,
+                      tabs: tabTextContent.map((String textContent) {
+                        return Tab(text: textContent);
+                      }).toList(),
+                    )
+                    : null,
+                ),
+                body: tabTextContent.isNotEmpty
+                  ? TabBarView(
+                    children: tabTextContent.map((String textContent) {
+                      return Tab(text: '$textContent\'s view');
+                    }).toList())
+                  : const Center(child: Text('No tabs')),
+                bottomNavigationBar: BottomAppBar(
+                  child: Row(
+                    mainAxisSize: MainAxisSize.max,
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: <Widget>[
+                      IconButton(
+                        key: const Key('Add tab'),
+                        icon: const Icon(Icons.add),
+                        onPressed: () {
+                          setState(() {
+                            tabTextContent = List<String>.from(tabTextContent)
+                              ..add('Tab ${tabTextContent.length + 1}');
+                          });
+                        },
+                      ),
+                      IconButton(
+                        key: const Key('Del tab'),
+                        icon: const Icon(Icons.delete),
+                        onPressed: () {
+                          setState(() {
+                            tabTextContent = List<String>.from(tabTextContent)
+                              ..removeLast();
+                          });
+                        },
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    expect(find.text('No tabs'), findsOneWidget);
+    await tester.tap(find.byKey(const Key('Add tab')));
+    await tester.pumpAndSettle();
+    expect(find.text('Tab 1'), findsOneWidget);
+    expect(find.text('Tab 1\'s view'), findsOneWidget);
+    await tester.tap(find.byKey(const Key('Del tab')));
+    await tester.pumpAndSettle();
+    expect(find.text('No tabs'), findsOneWidget);
+  });
 }

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2411,11 +2411,14 @@ void main() {
       ),
     );
 
+    // Initializes with zero tabs properly
     expect(find.text('No tabs'), findsOneWidget);
     await tester.tap(find.byKey(const Key('Add tab')));
     await tester.pumpAndSettle();
     expect(find.text('Tab 1'), findsOneWidget);
     expect(find.text('Tab 1\'s view'), findsOneWidget);
+
+    // Dynamically updates to zero tabs properly
     await tester.tap(find.byKey(const Key('Delete tab')));
     await tester.pumpAndSettle();
     expect(find.text('No tabs'), findsOneWidget);

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2352,6 +2352,7 @@ void main() {
   });
 
   testWidgets('DefaultTabController should allow for a length of zero', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/20292.
     List<String> tabTextContent = <String>[];
 
     await tester.pumpWidget(
@@ -2365,18 +2366,15 @@ void main() {
                   title: const Text('Default TabBar Preview'),
                   bottom: tabTextContent.isNotEmpty
                     ? TabBar(
-                      isScrollable: true,
-                      tabs: tabTextContent.map((String textContent) {
-                        return Tab(text: textContent);
-                      }).toList(),
-                    )
+                       isScrollable: true,
+                       tabs: tabTextContent.map((String textContent) => Tab(text: textContent)).toList(),
+                     )
                     : null,
                 ),
                 body: tabTextContent.isNotEmpty
                   ? TabBarView(
-                    children: tabTextContent.map((String textContent) {
-                      return Tab(text: '$textContent\'s view');
-                    }).toList())
+                      children: tabTextContent.map((String textContent) => Tab(text: '$textContent\'s view')).toList()
+                    )
                   : const Center(child: Text('No tabs')),
                 bottomNavigationBar: BottomAppBar(
                   child: Row(


### PR DESCRIPTION
## Description

A continuation of https://github.com/flutter/flutter/pull/37140. This change prevents an assert error when the DefaultTabController is created and contains no tabs.

Credit for work primarily goes to @matthew5025.

## Related Issues

Fixes #37139

## Tests

I added the following tests:
- A test to verify that a length of zero is allowed for `DefaultTabController`s

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
