### PR TITLE
remove period from URL so that it opens correctly in vscode

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -128,7 +128,7 @@ class ResidentWebRunner extends ResidentRunner {
     );
     printStatus('Warning: Flutter\'s support for web development is not stable yet and hasn\'t');
     printStatus('been thoroughly tested in production environments.');
-    printStatus('For more information see https://flutter.dev/web.');
+    printStatus('For more information see https://flutter.dev/web');
     printStatus('');
     printStatus(message);
     const String quitMessage = 'To quit, press "q".';

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -301,6 +301,8 @@ void main() {
     final BufferLogger bufferLogger = logger;
 
     expect(bufferLogger.statusText, contains('Warning'));
+    expect(bufferLogger.statusText, contains('https://flutter.dev/web'));
+    expect(bufferLogger.statusText, isNot(contains('https://flutter.dev/web.')));
   }));
 
   test('debugDumpApp', () => testbed.run(() async {


### PR DESCRIPTION
## Description
vscode attempts to open a URL with a period at the end.

Fixes https://github.com/flutter/flutter/issues/43199