### PR TITLE
Soften layer breakage

### DIFF
--- a/packages/flutter/lib/src/gestures/mouse_tracking.dart
+++ b/packages/flutter/lib/src/gestures/mouse_tracking.dart
@@ -123,7 +123,7 @@ class MouseTracker extends ChangeNotifier {
   ///
   /// The second parameter is a function with which the [MouseTracker] can
   /// search for [MouseTrackerAnnotation]s at a given position.
-  /// Usually it is [Layer.findAll] of the root layer.
+  /// Usually it is [Layer.findAllAnnotations] of the root layer.
   ///
   /// All of the parameters must not be null.
   MouseTracker(this._router, this.annotationFinder)

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -279,8 +279,9 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
   /// location described by `localPosition`.
   ///
   /// This method is called by the default implementation of [find] and
-  /// [findAll]. Override this method to customize how the layer should search
-  /// for annotations, or if the layer has its own annotations to add.
+  /// [findAllAnnotations]. Override this method to customize how the layer
+  /// should search for annotations, or if the layer has its own annotations to
+  /// add.
   ///
   /// ## About layer annotations
   ///
@@ -326,14 +327,6 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
     Offset localPosition, {
     @required bool onlyFirst,
   }) {
-    debugPrint(
-      'Layer $runtimeType has not implemented Layer.findAnnotations. '
-      'If the layer class does not care about annotations, override '
-      'findAnnotations with a simple "return false". '
-      'If it overrides find and findAll to add custom behaviors, '
-      'please change to overriding Layer.findAnnotations instead, '
-      'otherwise these behaviors will no longer take effect. '
-      'See https://github.com/flutter/flutter/pull/37896 for details.');
     return false;
   }
 
@@ -352,8 +345,8 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
   ///
   /// See also:
   ///
