### PR TITLE
Update label applied for performance template bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/performance.md
+++ b/.github/ISSUE_TEMPLATE/performance.md
@@ -1,5 +1,5 @@
 ---
-name: I have a performance problem with my application
+name: My app is slow or missing frames.
 about: You are writing an application but have discovered that it is slow, you are
   not hitting 60Hz, or you are getting jank (missed frames).
 title: ''

--- a/.github/ISSUE_TEMPLATE/performance.md
+++ b/.github/ISSUE_TEMPLATE/performance.md
@@ -3,7 +3,7 @@ name: I have a performance problem with my application
 about: You are writing an application but have discovered that it is slow, you are
   not hitting 60Hz, or you are getting jank (missed frames).
 title: ''
-labels: 'severe: performance'
+labels: 'created via performance template'
 assignees: ''
 
 ---


### PR DESCRIPTION
Sometimes, people use this template even though the issue may not actually be a `servere: performance` issue. This should help with traige of these bugs - we can still apply the performance label if it is relevant.

Fixes: https://github.com/flutter/flutter/issues/41655

/cc @stuartmorgan @Hixie @liyuqian

