### PR TITLE
Fix and enable painting tests on the Web

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -443,7 +443,6 @@ Future<void> _runWebTests() async {
     'test/cupertino',
     'test/examples',
     'test/material',
-    'test/painting',
     'test/rendering',
     'test/widgets',
   ];

--- a/packages/flutter/test/painting/image_provider_test.dart
+++ b/packages/flutter/test/painting/image_provider_test.dart
@@ -181,7 +181,7 @@ void main() {
             .having((NetworkImageLoadException e) => e.statusCode, 'statusCode', errorStatusCode)
             .having((NetworkImageLoadException e) => e.uri, 'uri', Uri.base.resolve(requestUrl)),
         );
-      });
+      }, skip: isBrowser);  // Browser implementation does not use HTTP client but a <img> tag.
 
       test('Disallows null urls', () {
         expect(() {

--- a/packages/flutter/test/painting/system_fonts_test.dart
+++ b/packages/flutter/test/painting/system_fonts_test.dart
@@ -91,7 +91,7 @@ void main() {
     expect(cache.isEmpty, isTrue);
     final Element element = tester.element(find.byType(CupertinoDatePicker));
     expect(element.dirty, isTrue);
-  });
+  }, skip: isBrowser);  // TODO: cupertino does not work on the Web yet: https://github.com/flutter/flutter/issues/41920
 
   testWidgets('CupertinoDatePicker reset cache upon system fonts change - date mode', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -118,7 +118,7 @@ void main() {
     expect(cache.isNotEmpty, isTrue);
     final Element element = tester.element(find.byType(CupertinoDatePicker));
     expect(element.dirty, isTrue);
-  });
+  }, skip: isBrowser);  // TODO: cupertino does not work on the Web yet: https://github.com/flutter/flutter/issues/41920
 
   testWidgets('CupertinoDatePicker reset cache upon system fonts change - time mode', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -147,7 +147,7 @@ void main() {
     expect(state.numberLabelBaseline - 18.400070190429688 < precisionErrorTolerance, isTrue);
     final Element element = tester.element(find.byType(CupertinoTimerPicker));
     expect(element.dirty, isTrue);
-  });
+  }, skip: isBrowser);  // TODO: cupertino does not work on the Web yet: https://github.com/flutter/flutter/issues/41920
 
   testWidgets('RangeSlider relayout upon system fonts changes', (WidgetTester tester) async {
     await tester.pumpWidget(

--- a/packages/flutter/test/painting/system_fonts_test.dart
+++ b/packages/flutter/test/painting/system_fonts_test.dart
@@ -91,7 +91,7 @@ void main() {
     expect(cache.isEmpty, isTrue);
     final Element element = tester.element(find.byType(CupertinoDatePicker));
     expect(element.dirty, isTrue);
-  }, skip: isBrowser);  // TODO: cupertino does not work on the Web yet: https://github.com/flutter/flutter/issues/41920
+  }, skip: isBrowser);  // TODO(yjbanov): cupertino does not work on the Web yet: https://github.com/flutter/flutter/issues/41920
 
   testWidgets('CupertinoDatePicker reset cache upon system fonts change - date mode', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -118,7 +118,7 @@ void main() {
     expect(cache.isNotEmpty, isTrue);
     final Element element = tester.element(find.byType(CupertinoDatePicker));
     expect(element.dirty, isTrue);
-  }, skip: isBrowser);  // TODO: cupertino does not work on the Web yet: https://github.com/flutter/flutter/issues/41920
+  }, skip: isBrowser);  // TODO(yjbanov): cupertino does not work on the Web yet: https://github.com/flutter/flutter/issues/41920
 
   testWidgets('CupertinoDatePicker reset cache upon system fonts change - time mode', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -147,7 +147,7 @@ void main() {
     expect(state.numberLabelBaseline - 18.400070190429688 < precisionErrorTolerance, isTrue);
     final Element element = tester.element(find.byType(CupertinoTimerPicker));
     expect(element.dirty, isTrue);
-  }, skip: isBrowser);  // TODO: cupertino does not work on the Web yet: https://github.com/flutter/flutter/issues/41920
+  }, skip: isBrowser);  // TODO(yjbanov): cupertino does not work on the Web yet: https://github.com/flutter/flutter/issues/41920
 
   testWidgets('RangeSlider relayout upon system fonts changes', (WidgetTester tester) async {
     await tester.pumpWidget(

--- a/packages/flutter_tools/lib/src/build_runner/build_script.dart
+++ b/packages/flutter_tools/lib/src/build_runner/build_script.dart
@@ -277,7 +277,8 @@ Future<void> main() async {
   // The following parameters are hard-coded in Flutter's test embedder. Since
   // we don't have an embedder yet this is the lowest-most layer we can put
   // this stuff in.
-  await ui.webOnlyInitializeEngine();
+  ui.debugEmulateFlutterTesterEnvironment = true;
+  await ui.webOnlyInitializePlatform();
   // TODO(flutterweb): remove need for dynamic cast.
   (ui.window as dynamic).debugOverrideDevicePixelRatio(3.0);
   (ui.window as dynamic).webOnlyDebugPhysicalSizeOverride = const ui.Size(2400, 1800);

--- a/packages/flutter_tools/lib/src/build_runner/build_script.dart
+++ b/packages/flutter_tools/lib/src/build_runner/build_script.dart
@@ -278,7 +278,7 @@ Future<void> main() async {
   // we don't have an embedder yet this is the lowest-most layer we can put
   // this stuff in.
   ui.debugEmulateFlutterTesterEnvironment = true;
-  await ui.webOnlyInitializePlatform();
+  await ui.webOnlyInitializeEngine();
   // TODO(flutterweb): remove need for dynamic cast.
   (ui.window as dynamic).debugOverrideDevicePixelRatio(3.0);
   (ui.window as dynamic).webOnlyDebugPhysicalSizeOverride = const ui.Size(2400, 1800);

--- a/packages/flutter_web_plugins/test/plugin_event_channel_test.dart
+++ b/packages/flutter_web_plugins/test/plugin_event_channel_test.dart
@@ -5,12 +5,16 @@
 @TestOn('chrome') // Uses web-only Flutter SDK
 
 import 'dart:async';
+import 'dart:ui' as ui;
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
 void main() {
+  // Disabling tester emulation because this test relies on real message channel communication.
+  ui.debugEmulateFlutterTesterEnvironment = false; // ignore: undefined_prefixed_name
+
   group('Plugin Event Channel', () {
     setUp(() {
       TestWidgetsFlutterBinding.ensureInitialized();

--- a/packages/flutter_web_plugins/test/plugin_registry_test.dart
+++ b/packages/flutter_web_plugins/test/plugin_registry_test.dart
@@ -4,6 +4,8 @@
 
 @TestOn('chrome') // Uses web-only Flutter SDK
 
+import 'dart:ui' as ui;
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
@@ -27,6 +29,9 @@ class TestPlugin {
 }
 
 void main() {
+  // Disabling tester emulation because this test relies on real message channel communication.
+  ui.debugEmulateFlutterTesterEnvironment = false; // ignore: undefined_prefixed_name
+
   group('Plugin Registry', () {
     setUp(() {
       TestWidgetsFlutterBinding.ensureInitialized();


### PR DESCRIPTION
## Description

Fix and enable painting tests on the Web.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/41915.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.