### PR TITLE
Clean up ProjectFileInvalidator.findInvalidated a bit

### DIFF
--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -283,7 +283,7 @@ class HotRunner extends ResidentRunner {
   }
 
   Future<UpdateFSReport> _updateDevFS({ bool fullRestart = false }) async {
-    final bool isFirstUpload = assetBundle.wasBuiltOnce() == false;
+    final bool isFirstUpload = !assetBundle.wasBuiltOnce();
     final bool rebuildBundle = assetBundle.needsBuild();
     if (rebuildBundle) {
       printTrace('Updating assets');
@@ -308,7 +308,7 @@ class HotRunner extends ResidentRunner {
         bundle: assetBundle,
         firstBuildTime: firstBuildTime,
         bundleFirstUpload: isFirstUpload,
-        bundleDirty: isFirstUpload == false && rebuildBundle,
+        bundleDirty: !isFirstUpload && rebuildBundle,
         fullRestart: fullRestart,
         projectRootPath: projectRootPath,
         pathToReload: getReloadPath(fullRestart: fullRestart),

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -1041,7 +1041,7 @@ class ProjectFileInvalidator {
   static const String _pubCachePathWindows = 'Pub/Cache';
 
   static List<Uri> findInvalidated({
-    @required DateTime /*?*/ lastCompiled,
+    @required DateTime lastCompiled,
     @required List<Uri> urisToMonitor,
     @required String packagesPath,
   }) {

--- a/packages/flutter_tools/test/general.shard/project_file_invalidator_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_file_invalidator_test.dart
@@ -12,6 +12,12 @@ import '../src/context.dart';
 void main() {
   group('ProjectFileInvalidator', () {
     final MemoryFileSystem memoryFileSystem = MemoryFileSystem();
+    testUsingContext('No last compile', () async {
+      expect(
+        ProjectFileInvalidator.findInvalidated(lastCompiled: null, urisToMonitor: <Uri>[], packagesPath: ''),
+        isEmpty);
+    });
+
     testUsingContext('Empty project', () async {
       expect(
         ProjectFileInvalidator.findInvalidated(lastCompiled: DateTime.now(), urisToMonitor: <Uri>[], packagesPath: ''),


### PR DESCRIPTION
In preparation for some refactoring that I will be doing to
`ProjectFileInvalidator.findInvalidated`, make its code a bit clearer:
* Indicate which arguments may be null.
* Don't bother calling `File.statSync` on the `.packages` file for the
  initial load.  This makes the checks for the `.packages` file
  consistent with those for other files.
* Use `DateTime.isAfter()` instead of comparing microseconds ourselves.

While I was touching this file, I also removed some unnecessary
comparisons to `false`. (`_ManifestAssetBundle.wasBuiltOnce()` is the
only implementation I can find of `AssetBundle.wasBuiltOnce()`, and it
never returns `null`.)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
