### PR TITLE
Redirect Firebase issues to FirebaseExtended/flutterfire

### DIFF
--- a/.github/ISSUE_TEMPLATE/FlutterFire.md
+++ b/.github/ISSUE_TEMPLATE/FlutterFire.md
@@ -2,7 +2,6 @@
 name: FlutterFire
 about: FlutterFire has been moved to [FirebaseExtended/flutterfire](https://github.com/FirebaseExtended/flutterfire).
        All issues related to FlutterFire should be filed there.
-       addressed there.
 title: ''
 labels: ''
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/FlutterFire.md
+++ b/.github/ISSUE_TEMPLATE/FlutterFire.md
@@ -1,7 +1,7 @@
 ---
 name: FlutterFire
 about: FlutterFire has been moved to [FirebaseExtended/flutterfire](https://github.com/FirebaseExtended/flutterfire).
-       All issues related to FlutterFire should be filed and will be
+       All issues related to FlutterFire should be filed there.
        addressed there.
 title: ''
 labels: ''

--- a/.github/ISSUE_TEMPLATE/FlutterFire.md
+++ b/.github/ISSUE_TEMPLATE/FlutterFire.md
@@ -1,0 +1,10 @@
+---
+name: FlutterFire
+about: FlutterFire has been moved to [FirebaseExtended/flutterfire](https://github.com/FirebaseExtended/flutterfire).
+       All issues related to FlutterFire should be filed and will be
+       addressed there.
+title: ''
+labels: ''
+assignees: ''
+
+---


### PR DESCRIPTION
## Description

Since FlutterFire has been moved to FirebaseExtended/flutterfire issues related to Firebase should be reported there. This PR creates an issue template that will alert developers that there is a better place to report Firebase issues.