### PR TITLE
Fix Tooltip implementation of PopupMenuButton

### DIFF
--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -1085,21 +1085,17 @@ class _PopupMenuButtonState<T> extends State<PopupMenuButton<T>> {
 
     if (widget.child != null)
       return Tooltip(
-        message:
-        widget.tooltip ?? MaterialLocalizations.of(context).showMenuTooltip,
+        message: widget.tooltip ?? MaterialLocalizations.of(context).showMenuTooltip,
         child: InkWell(
           onTap: widget.enabled ? showButtonMenu : null,
           child: widget.child,
         ),
       );
 
-    // If there is no child, it does not matter if icon == null because
-    // a default icon will be used if both child and icon are null.
     return IconButton(
       icon: widget.icon ?? _getIcon(Theme.of(context).platform),
       padding: widget.padding,
-      tooltip:
-          widget.tooltip ?? MaterialLocalizations.of(context).showMenuTooltip,
+      tooltip: widget.tooltip ?? MaterialLocalizations.of(context).showMenuTooltip,
       onPressed: widget.enabled ? showButtonMenu : null,
     );
   }

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -1083,28 +1083,24 @@ class _PopupMenuButtonState<T> extends State<PopupMenuButton<T>> {
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterialLocalizations(context));
 
-    if (widget.child == null)
-      return IconButton(
-        icon: widget.icon ?? _getIcon(Theme.of(context).platform),
-        padding: widget.padding,
-        tooltip:
-            widget.tooltip ?? MaterialLocalizations.of(context).showMenuTooltip,
-        onPressed: widget.enabled ? showButtonMenu : null,
-      );
-
-    Widget result = InkWell(
-      onTap: widget.enabled ? showButtonMenu : null,
-      child: widget.child,
-    );
-
-    if (widget.tooltip != null) {
-      result = Tooltip(
+    if (widget.child != null)
+      return Tooltip(
         message:
-            widget.tooltip ?? MaterialLocalizations.of(context).showMenuTooltip,
-        child: result,
+        widget.tooltip ?? MaterialLocalizations.of(context).showMenuTooltip,
+        child: InkWell(
+          onTap: widget.enabled ? showButtonMenu : null,
+          child: widget.child,
+        ),
       );
-    }
 
-    return result;
+    // If there is no child, it does not matter if icon == null because
+    // a default icon will be used if both child and icon are null.
+    return IconButton(
+      icon: widget.icon ?? _getIcon(Theme.of(context).platform),
+      padding: widget.padding,
+      tooltip:
+          widget.tooltip ?? MaterialLocalizations.of(context).showMenuTooltip,
+      onPressed: widget.enabled ? showButtonMenu : null,
+    );
   }
 }

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
@@ -20,6 +19,7 @@ import 'material.dart';
 import 'material_localizations.dart';
 import 'popup_menu_theme.dart';
 import 'theme.dart';
+import 'tooltip.dart';
 
 // Examples can assume:
 // enum Commands { heroAndScholar, hurricaneCame }

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -1099,7 +1099,8 @@ class _PopupMenuButtonState<T> extends State<PopupMenuButton<T>> {
 
     if (widget.tooltip != null) {
       result = Tooltip(
-        message: widget.tooltip,
+        message:
+            widget.tooltip ?? MaterialLocalizations.of(context).showMenuTooltip,
         child: result,
       );
     }

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
@@ -939,7 +940,8 @@ class PopupMenuButton<T> extends StatefulWidget {
        assert(offset != null),
        assert(enabled != null),
        assert(captureInheritedThemes != null),
-       assert(!(child != null && icon != null)), // fails if passed both parameters
+       assert(!(child != null && icon != null),
+           'You can only pass [child] or [icon], not both.'),
        super(key: key);
 
   /// Called when the button is pressed to create the items to show in the menu.
@@ -1080,16 +1082,28 @@ class _PopupMenuButtonState<T> extends State<PopupMenuButton<T>> {
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterialLocalizations(context));
-    return widget.child != null
-      ? InkWell(
-          onTap: widget.enabled ? showButtonMenu : null,
-          child: widget.child,
-        )
-      : IconButton(
-          icon: widget.icon ?? _getIcon(Theme.of(context).platform),
-          padding: widget.padding,
-          tooltip: widget.tooltip ?? MaterialLocalizations.of(context).showMenuTooltip,
-          onPressed: widget.enabled ? showButtonMenu : null,
-        );
+
+    if (widget.child == null)
+      return IconButton(
+        icon: widget.icon ?? _getIcon(Theme.of(context).platform),
+        padding: widget.padding,
+        tooltip:
+            widget.tooltip ?? MaterialLocalizations.of(context).showMenuTooltip,
+        onPressed: widget.enabled ? showButtonMenu : null,
+      );
+
+    Widget result = InkWell(
+      onTap: widget.enabled ? showButtonMenu : null,
+      child: widget.child,
+    );
+
+    if (widget.tooltip != null) {
+      result = Tooltip(
+        message: widget.tooltip,
+        child: result,
+      );
+    }
+
+    return result;
   }
 }

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -852,26 +852,21 @@ void main() {
     expect(tester.getTopLeft(find.text('Item 1')).dx, 72);
   });
 
