### PR TITLE
[web] Make it clear that lowercase "r" can also perform hot restart

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -120,7 +120,7 @@ class ResidentWebRunner extends ResidentRunner {
     }
     const String fire = '🔥';
     const String rawMessage =
-        '  To hot restart (and rebuild state), press "R".';
+        '  To hot restart (and rebuild state), press "r" or "R".';
     final String message = terminal.color(
       fire + terminal.bolden(rawMessage),
       TerminalColor.red,


### PR DESCRIPTION
When running a flutter web app, make it clear in the command line output that pressing "r" also performs a hot restart.
