### PR TITLE
Run secondary animation of previous route when using pushReplacement(…

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -1892,6 +1892,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
       }
     });
     newRoute.didChangeNext(null);
+    oldRoute.didChangeNext(newRoute);
     if (index > 0) {
       _history[index - 1].didChangeNext(newRoute);
       newRoute.didChangePrevious(_history[index - 1]);
@@ -1961,14 +1962,15 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
             observer.didRemove(removedRoute, newPrecedingRoute);
           removedRoute.dispose();
         }
-
-        if (newPrecedingRoute != null)
-          newPrecedingRoute.didChangeNext(newRoute);
       }
     });
 
     // Notify for newRoute
     newRoute.didChangeNext(null);
+    if (precedingRoute != null) {
+      newRoute.didChangePrevious(precedingRoute);
+      precedingRoute.didChangeNext(newRoute);
+    }
     for (final NavigatorObserver observer in widget.observers)
       observer.didPush(newRoute, precedingRoute);
 

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -1968,8 +1968,11 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
     // Notify for newRoute
     newRoute.didChangeNext(null);
     if (precedingRoute != null) {
-      newRoute.didChangePrevious(precedingRoute);
       precedingRoute.didChangeNext(newRoute);
+    }
+    if (newPrecedingRoute != null) {
+      newPrecedingRoute.didChangeNext(newRoute);
+      newRoute.didChangePrevious(newPrecedingRoute);
     }
     for (final NavigatorObserver observer in widget.observers)
       observer.didPush(newRoute, precedingRoute);


### PR DESCRIPTION
…) or pushAndRemoveUntil. Resolves #41680

## Description

Currently the navigator will not cause the secondary animation to run on the previous topmost route when using `pushReplacement()` or `pushAndRemoveUntil()`. This is inconsistent with the animation behaviour of a 'push', of which these methods are specific types.

This is a particular issue where a custom route transition is used, such as one that slides out the previous route as the new route slides in.

This PR ensures that the secondary animation of the previous topmost route is run.

## Related Issues

RESOLVED - Secondary animations should still run when using Navigator pushAndRemoveUntil() or pushReplacement() #41680

## Tests

I added the following tests:

In navigator_test.dart:
* replaceNamed triggers secondaryAnimation
* pushAndRemoveUntil triggers secondaryAnimation
* replaceNamed sets secondaryAnimation after transition with history change during transition

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR. 

The analyzer reports many problems on the master branch of flutter, unrelated to my PR.

- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (Please read [Handling breaking changes]). https://groups.google.com/forum/#!topic/flutter-announce/y0SvesRHlcE
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
