### PR TITLE
Disable CPU/GPU measurement on BackdropFilter test

### DIFF
--- a/dev/devicelab/bin/tasks/backdrop_filter_perf_ios__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/backdrop_filter_perf_ios__timeline_summary.dart
@@ -10,5 +10,5 @@ import 'package:flutter_devicelab/framework/framework.dart';
 
 Future<void> main() async {
   deviceOperatingSystem = DeviceOperatingSystem.ios;
-  await task(createBackdropFilterPerfTest(needsMeasureCpuGpu: true));
+  await task(createBackdropFilterPerfTest());
 }


### PR DESCRIPTION
This test is flaky if CPU/GPU measurement is enabled due to
https://github.com/flutter/flutter/issues/41577
