### PR TITLE
Download android x64 release artifacts

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -1221,6 +1221,7 @@ const List<List<String>> _androidBinaryDirs = <List<String>>[
   <String>['android-arm64', 'android-arm64/artifacts.zip'],
   <String>['android-arm64-profile', 'android-arm64-profile/artifacts.zip'],
   <String>['android-arm64-release', 'android-arm64-release/artifacts.zip'],
+  <String>['android-x64-release', 'android-x64-release/artifacts.zip'],
 ];
 
 const List<List<String>> _dartSdks = <List<String>> [


### PR DESCRIPTION
## Description

Adds these artifacts to the download cache under android-x64-release.

https://github.com/flutter/flutter/issues/9253

cc @chingjun 