### PR TITLE
Only dismiss dropdowns if the orientation changes, not the size.

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -912,8 +912,6 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
   void initState() {
     super.initState();
     _updateSelectedIndex();
-    _lastSize = WidgetsBinding.instance.window.physicalSize;
-    WidgetsBinding.instance.addObserver(this);
   }
 
   @override
@@ -923,22 +921,10 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     super.dispose();
   }
 
-  // Typically called because the device's orientation has changed.
-  // Defined by WidgetsBindingObserver
-  @override
-  void didChangeMetrics() {
-    final Size newSize = WidgetsBinding.instance.window.physicalSize;
-    if (newSize.width != _lastSize.width && newSize.height != _lastSize.height) {
-      // Only remove the dropdown if the orientation changes, not if the
-      // keyboard is shown or hidden.
-      _removeDropdownRoute();
-    }
-    _lastSize = newSize;
-  }
-
   void _removeDropdownRoute() {
     _dropdownRoute?._dismiss();
     _dropdownRoute = null;
+    _lastSize = null;
   }
 
   @override
@@ -1048,6 +1034,16 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterial(context));
     assert(debugCheckHasMaterialLocalizations(context));
+    final Size newSize = MediaQuery.of(context).size;
+    _lastSize ??= newSize;
+    if (MediaQuery.of(context).size != _lastSize) {
+      if (newSize.width != _lastSize.width && newSize.height != _lastSize.height) {
+        // Only remove the dropdown if the orientation changes, not if the
+        // keyboard is shown or hidden.
+        _removeDropdownRoute();
+      }
+      _lastSize = newSize;
+    }
 
     // The width of the button and the menu are defined by the widest
     // item and the width of the hint.

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:math' as math;
+import 'dart:ui' show window;
 
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -1030,13 +1031,24 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
 
   bool get _enabled => widget.items != null && widget.items.isNotEmpty && widget.onChanged != null;
 
+  Orientation _getOrientation(BuildContext context) {
+    Orientation result = MediaQuery.of(context, nullOk: true)?.orientation;
+    if (result == null) {
+      // If there's no MediaQuery, then use the window aspect to determine
+      // orientation.
+      final Size size = window.physicalSize;
+      result = size.width > size.height ? Orientation.landscape : Orientation.portrait;
+    }
+    return result;
+  }
+
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterial(context));
     assert(debugCheckHasMaterialLocalizations(context));
-    final Orientation newOrientation = MediaQuery.of(context).orientation;
+    final Orientation newOrientation = _getOrientation(context);
     _lastOrientation ??= newOrientation;
