### PR TITLE
don't precompile dependencies when building the flutter tool

### DIFF
--- a/bin/flutter
+++ b/bin/flutter
@@ -43,7 +43,7 @@ function retry_upgrade {
   local total_tries="10"
   local remaining_tries=$((total_tries - 1))
   while [[ "$remaining_tries" -gt 0 ]]; do
-    (cd "$FLUTTER_TOOLS_DIR" && "$PUB" upgrade "$VERBOSITY") && break
+    (cd "$FLUTTER_TOOLS_DIR" && "$PUB" upgrade "$VERBOSITY" --no-precompile) && break
     echo "Error: Unable to 'pub upgrade' flutter tool. Retrying in five seconds... ($remaining_tries tries left)"
     remaining_tries=$((remaining_tries - 1))
     sleep 5

--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -136,7 +136,7 @@ GOTO :after_subroutine
       SET /A remaining_tries=%total_tries%-1
       :retry_pub_upgrade
         ECHO Running pub upgrade...
-        CALL "%pub%" upgrade "%VERBOSITY%"
+        CALL "%pub%" upgrade "%VERBOSITY%" --no-precompile
         IF "%ERRORLEVEL%" EQU "0" goto :upgrade_succeeded
         ECHO Error (%ERRORLEVEL%): Unable to 'pub upgrade' flutter tool. Retrying in five seconds... (%remaining_tries% tries left)
         timeout /t 5 /nobreak 2>NUL


### PR DESCRIPTION
## Description

Pub by default creates a snapshot of all executables from all direct dependencies on `pub get/upgrade` which is slow.

To make things worse, since flutter_tool pins all transitive deps that means it compiles all transitive executables since they all look like immediate deps.

Passing --no-precompile speeds up the `pub get/upgrade` step for flutter tool significantly by skipping this precompile step.

### Timing breakdown

Without --no-precompile:

real	0m20.911s
user	1m38.711s
sys	0m4.446s

With --no-precompile:

real	0m6.257s
user	0m1.756s
sys	0m0.167s

These differences will be a lot more pronounced on machines with fewer cores as well.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.