### PR TITLE
Remove use_modular_headers from Podfiles using libraries

### DIFF
--- a/dev/integration_tests/android_views/ios/Podfile
+++ b/dev/integration_tests/android_views/ios/Podfile
@@ -33,8 +33,6 @@ def parse_KV_file(file, separator='=')
 end
 
 target 'Runner' do
-  use_modular_headers!
-  
   # Flutter Pod
 
   copied_flutter_dir = File.join(__dir__, 'Flutter')

--- a/dev/integration_tests/ios_add2app/Podfile
+++ b/dev/integration_tests/ios_add2app/Podfile
@@ -5,7 +5,6 @@ flutter_application_path = 'flutterapp/'
 load File.join(flutter_application_path, '.ios', 'Flutter', 'podhelper.rb')
 
 target 'ios_add2app' do
-  use_modular_headers!
   install_all_flutter_pods(flutter_application_path)
 end
 

--- a/dev/integration_tests/ios_host_app/Host/ViewController.m
+++ b/dev/integration_tests/ios_host_app/Host/ViewController.m
@@ -1,11 +1,6 @@
 #import "ViewController.h"
-
-@import Flutter;
-@import FlutterPluginRegistrant;
-
-// Prove plugins can be module-imported from the host app.
-@import device_info;
-@import google_maps_flutter;
+#import <Flutter/Flutter.h>
+#import <FlutterPluginRegistrant/GeneratedPluginRegistrant.h>
 
 @implementation ViewController
 

--- a/dev/integration_tests/ios_host_app/Podfile
+++ b/dev/integration_tests/ios_host_app/Podfile
@@ -4,6 +4,5 @@ flutter_application_path = '../hello'
 load File.join(flutter_application_path, '.ios', 'Flutter', 'podhelper.rb')
 
 target 'Host' do
-  use_modular_headers!
   install_all_flutter_pods flutter_application_path
 end

--- a/dev/integration_tests/ios_host_app_swift/Podfile
+++ b/dev/integration_tests/ios_host_app_swift/Podfile
@@ -4,6 +4,5 @@ flutter_application_path = '../hello'
 load File.join(flutter_application_path, '.ios', 'Flutter', 'podhelper.rb')
 
 target 'Host' do
-  use_modular_headers!
   install_all_flutter_pods flutter_application_path
 end

--- a/dev/integration_tests/release_smoke_test/ios/Podfile
+++ b/dev/integration_tests/release_smoke_test/ios/Podfile
@@ -33,8 +33,6 @@ def parse_KV_file(file, separator='=')
 end
 
 target 'Runner' do
-  use_modular_headers!
-  
   # Flutter Pod
 
   copied_flutter_dir = File.join(__dir__, 'Flutter')

--- a/examples/flutter_gallery/ios/Podfile
+++ b/examples/flutter_gallery/ios/Podfile
@@ -33,8 +33,6 @@ def parse_KV_file(file, separator='=')
 end
 
 target 'Runner' do
-  use_modular_headers!
-  
   # Flutter Pod
 
   copied_flutter_dir = File.join(__dir__, 'Flutter')

--- a/examples/platform_view/ios/Podfile
+++ b/examples/platform_view/ios/Podfile
@@ -33,8 +33,6 @@ def parse_KV_file(file, separator='=')
 end
 
 target 'Runner' do
-  use_modular_headers!
-  
   # Flutter Pod
 
   copied_flutter_dir = File.join(__dir__, 'Flutter')

--- a/packages/flutter_tools/templates/cocoapods/Podfile-ios-objc
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-ios-objc
@@ -33,8 +33,6 @@ def parse_KV_file(file, separator='=')
 end
 
 target 'Runner' do
-  use_modular_headers!
-  
   # Flutter Pod
 
   copied_flutter_dir = File.join(__dir__, 'Flutter')

--- a/packages/flutter_tools/templates/module/ios/host_app_ephemeral_cocoapods/Podfile.copy.tmpl
+++ b/packages/flutter_tools/templates/module/ios/host_app_ephemeral_cocoapods/Podfile.copy.tmpl
@@ -6,8 +6,6 @@ load File.join(flutter_application_path, '.ios', 'Flutter', 'podhelper.rb')
 use_frameworks!
 
 target 'Runner' do
-  use_modular_headers!
-  
   install_flutter_engine_pod
   install_flutter_plugin_pods flutter_application_path
 end


### PR DESCRIPTION
## Description

New iOS flutter project using cloud_firestore plugin does not compile:
```
Error:
Pods/Headers/Private/openssl_grpc/BoringSSL-GRPC.modulemap' not found
```

`use_modular_headers!` was introduced to the Podfile template with https://github.com/flutter/flutter/pull/42204.  However, CocoaPods [does not support static libraries with custom module maps](https://github.com/CocoaPods/CocoaPods/issues/9023), in this case, the BoringSSL-GRPC pod.

`use_modular_headers!` works for frameworks, so only remove `use_modular_headers!` from Podfiles that are using libraries.  Leave it on the Swift Podfiles because they still have `use_frameworks!`.

## Related Issues

Reverts part of https://github.com/flutter/flutter/pull/42204.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.