### PR TITLE
dispose devices on cleanupAtFinish() for run_cold.dart

### DIFF
--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -168,6 +168,10 @@ class ColdRunner extends ResidentRunner {
 
   @override
   Future<void> cleanupAtFinish() async {
+    for (FlutterDevice flutterDevice in flutterDevices) {
+      flutterDevice.device.dispose();
+    }
+
     await stopEchoingDeviceLog();
   }
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -43,7 +43,6 @@ void main() {
       }
     });
 
-
     group('dart-flags option', () {
       setUpAll(() {
         when(mockDeviceManager.getDevices()).thenAnswer((Invocation invocation) {

--- a/packages/flutter_tools/test/general.shard/cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/cold_test.dart
@@ -111,6 +111,26 @@ void main() {
       verify(mockFlutterDevice2.stopEchoingDeviceLog());
     });
   });
+
+  group('cold run', () {
+    BufferLogger mockLogger;
+
+    setUp(() {
+      mockLogger = BufferLogger();
+    });
+
+    testUsingContext('returns 1 if not prebuilt mode & mainPath does not exist', () async {
+      final MockDevice mockDevice = MockDevice();
+      final MockFlutterDevice mockFlutterDevice = MockFlutterDevice();
+      when(mockFlutterDevice.device).thenReturn(mockDevice);
+      final List<FlutterDevice> devices = <FlutterDevice>[mockFlutterDevice];
+      final int result = await ColdRunner(devices).run();
+      expect(result, 1);
+      expect(mockLogger.errorText, matches(r'Tried to run .*, but that file does not exist\.'));
+    }, overrides: <Type, Generator>{
+      Logger: () => mockLogger,
+    });
+  });
 }
 
 class MockFlutterDevice extends Mock implements FlutterDevice {}

--- a/packages/flutter_tools/test/general.shard/cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/cold_test.dart
@@ -84,8 +84,36 @@ void main() {
       Logger: () => mockLogger,
     });
   });
+
+  group('cleanupAtFinish()', () {
+    MockFlutterDevice mockFlutterDeviceFactory(Device device) {
+      final MockFlutterDevice mockFlutterDevice = MockFlutterDevice();
+      when(mockFlutterDevice.stopEchoingDeviceLog()).thenAnswer((Invocation invocation) => Future<void>.value(null));
+      when(mockFlutterDevice.device).thenReturn(device);
+      return mockFlutterDevice;
+    }
+
+    testUsingContext('disposes each device', () async {
+      final MockDevice mockDevice1 = MockDevice();
+      final MockDevice mockDevice2 = MockDevice();
+      final MockFlutterDevice mockFlutterDevice1 = mockFlutterDeviceFactory(mockDevice1);
+      final MockFlutterDevice mockFlutterDevice2 = mockFlutterDeviceFactory(mockDevice2);
+
+      final List<FlutterDevice> devices = <FlutterDevice>[mockFlutterDevice1, mockFlutterDevice2];
+
+      await ColdRunner(devices,
+        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      ).cleanupAtFinish();
+
+      verify(mockDevice1.dispose());
+      verify(mockFlutterDevice1.stopEchoingDeviceLog());
+      verify(mockDevice2.dispose());
+      verify(mockFlutterDevice2.stopEchoingDeviceLog());
+    });
+  });
 }
 
+class MockFlutterDevice extends Mock implements FlutterDevice {}
 class MockDevice extends Mock implements Device {
   MockDevice() {
     when(isSupported()).thenReturn(true);

--- a/packages/flutter_tools/test/general.shard/hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/hot_test.dart
@@ -337,6 +337,38 @@ void main() {
       HotRunnerConfig: () => TestHotRunnerConfig(successfulSetup: true),
     });
   });
+
+  group('hot cleanupAtFinish()', () {
+    MockFlutterDevice mockFlutterDeviceFactory(Device device) {
+      final MockFlutterDevice mockFlutterDevice = MockFlutterDevice();
+      when(mockFlutterDevice.stopEchoingDeviceLog()).thenAnswer((Invocation invocation) => Future<void>.value(null));
+      when(mockFlutterDevice.device).thenReturn(device);
+      return mockFlutterDevice;
+    }
+
+    testUsingContext('disposes each device', () async {
+      final MockDevice mockDevice1 = MockDevice();
+      when(mockDevice1.name).thenReturn('Al');
+      final MockDevice mockDevice2 = MockDevice();
+      when(mockDevice2.name).thenReturn('Ferny');
+      final MockFlutterDevice mockFlutterDevice1 = mockFlutterDeviceFactory(mockDevice1);
+      final MockFlutterDevice mockFlutterDevice2 = mockFlutterDeviceFactory(mockDevice2);
+
+      final List<FlutterDevice> devices = <FlutterDevice>[
+        mockFlutterDevice1,
+        mockFlutterDevice2,
+      ];
+
+      await HotRunner(devices,
+        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      ).cleanupAtFinish();
+
+      verify(mockDevice1.dispose());
+      verify(mockFlutterDevice1.stopEchoingDeviceLog());
+      verify(mockDevice2.dispose());
+      verify(mockFlutterDevice2.stopEchoingDeviceLog());
+    });
+  });
 }
 
 class MockDevFs extends Mock implements DevFS {}
@@ -348,6 +380,8 @@ class MockDevice extends Mock implements Device {
     when(isSupported()).thenReturn(true);
   }
 }
+
+class MockFlutterDevice extends Mock implements FlutterDevice {}
 
 class TestFlutterDevice extends FlutterDevice {
   TestFlutterDevice({

--- a/packages/flutter_tools/test/general.shard/hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/hot_test.dart
@@ -348,9 +348,7 @@ void main() {
 
     testUsingContext('disposes each device', () async {
       final MockDevice mockDevice1 = MockDevice();
-      when(mockDevice1.name).thenReturn('Al');
       final MockDevice mockDevice2 = MockDevice();
-      when(mockDevice2.name).thenReturn('Ferny');
       final MockFlutterDevice mockFlutterDevice1 = mockFlutterDeviceFactory(mockDevice1);
       final MockFlutterDevice mockFlutterDevice2 = mockFlutterDeviceFactory(mockDevice2);
 


### PR DESCRIPTION
## Description

In https://github.com/flutter/flutter/pull/42026 I added code to dispose all devices when exiting the hot runner, but forgot to do the same for the cold runner. This adds said code.

## Tests

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
