### PR TITLE
Add BoxDecoration styling to CupertinoPicker

### DIFF
--- a/packages/flutter/lib/src/cupertino/picker.dart
+++ b/packages/flutter/lib/src/cupertino/picker.dart
@@ -62,6 +62,7 @@ class CupertinoPicker extends StatefulWidget {
     Key key,
     this.diameterRatio = _kDefaultDiameterRatio,
     this.backgroundColor = _kDefaultBackground,
+    this.decoration,
     this.offAxisFraction = 0.0,
     this.useMagnifier = false,
     this.magnification = 1.0,
@@ -105,6 +106,7 @@ class CupertinoPicker extends StatefulWidget {
     Key key,
     this.diameterRatio = _kDefaultDiameterRatio,
     this.backgroundColor = _kDefaultBackground,
+    this.decoration,
     this.offAxisFraction = 0.0,
     this.useMagnifier = false,
     this.magnification = 1.0,
@@ -144,6 +146,9 @@ class CupertinoPicker extends StatefulWidget {
   /// Any alpha value less 255 (fully opaque) will cause the removal of the
   /// wheel list edge fade gradient from rendering of the widget.
   final Color backgroundColor;
+
+  /// [BoxDecoration] for magnifier so that color and border can be customized
+  final BoxDecoration decoration;
 
   /// {@macro flutter.rendering.wheelList.offAxisFraction}
   final double offAxisFraction;
@@ -283,6 +288,13 @@ class _CupertinoPickerState extends State<CupertinoPicker> {
       (widget.backgroundColor.alpha * _kForegroundScreenOpacityFraction).toInt()
     );
 
+    const BoxDecoration decoration = BoxDecoration(
+      border: Border(
+        top: BorderSide(width: 0.0, color: _kHighlighterBorder),
+        bottom: BorderSide(width: 0.0, color: _kHighlighterBorder),
+      ),
+    );
+
     return IgnorePointer(
       child: Column(
         children: <Widget>[
@@ -292,14 +304,9 @@ class _CupertinoPickerState extends State<CupertinoPicker> {
             ),
           ),
           Container(
-            decoration: const BoxDecoration(
-              border: Border(
-                top: BorderSide(width: 0.0, color: _kHighlighterBorder),
-                bottom: BorderSide(width: 0.0, color: _kHighlighterBorder),
-              ),
-            ),
+            decoration: widget.decoration ?? decoration,
             constraints: BoxConstraints.expand(
-                height: widget.itemExtent * widget.magnification,
+              height: widget.itemExtent * widget.magnification,
             ),
           ),
           Expanded(

--- a/packages/flutter/test/cupertino/picker_test.dart
+++ b/packages/flutter/test/cupertino/picker_test.dart
@@ -214,6 +214,45 @@ void main() {
     });
   });
 
+  group('decoration', () {
+    testWidgets('can change border color', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: SizedBox(
+            height: 300,
+            width: 300,
+            child: CupertinoPicker(
+              decoration: const BoxDecoration(
+                border: Border(
+                  top: BorderSide(width: 0.0, color: CupertinoColors.activeBlue),
+                  bottom: BorderSide(width: 0.0, color: CupertinoColors.activeOrange),
+                ),
+              ),
+              itemExtent: 15.0,
+              children: const <Widget>[
+                Text('1'),
+                Text('2'),
+                Text('3'),
+              ],
+              onSelectedItemChanged: (int i) {},
+            ),
+          ),
+        ),
+      );
+
+      final Container container = tester
+          .widgetList(find.byType(Container))
+          .skip(2)
+          .first;
+
+      final BoxDecoration boxDecoration = container.decoration;
+
+      expect(boxDecoration.border.top.color, CupertinoColors.activeBlue);
+      expect(boxDecoration.border.bottom.color, CupertinoColors.activeOrange);
+    });
+  });
+
   group('scroll', () {
     testWidgets(
       'scrolling calls onSelectedItemChanged and triggers haptic feedback',


### PR DESCRIPTION

## Description
Allow user to add box decoration styling to CupertinoPicker. Right now background is changeable but ideally the border line of magnifier screen color should be customisable to match background color.

```dart
CupertinoPicker(
  itemExtent: 50,
  decoration: BoxDecoration(
    border: Border(
      top: BorderSide(width: 0.0, color: CupertinoColors.activeGreen),
      bottom: BorderSide(width: 0.0, color: CupertinoColors.activeOrange),
    ),
  ),
  onSelectedItemChanged: (int index) {},
  children: List<Widget>.generate(10, (int index) {
    return Center(
      child: Text(index.toString()),
    );
  }),
);
```

## Related Issues


## Tests
I added a test in packages/flutter/test/cupertino/picker_test.dart 
Creating a CupertinoPicker with BoxDecoration given a custom color

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.