### PR TITLE
Add use_modular_headers! to default Podfile

### DIFF
--- a/dev/benchmarks/macrobenchmarks/ios/Runner/AppDelegate.m
+++ b/dev/benchmarks/macrobenchmarks/ios/Runner/AppDelegate.m
@@ -1,5 +1,5 @@
-#include "AppDelegate.h"
-#include "GeneratedPluginRegistrant.h"
+#import "AppDelegate.h"
+#import "GeneratedPluginRegistrant.h"
 
 @implementation AppDelegate
 

--- a/dev/integration_tests/android_views/ios/Podfile
+++ b/dev/integration_tests/android_views/ios/Podfile
@@ -33,6 +33,8 @@ def parse_KV_file(file, separator='=')
 end
 
 target 'Runner' do
+  use_modular_headers!
+
   # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
   # referring to absolute paths on developers' machines.
   system('rm -rf .symlinks')

--- a/dev/integration_tests/android_views/ios/Runner/AppDelegate.m
+++ b/dev/integration_tests/android_views/ios/Runner/AppDelegate.m
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "AppDelegate.h"
-#include "GeneratedPluginRegistrant.h"
+#import "AppDelegate.h"
+#import "GeneratedPluginRegistrant.h"
 
 @implementation AppDelegate
 

--- a/dev/integration_tests/channels/ios/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/dev/integration_tests/channels/ios/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/dev/integration_tests/channels/ios/Runner/AppDelegate.m
+++ b/dev/integration_tests/channels/ios/Runner/AppDelegate.m
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "AppDelegate.h"
-#include "GeneratedPluginRegistrant.h"
+#import "AppDelegate.h"
+#import "GeneratedPluginRegistrant.h"
 
 @interface Pair : NSObject
 @property(atomic, readonly, strong, nullable) NSObject* left;

--- a/dev/integration_tests/codegen/ios/Runner/AppDelegate.m
+++ b/dev/integration_tests/codegen/ios/Runner/AppDelegate.m
@@ -1,5 +1,5 @@
-#include "AppDelegate.h"
-#include "GeneratedPluginRegistrant.h"
+#import "AppDelegate.h"
+#import "GeneratedPluginRegistrant.h"
 
 @implementation AppDelegate
 

--- a/dev/integration_tests/external_ui/ios/Runner/AppDelegate.m
+++ b/dev/integration_tests/external_ui/ios/Runner/AppDelegate.m
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "AppDelegate.h"
+#import "AppDelegate.h"
 
 @interface AppDelegate ()
   @property (atomic) uint64_t textureId;

--- a/dev/integration_tests/flavors/ios/Runner/AppDelegate.m
+++ b/dev/integration_tests/flavors/ios/Runner/AppDelegate.m
@@ -1,5 +1,5 @@
-#include "AppDelegate.h"
-#include "GeneratedPluginRegistrant.h"
+#import "AppDelegate.h"
+#import "GeneratedPluginRegistrant.h"
 
 @implementation AppDelegate
 

--- a/dev/integration_tests/ios_add2app/Podfile
+++ b/dev/integration_tests/ios_add2app/Podfile
@@ -5,6 +5,7 @@ flutter_application_path = 'flutterapp/'
 load File.join(flutter_application_path, '.ios', 'Flutter', 'podhelper.rb')
 
 target 'ios_add2app' do
+  use_modular_headers!
   install_all_flutter_pods(flutter_application_path)
 end
 

--- a/dev/integration_tests/ios_host_app/Host/ViewController.m
+++ b/dev/integration_tests/ios_host_app/Host/ViewController.m
@@ -1,6 +1,11 @@
 #import "ViewController.h"
-#import <Flutter/Flutter.h>
-#import <FlutterPluginRegistrant/GeneratedPluginRegistrant.h>
+
+@import Flutter;
+@import FlutterPluginRegistrant;
+
+// Prove plugins can be module-imported from the host app.
+@import device_info;
+@import google_maps_flutter;
 
 @implementation ViewController
 

--- a/dev/integration_tests/ios_host_app/Podfile
+++ b/dev/integration_tests/ios_host_app/Podfile
@@ -4,5 +4,6 @@ flutter_application_path = '../hello'
 load File.join(flutter_application_path, '.ios', 'Flutter', 'podhelper.rb')
 
 target 'Host' do
