### PR TITLE
Update android semantics test to match existing engine behavior.

### DIFF
--- a/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
+++ b/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
@@ -369,9 +369,10 @@ void main() {
                   isEnabled: true,
                   isFocusable: true,
                   actions: <AndroidSemanticsAction>[
-                    if (item == popupItems.first) AndroidSemanticsAction.clearAccessibilityFocus,
-                    if (item != popupItems.first) AndroidSemanticsAction.accessibilityFocus,
-                    AndroidSemanticsAction.click,
+                    // TODO(gspencergoog): This should really be clearAccessibilityFocus,
+                    // but TalkBack doesn't find it for some reason.
+                    // https://github.com/flutter/flutter/issues/40101
+                    AndroidSemanticsAction.accessibilityFocus,
                   ],
                 ),
                 reason: "Popup $item doesn't have the right semantics");
@@ -393,10 +394,10 @@ void main() {
                   isEnabled: true,
                   isFocusable: true,
                   actions: <AndroidSemanticsAction>[
-                    // TODO(gspencergoog): This should really be identical to the first time,
-                    // but TalkBack doesn't find it the second time for some reason.
+                    // TODO(gspencergoog): This should really be clearAccessibilityFocus,
+                    // but TalkBack doesn't find it for some reason.
+                    // https://github.com/flutter/flutter/issues/40101
                     AndroidSemanticsAction.accessibilityFocus,
-                    AndroidSemanticsAction.click,
                   ],
                 ),
                 reason: "Popup $item doesn't have the right semantics the second time");


### PR DESCRIPTION
This updated the broken android_semantics_test to correspond to existing engine behavior.