### PR TITLE
Refactor sdk_validation_test

### DIFF
--- a/packages/flutter_tools/test/general.shard/dart/sdk_validation_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/sdk_validation_test.dart
@@ -9,125 +9,64 @@ import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/dart/analysis.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/dart/sdk.dart';
-import 'package:meta/meta.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
 
 void main() {
-  group('sdk validation', () {
-    AnalysisServer server;
-    Directory tempDir;
-
-    setUpAll(() {
-      Cache.disableLocking();
-      tempDir =
-          fs.systemTempDirectory.createTempSync('sdk_validation_test').absolute;
-    });
-
-    tearDownAll(() {
-      Cache.enableLocking();
-      tryToDelete(tempDir);
-      return server?.dispose();
-    });
-
-    testUsingContext('contains dart:ui', () async {
-      createSampleProject(tempDir, dartSource: '''
-import 'dart:ui' as ui;
-void main() {
-  // ignore: unnecessary_statements
-  ui.Window;
-}
-''');
-
-      await pubGet(context: PubContext.flutterTests, directory: tempDir.path);
-
-      server = AnalysisServer(dartSdkPath, <String>[tempDir.path]);
-
-      final int errorCount = await analyze(server);
-      expect(errorCount, 0);
-    });
-
-    testUsingContext('contains dart:html', () async {
-      createSampleProject(tempDir, dartSource: '''
-import 'dart:html' as html;
-void main() {
-  // ignore: unnecessary_statements
-  html.HttpStatus;
-}
-''');
-
-      await pubGet(context: PubContext.flutterTests, directory: tempDir.path);
-
-      server = AnalysisServer(dartSdkPath, <String>[tempDir.path]);
-
-      final int errorCount = await analyze(server);
-      expect(errorCount, 0);
-    });
-
-    testUsingContext('contains dart:js', () async {
-      createSampleProject(tempDir, dartSource: '''
-import 'dart:js' as js;
-void main() {
-  // ignore: unused_local_variable
-  var foo = js.allowInterop(null);
-}
-''');
-
-      await pubGet(context: PubContext.flutterTests, directory: tempDir.path);
-
-      server = AnalysisServer(dartSdkPath, <String>[tempDir.path]);
-
-      final int errorCount = await analyze(server);
-      expect(errorCount, 0);
-    });
-
-    testUsingContext('contains dart:js_util', () async {
-      createSampleProject(tempDir, dartSource: '''
-import 'dart:js_util' as js_util;
-void main() {
-  // ignore: unused_local_variable
-  var bar = js_util.jsify(null);
-}
-''');
-
-      await pubGet(context: PubContext.flutterTests, directory: tempDir.path);
-
-      server = AnalysisServer(dartSdkPath, <String>[tempDir.path]);
-
-      final int errorCount = await analyze(server);
-      expect(errorCount, 0);
-    });
-  }, skip: true);
+  testSampleProject('ui', 'Window');
+  testSampleProject('html', 'HttpStatus');
+  testSampleProject('js', 'allowInterop');
+  testSampleProject('js_util', 'jsify');
 }
 
-void createSampleProject(Directory directory, {@required String dartSource}) {
-  final File pubspecFile =
-      fs.file(fs.path.join(directory.path, 'pubspec.yaml'));
-  pubspecFile.writeAsStringSync('''
-name: foo_project
+void testSampleProject(String lib, String member) {
+  testUsingContext('contains dart:$lib', () async {
+    Cache.disableLocking();
+    final Directory projectDirectory = fs.systemTempDirectory.createTempSync('flutter_sdk_validation_${lib}_test.').absolute;
+
+    try {
+      final File pubspecFile = fs.file(fs.path.join(projectDirectory.path, 'pubspec.yaml'));
+      pubspecFile.writeAsStringSync('''
+name: ${lib}_project
 dependencies:
   flutter:
     sdk: flutter
 ''');
 
-  final File dartFile =
-      fs.file(fs.path.join(directory.path, 'lib', 'main.dart'));
-  dartFile.parent.createSync();
-  dartFile.writeAsStringSync(dartSource);
+      final File dartFile = fs.file(fs.path.join(projectDirectory.path, 'lib', 'main.dart'));
+      dartFile.parent.createSync();
+      dartFile.writeAsStringSync('''
+import 'dart:$lib' as $lib;
+void main() {
+  // ignore: unnecessary_statements
+  $lib.$member;
+}
+''');
+
+      await pubGet(context: PubContext.flutterTests, directory: projectDirectory.path);
+      final AnalysisServer server = AnalysisServer(dartSdkPath, <String>[projectDirectory.path]);
+      try {
+        final int errorCount = await analyze(server);
+        expect(errorCount, 0);
+      } finally {
+        await server.dispose();
+      }
+    } finally {
+      tryToDelete(projectDirectory);
+      Cache.enableLocking();
+    }
+  });
 }
 
-Future<int> analyze(AnalysisServer server, {bool printErrors = true}) async {
+Future<int> analyze(AnalysisServer server) async {
   int errorCount = 0;
-  final Future<bool> onDone =
-      server.onAnalyzing.where((bool analyzing) => analyzing == false).first;
-  server.onErrors.listen((FileAnalysisErrors errors) {
-    if (printErrors) {
-      for (AnalysisError error in errors.errors) {
-        print(error.toString().trim());
-      }
+  final Future<bool> onDone = server.onAnalyzing.where((bool analyzing) => analyzing == false).first;
+  server.onErrors.listen((FileAnalysisErrors result) {
+    for (AnalysisError error in result.errors) {
+      print(error.toString().trim());
     }
-    errorCount += errors.errors.length;
+    errorCount += result.errors.length;
   });
 
   await server.start();


### PR DESCRIPTION
In an attempt to either fix or track down the issue mentioned in https://github.com/flutter/flutter/issues/42039, I tried to refactor this test to avoid any risky features like tearDownAll.

The only meaningful change here is that I await the analyzer's `dispose` method. There's a chance that will fix it, though.

cc @dnfield @devoncarew 