### PR TITLE
[flutter_tool] Improve yaml font map validation

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -439,8 +439,13 @@ void _validateFonts(YamlList fonts, List<String> errors) {
       errors.add('Expected "fonts" to either be null or a list.');
       continue;
     }
-    for (final YamlMap fontListItem in fontMap['fonts']) {
-      for (final MapEntry<dynamic, dynamic> kvp in fontListItem.entries) {
+    for (final dynamic fontListItem in fontMap['fonts']) {
+      if (fontListItem is! YamlMap) {
+        errors.add('Expected "fonts" to be a list of maps.');
+        continue;
+      }
+      final YamlMap fontMapList = fontListItem;
+      for (final MapEntry<dynamic, dynamic> kvp in fontMapList.entries) {
         if (kvp.key is! String) {
           errors.add('Expected "${kvp.key}" under "fonts" to be a string.');
         }

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
@@ -534,6 +534,25 @@ flutter:
       expect(logger.errorText, contains('Expected "fonts" to either be null or a list.'));
     });
 
+    testUsingContext('Returns proper error when font detail is not a list of maps', () async {
+      final BufferLogger logger = context.get<Logger>();
+      const String manifest = '''
+name: test
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+  fonts:
+    - family: foo
+      fonts:
+        - asset
+''';
+      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
+
+      expect(flutterManifest, null);
+      expect(logger.errorText, contains('Expected "fonts" to be a list of maps.'));
+    });
+
     testUsingContext('Returns proper error when font is a map instead of a list', () async {
       final BufferLogger logger = context.get<Logger>();
       const String manifest = '''


### PR DESCRIPTION
## Description

Catch the case when the 'fonts' is a list, but not a list of maps.

## Related Issues

Seen in crash logging.

## Tests

I added the following tests:

Added a test to flutter_manifest_test.dart

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.