### PR TITLE
Adding thumb color customisation functionality to CupertinoSlider

### DIFF
--- a/packages/flutter/lib/src/cupertino/slider.dart
+++ b/packages/flutter/lib/src/cupertino/slider.dart
@@ -197,6 +197,8 @@ class CupertinoSlider extends StatefulWidget {
 
   /// The color to use for the thumb of the slider.
   ///
+  /// Thumb color must not be null.
+  ///
   /// Defaults to [CupertinoColors.white].
   final Color thumbColor;
 

--- a/packages/flutter/lib/src/cupertino/slider.dart
+++ b/packages/flutter/lib/src/cupertino/slider.dart
@@ -60,6 +60,7 @@ class CupertinoSlider extends StatefulWidget {
     this.max = 1.0,
     this.divisions,
     this.activeColor,
+    this.thumbColor,
   }) : assert(value != null),
        assert(min != null),
        assert(max != null),
@@ -193,6 +194,11 @@ class CupertinoSlider extends StatefulWidget {
   /// Defaults to the [CupertinoTheme]'s primary color if null.
   final Color activeColor;
 
+  /// The color to use for the thumb of the slider.
+  ///
+  /// Defaults to the [CupertinoColors]'s white if null.
+  final Color thumbColor;
+
   @override
   _CupertinoSliderState createState() => _CupertinoSliderState();
 
@@ -233,6 +239,7 @@ class _CupertinoSliderState extends State<CupertinoSlider> with TickerProviderSt
         widget.activeColor ?? CupertinoTheme.of(context).primaryColor,
         context,
       ),
+      thumbColor: widget.thumbColor ?? CupertinoColors.white,
       onChanged: widget.onChanged != null ? _handleChanged : null,
       onChangeStart: widget.onChangeStart != null ? _handleDragStart : null,
       onChangeEnd: widget.onChangeEnd != null ? _handleDragEnd : null,
