### PR TITLE
Print correct hostname when web server is launched

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/web_fs.dart
+++ b/packages/flutter_tools/lib/src/build_runner/web_fs.dart
@@ -209,6 +209,7 @@ class WebFs {
     };
 
     // Initialize the dwds server.
+    final String effectiveHostname = hostname ?? _kHostName;
     final int hostPort = port == null ? await os.findFreePort() : int.tryParse(port);
 
     final Pipeline pipeline = const Pipeline().addMiddleware((Handler innerHandler) {
@@ -279,10 +280,10 @@ class WebFs {
         final BuildRunnerAssetHandler assetHandler = BuildRunnerAssetHandler(
           daemonAssetPort,
           kBuildTargetName,
-          hostname ?? _kHostName,
+          effectiveHostname,
           hostPort);
         dwds = await dwdsFactory(
-          hostname: hostname ?? _kHostName,
+          hostname: effectiveHostname,
           assetHandler: assetHandler,
           buildResults: filteredBuildResults,
           chromeConnection: () async {
@@ -309,13 +310,13 @@ class WebFs {
     Cascade cascade = Cascade();
     cascade = cascade.add(handler);
     cascade = cascade.add(assetServer.handle);
-    final HttpServer server = await httpMultiServerFactory(hostname ?? _kHostName, hostPort);
+    final HttpServer server = await httpMultiServerFactory(effectiveHostname, hostPort);
     shelf_io.serveRequests(server, cascade.handler);
     final WebFs webFS = WebFs(
       client,
       server,
       dwds,
-      'http://$_kHostName:$hostPort/',
+      'http://$effectiveHostname:$hostPort/',
       assetServer,
       buildInfo.isDebug,
       flutterProject,

--- a/packages/flutter_tools/test/general.shard/web/web_fs_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/web_fs_test.dart
@@ -167,7 +167,7 @@ void main() {
 
   test('Uses provided port number and hostname.', () => testbed.run(() async {
     final FlutterProject flutterProject = FlutterProject.current();
-    await WebFs.start(
+    final WebFs webFs = await WebFs.start(
       skipDwds: false,
       target: fs.path.join('lib', 'main.dart'),
       buildInfo: BuildInfo.debug,
@@ -177,6 +177,7 @@ void main() {
       port: '1234',
     );
 
+    expect(webFs.uri, contains('foo:1234'));
     expect(lastPort, 1234);
     expect(lastAddress, contains('foo'));
   }));


### PR DESCRIPTION
## Description

Currently, the flutter tool always prints `http://localhost:$port` when the web server is launched. This doesn't take into consideration the `--web-hostname` flag.

This PR makes sure we always print the effective hostname being used in the web server.

## Tests

I modified the following tests:
* `packages/flutter_tools/test/general.shard/web/web_fs_test.dart`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
