### PR TITLE
Enable macOS desktop on dev channel

### DIFF
--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -98,6 +98,10 @@ const Feature flutterMacOSDesktopFeature = Feature(
     available: true,
     enabledByDefault: false,
   ),
+  dev: FeatureChannelSetting(
+    available: true,
+    enabledByDefault: false,
+  ),
 );
 
 /// The [Feature] for Linux desktop.

--- a/packages/flutter_tools/test/general.shard/features_test.dart
+++ b/packages/flutter_tools/test/general.shard/features_test.dart
@@ -78,19 +78,27 @@ void main() {
     }));
 
     test('flutter web help string', () {
-      expect(flutterWebFeature.generateHelpMessage(), 'Enable or disable Flutter for web. This setting will take effect on the master and dev channels.');
+      expect(flutterWebFeature.generateHelpMessage(),
+        'Enable or disable Flutter for web. This setting will take effect on '
+        'the master and dev channels.');
     });
 
     test('flutter macOS desktop help string', () {
-      expect(flutterMacOSDesktopFeature.generateHelpMessage(), 'Enable or disable Flutter for desktop on macOS. This setting will take effect on the master channel.');
+      expect(flutterMacOSDesktopFeature.generateHelpMessage(),
+        'Enable or disable Flutter for desktop on macOS. This setting will take'
+        ' effect on the master and dev channels.');
     });
 
     test('flutter Linux desktop help string', () {
-      expect(flutterLinuxDesktopFeature.generateHelpMessage(), 'Enable or disable Flutter for desktop on Linux. This setting will take effect on the master channel.');
+      expect(flutterLinuxDesktopFeature.generateHelpMessage(),
+        'Enable or disable Flutter for desktop on Linux. This setting will take'
+        ' effect on the master channel.');
     });
 
     test('flutter Windows desktop help string', () {
-      expect(flutterWindowsDesktopFeature.generateHelpMessage(), 'Enable or disable Flutter for desktop on Windows. This setting will take effect on the master channel.');
+      expect(flutterWindowsDesktopFeature.generateHelpMessage(),
+        'Enable or disable Flutter for desktop on Windows. This setting will '
+        'take effect on the master channel.');
     });
 
     test('help string on multiple channels', () {
@@ -217,18 +225,18 @@ void main() {
       expect(featureFlags.isMacOSEnabled, false);
     }));
 
-    test('flutter macos desktop not enabled with config on dev', () => testbed.run(() {
+    test('flutter macos desktop enabled with config on dev', () => testbed.run(() {
       when(mockFlutterVerion.channel).thenReturn('dev');
-      when<bool>(mockFlutterConfig.getValue('flutter-desktop-macos')).thenReturn(true);
+      when<bool>(mockFlutterConfig.getValue('enable-macos-desktop')).thenReturn(true);
 
-      expect(featureFlags.isMacOSEnabled, false);
+      expect(featureFlags.isMacOSEnabled, true);
     }));
 
-    test('flutter macos desktop not enabled with environment variable on dev', () => testbed.run(() {
+    test('flutter macos desktop enabled with environment variable on dev', () => testbed.run(() {
       when(mockFlutterVerion.channel).thenReturn('dev');
       when(mockPlatform.environment).thenReturn(<String, String>{'ENABLE_FLUTTER_DESKTOP': 'true'});
 
-      expect(featureFlags.isMacOSEnabled, false);
+      expect(featureFlags.isMacOSEnabled, true);
     }));
 
     test('flutter macos desktop off by default on beta', () => testbed.run(() {
@@ -239,7 +247,7 @@ void main() {
 
     test('fflutter macos desktop not enabled with config on beta', () => testbed.run(() {
       when(mockFlutterVerion.channel).thenReturn('beta');
-      when<bool>(mockFlutterConfig.getValue('flutter-desktop-macos')).thenReturn(true);
+      when<bool>(mockFlutterConfig.getValue('enable-macos-desktop')).thenReturn(true);
 
       expect(featureFlags.isMacOSEnabled, false);
     }));
@@ -259,7 +267,7 @@ void main() {
 
     test('flutter macos desktop not enabled with config on stable', () => testbed.run(() {
       when(mockFlutterVerion.channel).thenReturn('stable');
-      when<bool>(mockFlutterConfig.getValue('flutter-desktop-macos')).thenReturn(true);
+      when<bool>(mockFlutterConfig.getValue('enable-macos-desktop')).thenReturn(true);
 
       expect(featureFlags.isMacOSEnabled, false);
     }));


### PR DESCRIPTION
## Description

Using the same config value as for master, this PR makes macOS desktop available on the dev channel.