-  ///  * [findAll], which is similar but returns all annotations found at the
-  ///    given position.
+  ///  * [findAllAnnotations], which is similar but returns all annotations found
+  ///    at the given position.
   ///  * [AnnotatedRegionLayer], for placing values in the layer tree.
   S find<S>(Offset localPosition) {
     final AnnotationResult<S> result = AnnotationResult<S>();
@@ -370,10 +363,6 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
   /// false` and returns the annotations of its result. It is encouraged to
   /// override [findAnnotations] instead of this method.
   ///
-  /// This method is similar to [findAllAnnotations], except that it returns a
-  /// list of annotations instead of an [AnnotationResult], which contains less
-  /// information. It is recommended to use [findAllAnnotations] over this one.
-  ///
   /// ## About layer annotations
   ///
   /// {@macro flutter.rendering.layer.findAnnotations.aboutAnnotations}
@@ -387,6 +376,7 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
   ///    position of the event related to each annotation, and is equally fast,
   ///    hence is preferred over [findAll].
   ///  * [AnnotatedRegionLayer], for placing values in the layer tree.
+  @Deprecated('Use findAllAnnotations instead. This API will be removed in early 2020.')
   Iterable<S> findAll<S>(Offset localPosition) {
     final AnnotationResult<S> result = findAllAnnotations(localPosition);
     return result.entries.map((AnnotationEntry<S> entry) => entry.annotation);
@@ -401,8 +391,6 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
   /// false` and returns the annotations of its result. It is encouraged to
   /// override [findAnnotations] instead of this method.
   ///
-  /// This method is similar to [findAll], except that it
-  ///
   /// ## About layer annotations
   ///
   /// {@macro flutter.rendering.layer.findAnnotations.aboutAnnotations}
@@ -411,10 +399,6 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
   ///
   ///  * [find], which is similar but returns the first annotation found at the
   ///    given position.
-  ///  * [findAll], which is similar but returns a list of annotations.
-  ///    The [findAllAnnotations] returns an [AnnotationResult] that contains
-  ///    more information, such as the local position of the event related to
-  ///    each annotation, and is equally fast, hence is preferred over [findAll].
   ///  * [AnnotatedRegionLayer], for placing values in the layer tree.
   AnnotationResult<S> findAllAnnotations<S>(Offset localPosition) {
     final AnnotationResult<S> result = AnnotationResult<S>();
@@ -2293,10 +2277,10 @@ class FollowerLayer extends ContainerLayer {
 /// layer to the tree is the common way of adding an annotation.
 ///
 /// An annotation is an optional object of any type that, when attached with a
-/// layer, can be retrieved using [Layer.find] or [Layer.findAll] with a
-/// position. The search process is done recursively, controlled by a concept
-/// of being opaque to a type of annotation, explained in the document of
-/// [Layer.findAnnotations].
+/// layer, can be retrieved using [Layer.find] or [Layer.findAllAnnotations]
+/// with a position. The search process is done recursively, controlled by a
+/// concept of being opaque to a type of annotation, explained in the document
+/// of [Layer.findAnnotations].
 ///
 /// When an annotation search arrives, this layer defers the same search to each
 /// of this layer's children, respecting their opacity. Then it adds this

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -283,20 +283,24 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
   /// should search for annotations, or if the layer has its own annotations to
   /// add.
   ///
+  /// The default implementation simply returns `false`, which means neither
+  /// the layer nor its children has annotations, and the annotation search
+  /// is not absorbed either (see below for explanation).
+  ///
   /// ## About layer annotations
   ///
   /// {@template flutter.rendering.layer.findAnnotations.aboutAnnotations}
-  /// Annotation is an optional object of any type that can be carried with a
+  /// An annotation is an optional object of any type that can be carried with a
   /// layer. An annotation can be found at a location as long as the owner layer
   /// contains the location and is walked to.
   ///
-  /// The annotations are searched by first visitng each child recursively, then
-  /// this layer, resulting in an order from visually front to back. Annotations
-  /// must meet the given restrictions, such as type and position.
+  /// The annotations are searched by first visiting each child recursively,
+  /// then this layer, resulting in an order from visually front to back.
+  /// Annotations must meet the given restrictions, such as type and position.
   ///
   /// The common way for a value to be found here is by pushing an
   /// [AnnotatedRegionLayer] into the layer tree, or by adding the desired
-  /// annotation by overriding `findAnnotations`.
+  /// annotation by overriding [findAnnotations].
   /// {@endtemplate}
   ///
   /// ## Parameters and return value
@@ -336,8 +340,10 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
   /// Returns null if no matching annotations are found.
   ///
   /// By default this method simply calls [findAnnotations] with `onlyFirst:
-  /// true` and returns the annotation of the first result. It is encouraged to
-  /// override [findAnnotations] instead of this method.
+  /// true` and returns the annotation of the first result. Prefer overriding
+  /// [findAnnotations] instead of this method, because during an annotation
+  /// search, only [findAnnotations] is recursively called, while custom
+  /// behavior in this method is ignored.
   ///
   /// ## About layer annotations
   ///
@@ -360,8 +366,10 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
   /// Returns a result with empty entries if no matching annotations are found.
   ///
   /// By default this method simply calls [findAnnotations] with `onlyFirst:
-  /// false` and returns the annotations of its result. It is encouraged to
-  /// override [findAnnotations] instead of this method.
+  /// false` and returns the annotations of its result. Prefer overriding
+  /// [findAnnotations] instead of this method, because during an annotation
+  /// search, only [findAnnotations] is recursively called, while custom
+  /// behavior in this method is ignored.
   ///
   /// ## About layer annotations
   ///
@@ -388,8 +396,10 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
   /// Returns a result with empty entries if no matching annotations are found.
   ///
   /// By default this method simply calls [findAnnotations] with `onlyFirst:
-  /// false` and returns the annotations of its result. It is encouraged to
-  /// override [findAnnotations] instead of this method.
+  /// false` and returns the annotations of its result. Prefer overriding
+  /// [findAnnotations] instead of this method, because during an annotation
+  /// search, only [findAnnotations] is recursively called, while custom
+  /// behavior in this method is ignored.
   ///
   /// ## About layer annotations
   ///

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -18,8 +18,7 @@ import 'debug.dart';
 ///
 /// See also:
 ///
-///  * [Layer.find], [Layer.findAll], and [Layer.findAnnotations], which create
-///    and use objects of this class.
+///  * [Layer.findAnnotations], which create and use objects of this class.
 @immutable
 class AnnotationEntry<T> {
   /// Create an entry of found annotation by providing the oject and related
@@ -48,8 +47,8 @@ class AnnotationEntry<T> {
 /// See also:
 ///
 ///  * [AnnotationEntry], which are members of this class.
-///  * [Layer.findAll], and [Layer.findAnnotations], which create and use an
-///    object of this class.
+///  * [Layer.findAllAnnotations], and [Layer.findAnnotations], which create and
+///    use an object of this class.
 class AnnotationResult<T> {
   final List<AnnotationEntry<T>> _entries = <AnnotationEntry<T>>[];
 
@@ -334,8 +333,8 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
   /// Returns null if no matching annotations are found.
   ///
   /// By default this method simply calls [findAnnotations] with `onlyFirst:
-  /// true` and returns the first result. It is encouraged to override
-  /// [findAnnotations] instead of this method.
+  /// true` and returns the annotation of the first result. It is encouraged to
+  /// override [findAnnotations] instead of this method.
   ///
   /// ## About layer annotations
   ///
@@ -346,10 +345,10 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
   ///  * [findAll], which is similar but returns all annotations found at the
   ///    given position.
   ///  * [AnnotatedRegionLayer], for placing values in the layer tree.
-  AnnotationEntry<S> find<S>(Offset localPosition) {
+  S find<S>(Offset localPosition) {
     final AnnotationResult<S> result = AnnotationResult<S>();
     findAnnotations<S>(result, localPosition, onlyFirst: true);
-    return result.entries.isEmpty ? null : result.entries.first;
+    return result.entries.isEmpty ? null : result.entries.first.annotation;
   }
 
   /// Search this layer and its subtree for all annotations of type `S` under
@@ -358,8 +357,12 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
   /// Returns a result with empty entries if no matching annotations are found.
   ///
   /// By default this method simply calls [findAnnotations] with `onlyFirst:
-  /// false` and returns its result. It is encouraged to override
-  /// [findAnnotations] instead of this method.
+  /// false` and returns the annotations of its result. It is encouraged to
+  /// override [findAnnotations] instead of this method.
+  ///
+  /// This method is similar to [findAllAnnotations], except that it returns a
+  /// list of annotations instead of an [AnnotationResult], which contains less
+  /// information. It is recommended to use [findAllAnnotations] over this one.
   ///
   /// ## About layer annotations
   ///
@@ -369,8 +372,41 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
   ///
   ///  * [find], which is similar but returns the first annotation found at the
   ///    given position.
+  ///  * [findAllAnnotations], which is similar but returns an
+  ///    [AnnotationResult], which contains more information, such as the local
+  ///    position of the event related to each annotation, and is equally fast,
+  ///    hence is preferred over [findAll].
   ///  * [AnnotatedRegionLayer], for placing values in the layer tree.
-  AnnotationResult<S> findAll<S>(Offset localPosition) {
+  Iterable<S> findAll<S>(Offset localPosition) {
+    final AnnotationResult<S> result = findAllAnnotations(localPosition);
+    return result.entries.map((AnnotationEntry<S> entry) => entry.annotation);
+  }
+
+  /// Search this layer and its subtree for all annotations of type `S` under
+  /// the point described by `localPosition`.
+  ///
+  /// Returns a result with empty entries if no matching annotations are found.
+  ///
+  /// By default this method simply calls [findAnnotations] with `onlyFirst:
+  /// false` and returns the annotations of its result. It is encouraged to
+  /// override [findAnnotations] instead of this method.
+  ///
+  /// This method is similar to [findAll], except that it
+  ///
+  /// ## About layer annotations
+  ///
+  /// {@macro flutter.rendering.layer.findAnnotations.aboutAnnotations}
+  ///
+  /// See also:
+  ///
+  ///  * [find], which is similar but returns the first annotation found at the
+  ///    given position.
+  ///  * [findAll], which is similar but returns a list of annotations.
+  ///    The [findAllAnnotations] returns an [AnnotationResult] that contains
+  ///    more information, such as the local position of the event related to
+  ///    each annotation, and is equally fast, hence is preferred over [findAll].
+  ///  * [AnnotatedRegionLayer], for placing values in the layer tree.
+  AnnotationResult<S> findAllAnnotations<S>(Offset localPosition) {
     final AnnotationResult<S> result = AnnotationResult<S>();
     findAnnotations<S>(result, localPosition, onlyFirst: false);
     return result;

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -327,11 +327,13 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
     @required bool onlyFirst,
   }) {
     debugPrint(
-      'This layer did not implement Layer.findAnnotations. If this is a custom '
-      'layer class and has overridden find and findAll, '
-      'please change to overriding Layer.findAnnotations instead '
-      'to avoid unexpected behavior. '
-      'See https://github.com/flutter/flutter/pull/37424 for details.');
+      'Layer $runtimeType has not implemented Layer.findAnnotations. '
+      'If the layer class does not care about annotations, override '
+      'findAnnotations with a simple "return false". '
+      'If it overrides find and findAll to add custom behaviors, '
+      'please change to overriding Layer.findAnnotations instead, '
+      'otherwise these behaviors will no longer take effect. '
+      'See https://github.com/flutter/flutter/pull/37896 for details.');
     return false;
   }
 

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -325,7 +325,15 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
     AnnotationResult<S> result,
     Offset localPosition, {
     @required bool onlyFirst,
-  });
+  }) {
+    debugPrint(
+      'This layer did not implement Layer.findAnnotations. If this is a custom '
+      'layer class and has overridden find and findAll, '
+      'please change to overriding Layer.findAnnotations instead '
+      'to avoid unexpected behavior. '
+      'See https://github.com/flutter/flutter/pull/37424 for details.');
+    return false;
+  }
 
   /// Search this layer and its subtree for the first annotation of type `S`
   /// under the point described by `localPosition`.

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -190,13 +190,13 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
   ///
   /// See also:
   ///
-  /// * [Layer.findAll], which is used by this method to find all
+  /// * [Layer.findAllAnnotations], which is used by this method to find all
   ///   [AnnotatedRegionLayer]s annotated for mouse tracking.
   Iterable<MouseTrackerAnnotation> hitTestMouseTrackers(Offset position) {
     // Layer hit testing is done using device pixels, so we have to convert
     // the logical coordinates of the event location back to device pixels
     // here.
-    return layer.findAll<MouseTrackerAnnotation>(
+    return layer.findAllAnnotations<MouseTrackerAnnotation>(
       position * configuration.devicePixelRatio
     ).annotations;
   }
@@ -243,12 +243,12 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
     final Rect bounds = paintBounds;
     final Offset top = Offset(bounds.center.dx, _window.padding.top / _window.devicePixelRatio);
     final Offset bottom = Offset(bounds.center.dx, bounds.center.dy - _window.padding.bottom / _window.devicePixelRatio);
-    final SystemUiOverlayStyle upperOverlayStyle = layer.find<SystemUiOverlayStyle>(top)?.annotation;
+    final SystemUiOverlayStyle upperOverlayStyle = layer.find<SystemUiOverlayStyle>(top);
     // Only android has a customizable system navigation bar.
     SystemUiOverlayStyle lowerOverlayStyle;
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
-        lowerOverlayStyle = layer.find<SystemUiOverlayStyle>(bottom)?.annotation;
+        lowerOverlayStyle = layer.find<SystemUiOverlayStyle>(bottom);
         break;
       case TargetPlatform.iOS:
       case TargetPlatform.fuchsia:

--- a/packages/flutter/test/rendering/annotated_region_test.dart
+++ b/packages/flutter/test/rendering/annotated_region_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter/widgets.dart';
 import '../flutter_test_alternative.dart';
 
 void main() {
-  group('$AnnotatedRegion find', () {
+  group('AnnotatedRegion find', () {
     test('finds the first value in a OffsetLayer when sized', () {
       final ContainerLayer containerLayer = ContainerLayer();
       final List<OffsetLayer> layers = <OffsetLayer>[
@@ -22,9 +22,9 @@ void main() {
         i += 1;
       }
 
-      expect(containerLayer.find<int>(const Offset(0.0, 1.0)).annotation, 0);
-      expect(containerLayer.find<int>(const Offset(0.0, 101.0)).annotation, 1);
-      expect(containerLayer.find<int>(const Offset(0.0, 201.0)).annotation, 2);
+      expect(containerLayer.find<int>(const Offset(0.0, 1.0)), 0);
+      expect(containerLayer.find<int>(const Offset(0.0, 101.0)), 1);
+      expect(containerLayer.find<int>(const Offset(0.0, 201.0)), 2);
     });
 
     test('finds a value within the clip in a ClipRectLayer', () {
@@ -41,9 +41,9 @@ void main() {
         i += 1;
       }
 
-      expect(containerLayer.find<int>(const Offset(0.0, 1.0)).annotation, 0);
-      expect(containerLayer.find<int>(const Offset(0.0, 101.0)).annotation, 1);
-      expect(containerLayer.find<int>(const Offset(0.0, 201.0)).annotation, 2);
+      expect(containerLayer.find<int>(const Offset(0.0, 1.0)), 0);
+      expect(containerLayer.find<int>(const Offset(0.0, 101.0)), 1);
+      expect(containerLayer.find<int>(const Offset(0.0, 201.0)), 2);
     });
 
 
@@ -61,9 +61,9 @@ void main() {
         i += 1;
       }
 
-      expect(containerLayer.find<int>(const Offset(5.0, 5.0)).annotation, 0);
-      expect(containerLayer.find<int>(const Offset(5.0, 105.0)).annotation, 1);
-      expect(containerLayer.find<int>(const Offset(5.0, 205.0)).annotation, 2);
+      expect(containerLayer.find<int>(const Offset(5.0, 5.0)), 0);
+      expect(containerLayer.find<int>(const Offset(5.0, 105.0)), 1);
+      expect(containerLayer.find<int>(const Offset(5.0, 205.0)), 2);
     });
 
     test('finds a value under a TransformLayer', () {
@@ -87,11 +87,11 @@ void main() {
         i += 1;
       }
 
-      expect(transformLayer.find<int>(const Offset(0.0, 100.0)).annotation, 0);
-      expect(transformLayer.find<int>(const Offset(0.0, 200.0)).annotation, 0);
-      expect(transformLayer.find<int>(const Offset(0.0, 270.0)).annotation, 1);
-      expect(transformLayer.find<int>(const Offset(0.0, 400.0)).annotation, 1);
-      expect(transformLayer.find<int>(const Offset(0.0, 530.0)).annotation, 2);
+      expect(transformLayer.find<int>(const Offset(0.0, 100.0)), 0);
+      expect(transformLayer.find<int>(const Offset(0.0, 200.0)), 0);
+      expect(transformLayer.find<int>(const Offset(0.0, 270.0)), 1);
+      expect(transformLayer.find<int>(const Offset(0.0, 400.0)), 1);
+      expect(transformLayer.find<int>(const Offset(0.0, 530.0)), 2);
     });
 
     test('looks for child AnnotatedRegions before parents', () {
@@ -101,7 +101,7 @@ void main() {
       parent.append(child);
       layer.append(parent);
 
-      expect(parent.find<int>(Offset.zero).annotation, 2);
+      expect(parent.find<int>(Offset.zero), 2);
     });
 
     test('looks for correct type', () {
@@ -111,7 +111,7 @@ void main() {
       layer.append(child2);
       layer.append(child1);
 
-      expect(layer.find<String>(Offset.zero).annotation, 'hello');
+      expect(layer.find<String>(Offset.zero), 'hello');
     });
 
     test('does not clip Layer.find on an AnnotatedRegion with an unrelated type', () {
@@ -121,7 +121,7 @@ void main() {
       parent.append(child);
       layer.append(parent);
 
-      expect(layer.find<int>(const Offset(100.0, 100.0)).annotation, 1);
+      expect(layer.find<int>(const Offset(100.0, 100.0)), 1);
     });
 
     test('handles non-invertable transforms', () {
@@ -133,10 +133,10 @@ void main() {
 
       parent.transform = Matrix4.diagonal3Values(1.0, 1.0, 1.0);
 
-      expect(parent.find<int>(const Offset(0.0, 0.0)).annotation, 1);
+      expect(parent.find<int>(const Offset(0.0, 0.0)), 1);
     });
   });
-  group('$AnnotatedRegion findAll', () {
+  group('$AnnotatedRegion findAllAnnotations', () {
     test('finds the first value in a OffsetLayer when sized', () {
       final ContainerLayer containerLayer = ContainerLayer();
       final List<OffsetLayer> layers = <OffsetLayer>[
@@ -151,9 +151,9 @@ void main() {
         i += 1;
       }
 
-      expect(containerLayer.findAll<int>(const Offset(0.0, 1.0)).annotations.toList(), equals(<int>[0]));
-      expect(containerLayer.findAll<int>(const Offset(0.0, 101.0)).annotations.toList(), equals(<int>[1]));
-      expect(containerLayer.findAll<int>(const Offset(0.0, 201.0)).annotations.toList(), equals(<int>[2]));
+      expect(containerLayer.findAllAnnotations<int>(const Offset(0.0, 1.0)).annotations.toList(), equals(<int>[0]));
+      expect(containerLayer.findAllAnnotations<int>(const Offset(0.0, 101.0)).annotations.toList(), equals(<int>[1]));
+      expect(containerLayer.findAllAnnotations<int>(const Offset(0.0, 201.0)).annotations.toList(), equals(<int>[2]));
     });
 
     test('finds a value within the clip in a ClipRectLayer', () {
@@ -170,9 +170,9 @@ void main() {
         i += 1;
       }
 
-      expect(containerLayer.findAll<int>(const Offset(0.0, 1.0)).annotations.toList(), equals(<int>[0]));
-      expect(containerLayer.findAll<int>(const Offset(0.0, 101.0)).annotations.toList(), equals(<int>[1]));
-      expect(containerLayer.findAll<int>(const Offset(0.0, 201.0)).annotations.toList(), equals(<int>[2]));
+      expect(containerLayer.findAllAnnotations<int>(const Offset(0.0, 1.0)).annotations.toList(), equals(<int>[0]));
+      expect(containerLayer.findAllAnnotations<int>(const Offset(0.0, 101.0)).annotations.toList(), equals(<int>[1]));
+      expect(containerLayer.findAllAnnotations<int>(const Offset(0.0, 201.0)).annotations.toList(), equals(<int>[2]));
     });
 
 
@@ -190,9 +190,9 @@ void main() {
         i += 1;
       }
 
-      expect(containerLayer.findAll<int>(const Offset(5.0, 5.0)).annotations.toList(), equals(<int>[0]));
-      expect(containerLayer.findAll<int>(const Offset(5.0, 105.0)).annotations.toList(), equals(<int>[1]));
-      expect(containerLayer.findAll<int>(const Offset(5.0, 205.0)).annotations.toList(), equals(<int>[2]));
+      expect(containerLayer.findAllAnnotations<int>(const Offset(5.0, 5.0)).annotations.toList(), equals(<int>[0]));
+      expect(containerLayer.findAllAnnotations<int>(const Offset(5.0, 105.0)).annotations.toList(), equals(<int>[1]));
+      expect(containerLayer.findAllAnnotations<int>(const Offset(5.0, 205.0)).annotations.toList(), equals(<int>[2]));
     });
 
     test('finds a value under a TransformLayer', () {
@@ -216,11 +216,11 @@ void main() {
         i += 1;
       }
 
-      expect(transformLayer.findAll<int>(const Offset(0.0, 100.0)).annotations.toList(), equals(<int>[0]));
-      expect(transformLayer.findAll<int>(const Offset(0.0, 200.0)).annotations.toList(), equals(<int>[0]));
-      expect(transformLayer.findAll<int>(const Offset(0.0, 270.0)).annotations.toList(), equals(<int>[1]));
-      expect(transformLayer.findAll<int>(const Offset(0.0, 400.0)).annotations.toList(), equals(<int>[1]));
-      expect(transformLayer.findAll<int>(const Offset(0.0, 530.0)).annotations.toList(), equals(<int>[2]));
+      expect(transformLayer.findAllAnnotations<int>(const Offset(0.0, 100.0)).annotations.toList(), equals(<int>[0]));
+      expect(transformLayer.findAllAnnotations<int>(const Offset(0.0, 200.0)).annotations.toList(), equals(<int>[0]));
+      expect(transformLayer.findAllAnnotations<int>(const Offset(0.0, 270.0)).annotations.toList(), equals(<int>[1]));
+      expect(transformLayer.findAllAnnotations<int>(const Offset(0.0, 400.0)).annotations.toList(), equals(<int>[1]));
+      expect(transformLayer.findAllAnnotations<int>(const Offset(0.0, 530.0)).annotations.toList(), equals(<int>[2]));
     });
 
     test('finds multiple nested, overlapping regions', () {
@@ -237,7 +237,7 @@ void main() {
         parent.append(layer);
       }
 
-      expect(parent.findAll<int>(const Offset(0.0, 0.0)).annotations.toList(), equals(<int>[3, 1, 2, 0,]));
+      expect(parent.findAllAnnotations<int>(const Offset(0.0, 0.0)).annotations.toList(), equals(<int>[3, 1, 2, 0,]));
     });
 
     test('looks for child AnnotatedRegions before parents', () {
@@ -251,7 +251,7 @@ void main() {
       parent.append(child3);
       layer.append(parent);
 
-      expect(parent.findAll<int>(Offset.zero).annotations.toList(), equals(<int>[4, 3, 2, 1]));
+      expect(parent.findAllAnnotations<int>(Offset.zero).annotations.toList(), equals(<int>[4, 3, 2, 1]));
     });
 
     test('looks for correct type', () {
@@ -261,7 +261,7 @@ void main() {
       layer.append(child2);
       layer.append(child1);
 
-      expect(layer.findAll<String>(Offset.zero).annotations.toList(), equals(<String>['hello']));
+      expect(layer.findAllAnnotations<String>(Offset.zero).annotations.toList(), equals(<String>['hello']));
     });
 
     test('does not clip Layer.find on an AnnotatedRegion with an unrelated type', () {
@@ -271,7 +271,7 @@ void main() {
       parent.append(child);
       layer.append(parent);
 
-      expect(layer.findAll<int>(const Offset(100.0, 100.0)).annotations.toList(), equals(<int>[1]));
+      expect(layer.findAllAnnotations<int>(const Offset(100.0, 100.0)).annotations.toList(), equals(<int>[1]));
     });
 
     test('handles non-invertable transforms', () {
@@ -279,11 +279,11 @@ void main() {
       final TransformLayer parent = TransformLayer(transform: Matrix4.diagonal3Values(0.0, 1.0, 1.0));
       parent.append(child);
 
-      expect(parent.findAll<int>(const Offset(0.0, 0.0)).annotations.toList(), equals(<int>[]));
+      expect(parent.findAllAnnotations<int>(const Offset(0.0, 0.0)).annotations.toList(), equals(<int>[]));
 
       parent.transform = Matrix4.diagonal3Values(1.0, 1.0, 1.0);
 
-      expect(parent.findAll<int>(const Offset(0.0, 0.0)).annotations.toList(), equals(<int>[1]));
+      expect(parent.findAllAnnotations<int>(const Offset(0.0, 0.0)).annotations.toList(), equals(<int>[1]));
     });
   });
 }

--- a/packages/flutter/test/rendering/annotated_region_test.dart
+++ b/packages/flutter/test/rendering/annotated_region_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter/widgets.dart';
 import '../flutter_test_alternative.dart';
 
 void main() {
-  group('AnnotatedRegion find', () {
+  group('$AnnotatedRegion find', () {
     test('finds the first value in a OffsetLayer when sized', () {
       final ContainerLayer containerLayer = ContainerLayer();
       final List<OffsetLayer> layers = <OffsetLayer>[

--- a/packages/flutter/test/rendering/layer_annotations_test.dart
+++ b/packages/flutter/test/rendering/layer_annotations_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 void main() {
-  test('ContainerLayer.findAll returns all results from its children', () {
+  test('ContainerLayer.findAllAnnotations returns all results from its children', () {
     final Layer root = _Layers(
       ContainerLayer(),
       children: <Object>[
@@ -21,7 +21,7 @@ void main() {
     ).build();
 
     expect(
-      root.findAll<int>(Offset.zero).entries.toList(),
+      root.findAllAnnotations<int>(Offset.zero).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 3, localPosition: Offset.zero),
         const AnnotationEntry<int>(annotation: 2, localPosition: Offset.zero),
@@ -40,12 +40,11 @@ void main() {
       ]
     ).build();
 
-    final AnnotationEntry<int> result = root.find<int>(Offset.zero);
-    expect(result.annotation, 3);
-    expect(result.localPosition, Offset.zero);
+    final int result = root.find<int>(Offset.zero);
+    expect(result, 3);
   });
 
-  test('ContainerLayer.findAll returns empty result when finding nothing', () {
+  test('ContainerLayer.findAllAnnotations returns empty result when finding nothing', () {
     final Layer root = _Layers(
       ContainerLayer(),
       children: <Object>[
@@ -55,7 +54,7 @@ void main() {
       ]
     ).build();
 
-    expect(root.findAll<double>(Offset.zero).entries.isEmpty, isTrue);
+    expect(root.findAllAnnotations<double>(Offset.zero).entries.isEmpty, isTrue);
   });
 
   test('ContainerLayer.find returns null when finding nothing', () {
@@ -71,7 +70,7 @@ void main() {
     expect(root.find<double>(Offset.zero), isNull);
   });
 
-  test('ContainerLayer.findAll stops at the first opaque child', () {
+  test('ContainerLayer.findAllAnnotations stops at the first opaque child', () {
     final Layer root = _Layers(
       ContainerLayer(),
       children: <Object>[
@@ -82,7 +81,7 @@ void main() {
     ).build();
 
     expect(
-      root.findAll<int>(Offset.zero).entries.toList(),
+      root.findAllAnnotations<int>(Offset.zero).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 3, localPosition: Offset(0, 0)),
         const AnnotationEntry<int>(annotation: 2, localPosition: Offset(0, 0)),
@@ -90,7 +89,7 @@ void main() {
     );
   });
 
-  test('ContainerLayer.findAll returns children\'s opacity (true)', () {
+  test('ContainerLayer.findAllAnnotations returns children\'s opacity (true)', () {
     final Layer root = _appendAnnotationIfNotOpaque(1000,
       _Layers(
         ContainerLayer(),
@@ -101,14 +100,14 @@ void main() {
     );
 
     expect(
-      root.findAll<int>(Offset.zero).entries.toList(),
+      root.findAllAnnotations<int>(Offset.zero).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 2, localPosition: Offset(0, 0)),
       ]),
     );
   });
 
-  test('ContainerLayer.findAll returns children\'s opacity (false)', () {
+  test('ContainerLayer.findAllAnnotations returns children\'s opacity (false)', () {
     final Layer root = _appendAnnotationIfNotOpaque(1000,
       _Layers(
         ContainerLayer(),
@@ -119,7 +118,7 @@ void main() {
     );
 
     expect(
-      root.findAll<int>(Offset.zero).entries.toList(),
+      root.findAllAnnotations<int>(Offset.zero).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 2, localPosition: Offset(0, 0)),
         const AnnotationEntry<int>(annotation: 1000, localPosition: Offset(0, 0)),
@@ -127,7 +126,7 @@ void main() {
     );
   });
 
-  test('ContainerLayer.findAll returns false as opacity when finding nothing', () {
+  test('ContainerLayer.findAllAnnotations returns false as opacity when finding nothing', () {
     final Layer root = _appendAnnotationIfNotOpaque(1000,
       _Layers(
         ContainerLayer(),
@@ -138,14 +137,14 @@ void main() {
     );
 
     expect(
-      root.findAll<int>(Offset.zero).entries.toList(),
+      root.findAllAnnotations<int>(Offset.zero).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 1000, localPosition: Offset(0, 0)),
       ]),
     );
   });
 
-  test('OffsetLayer.findAll respects offset', () {
+  test('OffsetLayer.findAllAnnotations respects offset', () {
     const Offset insidePosition = Offset(-5, 5);
     const Offset outsidePosition = Offset(5, 5);
 
@@ -159,20 +158,20 @@ void main() {
     );
 
     expect(
-      root.findAll<int>(insidePosition).entries.toList(),
+      root.findAllAnnotations<int>(insidePosition).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 1, localPosition: Offset(5, 5)),
       ]),
     );
     expect(
-      root.findAll<int>(outsidePosition).entries.toList(),
+      root.findAllAnnotations<int>(outsidePosition).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 1000, localPosition: Offset(5, 5)),
       ]),
     );
   });
 
-  test('ClipRectLayer.findAll respects clipRect', () {
+  test('ClipRectLayer.findAllAnnotations respects clipRect', () {
     const Offset insidePosition = Offset(11, 11);
     const Offset outsidePosition = Offset(19, 19);
 
@@ -191,20 +190,20 @@ void main() {
     );
 
     expect(
-      root.findAll<int>(insidePosition).entries.toList(),
+      root.findAllAnnotations<int>(insidePosition).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 1, localPosition: insidePosition),
       ]),
     );
     expect(
-      root.findAll<int>(outsidePosition).entries.toList(),
+      root.findAllAnnotations<int>(outsidePosition).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 1000, localPosition: outsidePosition),
       ]),
     );
   });
 
-  test('ClipRRectLayer.findAll respects clipRRect', () {
+  test('ClipRRectLayer.findAllAnnotations respects clipRRect', () {
     // For a curve of radius 4 centered at (4, 4),
     // location (1, 1) is outside, while (2, 2) is inside.
     // Here we shift this RRect by (10, 10).
@@ -230,20 +229,20 @@ void main() {
     );
 
     expect(
-      root.findAll<int>(insidePosition).entries.toList(),
+      root.findAllAnnotations<int>(insidePosition).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 1, localPosition: insidePosition),
       ]),
     );
     expect(
-      root.findAll<int>(outsidePosition).entries.toList(),
+      root.findAllAnnotations<int>(outsidePosition).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 1000, localPosition: outsidePosition),
       ]),
     );
   });
 
-  test('ClipPathLayer.findAll respects clipPath', () {
+  test('ClipPathLayer.findAllAnnotations respects clipPath', () {
     // For this triangle, location (1, 1) is inside, while (2, 2) is outside.
     //         2
     //    —————
@@ -274,20 +273,20 @@ void main() {
     );
 
     expect(
-      root.findAll<int>(insidePosition).entries.toList(),
+      root.findAllAnnotations<int>(insidePosition).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 1, localPosition: insidePosition),
       ]),
     );
     expect(
-      root.findAll<int>(outsidePosition).entries.toList(),
+      root.findAllAnnotations<int>(outsidePosition).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 1000, localPosition: outsidePosition),
       ]),
     );
   });
 
-  test('TransformLayer.findAll respects transform', () {
+  test('TransformLayer.findAllAnnotations respects transform', () {
     // Matrix `transform` enlarges the target by (2x, 4x), then shift it by
     // (10, 20).
     final Matrix4 transform = Matrix4.diagonal3Values(2, 4, 1)
@@ -312,20 +311,20 @@ void main() {
     );
 
     expect(
-      root.findAll<int>(insidePosition).entries.toList(),
+      root.findAllAnnotations<int>(insidePosition).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 1, localPosition: Offset(15, 15)),
       ]),
     );
     expect(
-      root.findAll<int>(outsidePosition).entries.toList(),
+      root.findAllAnnotations<int>(outsidePosition).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 1000, localPosition: outsidePosition),
       ]),
     );
   });
 
-  test('TransformLayer.findAll skips when transform is irreversible', () {
+  test('TransformLayer.findAllAnnotations skips when transform is irreversible', () {
     final Matrix4 transform = Matrix4.diagonal3Values(1, 0, 1);
 
     final Layer root = _appendAnnotationIfNotOpaque(1000,
@@ -338,14 +337,14 @@ void main() {
     );
 
     expect(
-      root.findAll<int>(Offset.zero).entries.toList(),
+      root.findAllAnnotations<int>(Offset.zero).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 1000, localPosition: Offset.zero),
       ]),
     );
   });
 
-  test('PhysicalModelLayer.findAll respects clipPath', () {
+  test('PhysicalModelLayer.findAllAnnotations respects clipPath', () {
     // For this triangle, location (1, 1) is inside, while (2, 2) is outside.
     //         2
     //    —————
@@ -381,13 +380,13 @@ void main() {
     );
 
     expect(
-      root.findAll<int>(insidePosition).entries.toList(),
+      root.findAllAnnotations<int>(insidePosition).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 1, localPosition: insidePosition),
       ]),
     );
     expect(
-      root.findAll<int>(outsidePosition).entries.toList(),
+      root.findAllAnnotations<int>(outsidePosition).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 1000, localPosition: outsidePosition),
       ]),
@@ -395,7 +394,7 @@ void main() {
   });
 
 
-  test('LeaderLayer.findAll respects offset', () {
+  test('LeaderLayer.findAllAnnotations respects offset', () {
     const Offset insidePosition = Offset(-5, 5);
     const Offset outsidePosition = Offset(5, 5);
 
@@ -412,20 +411,20 @@ void main() {
     );
 
     expect(
-      root.findAll<int>(insidePosition).entries.toList(),
+      root.findAllAnnotations<int>(insidePosition).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 1, localPosition: Offset(5, 5)),
       ]),
     );
     expect(
-      root.findAll<int>(outsidePosition).entries.toList(),
+      root.findAllAnnotations<int>(outsidePosition).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 1000, localPosition: outsidePosition),
       ]),
     );
   });
 
-  test('AnnotatedRegionLayer.findAll should append to the list '
+  test('AnnotatedRegionLayer.findAllAnnotations should append to the list '
     'and return the given opacity (false) during a successful hit', () {
     const Offset position = Offset(5, 5);
 
@@ -439,7 +438,7 @@ void main() {
     );
 
     expect(
-      root.findAll<int>(position).entries.toList(),
+      root.findAllAnnotations<int>(position).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 2, localPosition: position),
         const AnnotationEntry<int>(annotation: 1, localPosition: position),
@@ -448,7 +447,7 @@ void main() {
     );
   });
 
-  test('AnnotatedRegionLayer.findAll should append to the list '
+  test('AnnotatedRegionLayer.findAllAnnotations should append to the list '
     'and return the given opacity (true) during a successful hit', () {
     const Offset position = Offset(5, 5);
 
@@ -462,7 +461,7 @@ void main() {
     );
 
     expect(
-      root.findAll<int>(position).entries.toList(),
+      root.findAllAnnotations<int>(position).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 2, localPosition: position),
         const AnnotationEntry<int>(annotation: 1, localPosition: position),
@@ -470,7 +469,7 @@ void main() {
     );
   });
 
-  test('AnnotatedRegionLayer.findAll has default opacity as false', () {
+  test('AnnotatedRegionLayer.findAllAnnotations has default opacity as false', () {
     const Offset position = Offset(5, 5);
 
     final Layer root = _appendAnnotationIfNotOpaque(1000,
@@ -483,7 +482,7 @@ void main() {
     );
 
     expect(
-      root.findAll<int>(position).entries.toList(),
+      root.findAllAnnotations<int>(position).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 2, localPosition: position),
         const AnnotationEntry<int>(annotation: 1, localPosition: position),
@@ -492,7 +491,7 @@ void main() {
     );
   });
 
-  test('AnnotatedRegionLayer.findAll should still check children and return'
+  test('AnnotatedRegionLayer.findAllAnnotations should still check children and return'
     'children\'s opacity (false) during a failed hit', () {
     const Offset position = Offset(5, 5);
 
@@ -506,7 +505,7 @@ void main() {
     );
 
     expect(
-      root.findAll<int>(position).entries.toList(),
+      root.findAllAnnotations<int>(position).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 2, localPosition: position),
         const AnnotationEntry<int>(annotation: 1000, localPosition: position),
@@ -514,7 +513,7 @@ void main() {
     );
   });
 
-  test('AnnotatedRegionLayer.findAll should still check children and return'
+  test('AnnotatedRegionLayer.findAllAnnotations should still check children and return'
     'children\'s opacity (true) during a failed hit', () {
     const Offset position = Offset(5, 5);
 
@@ -528,14 +527,14 @@ void main() {
     );
 
     expect(
-      root.findAll<int>(position).entries.toList(),
+      root.findAllAnnotations<int>(position).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 2, localPosition: position),
       ]),
     );
   });
 
-  test('AnnotatedRegionLayer.findAll should not add to children\'s opacity '
+  test('AnnotatedRegionLayer.findAllAnnotations should not add to children\'s opacity '
     'during a successful hit if it is not opaque', () {
     const Offset position = Offset(5, 5);
 
@@ -549,7 +548,7 @@ void main() {
     );
 
     expect(
-      root.findAll<int>(position).entries.toList(),
+      root.findAllAnnotations<int>(position).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 2, localPosition: position),
         const AnnotationEntry<int>(annotation: 1, localPosition: position),
@@ -558,7 +557,7 @@ void main() {
     );
   });
 
-  test('AnnotatedRegionLayer.findAll should add to children\'s opacity '
+  test('AnnotatedRegionLayer.findAllAnnotations should add to children\'s opacity '
     'during a successful hit if it is opaque', () {
     const Offset position = Offset(5, 5);
 
@@ -572,7 +571,7 @@ void main() {
     );
 
     expect(
-      root.findAll<int>(position).entries.toList(),
+      root.findAllAnnotations<int>(position).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 2, localPosition: position),
         const AnnotationEntry<int>(annotation: 1, localPosition: position),
@@ -580,7 +579,7 @@ void main() {
     );
   });
 
-  test('AnnotatedRegionLayer.findAll should clip its annotation '
+  test('AnnotatedRegionLayer.findAllAnnotations should clip its annotation '
     'using size and offset (positive)', () {
     // The target position would have fallen outside if not for the offset.
     const Offset position = Offset(100, 100);
@@ -606,7 +605,7 @@ void main() {
     );
 
     expect(
-      root.findAll<int>(position).entries.toList(),
+      root.findAllAnnotations<int>(position).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 2, localPosition: position),
         const AnnotationEntry<int>(annotation: 1, localPosition: position),
@@ -615,7 +614,7 @@ void main() {
     );
   });
 
-  test('AnnotatedRegionLayer.findAll should clip its annotation '
+  test('AnnotatedRegionLayer.findAllAnnotations should clip its annotation '
     'using size and offset (negative)', () {
     // The target position would have fallen inside if not for the offset.
     const Offset position = Offset(10, 10);
@@ -634,7 +633,7 @@ void main() {
     );
 
     expect(
-      root.findAll<int>(position).entries.toList(),
+      root.findAllAnnotations<int>(position).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 2, localPosition: position),
         const AnnotationEntry<int>(annotation: 1000, localPosition: position),

--- a/packages/flutter/test/widgets/annotated_region_test.dart
+++ b/packages/flutter/test/widgets/annotated_region_test.dart
@@ -34,12 +34,12 @@ void main() {
     int result = RendererBinding.instance.renderView.debugLayer.find<int>(Offset(
       10.0 * window.devicePixelRatio,
       10.0 * window.devicePixelRatio,
-    ))?.annotation;
+    ));
     expect(result, null);
     result = RendererBinding.instance.renderView.debugLayer.find<int>(Offset(
       50.0 * window.devicePixelRatio,
       50.0 * window.devicePixelRatio,
-    )).annotation;
+    ));
     expect(result, 1);
   });
 }


### PR DESCRIPTION
## Description

This PR handles some changes introduced in https://github.com/flutter/flutter/pull/37896 to avoid hard API breakage. 

### Compared to #37896
It reverts the signature change of `Layer.find` and `Layer.findAll`, and adds a new method `Layer.findAllAnnotations` that returns a `AnnotationResult` (as the `Layer.findAll` in #37896 does). `Layer.findAll` is marked deprecated.

It adds a default implementation to `Layer.findAnnotations`.

The change is breaking in terms of compile.

### Compared to before #37896
It adds a new method `Layer.findAllAnnotations` that is similar to `findAll` but instead returns an `AnnotationResult`.

`Layer.findAll` is marked deprecated.

The change is not breaking in terms of compile, but has a silent behavioral breaking change that custom layer classes that override `find` and `findAll` will no longer take effect, instead they should override `findAnnotations`. (I tried to come up with a way to alleviate this or at least print some warning, but can not think of one)

## Related Issues

- Based on: https://github.com/flutter/flutter/pull/37896

## Tests

I changed the following tests:

- All tests about `Layer.findAll` now tests `Layer.findAllAnnotations`. It should be fine since `Layer.findAll` directly calls `Layer.findAllAnnotations` and returns its result.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (Please read [Handling breaking changes]). See above.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
