### PR TITLE
Reduce log verbosity by removing individual used files

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -1222,6 +1222,7 @@ const List<List<String>> _androidBinaryDirs = <List<String>>[
   <String>['android-arm64-profile', 'android-arm64-profile/artifacts.zip'],
   <String>['android-arm64-release', 'android-arm64-release/artifacts.zip'],
   <String>['android-x64-release', 'android-x64-release/artifacts.zip'],
+  <String>['android-x86-jit-release', 'android-x86-jit-release/artifacts.zip'],
 ];
 
 const List<List<String>> _dartSdks = <List<String>> [

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -1222,7 +1222,6 @@ const List<List<String>> _androidBinaryDirs = <List<String>>[
   <String>['android-arm64-profile', 'android-arm64-profile/artifacts.zip'],
   <String>['android-arm64-release', 'android-arm64-release/artifacts.zip'],
   <String>['android-x64-release', 'android-x64-release/artifacts.zip'],
-  <String>['android-x86-jit-release', 'android-x86-jit-release/artifacts.zip'],
 ];
 
 const List<List<String>> _dartSdks = <List<String>> [

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -101,7 +101,6 @@ class StdoutHandler {
   bool _badState = false;
 
   void handler(String message) {
-    printTrace('-> $message');
     if (_badState) {
       return;
     }

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -525,7 +525,6 @@ class ResidentCompiler {
     printTrace('<- recompile $mainUri$inputKey');
     for (Uri fileUri in request.invalidatedFiles) {
       _server.stdin.writeln(_mapFileUri(fileUri.toString(), packageUriMapper));
-      printTrace('<- ${_mapFileUri(fileUri.toString(), packageUriMapper)}');
     }
     _server.stdin.writeln(inputKey);
     printTrace('<- $inputKey');


### PR DESCRIPTION
## Description

The verbose logs are currently too verbose. We don't need to see every source file used in the compilation twice (once when provided, once when returned)