### PR TITLE
Small cleanup of web code

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -274,12 +274,13 @@ class ResidentWebRunner extends ResidentRunner {
         printStatus('Restarted application in ${getElapsedAsMilliseconds(timer.elapsed)}.');
 
         // Send timing analytics for full restart and for refresh.
+        final bool wasSuccessful = reloadResponse.type == 'Success';
+        if (!wasSuccessful) {
+          return OperationResult(1, reloadResponse.toString());
+        }
         flutterUsage.sendTiming('hot', 'web-restart', timer.elapsed);
         flutterUsage.sendTiming('hot', 'web-refresh', timer.elapsed - recompileDuration);
-
-        return reloadResponse.type == 'Success'
-            ? OperationResult.ok
-            : OperationResult(1, reloadResponse.toString());
+        return OperationResult.ok;
       } on vmservice.RPCError {
         return OperationResult(1, 'Page requires refresh.');
       } finally {

--- a/packages/flutter_tools/lib/src/build_runner/web_fs.dart
+++ b/packages/flutter_tools/lib/src/build_runner/web_fs.dart
@@ -289,7 +289,7 @@ class WebFs {
             return (await ChromeLauncher.connectedInstance).chromeConnection;
           },
           reloadConfiguration: ReloadConfiguration.none,
-          serveDevTools: true,
+          serveDevTools: false,
           verbose: false,
           enableDebugExtension: true,
           logWriter: (dynamic level, String message) => printTrace(message),

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -240,6 +240,11 @@ void main() {
 
     expect(result.code, 1);
     expect(result.message, contains('Failed to recompile application.'));
+    verifyNever(Usage.instance.sendTiming('hot', 'web-restart', any));
+    verifyNever(Usage.instance.sendTiming('hot', 'web-refresh', any));
+    verifyNever(Usage.instance.sendTiming('hot', 'web-recompile', any));
+  }, overrides: <Type, Generator>{
+    Usage: () => MockFlutterUsage(),
   }));
 
   test('Fails on vmservice response error', () => testbed.run(() async {
@@ -259,6 +264,11 @@ void main() {
 
     expect(result.code, 1);
     expect(result.message, contains('Failed'));
+    verifyNever(Usage.instance.sendTiming('hot', 'web-restart', any));
+    verifyNever(Usage.instance.sendTiming('hot', 'web-refresh', any));
+    verify(Usage.instance.sendTiming('hot', 'web-recompile', any)).called(1);
+  }, overrides: <Type, Generator>{
+    Usage: () => MockFlutterUsage(),
   }));
 
   test('Fails on vmservice RpcError', () => testbed.run(() async {


### PR DESCRIPTION
## Description

Don't always serve devtools. The IDEs can also launch it. Don't send analytics event for reload/refresh if it is rejected.

Tests updated for second case.