### PR TITLE
Add a scope parameter InheritedWidget+subclasses

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1587,7 +1587,7 @@ abstract class InheritedWidget extends ProxyWidget {
   const InheritedWidget({ Key key, this.scope, Widget child })
     : super(key: key, child: child);
 
-  /// An identifier that allows two differenciate between two [InheritedWidget]
+  /// An identifier that allows to differentiate between two [InheritedWidget]
   /// of same type.
   ///
   /// If a [scope] is specified, that same object must be passed to
@@ -1595,7 +1595,7 @@ abstract class InheritedWidget extends ProxyWidget {
   /// [Context.inheritFromWidgetOfExactType] to be able to obtain this
   /// [InheritedWidget].
   ///
-  /// Defaults to `null`.
+  /// Defaults to null.
   final Object scope;
 
   @override

--- a/packages/flutter/lib/src/widgets/inherited_model.dart
+++ b/packages/flutter/lib/src/widgets/inherited_model.dart
@@ -97,7 +97,7 @@ abstract class InheritedModel<T> extends InheritedWidget {
   /// Creates an inherited widget that supports dependencies qualified by
   /// "aspects", i.e. a descendant widget can indicate that it should
   /// only be rebuilt if a specific aspect of the model changes.
-  const InheritedModel({ Key key, Widget child }) : super(key: key, child: child);
+  const InheritedModel({ Key key, Object scope, Widget child }) : super(key: key, scope: scope, child: child);
 
   @override
   InheritedModelElement<T> createElement() => InheritedModelElement<T>(this);

--- a/packages/flutter/lib/src/widgets/inherited_notifier.dart
+++ b/packages/flutter/lib/src/widgets/inherited_notifier.dart
@@ -46,9 +46,10 @@ abstract class InheritedNotifier<T extends Listenable> extends InheritedWidget {
   const InheritedNotifier({
     Key key,
     this.notifier,
+    Object scope,
     @required Widget child,
   }) : assert(child != null),
-       super(key: key, child: child);
+       super(key: key, scope: scope, child: child);
 
   /// The [Listenable] object to which to listen.
   ///

--- a/packages/flutter/test/widgets/inherited_model_test.dart
+++ b/packages/flutter/test/widgets/inherited_model_test.dart
@@ -479,7 +479,7 @@ void main() {
   testWidgets('InheritedModel can be scoped', (WidgetTester tester) async {
     final GlobalKey<void> scopedKey = GlobalKey();
     final GlobalKey<void> unscopedKey = GlobalKey();
-    
+
     await tester.pumpWidget(
       ABCModel(
         key: unscopedKey,

--- a/packages/flutter/test/widgets/inherited_model_test.dart
+++ b/packages/flutter/test/widgets/inherited_model_test.dart
@@ -476,7 +476,7 @@ void main() {
     expect(find.text('a: 101 b: 102 c: null'), findsOneWidget); // inner model's a, b, c
   });
 
-  testWidgets('InheritedNotifier can be scoped', (WidgetTester tester) async {
+  testWidgets('InheritedModel can be scoped', (WidgetTester tester) async {
     final GlobalKey<void> scopedKey = GlobalKey();
     final GlobalKey<void> unscopedKey = GlobalKey();
     

--- a/packages/flutter/test/widgets/inherited_test.dart
+++ b/packages/flutter/test/widgets/inherited_test.dart
@@ -57,8 +57,8 @@ class ExpectFailState extends State<ExpectFail> {
 }
 
 class ChangeNotifierInherited extends InheritedNotifier<ChangeNotifier> {
-  const ChangeNotifierInherited({ Key key, Widget child, ChangeNotifier notifier })
-    : super(key: key, child: child, notifier: notifier);
+  const ChangeNotifierInherited({ Key key, Widget child, Object scope, ChangeNotifier notifier })
+    : super(key: key, child: child, scope: scope, notifier: notifier);
 }
 
 void main() {
@@ -102,7 +102,6 @@ void main() {
         ),
       ),
     );
-
 
     final BuildContext context = tester.element(find.byType(Container));
 
@@ -557,4 +556,41 @@ void main() {
     ));
     expect(buildCount, equals(3));
   });
+
+  testWidgets('InheritedNotifier can be scoped', (WidgetTester tester) async {
+    final GlobalKey<void> scopedKey = GlobalKey();
+    final GlobalKey<void> unscopedKey = GlobalKey();
+    
+    await tester.pumpWidget(
+      ChangeNotifierInherited(
+        key: unscopedKey,
+        child: ChangeNotifierInherited(
+          key: scopedKey,
+          scope: 42,
+          child: Container(),
+        ),
+      ),
+    );
+
+    final BuildContext context = tester.element(find.byType(Container));
+
+    expect(
+      context.ancestorInheritedElementForWidgetOfExactType(ChangeNotifierInherited, scope: 42).widget,
+      equals(scopedKey.currentWidget),
+    );
+    expect(
+      context.ancestorInheritedElementForWidgetOfExactType(ChangeNotifierInherited).widget,
+      equals(unscopedKey.currentWidget),
+    );
+
+    expect(
+      context.inheritFromWidgetOfExactType(ChangeNotifierInherited, scope: 42),
+      equals(scopedKey.currentWidget),
+    );
+    expect(
+      context.inheritFromWidgetOfExactType(ChangeNotifierInherited),
+      equals(unscopedKey.currentWidget),
+    );
+  });
+
 }

--- a/packages/flutter/test/widgets/inherited_test.dart
+++ b/packages/flutter/test/widgets/inherited_test.dart
@@ -91,7 +91,7 @@ void main() {
   testWidgets('Inherited can be scoped', (WidgetTester tester) async {
     final GlobalKey<void> scopedKey = GlobalKey();
     final GlobalKey<void> unscopedKey = GlobalKey();
-    
+
     await tester.pumpWidget(
       TestInherited(
         key: unscopedKey,
@@ -560,7 +560,7 @@ void main() {
   testWidgets('InheritedNotifier can be scoped', (WidgetTester tester) async {
     final GlobalKey<void> scopedKey = GlobalKey();
     final GlobalKey<void> unscopedKey = GlobalKey();
-    
+
     await tester.pumpWidget(
       ChangeNotifierInherited(
         key: unscopedKey,


### PR DESCRIPTION
## Description

This adds a `scope` parameter to `InheritedWidget` + its subclasses, and to the associated methods on `BuildContext`.

It allows having two `InheritedWidget` of the same `runtimeType` in the widget tree and be able to obtain both of them independently from each other.

## Related Issues

## Tests

I added the following tests:

- InheritedWidget can be scoped
- InheritedModel can be scoped
- InheritedNotifier can be scoped

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
