### PR TITLE
fixes sliver list child layout offset calculation

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -928,13 +928,16 @@ class SliverLogicalParentData extends ParentData {
   ///
   /// The number of pixels from from the zero scroll offset of the parent sliver
   /// (the line at which its [SliverConstraints.scrollOffset] is zero) to the
-  /// side of the child closest to that offset.
+  /// side of the child closest to that offset. A [layoutOffset] can be null
+  /// when it cannot be determined. The value will be set after layout.
   ///
   /// In a typical list, this does not change as the parent is scrolled.
-  double layoutOffset = 0.0;
+  ///
+  /// Defaults to null.
+  double layoutOffset;
 
   @override
-  String toString() => 'layoutOffset=${layoutOffset.toStringAsFixed(1)}';
+  String toString() => 'layoutOffset=${layoutOffset == null ? 'None': layoutOffset.toStringAsFixed(1)}';
 }
 
 /// Parent data for slivers that have multiple children and that position their

--- a/packages/flutter/lib/src/rendering/sliver_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_list.dart
@@ -91,8 +91,28 @@ class RenderSliverList extends RenderSliverMultiBoxAdaptor {
     // it's possible for a child to get removed without notice.
     RenderBox leadingChildWithLayout, trailingChildWithLayout;
 
-    // Find the last child that is at or before the scrollOffset.
     RenderBox earliestUsefulChild = firstChild;
+
+    // A firstChild with null layout offset is likely a result of children
+    // reordering.
+    //
+    // We rely on firstChild to have accurate layout offset. In the case of null
+    // layout offset, we have to find the first child that has valid layout
+    // offset.
+    if (childScrollOffset(firstChild) == null) {
+      int leadingChildrenWithoutLayoutOffset = 0;
+      while (childScrollOffset(earliestUsefulChild) == null) {
+        earliestUsefulChild = childAfter(firstChild);
+        leadingChildrenWithoutLayoutOffset += 1;
+      }
+      // We should be able to destroy children with null layout offset safely,
+      // because they are likely outside of viewport
+      collectGarbage(leadingChildrenWithoutLayoutOffset, 0);
+      assert(firstChild != null);
+    }
+
+    // Find the last child that is at or before the scrollOffset.
+    earliestUsefulChild = firstChild;
     for (double earliestScrollOffset = childScrollOffset(earliestUsefulChild);
         earliestScrollOffset > scrollOffset;
         earliestScrollOffset = childScrollOffset(earliestUsefulChild)) {
@@ -140,12 +160,15 @@ class RenderSliverList extends RenderSliverMultiBoxAdaptor {
           correction += paintExtentOf(firstChild);
           earliestUsefulChild = insertAndLayoutLeadingChild(childConstraints, parentUsesSize: true);
         }
-        geometry = SliverGeometry(
-          scrollOffsetCorrection: correction - earliestScrollOffset,
-        );
-        final SliverMultiBoxAdaptorParentData childParentData = firstChild.parentData as SliverMultiBoxAdaptorParentData;
-        childParentData.layoutOffset = 0.0;
-        return;
+        earliestUsefulChild = firstChild;
+        if ((correction - earliestScrollOffset).abs() > precisionErrorTolerance) {
+          geometry = SliverGeometry(
+            scrollOffsetCorrection: correction - earliestScrollOffset,
+          );
+          final SliverMultiBoxAdaptorParentData childParentData = firstChild.parentData as SliverMultiBoxAdaptorParentData;
+          childParentData.layoutOffset = 0.0;
+          return;
+        }
       }
 
       final SliverMultiBoxAdaptorParentData childParentData = earliestUsefulChild.parentData as SliverMultiBoxAdaptorParentData;

--- a/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
+++ b/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
@@ -578,7 +578,6 @@ abstract class RenderSliverMultiBoxAdaptor extends RenderSliver
     assert(child != null);
     assert(child.parent == this);
     final SliverMultiBoxAdaptorParentData childParentData = child.parentData as SliverMultiBoxAdaptorParentData;
-    assert(childParentData.layoutOffset != null);
     return childParentData.layoutOffset;
   }
 

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1069,6 +1069,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
     assert(_currentlyUpdatingChildIndex == null);
     try {
       final SplayTreeMap<int, Element> newChildren = SplayTreeMap<int, Element>();
+      final Map<int, double> indexToLayoutOffset = HashMap<int, double>();
 
       void processElement(int index) {
         _currentlyUpdatingChildIndex = index;
@@ -1080,17 +1081,31 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
         if (newChild != null) {
           _childElements[index] = newChild;
           final SliverMultiBoxAdaptorParentData parentData = newChild.renderObject.parentData as SliverMultiBoxAdaptorParentData;
+          if (index == 0) {
+            parentData.layoutOffset = 0.0;
+          } else if (indexToLayoutOffset.containsKey(index)) {
+            parentData.layoutOffset = indexToLayoutOffset[index];
+          }
           if (!parentData.keptAlive)
             _currentBeforeChild = newChild.renderObject as RenderBox;
         } else {
           _childElements.remove(index);
         }
       }
-
       for (final int index in _childElements.keys.toList()) {
         final Key key = _childElements[index].widget.key;
         final int newIndex = key == null ? null : widget.delegate.findIndexByKey(key);
+        final SliverMultiBoxAdaptorParentData childParentData =
+          _childElements[index].renderObject?.parentData as SliverMultiBoxAdaptorParentData;
+
+        if (childParentData != null && childParentData.layoutOffset != null)
+          indexToLayoutOffset[index] = childParentData.layoutOffset;
+
         if (newIndex != null && newIndex != index) {
+          // The layout offset of the child being moved is no longer accurate.
+          if (childParentData != null)
+            childParentData.layoutOffset = null;
+
           newChildren[newIndex] = _childElements[index];
           // We need to make sure the original index gets processed.
           newChildren.putIfAbsent(index, () => null);
@@ -1309,7 +1324,8 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
           break;
       }
 
-      return parentData.layoutOffset < renderObject.constraints.scrollOffset + renderObject.constraints.remainingPaintExtent &&
+      return parentData.layoutOffset != null &&
+          parentData.layoutOffset < renderObject.constraints.scrollOffset + renderObject.constraints.remainingPaintExtent &&
           parentData.layoutOffset + itemExtent > renderObject.constraints.scrollOffset;
     }).forEach(visitor);
   }

