### PR TITLE
[flutter_tool] Re-work analytics events to use labels and values

### DIFF
--- a/packages/flutter_tools/lib/src/reporting/disabled_usage.dart
+++ b/packages/flutter_tools/lib/src/reporting/disabled_usage.dart
@@ -27,7 +27,13 @@ class DisabledUsage implements Usage {
   void sendCommand(String command, { Map<String, String> parameters }) { }
 
   @override
-  void sendEvent(String category, String parameter, { String label, Map<String, String> parameters }) { }
+  void sendEvent(
+    String category,
+    String parameter, {
+    String label,
+    int value,
+    Map<String, String> parameters,
+  }) { }
 
   @override
   void sendTiming(String category, String variableName, Duration duration, { String label }) { }

--- a/packages/flutter_tools/lib/src/reporting/usage.dart
+++ b/packages/flutter_tools/lib/src/reporting/usage.dart
@@ -125,6 +125,7 @@ abstract class Usage {
     String category,
     String parameter, {
     String label,
+    int value,
     Map<String, String> parameters,
   });
 
@@ -264,6 +265,7 @@ class _DefaultUsage implements Usage {
     String category,
     String parameter, {
     String label,
+    int value,
     Map<String, String> parameters,
   }) {
     if (suppressAnalytics) {
@@ -279,6 +281,7 @@ class _DefaultUsage implements Usage {
       category,
       parameter,
       label: label,
+      value: value,
       parameters: paramsWithLocalTime,
     );
   }

--- a/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
@@ -226,9 +226,9 @@ void main() {
 
       expect(
         verify(mockUsage.sendEvent(
-          'doctorResult.PassingValidator',
-          captureAny,
-          label: anyNamed('label'),
+          'doctor-result',
+          'PassingValidator',
+          label: captureAnyNamed('label'),
         )).captured,
         <dynamic>['installed', 'installed', 'installed'],
       );
@@ -243,25 +243,25 @@ void main() {
 
       expect(
         verify(mockUsage.sendEvent(
-          'doctorResult.PassingValidator',
-          captureAny,
-          label: anyNamed('label'),
+          'doctor-result',
+          'PassingValidator',
+          label: captureAnyNamed('label'),
         )).captured,
         <dynamic>['installed', 'installed'],
       );
       expect(
         verify(mockUsage.sendEvent(
-          'doctorResult.PartialValidatorWithHintsOnly',
-          captureAny,
-          label: anyNamed('label'),
+          'doctor-result',
+          'PartialValidatorWithHintsOnly',
+          label: captureAnyNamed('label'),
         )).captured,
         <dynamic>['partial'],
       );
       expect(
         verify(mockUsage.sendEvent(
-          'doctorResult.PartialValidatorWithErrors',
-          captureAny,
-          label: anyNamed('label'),
+          'doctor-result',
+          'PartialValidatorWithErrors',
+          label: captureAnyNamed('label'),
         )).captured,
         <dynamic>['partial'],
       );
@@ -275,41 +275,41 @@ void main() {
 
       expect(
         verify(mockUsage.sendEvent(
-          'doctorResult.PassingValidator',
-          captureAny,
-          label: anyNamed('label'),
+          'doctor-result',
+          'PassingValidator',
+          label: captureAnyNamed('label'),
         )).captured,
         <dynamic>['installed'],
       );
       expect(
         verify(mockUsage.sendEvent(
-          'doctorResult.MissingValidator',
-          captureAny,
-          label: anyNamed('label'),
+          'doctor-result',
+          'MissingValidator',
+          label: captureAnyNamed('label'),
         )).captured,
         <dynamic>['missing'],
       );
       expect(
         verify(mockUsage.sendEvent(
-          'doctorResult.NotAvailableValidator',
-          captureAny,
-          label: anyNamed('label'),
+          'doctor-result',
+          'NotAvailableValidator',
+          label: captureAnyNamed('label'),
         )).captured,
         <dynamic>['notAvailable'],
       );
       expect(
         verify(mockUsage.sendEvent(
-          'doctorResult.PartialValidatorWithHintsOnly',
-          captureAny,
-          label: anyNamed('label'),
+          'doctor-result',
+          'PartialValidatorWithHintsOnly',
+          label: captureAnyNamed('label'),
         )).captured,
         <dynamic>['partial'],
       );
       expect(
         verify(mockUsage.sendEvent(
-          'doctorResult.PartialValidatorWithErrors',
-          captureAny,
-          label: anyNamed('label'),
+          'doctor-result',
+          'PartialValidatorWithErrors',
+          label: captureAnyNamed('label'),
         )).captured,
         <dynamic>['partial'],
       );
@@ -323,17 +323,17 @@ void main() {
 
       expect(
         verify(mockUsage.sendEvent(
-          'doctorResult.PassingGroupedValidator',
-          captureAny,
-          label: anyNamed('label'),
+          'doctor-result',
+          'PassingGroupedValidator',
+          label: captureAnyNamed('label'),
         )).captured,
         <dynamic>['installed', 'installed', 'installed'],
       );
       expect(
         verify(mockUsage.sendEvent(
-          'doctorResult.MissingGroupedValidator',
-          captureAny,
-          label: anyNamed('label'),
+          'doctor-result',
+          'MissingGroupedValidator',
+          label: captureAnyNamed('label'),
         )).captured,
         <dynamic>['missing'],
       );

--- a/packages/flutter_tools/test/general.shard/analytics_test.dart
+++ b/packages/flutter_tools/test/general.shard/analytics_test.dart
@@ -55,7 +55,7 @@ void main() {
 
       flutterUsage.enabled = true;
       await createProject(tempDir);
-      expect(count, flutterUsage.isFirstRun ? 0 : 3);
+      expect(count, flutterUsage.isFirstRun ? 0 : 4);
 
       count = 0;
       flutterUsage.enabled = false;

--- a/packages/flutter_tools/test/general.shard/commands/build_apk_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_apk_test.dart
@@ -241,8 +241,9 @@ void main() {
           contains('To learn more, see: https://developer.android.com/studio/build/shrink-code'));
 
       verify(mockUsage.sendEvent(
-        'build-apk',
-        'r8-failure',
+        'build',
+        'apk',
+        label: 'r8-failure',
         parameters: anyNamed('parameters'),
       )).called(1);
     },

--- a/packages/flutter_tools/test/general.shard/commands/build_appbundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_appbundle_test.dart
@@ -230,8 +230,9 @@ void main() {
           contains('To learn more, see: https://developer.android.com/studio/build/shrink-code'));
 
       verify(mockUsage.sendEvent(
-        'build-appbundle',
-        'r8-failure',
+        'build',
+        'appbundle',
+        label: 'r8-failure',
         parameters: anyNamed('parameters'),
       )).called(1);
     },

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -154,7 +154,7 @@ void main() {
   testUsingContext('analytics sent on success', () async {
     MockDirectory.findCache = true;
     await pubGet(context: PubContext.flutterTests, checkLastModified: false);
-    verify(flutterUsage.sendEvent('pub', 'flutter-tests', label: 'success')).called(1);
+    verify(flutterUsage.sendEvent('pub-result', 'flutter-tests', label: 'success')).called(1);
   }, overrides: <Type, Generator>{
     ProcessManager: () => MockProcessManager(0),
     FileSystem: () => MockFileSystem(),
@@ -173,7 +173,7 @@ void main() {
     } on ToolExit {
       // Ignore.
     }
-    verify(flutterUsage.sendEvent('pub', 'flutter-tests', label: 'failure')).called(1);
+    verify(flutterUsage.sendEvent('pub-result', 'flutter-tests', label: 'failure')).called(1);
   }, overrides: <Type, Generator>{
     ProcessManager: () => MockProcessManager(1),
     FileSystem: () => MockFileSystem(),
@@ -192,7 +192,7 @@ void main() {
     } on ToolExit {
       // Ignore.
     }
-    verify(flutterUsage.sendEvent('pub', 'flutter-tests', label: 'version-solving-failed')).called(1);
+    verify(flutterUsage.sendEvent('pub-result', 'flutter-tests', label: 'version-solving-failed')).called(1);
   }, overrides: <Type, Generator>{
     ProcessManager: () => MockProcessManager(
       1,

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -246,7 +246,9 @@ void main() {
       );
 
       await diagnoseXcodeBuildFailure(buildResult);
-      verify(mockUsage.sendEvent('build', 'xcode-bitcode-failure',
+      verify(mockUsage.sendEvent('build',
+        any,
+        label: 'xcode-bitcode-failure',
         parameters: <String, String>{
           cdKey(CustomDimensions.buildEventCommand): buildCommands.toString(),
           cdKey(CustomDimensions.buildEventSettings): buildSettings.toString(),

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -77,8 +77,24 @@ void main() {
       );
       await flutterCommand.run();
 
-      verify(usage.sendCommand(captureAny, parameters: captureAnyNamed('parameters')));
-      verify(usage.sendEvent(captureAny, 'success', parameters: captureAnyNamed('parameters')));
+      verify(usage.sendCommand(
+        'dummy',
+        parameters: anyNamed('parameters'),
+      ));
+      verify(usage.sendEvent(
+        'tool-command-result',
+        'dummy',
+        label: 'success',
+        parameters: anyNamed('parameters'),
+      ));
+      expect(verify(usage.sendEvent(
+          'tool-command-max-rss',
+          'dummy',
+          label: 'success',
+          value: captureAnyNamed('value'),
+        )).captured[0],
+        10,
+      );
     });
 
     testUsingCommandContext('reports command that results in warning', () async {
@@ -92,8 +108,24 @@ void main() {
       );
       await flutterCommand.run();
 
-      verify(usage.sendCommand(captureAny, parameters: captureAnyNamed('parameters')));
-      verify(usage.sendEvent(captureAny, 'warning', parameters: captureAnyNamed('parameters')));
+      verify(usage.sendCommand(
+        'dummy',
+        parameters: anyNamed('parameters'),
+      ));
+      verify(usage.sendEvent(
+        'tool-command-result',
+        'dummy',
+        label: 'warning',
+        parameters: anyNamed('parameters'),
+      ));
+      expect(verify(usage.sendEvent(
+          'tool-command-max-rss',
+          'dummy',
+          label: 'warning',
+          value: captureAnyNamed('value'),
+        )).captured[0],
+        10,
+      );
     });
 
     testUsingCommandContext('reports command that results in failure', () async {
@@ -109,8 +141,24 @@ void main() {
       try {
         await flutterCommand.run();
       } on ToolExit {
-        verify(usage.sendCommand(captureAny, parameters: captureAnyNamed('parameters')));
-        verify(usage.sendEvent(captureAny, 'fail', parameters: captureAnyNamed('parameters')));
+        verify(usage.sendCommand(
+          'dummy',
+          parameters: anyNamed('parameters'),
+        ));
+        verify(usage.sendEvent(
+          'tool-command-result',
+          'dummy',
+          label: 'fail',
+          parameters: anyNamed('parameters'),
+        ));
+        expect(verify(usage.sendEvent(
+            'tool-command-max-rss',
+            'dummy',
+            label: 'fail',
+            value: captureAnyNamed('value'),
+          )).captured[0],
+          10,
+        );
       }
     });
 
@@ -129,8 +177,24 @@ void main() {
         await flutterCommand.run();
         fail('Mock should make this fail');
       } on ToolExit {
-        verify(usage.sendCommand(captureAny, parameters: captureAnyNamed('parameters')));
-        verify(usage.sendEvent(captureAny, 'fail', parameters: captureAnyNamed('parameters')));
+        verify(usage.sendCommand(
+          'dummy',
+          parameters: anyNamed('parameters'),
+        ));
+        verify(usage.sendEvent(
+          'tool-command-result',
+          'dummy',
+          label: 'fail',
+          parameters: anyNamed('parameters'),
+        ));
+        expect(verify(usage.sendEvent(
+            'tool-command-max-rss',
+            'dummy',
+            label: 'fail',
+            value: captureAnyNamed('value'),
+          )).captured[0],
+          10,
+        );
       }
     });
 
@@ -169,8 +233,24 @@ void main() {
         signalController.add(mockSignal);
         await completer.future;
 
-        verify(usage.sendCommand(any, parameters: anyNamed('parameters')));
-        verify(usage.sendEvent(any, 'killed', parameters: anyNamed('parameters')));
+        verify(usage.sendCommand(
+          'dummy',
+          parameters: anyNamed('parameters'),
+        ));
+        verify(usage.sendEvent(
+          'tool-command-result',
+          'dummy',
+          label: 'killed',
+          parameters: anyNamed('parameters'),
+        ));
+        expect(verify(usage.sendEvent(
+            'tool-command-max-rss',
+            'dummy',
+            label: 'killed',
+            value: captureAnyNamed('value'),
+          )).captured[0],
+          10,
+        );
       }, overrides: <Type, Generator>{
         ProcessInfo: () => mockProcessInfo,
         Signals: () => FakeSignals(
@@ -180,27 +260,6 @@ void main() {
         SystemClock: () => clock,
         Usage: () => usage,
       });
-    });
-
-    testUsingCommandContext('reports maxRss', () async {
-      // Crash if called a third time which is unexpected.
-      mockTimes = <int>[1000, 2000];
-
-      final DummyFlutterCommand flutterCommand = DummyFlutterCommand(
-        commandFunction: () async {
-          return const FlutterCommandResult(ExitStatus.success);
-        }
-      );
-      await flutterCommand.run();
-
-      verify(usage.sendCommand(captureAny, parameters: captureAnyNamed('parameters')));
-      expect(verify(usage.sendEvent(
-          any,
-          'success',
-          parameters: captureAnyNamed('parameters'),
-        )).captured[0],
-        containsPair(cdKey(CustomDimensions.commandResultEventMaxRss),
-            mockProcessInfo.maxRss.toString()));
     });
 
     testUsingCommandContext('report execution timing by default', () async {

--- a/packages/flutter_tools/test/general.shard/runner/runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/runner_test.dart
@@ -140,8 +140,15 @@ class CrashingUsage implements Usage {
     String category,
     String parameter, {
     String label,
+    int value,
     Map<String, String> parameters,
-  }) => _impl.sendEvent(category, parameter, label: label, parameters: parameters);
+  }) => _impl.sendEvent(
+    category,
+    parameter,
+    label: label,
+    value: value,
+    parameters: parameters,
+  );
 
   @override
   void sendTiming(

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -303,7 +303,11 @@ class FakeUsage implements Usage {
   void sendCommand(String command, { Map<String, String> parameters }) { }
 
   @override
-  void sendEvent(String category, String parameter, { String label, Map<String, String> parameters }) { }
+  void sendEvent(String category, String parameter, {
+    String label,
+    int value,
+    Map<String, String> parameters,
+  }) { }
 
   @override
   void sendTiming(String category, String variableName, Duration duration, { String label }) { }

--- a/packages/flutter_tools/test/src/testbed.dart
+++ b/packages/flutter_tools/test/src/testbed.dart
@@ -162,7 +162,11 @@ class NoOpUsage implements Usage {
   void sendCommand(String command, {Map<String, String> parameters}) {}
 
   @override
-  void sendEvent(String category, String parameter, { String label, Map<String, String> parameters }) {}
+  void sendEvent(String category, String parameter, {
+    String label,
+    int value,
+    Map<String, String> parameters,
+  }) {}
 
   @override
   void sendException(dynamic exception) {}


### PR DESCRIPTION
## Description

This PR cleans up analytics events by making use of labels and values that can be attached to events instead of relying only on the category, action, and custom dimensions.

## Tests

I added the following tests:

Adjusted existing tests to match the new event layout.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.