### PR TITLE
Add --cache-sksl flag to drive and run

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -326,8 +326,9 @@ class AndroidDevice extends Device {
       }
 
       return true;
-    } catch (e) {
+    } catch (e, stacktrace) {
       printError('Unexpected failure from adb: $e');
+      printError('Stacktrace: $stacktrace');
       return false;
     }
   }

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -574,6 +574,8 @@ class AndroidDevice extends Device {
         ...<String>['--ez', 'trace-systrace', 'true'],
       if (debuggingOptions.dumpSkpOnShaderCompilation)
         ...<String>['--ez', 'dump-skp-on-shader-compilation', 'true'],
+      if (debuggingOptions.cacheSkSL)
+      ...<String>['--ez', 'cache-sksl', 'true'],
       if (debuggingOptions.debuggingEnabled) ...<String>[
         if (debuggingOptions.buildInfo.isDebug) ...<String>[
           ...<String>['--ez', 'enable-checked-mode', 'true'],

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -275,6 +275,7 @@ Future<LaunchResult> _startApp(DriveCommand command) async {
       startPaused: true,
       observatoryPort: command.observatoryPort,
       verboseSystemLogs: command.verboseSystemLogs,
+      cacheSkSL: command.cacheSkSL,
     ),
     platformArgs: platformArgs,
     prebuiltApplication: !command.shouldBuild,

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -41,6 +41,9 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         negatable: false,
         help: 'Include verbose logging from the flutter engine.',
       )
+      ..addFlag('cache-sksl',
+        negatable: false,
+        help: 'Only cache the shader in SkSL instead of binary or GLSL.',)
       ..addOption('route',
         help: 'Which route to load when running the app.',
       );
@@ -54,6 +57,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
   }
 
   bool get traceStartup => argResults['trace-startup'];
+  bool get cacheSkSL => argResults['cache-sksl'];
 
   String get route => argResults['route'];
 }
@@ -301,6 +305,7 @@ class RunCommand extends RunCommandBase {
         traceSkia: argResults['trace-skia'],
         traceSystrace: argResults['trace-systrace'],
         dumpSkpOnShaderCompilation: argResults['dump-skp-on-shader-compilation'],
+        cacheSkSL: cacheSkSL,
         observatoryPort: observatoryPort,
         verboseSystemLogs: argResults['verbose-system-logs'],
         initializePlatform: argResults['web-initialize-platform'],

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -486,6 +486,7 @@ class DebuggingOptions {
     this.traceSkia = false,
     this.traceSystrace = false,
     this.dumpSkpOnShaderCompilation = false,
+    this.cacheSkSL = false,
     this.useTestFonts = false,
     this.verboseSystemLogs = false,
     this.observatoryPort,
@@ -506,6 +507,7 @@ class DebuggingOptions {
       traceSkia = false,
       traceSystrace = false,
       dumpSkpOnShaderCompilation = false,
+      cacheSkSL = false,
       verboseSystemLogs = false,
       observatoryPort = null,
       browserLaunch = true;
@@ -521,6 +523,7 @@ class DebuggingOptions {
   final bool traceSkia;
   final bool traceSystrace;
   final bool dumpSkpOnShaderCompilation;
+  final bool cacheSkSL;
   final bool useTestFonts;
   final bool verboseSystemLogs;
   /// Whether to invoke webOnlyInitializePlatform in Flutter for web.

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -496,7 +496,7 @@ class DebuggingOptions {
     this.browserLaunch = true,
    }) : debuggingEnabled = true;
 
-  DebuggingOptions.disabled(this.buildInfo, { this.initializePlatform = true, this.port, this.hostname })
+  DebuggingOptions.disabled(this.buildInfo, { this.initializePlatform = true, this.port, this.hostname, this.cacheSkSL = false, })
     : debuggingEnabled = false,
       useTestFonts = false,
       startPaused = false,
@@ -507,7 +507,6 @@ class DebuggingOptions {
       traceSkia = false,
       traceSystrace = false,
       dumpSkpOnShaderCompilation = false,
-      cacheSkSL = false,
       verboseSystemLogs = false,
       observatoryPort = null,
       browserLaunch = true;

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -325,6 +325,7 @@ class IOSDevice extends Device {
       if (debuggingOptions.traceSkia) '--trace-skia',
       if (debuggingOptions.dumpSkpOnShaderCompilation) '--dump-skp-on-shader-compilation',
       if (debuggingOptions.verboseSystemLogs) '--verbose-logging',
+      if (debuggingOptions.cacheSkSL) '--cache-sksl',
       if (platformArgs['trace-startup'] ?? false) '--trace-startup',
     ];
 

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -283,6 +283,50 @@ void main() {
         ProcessManager: () => mockProcessManager,
       });
 
+      testUsingContext(' succeeds with --cache-sksl', () async {
+        final IOSDevice device = IOSDevice('123');
+        device.setLogReader(mockApp, mockLogReader);
+        final Uri uri = Uri(
+          scheme: 'http',
+          host: '127.0.0.1',
+          port: 1234,
+          path: 'observatory',
+        );
+        when(mockMDnsObservatoryDiscovery.getObservatoryUri(any, any, any))
+            .thenAnswer((Invocation invocation) => Future<Uri>.value(uri));
+
+        List<String> args;
+        when(mockIosDeploy.runApp(
+          deviceId: anyNamed('deviceId'),
+          bundlePath: anyNamed('bundlePath'),
+          launchArguments: anyNamed('launchArguments'),
+        )).thenAnswer((Invocation inv) {
+          args = inv.namedArguments[const Symbol('launchArguments')];
+          return Future<int>.value(0);
+        });
+
+        final LaunchResult launchResult = await device.startApp(mockApp,
+          prebuiltApplication: true,
+          debuggingOptions: DebuggingOptions.enabled(
+              const BuildInfo(BuildMode.debug, null),
+              cacheSkSL: true,
+          ),
+          platformArgs: <String, dynamic>{},
+        );
+        expect(launchResult.started, isTrue);
+        expect(args, contains('--cache-sksl'));
+        expect(await device.stopApp(mockApp), isFalse);
+      }, overrides: <Type, Generator>{
+        Artifacts: () => mockArtifacts,
+        Cache: () => mockCache,
+        FileSystem: () => mockFileSystem,
+        MDnsObservatoryDiscovery: () => mockMDnsObservatoryDiscovery,
+        Platform: () => macPlatform,
+        ProcessManager: () => mockProcessManager,
+        Usage: () => mockUsage,
+        IOSDeploy: () => mockIosDeploy,
+      });
+
       void testNonPrebuilt({
         @required bool showBuildSettingsFlakes,
       }) {


### PR DESCRIPTION
So we can test SkSL precompile using the command line tools.
See https://github.com/flutter/engine/pull/12412.
