### PR TITLE
Partial deflaking of abstract_method_smoke_test

### DIFF
--- a/dev/integration_tests/abstract_method_smoke_test/android/app/src/main/kotlin/com/example/abstract_method_smoke_test/MainActivity.kt
+++ b/dev/integration_tests/abstract_method_smoke_test/android/app/src/main/kotlin/com/example/abstract_method_smoke_test/MainActivity.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.os.Bundle
 import android.view.inputmethod.InputMethodManager
 import io.flutter.app.FlutterActivity
+import io.flutter.plugin.common.MethodChannel;
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugins.GeneratedPluginRegistrant
 
 class MainActivity: FlutterActivity() {
@@ -12,8 +14,22 @@ class MainActivity: FlutterActivity() {
     GeneratedPluginRegistrant.registerWith(this)
 
     // Triggers the Android keyboard, which causes the resize of the Flutter view.
-    // https://github.com/flutter/flutter/issues/40126
+    // We need to wait for the app to complete.
+    MethodChannel(getFlutterView(), "com.example.abstract_method_smoke_test")
+        .setMethodCallHandler({ call, result ->
+          toggleInput()
+          result.success(null)
+        })
+  }
+
+  override fun onPause() {
+    // Hide the input when the app is closed.
+    toggleInput()
+    super.onPause()
+  }
+
+  fun toggleInput() {
     val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-    imm.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0)
+    imm.toggleSoftInput(InputMethodManager.SHOW_IMPLICIT, 0)
   }
 }

--- a/dev/integration_tests/abstract_method_smoke_test/lib/main.dart
+++ b/dev/integration_tests/abstract_method_smoke_test/lib/main.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  const MethodChannel channel = MethodChannel('com.example.abstract_method_smoke_test');
+  await channel.invokeMethod<void>('show_keyboard');
   runApp(MyApp());
   print('Test suceeded');
 }
@@ -48,9 +52,8 @@ class SecondPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       body: Column(
-        children: <Widget>[
-          TextFormField(),
-          const Expanded(
+        children: const <Widget>[
+          Expanded(
             child: GoogleMap(
               initialCameraPosition: CameraPosition(
                 target: LatLng(0, 0)


### PR DESCRIPTION
## Description

1. The platform code to show the keyboard wasn't working on certain
devices. From my testing it appears to be related to when the code was
firing. IMM won't show the soft input (or shows and then immediately
hides it, it's hard to tell) if it's called before the Flutter UI is
loaded. Change this to instead show the soft keyboard after a message
from Flutter that main() has been started.

2. A text field was visible in the UI, and the test was run under a
fuzzer that random tapped portions of the screen. Remove the text field
so that the fuzzer can't accidentally open the keyboard on its own at a
random time.

3. The keyboard was left open even after the app was closed. Also toggle
the input off when the app was closed, so that this test can be ran
multiple times in succession relatively hermetically.

## Related Issues

#42349

## Tests

I added the following tests:

- Updated abstract_method_smoke_test

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
