### PR TITLE
Make `ProjectFileInvalidator.findInvalidated` able to use the async `FileStat.stat`

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -173,14 +173,6 @@ class RunCommand extends RunCommandBase {
               'results out to "refresh_benchmark.json", and exit. This flag is '
               'intended for use in generating automated flutter benchmarks.',
       )
-      ..addFlag('async-scanning',
-        negatable: true,
-        hide: !verboseHelp,
-        help: 'Whether to scan for modified files using asynchronously. '
-              'Enabling this can reduce hot reload times for projects that '
-              'reside on network file systems but might be worse for projects '
-              'on local file systems.',
-      )
       ..addFlag('disable-service-auth-codes',
         negatable: false,
         hide: !verboseHelp,
@@ -455,7 +447,6 @@ class RunCommand extends RunCommandBase {
         dillOutputPath: argResults['output-dill'],
         stayResident: stayResident,
         ipv6: ipv6,
-        asyncScanning: argResults['async-scanning'],
       );
     } else if (webMode) {
       runner = webRunnerFactory.createWebRunner(

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -173,6 +173,14 @@ class RunCommand extends RunCommandBase {
               'results out to "refresh_benchmark.json", and exit. This flag is '
               'intended for use in generating automated flutter benchmarks.',
       )
+      ..addFlag('async-scanning',
+        negatable: true,
+        hide: !verboseHelp,
+        help: 'Whether to scan for modified files using asynchronously. '
+              'Enabling this can reduce hot reload times for projects that '
+              'reside on network file systems but might be worse for projects '
+              'on local file systems.',
+      )
       ..addFlag('disable-service-auth-codes',
         negatable: false,
         hide: !verboseHelp,
@@ -447,6 +455,7 @@ class RunCommand extends RunCommandBase {
         dillOutputPath: argResults['output-dill'],
         stayResident: stayResident,
         ipv6: ipv6,
+        asyncScanning: argResults['async-scanning'],
       );
     } else if (webMode) {
       runner = webRunnerFactory.createWebRunner(

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -301,13 +301,12 @@ class HotRunner extends ResidentRunner {
 
     // Picking up first device's compiler as a source of truth - compilers
     // for all devices should be in sync.
-    final List<Uri> invalidatedFiles =
-      await ProjectFileInvalidator.findInvalidated(
-        lastCompiled: flutterDevices[0].devFS.lastCompiled,
-        urisToMonitor: flutterDevices[0].devFS.sources,
-        packagesPath: packagesFilePath,
-        asyncScanning: hotRunnerConfig.asyncScanning,
-      );
+    final List<Uri> invalidatedFiles = await ProjectFileInvalidator.findInvalidated(
+      lastCompiled: flutterDevices[0].devFS.lastCompiled,
+      urisToMonitor: flutterDevices[0].devFS.sources,
+      packagesPath: packagesFilePath,
+      asyncScanning: hotRunnerConfig.asyncScanning,
+    );
     final UpdateFSReport results = UpdateFSReport(success: true);
     for (FlutterDevice device in flutterDevices) {
       results.incorporateResults(await device.updateDevFS(
@@ -1051,8 +1050,10 @@ class ProjectFileInvalidator {
   static const String _pubCachePathLinuxAndMac = '.pub-cache';
   static const String _pubCachePathWindows = 'Pub/Cache';
 
-  // As of writing, Dart supports up to 32 threads per isolate.  We also
-  // want to avoid hitting platform limits on open file handles/descriptors.
+  // As of writing, Dart supports up to 32 asynchronous I/O threads per
+  // isolate.  We also want to avoid hitting platform limits on open file
+  // handles/descriptors.
+  //
   // This value was chosen based on empirical tests scanning a set of
   // ~2000 files.
   static const int _kMaxPendingStats = 8;

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -1051,7 +1051,11 @@ class ProjectFileInvalidator {
   static const String _pubCachePathLinuxAndMac = '.pub-cache';
   static const String _pubCachePathWindows = 'Pub/Cache';
 
-  static const int _kMaxPendingStats = 16;
+  // As of writing, Dart supports up to 32 threads per isolate.  We also
+  // want to avoid hitting platform limits on open file handles/descriptors.
+  // This value was chosen based on empirical tests scanning a set of
+  // ~2000 files.
+  static const int _kMaxPendingStats = 8;
 
   static Future<List<Uri>> findInvalidated({
     @required DateTime lastCompiled,

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -29,6 +29,10 @@ import 'vmservice.dart';
 class HotRunnerConfig {
   /// Should the hot runner assume that the minimal Dart dependencies do not change?
   bool stableDartDependencies = false;
+
+  /// Whether the hot runner should scan for modified files asynchronously.
+  bool asyncScanning = false;
+
   /// A hook for implementations to perform any necessary initialization prior
   /// to a hot restart. Should return true if the hot restart should continue.
   Future<bool> setupHotRestart() async {
@@ -66,7 +70,6 @@ class HotRunner extends ResidentRunner {
     String dillOutputPath,
     bool stayResident = true,
     bool ipv6 = false,
-    this.asyncScanning = false,
   }) : super(devices,
              target: target,
              debuggingOptions: debuggingOptions,
@@ -80,7 +83,6 @@ class HotRunner extends ResidentRunner {
   final bool benchmarkMode;
   final File applicationBinary;
   final bool hostIsIde;
-  final bool asyncScanning;
   bool _didAttach = false;
 
   final Map<String, List<int>> benchmarkData = <String, List<int>>{};
@@ -303,7 +305,7 @@ class HotRunner extends ResidentRunner {
         lastCompiled: flutterDevices[0].devFS.lastCompiled,
         urisToMonitor: flutterDevices[0].devFS.sources,
         packagesPath: packagesFilePath,
-        asyncScanning: asyncScanning,
+        asyncScanning: hotRunnerConfig.asyncScanning,
       );
     final UpdateFSReport results = UpdateFSReport(success: true);
     for (FlutterDevice device in flutterDevices) {

--- a/packages/flutter_tools/test/general.shard/project_file_invalidator_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_file_invalidator_test.dart
@@ -16,7 +16,7 @@ void main() {
   group('ProjectFileInvalidator', () {
     testUsingContext('No last compile', () async {
       expect(
-        ProjectFileInvalidator.findInvalidated(
+        await ProjectFileInvalidator.findInvalidated(
           lastCompiled: null,
           urisToMonitor: <Uri>[],
           packagesPath: '',
@@ -27,7 +27,7 @@ void main() {
 
     testUsingContext('Empty project', () async {
       expect(
-        ProjectFileInvalidator.findInvalidated(
+        await ProjectFileInvalidator.findInvalidated(
           lastCompiled: inFuture,
           urisToMonitor: <Uri>[],
           packagesPath: '',
@@ -41,7 +41,7 @@ void main() {
 
     testUsingContext('Non-existent files are ignored', () async {
       expect(
-        ProjectFileInvalidator.findInvalidated(
+        await ProjectFileInvalidator.findInvalidated(
           lastCompiled: inFuture,
           urisToMonitor: <Uri>[Uri.parse('/not-there-anymore'),],
           packagesPath: '',

--- a/packages/flutter_tools/test/general.shard/project_file_invalidator_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_file_invalidator_test.dart
@@ -5,6 +5,7 @@
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/run_hot.dart';
+import 'package:meta/meta.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
@@ -14,43 +15,53 @@ final DateTime inFuture = DateTime.now().add(const Duration(days: 100));
 
 void main() {
   group('ProjectFileInvalidator', () {
-    testUsingContext('No last compile', () async {
-      expect(
-        await ProjectFileInvalidator.findInvalidated(
-          lastCompiled: null,
-          urisToMonitor: <Uri>[],
-          packagesPath: '',
-        ),
-        isEmpty,
-      );
-    });
+    _testProjectFileInvalidator(asyncScanning: false);
+  });
+  group('ProjectFileInvalidator (async scanning)', () {
+    _testProjectFileInvalidator(asyncScanning: true);
+  });
+}
 
-    testUsingContext('Empty project', () async {
-      expect(
-        await ProjectFileInvalidator.findInvalidated(
-          lastCompiled: inFuture,
-          urisToMonitor: <Uri>[],
-          packagesPath: '',
-        ),
-        isEmpty,
-      );
-    }, overrides: <Type, Generator>{
-      FileSystem: () => MemoryFileSystem(),
-      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
-    });
+void _testProjectFileInvalidator({@required bool asyncScanning}) {
+  testUsingContext('No last compile', () async {
+    expect(
+      await ProjectFileInvalidator.findInvalidated(
+        lastCompiled: null,
+        urisToMonitor: <Uri>[],
+        packagesPath: '',
+        asyncScanning: asyncScanning,
+      ),
+      isEmpty,
+    );
+  });
 
-    testUsingContext('Non-existent files are ignored', () async {
-      expect(
-        await ProjectFileInvalidator.findInvalidated(
-          lastCompiled: inFuture,
-          urisToMonitor: <Uri>[Uri.parse('/not-there-anymore'),],
-          packagesPath: '',
-        ),
-        isEmpty,
-      );
-    }, overrides: <Type, Generator>{
-      FileSystem: () => MemoryFileSystem(),
-      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
-    });
+  testUsingContext('Empty project', () async {
+    expect(
+      await ProjectFileInvalidator.findInvalidated(
+        lastCompiled: inFuture,
+        urisToMonitor: <Uri>[],
+        packagesPath: '',
+        asyncScanning: asyncScanning,
+      ),
+      isEmpty,
+    );
+  }, overrides: <Type, Generator>{
+    FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
+  });
+
+  testUsingContext('Non-existent files are ignored', () async {
+    expect(
+      await ProjectFileInvalidator.findInvalidated(
+        lastCompiled: inFuture,
+        urisToMonitor: <Uri>[Uri.parse('/not-there-anymore'),],
+        packagesPath: '',
+        asyncScanning: asyncScanning,
+      ),
+      isEmpty,
+    );
+  }, overrides: <Type, Generator>{
+    FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
   });
 }


### PR DESCRIPTION
Empirical measurements indicate on the network file system we use
internally, using `FileStat.stat` on thousands of files is much
faster than using `FileStat.statSync`. (It can be slower for files
on a local SSD, however.)

Add a flag to `ProjectFileInvalidator.findInvalidated` to let it
use `FileStat.stat` instead of `FileStat.statSync` when scanning for
modified files.  This can be enabled by overriding `HotRunnerConfig`.

I considered creating a separate, asynchronous version of
`findInvalidated`, but that led to more code duplication than I
liked, and it would be harder to avoid drift between the versions.

## Tests

I added async versions of the tests in `project_file_invalidator_test.dart`.  Note that currently all of the tests check for degenerate behavior, and none of them check for modifications to existing files.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
