### PR TITLE
remove println from flutter.gradle

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -220,7 +220,6 @@ class FlutterPlugin implements Plugin<Project> {
             }
         }
         String flutterBuildMode = buildModeFor(buildType)
-        println "flutter dependency"
         // Add the embedding dependency.
         addApiDependencies(project, buildType.name,
                 "io.flutter:flutter_embedding_$flutterBuildMode:1.0.0-$engineVersion")


### PR DESCRIPTION
## Description

This is causing run_release_test on android to fail with unexpected output. Seems like this may have been added accidentally?