### PR TITLE
Updated the docstring for SystemNavigator.pop.

### DIFF
--- a/packages/flutter/lib/src/services/system_navigator.dart
+++ b/packages/flutter/lib/src/services/system_navigator.dart
@@ -10,15 +10,20 @@ import 'system_channels.dart';
 class SystemNavigator {
   SystemNavigator._();
 
-  /// Instructs the system navigator to remove this activity from the stack and
-  /// return to the previous activity.
+  /// Removes the topmost Flutter instance, presenting what was before
+  /// it.
   ///
-  /// On iOS, calls to this method are ignored because Apple's human interface
-  /// guidelines state that applications should not exit themselves.
+  /// On Android, removes this activity from the stack and returns to
+  /// the previous activity.
   ///
-  /// This method should be preferred over calling `dart:io`'s [exit] method, as
-  /// the latter may cause the underlying platform to act as if the application
-  /// had crashed.
+  /// On iOS, calls `popViewControllerAnimated:` if the root view
+  /// controller is a `UINavigationController`, or
+  /// `dismissViewControllerAnimated:completion:` if the top view
+  /// controller is a `FlutterViewController`.
+  ///
+  /// This method should be preferred over calling `dart:io`'s [exit]
+  /// method, as the latter may cause the underlying platform to act
+  /// as if the application had crashed.
   static Future<void> pop() async {
     await SystemChannels.platform.invokeMethod<void>('SystemNavigator.pop');
   }


### PR DESCRIPTION
##  Description

Updated the docstring for SystemNavigator.pop.  It had an Android bias and was incorrect for iOS.

## Related Issues

https://github.com/flutter/flutter/issues/33000

## Tests

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
