### PR TITLE
Wire up canRequestFocus and skipTraversal in FocusScopeNode

### DIFF
--- a/examples/flutter_gallery/lib/gallery/backdrop.dart
+++ b/examples/flutter_gallery/lib/gallery/backdrop.dart
@@ -66,9 +66,13 @@ class _TappableWhileStatusIsState extends State<_TappableWhileStatusIs> {
 
   @override
   Widget build(BuildContext context) {
-    return AbsorbPointer(
-      absorbing: !_active,
-      child: widget.child,
+    return FocusScope(
+      canRequestFocus: _active,
+      debugLabel: '$_TappableWhileStatusIs',
+      child: AbsorbPointer(
+        absorbing: !_active,
+        child: widget.child,
+      ),
     );
   }
 }
@@ -239,11 +243,9 @@ class _BackdropState extends State<Backdrop> with SingleTickerProviderStateMixin
       _controller.fling(velocity: _controller.value < 0.5 ? -2.0 : 2.0);
   }
 
-  void _toggleFrontLayer() {
-    final AnimationStatus status = _controller.status;
-    final bool isOpen = status == AnimationStatus.completed || status == AnimationStatus.forward;
-    _controller.fling(velocity: isOpen ? -2.0 : 2.0);
-  }
+  bool get _isOpen => _controller.status == AnimationStatus.completed || _controller.status == AnimationStatus.forward;
+
+  void _toggleFrontLayer() => _controller.fling(velocity: _isOpen ? -2.0 : 2.0);
 
   Widget _buildStack(BuildContext context, BoxConstraints constraints) {
     final Animation<RelativeRect> frontRelativeRect = _controller.drive(RelativeRectTween(
@@ -275,10 +277,14 @@ class _BackdropState extends State<Backdrop> with SingleTickerProviderStateMixin
               ),
             ),
             Expanded(
-              child: Visibility(
-                child: widget.backLayer,
-                visible: _controller.status != AnimationStatus.completed,
-                maintainState: true,
+              child: _TappableWhileStatusIs(
+                AnimationStatus.dismissed,
+                controller: _controller,
+                child: Visibility(
+                  child: widget.backLayer,
+                  visible: _controller.status != AnimationStatus.completed,
+                  maintainState: true,
+                ),
               ),
             ),
           ],

--- a/examples/flutter_gallery/lib/gallery/backdrop.dart
+++ b/examples/flutter_gallery/lib/gallery/backdrop.dart
@@ -66,14 +66,19 @@ class _TappableWhileStatusIsState extends State<_TappableWhileStatusIs> {
 
   @override
   Widget build(BuildContext context) {
-    return FocusScope(
-      canRequestFocus: _active,
-      debugLabel: '$_TappableWhileStatusIs',
-      child: AbsorbPointer(
-        absorbing: !_active,
-        child: widget.child,
-      ),
+    Widget child = AbsorbPointer(
+      absorbing: !_active,
+      child: widget.child,
     );
+
+    if (!_active) {
+      child = FocusScope(
+        canRequestFocus: false,
+        debugLabel: '$_TappableWhileStatusIs',
+        child: child,
+      );
+    }
+    return child;
   }
 }
 
@@ -243,9 +248,11 @@ class _BackdropState extends State<Backdrop> with SingleTickerProviderStateMixin
       _controller.fling(velocity: _controller.value < 0.5 ? -2.0 : 2.0);
   }
 
-  bool get _isOpen => _controller.status == AnimationStatus.completed || _controller.status == AnimationStatus.forward;
-
-  void _toggleFrontLayer() => _controller.fling(velocity: _isOpen ? -2.0 : 2.0);
+  void _toggleFrontLayer() {
+    final AnimationStatus status = _controller.status;
+    final bool isOpen = status == AnimationStatus.completed || status == AnimationStatus.forward;
+    _controller.fling(velocity: isOpen ? -2.0 : 2.0);
+  }
 
   Widget _buildStack(BuildContext context, BoxConstraints constraints) {
     final Animation<RelativeRect> frontRelativeRect = _controller.drive(RelativeRectTween(

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -952,7 +952,16 @@ class FocusScopeNode extends FocusNode {
   FocusScopeNode({
     String debugLabel,
     FocusOnKeyCallback onKey,
-  }) : super(debugLabel: debugLabel, onKey: onKey);
+    bool skipTraversal = false,
+    bool canRequestFocus = true,
+  })  : assert(skipTraversal != null),
+        assert(canRequestFocus != null),
+        super(
+          debugLabel: debugLabel,
+          onKey: onKey,
+          canRequestFocus: canRequestFocus,
+          skipTraversal: skipTraversal,
+        );
 
   @override
   FocusScopeNode get nearestScope => this;

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -516,6 +516,8 @@ class FocusScope extends Focus {
     @required Widget child,
     bool autofocus = false,
     ValueChanged<bool> onFocusChange,
+    bool canRequestFocus,
+    bool skipTraversal,
     FocusOnKeyCallback onKey,
     String debugLabel,
   })  : assert(child != null),
@@ -526,6 +528,8 @@ class FocusScope extends Focus {
           focusNode: node,
           autofocus: autofocus,
           onFocusChange: onFocusChange,
+          canRequestFocus: canRequestFocus,
+          skipTraversal: skipTraversal,
           onKey: onKey,
           debugLabel: debugLabel,
         );
@@ -552,6 +556,8 @@ class _FocusScopeState extends _FocusState {
   FocusScopeNode _createNode() {
     return FocusScopeNode(
       debugLabel: widget.debugLabel,
+      canRequestFocus: widget.canRequestFocus ?? true,
+      skipTraversal: widget.skipTraversal ?? false,
     );
   }
 


### PR DESCRIPTION
## Description
This adds a `canRequestFocus` and `skipTraversal` argument to `FocusScope` and `FocusScopeNode`, so that a scope can prevent being traversed.

This allows a fix for a problem in the gallery where the focus while traversing the list of items would sometimes appear to disappear, since it would be focusing things that were in the backdrop that were part of the tree, but were not visible.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/42955

## Tests

- Added tests for `canRequestFocus` and `skipTraversal` for `FocusScopeNode`.

## Breaking Change

- [X] No, this is *not* a breaking change.