### PR TITLE
Set DEFINES_MODULE=YES in plugin templates

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -881,6 +881,7 @@ Future<void> _runIntegrationTests() async {
         await _runDevicelabTest('flutter_create_offline_test_windows');
       } else if (Platform.isMacOS) {
         await _runDevicelabTest('flutter_create_offline_test_mac');
+        await _runDevicelabTest('plugin_lint_mac');
 // TODO(jmagman): Re-enable once flakiness is resolved.
 //        await _runDevicelabTest('module_test_ios');
       }

--- a/dev/devicelab/bin/tasks/plugin_lint_mac.dart
+++ b/dev/devicelab/bin/tasks/plugin_lint_mac.dart
@@ -1,0 +1,69 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/framework/utils.dart';
+import 'package:path/path.dart' as path;
+
+/// Tests that the Flutter plugin template works. Use `pod lib lint`
+/// to confirm the plugin module can be imported into an app.
+Future<void> main() async {
+  await task(() async {
+    section('Create Objective-C iOS plugin');
+
+    final Directory tempDir = Directory.systemTemp.createTempSync('flutter_plugin_test.');
+    try {
+      const String objcPluginName = 'test_plugin_objc';
+      await inDirectory(tempDir, () async {
+        await flutter(
+          'create',
+          options: <String>[
+            '--org',
+            'io.flutter.devicelab',
+            '--template=plugin',
+            '--ios-language=objc',
+            objcPluginName,
+          ],
+        );
+      });
+
+      final String objcPodspecPath = path.join(tempDir.path, objcPluginName, 'ios', '$objcPluginName.podspec');
+      section('Lint Objective-C iOS plugin as framework');
+      await inDirectory(tempDir, () async {
+        await exec(
+          'pod',
+          <String>[
+            'lib',
+            'lint',
+            objcPodspecPath,
+            '--allow-warnings',
+          ],
+        );
+      });
+
+      section('Lint Objective-C iOS plugin as library');
+      await inDirectory(tempDir, () async {
+        await exec(
+          'pod',
+          <String>[
+            'lib',
+            'lint',
+            objcPodspecPath,
+            '--allow-warnings',
+            '--use-libraries',
+          ],
+        );
+      });
+
+      return TaskResult.success(null);
+    } catch (e) {
+      return TaskResult.failure(e.toString());
+    } finally {
+      rmTree(tempDir);
+    }
+  });
+}

--- a/packages/flutter_tools/templates/plugin/ios.tmpl/projectName.podspec.tmpl
+++ b/packages/flutter_tools/templates/plugin/ios.tmpl/projectName.podspec.tmpl
@@ -1,5 +1,6 @@
 #
-# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
+# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
+# Run `pod lib lint {{projectName}}.podspec' to validate before publishing.
 #
 Pod::Spec.new do |s|
   s.name             = '{{projectName}}'
@@ -15,7 +16,6 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-
-  s.ios.deployment_target = '8.0'
+  s.platform = :ios, '8.0'
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
 end
-

--- a/packages/flutter_tools/templates/plugin/ios.tmpl/projectName.podspec.tmpl
+++ b/packages/flutter_tools/templates/plugin/ios.tmpl/projectName.podspec.tmpl
@@ -17,5 +17,7 @@ Pod::Spec.new do |s|
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.platform = :ios, '8.0'
+
+  # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
 end

--- a/packages/flutter_tools/templates/plugin/macos.tmpl/projectName.podspec.tmpl
+++ b/packages/flutter_tools/templates/plugin/macos.tmpl/projectName.podspec.tmpl
@@ -1,5 +1,6 @@
 #
-# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
+# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
+# Run `pod lib lint {{projectName}}.podspec' to validate before publishing.
 #
 Pod::Spec.new do |s|
   s.name             = '{{projectName}}'
@@ -15,7 +16,6 @@ Pod::Spec.new do |s|
   s.source_files     = 'Classes/**/*'
   s.dependency 'FlutterMacOS'
 
-  s.platform = :osx
-  s.osx.deployment_target = '10.11'
+  s.platform = :osx, '10.11'
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 end
-


### PR DESCRIPTION
## Description

- Limit the supported podspec `platform` to iOS so tests don't run (and fail) for macOS.
- Define the module by setting `DEFINES_MODULE` in the podspec.  See [CocoaPod modular headers docs](http://blog.cocoapods.org/CocoaPods-1.5.0/). DEFINES_MODULE=YES by default when I make a new Obj-C or Swift framework in Xcode 11.
- Explicitly set `VALID_ARCHS` to x86_64 for the simulator.  This is the CocoaPods-suggested workaround to prevent tests from running on the i386 simulator.  See https://github.com/CocoaPods/CocoaPods/pull/8159.  
Flutter.framework doesn't include i386 and ONLY_ACTIVE_ARCH=NO on Release means Xcode will try to run the i386 simulator.  Limit it to x86_64 on the simulator https://github.com/CocoaPods/CocoaPods/issues/9210.  Not necessary on macOS since there is no simulator!

## Related Issues

Fixes https://github.com/flutter/flutter/issues/41801
See also https://github.com/flutter/flutter/issues/41007.

## Tests

I added the following tests:
- plugin_lint_mac creates and runs `pod lib lint` for Objective-C plugins.  

> But why not lint Swift plugins?

you may ask. Anything importing Swift plugins does not build when ONLY_ACTIVE_ARCH=NO (the default in Release) and a simulator is targeted since there is no i386 bits in the Flutter.framework.  This was true before this patch since Flutter doesn't run in Release on the simulator.  In any case, the Swift import doesn't build in Release, though I'm not really sure why it works for Objc.


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.