### PR TITLE
Make output directory a build input

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/build_system.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_system.dart
@@ -292,8 +292,6 @@ class Environment {
       buffer.write(key);
       buffer.write(defines[key]);
     }
-    // in case there was no configuration, provide some value.
-    buffer.write('Flutter is awesome');
     buffer.write(outputDir.path);
     final String output = buffer.toString();
     final Digest digest = md5.convert(utf8.encode(output));

--- a/packages/flutter_tools/lib/src/build_system/build_system.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_system.dart
@@ -294,6 +294,7 @@ class Environment {
     }
     // in case there was no configuration, provide some value.
     buffer.write('Flutter is awesome');
+    buffer.write(outputDir.path);
     final String output = buffer.toString();
     final Digest digest = md5.convert(utf8.encode(output));
     buildPrefix = hex.encode(digest.bytes);

--- a/packages/flutter_tools/test/general.shard/build_system/build_system_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/build_system_test.dart
@@ -334,6 +334,13 @@ void main() {
     await buildSystem.build(target, environment);
     expect(called, 1);
   }));
+
+  test('output directory is an input to the build',  () => testbed.run(() async {
+    final Environment environmentA = Environment(projectDir: fs.currentDirectory, outputDir: fs.directory('a'));
+    final Environment environmentB = Environment(projectDir: fs.currentDirectory, outputDir: fs.directory('b'));
+
+    expect(environmentA.buildDir.path, isNot(environmentB.buildDir.path));
+  }));
 }
 
 class MockPlatform extends Mock implements Platform {}


### PR DESCRIPTION
## Description

This allows repeated invocations of build bundle to not delete old invocations with the same arguments besides build directory.

Fixes https://github.com/flutter/flutter/issues/41861