### PR TITLE
Fix semantics testing now that dropdown can take a11y focus again.

### DIFF
--- a/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
+++ b/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
@@ -369,10 +369,9 @@ void main() {
                   isEnabled: true,
                   isFocusable: true,
                   actions: <AndroidSemanticsAction>[
-                    // TODO(gspencergoog): This should really be clearAccessibilityFocus,
-                    // but TalkBack doesn't find it for some reason.
-                    // https://github.com/flutter/flutter/issues/40101
-                    AndroidSemanticsAction.accessibilityFocus,
+                    if (item == popupItems.first) AndroidSemanticsAction.clearAccessibilityFocus,
+                    if (item != popupItems.first) AndroidSemanticsAction.accessibilityFocus,
+                    AndroidSemanticsAction.click,
                   ],
                 ),
                 reason: "Popup $item doesn't have the right semantics");
@@ -395,9 +394,10 @@ void main() {
                   isFocusable: true,
                   actions: <AndroidSemanticsAction>[
                     // TODO(gspencergoog): This should really be clearAccessibilityFocus,
-                    // but TalkBack doesn't find it for some reason.
+                    // but TalkBack doesn't focus it the second time for some reason.
                     // https://github.com/flutter/flutter/issues/40101
                     AndroidSemanticsAction.accessibilityFocus,
+                    AndroidSemanticsAction.click,
                   ],
                 ),
                 reason: "Popup $item doesn't have the right semantics the second time");


### PR DESCRIPTION
## Description

Fixes the `android_semantics_testing` integration test to have the right criteria now that https://github.com/flutter/flutter/commit/ce1509714c28fec0462fc702c8d9b8d2d4878bf4 has landed.
