### PR TITLE
Revert "Default colorScheme data in ButtonThemeData (fix for #38655)"

### DIFF
--- a/packages/flutter/lib/src/material/button_theme.dart
+++ b/packages/flutter/lib/src/material/button_theme.dart
@@ -83,7 +83,7 @@ class ButtonTheme extends InheritedTheme {
     Color hoverColor,
     Color highlightColor,
     Color splashColor,
-    ColorScheme colorScheme = const ColorScheme.light(),
+    ColorScheme colorScheme,
     MaterialTapTargetSize materialTapTargetSize,
     Widget child,
   }) : assert(textTheme != null),
@@ -91,7 +91,6 @@ class ButtonTheme extends InheritedTheme {
        assert(height != null && height >= 0.0),
        assert(alignedDropdown != null),
        assert(layoutBehavior != null),
-       assert(colorScheme != null),
        data = ButtonThemeData(
          textTheme: textTheme,
          minWidth: minWidth,
@@ -180,14 +179,13 @@ class ButtonTheme extends InheritedTheme {
     Color hoverColor,
     Color highlightColor,
     Color splashColor,
-    ColorScheme colorScheme = const ColorScheme.light(),
+    ColorScheme colorScheme,
     Widget child,
     ButtonBarLayoutBehavior layoutBehavior = ButtonBarLayoutBehavior.padded,
   }) : assert(textTheme != null),
        assert(minWidth != null && minWidth >= 0.0),
        assert(height != null && height >= 0.0),
        assert(alignedDropdown != null),
-       assert(colorScheme != null),
        data = ButtonThemeData(
          textTheme: textTheme,
          minWidth: minWidth,
@@ -219,13 +217,15 @@ class ButtonTheme extends InheritedTheme {
   static ButtonThemeData of(BuildContext context) {
     final ButtonTheme inheritedButtonTheme = context.inheritFromWidgetOfExactType(ButtonTheme);
     ButtonThemeData buttonTheme = inheritedButtonTheme?.data;
-    if (buttonTheme == null) {
+    if (buttonTheme?.colorScheme == null) { // if buttonTheme or buttonTheme.colorScheme is null
       final ThemeData theme = Theme.of(context);
       buttonTheme ??= theme.buttonTheme;
-      buttonTheme = buttonTheme.copyWith(
-        colorScheme: theme.buttonTheme.colorScheme ?? const ColorScheme.light(),
-      );
-      assert(buttonTheme.colorScheme != null);
+      if (buttonTheme.colorScheme == null) {
+        buttonTheme = buttonTheme.copyWith(
+          colorScheme: theme.buttonTheme.colorScheme ?? theme.colorScheme,
+        );
+        assert(buttonTheme.colorScheme != null);
+      }
     }
     return buttonTheme;
   }
@@ -270,14 +270,13 @@ class ButtonThemeData extends Diagnosticable {
     Color hoverColor,
     Color highlightColor,
     Color splashColor,
-    this.colorScheme = const ColorScheme.light(),
+    this.colorScheme,
     MaterialTapTargetSize materialTapTargetSize,
   }) : assert(textTheme != null),
        assert(minWidth != null && minWidth >= 0.0),
        assert(height != null && height >= 0.0),
        assert(alignedDropdown != null),
        assert(layoutBehavior != null),
-       assert(colorScheme != null),
        _buttonColor = buttonColor,
        _disabledColor = disabledColor,
        _focusColor = focusColor,

--- a/packages/flutter/test/material/button_theme_test.dart
+++ b/packages/flutter/test/material/button_theme_test.dart
@@ -18,7 +18,6 @@ void main() {
     ));
     expect(theme.alignedDropdown, false);
     expect(theme.layoutBehavior, ButtonBarLayoutBehavior.padded);
-    expect(theme.colorScheme, const ColorScheme.light());
   });
 
   test('ButtonThemeData default overrides', () {
@@ -29,14 +28,12 @@ void main() {
       padding: EdgeInsets.zero,
       shape: RoundedRectangleBorder(),
       alignedDropdown: true,
-      colorScheme: ColorScheme.dark()
     );
     expect(theme.textTheme, ButtonTextTheme.primary);
     expect(theme.constraints, const BoxConstraints(minWidth: 100.0, minHeight: 200.0));
     expect(theme.padding, EdgeInsets.zero);
     expect(theme.shape, const RoundedRectangleBorder());
     expect(theme.alignedDropdown, true);
-    expect(theme.colorScheme, const ColorScheme.dark());
   });
 
   testWidgets('ButtonTheme defaults', (WidgetTester tester) async {
@@ -83,7 +80,7 @@ void main() {
       borderRadius: BorderRadius.all(Radius.circular(2.0)),
     ));
     expect(alignedDropdown, false);
-    expect(colorScheme, const ColorScheme.light());
+    expect(colorScheme, ThemeData.light().colorScheme);
     expect(tester.widget<Material>(find.byType(Material)).shape, shape);
     expect(tester.getSize(find.byType(Material)), const Size(88.0, 36.0));
   });