-  test('PopupMenuButton takes only child or only icon', () {
-    // [PopupMenuButton] should assert that either child == null, icon == null,
-    // or that both are null because only one of the two can be displayed/used.
-    expect(() => PopupMenuButton<int>(
-      itemBuilder: (BuildContext context) => <PopupMenuItem<int>>[],
-      child: Container(),
-      icon: const Icon(Icons.error),
-    ), throwsAssertionError);
+  test("PopupMenuButton's child and icon properties cannot be simultaneously defined", () {
+    expect(() {
+      PopupMenuButton<int>(
+        itemBuilder: (BuildContext context) => <PopupMenuItem<int>>[],
+        child: Container(),
+        icon: const Icon(Icons.error),
+      );
+    }, throwsAssertionError);
   });
 
   testWidgets('PopupMenuButton default tooltip', (WidgetTester tester) async {
-    // If the tooltip parameter for [PopupMenuButton] is not specified,
-    // a default tooltip should be used instead.
     await tester.pumpWidget(
       MaterialApp(
         home: Material(
           child: Column(
-            // The default tooltip should be present when
-            // [PopupMenuButton.icon] or [PopupMenuButton.child] is defined
-            // and also when neither of the two is defined.
             children: <Widget>[
               // Default Tooltip should be present when [PopupMenuButton.child]
               // and [PopupMenuButton.child] are undefined.
@@ -924,17 +919,12 @@ void main() {
   });
 
   testWidgets('PopupMenuButton custom tooltip', (WidgetTester tester) async {
-    // A custom tooltip can be provided to [PopupMenuButton.tooltip]
-    // to replace the default tooltip, which is tested in the previous test.
     await tester.pumpWidget(
       MaterialApp(
         home: Material(
           child: Column(
-            // The tooltip should be present when
-            // [PopupMenuButton.icon] or [PopupMenuButton.child] is defined
-            // and also when neither of the two is defined.
             children: <Widget>[
-              // Tooltip should be work when [PopupMenuButton.child]
+              // Tooltip should work when [PopupMenuButton.child]
               // and [PopupMenuButton.child] are undefined.
               PopupMenuButton<int>(
                 itemBuilder: (BuildContext context) {

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -868,7 +868,7 @@ void main() {
         home: Material(
           child: Column(
             children: <Widget>[
-              // Default Tooltip should be present when [PopupMenuButton.child]
+              // Default Tooltip should be present when [PopupMenuButton.icon]
               // and [PopupMenuButton.child] are undefined.
               PopupMenuButton<int>(
                 itemBuilder: (BuildContext context) {
@@ -924,7 +924,7 @@ void main() {
         home: Material(
           child: Column(
             children: <Widget>[
-              // Tooltip should work when [PopupMenuButton.child]
+              // Tooltip should work when [PopupMenuButton.icon]
               // and [PopupMenuButton.child] are undefined.
               PopupMenuButton<int>(
                 itemBuilder: (BuildContext context) {

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -852,14 +852,29 @@ void main() {
     expect(tester.getTopLeft(find.text('Item 1')).dx, 72);
   });
 
-  testWidgets('test tooltip', (WidgetTester tester) async {
+  testWidgets('PopupMenuButton takes only child or only icon', (WidgetTester tester) async {
+    // [PopupMenuButton] should assert that either child == null, icon == null,
+    // or that both are null because only one of the two can be displayed/used.
+    expect(PopupMenuButton<int>(
+      itemBuilder: (BuildContext context) => <PopupMenuItem<int>>[],
+      child: Container(),
+      icon: const Icon(Icons.error),
+    ), throwsA(const TypeMatcher<AssertionError>()));
+  });
+
+  testWidgets('PopupMenuButton default tooltip', (WidgetTester tester) async {
+    // If the tooltip parameter for [PopupMenuButton] is not specified,
+    // a default tooltip should be used instead.
     await tester.pumpWidget(
       MaterialApp(
         home: Material(
           child: Column(
+            // The default tooltip should be present when
+            // [PopupMenuButton.icon] or [PopupMenuButton.child] is defined
+            // and also when neither of the two is defined.
             children: <Widget>[
-              // Using three different PopupMenuButton's to test
-              // passing child, icon, and neither of those.
+              // Default Tooltip should be present when [PopupMenuButton.child]
+              // and [PopupMenuButton.child] are undefined.
               PopupMenuButton<int>(
                 itemBuilder: (BuildContext context) {
                   return <PopupMenuEntry<int>>[
@@ -870,6 +885,8 @@ void main() {
                   ];
                 },
               ),
+              // Default Tooltip should be present when
+              // [PopupMenuButton.child] is defined.
               PopupMenuButton<int>(
                 itemBuilder: (BuildContext context) {
                   return <PopupMenuEntry<int>>[
@@ -881,6 +898,8 @@ void main() {
                 },
                 child: const Text('Test text'),
               ),
+              // Default Tooltip should be present when
+              // [PopupMenuButton.icon] is defined.
               PopupMenuButton<int>(
                 itemBuilder: (BuildContext context) {
                   return <PopupMenuEntry<int>>[
@@ -898,23 +917,26 @@ void main() {
       ),
     );
 
-    // The default tooltip is defined as MaterialLocalizations.showMenuTooltip
+    // The default tooltip is defined as [MaterialLocalizations.showMenuTooltip]
     // and it is used when no tooltip is provided.
     expect(find.byType(Tooltip), findsNWidgets(3));
     expect(find.byTooltip(const DefaultMaterialLocalizations().showMenuTooltip), findsNWidgets(3));
+  });
 
-    // Clear the widget tree.
-    await tester.pumpWidget(Container(key: UniqueKey()));
-
+  testWidgets('PopupMenuButton custom tooltip', (WidgetTester tester) async {
+    // A custom tooltip can be provided to [PopupMenuButton.tooltip]
+    // to replace the default tooltip, which is tested in the previous test.
     await tester.pumpWidget(
       MaterialApp(
         home: Material(
           child: Column(
+            // The tooltip should be present when
+            // [PopupMenuButton.icon] or [PopupMenuButton.child] is defined
+            // and also when neither of the two is defined.
             children: <Widget>[
-              // Using three different PopupMenuButton's to test
-              // passing child, icon, and neither of those.
+              // Tooltip should be work when [PopupMenuButton.child]
+              // and [PopupMenuButton.child] are undefined.
               PopupMenuButton<int>(
-                tooltip: 'Test tooltip',
                 itemBuilder: (BuildContext context) {
                   return <PopupMenuEntry<int>>[
                     const PopupMenuItem<int>(
@@ -923,9 +945,11 @@ void main() {
                     ),
                   ];
                 },
+                tooltip: 'Test tooltip',
               ),
+              // Tooltip should work when
+              // [PopupMenuButton.child] is defined.
               PopupMenuButton<int>(
-                tooltip: 'Test tooltip',
                 itemBuilder: (BuildContext context) {
                   return <PopupMenuEntry<int>>[
                     const PopupMenuItem<int>(
@@ -934,10 +958,12 @@ void main() {
                     ),
                   ];
                 },
+                tooltip: 'Test tooltip',
                 child: const Text('Test text'),
               ),
+              // Tooltip should work when
+              // [PopupMenuButton.icon] is defined.
               PopupMenuButton<int>(
-                tooltip: 'Test tooltip',
                 itemBuilder: (BuildContext context) {
                   return <PopupMenuEntry<int>>[
                     const PopupMenuItem<int>(
@@ -946,6 +972,7 @@ void main() {
                     ),
                   ];
                 },
+                tooltip: 'Test tooltip',
                 icon: const Icon(Icons.check),
               ),
             ],
@@ -955,7 +982,7 @@ void main() {
     );
 
     expect(find.byType(Tooltip), findsNWidgets(3));
-    expect(find.byTooltip('Test tooltip'), findsNWidgets(3));
+    expect(find.byTooltip('Test tooltip',), findsNWidgets(3));
   });
 }
 

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -898,7 +898,10 @@ void main() {
       ),
     );
 
-    expect(find.byType(Tooltip), findsNothing);
+    // The default tooltip is defined as MaterialLocalizations.showMenuTooltip
+    // and it is used when no tooltip is provided.
+    expect(find.byType(Tooltip), findsNWidgets(3));
+    expect(find.byTooltip(const DefaultMaterialLocalizations().showMenuTooltip), findsNWidgets(3));
 
     // Clear the widget tree.
     await tester.pumpWidget(Container(key: UniqueKey()));

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -852,14 +852,14 @@ void main() {
     expect(tester.getTopLeft(find.text('Item 1')).dx, 72);
   });
 
-  testWidgets('PopupMenuButton takes only child or only icon', (WidgetTester tester) async {
+  test('PopupMenuButton takes only child or only icon', () {
     // [PopupMenuButton] should assert that either child == null, icon == null,
     // or that both are null because only one of the two can be displayed/used.
     expect(PopupMenuButton<int>(
       itemBuilder: (BuildContext context) => <PopupMenuItem<int>>[],
       child: Container(),
       icon: const Icon(Icons.error),
-    ), throwsA(const TypeMatcher<AssertionError>()));
+    ), throwsAssertionError);
   });
 
   testWidgets('PopupMenuButton default tooltip', (WidgetTester tester) async {

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -851,6 +851,109 @@ void main() {
     expect(tester.getTopLeft(find.text('Item 0')).dx, 72);
     expect(tester.getTopLeft(find.text('Item 1')).dx, 72);
   });
+
+  testWidgets('test tooltip', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Column(
+            children: <Widget>[
+              // Using three different PopupMenuButton's to test
+              // passing child, icon, and neither of those.
+              PopupMenuButton<int>(
+                itemBuilder: (BuildContext context) {
+                  return <PopupMenuEntry<int>>[
+                    const PopupMenuItem<int>(
+                      value: 1,
+                      child: Text('Tap me please!'),
+                    ),
+                  ];
+                },
+              ),
+              PopupMenuButton<int>(
+                itemBuilder: (BuildContext context) {
+                  return <PopupMenuEntry<int>>[
+                    const PopupMenuItem<int>(
+                      value: 1,
+                      child: Text('Tap me please!'),
+                    ),
+                  ];
+                },
+                child: const Text('Test text'),
+              ),
+              PopupMenuButton<int>(
+                itemBuilder: (BuildContext context) {
+                  return <PopupMenuEntry<int>>[
+                    const PopupMenuItem<int>(
+                      value: 1,
+                      child: Text('Tap me please!'),
+                    ),
+                  ];
+                },
+                icon: const Icon(Icons.check),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(Tooltip), findsNothing);
+
+    // Clear the widget tree.
+    await tester.pumpWidget(Container(key: UniqueKey()));
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Column(
+            children: <Widget>[
+              // Using three different PopupMenuButton's to test
+              // passing child, icon, and neither of those.
+              PopupMenuButton<int>(
+                tooltip: 'Test tooltip',
+                itemBuilder: (BuildContext context) {
+                  return <PopupMenuEntry<int>>[
+                    const PopupMenuItem<int>(
+                      value: 1,
+                      child: Text('Tap me please!'),
+                    ),
+                  ];
+                },
+              ),
+              PopupMenuButton<int>(
+                tooltip: 'Test tooltip',
+                itemBuilder: (BuildContext context) {
+                  return <PopupMenuEntry<int>>[
+                    const PopupMenuItem<int>(
+                      value: 1,
+                      child: Text('Tap me please!'),
+                    ),
+                  ];
+                },
+                child: const Text('Test text'),
+              ),
+              PopupMenuButton<int>(
+                tooltip: 'Test tooltip',
+                itemBuilder: (BuildContext context) {
+                  return <PopupMenuEntry<int>>[
+                    const PopupMenuItem<int>(
+                      value: 1,
+                      child: Text('Tap me please!'),
+                    ),
+                  ];
+                },
+                icon: const Icon(Icons.check),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(Tooltip), findsNWidgets(3));
+    expect(find.byTooltip('Test tooltip'), findsNWidgets(3));
+  });
 }
 
 class TestApp extends StatefulWidget {

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -855,7 +855,7 @@ void main() {
   test('PopupMenuButton takes only child or only icon', () {
     // [PopupMenuButton] should assert that either child == null, icon == null,
     // or that both are null because only one of the two can be displayed/used.
-    expect(PopupMenuButton<int>(
+    expect(() => PopupMenuButton<int>(
       itemBuilder: (BuildContext context) => <PopupMenuItem<int>>[],
       child: Container(),
       icon: const Icon(Icons.error),


### PR DESCRIPTION
## Description

The `tooltip` parameter was previously ignored when `child != null`. I suppose that this was a simple oversight.

## Tests

I added tests for both the old and added tooltip implementations.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.