### PR TITLE
Build only required web tests; fix and enable most of material tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -150,7 +150,6 @@ task:
         # As of October 2019, the Web shards needed more than 6G of RAM.
         CPU: 2
         MEMORY: 8G
-      allow_failures: true
       script:
         - dart --enable-asserts ./dev/bots/test.dart
 
@@ -160,7 +159,6 @@ task:
         # As of October 2019, the Web shards needed more than 6G of RAM.
         CPU: 2
         MEMORY: 8G
-      allow_failures: true
       script:
         - dart --enable-asserts ./dev/bots/test.dart
 
@@ -170,7 +168,6 @@ task:
         # As of October 2019, the Web shards needed more than 6G of RAM.
         CPU: 2
         MEMORY: 8G
-      allow_failures: true
       script:
         - dart --enable-asserts ./dev/bots/test.dart
 
@@ -180,7 +177,6 @@ task:
         # As of October 2019, the Web shards needed more than 6G of RAM.
         CPU: 2
         MEMORY: 8G
-      allow_failures: true
       script:
         - dart --enable-asserts ./dev/bots/test.dart
 
@@ -190,17 +186,33 @@ task:
         # As of October 2019, the Web shards needed more than 6G of RAM.
         CPU: 2
         MEMORY: 8G
-      allow_failures: true
       script:
         - dart --enable-asserts ./dev/bots/test.dart
 
