### PR TITLE
Ensure `android.enableR8` is appended to a new line

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -387,8 +387,14 @@ void migrateToR8(Directory directory) {
   }
   printTrace('set `android.enableR8=true` in gradle.properties');
   try {
-    gradleProperties
-      .writeAsStringSync('android.enableR8=true\n', mode: FileMode.append);
+    // Add `android.enableR8=true` to the next line in gradle.properties.
+    if (propertiesContent.isNotEmpty && !propertiesContent.endsWith('\n')) {
+      gradleProperties
+        .writeAsStringSync('\nandroid.enableR8=true\n', mode: FileMode.append);
+    } else {
+      gradleProperties
+        .writeAsStringSync('android.enableR8=true\n', mode: FileMode.append);
+    }
   } on FileSystemException {
     throwToolExit(
       'The tool failed to add `android.enableR8=true` to ${gradleProperties.path}. '

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -1410,6 +1410,27 @@ Exception in thread "main" java.lang.NullPointerException
       FileSystem: () => memoryFileSystem,
       ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
     });
+
+    testUsingContext('appends android.enableR8=true to the new line', () {
+      final Directory sampleAppAndroid = fs.directory('/sample-app/android');
+      sampleAppAndroid.createSync(recursive: true);
+      sampleAppAndroid.childFile('gradle.properties')
+        .writeAsStringSync('org.gradle.jvmargs=-Xmx1536M');
+
+      migrateToR8(sampleAppAndroid);
+
+      expect(testLogger.traceText, contains('set `android.enableR8=true` in gradle.properties'));
+      expect(
+        sampleAppAndroid.childFile('gradle.properties').readAsStringSync(),
+        equals(
+          'org.gradle.jvmargs=-Xmx1536M\n'
+          'android.enableR8=true\n'
+        ),
+      );
+    }, overrides: <Type, Generator>{
+      FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager(<FakeCommand>[]),
+    });
   });
 
   group('isAppUsingAndroidX', () {


### PR DESCRIPTION
## Description

This is an issue if the file doesn't have a new line at the end of file.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/41016

## Tests

I added the following tests: unit tests

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
