### PR TITLE
Do not produce an error when encountering a new type in a service response.

### DIFF
--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -840,8 +840,12 @@ class VM extends ServiceObjectOwner {
         }
         return view;
       default:
-        throw VMServiceObjectLoadError(
-            'VM.getFromMap called for something other than an isolate', map);
+        // If we don't have a model object for this service object type, as a
+        // fallback return a ServiceMap object.
+        final serviceObject = ServiceMap._empty(owner);
+        // We have now constructed an empty service object, call update to populate it.
+        serviceObject.updateFromMap(map);
+        return serviceObject;
     }
   }
 

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -842,7 +842,7 @@ class VM extends ServiceObjectOwner {
       default:
         // If we don't have a model object for this service object type, as a
         // fallback return a ServiceMap object.
-        final serviceObject = ServiceMap._empty(owner);
+        final ServiceObject serviceObject = ServiceMap._empty(owner);
         // We have now constructed an empty service object, call update to populate it.
         serviceObject.updateFromMap(map);
         return serviceObject;


### PR DESCRIPTION
Flutter tool's service client library tries to "upgrade" sub-components of service responses with higher level model objects. It does this for all members of the response, rather than only those documented in the version it targets, and it errors out when encountering a new type. This causes it to fail when a new field is introduced with a new typed. Clients are required to ignore this.
