### PR TITLE
For --profile builds on web, still use -O4 but unminified names.

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -137,10 +137,10 @@ class Dart2JSTarget extends Target {
       '--libraries-spec=$specPath',
       if (dart2jsOptimization != null)
         '-$dart2jsOptimization'
-      else if (buildMode == BuildMode.profile)
-        '-O1'
       else
         '-O4',
+      if (buildMode == BuildMode.profile)
+        '--no-minify',
       '-o',
       environment.buildDir.childFile('main.dart.js').path,
       '--packages=$packageFile',

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -157,7 +157,8 @@ void main() {
       fs.path.join('bin', 'cache', 'dart-sdk', 'bin', 'dart'),
       fs.path.join('bin', 'cache', 'dart-sdk', 'bin', 'snapshots', 'dart2js.dart.snapshot'),
       '--libraries-spec=' + fs.path.join('bin', 'cache', 'flutter_web_sdk', 'libraries.json'),
-      '-O1', // lowest optimizations.
+      '-O4', // highest optimizations
+      '--no-minify', // but uses unminified names for debugging
       '-o',
       environment.buildDir.childFile('main.dart.js').absolute.path,
       '--packages=.packages',


### PR DESCRIPTION
## Description

Currently, in `--profile` mode, the web build uses `-O1`, which produces unminified code, but without many of the optimizations that would be in release mode, which makes it hard to profile the release build.

## Tests

I updated `test/general.shard/build_system/targets/web_test.dart` to expect the new Dart2js arguments for `--profile` mode.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
