### PR TITLE
[web] Always send the route name even if it's null

### DIFF
--- a/packages/flutter/lib/src/widgets/route_notification_messages.dart
+++ b/packages/flutter/lib/src/widgets/route_notification_messages.dart
@@ -29,14 +29,12 @@ class RouteNotificationMessages {
   static void _notifyRouteChange(String methodName, Route<dynamic> route, Route<dynamic> previousRoute) {
     final String previousRouteName = previousRoute?.settings?.name;
     final String routeName = route?.settings?.name;
-    if (previousRouteName != null || routeName != null) {
-      SystemChannels.navigation.invokeMethod<void>(
-        methodName,
-        <String, dynamic>{
-          'previousRouteName': previousRouteName,
-          'routeName': routeName,
-        },
-      );
-    }
+    SystemChannels.navigation.invokeMethod<void>(
+      methodName,
+      <String, dynamic>{
+        'previousRouteName': previousRouteName ?? '',
+        'routeName': routeName ?? '',
+      },
+    );
   }
 }

--- a/packages/flutter/lib/src/widgets/route_notification_messages.dart
+++ b/packages/flutter/lib/src/widgets/route_notification_messages.dart
@@ -32,8 +32,8 @@ class RouteNotificationMessages {
     SystemChannels.navigation.invokeMethod<void>(
       methodName,
       <String, dynamic>{
-        'previousRouteName': previousRouteName ?? '',
-        'routeName': routeName ?? '',
+        'previousRouteName': previousRouteName,
+        'routeName': routeName,
       },
     );
   }

--- a/packages/flutter/test/widgets/route_notification_messages_test.dart
+++ b/packages/flutter/test/widgets/route_notification_messages_test.dart
@@ -167,4 +167,51 @@ void main() {
           },
         ));
   });
+
+  testWidgets('Nameless routes should send platform messages', (WidgetTester tester) async {
+    final List<MethodCall> log = <MethodCall>[];
+    SystemChannels.navigation.setMockMethodCallHandler((MethodCall methodCall) async {
+      log.add(methodCall);
+    });
+
+    await tester.pumpWidget(MaterialApp(
+      initialRoute: '/home',
+      routes: <String, WidgetBuilder>{
+        '/home': (BuildContext context) {
+          return OnTapPage(
+            id: 'Home',
+            onTap: () {
+              // Create a route with no name.
+              final Route<void> route = MaterialPageRoute<void>(
+                builder: (BuildContext context) => const Text('Nameless Route'),
+              );
+              Navigator.push<void>(context, route);
+            },
+          );
+        },
+      },
+    ));
+
+    expect(log, hasLength(1));
+    expect(
+      log.last,
+      isMethodCall('routePushed', arguments: <String, dynamic>{
+        'previousRouteName': null,
+        'routeName': '/home',
+      }),
+    );
+
+    await tester.tap(find.text('Home'));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(log, hasLength(2));
+    expect(
+      log.last,
+      isMethodCall('routePushed', arguments: <String, dynamic>{
+        'previousRouteName': '/home',
+        'routeName': '',
+      }),
+    );
+  });
 }

--- a/packages/flutter/test/widgets/route_notification_messages_test.dart
+++ b/packages/flutter/test/widgets/route_notification_messages_test.dart
@@ -65,7 +65,7 @@ void main() {
         isMethodCall(
           'routePushed',
           arguments: <String, dynamic>{
-            'previousRouteName': '',
+            'previousRouteName': null,
             'routeName': '/',
           },
         ));
@@ -132,7 +132,7 @@ void main() {
         isMethodCall(
           'routePushed',
           arguments: <String, dynamic>{
-            'previousRouteName': '',
+            'previousRouteName': null,
             'routeName': '/',
           },
         ));
@@ -196,7 +196,7 @@ void main() {
     expect(
       log.last,
       isMethodCall('routePushed', arguments: <String, dynamic>{
-        'previousRouteName': '',
+        'previousRouteName': null,
         'routeName': '/home',
       }),
     );
@@ -210,7 +210,7 @@ void main() {
       log.last,
       isMethodCall('routePushed', arguments: <String, dynamic>{
         'previousRouteName': '/home',
-        'routeName': '',
+        'routeName': null,
       }),
     );
   });

--- a/packages/flutter/test/widgets/route_notification_messages_test.dart
+++ b/packages/flutter/test/widgets/route_notification_messages_test.dart
@@ -65,7 +65,7 @@ void main() {
         isMethodCall(
           'routePushed',
           arguments: <String, dynamic>{
-            'previousRouteName': null,
+            'previousRouteName': '',
             'routeName': '/',
           },
         ));
@@ -132,7 +132,7 @@ void main() {
         isMethodCall(
           'routePushed',
           arguments: <String, dynamic>{
-            'previousRouteName': null,
+            'previousRouteName': '',
             'routeName': '/',
           },
         ));
@@ -196,7 +196,7 @@ void main() {
     expect(
       log.last,
       isMethodCall('routePushed', arguments: <String, dynamic>{
-        'previousRouteName': null,
+        'previousRouteName': '',
         'routeName': '/home',
       }),
     );


### PR DESCRIPTION
## Description

When a nameless route is pushed, we should be sending a platform message with route name as `null` in order for the engine to be able clear the browser url.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/41375

## Tests

I added tests in following files:

* `test/widgets/route_notification_messages_test.dart`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