@@ -247,6 +254,7 @@ class _CupertinoSliderRenderObjectWidget extends LeafRenderObjectWidget {
     this.value,
     this.divisions,
     this.activeColor,
+    this.thumbColor,
     this.onChanged,
     this.onChangeStart,
     this.onChangeEnd,
@@ -256,11 +264,11 @@ class _CupertinoSliderRenderObjectWidget extends LeafRenderObjectWidget {
   final double value;
   final int divisions;
   final Color activeColor;
+  final Color thumbColor;
   final ValueChanged<double> onChanged;
   final ValueChanged<double> onChangeStart;
   final ValueChanged<double> onChangeEnd;
   final TickerProvider vsync;
-
 
   @override
   _RenderCupertinoSlider createRenderObject(BuildContext context) {
@@ -268,6 +276,7 @@ class _CupertinoSliderRenderObjectWidget extends LeafRenderObjectWidget {
       value: value,
       divisions: divisions,
       activeColor: activeColor,
+      thumbColor: thumbColor,
       trackColor: CupertinoDynamicColor.resolve(CupertinoColors.systemFill, context),
       onChanged: onChanged,
       onChangeStart: onChangeStart,
@@ -305,6 +314,7 @@ class _RenderCupertinoSlider extends RenderConstrainedBox {
     @required double value,
     int divisions,
     Color activeColor,
+    @required this.thumbColor,
     Color trackColor,
     ValueChanged<double> onChanged,
     this.onChangeStart,
@@ -313,6 +323,7 @@ class _RenderCupertinoSlider extends RenderConstrainedBox {
     @required TextDirection textDirection,
   }) : assert(value != null && value >= 0.0 && value <= 1.0),
        assert(textDirection != null),
+       assert(thumbColor != null),
        _value = value,
        _divisions = divisions,
        _activeColor = activeColor,
@@ -362,6 +373,8 @@ class _RenderCupertinoSlider extends RenderConstrainedBox {
     _activeColor = value;
     markNeedsPaint();
   }
+
+  final Color thumbColor;
 
   Color get trackColor => _trackColor;
   Color _trackColor;
@@ -512,7 +525,7 @@ class _RenderCupertinoSlider extends RenderConstrainedBox {
     }
 
     final Offset thumbCenter = Offset(trackActive, trackCenter);
-    const CupertinoThumbPainter().paint(canvas, Rect.fromCircle(center: thumbCenter, radius: CupertinoThumbPainter.radius));
+    CupertinoThumbPainter(color: thumbColor).paint(canvas, Rect.fromCircle(center: thumbCenter, radius: CupertinoThumbPainter.radius));
   }
 
   @override

--- a/packages/flutter/lib/src/cupertino/slider.dart
+++ b/packages/flutter/lib/src/cupertino/slider.dart
@@ -60,12 +60,13 @@ class CupertinoSlider extends StatefulWidget {
     this.max = 1.0,
     this.divisions,
     this.activeColor,
-    this.thumbColor,
+    this.thumbColor = CupertinoColors.white,
   }) : assert(value != null),
        assert(min != null),
        assert(max != null),
        assert(value >= min && value <= max),
        assert(divisions == null || divisions > 0),
+       assert(thumbColor != null),
        super(key: key);
 
   /// The currently selected value for this slider.
@@ -196,7 +197,7 @@ class CupertinoSlider extends StatefulWidget {
 
   /// The color to use for the thumb of the slider.
   ///
-  /// Defaults to the [CupertinoColors]'s white if null.
+  /// Defaults to [CupertinoColors.white] if null.
   final Color thumbColor;
 
   @override
@@ -239,7 +240,7 @@ class _CupertinoSliderState extends State<CupertinoSlider> with TickerProviderSt
         widget.activeColor ?? CupertinoTheme.of(context).primaryColor,
         context,
       ),
-      thumbColor: widget.thumbColor ?? CupertinoColors.white,
+      thumbColor: widget.thumbColor,
       onChanged: widget.onChanged != null ? _handleChanged : null,
       onChangeStart: widget.onChangeStart != null ? _handleDragStart : null,
       onChangeEnd: widget.onChangeEnd != null ? _handleDragEnd : null,
@@ -276,7 +277,7 @@ class _CupertinoSliderRenderObjectWidget extends LeafRenderObjectWidget {
       value: value,
       divisions: divisions,
       activeColor: activeColor,
-      thumbColor: thumbColor,
+      thumbColor: CupertinoDynamicColor.resolve(thumbColor, context),
       trackColor: CupertinoDynamicColor.resolve(CupertinoColors.systemFill, context),
       onChanged: onChanged,
       onChangeStart: onChangeStart,
@@ -292,6 +293,7 @@ class _CupertinoSliderRenderObjectWidget extends LeafRenderObjectWidget {
       ..value = value
       ..divisions = divisions
       ..activeColor = activeColor
+      ..thumbColor = CupertinoDynamicColor.resolve(thumbColor, context)
       ..trackColor = CupertinoDynamicColor.resolve(CupertinoColors.systemFill, context)
       ..onChanged = onChanged
       ..onChangeStart = onChangeStart
@@ -314,7 +316,7 @@ class _RenderCupertinoSlider extends RenderConstrainedBox {
     @required double value,
     int divisions,
     Color activeColor,
-    @required this.thumbColor,
+    Color thumbColor,
     Color trackColor,
     ValueChanged<double> onChanged,
     this.onChangeStart,
@@ -323,10 +325,10 @@ class _RenderCupertinoSlider extends RenderConstrainedBox {
     @required TextDirection textDirection,
   }) : assert(value != null && value >= 0.0 && value <= 1.0),
        assert(textDirection != null),
-       assert(thumbColor != null),
        _value = value,
        _divisions = divisions,
        _activeColor = activeColor,
+       _thumbColor = thumbColor,
        _trackColor = trackColor,
        _onChanged = onChanged,
        _textDirection = textDirection,
@@ -374,7 +376,14 @@ class _RenderCupertinoSlider extends RenderConstrainedBox {
     markNeedsPaint();
   }
 
-  final Color thumbColor;
+  Color get thumbColor => _thumbColor;
+  Color _thumbColor;
+  set thumbColor(Color value) {
+    if (value == _thumbColor)
+      return;
+    _thumbColor = value;
+    markNeedsPaint();
+  }
 
   Color get trackColor => _trackColor;
   Color _trackColor;

--- a/packages/flutter/lib/src/cupertino/slider.dart
+++ b/packages/flutter/lib/src/cupertino/slider.dart
@@ -197,7 +197,7 @@ class CupertinoSlider extends StatefulWidget {
 
   /// The color to use for the thumb of the slider.
   ///
-  /// Defaults to [CupertinoColors.white] if null.
+  /// Defaults to [CupertinoColors.white].
   final Color thumbColor;
 
   @override

--- a/packages/flutter/test/cupertino/slider_test.dart
+++ b/packages/flutter/test/cupertino/slider_test.dart
@@ -560,10 +560,9 @@ void main() {
   testWidgets('Thumb color can be overridden', (WidgetTester tester) async {
     await tester.pumpWidget(
       CupertinoApp(
-        theme: const CupertinoThemeData(brightness: Brightness.light),
         home: Center(
           child: CupertinoSlider(
-            thumbColor: CupertinoColors.activeGreen,
+            thumbColor: CupertinoColors.systemPurple,
             onChanged: (double value) { },
             value: 0,
           ),
@@ -573,12 +572,36 @@ void main() {
 
     expect(
       find.byType(CupertinoSlider),
-      paints..rrect(color: _kSystemFill.color),
+      paints
+      ..rrect()
+      ..rrect()
+      ..rrect()
+      ..rrect()
+      ..rrect()
+      ..rrect(color: CupertinoColors.systemPurple.color)
+    );
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(
+          child: CupertinoSlider(
+            thumbColor: CupertinoColors.activeOrange,
+            onChanged: (double value) { },
+            value: 0,
+          ),
+        ),
+      ),
     );
 
     expect(
-      find.byType(CupertinoSlider),
-      isNot(paints..rrect(color: _kSystemFill.darkColor)),
+        find.byType(CupertinoSlider),
+        paints
+          ..rrect()
+          ..rrect()
+          ..rrect()
+          ..rrect()
+          ..rrect()
+          ..rrect(color: CupertinoColors.activeOrange.color)
     );
   });
 }

--- a/packages/flutter/test/cupertino/slider_test.dart
+++ b/packages/flutter/test/cupertino/slider_test.dart
@@ -556,4 +556,29 @@ void main() {
       isNot(paints..rrect(color: _kSystemFill.color)),
     );
   });
+
+  testWidgets('Thumb color can be overridden', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      CupertinoApp(
+        theme: const CupertinoThemeData(brightness: Brightness.light),
+        home: Center(
+          child: CupertinoSlider(
+            thumbColor: CupertinoColors.activeGreen,
+            onChanged: (double value) { },
+            value: 0,
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      find.byType(CupertinoSlider),
+      paints..rrect(color: _kSystemFill.color),
+    );
+
+    expect(
+      find.byType(CupertinoSlider),
+      isNot(paints..rrect(color: _kSystemFill.darkColor)),
+    );
+  });
 }


### PR DESCRIPTION
## Description

Allowing the user to change the thumb color on the CupertinoSlider by passing it as a parameter. 
```dart
void main() => runApp(MyApp());

class MyApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return CupertinoApp(
      home: CupertinoSlider(
        thumbColor: CupertinoColors.activeGreen,
        onChanged: (double value) {},
        value: 0,
      ),
    );
  }
}
```
At first I was considering adding the thumbColor to the CupertinoTheme, but didn't know if it was the right place to put it, so I just defaulted to white (the current only possible color).

## Related Issues

Fixes [#42088](https://github.com/flutter/flutter/issues/42088)

## Tests

I added the following tests:
Creating a CupertinoSlider with a specific thumb color and verifying that the color was actually set.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
