### PR TITLE
Deflake wildcard asset test

### DIFF
--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -91,12 +91,14 @@ class _ManifestAssetBundle implements AssetBundle {
     }
 
     for (Directory directory in _wildcardDirectories.values) {
-      final DateTime dateTime = directory.statSync().modified;
-      if (dateTime == null) {
-        continue;
-      }
-      if (dateTime.isAfter(_lastBuildTimestamp)) {
-        return true;
+      for (File file in directory.listSync()) {
+        final DateTime dateTime = file.statSync().modified;
+        if (dateTime == null) {
+          continue;
+        }
+        if (dateTime.isAfter(_lastBuildTimestamp)) {
+          return true;
+        }
       }
     }
 

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -91,6 +91,9 @@ class _ManifestAssetBundle implements AssetBundle {
     }
 
     for (Directory directory in _wildcardDirectories.values) {
+      if (!directory.existsSync()) {
+        return true; // directory was deleted.
+      }
       for (File file in directory.listSync()) {
         final DateTime dateTime = file.statSync().modified;
         if (dateTime == null) {


### PR DESCRIPTION
## Description

For wildcard assets, filestat the individual contents instead of the directory. Deflake the test by manually setting the lastModifiedSync to the future.

Fixes https://github.com/flutter/flutter/issues/42230
Fixes https://github.com/flutter/flutter/issues/34446