### PR TITLE
Apply mocks to test command

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
@@ -20,6 +20,7 @@ import 'package:flutter_tools/src/web/compile.dart';
 import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
+import '../../src/mocks.dart';
 import '../../src/testbed.dart';
 
 void main() {
@@ -88,7 +89,9 @@ void main() {
   }));
 
   test('Builds a web bundle - end to end', () => testbed.run(() async {
-    final CommandRunner<void> runner = createTestCommandRunner(BuildCommand());
+    final BuildCommand buildCommand = BuildCommand();
+    applyMocksToCommand(buildCommand);
+    final CommandRunner<void> runner = createTestCommandRunner(buildCommand);
     final List<String> dependencies = <String>[
       fs.path.join('packages', 'flutter_tools', 'lib', 'src', 'build_system', 'targets', 'web.dart'),
       fs.path.join('bin', 'cache', 'flutter_web_sdk'),


### PR DESCRIPTION
## Description

Missed the call to applyMocks. This causes several pieces of real functionality like pub to be run during the test, making it significantly more flaky than it needs to be.