### PR TITLE
Allow customization of label styles for semantics debugger

### DIFF
--- a/packages/flutter/lib/src/widgets/semantics_debugger.dart
+++ b/packages/flutter/lib/src/widgets/semantics_debugger.dart
@@ -22,9 +22,11 @@ class SemanticsDebugger extends StatefulWidget {
   /// Creates a widget that visualizes the semantics for the child.
   ///
   /// The [child] argument must not be null.
+  ///
+  /// [labelStyle] dictates the [TextStyle] used for the semantics labels.
   const SemanticsDebugger({
     Key key,
-    this.child,
+    @required this.child,
     this.labelStyle = const TextStyle(
       color: Color(0xFF000000),
       fontSize: 10.0,

--- a/packages/flutter/lib/src/widgets/semantics_debugger.dart
+++ b/packages/flutter/lib/src/widgets/semantics_debugger.dart
@@ -22,12 +22,25 @@ class SemanticsDebugger extends StatefulWidget {
   /// Creates a widget that visualizes the semantics for the child.
   ///
   /// The [child] argument must not be null.
-  const SemanticsDebugger({ Key key, this.child }) : super(key: key);
+  const SemanticsDebugger({
+    Key key,
+    this.child,
+    this.labelStyle = const TextStyle(
+      color: Color(0xFF000000),
+      fontSize: 10.0,
+      height: 0.8,
+    ),
+  }) : assert(child != null),
+       assert(labelStyle != null),
+       super(key: key);
 
   /// The widget below this widget in the tree.
   ///
   /// {@macro flutter.widgets.child}
   final Widget child;
+
+  /// The [TextStyle] to use when rendering semantics labels.
+  final TextStyle labelStyle;
 
   @override
   _SemanticsDebuggerState createState() => _SemanticsDebuggerState();
@@ -150,6 +163,7 @@ class _SemanticsDebuggerState extends State<SemanticsDebugger> with WidgetsBindi
         _client.generation,
         _lastPointerDownLocation, // in physical pixels
         WidgetsBinding.instance.window.devicePixelRatio,
+        widget.labelStyle,
       ),
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
@@ -195,12 +209,13 @@ class _SemanticsClient extends ChangeNotifier {
 }
 
 class _SemanticsDebuggerPainter extends CustomPainter {
-  const _SemanticsDebuggerPainter(this.owner, this.generation, this.pointerPosition, this.devicePixelRatio);
+  const _SemanticsDebuggerPainter(this.owner, this.generation, this.pointerPosition, this.devicePixelRatio, this.labelStyle);
 
   final PipelineOwner owner;
   final int generation;
   final Offset pointerPosition; // in physical pixels
   final double devicePixelRatio;
+  final TextStyle labelStyle;
 
   SemanticsNode get _rootSemanticsNode {
     return owner.semanticsOwner?.rootSemanticsNode;
@@ -306,11 +321,7 @@ class _SemanticsDebuggerPainter extends CustomPainter {
     canvas.clipRect(rect);
     final TextPainter textPainter = TextPainter()
       ..text = TextSpan(
-        style: const TextStyle(
-          color: Color(0xFF000000),
-          fontSize: 10.0,
-          height: 0.8,
-        ),
+        style: labelStyle,
         text: message,
       )
       ..textDirection = TextDirection.ltr // _getMessage always returns LTR text, even if node.label is RTL

--- a/packages/flutter/test/widgets/semantics_debugger_test.dart
+++ b/packages/flutter/test/widgets/semantics_debugger_test.dart
@@ -460,6 +460,26 @@ void main() {
       'textfield',
     );
   });
+
+  testWidgets('SemanticsDebugger label style is used in the painter.', (WidgetTester tester) async {
+    final UniqueKey debugger = UniqueKey();
+    const TextStyle labelStyle = TextStyle(color: Colors.amber);
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: SemanticsDebugger(
+          key: debugger,
+          labelStyle: labelStyle,
+          child: Semantics(
+            label: 'label',
+            textDirection: TextDirection.ltr,
+          ),
+        ),
+      ),
+    );
+
+    expect(_getSemanticsDebuggerPainter(debuggerKey: debugger, tester: tester).labelStyle, labelStyle);
+  });
 }
 
 String _getMessageShownInSemanticsDebugger({


### PR DESCRIPTION
SemanticsDebugger uses the system font by default.

On certain platforms (such as flutter_tester) this defaults to box font which is not readable. If users wish to use screendiff tests for a11y via flutter_tester, they can now wrap their widgets in SemanticsDebugger and pass a label style to produce proper labels.