### PR TITLE
V1.9.1 hotfix

### DIFF
--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -359,7 +359,8 @@ class _HeroState extends State<Hero> {
   }
 
   // When `keepPlaceholder` is true, the placeholder will continue to be shown
-  // after the flight ends.
+  // after the flight ends. Otherwise the child of the Hero will become visible
+  // and its TickerMode will be re-enabled.
   void endFlight({ bool keepPlaceholder = false }) {
     if (!keepPlaceholder) {
       ensurePlaceholderIsHidden();
@@ -827,6 +828,13 @@ class HeroController extends NavigatorObserver {
       } else if (_flights[tag] != null) {
         _flights[tag].abort();
       }
+    }
+
+    // If the from hero is gone, the flight won't start and the to hero needs to
+    // be put on stage again.
+    for (Object tag in toHeroes.keys) {
+      if (fromHeroes[tag] == null)
+        toHeroes[tag].ensurePlaceholderIsHidden();
     }
   }
 


### PR DESCRIPTION
This fixes the issue described in https://github.com/flutter/flutter/issues/40239:

* Restore offstage and ticker mode after hero pop and the from hero is null (#40306)

There are two failing devicelab tests: android_splash_screen_integration_test and run_without_leak_mac. Both of them were disabled in https://github.com/flutter/flutter/pull/40155, so I am assuming that's fine.