-    - name: web_tests-5_last-linux # last Web shard must end with _last
+    - name: web_tests-5-linux
       only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_tools/lib/src/test/**', 'packages/flutter_web_plugins/**', 'bin/internal/**') || $CIRRUS_PR == ''"
       environment:
         # As of October 2019, the Web shards needed more than 6G of RAM.
         CPU: 2
         MEMORY: 8G
-      allow_failures: true
+      script:
+        - dart --enable-asserts ./dev/bots/test.dart
+
+    - name: web_tests-6-linux
+      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_tools/lib/src/test/**', 'packages/flutter_web_plugins/**', 'bin/internal/**') || $CIRRUS_PR == ''"
+      environment:
+        # As of October 2019, the Web shards needed more than 6G of RAM.
+        CPU: 2
+        MEMORY: 8G
+      script:
+        - dart --enable-asserts ./dev/bots/test.dart
+
+    - name: web_tests-7_last-linux # last Web shard must end with _last
+      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_tools/lib/src/test/**', 'packages/flutter_web_plugins/**', 'bin/internal/**') || $CIRRUS_PR == ''"
+      environment:
+        # As of October 2019, the Web shards needed more than 6G of RAM.
+        CPU: 2
+        MEMORY: 8G
       script:
         - dart --enable-asserts ./dev/bots/test.dart
 

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -50,7 +50,7 @@ const int kDeviceLabShardCount = 4;
 /// and make sure it runs _all_ shards.
 ///
 /// The last shard also runs the Web plugin tests.
-const int kWebShardCount = 6;
+const int kWebShardCount = 8;
 
 /// Maximum number of Web tests to run in a single `flutter test`. We found that
 /// large batches can get flaky, possibly because we reuse a single instance of
@@ -63,7 +63,6 @@ const int kWebBatchSize = 20;
 const List<String> kWebTestDirectoryBlacklist = <String>[
   'cupertino',
   'examples',
-  'material',
 ];
 const List<String> kWebTestFileBlacklist = <String>[
   'test/widgets/heroes_test.dart',
@@ -77,6 +76,11 @@ const List<String> kWebTestFileBlacklist = <String>[
   'test/widgets/widget_inspector_test.dart',
   'test/widgets/draggable_test.dart',
   'test/widgets/shortcuts_test.dart',
+  'test/material/text_form_field_test.dart',
+  'test/material/banner_theme_test.dart',
+  'test/material/popup_menu_test.dart',
+  'test/material/data_table_test.dart',
+  'test/material/toggle_buttons_test.dart',
 ];
 
 /// When you call this, you can pass additional arguments to pass custom

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -2620,6 +2620,7 @@ class _PaddleSliderTrackShapePathPainter {
   // Adds an arc to the path that has the attributes passed in. This is
   // a convenience to make adding arcs have less boilerplate.
   static void _addArc(Path path, Offset center, double radius, double startAngle, double endAngle) {
+    assert(center.isFinite);
     final Rect arcRect = Rect.fromCircle(center: center, radius: radius);
     path.arcTo(arcRect, startAngle, endAngle - startAngle, false);
   }
@@ -2692,6 +2693,12 @@ class _PaddleSliderTrackShapePathPainter {
     TextPainter labelPainter,
     Color strokePaintColor,
   ) {
+    if (scale == 0.0) {
+      // Zero scale essentially means "do not draw anything", so it's safe to just return. Otherwise,
+      // our math below will attempt to divide by zero and send needless NaNs to the engine.
+      return;
+    }
+
     // The entire value indicator should scale with the size of the label,
     // to keep it large enough to encompass the label text.
     final double textScaleFactor = labelPainter.height / _labelTextDesignSize;

--- a/packages/flutter/test/material/paginated_data_table_test.dart
+++ b/packages/flutter/test/material/paginated_data_table_test.dart
@@ -259,7 +259,7 @@ void main() {
     expect(find.text('501'), findsOneWidget);
     // Test that it fits:
     expect(tester.getTopRight(find.text('501')).dx, greaterThanOrEqualTo(tester.getTopRight(find.text('Rows per page:')).dx + 40.0));
-  });
+  }, skip: isBrowser);  // TODO(yjbanov): https://github.com/flutter/flutter/issues/43433
 
   testWidgets('PaginatedDataTable footer scrolls', (WidgetTester tester) async {
     final TestDataSource source = TestDataSource();

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -814,9 +814,39 @@ void main() {
 
     await gesture.up();
   });
+
+  testWidgets('PaddleRangeSliderValueIndicatorShape skips all painting at zero scale', (WidgetTester tester) async {
+    // Pump a slider with just a value indicator.
+    await tester.pumpWidget(_buildApp(
+      ThemeData().sliderTheme.copyWith(
+        trackHeight: 0,
+        overlayShape: SliderComponentShape.noOverlay,
+        thumbShape: SliderComponentShape.noThumb,
+        tickMarkShape: SliderTickMarkShape.noTickMark,
+        showValueIndicator: ShowValueIndicator.always,
+        rangeValueIndicatorShape: const PaddleRangeSliderValueIndicatorShape(),
+      ),
+      value: 0.5,
+      divisions: 4,
+    ));
+
+    final RenderBox sliderBox = tester.firstRenderObject<RenderBox>(find.byType(Slider));
+
+    // Tap the center of the track to kick off the animation of the value indicator.
+    final Offset center = tester.getCenter(find.byType(Slider));
+    final TestGesture gesture = await tester.startGesture(center);
+
+    // Nothing to paint at scale 0.
+    await tester.pump();
+    expect(sliderBox, paintsNothing);
+
+    // Painting a path for the value indicator.
+    await tester.pump(const Duration(milliseconds: 16));
+    expect(sliderBox, paintsExactlyCountTimes(#drawPath, 1));
+
+    await gesture.up();
+  });
 }
-
-
 
 Widget _buildApp(
   SliderThemeData sliderTheme, {
@@ -841,5 +871,3 @@ Widget _buildApp(
     ),
   );
 }
-
-

--- a/packages/flutter_tools/lib/src/build_runner/build_script.dart
+++ b/packages/flutter_tools/lib/src/build_runner/build_script.dart
@@ -278,7 +278,7 @@ Future<void> main() async {
   // we don't have an embedder yet this is the lowest-most layer we can put
   // this stuff in.
   ui.debugEmulateFlutterTesterEnvironment = true;
-  await ui.webOnlyInitializeEngine();
+  await ui.webOnlyInitializePlatform();
   // TODO(flutterweb): remove need for dynamic cast.
   (ui.window as dynamic).debugOverrideDevicePixelRatio(3.0);
   (ui.window as dynamic).webOnlyDebugPhysicalSizeOverride = const ui.Size(2400, 1800);

--- a/packages/flutter_tools/lib/src/build_runner/web_compilation_delegate.dart
+++ b/packages/flutter_tools/lib/src/build_runner/web_compilation_delegate.dart
@@ -30,6 +30,7 @@ class BuildRunnerWebCompilationProxy extends WebCompilationProxy {
   Future<bool> initialize({
     Directory projectDirectory,
     String testOutputDir,
+    List<String> testFiles,
     BuildMode mode,
     String projectName,
     bool initializePlatform,
@@ -46,8 +47,15 @@ class BuildRunnerWebCompilationProxy extends WebCompilationProxy {
       release: mode == BuildMode.release,
       profile: mode == BuildMode.profile,
       hasPlugins: hasWebPlugins,
-      includeTests: true,
       initializePlatform: initializePlatform,
+      testTargets: WebTestTargetManifest(
+        testFiles
+          .map<String>((String absolutePath) {
+            final String relativePath = path.relative(absolutePath, from: projectDirectory.path);
+            return '${path.withoutExtension(relativePath)}.*';
+          })
+          .toList(),
+      ),
     );
     client.startBuild();
     bool success = true;

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -139,7 +139,7 @@ class FlutterWebPlatform extends PlatformPlugin {
         requireJs.openRead(),
         headers: <String, String>{'Content-Type': 'text/javascript'},
       );
-    } else if (request.requestedUri.path.contains('Ahem.ttf')) {
+    } else if (request.requestedUri.path.contains('ahem.ttf')) {
       return shelf.Response.ok(ahem.openRead());
     } else if (request.requestedUri.path.contains('dart_sdk.js')) {
       return shelf.Response.ok(

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -71,6 +71,7 @@ Future<int> runTests(
     final bool result = await webCompilationProxy.initialize(
       projectDirectory: flutterProject.directory,
       testOutputDir: tempBuildDir,
+      testFiles: testFiles,
       projectName: flutterProject.manifest.appName,
       initializePlatform: true,
     );

--- a/packages/flutter_tools/lib/src/web/compile.dart
+++ b/packages/flutter_tools/lib/src/web/compile.dart
@@ -75,6 +75,7 @@ class WebCompilationProxy {
     @required Directory projectDirectory,
     @required String projectName,
     String testOutputDir,
+    List<String> testFiles,
     BuildMode mode,
     bool initializePlatform,
   }) async {


### PR DESCRIPTION
## Description

* Change `BuildDaemonCreator` to build only tests that were requested.
* Remove the `material/` directory from the web blacklist. This enables most of material tests. There are still a few tests that need to be looked at, which I added to the file blacklist.
* Change the slider theme to skip painting at scale 0. Otherwise, the math results in NaNs that we needlessly send to the engine.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/41914
Fixes https://github.com/flutter/flutter/issues/37810

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
