### PR TITLE
Reenable the dartdocs benchmark tracking

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -611,6 +611,12 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
 
+  dartdocs:
+    description: >
+      Tracks how many members are still lacking documentation.
+    stage: devicelab
+    required_agent_capabilities: ["linux/android"]
+
   technical_debt__cost:
     description: >
       Estimates our technical debt (TODOs, analyzer ignores, etc).


### PR DESCRIPTION
We disabled these back in May/June and haven't actually been tracking this number since. Oops.

cc @dnfield 