@@ -98,7 +95,7 @@ void main() {
       borderRadius: BorderRadius.all(Radius.circular(2.0)),
     ));
     expect(theme.alignedDropdown, false);
-    expect(theme.colorScheme, const ColorScheme.light());
+    expect(theme.colorScheme, null);
 
     theme = const ButtonThemeData().copyWith(
       textTheme: ButtonTextTheme.primary,
@@ -405,80 +402,4 @@ void main() {
   },
     semanticsEnabled: true,
   );
-
-  testWidgets('Default RaisedButton text color when textTheme is set to ButtonTextTheme.accent', (WidgetTester tester) async {
-    // Test for https://github.com/flutter/flutter/issues/38655
-    const Color defaultEnabledAccentTextColor = Color(0xff2196f3);
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: Center(
-            child: RaisedButton(
-              child: const Text('RaisedButton'),
-              onPressed: () {},
-              textTheme: ButtonTextTheme.accent,
-            ),
-          ),
-        ),
-      ),
-    );
-
-    Color getRaisedButtonTextColor() {
-      return tester.renderObject<RenderParagraph>(find.text('RaisedButton')).text.style.color;
-    }
-
-    expect(getRaisedButtonTextColor(), equals(defaultEnabledAccentTextColor));
-  });
-
-  testWidgets('default button theme primary color for RaisedButton', (WidgetTester tester) async {
-    // Test for https://github.com/flutter/flutter/issues/38655
-    const Color defaultEnabledPrimaryTextColor = Color(0xff000000);
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: Center(
-            child: RaisedButton(
-              child: const Text('RaisedButton'),
-              onPressed: () {},
-              textTheme: ButtonTextTheme.primary,
-            ),
-          ),
-        ),
-      ),
-    );
-
-    Color getRaisedButtonTextColor() {
-      return tester.renderObject<RenderParagraph>(find.text('RaisedButton')).text.style.color;
-    }
-
-    expect(getRaisedButtonTextColor(), equals(defaultEnabledPrimaryTextColor));
-  });
-
-  testWidgets('default button theme normal color for RaisedButton', (WidgetTester tester) async {
-    // Test for https://github.com/flutter/flutter/issues/38655
-    const Color defaultEnabledNormalTextColor = Color(0xffffffff);
-
-    await tester.pumpWidget(
-      MaterialApp(
-        theme: ThemeData.dark(),
-        home: Scaffold(
-          body: Center(
-            child: RaisedButton(
-              child: const Text('RaisedButton'),
-              onPressed: () {},
-              textTheme: ButtonTextTheme.normal
-            ),
-          ),
-        ),
-      ),
-    );
-
-    Color getRaisedButtonTextColor() {
-      return tester.renderObject<RenderParagraph>(find.text('RaisedButton')).text.style.color;
-    }
-
-    expect(getRaisedButtonTextColor(), equals(defaultEnabledNormalTextColor));
-  });
 }


### PR DESCRIPTION
This PR is problematic because it does not allow buttons to look at ThemeData's colorScheme, since ButtonTheme's colorScheme has a default value and cannot be null.

Reverts flutter/flutter#39627
Fixes https://github.com/flutter/flutter/issues/42838