### PR TITLE
Revert "Dsiable CPU/GPU measurement on BackdropFilter test (#41736)"

### DIFF
--- a/dev/devicelab/bin/tasks/backdrop_filter_perf_ios__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/backdrop_filter_perf_ios__timeline_summary.dart
@@ -10,5 +10,5 @@ import 'package:flutter_devicelab/framework/framework.dart';
 
 Future<void> main() async {
   deviceOperatingSystem = DeviceOperatingSystem.ios;
-  await task(createBackdropFilterPerfTest());
+  await task(createBackdropFilterPerfTest(needsMeasureCpuGpu: true));
 }


### PR DESCRIPTION
This reverts c9d920f3015e8fb158b5717758bafe6d555ca630  so that we can attempt to fix the build.  The build dashboard clearly shows that things started failing at this change, although it's not totally clear that it is the cause: tests succeed locally.

If it doesn't fix things we can re-land this.