### PR TITLE
Add onVisible callback to snackbar.

### DIFF
--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -280,7 +280,7 @@ class SnackBar extends StatefulWidget {
   }
 
   @override
-  State createState() => _SnackBarState();
+  State<SnackBar> createState() => _SnackBarState();
 }
 
 
@@ -294,17 +294,31 @@ class _SnackBarState extends State<SnackBar> {
   }
 
   @override
+  void didUpdateWidget(SnackBar oldWidget) {
+    if (widget.animation != oldWidget.animation) {
+      oldWidget.animation.removeStatusListener(_onAnimationStatusChanged);
+      widget.animation.addStatusListener(_onAnimationStatusChanged);
+    }
+    super.didUpdateWidget(oldWidget);
+  }
+
+  @override
   void dispose() {
     widget.animation.removeStatusListener(_onAnimationStatusChanged);
     super.dispose();
   }
 
   void _onAnimationStatusChanged(AnimationStatus animationStatus) {
-    if (animationStatus == AnimationStatus.completed) {
-      if (widget.onVisible != null && !_wasVisible) {
-        widget.onVisible();
+    switch (animationStatus) {
+      case AnimationStatus.dismissed:
+      case AnimationStatus.forward:
+      case AnimationStatus.reverse:
+        break;
+      case AnimationStatus.completed:
+        if (widget.onVisible != null && !_wasVisible) {
+          widget.onVisible();
+        }
         _wasVisible = true;
-      }
     }
   }
 

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -249,7 +249,7 @@ class SnackBar extends StatefulWidget {
   /// Called the first time that the snackbar is visible within a [Scaffold].
   final VoidCallback onVisible;
 
-  // API for Scaffold.addSnackBar():
+  // API for Scaffold.showSnackBar():
 
   /// Creates an animation controller useful for driving a snack bar's entrance and exit animation.
   static AnimationController createAnimationController({ @required TickerProvider vsync }) {
@@ -285,11 +285,26 @@ class SnackBar extends StatefulWidget {
 
 
 class _SnackBarState extends State<SnackBar> {
+  bool _wasVisible = false;
+
   @override
   void initState() {
     super.initState();
-    if (widget.onVisible != null) {
-      widget.onVisible();
+    widget.animation.addStatusListener(_onAnimationStatusChanged);
+  }
+
+  @override
+  void dispose() {
+    widget.animation.removeStatusListener(_onAnimationStatusChanged);
+    super.dispose();
+  }
+
+  void _onAnimationStatusChanged(AnimationStatus animationStatus) {
+    if (animationStatus == AnimationStatus.completed) {
+      if (widget.onVisible != null && !_wasVisible) {
+        widget.onVisible();
+        _wasVisible = true;
+      }
     }
   }
 

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -1065,4 +1065,85 @@ void main() {
     await tester.tap(find.byKey(tapTarget));
     expect(tester.takeException(), isNotNull);
   });
+
+  testWidgets('Snackbar calls onVisible once', (WidgetTester tester) async {
+    const Key tapTarget = Key('tap-target');
+    int called = 0;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (BuildContext context) {
+            return GestureDetector(
+              onTap: () {
+                Scaffold.of(context).showSnackBar(SnackBar(
+                  content: const Text('hello'),
+                  duration: const Duration(seconds: 1),
+                  onVisible: () {
+                    called += 1;
+                  },
+                ));
+              },
+              behavior: HitTestBehavior.opaque,
+              child: Container(
+                height: 100.0,
+                width: 100.0,
+                key: tapTarget,
+              ),
+            );
+          },
+        ),
+      ),
+    ));
+
+    await tester.tap(find.byKey(tapTarget));
+    await tester.pump(); // start animation
+    await tester.pumpAndSettle();
+
+    expect(find.text('hello'), findsOneWidget);
+    expect(called, 1);
+  });
+
+  testWidgets('Snackbar does not call onVisible when it is queued', (WidgetTester tester) async {
+    const Key tapTarget = Key('tap-target');
+    int called = 0;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (BuildContext context) {
+            return GestureDetector(
+              onTap: () {
+                Scaffold.of(context).showSnackBar(SnackBar(
+                  content: const Text('hello'),
+                  duration: const Duration(seconds: 1),
+                  onVisible: () {
+                    called += 1;
+                  },
+                ));
+                Scaffold.of(context).showSnackBar(SnackBar(
+                  content: const Text('hello 2'),
+                  duration: const Duration(seconds: 1),
+                  onVisible: () {
+                    called += 1;
+                  },
+                ));
+              },
+              behavior: HitTestBehavior.opaque,
+              child: Container(
+                height: 100.0,
+                width: 100.0,
+                key: tapTarget,
+              ),
+            );
+          },
+        ),
+      ),
+    ));
+
+    await tester.tap(find.byKey(tapTarget));
+    await tester.pump(); // start animation
+    await tester.pumpAndSettle();
+
+    expect(find.text('hello'), findsOneWidget);
+    expect(called, 1);
+  });
 }


### PR DESCRIPTION
## Description

Add a callback to the snackbar that is invoked the first time it is called. Requires updating the snackbar to a StatefulWidget.


Fixes https://github.com/flutter/flutter/issues/41427