### PR TITLE
Shard web tests; enable semantics tests on the Web

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -153,6 +153,7 @@ task:
         cpu: 8
         memory: 24G
     - name: web_tests-linux-shard-0
+      use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
       env:
         SHARD: web_tests
         WEB_SHARD: 0
@@ -162,6 +163,7 @@ task:
         cpu: 4
         memory: 12G
     - name: web_tests-linux-shard-1
+      use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
       env:
         SHARD: web_tests
         WEB_SHARD: 1
@@ -171,6 +173,7 @@ task:
         cpu: 4
         memory: 12G
     - name: web_tests-linux-shard-2
+      use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
       env:
         SHARD: web_tests
         WEB_SHARD: 2

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -152,10 +152,28 @@ task:
       container:
         cpu: 8
         memory: 24G
-    - name: web_tests-linux
-      allow_failures: true
+    - name: web_tests-linux-shard-0
       env:
         SHARD: web_tests
+        WEB_SHARD: 0
+      test_script:
+        - dart --enable-asserts ./dev/bots/test.dart
+      container:
+        cpu: 4
+        memory: 12G
+    - name: web_tests-linux-shard-1
+      env:
+        SHARD: web_tests
+        WEB_SHARD: 1
+      test_script:
+        - dart --enable-asserts ./dev/bots/test.dart
+      container:
+        cpu: 4
+        memory: 12G
+    - name: web_tests-linux-shard-2
+      env:
+        SHARD: web_tests
+        WEB_SHARD: 2
       test_script:
         - dart --enable-asserts ./dev/bots/test.dart
       container:

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -686,7 +686,7 @@ class EvalResult {
 }
 
 /// The number of Cirrus jobs that run web tests in parallel.
-/// 
+///
 /// WARNING: if you change this number, also change .cirrus.yml
 /// and make sure it runs _all_ shards.
 const int _kWebShardCount = 3;

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -720,7 +720,6 @@ Future<void> _runFlutterWebTest(String workingDirectory, {
 
   print(allTests.join('\n'));
   print('${allTests.length} tests total');
-  return;
 
   // Maximum number of tests to run in a single `flutter test`. We found that
   // large batches can get flaky, possibly because we reuse a single instance

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -445,7 +445,6 @@ Future<void> _runWebTests() async {
     'test/material',
     'test/painting',
     'test/rendering',
-    'test/semantics',
     'test/widgets',
   ];
 

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -685,10 +685,16 @@ class EvalResult {
   final int exitCode;
 }
 
+/// The number of Cirrus jobs that run web tests in parallel.
+/// 
+/// WARNING: if you change this number, also change .cirrus.yml
+/// and make sure it runs _all_ shards.
+const int _kWebShardCount = 3;
+
 Future<void> _runFlutterWebTest(String workingDirectory, {
   List<String> tests,
 }) async {
-  final List<String> allTests = <String>[];
+  List<String> allTests = <String>[];
   for (String testDirPath in tests) {
     final Directory testDir = Directory(path.join(workingDirectory, testDirPath));
     allTests.addAll(
@@ -698,8 +704,23 @@ Future<void> _runFlutterWebTest(String workingDirectory, {
         .map((File file) => path.relative(file.path, from: workingDirectory))
     );
   }
+
+  // If a shard is specified only run tests in that shard.
+  final int webShard = int.tryParse(Platform.environment['WEB_SHARD'] ?? 'n/a');
+  if (webShard != null) {
+    if (webShard >= _kWebShardCount) {
+      throw 'WEB_SHARD must be <= _kWebShardCount, but was $webShard';
+    }
+    final List<String> shard = <String>[];
+    for (int i = webShard; i < allTests.length; i += _kWebShardCount) {
+      shard.add(allTests[i]);
+    }
+    allTests = shard;
+  }
+
   print(allTests.join('\n'));
   print('${allTests.length} tests total');
+  return;
 
   // Maximum number of tests to run in a single `flutter test`. We found that
   // large batches can get flaky, possibly because we reuse a single instance


### PR DESCRIPTION
## Description

Web tests are approaching 10 minutes to run on Cirrus, and we haven't even added widget, material, cupertino, painting, and rendering tests yet.

This PR splits tests into multiple shards and runs them on Cirrus in parallel. The shards use compute credits as we can scale Cirrus Linux instances easily. It also enables all semantics tests that previously were skipped.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/41921

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
