### PR TITLE
Ensure plugin registrants are generated in build_web

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -55,12 +55,16 @@ class WebEntrypointTarget extends Target {
 
     String contents;
     if (hasPlugins) {
+      final String generatedPath = environment.projectDir
+        .childDirectory('lib')
+        .childFile('generated_plugin_registrant.dart')
+        .absolute.uri.toString();
       contents = '''
 import 'dart:ui' as ui;
 
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
-import 'generated_plugin_registrant.dart';
+import '$generatedPath';
 import "$import" as entrypoint;
 
 Future<void> main() async {

--- a/packages/flutter_tools/lib/src/web/compile.dart
+++ b/packages/flutter_tools/lib/src/web/compile.dart
@@ -27,6 +27,9 @@ Future<void> buildWeb(FlutterProject flutterProject, String target, BuildInfo bu
   }
   final bool hasWebPlugins = findPlugins(flutterProject)
     .any((Plugin p) => p.platforms.containsKey(WebPlugin.kConfigKey));
+  if (hasWebPlugins) {
+    await flutterProject.ensureReadyForPlatformSpecificTooling();
+  }
   final Status status = logger.startProgress('Compiling $target for the Web...', timeout: null);
   final Stopwatch sw = Stopwatch()..start();
   final BuildResult result = await const BuildSystem().build(const WebReleaseBundle(), Environment(

--- a/packages/flutter_tools/lib/src/web/compile.dart
+++ b/packages/flutter_tools/lib/src/web/compile.dart
@@ -30,7 +30,7 @@ Future<void> buildWeb(FlutterProject flutterProject, String target, BuildInfo bu
   await injectPlugins(flutterProject, checkProjects: true);
   final Status status = logger.startProgress('Compiling $target for the Web...', timeout: null);
   final Stopwatch sw = Stopwatch()..start();
-  final BuildResult result = await const BuildSystem().build(const WebReleaseBundle(), Environment(
+  final BuildResult result = await buildSystem.build(const WebReleaseBundle(), Environment(
     outputDir: fs.directory(getWebBuildDirectory()),
     projectDir: fs.currentDirectory,
     buildDir: flutterProject.directory

--- a/packages/flutter_tools/lib/src/web/compile.dart
+++ b/packages/flutter_tools/lib/src/web/compile.dart
@@ -27,9 +27,7 @@ Future<void> buildWeb(FlutterProject flutterProject, String target, BuildInfo bu
   }
   final bool hasWebPlugins = findPlugins(flutterProject)
     .any((Plugin p) => p.platforms.containsKey(WebPlugin.kConfigKey));
-  if (hasWebPlugins) {
-    await flutterProject.ensureReadyForPlatformSpecificTooling();
-  }
+  await injectPlugins(flutterProject, checkProjects: true);
   final Status status = logger.startProgress('Compiling $target for the Web...', timeout: null);
   final Stopwatch sw = Stopwatch()..start();
   final BuildResult result = await const BuildSystem().build(const WebReleaseBundle(), Environment(

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
@@ -6,8 +6,8 @@ import 'package:args/command_runner.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/platform.dart';
-import 'package:flutter_tools/src/base/process_manager.dart';
 import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build.dart';
 import 'package:flutter_tools/src/commands/build_web.dart';
@@ -18,10 +18,8 @@ import 'package:flutter_tools/src/build_runner/resident_web_runner.dart';
 import 'package:flutter_tools/src/version.dart';
 import 'package:flutter_tools/src/web/compile.dart';
 import 'package:mockito/mockito.dart';
-import 'package:process/process.dart';
 
 import '../../src/common.dart';
-import '../../src/mocks.dart';
 import '../../src/testbed.dart';
 
 void main() {
@@ -141,9 +139,8 @@ class UrlLauncherPlugin {}
 
     // Process calls. We're not testing that these invocations are correct because
     // that is covered in targets/web_test.dart.
-    fs.file(fs.path.join('.dart_tool', 'flutter_build', '61f7a30d1a3dbdc8a1baebbf511a0b79', 'main.dart.js')).createSync(recursive: true);
-    when(processManager.run(any)).thenAnswer((Invocation invocation) async {
-      return FakeProcessResult();
+    when(buildSystem.build(any, any)).thenAnswer((Invocation invocation) async {
+      return BuildResult(success: true);
     });
 
     await runner.run(<String>['build', 'web']);
@@ -151,7 +148,7 @@ class UrlLauncherPlugin {}
     expect(fs.file(fs.path.join('lib', 'generated_plugin_registrant.dart')).existsSync(), true);
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
-    ProcessManager: () => MockProcessManager(),
+    BuildSystem: () => MockBuildSystem(),
   }));
 
   test('hidden if feature flag is not enabled', () => testbed.run(() async {
@@ -167,7 +164,7 @@ class UrlLauncherPlugin {}
   }));
 }
 
-class MockProcessManager extends Mock implements ProcessManager {}
+class MockBuildSystem extends Mock implements BuildSystem {}
 class MockWebCompilationProxy extends Mock implements WebCompilationProxy {}
 class MockPlatform extends Mock implements Platform {
   @override

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
@@ -5,20 +5,25 @@
 import 'package:args/command_runner.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/process_manager.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build.dart';
 import 'package:flutter_tools/src/commands/build_web.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/features.dart';
+import 'package:flutter_tools/src/globals.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/build_runner/resident_web_runner.dart';
 import 'package:flutter_tools/src/version.dart';
 import 'package:flutter_tools/src/web/compile.dart';
 import 'package:mockito/mockito.dart';
+import 'package:process/process.dart';
 
 import '../../src/common.dart';
+import '../../src/mocks.dart';
 import '../../src/testbed.dart';
 
 void main() {
@@ -86,6 +91,71 @@ void main() {
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: false),
   }));
 
+  test('Builds a web bundle - end to end', () => testbed.run(() async {
+    final CommandRunner<void> runner = createTestCommandRunner(BuildCommand());
+    final List<String> dependencies = <String>[
+      fs.path.join('packages', 'flutter_tools', 'lib', 'src', 'build_system', 'targets', 'web.dart'),
+      fs.path.join('bin', 'cache', 'flutter_web_sdk'),
+      fs.path.join('bin', 'cache', 'dart-sdk', 'bin', 'snapshots', 'dart2js.dart.snapshot'),
+      fs.path.join('bin', 'cache', 'dart-sdk', 'bin', 'dart'),
+      fs.path.join('bin', 'cache', 'dart-sdk '),
+    ];
+    for (String dependency in dependencies) {
+      fs.file(dependency).createSync(recursive: true);
+    }
+
+    // Project files.
+    fs.file('.packages')
+      ..writeAsStringSync('''
+foo:lib/
+fizz:bar/lib/
+''');
+    fs.file('pubspec.yaml')
+      ..writeAsStringSync('''
+name: foo
+
+dependencies:
+  flutter:
+    sdk: flutter
+  fizz:
+    path:
+      bar/
+''');
+    fs.file(fs.path.join('bar', 'pubspec.yaml'))
+      ..createSync(recursive: true)
+      ..writeAsStringSync('''
+name: bar
+
+flutter:
+  plugin:
+    platforms:
+      web:
+        pluginClass: UrlLauncherPlugin
+        fileName: url_launcher_web.dart
+''');
+    fs.file(fs.path.join('bar', 'lib', 'url_launcher_web.dart'))
+      ..createSync(recursive: true)
+      ..writeAsStringSync('''
+class UrlLauncherPlugin {}
+''');
+    fs.file(fs.path.join('lib', 'main.dart'))
+      ..writeAsStringSync('void main() { }');
+
+    // Process calls. We're not testing that these invocations are correct because
+    // that is covered in targets/web_test.dart.
+    fs.file(fs.path.join('.dart_tool', 'flutter_build', '61f7a30d1a3dbdc8a1baebbf511a0b79', 'main.dart.js')).createSync(recursive: true);
+    when(processManager.run(any)).thenAnswer((Invocation invocation) async {
+      return FakeProcessResult();
+    });
+
+    await runner.run(<String>['build', 'web']);
+
+    expect(fs.file(fs.path.join('lib', 'generated_plugin_registrant.dart')).existsSync(), true);
+  }, overrides: <Type, Generator>{
+    FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
+    ProcessManager: () => MockProcessManager(),
+  }));
+
   test('hidden if feature flag is not enabled', () => testbed.run(() async {
     expect(BuildWebCommand().hidden, true);
   }, overrides: <Type, Generator>{
@@ -99,6 +169,7 @@ void main() {
   }));
 }
 
+class MockProcessManager extends Mock implements ProcessManager {}
 class MockWebCompilationProxy extends Mock implements WebCompilationProxy {}
 class MockPlatform extends Mock implements Platform {
   @override

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
@@ -5,7 +5,6 @@
 import 'package:args/command_runner.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/process_manager.dart';
 import 'package:flutter_tools/src/build_info.dart';
@@ -14,7 +13,6 @@ import 'package:flutter_tools/src/commands/build.dart';
 import 'package:flutter_tools/src/commands/build_web.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/features.dart';
-import 'package:flutter_tools/src/globals.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/build_runner/resident_web_runner.dart';
 import 'package:flutter_tools/src/version.dart';

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -56,7 +56,7 @@ void main() {
     final String generated = environment.buildDir.childFile('main.dart').readAsStringSync();
 
     // Plugins
-    expect(generated, contains("import 'generated_plugin_registrant.dart';"));
+    expect(generated, contains("import 'file:///lib/generated_plugin_registrant.dart';"));
     expect(generated, contains('registerPlugins(webPluginRegistry);'));
 
     // Platform
@@ -77,7 +77,7 @@ void main() {
     final String generated = environment.buildDir.childFile('main.dart').readAsStringSync();
 
     // Plugins
-    expect(generated, contains("import 'generated_plugin_registrant.dart';"));
+    expect(generated, contains("import 'file:///C:/lib/generated_plugin_registrant.dart';"));
     expect(generated, contains('registerPlugins(webPluginRegistry);'));
 
     // Platform
@@ -100,7 +100,7 @@ void main() {
     final String generated = environment.buildDir.childFile('main.dart').readAsStringSync();
 
     // Plugins
-    expect(generated, isNot(contains("import 'generated_plugin_registrant.dart';")));
+    expect(generated, isNot(contains("import 'file:///lib/generated_plugin_registrant.dart';")));
     expect(generated, isNot(contains('registerPlugins(webPluginRegistry);')));
 
     // Platform
@@ -118,7 +118,7 @@ void main() {
     final String generated = environment.buildDir.childFile('main.dart').readAsStringSync();
 
     // Plugins
-    expect(generated, contains("import 'generated_plugin_registrant.dart';"));
+    expect(generated, contains("import 'file:///lib/generated_plugin_registrant.dart';"));
     expect(generated, contains('registerPlugins(webPluginRegistry);'));
 
     // Platform
@@ -136,7 +136,7 @@ void main() {
     final String generated = environment.buildDir.childFile('main.dart').readAsStringSync();
 
     // Plugins
-    expect(generated, isNot(contains("import 'generated_plugin_registrant.dart';")));
+    expect(generated, isNot(contains("import 'file:///lib/generated_plugin_registrant.dart';")));
     expect(generated, isNot(contains('registerPlugins(webPluginRegistry);')));
 
     // Platform


### PR DESCRIPTION
## Description
Ensure plugin registrants are generated in build_web when there are web plugins. Add end to end test to assert this.

Fixes https://github.com/flutter/flutter/issues/41896