### PR TITLE
Re-enable asserts on Windows integration tests

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -266,8 +266,6 @@ Future<void> _runToolTests() async {
         testPath: path.join(kTest, '$subshard$kDotShard'),
         useBuildRunner: canUseBuildRunner,
         tableData: bigqueryApi?.tabledata,
-        // TODO(ianh): The integration tests fail to start on Windows if asserts are enabled.
-        // See https://github.com/flutter/flutter/issues/36476
         enableFlutterToolAsserts: true,
       );
     },

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -268,7 +268,7 @@ Future<void> _runToolTests() async {
         tableData: bigqueryApi?.tabledata,
         // TODO(ianh): The integration tests fail to start on Windows if asserts are enabled.
         // See https://github.com/flutter/flutter/issues/36476
-        enableFlutterToolAsserts: !(subshard == 'integration' && Platform.isWindows),
+        enableFlutterToolAsserts: true,
       );
     },
   );


### PR DESCRIPTION
I believe #36476 is fixed (either by a change I made or some other - see https://github.com/flutter/flutter/issues/36476#issuecomment-541721007). Enabling these asserts has not failed in many builds through rebasing this PR.

Fixes #36476.