### PR TITLE
Use processManager.run() instead of manually capturing streams in test_utils getPackages()

### DIFF
--- a/packages/flutter_tools/test/integration.shard/test_utils.dart
+++ b/packages/flutter_tools/test/integration.shard/test_utils.dart
@@ -46,13 +46,8 @@ Future<void> getPackages(String folder) async {
     'pub',
     'get',
   ];
-  final Process process = await processManager.start(command, workingDirectory: folder);
-  final StringBuffer output = StringBuffer();
-  final StringBuffer errorOutput = StringBuffer();
-  process.stdout.transform(utf8.decoder).listen(output.write);
-  process.stderr.transform(utf8.decoder).listen(errorOutput.write);
-  final int exitCode = await process.exitCode;
-  if (exitCode != 0) {
-    throw Exception('flutter pub get failed: $errorOutput\n$output');
+  final ProcessResult result = await processManager.run(command, workingDirectory: folder);
+  if (result.exitCode != 0) {
+    throw Exception('flutter pub get failed: ${result.stderr}\n${result.stdout}');
   }
 }

--- a/packages/flutter_tools/test/integration.shard/test_utils.dart
+++ b/packages/flutter_tools/test/integration.shard/test_utils.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';

--- a/packages/flutter_tools/test/integration.shard/test_utils.dart
+++ b/packages/flutter_tools/test/integration.shard/test_utils.dart
@@ -47,10 +47,12 @@ Future<void> getPackages(String folder) async {
     'get',
   ];
   final Process process = await processManager.start(command, workingDirectory: folder);
+  final StringBuffer output = StringBuffer();
   final StringBuffer errorOutput = StringBuffer();
+  process.stdout.transform(utf8.decoder).listen(output.write);
   process.stderr.transform(utf8.decoder).listen(errorOutput.write);
   final int exitCode = await process.exitCode;
   if (exitCode != 0) {
-    throw Exception('flutter pub get failed: $errorOutput');
+    throw Exception('flutter pub get failed: $errorOutput\n$output');
   }
 }


### PR DESCRIPTION
@Hixie found some hanging tests on Windows. I did some digging and found that if we don't listen to stdout for this spawned process (which fetches packages in integration tests), the process never ends, and the tests hang in their setup phase:

https://github.com/flutter/flutter/issues/36476#issuecomment-537013916

I don't understand why this happens (whether it's a Dart bug, a Windows bug, or something else) but if we collect stdout to include in the message, then we don't see this problem 🤷‍♂ 