### PR TITLE
comment out fastlane test archiving

### DIFF
--- a/dev/bots/deploy_gallery.sh
+++ b/dev/bots/deploy_gallery.sh
@@ -99,7 +99,8 @@ elif [[ "$OS" == "darwin" ]]; then
       echo "Testing archiving with distribution profile..."
       (
         cd examples/flutter_gallery/ios
-        fastlane build_and_deploy_testflight
+        # TODO(fujino) re-enable after resolving https://github.com/flutter/flutter/issues/43204
+        #fastlane build_and_deploy_testflight
       )
       echo "(Not deploying; Flutter Gallery is only deployed to TestFlight for tagged dev branch commits.)"
     fi


### PR DESCRIPTION
## Description

Currently cirrus is failing the mac deploy gallery test because fastlane is looking for a version of the Google Cloud SDK newer than that on the docker image. Re-building the docker image is complicated, so I am temporarily commenting out the offending step. Note, that this test will still fail on the next published release until the issue is resolved:  https://github.com/flutter/flutter/issues/43204.