### PR TITLE
example usage of extension methods in flutter_tools

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -104,10 +104,10 @@ class AndroidDevice extends Device {
           stderrEncoding: latin1,
         );
         if (result.exitCode == 0 || allowHeapCorruptionOnWindows(result.exitCode)) {
-          _properties = parseAdbDeviceProperties(result.stdout);
+          _properties = parseAdbDeviceProperties(result.stdoutText);
         } else {
           printError('Error ${result.exitCode} retrieving device properties for $name:');
-          printError(result.stderr);
+          printError(result.stderrText);
         }
       } on ProcessException catch (error) {
         printError('Error retrieving device properties for $name: $error');

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -151,6 +151,19 @@ typedef RunResultChecker = bool Function(int);
 
 ProcessUtils get processUtils => ProcessUtils.instance;
 
+/// Extension methods that add type safe getters to stdout and stderr strings.
+extension TypesafeProcess on ProcessResult {
+  /// stdout as a utf8 encoded string.
+  ///
+  /// This is only valud if an encoding was provided to the spawned process.
+  String get stdoutText => this.stdout?.toString();
+
+  /// stderr as a utf8 encoded string.
+  ///
+  /// This is only valud if an encoding was provided to the spawned process.
+  String get stderrText => this.stderr?.toString();
+}
+
 abstract class ProcessUtils {
   factory ProcessUtils() => _DefaultProcessUtils();
 

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -5,7 +5,7 @@ author: Flutter Authors <flutter-dev@googlegroups.com>
 
 environment:
   # The pub client defaults to an <2.0.0 sdk constraint which we need to explicitly overwrite.
-  sdk: ">=2.2.2 <3.0.0"
+  sdk: ">=2.6.0-dev <3.0.0"
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".


### PR DESCRIPTION
## Description

Flutter_tools currently has about 863 cases of implicit downcasts. While I'd desperately like to turn on that lint, many of these are due to SDK interfaces including dynamic in inconvenient places. extension methods provide for us a reasonable way to update these interfaces into more type safe methods, as demonstrated below.