### PR TITLE
Add stub to make analyzer happy (#41563)

### DIFF
--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -38,6 +38,13 @@ class PlatformViewsRegistry {
   /// Typically a platform view identifier is passed to a [PlatformView] widget
   /// which creates the platform view and manages its lifecycle.
   int getNextPlatformViewId() => _nextPlatformViewId++;
+  
+  /// Register [viewTypeId] as being creating by the given [factory].
+  /// Works only on Flutter Web
+  /// On other platforms always returns false
+  bool registerViewFactory(String viewTypeId, dynamic Function(int viewId) factory) {
+    return false;
+  }
 }
 
 /// Callback signature for when a platform view was created.


### PR DESCRIPTION
## Description

This PR adds stub to allow using `registerViewFactory` on Flutter Web without dart analyzer errors

## Related Issues

Fixes: #41563 

## Tests

I don't see any sense in testing empty method that always returns true

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
