### PR TITLE
Added strokeWidth to RefreshIndicator

### DIFF
--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -102,9 +102,11 @@ class RefreshIndicator extends StatefulWidget {
     this.notificationPredicate = defaultScrollNotificationPredicate,
     this.semanticsLabel,
     this.semanticsValue,
+    this.strokeWidth = 2.0,
   }) : assert(child != null),
        assert(onRefresh != null),
        assert(notificationPredicate != null),
+       assert(strokeWidth != null),
        super(key: key);
 
   /// The widget below this widget in the tree.
@@ -148,6 +150,9 @@ class RefreshIndicator extends StatefulWidget {
 
   /// {@macro flutter.material.progressIndicator.semanticsValue}
   final String semanticsValue;
+
+  /// The width of the line used to draw the circle.
+  final double strokeWidth;
 
   @override
   RefreshIndicatorState createState() => RefreshIndicatorState();
@@ -458,6 +463,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
                       value: showIndeterminateIndicator ? null : _value.value,
                       valueColor: _valueColor,
                       backgroundColor: widget.backgroundColor,
+                      strokeWidth: widget.strokeWidth,
                     );
                   },
                 ),

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -423,4 +423,57 @@ void main() {
 
     debugDefaultTargetPlatformOverride = null;
   });
+
+  testWidgets('RefreshIndicator - default strokeWidth', (WidgetTester tester) async {
+    refreshCalled = true;
+    const double defaultStrokeWidth = 2.0;
+    final Key refreshIndicatorKey = UniqueKey();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RefreshIndicator(
+          key: refreshIndicatorKey,
+          onRefresh: holdRefresh,
+          child: ListView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            children: const <Widget>[
+              SizedBox(
+                height: 200.0,
+                child: Text('label'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final RefreshIndicator refreshIndicator = tester.widget(find.byKey(refreshIndicatorKey));
+    expect(refreshIndicator.strokeWidth, defaultStrokeWidth);
+  });
+
+  testWidgets('RefreshIndicator - custom strokeWidth', (WidgetTester tester) async {
+    refreshCalled = true;
+    const double customStrokeWidth = 5.0;
+    final Key refreshIndicatorKey = UniqueKey();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RefreshIndicator(
+          key: refreshIndicatorKey,
+          onRefresh: holdRefresh,
+          strokeWidth: customStrokeWidth,
+          child: ListView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            children: const <Widget>[
+              SizedBox(
+                height: 200.0,
+                child: Text('label'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final RefreshIndicator refreshIndicator = tester.widget(find.byKey(refreshIndicatorKey));
+    expect(refreshIndicator.strokeWidth, customStrokeWidth);
+  });
 }


### PR DESCRIPTION
## Description

Added `strokeWidth` property to the `RefreshIndicator`.

## Related Issues

Fixes #42570

## Tests

I added the following tests:

`RefreshIndicator - default strokeWidth`
`RefreshIndicator - custom strokeWidth`

in file `refresh_indicator_test.dart`

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
