### PR TITLE
Run flutter pub get before pod install in platform_view_ios__start_up test

### DIFF
--- a/dev/devicelab/bin/tasks/platform_view_ios__start_up.dart
+++ b/dev/devicelab/bin/tasks/platform_view_ios__start_up.dart
@@ -13,8 +13,15 @@ import 'package:flutter_devicelab/framework/framework.dart';
 Future<void> main() async {
   deviceOperatingSystem = DeviceOperatingSystem.ios;
   await task(() async {
+    final String platformViewDirectoryPath = '${flutterDirectory.path}/examples/platform_view';
+    final Directory platformViewDirectory = dir(
+      platformViewDirectoryPath
+    );
+    await inDirectory(platformViewDirectory, () async {
+      await flutter('pub', options: <String>['get']);
+    });
     final Directory iosDirectory = dir(
-      '${flutterDirectory.path}/examples/platform_view/ios',
+      '$platformViewDirectoryPath/ios',
     );
     await inDirectory(iosDirectory, () async {
       await exec('pod', <String>['install']);


### PR DESCRIPTION
## Description

`flutter pub get` must be run before `pod install`.  This behavior was always true, but now it's enforced.

## Related Issues

Caused by https://github.com/flutter/flutter/pull/42029.

## Tests

platform_view_ios__start_up now passes.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.