--- a/packages/flutter/test/rendering/slivers_block_test.dart
+++ b/packages/flutter/test/rendering/slivers_block_test.dart
@@ -340,18 +340,20 @@ void main() {
     final SliverMultiBoxAdaptorParentData candidate = SliverMultiBoxAdaptorParentData();
     expect(candidate.keepAlive, isFalse);
     expect(candidate.index, isNull);
-    expect(candidate.toString(), 'index=null; layoutOffset=0.0');
+    expect(candidate.toString(), 'index=null; layoutOffset=None');
     candidate.keepAlive = null;
-    expect(candidate.toString(), 'index=null; layoutOffset=0.0');
+    expect(candidate.toString(), 'index=null; layoutOffset=None');
     candidate.keepAlive = true;
-    expect(candidate.toString(), 'index=null; keepAlive; layoutOffset=0.0');
+    expect(candidate.toString(), 'index=null; keepAlive; layoutOffset=None');
     candidate.keepAlive = false;
-    expect(candidate.toString(), 'index=null; layoutOffset=0.0');
+    expect(candidate.toString(), 'index=null; layoutOffset=None');
     candidate.index = 0;
-    expect(candidate.toString(), 'index=0; layoutOffset=0.0');
+    expect(candidate.toString(), 'index=0; layoutOffset=None');
     candidate.index = 1;
-    expect(candidate.toString(), 'index=1; layoutOffset=0.0');
+    expect(candidate.toString(), 'index=1; layoutOffset=None');
     candidate.index = -1;
-    expect(candidate.toString(), 'index=-1; layoutOffset=0.0');
+    expect(candidate.toString(), 'index=-1; layoutOffset=None');
+    candidate.layoutOffset = 100.0;
+    expect(candidate.toString(), 'index=-1; layoutOffset=100.0');
   });
 }

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -50,7 +50,8 @@ Future<void> testSliverFixedExtentList(WidgetTester tester, List<String> items) 
               findChildIndexCallback: (Key key) {
                 final ValueKey<String> valueKey = key as ValueKey<String>;
                 final String data = valueKey.value;
-                return items.indexOf(data);
+                final int index = items.indexOf(data);
+                return index == -1 ? null : index;
               },
             ),
           ),


### PR DESCRIPTION
## Description

Sliver list layout rely on the first child layout offset is accurate in order to adjust scroll offset and layout offset of remaining children.

If the first child layout offset is inaccurate there are two things that can happens.

1, if first child has layout offset of zero, it will prevent scrollable to scroll back if there is more children above it.

2, the scroll offset will jump after correction.
For example
scroll offset is 1000 and visible children have layout offsets of 1000, 1200, 1400
If the first child layout offset become 0 after reordering. it will update the children layout offsets to 0, 200, 400 with max scroll extent of only 400. This will cause it to overscroll and fire a ballistic scroll animation from 1000 to 400 which result in a jump.

To fix these two issues, I make the default value of layout offset to be null. When a reordering happens, the children that get moved around will have their layout offsets set to null again to indicate the layout offset is inaccurate.

During the layout of sliver_list, it will first check if the first child has null layout offset, and recalculate if needed.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/42142

## Tests

I added the following tests:

'SliverList should recalculate inaccurate layout offset'

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
