### PR TITLE
Reland "Dsiable CPU/GPU measurement on BackdropFilter test (#41736)"

### DIFF
--- a/dev/devicelab/bin/tasks/backdrop_filter_perf_ios__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/backdrop_filter_perf_ios__timeline_summary.dart
@@ -10,5 +10,5 @@ import 'package:flutter_devicelab/framework/framework.dart';
 
 Future<void> main() async {
   deviceOperatingSystem = DeviceOperatingSystem.ios;
-  await task(createBackdropFilterPerfTest(needsMeasureCpuGpu: true));
+  await task(createBackdropFilterPerfTest());
 }


### PR DESCRIPTION
Reverts flutter/flutter#41780

The attempted revert doesn't fix the problem, so we'll reland.