### PR TITLE
Add support for downloading x86 JIT release artifact

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -1222,6 +1222,7 @@ const List<List<String>> _androidBinaryDirs = <List<String>>[
   <String>['android-arm64-profile', 'android-arm64-profile/artifacts.zip'],
   <String>['android-arm64-release', 'android-arm64-release/artifacts.zip'],
   <String>['android-x64-release', 'android-x64-release/artifacts.zip'],
+  <String>['android-x86-jit-release', 'android-x86-jit-release/artifacts.zip'],
 ];
 
 const List<List<String>> _dartSdks = <List<String>> [


### PR DESCRIPTION
## Description

This must be used with a kernel_blob.bin artifact that is _not_ built in AOT mode, but contains `dDart.vm.product=true`.


https://github.com/flutter/flutter/issues/9253