### PR TITLE
Add compiler configuration to support dartdevc target

### DIFF
--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -40,6 +40,8 @@ enum Artifact {
   kernelWorkerSnapshot,
   /// The root of the web implementation of the dart SDK.
   flutterWebSdk,
+  /// The summary dill for the dartdevc target.
+  webPlatformKernelDill,
   iosDeploy,
   ideviceinfo,
   ideviceId,
@@ -126,6 +128,8 @@ String _artifactToFileName(Artifact artifact, [ TargetPlatform platform, BuildMo
       return 'sky_engine';
     case Artifact.flutterMacOSPodspec:
       return 'FlutterMacOS.podspec';
+    case Artifact.webPlatformKernelDill:
+      return 'flutter_ddc_sdk.dill';
   }
   assert(false, 'Invalid artifact $artifact.');
   return null;
@@ -290,6 +294,8 @@ class CachedArtifacts extends Artifacts {
         return _getFlutterPatchedSdkPath(mode);
       case Artifact.flutterWebSdk:
         return _getFlutterWebSdkPath();
+      case Artifact.webPlatformKernelDill:
+        return fs.path.join(_getFlutterWebSdkPath(), 'kernel', _artifactToFileName(artifact));
       case Artifact.dart2jsSnapshot:
         return fs.path.join(dartSdkPath, 'bin', 'snapshots', _artifactToFileName(artifact));
       case Artifact.dartdevcSnapshot:
@@ -422,6 +428,8 @@ class LocalEngineArtifacts extends Artifacts {
         return fs.path.join(_hostEngineOutPath, 'gen', 'dart-pkg', artifactFileName);
       case Artifact.flutterMacOSPodspec:
         return fs.path.join(_hostEngineOutPath, _artifactToFileName(artifact));
+      case Artifact.webPlatformKernelDill:
+        return fs.path.join(_getFlutterWebSdkPath(), 'kernel', _artifactToFileName(artifact));
     }
     assert(false, 'Invalid artifact $artifact.');
     return null;

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -52,6 +52,8 @@ class TargetModel {
         return flutterRunner;
       case 'vm':
         return vm;
+      case 'dartdevc':
+        return dartdevc;
     }
     assert(false);
     return null;
@@ -67,6 +69,9 @@ class TargetModel {
 
   /// The Dart vm.
   static const TargetModel vm = TargetModel._('vm');
+
+  /// The development compiler for JavaScript.
+  static const TargetModel dartdevc = TargetModel._('dartdevc');
 
   final String _value;
 
@@ -459,6 +464,7 @@ class ResidentCompiler {
     TargetModel targetModel = TargetModel.flutter,
     bool unsafePackageSerialization,
     List<String> experimentalFlags,
+    String platformDill,
   }) : assert(_sdkRoot != null),
        _buildMode = buildMode,
        _causalAsyncStacks = causalAsyncStacks,
@@ -471,6 +477,7 @@ class ResidentCompiler {
        _controller = StreamController<_CompilationRequest>(),
        _initializeFromDill = initializeFromDill,
        _unsafePackageSerialization = unsafePackageSerialization,
+       _platformDill = platformDill,
        _experimentalFlags = experimentalFlags {
     // This is a URI, not a file path, so the forward slash is correct even on Windows.
     if (!_sdkRoot.endsWith('/')) {
@@ -491,6 +498,7 @@ class ResidentCompiler {
   final String _initializeFromDill;
   final bool _unsafePackageSerialization;
   final List<String> _experimentalFlags;
+  final String _platformDill;
   bool _compileRequestNeedsConfirmation = false;
 
   final StreamController<_CompilationRequest> _controller;
@@ -619,6 +627,10 @@ class ResidentCompiler {
       if (_initializeFromDill != null) ...<String>[
         '--initialize-from-dill',
         _initializeFromDill,
+      ],
+      if (_platformDill != null) ...<String>[
+        '--platform',
+        _platformDill,
       ],
       if (_unsafePackageSerialization == true) '--unsafe-package-serialization',
       if ((_experimentalFlags != null) && _experimentalFlags.isNotEmpty)

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -388,9 +388,9 @@ abstract class _CompilationRequest {
 
   Completer<CompilerOutput> completer;
 
-  Future<CompilerOutput> _run(ResidentCompiler compiler);
+  Future<CompilerOutput> _run(DefaultResidentCompiler compiler);
 
-  Future<void> run(ResidentCompiler compiler) async {
+  Future<void> run(DefaultResidentCompiler compiler) async {
     completer.complete(await _run(compiler));
   }
 }
@@ -410,7 +410,7 @@ class _RecompileRequest extends _CompilationRequest {
   String packagesFilePath;
 
   @override
-  Future<CompilerOutput> _run(ResidentCompiler compiler) async =>
+  Future<CompilerOutput> _run(DefaultResidentCompiler compiler) async =>
       compiler._recompile(this);
 }
 
@@ -433,7 +433,7 @@ class _CompileExpressionRequest extends _CompilationRequest {
   bool isStatic;
 
   @override
-  Future<CompilerOutput> _run(ResidentCompiler compiler) async =>
+  Future<CompilerOutput> _run(DefaultResidentCompiler compiler) async =>
       compiler._compileExpression(this);
 }
 
@@ -441,7 +441,7 @@ class _RejectRequest extends _CompilationRequest {
   _RejectRequest(Completer<CompilerOutput> completer) : super(completer);
 
   @override
-  Future<CompilerOutput> _run(ResidentCompiler compiler) async =>
+  Future<CompilerOutput> _run(DefaultResidentCompiler compiler) async =>
       compiler._reject();
 }
 
@@ -450,58 +450,22 @@ class _RejectRequest extends _CompilationRequest {
 ///
 /// The wrapper is intended to stay resident in memory as user changes, reloads,
 /// restarts the Flutter app.
-class ResidentCompiler {
-  ResidentCompiler(
-    this._sdkRoot, {
+abstract class ResidentCompiler {
+  factory ResidentCompiler(String sdkRoot, {
     @required BuildMode buildMode,
-    bool causalAsyncStacks = true,
-    bool trackWidgetCreation = false,
+    bool causalAsyncStacks,
+    bool trackWidgetCreation,
     String packagesPath,
     List<String> fileSystemRoots,
     String fileSystemScheme,
-    CompilerMessageConsumer compilerMessageConsumer = printError,
+    CompilerMessageConsumer compilerMessageConsumer,
     String initializeFromDill,
-    TargetModel targetModel = TargetModel.flutter,
+    TargetModel targetModel,
     bool unsafePackageSerialization,
     List<String> experimentalFlags,
     String platformDill,
-  }) : assert(_sdkRoot != null),
-       _buildMode = buildMode,
-       _causalAsyncStacks = causalAsyncStacks,
-       _trackWidgetCreation = trackWidgetCreation,
-       _packagesPath = packagesPath,
-       _fileSystemRoots = fileSystemRoots,
-       _fileSystemScheme = fileSystemScheme,
-       _targetModel = targetModel,
-       _stdoutHandler = StdoutHandler(consumer: compilerMessageConsumer),
-       _controller = StreamController<_CompilationRequest>(),
-       _initializeFromDill = initializeFromDill,
-       _unsafePackageSerialization = unsafePackageSerialization,
-       _platformDill = platformDill,
-       _experimentalFlags = experimentalFlags {
-    // This is a URI, not a file path, so the forward slash is correct even on Windows.
-    if (!_sdkRoot.endsWith('/')) {
-      _sdkRoot = '$_sdkRoot/';
-    }
-  }
+  }) = DefaultResidentCompiler;
 
-  final BuildMode _buildMode;
-  final bool _causalAsyncStacks;
-  final bool _trackWidgetCreation;
-  final String _packagesPath;
-  final TargetModel _targetModel;
-  final List<String> _fileSystemRoots;
-  final String _fileSystemScheme;
-  String _sdkRoot;
-  Process _server;
-  final StdoutHandler _stdoutHandler;
-  final String _initializeFromDill;
-  final bool _unsafePackageSerialization;
-  final List<String> _experimentalFlags;
-  final String _platformDill;
-  bool _compileRequestNeedsConfirmation = false;
-
-  final StreamController<_CompilationRequest> _controller;
 
   /// If invoked for the first time, it compiles Dart script identified by
   /// [mainPath], [invalidatedFiles] list is ignored.
@@ -510,6 +474,89 @@ class ResidentCompiler {
   /// point that is used for recompilation.
   /// Binary file name is returned if compilation was successful, otherwise
   /// null is returned.
+  Future<CompilerOutput> recompile(
+    String mainPath,
+    List<Uri> invalidatedFiles, {
+    @required String outputPath,
+    String packagesFilePath,
+  });
+
+  Future<CompilerOutput> compileExpression(
+    String expression,
+    List<String> definitions,
+    List<String> typeDefinitions,
+    String libraryUri,
+    String klass,
+    bool isStatic,
+  );
+
+  /// Should be invoked when results of compilation are accepted by the client.
+  ///
+  /// Either [accept] or [reject] should be called after every [recompile] call.
+  void accept();
+
+  /// Should be invoked when results of compilation are rejected by the client.
+  ///
+  /// Either [accept] or [reject] should be called after every [recompile] call.
+  Future<CompilerOutput> reject();
+
+  /// Should be invoked when frontend server compiler should forget what was
+  /// accepted previously so that next call to [recompile] produces complete
+  /// kernel file.
+  void reset();
+
+  Future<dynamic> shutdown();
+}
+
+@visibleForTesting
+class DefaultResidentCompiler implements ResidentCompiler {
+  DefaultResidentCompiler(
+    String sdkRoot, {
+    @required this.buildMode,
+    this.causalAsyncStacks = true,
+    this.trackWidgetCreation = false,
+    this.packagesPath,
+    this.fileSystemRoots,
+    this.fileSystemScheme,
+    CompilerMessageConsumer compilerMessageConsumer = printError,
+    this.initializeFromDill,
+    this.targetModel = TargetModel.flutter,
+    this.unsafePackageSerialization,
+    this.experimentalFlags,
+    this.platformDill,
+  }) : assert(sdkRoot != null),
+       _stdoutHandler = StdoutHandler(consumer: compilerMessageConsumer),
+       // This is a URI, not a file path, so the forward slash is correct even on Windows.
+       sdkRoot = sdkRoot.endsWith('/') ? sdkRoot : '$sdkRoot/';
+
+  final BuildMode buildMode;
+  final bool causalAsyncStacks;
+  final bool trackWidgetCreation;
+  final String packagesPath;
+  final TargetModel targetModel;
+  final List<String> fileSystemRoots;
+  final String fileSystemScheme;
+  final String initializeFromDill;
+  final bool unsafePackageSerialization;
+  final List<String> experimentalFlags;
+
+  /// The path to the root of the Dart SDK used to compile.
+  ///
+  /// This is used to resolve the [platformDill].
+  final String sdkRoot;
+
+  /// The path to the platform dill file.
+  ///
+  /// This does not need to be provided for the normal Flutter workflow.
+  final String platformDill;
+
+  Process _server;
+  final StdoutHandler _stdoutHandler;
+  bool _compileRequestNeedsConfirmation = false;
+
+  final StreamController<_CompilationRequest> _controller = StreamController<_CompilationRequest>();
+
+  @override
   Future<CompilerOutput> recompile(
     String mainPath,
     List<Uri> invalidatedFiles, {
@@ -534,12 +581,12 @@ class ResidentCompiler {
     // First time recompile is called we actually have to compile the app from
     // scratch ignoring list of invalidated files.
     PackageUriMapper packageUriMapper;
-    if (request.packagesFilePath != null || _packagesPath != null) {
+    if (request.packagesFilePath != null || packagesPath != null) {
       packageUriMapper = PackageUriMapper(
         request.mainPath,
-        request.packagesFilePath ?? _packagesPath,
-        _fileSystemScheme,
-        _fileSystemRoots,
+        request.packagesFilePath ?? packagesPath,
+        fileSystemScheme,
+        fileSystemRoots,
       );
     }
 
@@ -549,7 +596,7 @@ class ResidentCompiler {
       return _compile(
           _mapFilename(request.mainPath, packageUriMapper),
           request.outputPath,
-          _mapFilename(request.packagesFilePath ?? _packagesPath, /* packageUriMapper= */ null),
+          _mapFilename(request.packagesFilePath ?? packagesPath, /* packageUriMapper= */ null),
       );
     }
 
@@ -597,11 +644,11 @@ class ResidentCompiler {
       artifacts.getArtifactPath(Artifact.engineDartBinary),
       frontendServer,
       '--sdk-root',
-      _sdkRoot,
+      sdkRoot,
       '--incremental',
       '--strong',
-      '--target=$_targetModel',
-      '-Ddart.developer.causal_async_stacks=$_causalAsyncStacks',
+      '--target=$targetModel',
+      '-Ddart.developer.causal_async_stacks=$causalAsyncStacks',
       if (outputPath != null) ...<String>[
         '--output-dill',
         outputPath,
@@ -609,32 +656,32 @@ class ResidentCompiler {
       if (packagesFilePath != null) ...<String>[
         '--packages',
         packagesFilePath,
-      ] else if (_packagesPath != null) ...<String>[
+      ] else if (packagesPath != null) ...<String>[
         '--packages',
-        _packagesPath,
+        packagesPath,
       ],
-      ..._buildModeOptions(_buildMode),
-      if (_trackWidgetCreation) '--track-widget-creation',
-      if (_fileSystemRoots != null)
-        for (String root in _fileSystemRoots) ...<String>[
+      ..._buildModeOptions(buildMode),
+      if (trackWidgetCreation) '--track-widget-creation',
+      if (fileSystemRoots != null)
+        for (String root in fileSystemRoots) ...<String>[
           '--filesystem-root',
           root,
         ],
-      if (_fileSystemScheme != null) ...<String>[
+      if (fileSystemScheme != null) ...<String>[
         '--filesystem-scheme',
-        _fileSystemScheme,
+        fileSystemScheme,
       ],
-      if (_initializeFromDill != null) ...<String>[
+      if (initializeFromDill != null) ...<String>[
         '--initialize-from-dill',
-        _initializeFromDill,
+        initializeFromDill,
       ],
-      if (_platformDill != null) ...<String>[
+      if (platformDill != null) ...<String>[
         '--platform',
-        _platformDill,
+        platformDill,
       ],
-      if (_unsafePackageSerialization == true) '--unsafe-package-serialization',
-      if ((_experimentalFlags != null) && _experimentalFlags.isNotEmpty)
-        '--enable-experiment=${_experimentalFlags.join(',')}',
+      if (unsafePackageSerialization == true) '--unsafe-package-serialization',
+      if ((experimentalFlags != null) && experimentalFlags.isNotEmpty)
+        '--enable-experiment=${experimentalFlags.join(',')}',
     ];
     printTrace(command.join(' '));
     _server = await processManager.start(command);
@@ -669,6 +716,7 @@ class ResidentCompiler {
     return _stdoutHandler.compilerOutput.future;
   }
 
+  @override
   Future<CompilerOutput> compileExpression(
     String expression,
     List<String> definitions,
@@ -712,9 +760,7 @@ class ResidentCompiler {
     return _stdoutHandler.compilerOutput.future;
   }
 
-  /// Should be invoked when results of compilation are accepted by the client.
-  ///
-  /// Either [accept] or [reject] should be called after every [recompile] call.
+  @override
   void accept() {
     if (_compileRequestNeedsConfirmation) {
       _server.stdin.writeln('accept');
@@ -723,9 +769,7 @@ class ResidentCompiler {
     _compileRequestNeedsConfirmation = false;
   }
 
-  /// Should be invoked when results of compilation are rejected by the client.
-  ///
-  /// Either [accept] or [reject] should be called after every [recompile] call.
+  @override
   Future<CompilerOutput> reject() {
     if (!_controller.hasListener) {
       _controller.stream.listen(_handleCompilationRequest);
@@ -747,9 +791,7 @@ class ResidentCompiler {
     return _stdoutHandler.compilerOutput.future;
   }
 
-  /// Should be invoked when frontend server compiler should forget what was
-  /// accepted previously so that next call to [recompile] produces complete
-  /// kernel file.
+  @override
   void reset() {
     _server?.stdin?.writeln('reset');
     printTrace('<- reset');
@@ -777,21 +819,22 @@ class ResidentCompiler {
       }
     }
 
-    if (_fileSystemRoots != null) {
-      for (String root in _fileSystemRoots) {
+    if (fileSystemRoots != null) {
+      for (String root in fileSystemRoots) {
         if (filename.startsWith(root)) {
           return Uri(
-              scheme: _fileSystemScheme, path: filename.substring(root.length))
+              scheme: fileSystemScheme, path: filename.substring(root.length))
               .toString();
         }
       }
     }
-    if (platform.isWindows && _fileSystemRoots != null && _fileSystemRoots.length > 1) {
+    if (platform.isWindows && fileSystemRoots != null && fileSystemRoots.length > 1) {
       return Uri.file(filename, windows: platform.isWindows).toString();
     }
     return null;
   }
 
+  @override
   Future<dynamic> shutdown() async {
     // Server was never successfully created.
     if (_server == null) {

--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -39,8 +39,8 @@ class FeatureFlags {
   /// Whether the Android embedding V2 is enabled.
   bool get isAndroidEmbeddingV2Enabled => isEnabled(flutterAndroidEmbeddingV2Feature);
 
-  /// Whether the incremental compiler is enabled.
-  bool get isIncrementalCompilerEnabled => isEnabled(flutterIncrementalCompiler);
+  /// Whether the web incremental compiler is enabled.
+  bool get isWebIncrementalCompilerEnabled => isEnabled(flutterWebIncrementalCompiler);
 
   /// Whether a particular feature is enabled for the current channel.
   ///
@@ -75,7 +75,7 @@ const List<Feature> allFeatures = <Feature>[
   flutterWindowsDesktopFeature,
   flutterBuildPluginAsAarFeature,
   flutterAndroidEmbeddingV2Feature,
-  flutterIncrementalCompiler,
+  flutterWebIncrementalCompiler,
 ];
 
 /// The [Feature] for flutter web.
@@ -148,8 +148,8 @@ const Feature flutterAndroidEmbeddingV2Feature = Feature(
 );
 
 /// The [Feature] for using the incremental compiler instead of build runner.
-const Feature flutterIncrementalCompiler = Feature(
-  name: 'Enable the incremental compiler for web buiilds',
+const Feature flutterWebIncrementalCompiler = Feature(
+  name: 'Enable the incremental compiler for web builds',
   configSetting: 'enable-web-incremental-compiler',
   master: FeatureChannelSetting(
     available: true,

--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -39,6 +39,9 @@ class FeatureFlags {
   /// Whether the Android embedding V2 is enabled.
   bool get isAndroidEmbeddingV2Enabled => isEnabled(flutterAndroidEmbeddingV2Feature);
 
+  /// Whether the incremental compiler is enabled.
+  bool get isIncrementalCompilerEnabled => isEnabled(flutterIncrementalCompiler);
+
   /// Whether a particular feature is enabled for the current channel.
   ///
   /// Prefer using one of the specific getters above instead of this API.
@@ -72,6 +75,7 @@ const List<Feature> allFeatures = <Feature>[
   flutterWindowsDesktopFeature,
   flutterBuildPluginAsAarFeature,
   flutterAndroidEmbeddingV2Feature,
+  flutterIncrementalCompiler,
 ];
 
 /// The [Feature] for flutter web.
@@ -137,6 +141,16 @@ const Feature flutterAndroidEmbeddingV2Feature = Feature(
   name: 'flutter create generates projects using the Android embedding V2',
   environmentOverride: 'ENABLE_ANDROID_EMBEDDING_V2',
   configSetting: 'enable-android-embedding-v2',
+  master: FeatureChannelSetting(
+    available: true,
+    enabledByDefault: false,
+  ),
+);
+
+/// The [Feature] for using the incremental compiler instead of build runner.
+const Feature flutterIncrementalCompiler = Feature(
+  name: 'Enable the incremental compiler for web buiilds',
+  configSetting: 'enable-web-incremental-compiler',
   master: FeatureChannelSetting(
     available: true,
     enabledByDefault: false,

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -22,6 +22,7 @@ import 'compile.dart';
 import 'dart/package_map.dart';
 import 'devfs.dart';
 import 'device.dart';
+import 'features.dart';
 import 'globals.dart';
 import 'project.dart';
 import 'run_cold.dart';
@@ -65,7 +66,19 @@ class FlutterDevice {
     ResidentCompiler generator,
   }) async {
     ResidentCompiler generator;
-    if (flutterProject.hasBuilders) {
+    if (featureFlags.isIncrementalCompilerEnabled &&
+        await device.targetPlatform == TargetPlatform.web_javascript) {
+      generator = ResidentCompiler(
+        artifacts.getArtifactPath(Artifact.flutterWebSdk, mode: buildMode),
+        buildMode: buildMode,
+        trackWidgetCreation: trackWidgetCreation,
+        fileSystemRoots: fileSystemRoots,
+        fileSystemScheme: fileSystemScheme,
+        targetModel: TargetModel.dartdevc,
+        experimentalFlags: experimentalFlags,
+        platformDill: artifacts.getArtifactPath(Artifact.webPlatformKernelDill, mode: buildMode),
+      );
+    } else if (flutterProject.hasBuilders) {
       generator = await CodeGeneratingResidentCompiler.create(
         buildMode: buildMode,
         flutterProject: flutterProject,

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -66,7 +66,7 @@ class FlutterDevice {
     ResidentCompiler generator,
   }) async {
     ResidentCompiler generator;
-    if (featureFlags.isIncrementalCompilerEnabled &&
+    if (featureFlags.isWebIncrementalCompilerEnabled &&
         await device.targetPlatform == TargetPlatform.web_javascript) {
       generator = ResidentCompiler(
         artifacts.getArtifactPath(Artifact.flutterWebSdk, mode: buildMode),

--- a/packages/flutter_tools/test/general.shard/compile_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_test.dart
@@ -37,6 +37,10 @@ void main() {
 
     expect(TargetModel('flutter_runner'), TargetModel.flutterRunner);
     expect(TargetModel.flutterRunner.toString(), 'flutter_runner');
+
+    expect(TargetModel('dartdevc'), TargetModel.dartdevc);
+    expect(TargetModel.dartdevc.toString(), 'dartdevc');
+
     expect(() => TargetModel('foobar'), throwsA(isInstanceOf<AssertionError>()));
   });
 }

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -10,9 +10,8 @@ import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
-import 'package:flutter_tools/src/base/process_manager.dart';
 import 'package:flutter_tools/src/build_info.dart';
-import 'package:flutter_tools/src/convert.dart';
+import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/features.dart';
@@ -28,7 +27,6 @@ import 'package:mockito/mockito.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
-import '../src/mocks.dart';
 import '../src/testbed.dart';
 
 void main() {
@@ -608,39 +606,24 @@ void main() {
 
   test('FlutterDevice uses dartdevc configuration when targeting web', () => testbed.run(() async {
     final MockDevice mockDevice = MockDevice();
-    final StreamController<List<int>> stdout = StreamController<List<int>>();
     when(mockDevice.targetPlatform).thenAnswer((Invocation invocation) async {
       return TargetPlatform.web_javascript;
     });
-    when(processManager.start(any)).thenAnswer((Invocation invocation) async {
-      final List<String> arguments = invocation.positionalArguments.first;
-      // Contains configuration for dartdevc target.
-      expect(arguments,
-        contains(artifacts.getArtifactPath(Artifact.flutterWebSdk, mode: BuildMode.debug) + '/'));
-      expect(arguments,
-        contains(artifacts.getArtifactPath(Artifact.webPlatformKernelDill, mode: BuildMode.debug)));
-      expect(arguments,
-        contains('--target=dartdevc'));
-      return FakeProcess(
-        stdout: stdout.stream,
-      );
-    });
 
-    final FlutterDevice flutterDevice = await FlutterDevice.create(
+    final DefaultResidentCompiler residentCompiler = (await FlutterDevice.create(
       mockDevice,
       buildMode: BuildMode.debug,
       flutterProject: FlutterProject.current(),
       target: null,
       trackWidgetCreation: true,
-    );
-    final Future<void> onDone = flutterDevice.generator.recompile('main.dart', <Uri>[], outputPath: 'app.dill');
-    stdout.add(utf8.encode('result 578145e3-fe1c-4094-9dda-c208d5a60168\n'));
-    stdout.add(utf8.encode('578145e3-fe1c-4094-9dda-c208d5a60168\n'));
-    stdout.add(utf8.encode('+file:///foo/flutter/packages/flutter/lib/src/physics/utils.dart\n'));
-    stdout.add(utf8.encode('578145e3-fe1c-4094-9dda-c208d5a60168 app.dill 0\n'));
-    await onDone;
+    )).generator;
+
+    expect(residentCompiler.targetModel, TargetModel.dartdevc);
+    expect(residentCompiler.sdkRoot,
+      artifacts.getArtifactPath(Artifact.flutterWebSdk, mode: BuildMode.debug) + '/');
+    expect(residentCompiler.platformDill,
+      artifacts.getArtifactPath(Artifact.webPlatformKernelDill, mode: BuildMode.debug));
   }, overrides: <Type, Generator>{
-    ProcessManager: () => MockProcessManager(),
     FeatureFlags: () => TestFeatureFlags(isIncrementalCompilerEnabled: true),
   }));
 }

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -624,7 +624,7 @@ void main() {
     expect(residentCompiler.platformDill,
       artifacts.getArtifactPath(Artifact.webPlatformKernelDill, mode: BuildMode.debug));
   }, overrides: <Type, Generator>{
-    FeatureFlags: () => TestFeatureFlags(isIncrementalCompilerEnabled: true),
+    FeatureFlags: () => TestFeatureFlags(isWebIncrementalCompilerEnabled: true),
   }));
 }
 

--- a/packages/flutter_tools/test/src/testbed.dart
+++ b/packages/flutter_tools/test/src/testbed.dart
@@ -734,7 +734,7 @@ class TestFeatureFlags implements FeatureFlags {
         return isWindowsEnabled;
       case flutterAndroidEmbeddingV2Feature:
         return isAndroidEmbeddingV2Enabled;
-      case flutterWebIncrementalCompilerFeature:
+      case flutterWebIncrementalCompiler:
         return isWebIncrementalCompilerEnabled;
     }
     return false;

--- a/packages/flutter_tools/test/src/testbed.dart
+++ b/packages/flutter_tools/test/src/testbed.dart
@@ -700,7 +700,7 @@ class TestFeatureFlags implements FeatureFlags {
     this.isWebEnabled = false,
     this.isWindowsEnabled = false,
     this.isAndroidEmbeddingV2Enabled = false,
-    this.isIncrementalCompilerEnabled = false,
+    this.isWebIncrementalCompilerEnabled = false,
 });
 
   @override
@@ -719,7 +719,7 @@ class TestFeatureFlags implements FeatureFlags {
   final bool isAndroidEmbeddingV2Enabled;
 
   @override
-  final bool isIncrementalCompilerEnabled;
+  final bool isWebIncrementalCompilerEnabled;
 
   @override
   bool isEnabled(Feature feature) {
@@ -734,6 +734,8 @@ class TestFeatureFlags implements FeatureFlags {
         return isWindowsEnabled;
       case flutterAndroidEmbeddingV2Feature:
         return isAndroidEmbeddingV2Enabled;
+      case flutterWebIncrementalCompilerFeature:
+        return isWebIncrementalCompilerEnabled;
     }
     return false;
   }

--- a/packages/flutter_tools/test/src/testbed.dart
+++ b/packages/flutter_tools/test/src/testbed.dart
@@ -700,6 +700,7 @@ class TestFeatureFlags implements FeatureFlags {
     this.isWebEnabled = false,
     this.isWindowsEnabled = false,
     this.isAndroidEmbeddingV2Enabled = false,
+    this.isIncrementalCompilerEnabled = false,
 });
 
   @override
@@ -716,6 +717,9 @@ class TestFeatureFlags implements FeatureFlags {
 
   @override
   final bool isAndroidEmbeddingV2Enabled;
+
+  @override
+  final bool isIncrementalCompilerEnabled;
 
   @override
   bool isEnabled(Feature feature) {


### PR DESCRIPTION
## Description

Implements, but does not use, the necessary compiler configuration for the dartdevc target. This is placed behind an off by default experimental feature.