### PR TITLE
handle empty entry in asset list and add more explicit validation

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -191,11 +191,24 @@ class FlutterManifest {
     if (assets == null) {
       return const <Uri>[];
     }
-    return assets
-        .cast<String>()
-        .map<String>(Uri.encodeFull)
-        ?.map<Uri>(Uri.parse)
-        ?.toList();
+    final List<Uri> results = <Uri>[];
+    for (Object asset in assets) {
+      if (asset is! String) {
+        printError('Asset manifest contains invalid uri: $asset.');
+        continue;
+      }
+      final String stringAsset = asset;
+      if (stringAsset == null || stringAsset.isEmpty) {
+        printError('Asset manifest contains invalid uri: $asset.');
+        continue;
+      }
+      try {
+        results.add(Uri.parse(Uri.encodeFull(stringAsset)));
+      } on FormatException {
+        printError('Asset manifest contains invalid uri: $asset.');
+      }
+    }
+    return results;
   }
 
   List<Font> _fonts;

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -186,22 +186,20 @@ class FlutterManifest {
         : fontList.map<Map<String, dynamic>>(castStringKeyedMap).toList();
   }
 
-  List<Uri> get assets {
+  List<Uri> get assets => _assets ??= _computeAssets();
+  List<Uri> _assets;
+  List<Uri> _computeAssets() {
     final List<dynamic> assets = _flutterDescriptor['assets'];
     if (assets == null) {
       return const <Uri>[];
     }
     final List<Uri> results = <Uri>[];
     for (Object asset in assets) {
-      if (asset is! String) {
-        printError('Asset manifest contains invalid uri: $asset.');
+      if (asset is! String || asset == null || asset == '') {
+        printError('Asset manifest contains a null or empty uri.');
         continue;
       }
       final String stringAsset = asset;
-      if (stringAsset == null || stringAsset.isEmpty) {
-        printError('Asset manifest contains invalid uri: $asset.');
-        continue;
-      }
       try {
         results.add(Uri.parse(Uri.encodeFull(stringAsset)));
       } on FormatException {

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
@@ -594,26 +594,6 @@ flutter:
     });
   });
 
-  testUsingContext('Does not crash on invalid URI', () async {
-      final BufferLogger logger = context.get<Logger>();
-      const String manifest = '''
-name: test
-dependencies:
-  flutter:
-    sdk: flutter
-flutter:
-  uses-material-design: true
-  fonts:
-    - family: foo
-      fonts:
-        - asset: a/bar
-    - string
-''';
-      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
-      expect(flutterManifest, null);
-      expect(logger.errorText, contains('Expected a map.'));
-    });
-
   group('FlutterManifest with MemoryFileSystem', () {
     Future<void> assertSchemaIsReadable() async {
       const String manifest = '''

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
@@ -572,7 +572,47 @@ flutter:
       expect(flutterManifest, null);
       expect(logger.errorText, contains('Expected a map.'));
     });
+
+    testUsingContext('Does not crash on empty entry', () async {
+      final BufferLogger logger = context.get<Logger>();
+      const String manifest = '''
+name: test
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+  uses-material-design: true
+  assets:
+    - lib/gallery/example_code.dart
+    -
+''';
+      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
+      final List<Uri> assets = flutterManifest.assets;
+
+      expect(logger.errorText, contains('Asset manifest contains invalid uri: null.'));
+      expect(assets.length, 1);
+    });
   });
+
+  testUsingContext('Does not crash on invalid URI', () async {
+      final BufferLogger logger = context.get<Logger>();
+      const String manifest = '''
+name: test
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+  uses-material-design: true
+  fonts:
+    - family: foo
+      fonts:
+        - asset: a/bar
+    - string
+''';
+      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
+      expect(flutterManifest, null);
+      expect(logger.errorText, contains('Expected a map.'));
+    });
 
   group('FlutterManifest with MemoryFileSystem', () {
     Future<void> assertSchemaIsReadable() async {

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
@@ -589,7 +589,7 @@ flutter:
       final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
       final List<Uri> assets = flutterManifest.assets;
 
-      expect(logger.errorText, contains('Asset manifest contains invalid uri: null.'));
+      expect(logger.errorText, contains('Asset manifest contains a null or empty uri.'));
       expect(assets.length, 1);
     });
   });


### PR DESCRIPTION
## Description
Fix an error not caught by validation, where an empty string '' would fail when attempting to Uri encode it. Added test case and made error handling of asset parsing more explicit.

Fixes https://github.com/flutter/flutter/issues/41702