### PR TITLE
Provide onBlur handler for when the Dropdown focus out

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -687,6 +687,7 @@ class DropdownButton<T> extends StatefulWidget {
     this.hint,
     this.disabledHint,
     @required this.onChanged,
+    this.onBlur,
     this.elevation = 8,
     this.style,
     this.underline,
@@ -735,6 +736,11 @@ class DropdownButton<T> extends StatefulWidget {
   /// will display the [disabledHint] widget if it is non-null.
   /// {@endtemplate}
   final ValueChanged<T> onChanged;
+
+  /// {@template flutter.material.DropdownButton.onBlur}
+  /// Called when the component has its focus lost.
+  /// {@endtemplate}
+  final void Function() onBlur;
 
   /// A builder to customize the dropdown buttons corresponding to the
   /// [DropdownMenuItem]s in [items].
@@ -990,7 +996,11 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
 
     Navigator.push(context, _dropdownRoute).then<void>((_DropdownRouteResult<T> newValue) {
       _dropdownRoute = null;
-      if (!mounted || newValue == null)
+      if (!mounted)
+        return;
+      if (widget.onBlur != null)
+        widget.onBlur();
+      if (newValue == null)
         return;
       if (widget.onChanged != null)
         widget.onChanged(newValue.result);


### PR DESCRIPTION
## Description

There's no easy way to currently know when the Dropdown component did focus out. Flutter has no consistent concept of focus, so this is what I mean: when user press the button and the list of items appear, the component is focused. When the user choose one of the items or press/click outside the list (returning null), the component is focusing out, meaning a **blur**.

I'm sure a **onFocus** or **onTap** would be equally useful, but it may be subject of a separated issue/PR.

By searching a way of dealing with the need of knowing the focus out of a dropdown, I didn't found anything useful. [This](https://stackoverflow.com/questions/57529394/how-to-open-dropdownbutton-when-other-widget-is-tapped-in-flutter) question on Stack Overflow, however, enlightened me a bit to the fact that this simply is not possible with the current API. Being so, I had to copy `dropdown.dart` into my project and made the changes I needed.

The major problem herer, is, however, that, although the real changes happen in less than a dozen of lines (as you can see in this commit), the final file (I called it `blurrable_dropdown.dart`) has more than a thousand lines. This happens because (1) I can't simply inherit DropdownButton; and (2) there's a lot of internal private dependencies that had to be kept on the code (_DropdownMenuPainter,  _DropdownScrollBehavior etc). As they are not public, I can't reuse them. Thus, it seems to be a good idea to include this in the core. It's simple and (almost if not virtually) costless.

I can't really prove that other people need this feature. In my specific case, I am developing a app where the forms validations happens per field, on blur. I.e., the user select the input and, after he leaves the field, it validates itself. This is a real use-case, although I don't know if common.

## Related Issues

I did not openend a issue, but I can if necessary. Also, didn't found any previous related issue.

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behaviour with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
