### PR TITLE
resident_web_runner doesn't close debug connection

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -106,7 +106,6 @@ class ResidentWebRunner extends ResidentRunner {
     if (_exited) {
       return;
     }
-    await _connectionResult?.debugConnection?.close();
     await _stdOutSub?.cancel();
     await _webFs?.stop();
     await device.stopApp(null);

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -430,11 +430,12 @@ void main() {
   test('cleanup of resources is safe to call multiple times', () => testbed.run(() async {
     _setupMocks();
     bool debugClosed = false;
-    when(mockDebugConnection.close()).thenAnswer((Invocation invocation) async {
+    when(mockWebDevice.stopApp(any)).thenAnswer((Invocation invocation) async {
       if (debugClosed) {
         throw StateError('debug connection closed twice');
       }
       debugClosed = true;
+      return true;
     });
     final Completer<DebugConnectionInfo> connectionInfoCompleter = Completer<DebugConnectionInfo>();
     unawaited(residentWebRunner.run(
@@ -444,6 +445,8 @@ void main() {
 
     await residentWebRunner.exit();
     await residentWebRunner.exit();
+
+    verifyNever(mockDebugConnection.close());
   }));
 
   test('Prints target and device name on run', () => testbed.run(() async {


### PR DESCRIPTION
## Description

This will crash if it is called twice - but it can also be called by dwds itself - and otherwise doesn't seem to hold onto resources. Example stack:

```
Thread 0 main thread CRASHEDStateError: Bad state: Future already completed
at _Completer.completeError	(future_impl.dart:21 )
at VmService.dispose.<anonymous closure>	(vm_service.dart:1628 )
at Iterable.forEach	(iterable.dart:277 )
at VmService.dispose	(vm_service.dart:1628 )
at DwdsVmClient.close	(dwds_vm_client.dart:25 )
at <asynchronous gap>	(async )
at AppDebugServices.close	(app_debug_services.dart:27 )
at DebugConnection.close	(debug_connection.dart:38 )
at _AsyncAwaitCompleter.start	(async_patch.dart:43 )
at DebugConnection.close	(debug_connection.dart:35 )
at new DebugConnection.<anonymous closure>	(debug_connection.dart:22 )
at _rootRunUnary	(zone.dart:1132 )
at _CustomZone.runUnary	(zone.dart:1029 )
at _FutureListener.handleValue	(future_impl.dart:137 )
at Future._propagateToListeners.handleValueCallback	(future_impl.dart:678 )
at Future._propagateToListeners	(future_impl.dart:707 )
at Future._complete	(future_impl.dart:512 )
at _cancelAndValue	(stream_pipe.dart:63 )
at Stream.first.<anonymous closure>	(stream.dart:1249 )
at _rootRunUnary	(zone.dart:1132 )
at _CustomZone.runUnary	(zone.dart:1029 )
at _CustomZone.runUnaryGuarded	(zone.dart:931 )
at _BufferingStreamSubscription._sendData	(stream_impl.dart:336 )
at _DelayedData.perform	(stream_impl.dart:591 )
at _StreamImplEvents.handleNext	(stream_impl.dart:707 )
at _PendingEvents.schedule.<anonymous closure>	(stream_impl.dart:667 )
at _rootRun	(zone.dart:1120 )
at _CustomZone.run	(zone.dart:1021 )
at _CustomZone.runGuarded	(zone.dart:923 )
at _CustomZone.bindCallbackGuarded.<anonymous closure>	(zone.dart:963 )
at _rootRun	(zone.dart:1124 )
at _CustomZone.run	(zone.dart:1021 )
at _CustomZone.runGuarded	(zone.dart:923 )
at _CustomZone.bindCallbackGuarded.<anonymous closure>	(zone.dart:963 )
at _microtaskLoop	(schedule_microtask.dart:41 )
at _startMicrotaskLoop	(schedule_microtask.dart:50 )
at _runPendingImmediateCallback	(isolate_patch.dart:116 )
at _RawReceivePortImpl._handleMessage	(isolate_patch.dart:173 )

```