### PR TITLE
Reading deviceId for RawKeyEventDataAndroid event

### DIFF
--- a/packages/flutter/lib/src/services/raw_keyboard.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard.dart
@@ -260,6 +260,7 @@ abstract class RawKeyEvent extends Diagnosticable {
           eventSource: message['source'] ?? 0,
           vendorId: message['vendorId'] ?? 0,
           productId: message['productId'] ?? 0,
+          deviceId: message['deviceId'] ?? 0,
         );
         break;
       case 'fuchsia':

--- a/packages/flutter/lib/src/services/raw_keyboard_android.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_android.dart
@@ -36,6 +36,7 @@ class RawKeyEventDataAndroid extends RawKeyEventData {
     this.eventSource = 0,
     this.vendorId = 0,
     this.productId = 0,
+    this.deviceId = 0,
   }) : assert(flags != null),
        assert(codePoint != null),
        assert(keyCode != null),
@@ -126,6 +127,12 @@ class RawKeyEventDataAndroid extends RawKeyEventData {
   /// See <https://developer.android.com/reference/android/view/InputDevice.html#getProductId()>
   /// for the numerical values of the `productId`.
   final int productId;
+
+
+  /// The ID of the device that produced the event.
+  ///
+  /// See https://developer.android.com/reference/android/view/InputDevice.html#getId()
+  final int deviceId;
 
   // The source code that indicates that an event came from a joystick.
   // from https://developer.android.com/reference/android/view/InputDevice.html#SOURCE_JOYSTICK

--- a/packages/flutter/test/services/raw_keyboard_test.dart
+++ b/packages/flutter/test/services/raw_keyboard_test.dart
@@ -209,6 +209,22 @@ void main() {
       expect(data.logicalKey, equals(LogicalKeyboardKey.select));
       expect(data.keyLabel, isNull);
     });
+    test('Device id is read from message', () {
+      final RawKeyEvent joystickDpadCenter = RawKeyEvent.fromMessage(const <String, dynamic>{
+        'type': 'keydown',
+        'keymap': 'android',
+        'keyCode': 23,  // DPAD_CENTER code.
+        'plainCodePoint': 0,
+        'codePoint': 0,
+        'character': null,
+        'scanCode': 317,  // Left side thumb joystick center click button.
+        'metaState': 0,
+        'source': 0x501, // Gamepad and keyboard source.
+        'deviceId': 10,
+      });
+      final RawKeyEventDataAndroid data = joystickDpadCenter.data;
+      expect(data.deviceId, equals(10));
+    });
   });
   group('RawKeyEventDataFuchsia', () {
     const Map<int, _ModifierCheck> modifierTests = <int, _ModifierCheck>{

--- a/packages/flutter/test/services/raw_keyboard_test.dart
+++ b/packages/flutter/test/services/raw_keyboard_test.dart
@@ -40,6 +40,7 @@ void main() {
           'scanCode': 0x20,
           'metaState': modifier,
           'source': 0x101, // Keyboard source.
+          'deviceId': 1,
         });
         final RawKeyEventDataAndroid data = event.data;
         for (ModifierKey key in ModifierKey.values) {
@@ -75,6 +76,7 @@ void main() {
           'scanCode': 0x20,
           'metaState': modifier | RawKeyEventDataAndroid.modifierFunction,
           'source': 0x101, // Keyboard source.
+          'deviceId': 1,
         });
         final RawKeyEventDataAndroid data = event.data;
         for (ModifierKey key in ModifierKey.values) {
@@ -112,6 +114,7 @@ void main() {
         'scanCode': 30,
         'metaState': 0x0,
         'source': 0x101, // Keyboard source.
+        'deviceId': 1,
       });
       final RawKeyEventDataAndroid data = keyAEvent.data;
       expect(data.physicalKey, equals(PhysicalKeyboardKey.keyA));
@@ -128,6 +131,7 @@ void main() {
         'scanCode': 1,
         'metaState': 0x0,
         'source': 0x101, // Keyboard source.
+        'deviceId': 1,
       });
       final RawKeyEventDataAndroid data = escapeKeyEvent.data;
       expect(data.physicalKey, equals(PhysicalKeyboardKey.escape));
@@ -145,6 +149,7 @@ void main() {
         'scanCode': 42,
         'metaState': RawKeyEventDataAndroid.modifierLeftShift,
         'source': 0x101, // Keyboard source.
+        'deviceId': 1,
       });
       final RawKeyEventDataAndroid data = shiftLeftKeyEvent.data;
       expect(data.physicalKey, equals(PhysicalKeyboardKey.shiftLeft));
@@ -162,6 +167,7 @@ void main() {
         'scanCode': 0,
         'metaState': 0,
         'source': 0x1000010, // Joystick source.
+        'deviceId': 1,
       });
       final RawKeyEventDataAndroid data = joystickDpadDown.data;
       expect(data.physicalKey, equals(PhysicalKeyboardKey.arrowDown));
@@ -196,6 +202,7 @@ void main() {
         'scanCode': 317,  // Left side thumb joystick center click button.
         'metaState': 0,
         'source': 0x501, // Gamepad and keyboard source.
+        'deviceId': 1,
       });
       final RawKeyEventDataAndroid data = joystickDpadCenter.data;
       expect(data.physicalKey, equals(PhysicalKeyboardKey.gameButtonThumbLeft));


### PR DESCRIPTION
## Description

This PR adds a new property on RawKeyEventDataAndroid to hold the deviceId from which that event was generated. The deviceId is been sent from the engine on the changes from this PR: https://github.com/flutter/engine/pull/12958

With this, we will be able to identify from where the event came from, adding the ability to support local multiplayer games, with multiple gamepads.

## Tests

I added a simple test case on `test/services/raw_keyboard_test.dart`

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
