### PR TITLE
Fix an issue when connected ios device is upgrading.

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -186,9 +186,12 @@ class IOSDevice extends Device {
       } on IOSDeviceNotFoundError catch (error) {
         // Unable to find device with given udid. Possibly a network device.
         printTrace('Error getting attached iOS device: $error');
-      } on IOSDeviceNotTrustedError catch (error) {
+      } on IOSDeviceLockdownError catch (error) {
         printTrace('Error getting attached iOS device information: $error');
-        UsageEvent('device', 'ios-trust-failure').send();
+        if (LockdownReturnCode.pairingDialogResponsePending.code == error.lockdownCode.code ||
+            LockdownReturnCode.invalidHostId.code == error.lockdownCode.code) {
+          UsageEvent('device', 'ios-trust-failure').send();
+        }
       }
     }
     return devices;


### PR DESCRIPTION
## Description
When I'm upgrading my iOS device into latest version, 'flutter devices' is run while two devices are connected(one iOS and one android). However, the flutter tools crashed with information below:
![image](https://user-images.githubusercontent.com/817851/65316948-75a46f00-dbcd-11e9-87da-5d6e530c0b99.png)
And the command exits with error below:
```shell
ideviceinfo returned an error:
ERROR: Could not connect to lockdownd, error code -3


Process finished with exit code 1
```

I think flutter_tools should deal with this case softly. In other words, when ideviceinfo fails, it can continue to run `adb devices` to find android devices. Developers can get details about the error message using verbose flag. 


`flutter doctor -v`:
```shell
kylewong@KyleWongdeMacBook-Pro flutter_tools % flutter doctor -v
[✓] Flutter (Channel alf_master_refactor_process_lockdown_logic,
    v1.10.15-pre.18, on Mac OS X 10.15 19A582a, locale en-CN)
    • Flutter version 1.10.15-pre.18 at
      /Users/kylewong/Codes/Flutter/alibaba-flutter/flutter
    • Framework revision 5e4781c369 (9 hours ago), 2019-10-09 00:39:11 +0800
    • Engine revision a29385d9fe
    • Dart version 2.6.0 (build 2.6.0-dev.0.0 f4a72bfc64)

[✓] Android toolchain - develop for Android devices (Android SDK version 29.0.2)
    • Android SDK at /Users/kylewong/Library/Android/sdk
    • Android NDK location not configured (optional; useful for native profiling
      support)
    • Platform android-29, build-tools 29.0.2
    • Java binary at: /Applications/Android
      Studio.app/Contents/jre/jdk/Contents/Home/bin/java
    • Java version OpenJDK Runtime Environment (build
      1.8.0_202-release-1483-b49-5587405)
    • All Android licenses accepted.

[!] Xcode - develop for iOS and macOS (Xcode 11.2)
    • Xcode at /Applications/Xcode-beta.app/Contents/Developer
    • Xcode 11.2, Build version 11B41
    ! Unknown CocoaPods version installed.
        Flutter is unable to determine the installed CocoaPods's version.
        Ensure that the output of 'pod --version' contains only digits and . to
        be recognized by Flutter.
      To upgrade:
        sudo gem install cocoapods

[✓] Android Studio (version 3.5)
    • Android Studio at /Applications/Android Studio.app/Contents
    • Flutter plugin version 39.0.3
    • Dart plugin version 191.8423
    • Java version OpenJDK Runtime Environment (build
      1.8.0_202-release-1483-b49-5587405)

[✓] VS Code (version 1.37.1)
    • VS Code at /Applications/Visual Studio Code.app/Contents
    • Flutter extension version 3.3.0
```
