### PR TITLE
Quick fix on material dialog docs

### DIFF
--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -74,7 +74,7 @@ class Dialog extends StatelessWidget {
   /// The curve to use for the animation shown when the system keyboard intrudes
   /// into the space that the dialog is placed in.
   ///
-  /// Defaults to [Curves.fastOutSlowIn].
+  /// Defaults to [Curves.decelerate].
   final Curve insetAnimationCurve;
 
   /// {@template flutter.material.dialog.shape}


### PR DESCRIPTION
The default assumed in the constructor is `Curves.decelerate`, not
`Curves.fastOutSlowIn`.

Fix docs to reflect that.