### PR TITLE
Always fake ProcessManager when you fake Filesystem in tests

### DIFF
--- a/packages/flutter_tools/README.md
+++ b/packages/flutter_tools/README.md
@@ -23,6 +23,7 @@ $ ../../bin/cache/dart-sdk/bin/dart bin/flutter_tools.dart
 ```
 followed by command line arguments, as usual.
 
+
 ### Analyzing
 
 To run the analyzer on Flutter Tools, in this directory run:
@@ -56,6 +57,8 @@ run:
 ```shell
 $ ../../bin/cache/dart-sdk/bin/pub run build_runner test
 ```
+This is what we do in the continuous integration bots.
+
 
 ### Forcing snapshot regeneration
 

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -1069,7 +1069,8 @@ class ProjectFileInvalidator {
     final List<Uri> invalidatedFiles = <Uri>[];
     for (final Uri uri in urisToScan) {
       final DateTime updatedAt = fs.statSync(
-          uri.toFilePath(windows: platform.isWindows)).modified;
+        uri.toFilePath(windows: platform.isWindows),
+      ).modified;
       if (updatedAt != null && updatedAt.isAfter(lastCompiled)) {
         invalidatedFiles.add(uri);
       }

--- a/packages/flutter_tools/test/commands.shard/hermetic/analyze_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/analyze_test.dart
@@ -48,6 +48,7 @@ void main() {
       inRepo(<String>[]);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
   });
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -19,6 +19,7 @@ import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:flutter_tools/src/run_hot.dart';
 import 'package:meta/meta.dart';
 import 'package:mockito/mockito.dart';
+import 'package:process/process.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
@@ -99,6 +100,7 @@ void main() {
         await loggerSubscription.cancel();
       }, overrides: <Type, Generator>{
         FileSystem: () => testFileSystem,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         Logger: () => logger,
       });
 
@@ -116,6 +118,7 @@ void main() {
                throwsA(isA<ToolExit>()));
       }, overrides: <Type, Generator>{
         FileSystem: () => testFileSystem,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         Logger: () => logger,
       });
 
@@ -195,6 +198,7 @@ void main() {
         expect(flutterDevice.fileSystemRoots, const <String>[filesystemRoot]);
       }, overrides: <Type, Generator>{
         FileSystem: () => testFileSystem,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       });
 
       testUsingContext('exits when ipv6 is specified and debug-port is not', () async {
@@ -218,6 +222,7 @@ void main() {
         );
       }, overrides: <Type, Generator>{
         FileSystem: () => testFileSystem,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       },);
 
       testUsingContext('exits when observatory-port is specified and debug-port is not', () async {
@@ -241,6 +246,7 @@ void main() {
         );
       }, overrides: <Type, Generator>{
         FileSystem: () => testFileSystem,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       },);
     });
 
@@ -302,6 +308,7 @@ void main() {
       )).called(1);
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     group('forwarding to given port', () {
@@ -344,6 +351,7 @@ void main() {
         await loggerSubscription.cancel();
       }, overrides: <Type, Generator>{
         FileSystem: () => testFileSystem,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         Logger: () => logger,
       });
 
@@ -367,6 +375,7 @@ void main() {
         await loggerSubscription.cancel();
       }, overrides: <Type, Generator>{
         FileSystem: () => testFileSystem,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         Logger: () => logger,
       });
 
@@ -397,6 +406,7 @@ void main() {
         await loggerSubscription.cancel();
       }, overrides: <Type, Generator>{
         FileSystem: () => testFileSystem,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         Logger: () => logger,
       });
 
@@ -428,6 +438,7 @@ void main() {
         await loggerSubscription.cancel();
       }, overrides: <Type, Generator>{
         FileSystem: () => testFileSystem,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         Logger: () => logger,
       });
     });
@@ -441,6 +452,7 @@ void main() {
       expect(testLogger.statusText, contains('No supported devices connected'));
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('exits when multiple devices connected', () async {
@@ -465,6 +477,7 @@ void main() {
       expect(testLogger.statusText, contains('yy2'));
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
   });
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_fuchsia_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_fuchsia_test.dart
@@ -15,6 +15,7 @@ import 'package:flutter_tools/src/fuchsia/fuchsia_sdk.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:meta/meta.dart';
 import 'package:mockito/mockito.dart';
+import 'package:process/process.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
@@ -23,7 +24,6 @@ import '../../src/mocks.dart';
 void main() {
   Cache.disableLocking();
 
-  MemoryFileSystem memoryFileSystem;
   MockPlatform linuxPlatform;
   MockPlatform windowsPlatform;
   MockFuchsiaSdk fuchsiaSdk;
@@ -31,7 +31,6 @@ void main() {
   MockFuchsiaArtifacts fuchsiaArtifactsNoCompiler;
 
   setUp(() {
-    memoryFileSystem = MemoryFileSystem();
     linuxPlatform = MockPlatform();
     windowsPlatform = MockPlatform();
     fuchsiaSdk = MockFuchsiaSdk();
@@ -57,7 +56,8 @@ void main() {
           throwsA(isInstanceOf<ToolExit>()));
     }, overrides: <Type, Generator>{
       Platform: () => linuxPlatform,
-      FileSystem: () => memoryFileSystem,
+      FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       FuchsiaArtifacts: () => fuchsiaArtifacts,
     });
 
@@ -74,7 +74,8 @@ void main() {
           throwsA(isInstanceOf<ToolExit>()));
     }, overrides: <Type, Generator>{
       Platform: () => linuxPlatform,
-      FileSystem: () => memoryFileSystem,
+      FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       FuchsiaArtifacts: () => fuchsiaArtifacts,
     });
 
@@ -96,7 +97,8 @@ void main() {
           throwsA(isInstanceOf<ToolExit>()));
     }, overrides: <Type, Generator>{
       Platform: () => windowsPlatform,
-      FileSystem: () => memoryFileSystem,
+      FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       FuchsiaArtifacts: () => fuchsiaArtifacts,
     });
 
@@ -118,7 +120,8 @@ void main() {
           throwsA(isInstanceOf<ToolExit>()));
     }, overrides: <Type, Generator>{
       Platform: () => linuxPlatform,
-      FileSystem: () => memoryFileSystem,
+      FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       FuchsiaArtifacts: () => fuchsiaArtifactsNoCompiler,
     });
   });
@@ -143,7 +146,8 @@ void main() {
     expect(fs.file(farPath).existsSync(), isTrue);
   }, overrides: <Type, Generator>{
     Platform: () => linuxPlatform,
-    FileSystem: () => memoryFileSystem,
+    FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     FuchsiaSdk: () => fuchsiaSdk,
   });
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
@@ -83,6 +83,7 @@ void main() {
   }, overrides: <Type, Generator>{
     Platform: () => linuxPlatform,
     FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
   });
 
@@ -97,6 +98,7 @@ void main() {
   }, overrides: <Type, Generator>{
     Platform: () => notLinuxPlatform,
     FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
   });
 
@@ -185,6 +187,7 @@ BINARY_NAME=fizz_bar
     expect(makefileExecutableName(flutterProject.linux), 'fizz_bar');
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
   });
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -36,7 +36,6 @@ class FakeXcodeProjectInterpreterWithProfile extends FakeXcodeProjectInterpreter
 
 void main() {
   MockProcessManager mockProcessManager;
-  MemoryFileSystem memoryFilesystem;
   MockProcess mockProcess;
   MockPlatform macosPlatform;
   MockPlatform notMacosPlatform;
@@ -47,7 +46,6 @@ void main() {
 
   setUp(() {
     mockProcessManager = MockProcessManager();
-    memoryFilesystem = MemoryFileSystem();
     mockProcess = MockProcess();
     macosPlatform = MockPlatform();
     notMacosPlatform = MockPlatform();
@@ -121,7 +119,8 @@ void main() {
     ), throwsA(isInstanceOf<ToolExit>()));
   }, overrides: <Type, Generator>{
     Platform: () => notMacosPlatform,
-    FileSystem: () => memoryFilesystem,
+    FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
   });
 
@@ -135,7 +134,7 @@ void main() {
       const <String>['build', 'macos', '--debug']
     );
   }, overrides: <Type, Generator>{
-    FileSystem: () => memoryFilesystem,
+    FileSystem: () => MemoryFileSystem(),
     ProcessManager: () => mockProcessManager,
     Platform: () => macosPlatform,
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
@@ -151,7 +150,7 @@ void main() {
       const <String>['build', 'macos', '--profile']
     );
   }, overrides: <Type, Generator>{
-    FileSystem: () => memoryFilesystem,
+    FileSystem: () => MemoryFileSystem(),
     ProcessManager: () => mockProcessManager,
     Platform: () => macosPlatform,
     XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithProfile(),
@@ -168,7 +167,7 @@ void main() {
       const <String>['build', 'macos', '--release']
     );
   }, overrides: <Type, Generator>{
-    FileSystem: () => memoryFilesystem,
+    FileSystem: () => MemoryFileSystem(),
     ProcessManager: () => mockProcessManager,
     Platform: () => macosPlatform,
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_windows_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_windows_test.dart
@@ -25,7 +25,6 @@ import '../../src/testbed.dart';
 
 void main() {
   MockProcessManager mockProcessManager;
-  MemoryFileSystem memoryFilesystem;
   MockProcess mockProcess;
   MockPlatform windowsPlatform;
   MockPlatform notWindowsPlatform;
@@ -40,7 +39,6 @@ void main() {
 
   setUp(() {
     mockProcessManager = MockProcessManager();
-    memoryFilesystem = MemoryFileSystem(style: FileSystemStyle.windows);
     mockProcess = MockProcess();
     windowsPlatform = MockPlatform()
         ..environment['PROGRAMFILES(X86)'] = r'C:\Program Files (x86)\';
@@ -68,7 +66,8 @@ void main() {
     ), throwsA(isInstanceOf<ToolExit>()));
   }, overrides: <Type, Generator>{
     Platform: () => windowsPlatform,
-    FileSystem: () => memoryFilesystem,
+    FileSystem: () => MemoryFileSystem(style: FileSystemStyle.windows),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     VisualStudio: () => mockVisualStudio,
     FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),
   });
@@ -82,7 +81,8 @@ void main() {
     ), throwsA(isInstanceOf<ToolExit>()));
   }, overrides: <Type, Generator>{
     Platform: () => windowsPlatform,
-    FileSystem: () => memoryFilesystem,
+    FileSystem: () => MemoryFileSystem(style: FileSystemStyle.windows),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     VisualStudio: () => mockVisualStudio,
     FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),
   });
@@ -101,7 +101,8 @@ void main() {
     ), throwsA(isInstanceOf<ToolExit>()));
   }, overrides: <Type, Generator>{
     Platform: () => notWindowsPlatform,
-    FileSystem: () => memoryFilesystem,
+    FileSystem: () => MemoryFileSystem(style: FileSystemStyle.windows),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     VisualStudio: () => mockVisualStudio,
     FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),
   });
@@ -136,7 +137,7 @@ void main() {
     expect(props.findAllElements('ItemGroup').length, 1);
     expect(props.findAllElements('FLUTTER_ROOT').first.text, r'C:\');
   }, overrides: <Type, Generator>{
-    FileSystem: () => memoryFilesystem,
+    FileSystem: () => MemoryFileSystem(style: FileSystemStyle.windows),
     ProcessManager: () => mockProcessManager,
     Platform: () => windowsPlatform,
     VisualStudio: () => mockVisualStudio,
@@ -168,7 +169,7 @@ void main() {
     final BufferLogger bufferLogger = logger;
     expect(bufferLogger.statusText, contains('🚧'));
   }, overrides: <Type, Generator>{
-    FileSystem: () => memoryFilesystem,
+    FileSystem: () => MemoryFileSystem(style: FileSystemStyle.windows),
     ProcessManager: () => mockProcessManager,
     Platform: () => windowsPlatform,
     VisualStudio: () => mockVisualStudio,

--- a/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
@@ -84,6 +84,7 @@ void main() {
       }
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('returns 1 when app fails to run', () async {
@@ -111,6 +112,7 @@ void main() {
       }
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('returns 1 when app file is outside package', () async {
@@ -133,6 +135,7 @@ void main() {
       }
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('returns 1 when app file is in the root dir', () async {
@@ -156,6 +159,7 @@ void main() {
       }
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('returns 0 when test ends successfully', () async {
@@ -188,6 +192,7 @@ void main() {
       expect(testLogger.errorText, isEmpty);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('returns exitCode set by test runner', () async {
@@ -224,6 +229,7 @@ void main() {
       }
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     group('findTargetDevice', () {
@@ -238,6 +244,7 @@ void main() {
         expect(device.name, 'specified-device');
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       });
     });
 
@@ -248,6 +255,7 @@ void main() {
         expect(await findTargetDevice(), isNull);
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         Platform: platform,
       });
 
@@ -260,6 +268,7 @@ void main() {
         expect(device.name, 'mock-android-device');
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         Platform: platform,
       });
 
@@ -291,6 +300,7 @@ void main() {
         expect(device.name, 'mock-android-device');
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         Platform: platform,
       });
     }
@@ -318,6 +328,7 @@ void main() {
         expect(device.name, 'mock-simulator');
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         Platform: macOsPlatform,
       });
     });
@@ -389,6 +400,7 @@ void main() {
         ));
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       });
 
       testUsingContext('does not use pre-built app if --build arg provided', () async {
@@ -416,6 +428,7 @@ void main() {
         ));
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       });
 
       testUsingContext('uses prebuilt app if --no-build arg provided', () async {
@@ -443,6 +456,7 @@ void main() {
         ));
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       });
     });
   });

--- a/packages/flutter_tools/test/commands.shard/hermetic/shell_completion_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/shell_completion_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/shell_completion.dart';
+import 'package:process/process.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
@@ -51,6 +52,7 @@ void main() {
       expect(fs.file(outputFile).readAsStringSync(), contains('__flutter_completion'));
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       Stdio: () => mockStdio,
     });
 
@@ -71,6 +73,7 @@ void main() {
       expect(fs.file(outputFile).readAsStringSync(), isEmpty);
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       Stdio: () => mockStdio,
     });
 
@@ -85,6 +88,7 @@ void main() {
       expect(fs.file(outputFile).readAsStringSync(), contains('__flutter_completion'));
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       Stdio: () => mockStdio,
     });
   });

--- a/packages/flutter_tools/test/commands.shard/permeable/build_bundle_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_bundle_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter_tools/src/commands/build_bundle.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:mockito/mockito.dart';
+import 'package:process/process.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
@@ -108,6 +109,7 @@ void main() {
     ]), throwsA(isInstanceOf<ToolExit>()));
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: false),
   });
 
@@ -125,6 +127,7 @@ void main() {
     ]), throwsA(isInstanceOf<ToolExit>()));
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: false),
   });
 
@@ -142,6 +145,7 @@ void main() {
     ]), throwsA(isInstanceOf<ToolExit>()));
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: false),
   });
 
@@ -159,6 +163,7 @@ void main() {
     ]);
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),
   });
 
@@ -176,6 +181,7 @@ void main() {
     ]);
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
   });
 
@@ -193,6 +199,7 @@ void main() {
     ]);
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
   });
 }

--- a/packages/flutter_tools/test/general.shard/analytics_test.dart
+++ b/packages/flutter_tools/test/general.shard/analytics_test.dart
@@ -108,6 +108,7 @@ void main() {
         'FLUTTER_ANALYTICS_LOG_FILE': 'test',
       }),
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('Usage records multiple features in experiment setting', () async {
@@ -129,6 +130,7 @@ void main() {
         'FLUTTER_ANALYTICS_LOG_FILE': 'test',
       }),
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
   });
 
@@ -221,6 +223,7 @@ void main() {
       expect(log.contains(formatDateTime(dateTime)), isTrue);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       SystemClock: () => mockClock,
       Platform: () => FakePlatform(
         environment: <String, String>{
@@ -246,6 +249,7 @@ void main() {
       expect(log.contains(formatDateTime(dateTime)), isTrue);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       SystemClock: () => mockClock,
       Platform: () => FakePlatform(
         environment: <String, String>{

--- a/packages/flutter_tools/test/general.shard/android/android_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_test.dart
@@ -280,6 +280,7 @@ flutter:
     expect(AndroidDevice('test').isSupportedForProject(flutterProject), true);
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
   });
 
   testUsingContext('isSupportedForProject is true with editable host app', () async {
@@ -291,6 +292,7 @@ flutter:
     expect(AndroidDevice('test').isSupportedForProject(flutterProject), true);
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
   });
 
   testUsingContext('isSupportedForProject is false with no host app and no module', () async {
@@ -301,6 +303,7 @@ flutter:
     expect(AndroidDevice('test').isSupportedForProject(flutterProject), false);
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
   });
 
   group('emulatorId', () {

--- a/packages/flutter_tools/test/general.shard/android/android_sdk_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_sdk_test.dart
@@ -45,6 +45,7 @@ void main() {
       expect(sdk.latestVersion.sdkLevel, 23);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('parse sdk N', () {
@@ -56,6 +57,7 @@ void main() {
       expect(sdk.latestVersion.sdkLevel, 24);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('returns sdkmanager path', () {
@@ -66,6 +68,7 @@ void main() {
       expect(sdk.sdkManagerPath, fs.path.join(sdk.directory, 'tools', 'bin', 'sdkmanager'));
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('returns sdkmanager version', () {
@@ -158,6 +161,7 @@ void main() {
           expect(sdk.ndk.compilerArgs, <String>['--sysroot', realNdkSysroot]);
         }, overrides: <Type, Generator>{
           FileSystem: () => fs,
+          ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
           Platform: () => FakePlatform(operatingSystem: os),
         });
 
@@ -192,6 +196,7 @@ void main() {
           expect(sdk.ndk.compilerArgs, <String>['--sysroot', realNdkSysroot, '-fuse-ld=$realNdkLinker']);
         }, overrides: <Type, Generator>{
           FileSystem: () => fs,
+          ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
           Platform: () => FakePlatform(operatingSystem: os),
         });
       });
@@ -209,6 +214,7 @@ void main() {
           expect(explanation, contains('Can not locate ndk-bundle'));
         }, overrides: <Type, Generator>{
           FileSystem: () => fs,
+          ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
           Platform: () => FakePlatform(operatingSystem: os),
         });
       }

--- a/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
@@ -66,6 +66,7 @@ void main() {
           equals('/home/me/.AndroidStudioWithCheese5.0/config/plugins'));
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       // Custom home paths are not supported on macOS nor Windows yet,
       // so we force the platform to fake Linux here.
       Platform: () => linuxPlatform(),
@@ -85,6 +86,7 @@ void main() {
           equals(fs.path.join(homeMac, 'Library', 'Application Support', 'AndroidStudio3.3')));
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       // Custom home paths are not supported on macOS nor Windows yet,
       // so we force the platform to fake Linux here.
       Platform: () => macPlatform(),
@@ -114,6 +116,7 @@ void main() {
           equals(fs.path.join(homeMac, 'Library', 'Application Support', 'AndroidStudio3.3')));
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       // Custom home paths are not supported on macOS nor Windows yet,
       // so we force the platform to fake Linux here.
       Platform: () => macPlatform(),

--- a/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
@@ -51,8 +51,8 @@ void main() {
   }, overrides: <Type, Generator>{
     AndroidSdk: () => sdk,
     FileSystem: () => fs,
-    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
     ProcessManager: () => processManager,
+    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
     Stdio: () => stdio,
   });
 
@@ -65,8 +65,8 @@ void main() {
   }, overrides: <Type, Generator>{
     AndroidSdk: () => sdk,
     FileSystem: () => fs,
-    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
     ProcessManager: () => processManager,
+    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
     Stdio: () => stdio,
   });
 
@@ -80,8 +80,8 @@ void main() {
   }, overrides: <Type, Generator>{
     AndroidSdk: () => sdk,
     FileSystem: () => fs,
-    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
     ProcessManager: () => processManager,
+    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
     Stdio: () => stdio,
   });
 
@@ -98,8 +98,8 @@ void main() {
   }, overrides: <Type, Generator>{
     AndroidSdk: () => sdk,
     FileSystem: () => fs,
-    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
     ProcessManager: () => processManager,
+    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
     Stdio: () => stdio,
   });
 
@@ -117,8 +117,8 @@ void main() {
   }, overrides: <Type, Generator>{
     AndroidSdk: () => sdk,
     FileSystem: () => fs,
-    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
     ProcessManager: () => processManager,
+    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
     Stdio: () => stdio,
   });
 
@@ -136,8 +136,8 @@ void main() {
   }, overrides: <Type, Generator>{
     AndroidSdk: () => sdk,
     FileSystem: () => fs,
-    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
     ProcessManager: () => processManager,
+    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
     Stdio: () => stdio,
   });
 
@@ -149,8 +149,8 @@ void main() {
   }, overrides: <Type, Generator>{
     AndroidSdk: () => sdk,
     FileSystem: () => fs,
-    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
     ProcessManager: () => processManager,
+    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
     Stdio: () => stdio,
   });
 
@@ -162,8 +162,8 @@ void main() {
   }, overrides: <Type, Generator>{
     AndroidSdk: () => sdk,
     FileSystem: () => fs,
-    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
     ProcessManager: () => processManager,
+    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
     Stdio: () => stdio,
   });
 
@@ -175,8 +175,8 @@ void main() {
   }, overrides: <Type, Generator>{
     AndroidSdk: () => sdk,
     FileSystem: () => fs,
-    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
     ProcessManager: () => processManager,
+    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
     Stdio: () => stdio,
   });
 
@@ -188,8 +188,8 @@ void main() {
   }, overrides: <Type, Generator>{
     AndroidSdk: () => sdk,
     FileSystem: () => fs,
-    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
     ProcessManager: () => processManager,
+    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
     Stdio: () => stdio,
   });
 
@@ -201,8 +201,8 @@ void main() {
   }, overrides: <Type, Generator>{
     AndroidSdk: () => sdk,
     FileSystem: () => fs,
-    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
     ProcessManager: () => processManager,
+    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
     Stdio: () => stdio,
   });
 
@@ -218,8 +218,8 @@ void main() {
   }, overrides: <Type, Generator>{
     AndroidSdk: () => sdk,
     FileSystem: () => fs,
-    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
     ProcessManager: () => processManager,
+    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
     Stdio: () => stdio,
   });
 
@@ -272,8 +272,8 @@ void main() {
   }, overrides: <Type, Generator>{
     AndroidSdk: () => sdk,
     FileSystem: () => fs,
-    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
     ProcessManager: () => processManager,
+    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
     Stdio: () => stdio,
   });
 

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -58,6 +58,7 @@ void main() {
       expect(findApkFiles(gradleProject, buildInfo), <File>[]);
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     test('androidXFailureRegex should match lines with likely AndroidX errors', () {
@@ -130,6 +131,7 @@ void main() {
       expect(bundle.path, '/foo_barRelease/app.aab');
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('Finds app bundle when flavor doesn\'t contain underscores in release mode', () {
@@ -139,6 +141,7 @@ void main() {
       expect(bundle.path, '/fooRelease/app.aab');
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('Finds app bundle when no flavor is used in release mode', () {
@@ -148,6 +151,7 @@ void main() {
       expect(bundle.path, '/release/app.aab');
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('Finds app bundle when flavor contains underscores in debug mode', () {
@@ -157,6 +161,7 @@ void main() {
       expect(bundle.path, '/foo_barDebug/app.aab');
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('Finds app bundle when flavor doesn\'t contain underscores in debug mode', () {
@@ -166,6 +171,7 @@ void main() {
       expect(bundle.path, '/fooDebug/app.aab');
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('Finds app bundle when no flavor is used in debug mode', () {
@@ -175,6 +181,7 @@ void main() {
       expect(bundle.path, '/debug/app.aab');
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('Finds app bundle when flavor contains underscores in profile mode', () {
@@ -184,6 +191,7 @@ void main() {
       expect(bundle.path, '/foo_barProfile/app.aab');
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('Finds app bundle when flavor doesn\'t contain underscores in profile mode', () {
@@ -193,6 +201,7 @@ void main() {
       expect(bundle.path, '/fooProfile/app.aab');
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('Finds app bundle when no flavor is used in profile mode', () {
@@ -202,6 +211,7 @@ void main() {
       expect(bundle.path, '/profile/app.aab');
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('Finds app bundle in release mode - Gradle 3.5', () {
@@ -211,6 +221,7 @@ void main() {
       expect(bundle.path, '/release/app-release.aab');
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('Finds app bundle in profile mode - Gradle 3.5', () {
@@ -220,6 +231,7 @@ void main() {
       expect(bundle.path, '/profile/app-profile.aab');
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('Finds app bundle in debug mode - Gradle 3.5', () {
@@ -229,6 +241,7 @@ void main() {
       expect(bundle.path, '/debug/app-debug.aab');
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('Finds app bundle when flavor contains underscores in release mode - Gradle 3.5', () {
@@ -238,6 +251,7 @@ void main() {
       expect(bundle.path, '/foo_barRelease/app-foo_bar-release.aab');
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('Finds app bundle when flavor contains underscores in profile mode - Gradle 3.5', () {
@@ -247,6 +261,7 @@ void main() {
       expect(bundle.path, '/foo_barProfile/app-foo_bar-profile.aab');
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('Finds app bundle when flavor contains underscores in debug mode - Gradle 3.5', () {
@@ -256,6 +271,7 @@ void main() {
       expect(bundle.path, '/foo_barDebug/app-foo_bar-debug.aab');
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
   });
 
@@ -492,6 +508,7 @@ include ':app'
 
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       Logger: () => mockLogger,
     });
 
@@ -525,6 +542,7 @@ include ':app'
 
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       Logger: () => mockLogger,
     });
   });
@@ -587,9 +605,9 @@ include ':app'
     void testUsingAndroidContext(String description, dynamic testMethod()) {
       testUsingContext(description, testMethod, overrides: <Type, Generator>{
         Artifacts: () => mockArtifacts,
-        ProcessManager: () => mockProcessManager,
         Platform: () => android,
         FileSystem: () => fs,
+        ProcessManager: () => mockProcessManager,
       });
     }
 
@@ -1011,6 +1029,7 @@ at org.gradle.wrapper.GradleWrapperMain.main(GradleWrapperMain.java:61)''';
     }, overrides: <Type, Generator>{
       Cache: () => Cache(rootOverride: tempDir),
       FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('Inject the wrapper when some files are missing', () {
@@ -1051,6 +1070,7 @@ at org.gradle.wrapper.GradleWrapperMain.main(GradleWrapperMain.java:61)''';
     }, overrides: <Type, Generator>{
       Cache: () => Cache(rootOverride: tempDir),
       FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('Gives executable permission to gradle', () {
@@ -1068,6 +1088,7 @@ at org.gradle.wrapper.GradleWrapperMain.main(GradleWrapperMain.java:61)''';
     }, overrides: <Type, Generator>{
       Cache: () => Cache(rootOverride: tempDir),
       FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       OperatingSystemUtils: () => OperatingSystemUtils(),
     });
   });
@@ -1089,6 +1110,7 @@ at org.gradle.wrapper.GradleWrapperMain.main(GradleWrapperMain.java:61)''';
 
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('throws ToolExit if it cannot write gradle.properties', () {
@@ -1126,6 +1148,7 @@ at org.gradle.wrapper.GradleWrapperMain.main(GradleWrapperMain.java:61)''';
         equals('android.enableR8=true'));
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('sets android.enableR8=true', () {
@@ -1146,6 +1169,7 @@ at org.gradle.wrapper.GradleWrapperMain.main(GradleWrapperMain.java:61)''';
       );
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
   });
 
@@ -1167,6 +1191,7 @@ at org.gradle.wrapper.GradleWrapperMain.main(GradleWrapperMain.java:61)''';
 
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('returns false when the project is not using AndroidX', () async {
@@ -1180,6 +1205,7 @@ at org.gradle.wrapper.GradleWrapperMain.main(GradleWrapperMain.java:61)''';
 
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('returns false when gradle.properties does not exist', () async {
@@ -1189,6 +1215,7 @@ at org.gradle.wrapper.GradleWrapperMain.main(GradleWrapperMain.java:61)''';
 
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
   });
 
@@ -1291,8 +1318,8 @@ plugin2=${plugin2.path}
     }, overrides: <Type, Generator>{
       AndroidSdk: () => mockAndroidSdk,
       FileSystem: () => fs,
-      GradleUtils: () => FakeGradleUtils(),
       ProcessManager: () => mockProcessManager,
+      GradleUtils: () => FakeGradleUtils(),
     });
   });
 
@@ -1405,9 +1432,9 @@ plugin2=${plugin2.path}
       AndroidStudio: () => mockAndroidStudio,
       Artifacts: () => mockArtifacts,
       Cache: () => cache,
-      ProcessManager: () => mockProcessManager,
       Platform: () => android,
       FileSystem: () => fs,
+      ProcessManager: () => mockProcessManager,
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -211,6 +211,7 @@ void main() {
   group('PrebuiltIOSApp', () {
     final Map<Type, Generator> overrides = <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       PlistParser: () => MockPlistUtils(),
       Platform: _kNoColorTerminalPlatform,
       OperatingSystemUtils: () => MockOperatingSystemUtils(),
@@ -362,6 +363,7 @@ void main() {
   group('FuchsiaApp', () {
     final Map<Type, Generator> overrides = <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       Platform: _kNoColorTerminalPlatform,
       OperatingSystemUtils: () => MockOperatingSystemUtils(),
     };

--- a/packages/flutter_tools/test/general.shard/artifacts_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifacts_test.dart
@@ -45,6 +45,7 @@ void main() {
       }, overrides: <Type, Generator>{
         Cache: () => Cache(rootOverride: tempDir),
         FileSystem: () => memoryFileSystem,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         Platform: () => FakePlatform(operatingSystem: 'linux'),
       });
 
@@ -64,6 +65,7 @@ void main() {
       }, overrides: <Type, Generator>{
         Cache: () => Cache(rootOverride: tempDir),
         FileSystem: () => memoryFileSystem,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         Platform: () => FakePlatform(operatingSystem: 'linux'),
       });
     });
@@ -93,6 +95,7 @@ void main() {
         );
       }, overrides: <Type, Generator>{
         FileSystem: () => memoryFileSystem,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         Platform: () => FakePlatform(operatingSystem: 'linux'),
       });
 
@@ -111,6 +114,7 @@ void main() {
         );
       }, overrides: <Type, Generator>{
         FileSystem: () => memoryFileSystem,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         Platform: () => FakePlatform(operatingSystem: 'linux'),
       });
 
@@ -118,6 +122,7 @@ void main() {
         expect(artifacts.getArtifactPath(Artifact.engineDartBinary), contains('.exe'));
       }, overrides: <Type, Generator>{
         FileSystem: () => memoryFileSystem,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         Platform: () => FakePlatform(operatingSystem: 'windows'),
       });
 
@@ -125,6 +130,7 @@ void main() {
         expect(artifacts.getArtifactPath(Artifact.engineDartBinary), isNot(contains('.exe')));
       }, overrides: <Type, Generator>{
         FileSystem: () => memoryFileSystem,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         Platform: () => FakePlatform(operatingSystem: 'linux'),
       });
     });

--- a/packages/flutter_tools/test/general.shard/asset_bundle_package_fonts_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_package_fonts_test.dart
@@ -126,6 +126,7 @@ $fontsSection
       expect(bundle.entries.containsKey('FontManifest.json'), isTrue);
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('App font uses font file from package', () async {
@@ -154,6 +155,7 @@ $fontsSection
       );
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('App font uses local font file and package font file', () async {
@@ -186,6 +188,7 @@ $fontsSection
       );
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('App uses package font with own font file', () async {
@@ -219,6 +222,7 @@ $fontsSection
       );
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('App uses package font with font file from another package', () async {
@@ -253,6 +257,7 @@ $fontsSection
       );
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('App uses package font with properties and own font file', () async {
@@ -288,6 +293,7 @@ $fontsSection
       );
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('App uses local font and package font with own font file.', () async {
@@ -327,6 +333,7 @@ $fontsSection
       );
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/asset_bundle_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_package_test.dart
@@ -135,6 +135,7 @@ $assetsSection
       );
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('No assets are bundled when the package has an asset that is not listed', () async {
@@ -162,6 +163,7 @@ $assetsSection
       );
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('One asset is bundled when the package has and lists one asset its pubspec', () async {
@@ -189,6 +191,7 @@ $assetsSection
       );
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext("One asset is bundled when the package has one asset, listed in the app's pubspec", () async {
@@ -216,6 +219,7 @@ $assetsSection
       );
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('One asset and its variant are bundled when the package has an asset and a variant, and lists the asset in its pubspec', () async {
@@ -243,6 +247,7 @@ $assetsSection
       );
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('One asset and its variant are bundled when the package has an asset and a variant, and the app lists the asset in its pubspec', () async {
@@ -273,6 +278,7 @@ $assetsSection
       );
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('Two assets are bundled when the package has and lists two assets in its pubspec', () async {
@@ -301,6 +307,7 @@ $assetsSection
       );
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext("Two assets are bundled when the package has two assets, listed in the app's pubspec", () async {
@@ -336,6 +343,7 @@ $assetsSection
       );
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('Two assets are bundled when two packages each have and list an asset their pubspec', () async {
@@ -375,6 +383,7 @@ $assetsSection
       );
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext("Two assets are bundled when two packages each have an asset, listed in the app's pubspec", () async {
@@ -417,6 +426,7 @@ $assetsSection
       );
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('One asset is bundled when the app depends on a package, listing in its pubspec an asset from another package', () async {
@@ -451,6 +461,7 @@ $assetsSection
       );
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
   });
 
@@ -480,6 +491,7 @@ $assetsSection
     );
   }, overrides: <Type, Generator>{
     FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
   });
 
   group('AssetBundle assets from scanned paths', () {
@@ -511,6 +523,7 @@ $assetsSection
       );
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('Two assets are bundled when listing one and scanning second directory', () async {
@@ -541,6 +554,7 @@ $assetsSection
       );
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('One asset is bundled with variant, scanning wrong directory', () async {
@@ -566,6 +580,7 @@ $assetsSection
       assert(bundle.entries['AssetManifest.json'] == null,'Invalid pubspec.yaml should not generate AssetManifest.json'  );
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
   });
 
@@ -597,6 +612,7 @@ $assetsSection
       );
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('No asset is bundled with variant, no assets or directories are listed', () async {
@@ -625,6 +641,7 @@ $assetsSection
       );
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('Expect error generating manifest, wrong non-existing directory is listed', () async {
@@ -658,6 +675,7 @@ $assetsSection
       }
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
   });

--- a/packages/flutter_tools/test/general.shard/asset_bundle_variant_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_variant_test.dart
@@ -92,6 +92,7 @@ flutter:
       }
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/base/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/build_test.dart
@@ -254,6 +254,7 @@ void main() {
       AndroidSdk: () => mockAndroidSdk,
       Artifacts: () => mockArtifacts,
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       GenSnapshot: () => genSnapshot,
       Xcode: () => mockXcode,
       Logger: () => bufferLogger,

--- a/packages/flutter_tools/test/general.shard/base/file_system_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/file_system_test.dart
@@ -20,12 +20,18 @@ void main() {
     testUsingContext('recursively creates a directory if it does not exist', () async {
       ensureDirectoryExists('foo/bar/baz.flx');
       expect(fs.isDirectorySync('foo/bar'), true);
-    }, overrides: <Type, Generator>{FileSystem: () => fs});
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
+    });
 
     testUsingContext('throws tool exit on failure to create', () async {
       fs.file('foo').createSync();
       expect(() => ensureDirectoryExists('foo/bar.flx'), throwsToolExit());
-    }, overrides: <Type, Generator>{FileSystem: () => fs});
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
+    });
   });
 
   group('copyDirectorySync', () {
@@ -80,6 +86,7 @@ void main() {
       expect(destination.childDirectory('nested').childFile('a.txt').existsSync(), isFalse);
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
   });
 

--- a/packages/flutter_tools/test/general.shard/base/fingerprint_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/fingerprint_test.dart
@@ -30,6 +30,7 @@ void main() {
 
     final Map<Type, Generator> contextOverrides = <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     };
 
     testUsingContext('throws when depfile is malformed', () {
@@ -290,7 +291,10 @@ void main() {
           () => Fingerprint.fromBuildInputs(<String, String>{}, <String>['a.dart', 'b.dart']),
           throwsArgumentError,
         );
-      }, overrides: <Type, Generator>{FileSystem: () => fs});
+      }, overrides: <Type, Generator>{
+        FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
+      });
 
       testUsingContext('populates checksums for valid files', () {
         fs.file('a.dart').writeAsStringSync('This is a');
@@ -301,7 +305,10 @@ void main() {
         expect(jsonObject['files'], hasLength(2));
         expect(jsonObject['files']['a.dart'], '8a21a15fad560b799f6731d436c1b698');
         expect(jsonObject['files']['b.dart'], '6f144e08b58cd0925328610fad7ac07c');
-      }, overrides: <Type, Generator>{FileSystem: () => fs});
+      }, overrides: <Type, Generator>{
+        FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
+      });
 
       testUsingContext('includes framework version', () {
         final Fingerprint fingerprint = Fingerprint.fromBuildInputs(<String, String>{}, <String>[]);
@@ -480,7 +487,10 @@ void main() {
       fs = MemoryFileSystem();
     });
 
-    final Map<Type, Generator> contextOverrides = <Type, Generator>{FileSystem: () => fs};
+    final Map<Type, Generator> contextOverrides = <Type, Generator>{
+      FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
+    };
 
     testUsingContext('returns one file if only one is listed', () {
       fs.file('a.d').writeAsStringSync('snapshot.d: /foo/a.dart');

--- a/packages/flutter_tools/test/general.shard/build_system/targets/windows_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/windows_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_tools/src/cache.dart';
 import 'package:mockito/mockito.dart';
 
 import '../../../src/common.dart';
+import '../../../src/fake_process_manager.dart';
 import '../../../src/testbed.dart';
 
 void main() {
@@ -51,6 +52,7 @@ void main() {
       fs.directory('windows').createSync();
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(style: FileSystemStyle.windows),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       Platform: () => platform,
     });
   });

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -64,6 +64,7 @@ void main() {
       Cache.releaseLockEarly();
     }, overrides: <Type, Generator>{
       FileSystem: () => mockFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('throws tool exit when lockfile open fails', () async {
@@ -72,6 +73,7 @@ void main() {
       expect(() async => await Cache.lock(), throwsA(isA<ToolExit>()));
     }, overrides: <Type, Generator>{
       FileSystem: () => mockFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('should not throw when FLUTTER_ALREADY_LOCKED is set', () async {
@@ -100,6 +102,7 @@ void main() {
     }, overrides: <Type, Generator>{
       Cache: ()=> mockCache,
       FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('Gradle wrapper should be up to date, only if all cached artifact are available', () {
@@ -115,6 +118,7 @@ void main() {
     }, overrides: <Type, Generator>{
       Cache: ()=> mockCache,
       FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     test('should not be up to date, if some cached artifact is not', () {
@@ -206,6 +210,7 @@ void main() {
     expect(flattenNameSubdirs(Uri.parse('https://www.flutter.dev')), 'www.flutter.dev');
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
   });
 
   test('Unstable artifacts', () {
@@ -256,6 +261,7 @@ void main() {
     }, overrides: <Type, Generator>{
       Cache: ()=> mockCache,
       FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       HttpClientFactory: () => () => fakeHttpClient,
       OperatingSystemUtils: () => mockOperatingSystemUtils,
       Platform: () => fakePlatform,

--- a/packages/flutter_tools/test/general.shard/channel_test.dart
+++ b/packages/flutter_tools/test/general.shard/channel_test.dart
@@ -157,8 +157,8 @@ void main() {
         environment: anyNamed('environment'),
       )).called(1);
     }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => mockProcessManager,
     });
 
     // This verifies that bug https://github.com/flutter/flutter/issues/21134
@@ -218,8 +218,8 @@ void main() {
       expect(testLogger.errorText, hasLength(0));
       expect(versionCheckFile.existsSync(), isFalse);
     }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => mockProcessManager,
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/commands/build_aot_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_aot_test.dart
@@ -41,6 +41,7 @@ void main() {
   }, overrides: <Type, Generator>{
     Artifacts: () => LocalEngineArtifacts('/engine', 'ios_profile', 'host_profile'),
     FileSystem: () => memoryFileSystem,
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
   });
 
   testUsingContext('build aot prints error if Clang version invalid', () async {

--- a/packages/flutter_tools/test/general.shard/commands/build_apk_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_apk_test.dart
@@ -189,8 +189,8 @@ flutter:
       overrides: <Type, Generator>{
         AndroidSdk: () => mockAndroidSdk,
         GradleUtils: () => GradleUtils(),
-        ProcessManager: () => mockProcessManager,
         FileSystem: () => memoryFileSystem,
+        ProcessManager: () => mockProcessManager,
       });
     });
 

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -89,8 +89,8 @@ void main() {
     expect(testLogger.errorText, isEmpty);
     expect(error, isNull);
   }, overrides: <Type, Generator>{
-    ProcessManager: () => MockProcessManager(69),
     FileSystem: () => MockFileSystem(),
+    ProcessManager: () => MockProcessManager(69),
     Platform: () => FakePlatform(
       environment: UnmodifiableMapView<String, String>(<String, String>{}),
     ),
@@ -144,8 +144,8 @@ void main() {
       expect(error, isNull);
     });
   }, overrides: <Type, Generator>{
-    ProcessManager: () => MockProcessManager(69),
     FileSystem: () => MockFileSystem(),
+    ProcessManager: () => MockProcessManager(69),
     Platform: () => FakePlatform(
       environment: UnmodifiableMapView<String, String>(<String, String>{}),
     ),
@@ -171,8 +171,8 @@ void main() {
       expect(error, isNull);
     });
   }, overrides: <Type, Generator>{
-    ProcessManager: () => MockProcessManager(69),
     FileSystem: () => MockFileSystem(),
+    ProcessManager: () => MockProcessManager(69),
     Platform: () => FakePlatform(
       environment: UnmodifiableMapView<String, String>(<String, String>{
         'PUB_CACHE': 'custom/pub-cache/path',
@@ -186,8 +186,8 @@ void main() {
     await pub.get(context: PubContext.flutterTests, checkLastModified: false);
     verify(flutterUsage.sendEvent('pub-result', 'flutter-tests', label: 'success')).called(1);
   }, overrides: <Type, Generator>{
-    ProcessManager: () => MockProcessManager(0),
     FileSystem: () => MockFileSystem(),
+    ProcessManager: () => MockProcessManager(0),
     Platform: () => FakePlatform(
       environment: UnmodifiableMapView<String, String>(<String, String>{
         'PUB_CACHE': 'custom/pub-cache/path',
@@ -206,8 +206,8 @@ void main() {
     }
     verify(flutterUsage.sendEvent('pub-result', 'flutter-tests', label: 'failure')).called(1);
   }, overrides: <Type, Generator>{
-    ProcessManager: () => MockProcessManager(1),
     FileSystem: () => MockFileSystem(),
+    ProcessManager: () => MockProcessManager(1),
     Platform: () => FakePlatform(
       environment: UnmodifiableMapView<String, String>(<String, String>{
         'PUB_CACHE': 'custom/pub-cache/path',
@@ -226,11 +226,11 @@ void main() {
     }
     verify(flutterUsage.sendEvent('pub-result', 'flutter-tests', label: 'version-solving-failed')).called(1);
   }, overrides: <Type, Generator>{
+    FileSystem: () => MockFileSystem(),
     ProcessManager: () => MockProcessManager(
       1,
       stderr: 'version solving failed',
     ),
-    FileSystem: () => MockFileSystem(),
     Platform: () => FakePlatform(
       environment: UnmodifiableMapView<String, String>(<String, String>{
         'PUB_CACHE': 'custom/pub-cache/path',

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -89,6 +89,7 @@ void main() {
       expect(content.isModified, isFalse);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     }, skip: Platform.isWindows); // TODO(jonahwilliams): fix or disable this functionality.
   });
 
@@ -158,6 +159,7 @@ void main() {
       verify(httpRequest.close()).called(kFailedAttempts + 1);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
   });
 
@@ -206,6 +208,7 @@ void main() {
       expect(report.success, true);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('delete dev file system', () async {
@@ -215,6 +218,7 @@ void main() {
       expect(devFS.assetPathsToEvict, isEmpty);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('cleanup preexisting file system', () async {
@@ -242,6 +246,7 @@ void main() {
       expect(devFS.assetPathsToEvict, isEmpty);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('reports unsuccessful compile when errors are returned', () async {
@@ -271,6 +276,7 @@ void main() {
       expect(devFS.lastCompiled, previousCompile);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('correctly updates last compiled time when compilation does not fail', () async {
@@ -304,6 +310,7 @@ void main() {
       expect(devFS.lastCompiled, isNot(previousCompile));
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
@@ -621,6 +621,7 @@ flutter:
         },
         overrides: <Type, Generator>{
           FileSystem: () => filesystem,
+          ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         },
       );
     }

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
@@ -75,6 +75,7 @@ void main() {
       expect(device.isSupportedForProject(FlutterProject.current()), true);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('supported for project', () async {
@@ -84,6 +85,7 @@ void main() {
       expect(device.isSupportedForProject(FlutterProject.current()), true);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('not supported for project', () async {
@@ -92,6 +94,7 @@ void main() {
       expect(device.isSupportedForProject(FlutterProject.current()), false);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
   });
 
@@ -445,6 +448,7 @@ void main() {
       expect(launchResult.hasObservatory, isFalse);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       FuchsiaDeviceTools: () => fuchsiaDeviceTools,
       FuchsiaSdk: () => fuchsiaSdk,
       OperatingSystemUtils: () => osUtils,
@@ -469,6 +473,7 @@ void main() {
       expect(await device.stopApp(app), isTrue);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       FuchsiaDeviceTools: () => fuchsiaDeviceTools,
       FuchsiaSdk: () => fuchsiaSdk,
       OperatingSystemUtils: () => osUtils,
@@ -481,6 +486,7 @@ void main() {
       expect(launchResult.hasObservatory, isTrue);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       FuchsiaDeviceTools: () => fuchsiaDeviceTools,
       FuchsiaSdk: () => fuchsiaSdk,
       OperatingSystemUtils: () => osUtils,
@@ -493,6 +499,7 @@ void main() {
       expect(launchResult.hasObservatory, isFalse);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       FuchsiaDeviceTools: () => fuchsiaDeviceTools,
       FuchsiaSdk: () => fuchsiaSdk,
       OperatingSystemUtils: () => osUtils,
@@ -505,6 +512,7 @@ void main() {
       expect(launchResult.hasObservatory, isTrue);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       FuchsiaDeviceTools: () => fuchsiaDeviceTools,
       FuchsiaSdk: () => fuchsiaSdk,
       OperatingSystemUtils: () => osUtils,
@@ -517,6 +525,7 @@ void main() {
       expect(launchResult.hasObservatory, isFalse);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       FuchsiaDeviceTools: () => fuchsiaDeviceTools,
       FuchsiaSdk: () => MockFuchsiaSdk(devFinder: FailingDevFinder()),
       OperatingSystemUtils: () => osUtils,
@@ -529,6 +538,7 @@ void main() {
       expect(launchResult.hasObservatory, isFalse);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       FuchsiaDeviceTools: () => fuchsiaDeviceTools,
       FuchsiaSdk: () => MockFuchsiaSdk(pm: FailingPM()),
       OperatingSystemUtils: () => osUtils,
@@ -541,6 +551,7 @@ void main() {
       expect(launchResult.hasObservatory, isFalse);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       FuchsiaDeviceTools: () => FakeFuchsiaDeviceTools(amber: FailingAmberCtl()),
       FuchsiaSdk: () => fuchsiaSdk,
       OperatingSystemUtils: () => osUtils,
@@ -553,6 +564,7 @@ void main() {
       expect(launchResult.hasObservatory, isFalse);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       FuchsiaDeviceTools: () => FakeFuchsiaDeviceTools(tiles: FailingTilesCtl()),
       FuchsiaSdk: () => fuchsiaSdk,
       OperatingSystemUtils: () => osUtils,

--- a/packages/flutter_tools/test/general.shard/intellij/intellij_test.dart
+++ b/packages/flutter_tools/test/general.shard/intellij/intellij_test.dart
@@ -69,6 +69,7 @@ void main() {
         expect(message.message, contains('recommended minimum version'));
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       });
 
       testUsingContext('not found', () async {
@@ -89,6 +90,7 @@ void main() {
         expect(message.message, contains('Flutter plugin not installed'));
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       });
     });
   });

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -763,6 +763,7 @@ flutter:
     expect(IOSDevice('test').isSupportedForProject(flutterProject), true);
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     Platform: () => macPlatform,
   });
   testUsingContext('IOSDevice.isSupportedForProject is true with editable host app', () async {
@@ -774,6 +775,7 @@ flutter:
     expect(IOSDevice('test').isSupportedForProject(flutterProject), true);
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     Platform: () => macPlatform,
   });
 
@@ -785,6 +787,7 @@ flutter:
     expect(IOSDevice('test').isSupportedForProject(flutterProject), false);
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     Platform: () => macPlatform,
   });
 }

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -486,6 +486,7 @@ flutter:
     expect(IOSSimulator('test').isSupportedForProject(flutterProject), true);
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
   });
 
   testUsingContext('IOSDevice.isSupportedForProject is true with editable host app', () async {
@@ -497,6 +498,7 @@ flutter:
     expect(IOSSimulator('test').isSupportedForProject(flutterProject), true);
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
   });
 
   testUsingContext('IOSDevice.isSupportedForProject is false with no host app and no module', () async {
@@ -507,5 +509,6 @@ flutter:
     expect(IOSSimulator('test').isSupportedForProject(flutterProject), false);
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
   });
 }

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -39,9 +39,9 @@ void main() {
 
     void testUsingOsxContext(String description, dynamic testMethod()) {
       testUsingContext(description, testMethod, overrides: <Type, Generator>{
-        ProcessManager: () => mockProcessManager,
         Platform: () => macOS,
         FileSystem: () => fs,
+        ProcessManager: () => mockProcessManager,
       });
     }
 
@@ -188,9 +188,9 @@ void main() {
 
     void testUsingOsxContext(String description, dynamic testMethod()) {
       testUsingContext(description, testMethod, overrides: <Type, Generator>{
-        ProcessManager: () => mockProcessManager,
         Platform: () => macOS,
         FileSystem: () => fs,
+        ProcessManager: () => mockProcessManager,
       });
     }
 
@@ -355,9 +355,9 @@ Information about project "Runner":
     void testUsingOsxContext(String description, dynamic testMethod()) {
       testUsingContext(description, testMethod, overrides: <Type, Generator>{
         Artifacts: () => mockArtifacts,
-        ProcessManager: () => mockProcessManager,
         Platform: () => macOS,
         FileSystem: () => fs,
+        ProcessManager: () => mockProcessManager,
       });
     }
 

--- a/packages/flutter_tools/test/general.shard/linux/linux_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/linux/linux_device_test.dart
@@ -16,29 +16,27 @@ import '../../src/common.dart';
 import '../../src/context.dart';
 
 void main() {
-  group(LinuxDevice, () {
-    final LinuxDevice device = LinuxDevice();
-    final MockPlatform notLinux = MockPlatform();
+  final LinuxDevice device = LinuxDevice();
+  final MockPlatform notLinux = MockPlatform();
 
-    when(notLinux.isLinux).thenReturn(false);
+  when(notLinux.isLinux).thenReturn(false);
 
-    testUsingContext('defaults', () async {
-      final PrebuiltLinuxApp linuxApp = PrebuiltLinuxApp(executable: 'foo');
-      expect(await device.targetPlatform, TargetPlatform.linux_x64);
-      expect(device.name, 'Linux');
-      expect(await device.installApp(linuxApp), true);
-      expect(await device.uninstallApp(linuxApp), true);
-      expect(await device.isLatestBuildInstalled(linuxApp), true);
-      expect(await device.isAppInstalled(linuxApp), true);
-      expect(await device.stopApp(linuxApp), true);
-      expect(device.category, Category.desktop);
-    });
+  testUsingContext('LinuxDevice defaults', () async {
+    final PrebuiltLinuxApp linuxApp = PrebuiltLinuxApp(executable: 'foo');
+    expect(await device.targetPlatform, TargetPlatform.linux_x64);
+    expect(device.name, 'Linux');
+    expect(await device.installApp(linuxApp), true);
+    expect(await device.uninstallApp(linuxApp), true);
+    expect(await device.isLatestBuildInstalled(linuxApp), true);
+    expect(await device.isAppInstalled(linuxApp), true);
+    expect(await device.stopApp(linuxApp), true);
+    expect(device.category, Category.desktop);
+  });
 
-    testUsingContext('No devices listed if platform unsupported', () async {
-      expect(await LinuxDevices().devices, <Device>[]);
-    }, overrides: <Type, Generator>{
-      Platform: () => notLinux,
-    });
+  testUsingContext('LinuxDevice: no devices listed if platform unsupported', () async {
+    expect(await LinuxDevices().devices, <Device>[]);
+  }, overrides: <Type, Generator>{
+    Platform: () => notLinux,
   });
 
   testUsingContext('LinuxDevice.isSupportedForProject is true with editable host app', () async {
@@ -50,6 +48,7 @@ void main() {
     expect(LinuxDevice().isSupportedForProject(flutterProject), true);
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
   });
 
   testUsingContext('LinuxDevice.isSupportedForProject is false with no host app', () async {
@@ -60,9 +59,10 @@ void main() {
     expect(LinuxDevice().isSupportedForProject(flutterProject), false);
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
   });
 
-  testUsingContext('executablePathForDevice uses the correct package executable', () async {
+  testUsingContext('LinuxDevice.executablePathForDevice uses the correct package executable', () async {
     final MockLinuxApp mockApp = MockLinuxApp();
     const String debugPath = 'debug/executable';
     const String profilePath = 'profile/executable';
@@ -76,6 +76,7 @@ void main() {
     expect(LinuxDevice().executablePathForDevice(mockApp, BuildMode.release), releasePath);
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
   });
 }
 

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -166,9 +166,9 @@ void main() {
       pretendPodVersionIs('1.8.0');
       expect(await cocoaPodsUnderTest.isCocoaPodsInitialized, isTrue);
     }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
       Platform: () => FakePlatform(),
       FileSystem: () => fs,
+      ProcessManager: () => mockProcessManager,
     });
   });
 
@@ -179,6 +179,7 @@ void main() {
       expect(projectUnderTest.ios.podfile.readAsStringSync(), 'Objective-C iOS podfile template');
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('creates swift Podfile if swift', () async {
@@ -194,6 +195,7 @@ void main() {
       expect(projectUnderTest.ios.podfile.readAsStringSync(), 'Swift iOS podfile template');
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       XcodeProjectInterpreter: () => mockXcodeProjectInterpreter,
     });
 
@@ -204,6 +206,7 @@ void main() {
       expect(projectUnderTest.macos.podfile.readAsStringSync(), 'macOS podfile template');
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('does not recreate Podfile when already present', () async {
@@ -215,6 +218,7 @@ void main() {
       expect(projectUnderTest.ios.podfile.readAsStringSync(), 'Existing Podfile');
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('does not create Podfile when we cannot interpret Xcode projects', () async {
@@ -226,6 +230,7 @@ void main() {
       expect(projectUnderTest.ios.podfile.existsSync(), false);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       XcodeProjectInterpreter: () => mockXcodeProjectInterpreter,
     });
 
@@ -251,6 +256,7 @@ void main() {
       expect(releaseContents, contains('Existing release config'));
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
   });
 
@@ -279,6 +285,7 @@ void main() {
       expect(releaseContents, contains('Existing release config'));
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
   });
 

--- a/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
@@ -56,6 +56,7 @@ void main() {
       expect(MacOSDevice().isSupportedForProject(flutterProject), true);
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('isSupportedForProject is false with no host app', () async {
@@ -66,6 +67,7 @@ void main() {
       expect(MacOSDevice().isSupportedForProject(flutterProject), false);
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('executablePathForDevice uses the correct package executable', () async {
@@ -82,6 +84,7 @@ void main() {
       expect(MacOSDevice().executablePathForDevice(mockApp, BuildMode.release), releasePath);
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/package_uri_mapper_test.dart
+++ b/packages/flutter_tools/test/general.shard/package_uri_mapper_test.dart
@@ -40,6 +40,7 @@ void main() {
         'package:example/main.dart');
   }, overrides: <Type, Generator>{
     FileSystem: () => mockFileSystem,
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
   });
 
   testUsingContext('single-root maps file from other package to null', () async {
@@ -47,6 +48,7 @@ void main() {
     expect(packageUriMapper.map('/xml/lib/xml.dart'), null);
   }, overrides: <Type, Generator>{
     FileSystem: () => mockFileSystem,
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
   });
 
   testUsingContext('single-root maps non-main file from same package', () async {
@@ -55,6 +57,7 @@ void main() {
         'package:example/src/foo.dart');
   }, overrides: <Type, Generator>{
     FileSystem: () => mockFileSystem,
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
   });
 
   testUsingContext('multi-root maps main file from same package on multiroot scheme', () async {
@@ -73,6 +76,7 @@ void main() {
         'package:example/main.dart');
   }, overrides: <Type, Generator>{
     FileSystem: () => mockFileSystem,
+    ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
   });
 }
 

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -75,6 +75,7 @@ flutter:
       expect(flutterProject.flutterPluginsFile.existsSync(), false);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('Refreshing the plugin list deletes the plugin file when there were plugins but no longer are', () {
@@ -85,6 +86,7 @@ flutter:
       expect(flutterProject.flutterPluginsFile.existsSync(), false);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('Refreshing the plugin list creates a plugin directory when there are plugins', () {
@@ -95,6 +97,7 @@ flutter:
       expect(flutterProject.flutterPluginsFile.existsSync(), true);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('Changes to the plugin list invalidates the Cocoapod lockfiles', () {
@@ -108,6 +111,7 @@ flutter:
       expect(macosProject.podManifestLock.existsSync(), false);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
   });
 
@@ -157,6 +161,7 @@ flutter:
       expect(registrant.readAsStringSync(), contains('class GeneratedPluginRegistrant'));
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       FeatureFlags: () => featureFlags,
     });
 
@@ -182,6 +187,7 @@ flutter:
       expect(registrant.readAsStringSync(), contains('class GeneratedPluginRegistrant'));
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       FeatureFlags: () => featureFlags,
     });
 
@@ -278,6 +284,7 @@ plugin3:${pluginUsingOldEmbeddingDir.childDirectory('lib').uri.toString()}
 
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       FeatureFlags: () => featureFlags,
       XcodeProjectInterpreter: () => xcodeProjectInterpreter,
     });
@@ -304,6 +311,7 @@ plugin3:${pluginUsingOldEmbeddingDir.childDirectory('lib').uri.toString()}
       expect(registrant.readAsStringSync(), contains('class GeneratedPluginRegistrant'));
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       FeatureFlags: () => featureFlags,
     });
 
@@ -322,6 +330,7 @@ plugin3:${pluginUsingOldEmbeddingDir.childDirectory('lib').uri.toString()}
       expect(registrant.readAsStringSync(), contains('class GeneratedPluginRegistrant'));
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       FeatureFlags: () => featureFlags,
     });
 
@@ -347,6 +356,7 @@ plugin3:${pluginUsingOldEmbeddingDir.childDirectory('lib').uri.toString()}
       expect(registrant.readAsStringSync(), contains('class GeneratedPluginRegistrant'));
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       FeatureFlags: () => featureFlags,
     });
 
@@ -372,6 +382,7 @@ plugin3:${pluginUsingOldEmbeddingDir.childDirectory('lib').uri.toString()}
       expect(registrant.readAsStringSync(), contains('class GeneratedPluginRegistrant'));
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       FeatureFlags: () => featureFlags,
     });
   });

--- a/packages/flutter_tools/test/general.shard/project_file_invalidator_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_file_invalidator_test.dart
@@ -9,33 +9,48 @@ import 'package:flutter_tools/src/run_hot.dart';
 import '../src/common.dart';
 import '../src/context.dart';
 
+// assumption: tests have a timeout less than 100 days
+final DateTime inFuture = DateTime.now().add(const Duration(days: 100));
+
 void main() {
   group('ProjectFileInvalidator', () {
-    final MemoryFileSystem memoryFileSystem = MemoryFileSystem();
     testUsingContext('No last compile', () async {
       expect(
-        ProjectFileInvalidator.findInvalidated(lastCompiled: null, urisToMonitor: <Uri>[], packagesPath: ''),
-        isEmpty);
+        ProjectFileInvalidator.findInvalidated(
+          lastCompiled: null,
+          urisToMonitor: <Uri>[],
+          packagesPath: '',
+        ),
+        isEmpty,
+      );
     });
 
     testUsingContext('Empty project', () async {
       expect(
-        ProjectFileInvalidator.findInvalidated(lastCompiled: DateTime.now(), urisToMonitor: <Uri>[], packagesPath: ''),
-        isEmpty);
+        ProjectFileInvalidator.findInvalidated(
+          lastCompiled: inFuture,
+          urisToMonitor: <Uri>[],
+          packagesPath: '',
+        ),
+        isEmpty,
+      );
     }, overrides: <Type, Generator>{
-      FileSystem: () => memoryFileSystem,
+      FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('Non-existent files are ignored', () async {
       expect(
         ProjectFileInvalidator.findInvalidated(
-            lastCompiled: DateTime.now(),
-            urisToMonitor: <Uri>[Uri.parse('/not-there-anymore'),],
-            packagesPath: '',
-          ),
-        isEmpty);
+          lastCompiled: inFuture,
+          urisToMonitor: <Uri>[Uri.parse('/not-there-anymore'),],
+          packagesPath: '',
+        ),
+        isEmpty,
+      );
     }, overrides: <Type, Generator>{
-      FileSystem: () => memoryFileSystem,
+      FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -196,6 +196,7 @@ void main() {
         expectExists(project.macos.managedDirectory.childFile('GeneratedPluginRegistrant.swift'));
       }, overrides: <Type, Generator>{
         FileSystem: () => MemoryFileSystem(),
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
         FlutterProjectFactory: () => FlutterProjectFactory(),
       });
@@ -206,6 +207,7 @@ void main() {
         expectExists(project.macos.generatedXcodePropertiesFile);
       }, overrides: <Type, Generator>{
         FileSystem: () => MemoryFileSystem(),
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
         FlutterProjectFactory: () => FlutterProjectFactory(),
       });
@@ -217,6 +219,7 @@ void main() {
         expectExists(project.linux.managedDirectory.childFile('generated_plugin_registrant.cc'));
       }, overrides: <Type, Generator>{
         FileSystem: () => MemoryFileSystem(),
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
         FlutterProjectFactory: () => FlutterProjectFactory(),
       });
@@ -228,6 +231,7 @@ void main() {
         expectExists(project.windows.managedDirectory.childFile('generated_plugin_registrant.cc'));
       }, overrides: <Type, Generator>{
         FileSystem: () => MemoryFileSystem(),
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),
         FlutterProjectFactory: () => FlutterProjectFactory(),
       });
@@ -324,6 +328,7 @@ apply plugin: 'kotlin-android'
         expect(project.android.isKotlin, isTrue);
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         XcodeProjectInterpreter: () => mockXcodeProjectInterpreter,
         FlutterProjectFactory: () => flutterProjectFactory,
       });
@@ -344,6 +349,7 @@ apply plugin: 'kotlin-android'
       void testWithMocks(String description, Future<void> testMethod()) {
         testUsingContext(description, testMethod, overrides: <Type, Generator>{
           FileSystem: () => fs,
+          ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
           PlistParser: () => mockPlistUtils,
           XcodeProjectInterpreter: () => mockXcodeProjectInterpreter,
           FlutterProjectFactory: () => flutterProjectFactory,
@@ -606,6 +612,7 @@ void testInMemory(String description, Future<void> testMethod()) {
     testMethod,
     overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       Cache: () => Cache(),
       FlutterProjectFactory: () => flutterProjectFactory,
     },

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
@@ -67,6 +67,7 @@ void main() {
         expect(versionChecked, isTrue);
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         Platform: () => platform,
       }, initializeFlutterRoot: false);
 
@@ -78,6 +79,7 @@ void main() {
 
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         Platform: () => platform,
       }, initializeFlutterRoot: false);
 
@@ -93,6 +95,7 @@ void main() {
         await runner.run(<String>['dummy', '--local-engine=ios_debug']);
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         Platform: () => platform,
       }, initializeFlutterRoot: false);
 
@@ -102,6 +105,7 @@ void main() {
         await runner.run(<String>['dummy', '--local-engine-src-path=$_kArbitraryEngineRoot/src', '--local-engine=ios_debug']);
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         Platform: () => platform,
       }, initializeFlutterRoot: false);
 
@@ -111,6 +115,7 @@ void main() {
         await runner.run(<String>['dummy', '--local-engine=ios_debug']);
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         Platform: () => platform,
       }, initializeFlutterRoot: false);
     });
@@ -125,6 +130,7 @@ void main() {
 
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       Platform: () => platform,
     }, initializeFlutterRoot: false);
 
@@ -153,8 +159,8 @@ void main() {
         expect(version.toJson()['frameworkVersion'], '0.10.3');
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
-        Platform: () => platform,
         ProcessManager: () => processManager,
+        Platform: () => platform,
       }, initializeFlutterRoot: false);
     });
 
@@ -182,48 +188,53 @@ void main() {
         ]);
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         Platform: () => platform,
       }, initializeFlutterRoot: false);
     });
 
     group('wrapping', () {
       testUsingContext('checks that output wrapping is turned on when writing to a terminal', () async {
-        final FakeCommand fakeCommand = FakeCommand();
+        final FakeFlutterCommand fakeCommand = FakeFlutterCommand();
         runner.addCommand(fakeCommand);
         await runner.run(<String>['fake']);
         expect(fakeCommand.preferences.wrapText, isTrue);
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         Stdio: () => FakeStdio(hasFakeTerminal: true),
       }, initializeFlutterRoot: false);
 
       testUsingContext('checks that output wrapping is turned off when not writing to a terminal', () async {
-        final FakeCommand fakeCommand = FakeCommand();
+        final FakeFlutterCommand fakeCommand = FakeFlutterCommand();
         runner.addCommand(fakeCommand);
         await runner.run(<String>['fake']);
         expect(fakeCommand.preferences.wrapText, isFalse);
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         Stdio: () => FakeStdio(hasFakeTerminal: false),
       }, initializeFlutterRoot: false);
 
       testUsingContext('checks that output wrapping is turned off when set on the command line and writing to a terminal', () async {
-        final FakeCommand fakeCommand = FakeCommand();
+        final FakeFlutterCommand fakeCommand = FakeFlutterCommand();
         runner.addCommand(fakeCommand);
         await runner.run(<String>['--no-wrap', 'fake']);
         expect(fakeCommand.preferences.wrapText, isFalse);
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         Stdio: () => FakeStdio(hasFakeTerminal: true),
       }, initializeFlutterRoot: false);
 
       testUsingContext('checks that output wrapping is turned on when set on the command line, but not writing to a terminal', () async {
-        final FakeCommand fakeCommand = FakeCommand();
+        final FakeFlutterCommand fakeCommand = FakeFlutterCommand();
         runner.addCommand(fakeCommand);
         await runner.run(<String>['--wrap', 'fake']);
         expect(fakeCommand.preferences.wrapText, isTrue);
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
         Stdio: () => FakeStdio(hasFakeTerminal: false),
       }, initializeFlutterRoot: false);
     });
@@ -236,7 +247,7 @@ class FakeFlutterVersion extends FlutterVersion {
   String get frameworkVersion => '0.10.3';
 }
 
-class FakeCommand extends FlutterCommand {
+class FakeFlutterCommand extends FlutterCommand {
   OutputPreferences preferences;
 
   @override

--- a/packages/flutter_tools/test/general.shard/runner/runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/runner_test.dart
@@ -71,6 +71,7 @@ void main() {
         'FLUTTER_ROOT': '/',
       }),
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
       Usage: () => CrashingUsage(),
     });
   });

--- a/packages/flutter_tools/test/general.shard/tester/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/general.shard/tester/flutter_tester_test.dart
@@ -39,6 +39,7 @@ void main() {
       expect(app.packagesFile.path, fs.path.join(projectPath, '.packages'));
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
   });
 
@@ -108,8 +109,8 @@ void main() {
       final Map<Type, Generator> startOverrides = <Type, Generator>{
         Platform: () => FakePlatform(operatingSystem: 'linux'),
         FileSystem: () => fs,
-        Cache: () => Cache(rootOverride: fs.directory(flutterRoot)),
         ProcessManager: () => mockProcessManager,
+        Cache: () => Cache(rootOverride: fs.directory(flutterRoot)),
         KernelCompilerFactory: () => FakeKernelCompilerFactory(mockKernelCompiler),
         Artifacts: () => mockArtifacts,
       };

--- a/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
@@ -138,8 +138,8 @@ void main() {
       expect(visualStudio.isInstalled, false);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFilesystem,
-      Platform: () => windowsPlatform,
       ProcessManager: () => mockProcessManager,
+      Platform: () => windowsPlatform,
     });
 
     testUsingContext('vcvarsPath returns null when vswhere is missing', () {
@@ -153,8 +153,8 @@ void main() {
       expect(visualStudio.vcvarsPath, isNull);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFilesystem,
-      Platform: () => windowsPlatform,
       ProcessManager: () => mockProcessManager,
+      Platform: () => windowsPlatform,
     });
 
     testUsingContext('isInstalled returns false when vswhere returns non-zero', () {
@@ -181,8 +181,8 @@ void main() {
       expect(visualStudio.isInstalled, false);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFilesystem,
-      Platform: () => windowsPlatform,
       ProcessManager: () => mockProcessManager,
+      Platform: () => windowsPlatform,
     });
 
     testUsingContext('VisualStudio getters return the right values if no installation is found', () {
@@ -202,8 +202,8 @@ void main() {
       expect(visualStudio.fullVersion, null);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFilesystem,
-      Platform: () => windowsPlatform,
       ProcessManager: () => mockProcessManager,
+      Platform: () => windowsPlatform,
     });
 
     testUsingContext('necessaryComponentDescriptions suggest the right VS tools on major version 15', () {
@@ -213,8 +213,8 @@ void main() {
       expect(toolsString.contains('v141'), true);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFilesystem,
-      Platform: () => windowsPlatform,
       ProcessManager: () => mockProcessManager,
+      Platform: () => windowsPlatform,
     });
 
     testUsingContext('necessaryComponentDescriptions suggest the right VS tools on major version != 15', () {
@@ -224,8 +224,8 @@ void main() {
       expect(toolsString.contains('v142'), true);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFilesystem,
-      Platform: () => windowsPlatform,
       ProcessManager: () => mockProcessManager,
+      Platform: () => windowsPlatform,
     });
 
     testUsingContext('isInstalled returns true even with missing status information', () {
@@ -237,8 +237,8 @@ void main() {
       expect(visualStudio.isInstalled, true);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFilesystem,
-      Platform: () => windowsPlatform,
       ProcessManager: () => mockProcessManager,
+      Platform: () => windowsPlatform,
     });
 
     testUsingContext('isInstalled returns true when VS is present but missing components', () {
@@ -250,8 +250,8 @@ void main() {
       expect(visualStudio.isInstalled, true);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFilesystem,
-      Platform: () => windowsPlatform,
       ProcessManager: () => mockProcessManager,
+      Platform: () => windowsPlatform,
     });
 
     testUsingContext('isInstalled returns true when a prerelease version of VS is present', () {
@@ -267,8 +267,8 @@ void main() {
       expect(visualStudio.isPrerelease, true);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFilesystem,
-      Platform: () => windowsPlatform,
       ProcessManager: () => mockProcessManager,
+      Platform: () => windowsPlatform,
     });
 
     testUsingContext('isComplete returns false when an incomplete installation is found', () {
@@ -284,8 +284,8 @@ void main() {
       expect(visualStudio.isComplete, false);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFilesystem,
-      Platform: () => windowsPlatform,
       ProcessManager: () => mockProcessManager,
+      Platform: () => windowsPlatform,
     });
 
     testUsingContext('isLaunchable returns false if the installation can\'t be launched', () {
@@ -301,8 +301,8 @@ void main() {
       expect(visualStudio.isLaunchable, false);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFilesystem,
-      Platform: () => windowsPlatform,
       ProcessManager: () => mockProcessManager,
+      Platform: () => windowsPlatform,
     });
 
     testUsingContext('isRebootRequired returns true if the installation needs a reboot', () {
@@ -318,8 +318,8 @@ void main() {
       expect(visualStudio.isRebootRequired, true);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFilesystem,
-      Platform: () => windowsPlatform,
       ProcessManager: () => mockProcessManager,
+      Platform: () => windowsPlatform,
     });
 
 
@@ -332,8 +332,8 @@ void main() {
       expect(visualStudio.hasNecessaryComponents, false);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFilesystem,
-      Platform: () => windowsPlatform,
       ProcessManager: () => mockProcessManager,
+      Platform: () => windowsPlatform,
     });
 
     testUsingContext('vcvarsPath returns null when VS is present but missing components', () {
@@ -345,8 +345,8 @@ void main() {
       expect(visualStudio.vcvarsPath, isNull);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFilesystem,
-      Platform: () => windowsPlatform,
       ProcessManager: () => mockProcessManager,
+      Platform: () => windowsPlatform,
     });
 
     testUsingContext('vcvarsPath returns null when VS is present but with require components but installation is faulty', () {
@@ -359,8 +359,8 @@ void main() {
       expect(visualStudio.vcvarsPath, isNull);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFilesystem,
-      Platform: () => windowsPlatform,
       ProcessManager: () => mockProcessManager,
+      Platform: () => windowsPlatform,
     });
 
     testUsingContext('hasNecessaryComponents returns false when VS is present with required components but installation is faulty', () {
@@ -373,8 +373,8 @@ void main() {
       expect(visualStudio.hasNecessaryComponents, false);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFilesystem,
-      Platform: () => windowsPlatform,
       ProcessManager: () => mockProcessManager,
+      Platform: () => windowsPlatform,
     });
 
     testUsingContext('VS metadata is available when VS is present, even if missing components', () {
@@ -389,8 +389,8 @@ void main() {
       expect(visualStudio.fullVersion, equals('16.2.29306.81'));
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFilesystem,
-      Platform: () => windowsPlatform,
       ProcessManager: () => mockProcessManager,
+      Platform: () => windowsPlatform,
     });
 
     testUsingContext('Everything returns good values when VS is present with all components', () {
@@ -404,8 +404,8 @@ void main() {
       expect(visualStudio.vcvarsPath, equals(vcvarsPath));
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFilesystem,
-      Platform: () => windowsPlatform,
       ProcessManager: () => mockProcessManager,
+      Platform: () => windowsPlatform,
     });
 
     testUsingContext('Metadata is for compatible version when latest is missing components', () {
@@ -437,8 +437,8 @@ void main() {
       expect(visualStudio.displayVersion, equals('15.9.12'));
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFilesystem,
-      Platform: () => windowsPlatform,
       ProcessManager: () => mockProcessManager,
+      Platform: () => windowsPlatform,
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/windows/windows_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/windows_device_test.dart
@@ -49,6 +49,7 @@ void main() {
       expect(WindowsDevice().isSupportedForProject(flutterProject), true);
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('isSupportedForProject is false with no host app', () async {
@@ -59,6 +60,7 @@ void main() {
       expect(WindowsDevice().isSupportedForProject(flutterProject), false);
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
 
     testUsingContext('executablePathForDevice uses the correct package executable', () async {
@@ -75,6 +77,7 @@ void main() {
       expect(WindowsDevice().executablePathForDevice(mockApp, BuildMode.release), releasePath);
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
   });
 }

--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -42,7 +42,7 @@ String getFlutterRoot() {
     return platform.environment['FLUTTER_ROOT'];
   }
 
-  Error invalidScript() => StateError('Invalid script: ${platform.script}');
+  Error invalidScript() => StateError('Could not determine flutter_tools/ path from script URL (${platform.script}); consider setting FLUTTER_ROOT explicitly.');
 
   Uri scriptUri;
   switch (platform.script.scheme) {

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -30,9 +30,11 @@ import 'package:meta/meta.dart';
 import 'package:mockito/mockito.dart';
 
 import 'common.dart';
-import 'testbed.dart';
+import 'fake_process_manager.dart';
+import 'throwing_pub.dart';
 
 export 'package:flutter_tools/src/base/context.dart' show Generator;
+export 'fake_process_manager.dart' show ProcessManager, FakeProcessManager, FakeCommand;
 
 /// Return the test logger. This assumes that the current Logger is a BufferLogger.
 BufferLogger get testLogger => context.get<Logger>();
@@ -52,6 +54,14 @@ void testUsingContext(
   String testOn,
   bool skip, // should default to `false`, but https://github.com/dart-lang/test/issues/545 doesn't allow this
 }) {
+  if (overrides[FileSystem] != null && overrides[ProcessManager] == null) {
+    throw StateError(
+      'If you override the FileSystem context you must also provide a ProcessManager, '
+      'otherwise the processes you launch will not be dealing with the same file system '
+      'that you are dealing with in your test.'
+    );
+  }
+
   // Ensure we don't rely on the default [Config] constructor which will
   // leak a sticky $HOME/.flutter_settings behind!
   Directory configDir;

--- a/packages/flutter_tools/test/src/fake_process_manager.dart
+++ b/packages/flutter_tools/test/src/fake_process_manager.dart
@@ -1,0 +1,250 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io' as io show ProcessSignal;
+
+import 'package:flutter_tools/src/base/io.dart';
+import 'package:meta/meta.dart';
+import 'package:process/process.dart';
+
+export 'package:process/process.dart' show ProcessManager;
+
+/// A command for [FakeProcessManager].
+@immutable
+class FakeCommand {
+  const FakeCommand({
+    @required this.command,
+    this.workingDirectory,
+    this.environment,
+    this.duration = const Duration(),
+    @required this.exitCode,
+    @required this.stdout,
+    @required this.stderr,
+  }) : assert(command != null),
+       assert(duration != null),
+       assert(stdout != null),
+       assert(stderr != null);
+
+  /// The exact commands that must be matched for this [FakeCommand] to be
+  /// selected from those given to the [FakeProcessManager].
+  final List<String> command;
+
+  /// The exact working directory that must be matched for this [FakeCommand] to
+  /// be selected from those given to the [FakeProcessManager].
+  ///
+  /// If this is null, then it matches any working directory.
+  final String workingDirectory;
+
+  /// The environment that must be matched for this [FakeCommand] to be selected
+  /// from those given to the [FakeProcessManager].
+  ///
+  /// If this is null, then it matches any environment.
+  ///
+  /// Otherwise, each key in this environment must be present and must have a
+  /// value that matches the one given here for the [FakeCommand] to match.
+  final Map<String, String> environment;
+
+  /// The time to allow to elapse before returning the [exitCode], if this command
+  /// is "executed".
+  ///
+  /// If you set this to a non-zero time, you should use a [FakeAsync] zone,
+  /// otherwise the test will be artificially slow.
+  final Duration duration;
+
+  /// The process' exit code.
+  ///
+  /// To simulate a never-ending process, set [duration] to a value greated than
+  /// 15 minutes (the timeout for our tests).
+  ///
+  /// To simulate a crash, subtract the crash signal number from 256. For example,
+  /// SIGPIPE (-13) is 243.
+  final int exitCode;
+
+  /// The output to simulate on stdout. This will be encoded as UTF-8 and
+  /// returned in one go.
+  final String stdout;
+
+  /// The output to simulate on stderr. This will be encoded as UTF-8 and
+  /// returned in one go.
+  final String stderr;
+
+  static bool _listEquals<T>(List<T> a, List<T> b) {
+    if (a == null) {
+      return b == null;
+    }
+    if (b == null || a.length != b.length) {
+      return false;
+    }
+    for (int index = 0; index < a.length; index += 1) {
+      if (a[index] != b[index]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool _matches(List<String> command, String workingDirectory, Map<String, String> environment) {
+    if (!_listEquals(command, this.command)) {
+      return false;
+    }
+    if (this.workingDirectory != null && workingDirectory != this.workingDirectory) {
+      return false;
+    }
+    if (this.environment != null) {
+      if (environment == null) {
+        return false;
+      }
+      for (String key in environment.keys) {
+        if (environment[key] != this.environment[key]) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+}
+
+class _FakeProcess implements Process {
+  _FakeProcess(
+    this._exitCode,
+    Duration duration,
+    this.pid,
+    this._stderr,
+    this.stdin,
+    this._stdout,
+  ) : exitCode = Future<void>.delayed(duration).then((void value) => _exitCode),
+      stderr = Stream<List<int>>.value(utf8.encode(_stderr)),
+      stdout = Stream<List<int>>.value(utf8.encode(_stdout));
+  final int _exitCode;
+
+  @override
+  final Future<int> exitCode;
+
+  @override
+  final int pid;
+
+  final String _stderr;
+
+  @override
+  final Stream<List<int>> stderr;
+
+  @override
+  final IOSink stdin;
+
+  @override
+  final Stream<List<int>> stdout;
+
+  final String _stdout;
+
+  @override
+  bool kill([io.ProcessSignal signal = io.ProcessSignal.sigterm]) {
+    assert(false, 'Process.kill() should not be used directly in flutter_tools.');
+    return false;
+  }
+}
+
+/// A fake [ProcessManager] which responds to particular commands with particular results.
+///
+/// On creation, pass in a list of [FakeCommand] objects. When the [ProcessManager] methods
+/// such as [start] are invoked, the first matching [FakeCommand] is found and its settings
+/// are used to simulate the result of running that command.
+///
+/// If no command is found, then one is implied which immediately returns exit
+/// code 0 with no output.
+class FakeProcessManager implements ProcessManager {
+  FakeProcessManager(this._commands);
+
+  final List<FakeCommand> _commands;
+
+  FakeCommand _findCommand(List<String> command, String workingDirectory, Map<String, String> environment) {
+    for (FakeCommand candidate in _commands) {
+      if (candidate._matches(command, workingDirectory, environment)) {
+        return candidate;
+      }
+    }
+    return FakeCommand(
+      command: command,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      duration: const Duration(),
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    );
+  }
+
+  int _pid = 9999;
+
+  _FakeProcess _runCommand(List<String> command, String workingDirectory, Map<String, String> environment) {
+    _pid += 1;
+    final FakeCommand fakeCommand = _findCommand(command, workingDirectory, environment);
+    return _FakeProcess(
+      fakeCommand.exitCode,
+      fakeCommand.duration,
+      _pid,
+      fakeCommand.stdout,
+      null, // stdin
+      fakeCommand.stderr,
+    );
+  }
+
+  @override
+  Future<Process> start(
+    List<dynamic> command, {
+    String workingDirectory,
+    Map<String, String> environment,
+    bool includeParentEnvironment = true, // ignored
+    bool runInShell = false, // ignored
+    ProcessStartMode mode = ProcessStartMode.normal, // ignored
+  }) async => _runCommand(command, workingDirectory, environment);
+
+  @override
+  Future<ProcessResult> run(
+    List<dynamic> command, {
+    String workingDirectory,
+    Map<String, String> environment,
+    bool includeParentEnvironment = true, // ignored
+    bool runInShell = false, // ignored
+    Encoding stdoutEncoding = systemEncoding,
+    Encoding stderrEncoding = systemEncoding,
+  }) async {
+    final _FakeProcess process = _runCommand(command, workingDirectory, environment);
+    await process.exitCode;
+    return ProcessResult(
+      process.pid,
+      process._exitCode,
+      stdoutEncoding == null ? process.stdout : await stdoutEncoding.decodeStream(process.stdout),
+      stderrEncoding == null ? process.stderr : await stderrEncoding.decodeStream(process.stderr),
+    );
+  }
+
+  @override
+  ProcessResult runSync(
+    List<dynamic> command, {
+    String workingDirectory,
+    Map<String, String> environment,
+    bool includeParentEnvironment = true, // ignored
+    bool runInShell = false, // ignored
+    Encoding stdoutEncoding = systemEncoding, // actual encoder is ignored
+    Encoding stderrEncoding = systemEncoding, // actual encoder is ignored
+  }) {
+    final _FakeProcess process = _runCommand(command, workingDirectory, environment);
+    return ProcessResult(
+      process.pid,
+      process._exitCode,
+      stdoutEncoding == null ? utf8.encode(process._stdout) : process._stdout,
+      stderrEncoding == null ? utf8.encode(process._stderr) : process._stderr,
+    );
+  }
+
+  @override
+  bool canRun(dynamic executable, {String workingDirectory}) => true;
+
+  @override
+  bool killPid(int pid, [io.ProcessSignal signal = io.ProcessSignal.sigterm]) {
+    assert(false, 'ProcessManager.killPid() should not be used directly in flutter_tools.');
+    return false;
+  }
+}

--- a/packages/flutter_tools/test/src/testbed.dart
+++ b/packages/flutter_tools/test/src/testbed.dart
@@ -22,8 +22,11 @@ import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/version.dart';
+import 'package:process/process.dart';
 
 import 'context.dart';
+import 'fake_process_manager.dart';
+import 'throwing_pub.dart';
 
 export 'package:flutter_tools/src/base/context.dart' show Generator;
 
@@ -32,6 +35,7 @@ export 'package:flutter_tools/src/base/context.dart' show Generator;
 final Map<Type, Generator> _testbedDefaults = <Type, Generator>{
   // Keeps tests fast by avoiding the actual file system.
   FileSystem: () => MemoryFileSystem(style: platform.isWindows ? FileSystemStyle.windows : FileSystemStyle.posix),
+  ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
   Logger: () => BufferLogger(), // Allows reading logs and prevents stdout.
   OperatingSystemUtils: () => FakeOperatingSystemUtils(),
   OutputPreferences: () => OutputPreferences.test(), // configures BufferLogger to avoid color codes.
@@ -728,37 +732,5 @@ class TestFeatureFlags implements FeatureFlags {
         return isNewAndroidEmbeddingEnabled;
     }
     return false;
-  }
-}
-
-class ThrowingPub implements Pub {
-  @override
-  Future<void> batch(List<String> arguments, {
-    PubContext context,
-    String directory,
-    MessageFilter filter,
-    String failureMessage = 'pub failed',
-    bool retry,
-    bool showTraceForErrors,
-  }) {
-    throw UnsupportedError('Attempted to inovke pub during test.');
-  }
-
-  @override
-  Future<void> get({
-    PubContext context,
-    String directory,
-    bool skipIfAbsent = false,
-    bool upgrade = false,
-    bool offline = false,
-    bool checkLastModified = true,
-    bool skipPubspecYamlCheck = false,
-  }) {
-    throw UnsupportedError('Attempted to inovke pub during test.');
-  }
-
-  @override
-  Future<void> interactively(List<String> arguments, {String directory}) {
-    throw UnsupportedError('Attempted to inovke pub during test.');
   }
 }

--- a/packages/flutter_tools/test/src/throwing_pub.dart
+++ b/packages/flutter_tools/test/src/throwing_pub.dart
@@ -1,0 +1,39 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_tools/src/dart/pub.dart';
+
+class ThrowingPub implements Pub {
+  @override
+  Future<void> batch(List<String> arguments, {
+    PubContext context,
+    String directory,
+    MessageFilter filter,
+    String failureMessage = 'pub failed',
+    bool retry,
+    bool showTraceForErrors,
+  }) {
+    throw UnsupportedError('Attempted to inovke pub during test.');
+  }
+
+  @override
+  Future<void> get({
+    PubContext context,
+    String directory,
+    bool skipIfAbsent = false,
+    bool upgrade = false,
+    bool offline = false,
+    bool checkLastModified = true,
+    bool skipPubspecYamlCheck = false,
+  }) {
+    throw UnsupportedError('Attempted to inovke pub during test.');
+  }
+
+  @override
+  Future<void> interactively(List<String> arguments, {String directory}) {
+    throw UnsupportedError('Attempted to inovke pub during test.');
+  }
+}


### PR DESCRIPTION
...because otherwise, processes that think they're manipulating your
filesystem will be doing crazy things the test is ignoring, leading to
(at best) failures and (at worst) flakes or disk corruption.
