### PR TITLE
Restructure ProjectFileInvalidator.findInvalidated a bit

### DIFF
--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -1078,7 +1078,8 @@ class ProjectFileInvalidator {
     return invalidatedFiles;
   }
 
-  static bool _isInPubCache(Uri uri) =>
-    (platform.isWindows && uri.path.contains(_pubCachePathWindows))
-    || uri.path.contains(_pubCachePathLinuxAndMac);
+  static bool _isInPubCache(Uri uri) {
+    return (platform.isWindows && uri.path.contains(_pubCachePathWindows))
+        || uri.path.contains(_pubCachePathLinuxAndMac);
+  }
 }

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -1058,7 +1058,7 @@ class ProjectFileInvalidator {
 
     final List<Uri> urisToScan = <Uri>[
       // Don't watch pub cache directories to speed things up a little.
-      ...urisToMonitor.where((Uri uri) => !_isInPubCache(uri)),
+      ...urisToMonitor.where(_isNotInPubCache),
 
       // We need to check the .packages file too since it is not used in compilation.
       fs.file(packagesPath).uri,
@@ -1078,8 +1078,8 @@ class ProjectFileInvalidator {
     return invalidatedFiles;
   }
 
-  static bool _isInPubCache(Uri uri) {
-    return (platform.isWindows && uri.path.contains(_pubCachePathWindows))
-        || uri.path.contains(_pubCachePathLinuxAndMac);
+  static bool _isNotInPubCache(Uri uri) {
+    return !(platform.isWindows && uri.path.contains(_pubCachePathWindows))
+        && !uri.path.contains(_pubCachePathLinuxAndMac);
   }
 }

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -1049,33 +1049,36 @@ class ProjectFileInvalidator {
     assert(packagesPath != null);
 
     if (lastCompiled == null) {
+      // Initial load.
       assert(urisToMonitor.isEmpty);
       return <Uri>[];
     }
 
-    final List<Uri> invalidatedFiles = <Uri>[];
-    int scanned = 0;
     final Stopwatch stopwatch = Stopwatch()..start();
-    for (Uri uri in urisToMonitor) {
-      if ((platform.isWindows && uri.path.contains(_pubCachePathWindows))
-          || uri.path.contains(_pubCachePathLinuxAndMac)) {
-        // Don't watch pub cache directories to speed things up a little.
-        continue;
-      }
+
+    final List<Uri> urisToScan = <Uri>[
+      // Don't watch pub cache directories to speed things up a little.
+      ...urisToMonitor.where((Uri uri) => !_isInPubCache(uri)),
+
+      // We need to check the .packages file too since it is not used in compilation.
+      fs.file(packagesPath).uri,
+    ];
+    final List<Uri> invalidatedFiles = <Uri>[];
+    for (final Uri uri in urisToScan) {
       final DateTime updatedAt = fs.statSync(
           uri.toFilePath(windows: platform.isWindows)).modified;
-      scanned++;
       if (updatedAt != null && updatedAt.isAfter(lastCompiled)) {
         invalidatedFiles.add(uri);
       }
     }
-    // We need to check the .packages file too since it is not used in compilation.
-    final DateTime packagesUpdatedAt = fs.statSync(packagesPath).modified;
-    if (packagesUpdatedAt != null && packagesUpdatedAt.isAfter(lastCompiled)) {
-      invalidatedFiles.add(fs.file(packagesPath).uri);
-      scanned++;
-    }
-    printTrace('Scanned through $scanned files in ${stopwatch.elapsedMilliseconds}ms');
+    printTrace(
+      'Scanned through ${urisToScan.length} files in '
+      '${stopwatch.elapsedMilliseconds}ms',
+    );
     return invalidatedFiles;
   }
+
+  static bool _isInPubCache(Uri uri) =>
+    (platform.isWindows && uri.path.contains(_pubCachePathWindows))
+    || uri.path.contains(_pubCachePathLinuxAndMac);
 }


### PR DESCRIPTION
I plan to modify `ProjectFileInvalidator.findInvalidated` to allow
it to use `FileStat.stat` instead of `FileStat.statSync`.
Restructure `findInvalidated` a bit so that `FileStat.statSync` is
called in only one place.

Note that this change now always counts the `.packages` file as one
of the files scanned, even if it does not exist.  I think that this
is okay since it more accurately reflects the number of times that we
hit the filesystem with `stat()`, and it is consistent with how other
files are counted.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
