### PR TITLE
FadeInImage cacheWidth and cacheHeight support

### DIFF
--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -540,6 +540,18 @@ class ResizeImage extends ImageProvider<_SizeAwareCacheKey> {
   /// The height the image should decode to and cache.
   final int height;
 
+  /// Composes the `provider` in a [ResizeImage] only when `cacheWidth` and
+  /// `cacheHeight` are not both null.
+  ///
+  /// When `cacheWidth` and `cacheHeight` are both null, this will return the
+  /// `provider` directly.
+  static ImageProvider<dynamic> resizeIfNeeded(int cacheWidth, int cacheHeight, ImageProvider<dynamic> provider) {
+    if (cacheWidth != null || cacheHeight != null) {
+      return ResizeImage(provider, width: cacheWidth, height: cacheHeight);
+    }
+    return provider;
+  }
+
   @override
   ImageStreamCompleter load(_SizeAwareCacheKey key, DecoderCallback decode) {
     final DecoderCallback decodeResize = (Uint8List bytes, {int cacheWidth, int cacheHeight}) {

--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -16,6 +16,14 @@ import 'transitions.dart';
 // Examples can assume:
 // Uint8List bytes;
 
+// Same as in painting/image.dart.
+ImageProvider<dynamic> _resizeIfNeeded(int cacheWidth, int cacheHeight, ImageProvider<dynamic> provider) {
+  if (cacheWidth != null || cacheHeight != null) {
+    return ResizeImage(provider, width: cacheWidth, height: cacheHeight);
+  }
+  return provider;
+}
+
 /// An image that shows a [placeholder] image while the target [image] is
 /// loading, then fades in the new image when it loads.
 ///
@@ -73,8 +81,8 @@ class FadeInImage extends StatelessWidget {
   /// If [excludeFromSemantics] is true, then [imageSemanticLabel] will be ignored.
   const FadeInImage({
     Key key,
-    @required this.placeholder,
-    @required this.image,
+    @required ImageProvider placeholder,
+    @required ImageProvider image,
     this.excludeFromSemantics = false,
     this.imageSemanticLabel,
     this.fadeOutDuration = const Duration(milliseconds: 300),
@@ -87,8 +95,14 @@ class FadeInImage extends StatelessWidget {
     this.alignment = Alignment.center,
     this.repeat = ImageRepeat.noRepeat,
     this.matchTextDirection = false,
+    int placeholderCacheWidth,
+    int placeholderCacheHeight,
+    int imageCacheWidth,
+    int imageCacheHeight,
   }) : assert(placeholder != null),
        assert(image != null),
+       placeholder = _resizeIfNeeded(placeholderCacheWidth, placeholderCacheHeight, placeholder),
+       image = _resizeIfNeeded(imageCacheWidth, imageCacheHeight, image),
        assert(fadeOutDuration != null),
        assert(fadeOutCurve != null),
        assert(fadeInDuration != null),
@@ -137,6 +151,10 @@ class FadeInImage extends StatelessWidget {
     this.alignment = Alignment.center,
     this.repeat = ImageRepeat.noRepeat,
     this.matchTextDirection = false,
+    int placeholderCacheWidth,
+    int placeholderCacheHeight,
+    int imageCacheWidth,
+    int imageCacheHeight,
   }) : assert(placeholder != null),
        assert(image != null),
        assert(placeholderScale != null),
@@ -148,8 +166,8 @@ class FadeInImage extends StatelessWidget {
        assert(alignment != null),
        assert(repeat != null),
        assert(matchTextDirection != null),
-       placeholder = MemoryImage(placeholder, scale: placeholderScale),
-       image = NetworkImage(image, scale: imageScale),
+       placeholder = MemoryImage(placeholder, scale: placeholderScale, cacheWidth: placeholderCacheWidth, cacheHeight: placeholderCacheHeight),
+       image = NetworkImage(image, scale: imageScale, cacheWidth: imageCacheWidth, cacheHeight: imageCacheHeight),
        super(key: key);
 
   /// Creates a widget that uses a placeholder image stored in an asset bundle
@@ -195,11 +213,15 @@ class FadeInImage extends StatelessWidget {
     this.alignment = Alignment.center,
     this.repeat = ImageRepeat.noRepeat,
     this.matchTextDirection = false,
+    int placeholderCacheWidth,
+    int placeholderCacheHeight,
+    int imageCacheWidth,
+    int imageCacheHeight,
   }) : assert(placeholder != null),
        assert(image != null),
        placeholder = placeholderScale != null
          ? ExactAssetImage(placeholder, bundle: bundle, scale: placeholderScale)
-         : AssetImage(placeholder, bundle: bundle),
+         : AssetImage(placeholder, bundle: bundle, cacheWidth: placeholderCacheWidth, cacheHeight: placeholderCacheHeight),
        assert(imageScale != null),
        assert(fadeOutDuration != null),
        assert(fadeOutCurve != null),
@@ -208,7 +230,7 @@ class FadeInImage extends StatelessWidget {
        assert(alignment != null),
        assert(repeat != null),
        assert(matchTextDirection != null),
-       image = NetworkImage(image, scale: imageScale),
+       image = NetworkImage(image, scale: imageScale, cacheWidth: imageCacheWidth, cacheHeight: imageCacheHeight),
        super(key: key);
 
   /// Image displayed while the target [image] is loading.

--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -16,14 +16,6 @@ import 'transitions.dart';
 // Examples can assume:
 // Uint8List bytes;
 
-// Same as in painting/image.dart.
-ImageProvider<dynamic> _resizeIfNeeded(int cacheWidth, int cacheHeight, ImageProvider<dynamic> provider) {
-  if (cacheWidth != null || cacheHeight != null) {
-    return ResizeImage(provider, width: cacheWidth, height: cacheHeight);
-  }
-  return provider;
-}
-
 /// An image that shows a [placeholder] image while the target [image] is
 /// loading, then fades in the new image when it loads.
 ///
@@ -74,11 +66,8 @@ class FadeInImage extends StatelessWidget {
   /// Creates a widget that displays a [placeholder] while an [image] is loading,
   /// then fades-out the placeholder and fades-in the image.
   ///
-  /// To include a custom decode/cache size such as those provided by
-  /// the [FadeInImage.assetNetwork] and [FadeInImage.memoryNetwork] constructors'
-  /// `placeholderCacheWidth`, `placeholderCacheHeight`, `imageCacheWidth`,
-  /// and `imageCacheHeight` parameters, the [placeholder] and [image]
-  /// [ImageProviders] should be composed in a [ResizeImage].
+  /// The [placeholder] and [image] may be composed in a [ResizeImage] to provide
+  /// a custom decode/cache size.
   ///
   /// The [placeholder], [image], [fadeOutDuration], [fadeOutCurve],
   /// [fadeInDuration], [fadeInCurve], [alignment], [repeat], and
@@ -173,8 +162,8 @@ class FadeInImage extends StatelessWidget {
        assert(alignment != null),
        assert(repeat != null),
        assert(matchTextDirection != null),
-       placeholder = _resizeIfNeeded(placeholderCacheWidth, placeholderCacheHeight, MemoryImage(placeholder, scale: placeholderScale)),
-       image = _resizeIfNeeded(imageCacheWidth, imageCacheHeight, NetworkImage(image, scale: imageScale)),
+       placeholder = ResizeImage.resizeIfNeeded(placeholderCacheWidth, placeholderCacheHeight, MemoryImage(placeholder, scale: placeholderScale)),
+       image = ResizeImage.resizeIfNeeded(imageCacheWidth, imageCacheHeight, NetworkImage(image, scale: imageScale)),
        super(key: key);
 
   /// Creates a widget that uses a placeholder image stored in an asset bundle
@@ -234,8 +223,8 @@ class FadeInImage extends StatelessWidget {
   }) : assert(placeholder != null),
        assert(image != null),
        placeholder = placeholderScale != null
-         ? _resizeIfNeeded(placeholderCacheWidth, placeholderCacheHeight, ExactAssetImage(placeholder, bundle: bundle, scale: placeholderScale))
-         : _resizeIfNeeded(placeholderCacheWidth, placeholderCacheHeight, AssetImage(placeholder, bundle: bundle)),
+         ? ResizeImage.resizeIfNeeded(placeholderCacheWidth, placeholderCacheHeight, ExactAssetImage(placeholder, bundle: bundle, scale: placeholderScale))
+         : ResizeImage.resizeIfNeeded(placeholderCacheWidth, placeholderCacheHeight, AssetImage(placeholder, bundle: bundle)),
        assert(imageScale != null),
        assert(fadeOutDuration != null),
        assert(fadeOutCurve != null),
@@ -244,7 +233,7 @@ class FadeInImage extends StatelessWidget {
        assert(alignment != null),
        assert(repeat != null),
        assert(matchTextDirection != null),
-       image = _resizeIfNeeded(imageCacheWidth, imageCacheHeight, NetworkImage(image, scale: imageScale)),
+       image = ResizeImage.resizeIfNeeded(imageCacheWidth, imageCacheHeight, NetworkImage(image, scale: imageScale)),
        super(key: key);
 
   /// Image displayed while the target [image] is loading.

--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -74,6 +74,11 @@ class FadeInImage extends StatelessWidget {
   /// Creates a widget that displays a [placeholder] while an [image] is loading,
   /// then fades-out the placeholder and fades-in the image.
   ///
+  /// To include a custom decode/cache size in a manner such as that provided by
+  /// the image constructor `cacheWidth` and `cacheHeight` parameters, the
+  /// 'placeholder' and `image` [ImageProviders] should be composed in a
+  /// [ResizeImage].
+  ///
   /// The [placeholder], [image], [fadeOutDuration], [fadeOutCurve],
   /// [fadeInDuration], [fadeInCurve], [alignment], [repeat], and
   /// [matchTextDirection] arguments must not be null.
@@ -81,8 +86,8 @@ class FadeInImage extends StatelessWidget {
   /// If [excludeFromSemantics] is true, then [imageSemanticLabel] will be ignored.
   const FadeInImage({
     Key key,
-    @required ImageProvider placeholder,
-    @required ImageProvider image,
+    @required this.placeholder,
+    @required this.image,
     this.excludeFromSemantics = false,
     this.imageSemanticLabel,
     this.fadeOutDuration = const Duration(milliseconds: 300),
@@ -95,14 +100,8 @@ class FadeInImage extends StatelessWidget {
     this.alignment = Alignment.center,
     this.repeat = ImageRepeat.noRepeat,
     this.matchTextDirection = false,
-    int placeholderCacheWidth,
-    int placeholderCacheHeight,
-    int imageCacheWidth,
-    int imageCacheHeight,
   }) : assert(placeholder != null),
        assert(image != null),
-       placeholder = _resizeIfNeeded(placeholderCacheWidth, placeholderCacheHeight, placeholder),
-       image = _resizeIfNeeded(imageCacheWidth, imageCacheHeight, image),
        assert(fadeOutDuration != null),
        assert(fadeOutCurve != null),
        assert(fadeInDuration != null),
@@ -121,6 +120,13 @@ class FadeInImage extends StatelessWidget {
   ///
   /// The `placeholderScale` and `imageScale` arguments are passed to their
   /// respective [ImageProvider]s (see also [ImageInfo.scale]).
+  ///
+  /// If [placeholderCacheWidth], [placeholderCacheHeight], [imageCacheWidth],
+  /// or [imageCacheHeight] are provided, it indicates to the
+  /// engine that the respective image should be decoded at the specified size.
+  /// The image will be rendered to the constraints of the layout or [width]
+  /// and [height] regardless of these parameters. These parameters are primarily
+  /// intended to reduce the memory usage of [ImageCache].
   ///
   /// The [placeholder], [image], [placeholderScale], [imageScale],
   /// [fadeOutDuration], [fadeOutCurve], [fadeInDuration], [fadeInCurve],
@@ -166,8 +172,8 @@ class FadeInImage extends StatelessWidget {
        assert(alignment != null),
        assert(repeat != null),
        assert(matchTextDirection != null),
-       placeholder = MemoryImage(placeholder, scale: placeholderScale, cacheWidth: placeholderCacheWidth, cacheHeight: placeholderCacheHeight),
-       image = NetworkImage(image, scale: imageScale, cacheWidth: imageCacheWidth, cacheHeight: imageCacheHeight),
+       placeholder = _resizeIfNeeded(placeholderCacheWidth, placeholderCacheHeight, MemoryImage(placeholder, scale: placeholderScale)),
+       image = _resizeIfNeeded(imageCacheWidth, imageCacheHeight, NetworkImage(image, scale: imageScale)),
        super(key: key);
 
   /// Creates a widget that uses a placeholder image stored in an asset bundle
@@ -183,6 +189,13 @@ class FadeInImage extends StatelessWidget {
   /// If `placeholderScale` is omitted or is null, pixel-density-aware asset
   /// resolution will be attempted for the [placeholder] image. Otherwise, the
   /// exact asset specified will be used.
+  ///
+  /// If [placeholderCacheWidth], [placeholderCacheHeight], [imageCacheWidth],
+  /// or [imageCacheHeight] are provided, it indicates to the
+  /// engine that the respective image should be decoded at the specified size.
+  /// The image will be rendered to the constraints of the layout or [width]
+  /// and [height] regardless of these parameters. These parameters are primarily
+  /// intended to reduce the memory usage of [ImageCache].
   ///
   /// The [placeholder], [image], [imageScale], [fadeOutDuration],
   /// [fadeOutCurve], [fadeInDuration], [fadeInCurve], [alignment], [repeat],
@@ -220,8 +233,8 @@ class FadeInImage extends StatelessWidget {
   }) : assert(placeholder != null),
        assert(image != null),
        placeholder = placeholderScale != null
-         ? ExactAssetImage(placeholder, bundle: bundle, scale: placeholderScale)
-         : AssetImage(placeholder, bundle: bundle, cacheWidth: placeholderCacheWidth, cacheHeight: placeholderCacheHeight),
+         ? _resizeIfNeeded(placeholderCacheWidth, placeholderCacheHeight, ExactAssetImage(placeholder, bundle: bundle, scale: placeholderScale))
+         : _resizeIfNeeded(placeholderCacheWidth, placeholderCacheHeight, AssetImage(placeholder, bundle: bundle)),
        assert(imageScale != null),
        assert(fadeOutDuration != null),
        assert(fadeOutCurve != null),
@@ -230,7 +243,7 @@ class FadeInImage extends StatelessWidget {
        assert(alignment != null),
        assert(repeat != null),
        assert(matchTextDirection != null),
-       image = NetworkImage(image, scale: imageScale, cacheWidth: imageCacheWidth, cacheHeight: imageCacheHeight),
+       image = _resizeIfNeeded(imageCacheWidth, imageCacheHeight, NetworkImage(image, scale: imageScale)),
        super(key: key);
 
   /// Image displayed while the target [image] is loading.

--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -74,10 +74,11 @@ class FadeInImage extends StatelessWidget {
   /// Creates a widget that displays a [placeholder] while an [image] is loading,
   /// then fades-out the placeholder and fades-in the image.
   ///
-  /// To include a custom decode/cache size in a manner such as that provided by
-  /// the image constructor `cacheWidth` and `cacheHeight` parameters, the
-  /// 'placeholder' and `image` [ImageProviders] should be composed in a
-  /// [ResizeImage].
+  /// To include a custom decode/cache size such as those provided by
+  /// the [FadeInImage.assetNetwork] and [FadeInImage.memoryNetwork] constructors'
+  /// `placeholderCacheWidth`, `placeholderCacheHeight`, `imageCacheWidth`,
+  /// and `imageCacheHeight` parameters, the [placeholder] and [image]
+  /// [ImageProviders] should be composed in a [ResizeImage].
   ///
   /// The [placeholder], [image], [fadeOutDuration], [fadeOutCurve],
   /// [fadeInDuration], [fadeInCurve], [alignment], [repeat], and

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -55,6 +55,7 @@ ImageConfiguration createLocalImageConfiguration(BuildContext context, { Size si
   );
 }
 
+// Same as in widgets/fade_in_image.dart.
 ImageProvider<dynamic> _resizeIfNeeded(int cacheWidth, int cacheHeight, ImageProvider<dynamic> provider) {
   if (cacheWidth != null || cacheHeight != null) {
     return ResizeImage(provider, width: cacheWidth, height: cacheHeight);

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -55,14 +55,6 @@ ImageConfiguration createLocalImageConfiguration(BuildContext context, { Size si
   );
 }
 
-// Same as in widgets/fade_in_image.dart.
-ImageProvider<dynamic> _resizeIfNeeded(int cacheWidth, int cacheHeight, ImageProvider<dynamic> provider) {
-  if (cacheWidth != null || cacheHeight != null) {
-    return ResizeImage(provider, width: cacheWidth, height: cacheHeight);
-  }
-  return provider;
-}
-
 /// Prefetches an image into the image cache.
 ///
 /// Returns a [Future] that will complete when the first image yielded by the
@@ -359,7 +351,7 @@ class Image extends StatefulWidget {
     Map<String, String> headers,
     int cacheWidth,
     int cacheHeight,
-  }) : image = _resizeIfNeeded(cacheWidth, cacheHeight, NetworkImage(src, scale: scale, headers: headers)),
+  }) : image = ResizeImage.resizeIfNeeded(cacheWidth, cacheHeight, NetworkImage(src, scale: scale, headers: headers)),
        assert(alignment != null),
        assert(repeat != null),
        assert(matchTextDirection != null),
@@ -411,7 +403,7 @@ class Image extends StatefulWidget {
     this.filterQuality = FilterQuality.low,
     int cacheWidth,
     int cacheHeight,
-  }) : image = _resizeIfNeeded(cacheWidth, cacheHeight, FileImage(file, scale: scale)),
+  }) : image = ResizeImage.resizeIfNeeded(cacheWidth, cacheHeight, FileImage(file, scale: scale)),
        loadingBuilder = null,
        assert(alignment != null),
        assert(repeat != null),
@@ -574,7 +566,7 @@ class Image extends StatefulWidget {
     this.filterQuality = FilterQuality.low,
     int cacheWidth,
     int cacheHeight,
-  }) : image = _resizeIfNeeded(cacheWidth, cacheHeight, scale != null
+  }) : image = ResizeImage.resizeIfNeeded(cacheWidth, cacheHeight, scale != null
          ? ExactAssetImage(name, bundle: bundle, scale: scale, package: package)
          : AssetImage(name, bundle: bundle, package: package)
        ),
@@ -631,7 +623,7 @@ class Image extends StatefulWidget {
     this.filterQuality = FilterQuality.low,
     int cacheWidth,
     int cacheHeight,
-  }) : image = _resizeIfNeeded(cacheWidth, cacheHeight, MemoryImage(bytes, scale: scale)),
+  }) : image = ResizeImage.resizeIfNeeded(cacheWidth, cacheHeight, MemoryImage(bytes, scale: scale)),
        loadingBuilder = null,
        assert(alignment != null),
        assert(repeat != null),

--- a/packages/flutter/test/widgets/fade_in_image_test.dart
+++ b/packages/flutter/test/widgets/fade_in_image_test.dart
@@ -84,10 +84,6 @@ FadeInImageParts findFadeInImage(WidgetTester tester) {
   }
 }
 
-class ClosureTracker {
-  static bool called = false;
-}
-
 Future<void> main() async {
   // These must run outside test zone to complete
   final ui.Image targetImage = await createTestImage();

--- a/packages/flutter/test/widgets/fade_in_image_test.dart
+++ b/packages/flutter/test/widgets/fade_in_image_test.dart
@@ -4,10 +4,13 @@
 
 import 'dart:async';
 import 'dart:ui' as ui;
+import 'dart:typed_data';
 
 import 'package:flutter/widgets.dart';
+import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
 import '../painting/image_test_utils.dart';
+import '../painting/image_data.dart';
 
 const Duration animationDuration = Duration(milliseconds: 50);
 
@@ -260,6 +263,26 @@ Future<void> main() async {
       await tester.pump(animationDuration);
       expect(findFadeInImage(tester).placeholder.opacity, moreOrLessEquals(0));
       expect(findFadeInImage(tester).target.opacity, moreOrLessEquals(1));
+    });
+
+    testWidgets('placeholder cacheWidth and cacheHeight is passed through', (WidgetTester tester) async {
+      final Uint8List testBytes = Uint8List.fromList(kTransparentImage);
+      final FadeInImage image = FadeInImage.memoryNetwork(
+        placeholder: testBytes,
+        image: 'test.com',
+        placeholderCacheWidth: 20,
+        placeholderCacheHeight: 30,
+        imageCacheWidth: 40,
+        imageCacheHeight: 50,
+      );
+
+      final DecoderCallback decode1 = (Uint8List bytes, {int cacheWidth, int cacheHeight}) {
+        expect(cacheWidth, 20);
+        expect(cacheHeight, 30);
+        return PaintingBinding.instance.instantiateImageCodec(bytes, cacheWidth: cacheWidth, cacheHeight: cacheHeight);
+      };
+
+      image.placeholder.load(await image.placeholder.obtainKey(ImageConfiguration.empty), decode1);
     });
 
     group('semantics', () {

--- a/packages/flutter/test/widgets/fade_in_image_test.dart
+++ b/packages/flutter/test/widgets/fade_in_image_test.dart
@@ -280,18 +280,18 @@ Future<void> main() async {
         imageCacheHeight: 50,
       );
 
+      bool called = false;
       final DecoderCallback decode = (Uint8List bytes, {int cacheWidth, int cacheHeight}) {
         expect(cacheWidth, 20);
         expect(cacheHeight, 30);
-        ClosureTracker.called = true;
+        called = true;
         return PaintingBinding.instance.instantiateImageCodec(bytes, cacheWidth: cacheWidth, cacheHeight: cacheHeight);
       };
       final ImageProvider resizeImage = image.placeholder;
-      expect(image.placeholder is ResizeImage, true);
-      ClosureTracker.called = false;
-      expect(ClosureTracker.called, false);
+      expect(image.placeholder, isA<ResizeImage>());
+      expect(called, false);
       ImageStreamCompleter isc = resizeImage.load(await resizeImage.obtainKey(ImageConfiguration.empty), decode);
-      expect(ClosureTracker.called, true);
+      expect(called, true);
     });
 
     testWidgets('do not resize when null cache dimensions', (WidgetTester tester) async {
@@ -301,19 +301,19 @@ Future<void> main() async {
         image: 'test.com',
       );
 
+      bool called = false;
       final DecoderCallback decode = (Uint8List bytes, {int cacheWidth, int cacheHeight}) {
         expect(cacheWidth, null);
         expect(cacheHeight, null);
-        ClosureTracker.called = true;
+        called = true;
         return PaintingBinding.instance.instantiateImageCodec(bytes, cacheWidth: cacheWidth, cacheHeight: cacheHeight);
       };
       // image.placeholder should be an instance of MemoryImage instead of ResizeImage
       final ImageProvider memoryImage = image.placeholder;
-      expect(image.placeholder is MemoryImage, true);
-      ClosureTracker.called = false;
-      expect(ClosureTracker.called, false);
+      expect(image.placeholder, isA<MemoryImage>());
+      expect(called, false);
       memoryImage.load(await memoryImage.obtainKey(ImageConfiguration.empty), decode);
-      expect(ClosureTracker.called, true);
+      expect(called, true);
     });
 
     group('semantics', () {

--- a/packages/flutter/test/widgets/fade_in_image_test.dart
+++ b/packages/flutter/test/widgets/fade_in_image_test.dart
@@ -3,14 +3,14 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:ui' as ui;
 import 'dart:typed_data';
+import 'dart:ui' as ui;
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
-import '../painting/image_test_utils.dart';
 import '../painting/image_data.dart';
+import '../painting/image_test_utils.dart';
 
 const Duration animationDuration = Duration(milliseconds: 50);
 
@@ -265,7 +265,7 @@ Future<void> main() async {
       expect(findFadeInImage(tester).target.opacity, moreOrLessEquals(1));
     });
 
-    testWidgets('placeholder cacheWidth and cacheHeight is passed through', (WidgetTester tester) async {
+    testWidgets('memory placeholder cacheWidth and cacheHeight is passed through', (WidgetTester tester) async {
       final Uint8List testBytes = Uint8List.fromList(kTransparentImage);
       final FadeInImage image = FadeInImage.memoryNetwork(
         placeholder: testBytes,
@@ -276,13 +276,13 @@ Future<void> main() async {
         imageCacheHeight: 50,
       );
 
-      final DecoderCallback decode1 = (Uint8List bytes, {int cacheWidth, int cacheHeight}) {
+      final DecoderCallback decode = (Uint8List bytes, {int cacheWidth, int cacheHeight}) {
         expect(cacheWidth, 20);
         expect(cacheHeight, 30);
         return PaintingBinding.instance.instantiateImageCodec(bytes, cacheWidth: cacheWidth, cacheHeight: cacheHeight);
       };
-
-      image.placeholder.load(await image.placeholder.obtainKey(ImageConfiguration.empty), decode1);
+      final ResizeImage resizeImage = image.placeholder;
+      resizeImage.load(await resizeImage.obtainKey(ImageConfiguration.empty), decode);
     });
 
     group('semantics', () {

--- a/packages/flutter/test/widgets/fade_in_image_test.dart
+++ b/packages/flutter/test/widgets/fade_in_image_test.dart
@@ -285,6 +285,24 @@ Future<void> main() async {
       resizeImage.load(await resizeImage.obtainKey(ImageConfiguration.empty), decode);
     });
 
+    testWidgets('do not resize when null cache dimensions', (WidgetTester tester) async {
+      final Uint8List testBytes = Uint8List.fromList(kTransparentImage);
+      final FadeInImage image = FadeInImage.memoryNetwork(
+        placeholder: testBytes,
+        image: 'test.com',
+      );
+
+      final DecoderCallback decode = (Uint8List bytes, {int cacheWidth, int cacheHeight}) {
+        expect(cacheWidth, null);
+        expect(cacheHeight, null);
+        return PaintingBinding.instance.instantiateImageCodec(bytes, cacheWidth: cacheWidth, cacheHeight: cacheHeight);
+      };
+      // image.placeholder should be an instance of MemoryImage instead of ResizeImage
+      final MemoryImage memoryImage = image.placeholder;
+      expect(image.placeholder is MemoryImage, true);
+      memoryImage.load(await memoryImage.obtainKey(ImageConfiguration.empty), decode);
+    });
+
     group('semantics', () {
       testWidgets('only one Semantics node appears within FadeInImage', (WidgetTester tester) async {
         final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);


### PR DESCRIPTION
## Description

This adds support for `cacheWidth` and `cacheHeight` in `FadeInImage`. This is a continuation of https://github.com/flutter/flutter/pull/41415 and https://github.com/flutter/flutter/issues/26194

## Related Issues

https://github.com/flutter/flutter/issues/26194

This change was requested in https://github.com/flutter/flutter/pull/42785.