### PR TITLE
Set default borderRadius to zero in ClipRRect (as documented)

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -647,7 +647,7 @@ class ClipRRect extends SingleChildRenderObjectWidget {
   /// The [clipBehavior] argument must not be null or [Clip.none].
   const ClipRRect({
     Key key,
-    this.borderRadius,
+    this.borderRadius = BorderRadius.zero,
     this.clipper,
     this.clipBehavior = Clip.antiAlias,
     Widget child,

--- a/packages/flutter/test/widgets/clip_test.dart
+++ b/packages/flutter/test/widgets/clip_test.dart
@@ -92,6 +92,12 @@ void main() {
     expect(renderClip.clipBehavior, equals(Clip.hardEdge));
   });
 
+  test('ClipRRect constructs with the right default values', () {
+    const ClipRRect clipRRect = ClipRRect();
+    expect(clipRRect.clipBehavior, equals(Clip.antiAlias));
+    expect(clipRRect.borderRadius, equals(BorderRadius.zero));
+  });
+
   testWidgets('ClipRRect updates clipBehavior in updateRenderObject', (WidgetTester tester) async {
     await tester.pumpWidget(_UpdateCountedClipRRect());
 


### PR DESCRIPTION
## Description

The documentation of the default `ClipRRect` constructor states:
```
The [borderRadius] defaults to [BorderRadius.zero], i.e. a rectangle with
right-angled corners.
```

However the code was not in sync with the documented behaviour.

## Related Issues

## Tests

I added the following tests:
no tests added

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
