### PR TITLE
catch argument error from Make

### DIFF
--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
+++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
@@ -48,18 +48,18 @@ export PROJECT_DIR=${linuxProject.project.directory.path}
   // Invoke make.
   final String buildFlag = getNameForBuildMode(buildInfo.mode ?? BuildMode.release);
   final Stopwatch sw = Stopwatch()..start();
-  final Process process = await processManager.start(<String>[
-    'make',
-    '-C',
-    linuxProject.makeFile.parent.path,
-    'BUILD=$buildFlag',
-  ]);
   final Status status = logger.startProgress(
     'Building Linux application...',
     timeout: null,
   );
   int result;
   try {
+    final Process process = await processManager.start(<String>[
+      'make',
+      '-C',
+      linuxProject.makeFile.parent.path,
+      'BUILD=$buildFlag',
+    ]);
     process.stderr
       .transform(utf8.decoder)
       .transform(const LineSplitter())
@@ -69,6 +69,8 @@ export PROJECT_DIR=${linuxProject.project.directory.path}
       .transform(const LineSplitter())
       .listen(printTrace);
     result = await process.exitCode;
+  } on ArgumentError {
+    throwToolExit('make not found. Run \'flutter doctor\' for more information.');
   } finally {
     status.cancel();
   }

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
@@ -117,6 +117,27 @@ void main() {
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
   });
 
+  testUsingContext('Handles argument error from missing make', () async {
+    final BuildCommand command = BuildCommand();
+    applyMocksToCommand(command);
+    setUpMockProjectFilesForBuild();
+    when(mockProcessManager.start(<String>[
+      'make',
+      '-C',
+      '/linux',
+      'BUILD=release',
+    ])).thenThrow(ArgumentError());
+
+    expect(createTestCommandRunner(command).run(
+      const <String>['build', 'linux']
+    ), throwsToolExit(message: 'make not found. Run \'flutter doctor\' for more information.'));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => mockProcessManager,
+    Platform: () => linuxPlatform,
+    FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
+  });
+
   testUsingContext('Linux build --debug passes debug mode to make', () async {
     final BuildCommand command = BuildCommand();
     applyMocksToCommand(command);


### PR DESCRIPTION
## Description

If make is not installed, then processManager.start will throw an ArgumentError. catch this and suggest flutter doctor as a next step.