-    if (MediaQuery.of(context).orientation != _lastOrientation) {
+    if (newOrientation != _lastOrientation) {
       _removeDropdownRoute();
       _lastOrientation = newOrientation;
     }

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -906,11 +906,13 @@ class DropdownButton<T> extends StatefulWidget {
 class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindingObserver {
   int _selectedIndex;
   _DropdownRoute<T> _dropdownRoute;
+  Size _lastSize;
 
   @override
   void initState() {
     super.initState();
     _updateSelectedIndex();
+    _lastSize = WidgetsBinding.instance.window.physicalSize;
     WidgetsBinding.instance.addObserver(this);
   }
 
@@ -925,7 +927,13 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
   // Defined by WidgetsBindingObserver
   @override
   void didChangeMetrics() {
-    _removeDropdownRoute();
+    final Size newSize = WidgetsBinding.instance.window.physicalSize;
+    if (newSize.width != _lastSize.width && newSize.height != _lastSize.height) {
+      // Only remove the dropdown if the orientation changes, not if the
+      // keyboard is shown or hidden.
+      _removeDropdownRoute();
+    }
+    _lastSize = newSize;
   }
 
   void _removeDropdownRoute() {

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -906,7 +906,7 @@ class DropdownButton<T> extends StatefulWidget {
 class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindingObserver {
   int _selectedIndex;
   _DropdownRoute<T> _dropdownRoute;
-  Size _lastSize;
+  Orientation _lastOrientation;
 
   @override
   void initState() {
@@ -924,7 +924,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
   void _removeDropdownRoute() {
     _dropdownRoute?._dismiss();
     _dropdownRoute = null;
-    _lastSize = null;
+    _lastOrientation = null;
   }
 
   @override
@@ -1034,15 +1034,11 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterial(context));
     assert(debugCheckHasMaterialLocalizations(context));
-    final Size newSize = MediaQuery.of(context).size;
-    _lastSize ??= newSize;
-    if (MediaQuery.of(context).size != _lastSize) {
-      if (newSize.width != _lastSize.width && newSize.height != _lastSize.height) {
-        // Only remove the dropdown if the orientation changes, not if the
-        // keyboard is shown or hidden.
-        _removeDropdownRoute();
-      }
-      _lastSize = newSize;
+    final Orientation newOrientation = MediaQuery.of(context).orientation;
+    _lastOrientation ??= newOrientation;
+    if (MediaQuery.of(context).orientation != _lastOrientation) {
+      _removeDropdownRoute();
+      _lastOrientation = newOrientation;
     }
 
     // The width of the button and the menu are defined by the widest

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -124,9 +124,12 @@ abstract class WidgetsBindingObserver {
   /// }
   ///
   /// class _MetricsReactorState extends State<MetricsReactor> with WidgetsBindingObserver {
+  ///   Size _lastSize;
+  ///
   ///   @override
   ///   void initState() {
   ///     super.initState();
+  ///     _lastSize = WidgetsBinding.instance.window.physicalSize;
   ///     WidgetsBinding.instance.addObserver(this);
   ///   }
   ///
@@ -135,8 +138,6 @@ abstract class WidgetsBindingObserver {
   ///     WidgetsBinding.instance.removeObserver(this);
   ///     super.dispose();
   ///   }
-  ///
-  ///   Size _lastSize;
   ///
   ///   @override
   ///   void didChangeMetrics() {

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -661,10 +661,10 @@ class _ModalScopeState<T> extends State<_ModalScope<T>> {
                     // only necessary to rebuild the IgnorePointer widget and set
                     // the focus node's ability to focus.
                     AnimatedBuilder(
-                      animation: widget.route.navigator.userGestureInProgressNotifier,
+                      animation: widget.route.navigator?.userGestureInProgressNotifier ?? ValueNotifier<bool>(false),
                       builder: (BuildContext context, Widget child) {
                         final bool ignoreEvents = widget.route.animation?.status == AnimationStatus.reverse ||
-                            widget.route.navigator.userGestureInProgress;
+                            (widget.route.navigator?.userGestureInProgress ?? false);
                         focusScopeNode.canRequestFocus = !ignoreEvents;
                         return IgnorePointer(
                           ignoring: ignoreEvents,

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -43,9 +43,11 @@ Widget buildFrame({
   List<String> items = menuItems,
   Alignment alignment = Alignment.center,
   TextDirection textDirection = TextDirection.ltr,
+  Size mediaSize,
 }) {
   return TestApp(
     textDirection: textDirection,
+    mediaSize: mediaSize,
     child: Material(
       child: Align(
         alignment: alignment,
@@ -131,9 +133,10 @@ Widget buildFormFrame({
 }
 
 class TestApp extends StatefulWidget {
-  const TestApp({ this.textDirection, this.child });
+  const TestApp({ this.textDirection, this.child, this.mediaSize });
   final TextDirection textDirection;
   final Widget child;
+  final Size mediaSize;
   @override
   _TestAppState createState() => _TestAppState();
 }
@@ -148,7 +151,7 @@ class _TestAppState extends State<TestApp> {
         DefaultMaterialLocalizations.delegate,
       ],
       child: MediaQuery(
-        data: MediaQueryData.fromWindow(window),
+        data: MediaQueryData.fromWindow(window).copyWith(size: widget.mediaSize),
         child: Directionality(
           textDirection: widget.textDirection,
           child: Navigator(
@@ -937,13 +940,17 @@ void main() {
     expect(menuRect.bottomRight, const Offset(800.0, 600.0));
   });
 
-  testWidgets('Dropdown menus are dismissed on screen orientation changes', (WidgetTester tester) async {
-    await tester.pumpWidget(buildFrame(onChanged: onChanged));
+  testWidgets('Dropdown menus are dismissed on screen orientation changes, but not on keyboard hide', (WidgetTester tester) async {
+    await tester.pumpWidget(buildFrame(onChanged: onChanged, mediaSize: const Size(800, 600)));
     await tester.tap(find.byType(dropdownButtonType));
     await tester.pumpAndSettle();
     expect(find.byType(ListView), findsOneWidget);
 
-    window.onMetricsChanged();
+    await tester.pumpWidget(buildFrame(onChanged: onChanged, mediaSize: const Size(800, 300)));
+    await tester.pump();
+    expect(find.byType(ListView, skipOffstage: false), findsOneWidget);
+
+    await tester.pumpWidget(buildFrame(onChanged: onChanged, mediaSize: const Size(600, 800)));
     await tester.pump();
     expect(find.byType(ListView, skipOffstage: false), findsNothing);
   });

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -946,10 +946,17 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byType(ListView), findsOneWidget);
 
+    // Show a keyboard (simulate by shortening the height).
     await tester.pumpWidget(buildFrame(onChanged: onChanged, mediaSize: const Size(800, 300)));
     await tester.pump();
     expect(find.byType(ListView, skipOffstage: false), findsOneWidget);
 
+    // Hide a keyboard again (simulate by increasing the height).
+    await tester.pumpWidget(buildFrame(onChanged: onChanged, mediaSize: const Size(800, 600)));
+    await tester.pump();
+    expect(find.byType(ListView, skipOffstage: false), findsOneWidget);
+
+    // Rotate the device (simulate by changing the aspect ratio).
     await tester.pumpWidget(buildFrame(onChanged: onChanged, mediaSize: const Size(600, 800)));
     await tester.pump();
     expect(find.byType(ListView, skipOffstage: false), findsNothing);


### PR DESCRIPTION
## Description
This changes the `DropDownButton` so that instead of dismissing itself when any metrics change occurs, it only dismisses itself when the orientation changes.

This gets around the fact that we can't currently have a dropdown and a text field on the same page because the keyboard disappearing when the dropdown gets focus causes a metrics change, and the dropdown immediately disappears when activated.

It still will cause the keyboard to jump up and down between controls, but that's a larger issue. At least now we can use the two together again.
## Related Issues
Fixes https://github.com/flutter/flutter/issues/41881
## Tests

- Modified the dropdown test to look at orientation.

## Breaking Change

- [X] No, this is *not* a breaking change.