### PR TITLE
Fix memory leak in TransitionRoute

### DIFF
--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -504,6 +504,7 @@ void main() {
       verifyNoMoreInteractions(pageRouteAware);
     });
   });
+
   testWidgets('Can autofocus a TextField nested in a Focus in a route.', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController();
 
@@ -532,6 +533,264 @@ void main() {
 
     expect(focusNode.hasPrimaryFocus, isTrue);
   });
+
+  group('TrasitionRoute', () {
+    testWidgets('secondary animation is kDismissed when next route finishes pop', (WidgetTester tester) async {
+      final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: navigator,
+          home: const Text('home'),
+        )
+      );
+
+      // Push page one, its secondary animation is kAlwaysDismissedAnimation.
+      ProxyAnimation secondaryAnimationProxyPageOne;
+      ProxyAnimation animationPageOne;
+      navigator.currentState.push(
+        PageRouteBuilder<void>(
+          pageBuilder: (_, Animation<double> animation, Animation<double> secondaryAnimation) {
+            secondaryAnimationProxyPageOne = secondaryAnimation;
+            animationPageOne = animation;
+            return const Text('Page One');
+          },
+        ),
+      );
+      await tester.pump();
+      await tester.pumpAndSettle();
+      final ProxyAnimation secondaryAnimationPageOne = secondaryAnimationProxyPageOne.parent;
+      expect(animationPageOne.value, 1.0);
+      expect(secondaryAnimationPageOne.parent, kAlwaysDismissedAnimation);
+
+      // Push page two, the secondary animation of page one is the primary
+      // animation of page two.
+      ProxyAnimation secondaryAnimationProxyPageTwo;
+      ProxyAnimation animationPageTwo;
+      navigator.currentState.push(
+        PageRouteBuilder<void>(
+          pageBuilder: (_, Animation<double> animation, Animation<double> secondaryAnimation) {
+            secondaryAnimationProxyPageTwo = secondaryAnimation;
+            animationPageTwo = animation;
+            return const Text('Page Two');
+          },
+        ),
+      );
+      await tester.pump();
+      await tester.pumpAndSettle();
+      final ProxyAnimation secondaryAnimationPageTwo = secondaryAnimationProxyPageTwo.parent;
+      expect(animationPageTwo.value, 1.0);
+      expect(secondaryAnimationPageTwo.parent, kAlwaysDismissedAnimation);
+      expect(secondaryAnimationPageOne.parent, animationPageTwo.parent);
+
+      // Pop page two, the secondary animation of page one becomes
+      // kAlwaysDismissedAnimation.
+      navigator.currentState.pop();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(secondaryAnimationPageOne.parent, animationPageTwo.parent);
+      await tester.pumpAndSettle();
+      expect(animationPageTwo.value, 0.0);
+      expect(secondaryAnimationPageOne.parent, kAlwaysDismissedAnimation);
+    });
+
+    testWidgets('secondary animation is kDismissed when next route is removed', (WidgetTester tester) async {
+      final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+      await tester.pumpWidget(
+          MaterialApp(
+            navigatorKey: navigator,
+            home: const Text('home'),
+          )
+      );
+
+      // Push page one, its secondary animation is kAlwaysDismissedAnimation.
+      ProxyAnimation secondaryAnimationProxyPageOne;
+      ProxyAnimation animationPageOne;
+      navigator.currentState.push(
+        PageRouteBuilder<void>(
+          pageBuilder: (_, Animation<double> animation, Animation<double> secondaryAnimation) {
+            secondaryAnimationProxyPageOne = secondaryAnimation;
+            animationPageOne = animation;
+            return const Text('Page One');
+          },
+        ),
+      );
+      await tester.pump();
+      await tester.pumpAndSettle();
+      final ProxyAnimation secondaryAnimationPageOne = secondaryAnimationProxyPageOne.parent;
+      expect(animationPageOne.value, 1.0);
+      expect(secondaryAnimationPageOne.parent, kAlwaysDismissedAnimation);
+
+      // Push page two, the secondary animation of page one is the primary
+      // animation of page two.
+      ProxyAnimation secondaryAnimationProxyPageTwo;
+      ProxyAnimation animationPageTwo;
+      Route<void> secondRoute;
+      navigator.currentState.push(
+        secondRoute = PageRouteBuilder<void>(
+          pageBuilder: (_, Animation<double> animation, Animation<double> secondaryAnimation) {
+            secondaryAnimationProxyPageTwo = secondaryAnimation;
+            animationPageTwo = animation;
+            return const Text('Page Two');
+          },
+        ),
+      );
+      await tester.pump();
+      await tester.pumpAndSettle();
+      final ProxyAnimation secondaryAnimationPageTwo = secondaryAnimationProxyPageTwo.parent;
+      expect(animationPageTwo.value, 1.0);
+      expect(secondaryAnimationPageTwo.parent, kAlwaysDismissedAnimation);
+      expect(secondaryAnimationPageOne.parent, animationPageTwo.parent);
+
+      // Remove the second route, the secondary animation of page one is
+      // kAlwaysDismissedAnimation again.
+      navigator.currentState.removeRoute(secondRoute);
+      await tester.pump();
+      expect(secondaryAnimationPageOne.parent, kAlwaysDismissedAnimation);
+    });
+
+    testWidgets('secondary animation is kDismissed after train hopping finishes and pop', (WidgetTester tester) async {
+      final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+      await tester.pumpWidget(
+          MaterialApp(
+            navigatorKey: navigator,
+            home: const Text('home'),
+          )
+      );
+
+      // Push page one, its secondary animation is kAlwaysDismissedAnimation.
+      ProxyAnimation secondaryAnimationProxyPageOne;
+      ProxyAnimation animationPageOne;
+      navigator.currentState.push(
+        PageRouteBuilder<void>(
+          pageBuilder: (_, Animation<double> animation, Animation<double> secondaryAnimation) {
+            secondaryAnimationProxyPageOne = secondaryAnimation;
+            animationPageOne = animation;
+            return const Text('Page One');
+          },
+        ),
+      );
+      await tester.pump();
+      await tester.pumpAndSettle();
+      final ProxyAnimation secondaryAnimationPageOne = secondaryAnimationProxyPageOne.parent;
+      expect(animationPageOne.value, 1.0);
+      expect(secondaryAnimationPageOne.parent, kAlwaysDismissedAnimation);
+
+      // Push page two, the secondary animation of page one is the primary
+      // animation of page two.
+      ProxyAnimation animationPageTwo;
+      navigator.currentState.push(
+        PageRouteBuilder<void>(
+          pageBuilder: (_, Animation<double> animation, Animation<double> secondaryAnimation) {
+            animationPageTwo = animation;
+            return const Text('Page Two');
+          },
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(secondaryAnimationPageOne.parent, animationPageTwo.parent);
+
+      // Replace with a different route while push is ongoing to trigger
+      // TrainHopping.
+      ProxyAnimation animationPageThree;
+      navigator.currentState.pushReplacement(
+        TestPageRouteBuilder(
+          pageBuilder: (_, Animation<double> animation, Animation<double> secondaryAnimation) {
+            animationPageThree = animation;
+            return const Text('Page Three');
+          },
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 1));
+      expect(secondaryAnimationPageOne.parent, isA<TrainHoppingAnimation>());
+      final TrainHoppingAnimation trainHopper = secondaryAnimationPageOne.parent;
+      expect(trainHopper.currentTrain, animationPageTwo.parent);
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(secondaryAnimationPageOne.parent, isNot(isA<TrainHoppingAnimation>()));
+      expect(secondaryAnimationPageOne.parent, animationPageThree.parent);
+      expect(trainHopper.currentTrain, isNull); // Has been disposed.
+      await tester.pumpAndSettle();
+      expect(secondaryAnimationPageOne.parent, animationPageThree.parent);
+
+      // Pop page three.
+      navigator.currentState.pop();
+      await tester.pump();
+      await tester.pumpAndSettle();
+      expect(secondaryAnimationPageOne.parent, kAlwaysDismissedAnimation);
+    });
+
+    testWidgets('secondary animation is kDismissed when train hopping is interrupted', (WidgetTester tester) async {
+      final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+      await tester.pumpWidget(
+          MaterialApp(
+            navigatorKey: navigator,
+            home: const Text('home'),
+          )
+      );
+
+      // Push page one, its secondary animation is kAlwaysDismissedAnimation.
+      ProxyAnimation secondaryAnimationProxyPageOne;
+      ProxyAnimation animationPageOne;
+      navigator.currentState.push(
+        PageRouteBuilder<void>(
+          pageBuilder: (_, Animation<double> animation, Animation<double> secondaryAnimation) {
+            secondaryAnimationProxyPageOne = secondaryAnimation;
+            animationPageOne = animation;
+            return const Text('Page One');
+          },
+        ),
+      );
+      await tester.pump();
+      await tester.pumpAndSettle();
+      final ProxyAnimation secondaryAnimationPageOne = secondaryAnimationProxyPageOne.parent;
+      expect(animationPageOne.value, 1.0);
+      expect(secondaryAnimationPageOne.parent, kAlwaysDismissedAnimation);
+
+      // Push page two, the secondary animation of page one is the primary
+      // animation of page two.
+      ProxyAnimation animationPageTwo;
+      navigator.currentState.push(
+        PageRouteBuilder<void>(
+          pageBuilder: (_, Animation<double> animation, Animation<double> secondaryAnimation) {
+            animationPageTwo = animation;
+            return const Text('Page Two');
+          },
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(secondaryAnimationPageOne.parent, animationPageTwo.parent);
+
+      // Replace with a different route while push is ongoing to trigger
+      // TrainHopping.
+      ProxyAnimation animationPageThree;
+      navigator.currentState.pushReplacement(
+        TestPageRouteBuilder(
+          pageBuilder: (_, Animation<double> animation, Animation<double> secondaryAnimation) {
+            animationPageThree = animation;
+            return const Text('Page Three');
+          },
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 10));
+      expect(secondaryAnimationPageOne.parent, isA<TrainHoppingAnimation>());
+      final TrainHoppingAnimation trainHopper = secondaryAnimationPageOne.parent;
+      expect(trainHopper.currentTrain, animationPageTwo.parent);
+
+      // Pop page three while replacement push is ongoing.
+      navigator.currentState.pop();
+      await tester.pump();
+      expect(secondaryAnimationPageOne.parent, isA<TrainHoppingAnimation>());
+      final TrainHoppingAnimation trainHopper2 = secondaryAnimationPageOne.parent;
+      expect(trainHopper2.currentTrain, animationPageTwo.parent);
+      expect(trainHopper.currentTrain, isNull); // Has been disposed.
+      await tester.pumpAndSettle();
+      expect(secondaryAnimationPageOne.parent, kAlwaysDismissedAnimation);
+      expect(trainHopper2.currentTrain, isNull); // Has been disposed.
+    });
+  });
 }
 
 class MockPageRoute extends Mock implements PageRoute<dynamic> { }
@@ -539,3 +798,12 @@ class MockPageRoute extends Mock implements PageRoute<dynamic> { }
 class MockRoute extends Mock implements Route<dynamic> { }
 
 class MockRouteAware extends Mock implements RouteAware { }
+
+class TestPageRouteBuilder extends PageRouteBuilder<void> {
+  TestPageRouteBuilder({RoutePageBuilder pageBuilder}) : super(pageBuilder: pageBuilder);
+
+  @override
+  Animation<double> createAnimation() {
+    return CurvedAnimation(parent: super.createAnimation(), curve: Curves.easeOutExpo);
+  }
+}

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -764,11 +764,9 @@ void main() {
 
       // Replace with a different route while push is ongoing to trigger
       // TrainHopping.
-      ProxyAnimation animationPageThree;
       navigator.currentState.pushReplacement(
         TestPageRouteBuilder(
           pageBuilder: (_, Animation<double> animation, Animation<double> secondaryAnimation) {
-            animationPageThree = animation;
             return const Text('Page Three');
           },
         ),


### PR DESCRIPTION
## Description

Fixes a memory leak in the TransitionRoute that was keeping multiple routes in memory even though they have long been disposed. The secondary animation of a route points to the primary animation of the next route. We were not clearing this pointer even when the next route was disposed. This pointer kept most of the next route unnecessary in memory (until a different route was pushed on top of it).

Additionally, we were also not properly disposing the TrainHoppingAnimation when it was created at a time where `currentTrain.value == nextTrain.value` (because `onSwitchedTrain` never fires in these cases). This is also fixed in this PR.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/42422.
Fixes https://github.com/flutter/flutter/issues/5631.

## Tests

I added the following tests:

* secondary animation pointers are cleared when the route owning the actual animation is disposed.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
