### PR TITLE
Stop leaking iproxy processes

### DIFF
--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -571,6 +571,7 @@ class ForwardedPort {
   @override
   String toString() => 'ForwardedPort HOST:$hostPort to DEVICE:$devicePort';
 
+  /// Kill subprocess (if present) used in forwarding.
   bool killProcess() {
     final Process process = context;
 

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -475,6 +475,9 @@ abstract class Device {
     await descriptions(devices).forEach(printStatus);
   }
 
+  /// Clean up resources allocated by device
+  ///
+  /// For example log readers or port forwarders.
   void dispose() {}
 }
 

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -473,6 +473,9 @@ abstract class Device {
   static Future<void> printDevices(List<Device> devices) async {
     await descriptions(devices).forEach(printStatus);
   }
+
+  /// Kill any sub-processes that were spawned in support of this device.
+  void killSubProcesses() {}
 }
 
 class DebuggingOptions {

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -595,6 +595,7 @@ abstract class DevicePortForwarder {
   /// Stops forwarding [forwardedPort].
   Future<void> unforward(ForwardedPort forwardedPort);
 
+  /// Cleanup allocated resources, like forwardedPorts
   Future<void> dispose() async { }
 }
 

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -572,16 +572,12 @@ class ForwardedPort {
   String toString() => 'ForwardedPort HOST:$hostPort to DEVICE:$devicePort';
 
   /// Kill subprocess (if present) used in forwarding.
-  bool killProcess() {
+  void dispose() {
     final Process process = context;
 
     if (process != null) {
       process.kill();
-    } else {
-      printError('Forwarded port did not have a valid process');
-      return false;
     }
-    return true;
   }
 }
 

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -365,6 +365,7 @@ class IOSDevice extends Device {
       Uri localUri;
       try {
         printTrace('Application launched on the device. Waiting for observatory port.');
+        print('using mDNS on port ${debuggingOptions.observatoryPort}...');
         localUri = await MDnsObservatoryDiscovery.instance.getObservatoryUri(
           package.id,
           this,
@@ -375,6 +376,7 @@ class IOSDevice extends Device {
           UsageEvent('ios-mdns', 'success').send();
           return LaunchResult.succeeded(observatoryUri: localUri);
         }
+        print('did not succeed');
       } catch (error) {
         printError('Failed to establish a debug connection with $id using mdns: $error');
       }

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -365,7 +365,6 @@ class IOSDevice extends Device {
       Uri localUri;
       try {
         printTrace('Application launched on the device. Waiting for observatory port.');
-        print('using mDNS on port ${debuggingOptions.observatoryPort}...');
         localUri = await MDnsObservatoryDiscovery.instance.getObservatoryUri(
           package.id,
           this,
@@ -376,7 +375,6 @@ class IOSDevice extends Device {
           UsageEvent('ios-mdns', 'success').send();
           return LaunchResult.succeeded(observatoryUri: localUri);
         }
-        print('did not succeed');
       } catch (error) {
         printError('Failed to establish a debug connection with $id using mdns: $error');
       }
@@ -428,7 +426,7 @@ class IOSDevice extends Device {
   }
 
   @override
-  DevicePortForwarder get portForwarder => _portForwarder ??= _IOSDevicePortForwarder(this);
+  DevicePortForwarder get portForwarder => _portForwarder ??= IOSDevicePortForwarder(this);
 
   @visibleForTesting
   set portForwarder(DevicePortForwarder forwarder) {
@@ -606,8 +604,9 @@ class _IOSDeviceLogReader extends DeviceLogReader {
   }
 }
 
-class _IOSDevicePortForwarder extends DevicePortForwarder {
-  _IOSDevicePortForwarder(this.device) : _forwardedPorts = <ForwardedPort>[];
+@visibleForTesting
+class IOSDevicePortForwarder extends DevicePortForwarder {
+  IOSDevicePortForwarder(this.device) : _forwardedPorts = <ForwardedPort>[];
 
   final IOSDevice device;
 

--- a/packages/flutter_tools/lib/src/mdns_discovery.dart
+++ b/packages/flutter_tools/lib/src/mdns_discovery.dart
@@ -60,6 +60,7 @@ class MDnsObservatoryDiscovery {
           )
           .toList();
       if (pointerRecords.isEmpty) {
+        printTrace('No pointer records found.');
         return null;
       }
       // We have no guarantee that we won't get multiple hits from the same

--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -48,6 +48,9 @@ class ProtocolDiscovery {
   StreamSubscription<String> _deviceLogSubscription;
 
   /// The discovered service URI.
+  ///
+  /// Port forwarding is only attempted when this is invoked, in case we never
+  /// need to port forward.
   Future<Uri> get uri async {
     final Uri rawUri = await _completer.future;
     return await _forwardPort(rawUri);

--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -48,7 +48,10 @@ class ProtocolDiscovery {
   StreamSubscription<String> _deviceLogSubscription;
 
   /// The discovered service URI.
-  Future<Uri> get uri => _completer.future;
+  Future<Uri> get uri async {
+    final Uri rawUri = await _completer.future;
+    return await _forwardPort(rawUri);
+  }
 
   Future<void> cancel() => _stopScrapingLogs();
 
@@ -74,9 +77,8 @@ class ProtocolDiscovery {
     if (uri != null) {
       assert(!_completer.isCompleted);
       _stopScrapingLogs();
-      _completer.complete(_forwardPort(uri));
+      _completer.complete(uri);
     }
-
   }
 
   Future<Uri> _forwardPort(Uri deviceUri) async {

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -22,7 +22,6 @@ import 'convert.dart';
 import 'devfs.dart';
 import 'device.dart';
 import 'globals.dart';
-import 'ios/devices.dart';
 import 'reporting/reporting.dart';
 import 'resident_runner.dart';
 import 'vmservice.dart';
@@ -1033,7 +1032,7 @@ class HotRunner extends ResidentRunner {
   @override
   Future<void> cleanupAtFinish() async {
     for (FlutterDevice flutterDevice in flutterDevices) {
-      flutterDevice.device.killSubProcesses();
+      flutterDevice.device.dispose();
     }
     await _cleanupDevFS();
     await stopEchoingDeviceLog();

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -255,9 +255,7 @@ class HotRunner extends ResidentRunner {
 
     firstBuildTime = DateTime.now();
 
-    printTrace('in hot runner');
     for (FlutterDevice device in flutterDevices) {
-      printTrace('about to invoke .runHot() for device ${device.device.toString()}');
       final int result = await device.runHot(
         hotRunner: this,
         route: route,

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -22,6 +22,7 @@ import 'convert.dart';
 import 'devfs.dart';
 import 'device.dart';
 import 'globals.dart';
+import 'ios/devices.dart';
 import 'reporting/reporting.dart';
 import 'resident_runner.dart';
 import 'vmservice.dart';
@@ -254,7 +255,9 @@ class HotRunner extends ResidentRunner {
 
     firstBuildTime = DateTime.now();
 
+    printTrace('in hot runner');
     for (FlutterDevice device in flutterDevices) {
+      printTrace('about to invoke .runHot() for device ${device.device.toString()}');
       final int result = await device.runHot(
         hotRunner: this,
         route: route,
@@ -1031,6 +1034,9 @@ class HotRunner extends ResidentRunner {
 
   @override
   Future<void> cleanupAtFinish() async {
+    for (FlutterDevice flutterDevice in flutterDevices) {
+      flutterDevice.device.killSubProcesses();
+    }
     await _cleanupDevFS();
     await stopEchoingDeviceLog();
   }

--- a/packages/flutter_tools/test/general.shard/device_test.dart
+++ b/packages/flutter_tools/test/general.shard/device_test.dart
@@ -145,19 +145,19 @@ void main() {
     });
   });
   group('ForwardedPort', () {
-    group('killProcess()', () {
-      testUsingContext('returns false if there was no process available as context', () {
+    group('dispose()', () {
+      testUsingContext('does not throw exception if no process is present', () {
         final ForwardedPort forwardedPort = ForwardedPort(123, 456);
-        final bool result = forwardedPort.killProcess();
-        expect(result, isFalse);
+        expect(forwardedPort.context, isNull);
+        forwardedPort.dispose();
       });
 
-      testUsingContext('kills process and returns true if process was available', () {
+      testUsingContext('kills process if process was available', () {
         final MockProcess mockProcess = MockProcess();
         final ForwardedPort forwardedPort = ForwardedPort.withContext(123, 456, mockProcess);
-        final bool result = forwardedPort.killProcess();
+        forwardedPort.dispose();
+        expect(forwardedPort.context, isNotNull);
         verify(mockProcess.kill());
-        expect(result, isTrue);
       });
     });
   });

--- a/packages/flutter_tools/test/general.shard/device_test.dart
+++ b/packages/flutter_tools/test/general.shard/device_test.dart
@@ -6,7 +6,9 @@ import 'dart:async';
 
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/project.dart';
+import 'package:mockito/mockito.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
@@ -142,6 +144,23 @@ void main() {
       ]);
     });
   });
+  group('ForwardedPort', () {
+    group('killProcess()', () {
+      testUsingContext('returns false if there was no process available as context', () {
+        final ForwardedPort forwardedPort = ForwardedPort(123, 456);
+        final bool result = forwardedPort.killProcess();
+        expect(result, isFalse);
+      });
+
+      testUsingContext('kills process and returns true if process was available', () {
+        final MockProcess mockProcess = MockProcess();
+        final ForwardedPort forwardedPort = ForwardedPort.withContext(123, 456, mockProcess);
+        final bool result = forwardedPort.killProcess();
+        verify(mockProcess.kill());
+        expect(result, isTrue);
+      });
+    });
+  });
 }
 
 class TestDeviceManager extends DeviceManager {
@@ -186,3 +205,5 @@ class _MockDevice extends Device {
   @override
   bool isSupportedForProject(FlutterProject flutterProject) => _isSupported;
 }
+
+class MockProcess extends Mock implements Process {}

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -245,7 +245,7 @@ void main() {
       // we timeout on a port
       testUsingContext(' .forward() will kill iproxy processes before invoking a second', () async {
         const String deviceId = '123';
-        const int devicePort = 456; 
+        const int devicePort = 456;
         final IOSDevice device = IOSDevice(deviceId);
         final IOSDevicePortForwarder portForwarder = IOSDevicePortForwarder(device);
         bool firstRun = true;

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -80,7 +80,7 @@ void main() {
 
     group('dispose()', () {
       testUsingContext('Calling dispose() kills all log readers & port forwarders', () async {
-        IOSDevice device = IOSDevice('123');
+        final IOSDevice device = IOSDevice('123');
         final MockApplicationPackage applicationPackage1 = MockApplicationPackage();
         final MockApplicationPackage applicationPackage2 = MockApplicationPackage();
         final MockDeviceLogReader mockDeviceLogReader1 = MockDeviceLogReader();

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -34,6 +34,8 @@ import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/mocks.dart';
 
+// mocks.dart already defines MockDeviceLogReader which extends DeviceLogReader
+class EmptyMockDeviceLogReader extends Mock implements DeviceLogReader {}
 class MockIOSApp extends Mock implements IOSApp {}
 class MockApplicationPackage extends Mock implements ApplicationPackage {}
 class MockArtifacts extends Mock implements Artifacts {}
@@ -83,8 +85,8 @@ void main() {
         final IOSDevice device = IOSDevice('123');
         final MockApplicationPackage applicationPackage1 = MockApplicationPackage();
         final MockApplicationPackage applicationPackage2 = MockApplicationPackage();
-        final MockDeviceLogReader mockDeviceLogReader1 = MockDeviceLogReader();
-        final MockDeviceLogReader mockDeviceLogReader2 = MockDeviceLogReader();
+        final EmptyMockDeviceLogReader mockDeviceLogReader1 = EmptyMockDeviceLogReader();
+        final EmptyMockDeviceLogReader mockDeviceLogReader2 = EmptyMockDeviceLogReader();
         final MockDevicePortForwarder mockDevicePortForwarder = MockDevicePortForwarder();
         device.setLogReader(applicationPackage1, mockDeviceLogReader1);
         device.setLogReader(applicationPackage2, mockDeviceLogReader2);
@@ -93,6 +95,8 @@ void main() {
         verify(mockDeviceLogReader1.dispose());
         verify(mockDeviceLogReader2.dispose());
         verify(mockDevicePortForwarder.dispose());
+      }, overrides: <Type, Generator>{
+        Platform: () => macPlatform,
       });
     });
 

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -92,7 +92,6 @@ void main() {
         final MockProcess mockProcess2 = MockProcess();
         logReader1.idevicesyslogProcess = mockProcess1;
         logReader2.idevicesyslogProcess = mockProcess2;
-        //final MockDevicePortForwarder mockDevicePortForwarder = MockDevicePortForwarder();
         final IOSDevicePortForwarder portForwarder = IOSDevicePortForwarder(device);
         final MockForwardedPort mockForwardedPort = MockForwardedPort();
         portForwarder.addForwardedPorts(<ForwardedPort>[mockForwardedPort]);

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -79,8 +79,8 @@ void main() {
       });
     }
 
-    group('dispose()', () {
-      testUsingContext('Calling dispose() kills all log readers & port forwarders', () async {
+    group('.dispose()', () {
+      testUsingContext(' kills all log readers & port forwarders', () async {
         final IOSDevice device = IOSDevice('123');
         final MockApplicationPackage applicationPackage1 = MockApplicationPackage();
         final MockApplicationPackage applicationPackage2 = MockApplicationPackage();

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -128,7 +128,6 @@ void main() {
       const String installerPath = '/path/to/ideviceinstaller';
       const String iosDeployPath = '/path/to/iosdeploy';
       const String iproxyPath = '/path/to/iproxy';
-      // const String appId = '789';
       const MapEntry<String, String> libraryEntry = MapEntry<String, String>(
           'DYLD_LIBRARY_PATH',
           '/path/to/libraries',

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -35,12 +35,14 @@ import '../../src/context.dart';
 import '../../src/mocks.dart';
 
 class MockIOSApp extends Mock implements IOSApp {}
+class MockApplicationPackage extends Mock implements ApplicationPackage {}
 class MockArtifacts extends Mock implements Artifacts {}
 class MockCache extends Mock implements Cache {}
 class MockDirectory extends Mock implements Directory {}
 class MockFileSystem extends Mock implements FileSystem {}
 class MockIMobileDevice extends Mock implements IMobileDevice {}
 class MockIOSDeploy extends Mock implements IOSDeploy {}
+class MockDevicePortForwarder extends Mock implements DevicePortForwarder {}
 class MockMDnsObservatoryDiscovery extends Mock implements MDnsObservatoryDiscovery {}
 class MockMDnsObservatoryDiscoveryResult extends Mock implements MDnsObservatoryDiscoveryResult {}
 class MockXcode extends Mock implements Xcode {}
@@ -75,6 +77,24 @@ void main() {
         Platform: () => platform,
       });
     }
+
+    group('dispose()', () {
+      testUsingContext('Calling dispose() kills all log readers & port forwarders', () async {
+        IOSDevice device = IOSDevice('123');
+        final MockApplicationPackage applicationPackage1 = MockApplicationPackage();
+        final MockApplicationPackage applicationPackage2 = MockApplicationPackage();
+        final MockDeviceLogReader mockDeviceLogReader1 = MockDeviceLogReader();
+        final MockDeviceLogReader mockDeviceLogReader2 = MockDeviceLogReader();
+        final MockDevicePortForwarder mockDevicePortForwarder = MockDevicePortForwarder();
+        device.setLogReader(applicationPackage1, mockDeviceLogReader1);
+        device.setLogReader(applicationPackage2, mockDeviceLogReader2);
+        device.portForwarder = mockDevicePortForwarder;
+        device.dispose();
+        verify(mockDeviceLogReader1.dispose());
+        verify(mockDeviceLogReader2.dispose());
+        verify(mockDevicePortForwarder.dispose());
+      });
+    });
 
     group('startApp', () {
       MockIOSApp mockApp;

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -87,8 +87,9 @@ void main() {
       IOSDeviceLogReader logReader2;
       MockProcess mockProcess1;
       MockProcess mockProcess2;
+      MockProcess mockProcess3;
       IOSDevicePortForwarder portForwarder;
-      MockForwardedPort mockForwardedPort;
+      ForwardedPort forwardedPort;
 
       IOSDevicePortForwarder createPortForwarder(
           ForwardedPort forwardedPort,
@@ -114,14 +115,15 @@ void main() {
         when(appPackage2.name).thenReturn('flutterApp2');
         mockProcess1 = MockProcess();
         mockProcess2 = MockProcess();
-        mockForwardedPort = MockForwardedPort();
+        mockProcess3 = MockProcess();
+        forwardedPort = ForwardedPort.withContext(123, 456, mockProcess3);
       });
 
       testUsingContext(' kills all log readers & port forwarders', () async {
         device = IOSDevice('123');
         logReader1 = createLogReader(device, appPackage1, mockProcess1);
         logReader2 = createLogReader(device, appPackage2, mockProcess2);
-        portForwarder = createPortForwarder(mockForwardedPort, device);
+        portForwarder = createPortForwarder(forwardedPort, device);
         device.setLogReader(appPackage1, logReader1);
         device.setLogReader(appPackage2, logReader2);
         device.portForwarder = portForwarder;
@@ -130,7 +132,7 @@ void main() {
 
         verify(mockProcess1.kill());
         verify(mockProcess2.kill());
-        verify(mockForwardedPort.dispose());
+        verify(mockProcess3.kill());
       }, overrides: <Type, Generator>{
         Platform: () => macPlatform,
       });

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -570,6 +570,7 @@ class MockDeviceLogReader extends DeviceLogReader {
 
   void addLine(String line) => _linesController.add(line);
 
+  @override
   void dispose() {
     _linesController.close();
   }


### PR DESCRIPTION
## Description

This actually fixes two issues:

1. #41854, that there are situations when we spawn many subprocesses of `iproxy` and never close them (even after the tool exits), which build up in the devicelab until the processes have to be manually killed.
2. #41911 That in many cases, we were port forwarding twice, once through the log scanning flow and once through the mDNS discovery flow.

This PR adds a new method to `Device` class, called `void killSubProcesses()`, which has an empty default implementation, but for an `IOSDevice` will kill `iproxy` and `idevicesyslog` processes, if they exist. I imagine this method would be useful for other types of devices (I currently have a stray `adb -L fork-server server` process running).

## Related Issues

Fixes #41854 & #41911

## Tests

Add unit tests for:

1. That `ForwardedPort` calling `.dispose()` will send term signal to the attached process
1. `.dispose()` method for `IOSDevice` will call `.dispose()` to any port forwarders or log readers
1. That `startApp()` kills first process before invoking second.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.