### PR TITLE
Send pubspec.yaml back in time to fix flakiness

### DIFF
--- a/packages/flutter_tools/test/general.shard/web/web_fs_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/web_fs_test.dart
@@ -61,7 +61,6 @@ void main() {
     )).thenAnswer((Invocation invocation) async {
       final String workingDirectory = invocation.namedArguments[#workingDirectory];
       fs.file(fs.path.join(workingDirectory, '.packages')).createSync(recursive: true);
-      fs.file(fs.path.join(workingDirectory, 'pubspec.yaml')).createSync();
       return 0;
     });
     when(mockBuildDaemonClient.buildResults).thenAnswer((Invocation _) {
@@ -81,6 +80,9 @@ void main() {
     when(mockBuildDaemonCreator.assetServerPort(any)).thenReturn(4321);
     testbed = Testbed(
       setup: () {
+        fs.file(fs.path.join('packages', 'flutter_tools', 'pubspec.yaml'))
+          ..createSync(recursive: true)
+          ..setLastModifiedSync(DateTime(1991, 08, 23));
         // Create an empty .packages file so we can read it when we check for
         // plugins on WebFs.start()
         fs.file('.packages').createSync();


### PR DESCRIPTION
## Description

This was passing _sometimes_ due to filesystem granularity.