### PR TITLE
Add most of the widget tests; add more web test shards

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -182,6 +182,36 @@ task:
       container:
         cpu: 4
         memory: 12G
+    - name: web_tests-linux-shard-3
+      use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
+      env:
+        SHARD: web_tests
+        WEB_SHARD: 3
+      test_script:
+        - dart --enable-asserts ./dev/bots/test.dart
+      container:
+        cpu: 4
+        memory: 12G
+    - name: web_tests-linux-shard-4
+      use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
+      env:
+        SHARD: web_tests
+        WEB_SHARD: 4
+      test_script:
+        - dart --enable-asserts ./dev/bots/test.dart
+      container:
+        cpu: 4
+        memory: 12G
+    - name: web_tests-linux-shard-5
+      use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
+      env:
+        SHARD: web_tests
+        WEB_SHARD: 5
+      test_script:
+        - dart --enable-asserts ./dev/bots/test.dart
+      container:
+        cpu: 4
+        memory: 12G
     - name: build_tests-linux
       env:
         SHARD: build_tests

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -434,23 +434,35 @@ Future<void> _runTests() async {
   print('${bold}DONE: All tests successful.$reset');
 }
 
+// TODO(yjbanov): we're getting rid of these blacklists as part of https://github.com/flutter/flutter/projects/60
+const List<String> kWebTestDirectoryBlacklist = <String>[
+  'test/cupertino',
+  'test/examples',
+  'test/material',
+];
+const List<String> kWebTestFileBlacklist = <String>[
+  'test/widgets/heroes_test.dart',
+  'test/widgets/text_test.dart',
+  'test/widgets/selectable_text_test.dart',
+  'test/widgets/color_filter_test.dart',
+  'test/widgets/editable_text_cursor_test.dart',
+  'test/widgets/shadow_test.dart',
+  'test/widgets/raw_keyboard_listener_test.dart',
+  'test/widgets/editable_text_test.dart',
+  'test/widgets/widget_inspector_test.dart',
+  'test/widgets/draggable_test.dart',
+  'test/widgets/shortcuts_test.dart',
+];
+
 Future<void> _runWebTests() async {
   final Directory flutterPackageDir = Directory(path.join(flutterRoot, 'packages', 'flutter'));
   final Directory testDir = Directory(path.join(flutterPackageDir.path, 'test'));
-
-  // TODO(yjbanov): we're getting rid of this blacklist as part of https://github.com/flutter/flutter/projects/60
-  const List<String> kBlacklist = <String>[
-    'test/cupertino',
-    'test/examples',
-    'test/material',
-    'test/widgets',
-  ];
 
   final List<String> directories = testDir
     .listSync()
     .whereType<Directory>()
     .map<String>((Directory dir) => path.relative(dir.path, from: flutterPackageDir.path))
-    .where((String relativePath) => !kBlacklist.contains(relativePath))
+    .where((String relativePath) => !kWebTestDirectoryBlacklist.contains(relativePath))
     .toList();
 
   await _runFlutterWebTest(flutterPackageDir.path, tests: directories);
@@ -687,7 +699,7 @@ class EvalResult {
 ///
 /// WARNING: if you change this number, also change .cirrus.yml
 /// and make sure it runs _all_ shards.
-const int _kWebShardCount = 3;
+const int _kWebShardCount = 6;
 
 Future<void> _runFlutterWebTest(String workingDirectory, {
   List<String> tests,
@@ -699,7 +711,8 @@ Future<void> _runFlutterWebTest(String workingDirectory, {
       testDir.listSync(recursive: true)
         .whereType<File>()
         .where((File file) => file.path.endsWith('_test.dart'))
-        .map((File file) => path.relative(file.path, from: workingDirectory))
+        .map<String>((File file) => path.relative(file.path, from: workingDirectory))
+        .where((String filePath) => !kWebTestFileBlacklist.contains(filePath)),
     );
   }
 

--- a/packages/flutter/test/widgets/html_element_view_test.dart
+++ b/packages/flutter/test/widgets/html_element_view_test.dart
@@ -196,7 +196,8 @@ void main() {
       // is not yet in the tree.
       await tester.pump();
 
-      final SemanticsNode semantics = tester.getSemantics(find.byType(HtmlElementView));
+      // The platform view ID is set on the child of the HtmlElementView render object.
+      final SemanticsNode semantics = tester.getSemantics(find.byType(PlatformViewSurface));
 
       expect(semantics.platformViewId, currentViewId + 1);
       expect(semantics.rect, const Rect.fromLTWH(0, 0, 200, 100));


### PR DESCRIPTION
## Description

Add most of the /test/widgets/ tests to the CI matrix and increase the number of Web test shards.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/41913