### PR TITLE
enable rendering tests on the Web

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -443,7 +443,6 @@ Future<void> _runWebTests() async {
     'test/cupertino',
     'test/examples',
     'test/material',
-    'test/rendering',
     'test/widgets',
   ];
 

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -586,5 +586,5 @@ void main() {
 
     editable.layout(BoxConstraints.loose(const Size(1000.0, 1000.0)));
     expect(editable.maxScrollExtent, equals(10));
-  });
+  }, skip: isBrowser); // TODO(yjbanov): https://github.com/flutter/flutter/issues/42772
 }

--- a/packages/flutter/test/rendering/layers_test.dart
+++ b/packages/flutter/test/rendering/layers_test.dart
@@ -534,7 +534,7 @@ void main() {
     // Ensure we can render the same scene again after rendering an interior
     // layer.
     parent.buildScene(SceneBuilder());
-  });
+  }, skip: isBrowser); // TODO(yjbanov): `toImage` doesn't work on the Web: https://github.com/flutter/flutter/issues/42767
 }
 
 class _TestAlwaysNeedsAddToSceneLayer extends ContainerLayer {

--- a/packages/flutter/test/rendering/localized_fonts_test.dart
+++ b/packages/flutter/test/rendering/localized_fonts_test.dart
@@ -55,6 +55,7 @@ void main() {
         ),
       );
     },
+    skip: isBrowser, // TODO(yjbanov): implement goldens on the Web: https://github.com/flutter/flutter/issues/40297
   );
 
   testWidgets(
@@ -109,6 +110,7 @@ void main() {
         ),
       );
     },
+    skip: isBrowser, // TODO(yjbanov): implement goldens on the Web: https://github.com/flutter/flutter/issues/40297
   );
 
   testWidgets(
@@ -155,6 +157,7 @@ void main() {
         ),
       );
     },
+    skip: isBrowser, // TODO(yjbanov): implement goldens on the Web: https://github.com/flutter/flutter/issues/40297
   );
 
 }

--- a/packages/flutter/test/rendering/platform_view_test.dart
+++ b/packages/flutter/test/rendering/platform_view_test.dart
@@ -68,5 +68,5 @@ void main() {
 
       semanticsHandle.dispose();
     });
-  });
+  }, skip: isBrowser); // TODO(yjbanov): fails on Web with obscured stack trace: https://github.com/flutter/flutter/issues/42770
 }


### PR DESCRIPTION
## Description

Enable rendering rests on the Web

## Related Issues

Fixes https://github.com/flutter/flutter/issues/41916