### PR TITLE
Fix CachingAssetBundle not forwarding errors

### DIFF
--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -190,7 +190,7 @@ abstract class CachingAssetBundle extends AssetBundle {
         // completer's future is what we returned.
         completer.complete(value);
       }
-    });
+    }).catchError(completer.completeError);
     if (result != null) {
       // The code above ran synchronously, and came up with an answer.
       // Return the SynchronousFuture that we created above.

--- a/packages/flutter/test/services/asset_bundle_test.dart
+++ b/packages/flutter/test/services/asset_bundle_test.dart
@@ -49,7 +49,7 @@ void main() {
     expect(loadException, isFlutterError);
     
     try {
-      await bundle.loadStructuredData<String>('foo', (str) => str);
+      await bundle.loadStructuredData<String>('foo', (str) => Future.value(str));
     } catch (e) {
       loadException = e;
     }

--- a/packages/flutter/test/services/asset_bundle_test.dart
+++ b/packages/flutter/test/services/asset_bundle_test.dart
@@ -47,7 +47,7 @@ void main() {
       loadException = e;
     }
     expect(loadException, isFlutterError);
-    
+
     try {
       await bundle.loadStructuredData<String>('foo', (String str) => Future<String>.value(str));
     } catch (e) {

--- a/packages/flutter/test/services/asset_bundle_test.dart
+++ b/packages/flutter/test/services/asset_bundle_test.dart
@@ -47,6 +47,13 @@ void main() {
       loadException = e;
     }
     expect(loadException, isFlutterError);
+    
+    try {
+      await bundle.loadStructuredData('foo', (str) => str);
+    } catch (e) {
+      loadException = e;
+    }
+    expect(loadException, isFlutterError);
   });
 
   test('AssetImage.obtainKey succeeds with ImageConfiguration.empty', () async {

--- a/packages/flutter/test/services/asset_bundle_test.dart
+++ b/packages/flutter/test/services/asset_bundle_test.dart
@@ -49,7 +49,7 @@ void main() {
     expect(loadException, isFlutterError);
     
     try {
-      await bundle.loadStructuredData<String>('foo', (str) => Future.value(str));
+      await bundle.loadStructuredData<String>('foo', (String str) => Future<String>.value(str));
     } catch (e) {
       loadException = e;
     }

--- a/packages/flutter/test/services/asset_bundle_test.dart
+++ b/packages/flutter/test/services/asset_bundle_test.dart
@@ -49,7 +49,7 @@ void main() {
     expect(loadException, isFlutterError);
     
     try {
-      await bundle.loadStructuredData('foo', (str) => str);
+      await bundle.loadStructuredData<String>('foo', (str) => str);
     } catch (e) {
       loadException = e;
     }


### PR DESCRIPTION


## Description

`CachingAssetBundle.loadStructuredData` should forward errors thrown in `loadString` call.

## Related Issues

fixes https://github.com/flutter/flutter/issues/42390

## Tests

https://github.com/Nandiin/flutter/blob/0d5eb5b818325fd688d45607fb3603aa2b0a215c/packages/flutter/test/services/asset_bundle_test.dart#L50-L56

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
