### PR TITLE
Fix regression with ModalBottomSheets not responding to changes in theme

### DIFF
--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -380,6 +380,7 @@ class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
 
   @override
   Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
+    final BottomSheetThemeData sheetTheme = theme?.bottomSheetTheme ?? Theme.of(context).bottomSheetTheme;
     // By definition, the bottom sheet is aligned to the bottom of the page
     // and isn't exposed to the top padding of the MediaQuery.
     Widget bottomSheet = MediaQuery.removePadding(
@@ -387,8 +388,8 @@ class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
       removeTop: true,
       child: _ModalBottomSheet<T>(
         route: this,
-        backgroundColor: backgroundColor,
-        elevation: elevation,
+        backgroundColor: backgroundColor ?? sheetTheme?.modalBackgroundColor ?? sheetTheme?.backgroundColor,
+        elevation: elevation ?? sheetTheme?.modalElevation ?? sheetTheme?.elevation,
         shape: shape,
         clipBehavior: clipBehavior,
         isScrollControlled: isScrollControlled,
@@ -460,15 +461,13 @@ Future<T> showModalBottomSheet<T>({
   assert(debugCheckHasMediaQuery(context));
   assert(debugCheckHasMaterialLocalizations(context));
 
-  final BottomSheetThemeData theme = Theme.of(context).bottomSheetTheme;
-
   return Navigator.of(context, rootNavigator: useRootNavigator).push(_ModalBottomSheetRoute<T>(
     builder: builder,
     theme: Theme.of(context, shadowThemeOnly: true),
     isScrollControlled: isScrollControlled,
     barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
-    backgroundColor: backgroundColor ?? theme?.modalBackgroundColor ?? theme?.backgroundColor,
-    elevation: elevation ?? theme?.modalElevation ?? theme?.elevation,
+    backgroundColor: backgroundColor,
+    elevation: elevation,
     shape: shape,
     clipBehavior: clipBehavior,
   ));

--- a/packages/flutter/test/material/bottom_sheet_theme_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_theme_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -213,6 +214,75 @@ void main() {
     );
     expect(material.elevation, 0);
     expect(material.color, null);
+  });
+
+  testWidgets('Modal bottom sheets respond to theme changes', (WidgetTester tester) async {
+    const double lightElevation = 5.0;
+    const double darkElevation = 3.0;
+    const Color lightBackgroundColor = Colors.green;
+    const Color darkBackgroundColor = Colors.grey;
+
+    await tester.pumpWidget(MaterialApp(
+      theme: ThemeData.light().copyWith(
+        bottomSheetTheme: const BottomSheetThemeData(
+          elevation: lightElevation,
+          backgroundColor: lightBackgroundColor,
+        ),
+      ),
+      darkTheme: ThemeData.dark().copyWith(
+        bottomSheetTheme: const BottomSheetThemeData(
+          elevation: darkElevation,
+          backgroundColor: darkBackgroundColor,
+        ),
+      ),
+      home: Scaffold(
+        body: Builder(
+          builder: (BuildContext context) {
+            return Column(
+              children: <Widget>[
+                RawMaterialButton(
+                  child: const Text('Show Modal'),
+                  onPressed: () {
+                    showModalBottomSheet<void>(
+                      context: context,
+                      builder: (BuildContext context) {
+                        return Container(
+                          child: const Text('This is a modal bottom sheet.'),
+                        );
+                      },
+                    );
+                  },
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    ));
+    await tester.tap(find.text('Show Modal'));
+    await tester.pumpAndSettle();
+
+    final Material lightMaterial = tester.widget<Material>(
+      find.descendant(
+        of: find.byType(BottomSheet),
+        matching: find.byType(Material),
+      ),
+    );
+    expect(lightMaterial.elevation, lightElevation);
+    expect(lightMaterial.color, lightBackgroundColor);
+  
+    // Simulate the user changing to dark theme
+    tester.binding.window.platformBrightnessTestValue = Brightness.dark;
+    await tester.pumpAndSettle();
+
+    final Material darkMaterial = tester.widget<Material>(
+    find.descendant(
+      of: find.byType(BottomSheet),
+        matching: find.byType(Material),
+      ),
+    );
+    expect(darkMaterial.elevation, darkElevation);
+    expect(darkMaterial.color, darkBackgroundColor);
   });
 }
 

--- a/packages/flutter/test/material/bottom_sheet_theme_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_theme_test.dart
@@ -270,7 +270,7 @@ void main() {
     );
     expect(lightMaterial.elevation, lightElevation);
     expect(lightMaterial.color, lightBackgroundColor);
-  
+
     // Simulate the user changing to dark theme
     tester.binding.window.platformBrightnessTestValue = Brightness.dark;
     await tester.pumpAndSettle();


### PR DESCRIPTION
## Description

#39333 introduced a regression where `ModalBottomSheets` no longer responded to changes in the theme after they were shown. The fix was to move the color and elevation theme resolution out of the `showModalBottomSheet` function and into the the widget's build method. That way colors and elevation changes in the theme will be picked up when the widget is rebuilt.

## Related Issues

Fixes: #42128

## Tests

I added a new test that checks that color and elevation changes in the surrounding theme are picked up by the visible modal bottom sheet.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
