### PR TITLE
Fix NPE in Chrome Device

### DIFF
--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -1,4 +1,3 @@
-
 // Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -1,3 +1,4 @@
+
 // Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -61,7 +62,7 @@ class ChromeDevice extends Device {
 
   @override
   DeviceLogReader getLogReader({ApplicationPackage app}) {
-    return NoOpDeviceLogReader(app.name);
+    return NoOpDeviceLogReader(app?.name);
   }
 
   @override

--- a/packages/flutter_tools/test/general.shard/web/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devices_test.dart
@@ -42,6 +42,7 @@ void main() {
     expect(chromeDevice.supportsScreenshot, false);
     expect(await chromeDevice.isLocalEmulator, false);
     expect(chromeDevice.getLogReader(app: mockWebApplicationPackage), isInstanceOf<NoOpDeviceLogReader>());
+    expect(chromeDevice.getLogReader(), isInstanceOf<NoOpDeviceLogReader>());
     expect(await chromeDevice.portForwarder.forward(1), 1);
   });
 


### PR DESCRIPTION
## Description

Since the application package is not required, we need to handle being passed null.

Example stack:
```
NoSuchMethodError: The getter 'name' was called on null.
Receiver: null
Tried calling: name
  | at Object.noSuchMethod | (object_patch.dart:51 )
-- | -- | --
  | at ChromeDevice.getLogReader | (web_device.dart:64 )
  | at LogsCommand.runCommand | (logs.dart:49 )
  | at <asynchronous gap> | (async )
  | at FlutterCommand.verifyThenRunCommand | (flutter_command.dart:557 )
  | at _asyncThenWrapperHelper.<anonymous closure> | (async_patch.dart:71 )
  | at _rootRunUnary | (zone.dart:1132 )
  | at _CustomZone.runUnary | (zone.dart:1029 )
  | at _FutureListener.handleValue | (future_impl.dart:137 )
  | at Future._propagateToListeners.handleValueCallback | (future_impl.dart:678 )
  | at Future._propagateToListeners | (future_impl.dart:707 )
  | at Future._completeWithValue | (future_impl.dart:522 )
  | at Future._asyncComplete.<anonymous closure> | (future_impl.dart:552 )
  | at _rootRun | (zone.dart:1124 )
  | at _CustomZone.run | (zone.dart:1021 )
  | at _CustomZone.runGuarded | (zone.dart:923 )
  | at _CustomZone.bindCallbackGuarded.<anonymous closure> | (zone.dart:963 )
  | at _microtaskLoop | (schedule_microtask.dart:41 )
  | at _startMicrotaskLoop | (schedule_microtask.dart:50 )
  | at _runPendingImmediateCallback | (isolate_patch.dart:116 )
  | at _RawReceivePortImpl._handleMessage | (isolate_patch.dart:173 )
```