+  use_modular_headers!
   install_all_flutter_pods flutter_application_path
 end

--- a/dev/integration_tests/ios_host_app_swift/Host/AppDelegate.swift
+++ b/dev/integration_tests/ios_host_app_swift/Host/AppDelegate.swift
@@ -1,5 +1,9 @@
 import UIKit
 
+// Prove plugins can be module-imported from the host app.
+import device_info
+import google_maps_flutter
+
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
   func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {

--- a/dev/integration_tests/ios_host_app_swift/Podfile
+++ b/dev/integration_tests/ios_host_app_swift/Podfile
@@ -4,5 +4,6 @@ flutter_application_path = '../hello'
 load File.join(flutter_application_path, '.ios', 'Flutter', 'podhelper.rb')
 
 target 'Host' do
+  use_modular_headers!
   install_all_flutter_pods flutter_application_path
 end

--- a/dev/integration_tests/platform_interaction/ios/Runner/AppDelegate.m
+++ b/dev/integration_tests/platform_interaction/ios/Runner/AppDelegate.m
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "AppDelegate.h"
-#include "GeneratedPluginRegistrant.h"
+#import "AppDelegate.h"
+#import "GeneratedPluginRegistrant.h"
 
 @implementation AppDelegate
 

--- a/dev/integration_tests/release_smoke_test/ios/Podfile
+++ b/dev/integration_tests/release_smoke_test/ios/Podfile
@@ -33,6 +33,8 @@ def parse_KV_file(file, separator='=')
 end
 
 target 'Runner' do
+  use_modular_headers!
+  
   # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
   # referring to absolute paths on developers' machines.
   system('rm -rf .symlinks')

--- a/dev/integration_tests/release_smoke_test/ios/Runner/AppDelegate.m
+++ b/dev/integration_tests/release_smoke_test/ios/Runner/AppDelegate.m
@@ -1,5 +1,5 @@
-#include "AppDelegate.h"
-#include "GeneratedPluginRegistrant.h"
+#import "AppDelegate.h"
+#import "GeneratedPluginRegistrant.h"
 
 @implementation AppDelegate
 

--- a/dev/integration_tests/ui/ios/Runner/AppDelegate.m
+++ b/dev/integration_tests/ui/ios/Runner/AppDelegate.m
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "AppDelegate.h"
-#include "GeneratedPluginRegistrant.h"
+#import "AppDelegate.h"
+#import "GeneratedPluginRegistrant.h"
 
 @implementation AppDelegate
 

--- a/dev/manual_tests/ios/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/dev/manual_tests/ios/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/dev/manual_tests/ios/Runner/AppDelegate.m
+++ b/dev/manual_tests/ios/Runner/AppDelegate.m
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "AppDelegate.h"
-#include "GeneratedPluginRegistrant.h"
+#import "AppDelegate.h"
+#import "GeneratedPluginRegistrant.h"
 
 @implementation AppDelegate
 

--- a/examples/catalog/ios/Runner/AppDelegate.m
+++ b/examples/catalog/ios/Runner/AppDelegate.m
@@ -1,5 +1,5 @@
-#include "AppDelegate.h"
-#include "GeneratedPluginRegistrant.h"
+#import "AppDelegate.h"
+#import "GeneratedPluginRegistrant.h"
 
 @implementation AppDelegate
 

--- a/examples/flutter_gallery/ios/Podfile
+++ b/examples/flutter_gallery/ios/Podfile
@@ -27,6 +27,8 @@ def parse_KV_file(file,separator='=')
 end
 
 target 'Runner' do
+  use_modular_headers!
+  
   # Flutter Pods
   pod 'Flutter', :path => ENV['FLUTTER_FRAMEWORK_DIR']
   

--- a/examples/flutter_gallery/ios/Runner/AppDelegate.m
+++ b/examples/flutter_gallery/ios/Runner/AppDelegate.m
@@ -1,5 +1,5 @@
-#include "AppDelegate.h"
-#include "GeneratedPluginRegistrant.h"
+#import "AppDelegate.h"
+#import "GeneratedPluginRegistrant.h"
 
 @implementation AppDelegate
 

--- a/examples/flutter_view/ios/Podfile
+++ b/examples/flutter_view/ios/Podfile
@@ -7,6 +7,7 @@ install! 'cocoapods', :disable_input_output_paths => true
 target 'Runner' do
   # Uncomment this line if you're using Swift or would like to use dynamic frameworks
    use_frameworks!
+   use_modular_headers!
 
   # Pods for Runner
   pod 'MaterialControls', '~> 1.2.2'

--- a/examples/flutter_view/ios/Runner/AppDelegate.m
+++ b/examples/flutter_view/ios/Runner/AppDelegate.m
@@ -1,4 +1,4 @@
-#include "AppDelegate.h"
+#import "AppDelegate.h"
 #import <Flutter/Flutter.h>
 
 @implementation AppDelegate

--- a/examples/hello_world/ios/Runner/AppDelegate.m
+++ b/examples/hello_world/ios/Runner/AppDelegate.m
@@ -1,5 +1,5 @@
-#include "AppDelegate.h"
-#include "GeneratedPluginRegistrant.h"
+#import "AppDelegate.h"
+#import "GeneratedPluginRegistrant.h"
 
 @implementation AppDelegate
 

--- a/examples/hello_world/ios/Runner/GeneratedPluginRegistrant.h
+++ b/examples/hello_world/ios/Runner/GeneratedPluginRegistrant.h
@@ -7,8 +7,11 @@
 
 #import <Flutter/Flutter.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface GeneratedPluginRegistrant : NSObject
 + (void)registerWithRegistry:(NSObject<FlutterPluginRegistry>*)registry;
 @end
 
+NS_ASSUME_NONNULL_END
 #endif /* GeneratedPluginRegistrant_h */

--- a/examples/image_list/ios/Runner/AppDelegate.m
+++ b/examples/image_list/ios/Runner/AppDelegate.m
@@ -1,5 +1,5 @@
-#include "AppDelegate.h"
-#include "GeneratedPluginRegistrant.h"
+#import "AppDelegate.h"
+#import "GeneratedPluginRegistrant.h"
 
 @implementation AppDelegate
 

--- a/examples/layers/ios/Runner/AppDelegate.m
+++ b/examples/layers/ios/Runner/AppDelegate.m
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "AppDelegate.h"
-#include "GeneratedPluginRegistrant.h"
+#import "AppDelegate.h"
+#import "GeneratedPluginRegistrant.h"
 
 @implementation AppDelegate
 

--- a/examples/platform_view/ios/Podfile
+++ b/examples/platform_view/ios/Podfile
@@ -27,6 +27,8 @@ def parse_KV_file(file, separator='=')
 end
 
 target 'Runner' do
+  use_modular_headers!
+  
   # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
   # referring to absolute paths on developers' machines.
   system('rm -rf .symlinks')

--- a/examples/platform_view/ios/Runner/AppDelegate.m
+++ b/examples/platform_view/ios/Runner/AppDelegate.m
@@ -2,9 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-#include "AppDelegate.h"
-#include "GeneratedPluginRegistrant.h"
-#include "PlatformViewController.h"
+#import "AppDelegate.h"
+#import "GeneratedPluginRegistrant.h"
+#import "PlatformViewController.h"
 
 @implementation AppDelegate {
   FlutterResult _flutterResult;

--- a/examples/stocks/ios/Runner/AppDelegate.m
+++ b/examples/stocks/ios/Runner/AppDelegate.m
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "AppDelegate.h"
-#include "GeneratedPluginRegistrant.h"
+#import "AppDelegate.h"
+#import "GeneratedPluginRegistrant.h"
 
 @implementation AppDelegate
 

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -454,10 +454,13 @@ const String _objcPluginRegistryHeaderTemplate = '''//
 
 #import <{{framework}}/{{framework}}.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface GeneratedPluginRegistrant : NSObject
 + (void)registerWithRegistry:(NSObject<FlutterPluginRegistry>*)registry;
 @end
 
+NS_ASSUME_NONNULL_END
 #endif /* GeneratedPluginRegistrant_h */
 ''';
 
@@ -466,10 +469,15 @@ const String _objcPluginRegistryImplementationTemplate = '''//
 //
 
 #import "GeneratedPluginRegistrant.h"
-{{#plugins}}
-#import <{{name}}/{{class}}.h>
-{{/plugins}}
 
+{{#plugins}}
+#if __has_include(<{{name}}/{{class}}.h>)
+#import <{{name}}/{{class}}.h>
+#else
+@import {{name}};
+#endif
+
+{{/plugins}}
 @implementation GeneratedPluginRegistrant
 
 + (void)registerWithRegistry:(NSObject<FlutterPluginRegistry>*)registry {

--- a/packages/flutter_tools/templates/app/ios-objc.tmpl/Runner/AppDelegate.m
+++ b/packages/flutter_tools/templates/app/ios-objc.tmpl/Runner/AppDelegate.m
@@ -1,5 +1,5 @@
-#include "AppDelegate.h"
-#include "GeneratedPluginRegistrant.h"
+#import "AppDelegate.h"
+#import "GeneratedPluginRegistrant.h"
 
 @implementation AppDelegate
 

--- a/packages/flutter_tools/templates/cocoapods/Podfile-ios-objc
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-ios-objc
@@ -33,6 +33,8 @@ def parse_KV_file(file, separator='=')
 end
 
 target 'Runner' do
+  use_modular_headers!
+  
   # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
   # referring to absolute paths on developers' machines.
   system('rm -rf .symlinks')

--- a/packages/flutter_tools/templates/cocoapods/Podfile-ios-swift
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-ios-swift
@@ -34,6 +34,7 @@ end
 
 target 'Runner' do
   use_frameworks!
+  use_modular_headers!
 
   # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
   # referring to absolute paths on developers' machines.

--- a/packages/flutter_tools/templates/cocoapods/Podfile-macos
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-macos
@@ -44,6 +44,7 @@ end
 
 target 'Runner' do
   use_frameworks!
+  use_modular_headers!
 
   # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
   # referring to absolute paths on developers' machines.

--- a/packages/flutter_tools/templates/module/ios/host_app_ephemeral/Runner.tmpl/AppDelegate.m
+++ b/packages/flutter_tools/templates/module/ios/host_app_ephemeral/Runner.tmpl/AppDelegate.m
@@ -1,4 +1,4 @@
-#include "AppDelegate.h"
+#import "AppDelegate.h"
 
 @implementation AppDelegate
 

--- a/packages/flutter_tools/templates/module/ios/host_app_ephemeral_cocoapods/Podfile.copy.tmpl
+++ b/packages/flutter_tools/templates/module/ios/host_app_ephemeral_cocoapods/Podfile.copy.tmpl
@@ -6,6 +6,8 @@ load File.join(flutter_application_path, '.ios', 'Flutter', 'podhelper.rb')
 use_frameworks!
 
 target 'Runner' do
+  use_modular_headers!
+  
   install_flutter_engine_pod
   install_flutter_plugin_pods flutter_application_path
 end

--- a/packages/flutter_tools/templates/module/ios/host_app_ephemeral_cocoapods/Runner.tmpl/AppDelegate.m
+++ b/packages/flutter_tools/templates/module/ios/host_app_ephemeral_cocoapods/Runner.tmpl/AppDelegate.m
@@ -1,4 +1,4 @@
-#include "AppDelegate.h"
+#import "AppDelegate.h"
 #import "FlutterPluginRegistrant/GeneratedPluginRegistrant.h"
 
 @implementation AppDelegate


### PR DESCRIPTION
## Description

- Enable strict search paths and module map generation for pods by adding `use_modular_headers!` to the default Podfile.  Hopefully this lets Swift remove `use_frameworks!` and build as libraries in the future (soon?).  Compilation times will be faster because clang can use the module cache instead of doing pre-processing work.  See http://blog.cocoapods.org/CocoaPods-1.5.0/ for how this works.
- While I was looking at the generated code I added `NS_ASSUME_NONNULL_BEGIN` to get a compilation warning on a nil `registry` since the registration methods it calls require nonnull.
- I wanted to remove the `#ifndef GeneratedPluginRegistrant_h` in the same spot but I realized we couldn't because the template was using `#include` instead of `#import`.  Migrate them over to avoid including headers multiple times.


## Related Issues

See https://github.com/flutter/flutter/issues/41007 for what supporting modules will unlock.

## Tests

I updated the integration test Podfiles.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
