### PR TITLE
[WIP] Run web tooling in a zone

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import 'package:flutter_tools/src/base/io.dart';
 import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart' as vmservice;
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart' hide StackTrace;
@@ -13,6 +12,7 @@ import '../application_package.dart';
 import '../base/async_guard.dart';
 import '../base/common.dart';
 import '../base/file_system.dart';
+import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/terminal.dart';
 import '../base/utils.dart';


### PR DESCRIPTION
## Description

To address transient WebSocketExceptions falling through the zone, we can wrap the entire runner in an asyncGuard. Still figuring out how to test this.

Fixes https://github.com/dart-lang/webdev/issues/696