### PR TITLE
Skip test

### DIFF
--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -145,7 +145,7 @@ name: example''');
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
       ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
-    });
+    }, skip: true); // https://github.com/flutter/flutter/issues/34446
   });
 
 }


### PR DESCRIPTION
see #34446

This test can be made 100% failure (as well as the one above it for that matter) by using `MemoryFileSystem.test()`.

Core problem is that it's trying to compare an internal `DateTime` with the stat of file and directory entries in the MemoryFileSystem.

The behavior this is covering should also be safe to uncover - it just means that we may be doing more builds than absolutely necessary of DevFS when timestamps aren't what we expect.

@Hixie @jonahwilliams @tvolkert @gspencergoog 