### PR TITLE
Fixing focus traversal when the node options are empty

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -249,7 +249,11 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
         }
       }
     });
-    return sorted.first;
+
+    if (sorted.isNotEmpty)
+      return sorted.first;
+
+    return null;
   }
 
   // Sorts nodes from left to right horizontally, and removes nodes that are

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -1127,6 +1127,25 @@ void main() {
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
       expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
     });
+    testWidgets('Focus traversal does not break when no focusable is available on a MaterialApp',   (WidgetTester tester) async {
+      final List<RawKeyEvent> events = <RawKeyEvent>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Container()
+        )
+      );
+
+      RawKeyboard.instance.addListener((RawKeyEvent event) {
+        events.add(event);
+      });
+
+      await tester.idle();
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.idle();
+
+      expect(events.length, 2);
+    });
   });
 }
 


### PR DESCRIPTION
## Description

I am currently updating my [gamepad package](https://github.com/flame-engine/flame_gamepad) and while working on it I have apparently stomped on a little bug on Flutter, when any of the directional keys from the gamepad DPAD was pressed, the following exception was throw:

```
I/flutter (22401): ══╡ EXCEPTION CAUGHT BY SERVICES LIBRARY ╞══════════════════════════════════════════════════════════
I/flutter (22401): The following StateError was thrown during a platform message callback:
I/flutter (22401): Bad state: No element
I/flutter (22401):
I/flutter (22401): When the exception was thrown, this was the stack:
I/flutter (22401): #0      List.first (dart:core-patch/growable_array.dart:220:5)
I/flutter (22401): #1      DirectionalFocusTraversalPolicyMixin._sortAndFindInitial (package:flutter/src/widgets/focus_traversal.dart:254:21)
I/flutter (22401): #2      DirectionalFocusTraversalPolicyMixin.findFirstFocusInDirection (package:flutter/src/widgets/focus_traversal.dart:226:16)
I/flutter (22401): #3      DirectionalFocusTraversalPolicyMixin.inDirection (package:flutter/src/widgets/focus_traversal.dart:403:36)
I/flutter (22401): #4      FocusNode.focusInDirection (package:flutter/src/widgets/focus_manager.dart:893:92)
I/flutter (22401): #5      DirectionalFocusAction.invoke (package:flutter/src/widgets/focus_traversal.dart:940:12)
I/flutter (22401): #6      ActionDispatcher.invokeAction (package:flutter/src/widgets/actions.dart:158:14)
I/flutter (22401): #7      Actions.invoke (package:flutter/src/widgets/actions.dart:343:44)
I/flutter (22401): #8      ShortcutManager.handleKeypress (package:flutter/src/widgets/shortcuts.dart:216:22)
I/flutter (22401): #9      _ShortcutsState._handleOnKey (package:flutter/src/widgets/shortcuts.dart:343:20)
I/flutter (22401): #10     FocusManager._handleRawKeyEvent (package:flutter/src/widgets/focus_manager.dart:1304:38)
I/flutter (22401): #11     RawKeyboard._handleKeyEvent (package:flutter/src/services/raw_keyboard.dart:513:17)
I/flutter (22401): <asynchronous suspension>
I/flutter (22401): #12     BasicMessageChannel.setMessageHandler.<anonymous closure> (package:flutter/src/services/platform_channel.dart:74:49)
I/flutter (22401): <asynchronous suspension>
I/flutter (22401): #13     _DefaultBinaryMessenger.handlePlatformMessage (package:flutter/src/services/binding.dart:200:33)
I/flutter (22401): <asynchronous suspension>
I/flutter (22401): #14     _invoke3.<anonymous closure> (dart:ui/hooks.dart:303:15)
I/flutter (22401): #18     _invoke3 (dart:ui/hooks.dart:302:10)
I/flutter (22401): #19     _dispatchPlatformMessage (dart:ui/hooks.dart:162:5)
I/flutter (22401): (elided 3 frames from package dart:async)
I/flutter (22401): ════════════════════════════════════════════════════════════════════════════════════════════════════
```
From my investigation, that happened because there were no focusable elements on the example app.

So when a direction key was pressed, it triggered the focus traversal, an error happened because no focusable elements are available and the list is empty and then my RawKeyboard listener was not triggered because of the exception that just happened.

This simple verification prevents the exception from happening and now the listener is called.

## Tests

I wasn't able to figure out how to write an automated test for it, but I ran focus_traversal_test.dart file after my change and everything is still passing.

If you think this test is required and if you can help me with some orientation on how to test this, I can add a new commit with the test.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.