### PR TITLE
run services tests on the Web

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -465,13 +465,12 @@ Future<void> _runTests() async {
 }
 
 Future<void> _runWebTests() async {
-  // TODO(yjbanov): re-enable when web test cirrus flakiness is resolved
   await _runFlutterWebTest(path.join(flutterRoot, 'packages', 'flutter'), tests: <String>[
     'test/foundation/',
     'test/physics/',
+    'test/services/',
     // TODO(yjbanov): re-enable when flakiness is resolved
     // 'test/rendering/',
-    // 'test/services/',
     // 'test/painting/',
     // 'test/scheduler/',
     // 'test/semantics/',

--- a/packages/flutter/test/services/channel_buffers_test.dart
+++ b/packages/flutter/test/services/channel_buffers_test.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(yjbanov): enable Web when https://github.com/flutter/engine/pull/12747 rolls into the framework.
+@TestOn('!chrome')
+
 import 'dart:convert';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
@@ -39,7 +42,7 @@ void main() {
     bool didDrainData = false;
     binding.defaultBinaryMessenger.setMessageHandler(channel, (ByteData message) async {
       expect(_getString(message), payload);
-      didDrainData= true;
+      didDrainData = true;
       return null;
     });
     // Flush the event queue.


### PR DESCRIPTION
## Description

Run `test/services/` tests on CI for the Web. Temporarily `channel_buffers_test.dart` is disabled until https://github.com/flutter/engine/pull/12747 lands.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
