### PR TITLE
Support AppBars with jumbo titles

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -491,7 +491,7 @@ class _AppBarState extends State<AppBar> {
         overflow: TextOverflow.ellipsis,
         child: Semantics(
           namesRoute: namesRoute,
-          child: title,
+          child: _AppBarTitleBox(child: title),
           header: true,
         ),
       );
@@ -1239,5 +1239,39 @@ class _SliverAppBarState extends State<SliverAppBar> with TickerProviderStateMix
         ),
       ),
     );
+  }
+}
+
+// Layout the AppBar's title with unconstrained height, vertically
+// center it within its (NavigationToolbar) parent, and allow the
+// parent to constrain the title's actual height.
+class _AppBarTitleBox extends SingleChildRenderObjectWidget {
+  const _AppBarTitleBox({ Key key, @required Widget child }) : assert(child != null), super(key: key, child: child);
+
+  @override
+  _RenderAppBarTitleBox createRenderObject(BuildContext context) {
+    return _RenderAppBarTitleBox(
+      textDirection: Directionality.of(context),
+    );
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, _RenderAppBarTitleBox renderObject) {
+    renderObject.textDirection = Directionality.of(context);
+  }
+}
+
+class _RenderAppBarTitleBox extends RenderAligningShiftedBox {
+  _RenderAppBarTitleBox({
+    RenderBox child,
+    TextDirection textDirection,
+  }) : super(child: child, alignment: Alignment.center, textDirection: textDirection);
+
+  @override
+  void performLayout() {
+    final BoxConstraints innerConstraints = constraints.copyWith(maxHeight: double.infinity);
+    child.layout(innerConstraints, parentUsesSize: true);
+    size = constraints.constrain(child.size);
+    alignChild();
   }
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/42932
Fixes https://github.com/flutter/flutter/issues/36265

AppBar titles are now laid out without a height constraint, then centered within the toolbar.

In the [following example](https://gist.github.com/HansMuller/f782a76d600dd87f78dbd82b84899c8d) the AppBars have been created with a textScaleFactor of 1, 2, 3, 3.5, and 4.

| old | new |
| --- | --- |
| ![appbar_title_old](https://user-images.githubusercontent.com/1377460/67032322-38e26f80-f0c8-11e9-98b7-2a8fea221b05.png) | ![appbar_title_new](https://user-images.githubusercontent.com/1377460/67032360-4b5ca900-f0c8-11e9-8cce-50882f908238.png) |

