### PR TITLE
Update dartdoc to 0.28.7

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -104,7 +104,7 @@ if [[ -d "$FLUTTER_PUB_CACHE" ]]; then
 fi
 
 # Install and activate dartdoc.
-"$PUB" global activate dartdoc 0.28.5
+"$PUB" global activate dartdoc 0.28.7
 
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc.


### PR DESCRIPTION
Updates dartdoc to the most recent version.  In particular, this fixes a regression triggered by analyzer 0.38.5 in typedef return values.

### 0.28.7
* Remove obsolete references to Element.type and ElementHandle (dart-lang/dartdoc#2028, dart-lang/dartdoc#2031).
* Fix problem with return values for typedefs with analyzer 0.38.5 (dart-lang/dartdoc#2036).

### 0.28.6
* Support for 0.38.3 version of `package:analyzer`.
* Support generating docs for extension methods (dart-lang/dartdoc#2001).