### PR TITLE
[flutter_tool] Use engine flutter_runner prebuilts

### DIFF
--- a/examples/stocks/fuchsia/meta/stocks.cmx
+++ b/examples/stocks/fuchsia/meta/stocks.cmx
@@ -1,0 +1,22 @@
+{
+    "program": {
+        "data": "data/stocks"
+    },
+    "sandbox": {
+        "services": [
+            "fuchsia.cobalt.LoggerFactory",
+            "fuchsia.fonts.Provider",
+            "fuchsia.logger.LogSink",
+            "fuchsia.modular.Clipboard",
+            "fuchsia.modular.ContextWriter",
+            "fuchsia.modular.DeviceMap",
+            "fuchsia.modular.ModuleContext",
+            "fuchsia.sys.Environment",
+            "fuchsia.sys.Launcher",
+            "fuchsia.testing.runner.TestRunner",
+            "fuchsia.ui.input.ImeService",
+            "fuchsia.ui.policy.Presenter",
+            "fuchsia.ui.scenic.Scenic"
+        ]
+    }
+}

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -69,7 +69,8 @@ class ApplicationPackageFactory {
         return applicationBinary == null
             ? WindowsApp.fromWindowsProject(FlutterProject.current().windows)
             : WindowsApp.fromPrebuiltApp(applicationBinary);
-      case TargetPlatform.fuchsia:
+      case TargetPlatform.fuchsia_arm64:
+      case TargetPlatform.fuchsia_x64:
         return applicationBinary == null
             ? FuchsiaApp.fromFuchsiaProject(FlutterProject.current().fuchsia)
             : FuchsiaApp.fromPrebuiltApp(applicationBinary);
@@ -424,7 +425,8 @@ class ApplicationPackageStore {
       case TargetPlatform.ios:
         iOS ??= await IOSApp.fromIosProject(FlutterProject.current().ios);
         return iOS;
-      case TargetPlatform.fuchsia:
+      case TargetPlatform.fuchsia_arm64:
+      case TargetPlatform.fuchsia_x64:
         fuchsia ??= FuchsiaApp.fromFuchsiaProject(FlutterProject.current().fuchsia);
         return fuchsia;
       case TargetPlatform.darwin_x64:

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -271,7 +271,8 @@ enum TargetPlatform {
   darwin_x64,
   linux_x64,
   windows_x64,
-  fuchsia,
+  fuchsia_arm64,
+  fuchsia_x64,
   tester,
   web_javascript,
 }
@@ -339,8 +340,10 @@ String getNameForTargetPlatform(TargetPlatform platform) {
       return 'linux-x64';
     case TargetPlatform.windows_x64:
       return 'windows-x64';
-    case TargetPlatform.fuchsia:
-      return 'fuchsia';
+    case TargetPlatform.fuchsia_arm64:
+      return 'fuchsia-arm64';
+    case TargetPlatform.fuchsia_x64:
+      return 'fuchsia-x64';
     case TargetPlatform.tester:
       return 'flutter-tester';
     case TargetPlatform.web_javascript:
@@ -360,6 +363,10 @@ TargetPlatform getTargetPlatformForName(String platform) {
       return TargetPlatform.android_x64;
     case 'android-x86':
       return TargetPlatform.android_x86;
+    case 'fuchsia-arm64':
+      return TargetPlatform.fuchsia_arm64;
+    case 'fuchsia-x64':
+      return TargetPlatform.fuchsia_x64;
     case 'ios':
       return TargetPlatform.ios;
     case 'darwin-x64':
@@ -418,6 +425,18 @@ String getPlatformNameForAndroidArch(AndroidArch arch) {
   }
   assert(false);
   return null;
+}
+
+String fuchsiaArchForTargetPlatform(TargetPlatform targetPlatform) {
+  switch (targetPlatform) {
+    case TargetPlatform.fuchsia_arm64:
+      return 'arm64';
+    case TargetPlatform.fuchsia_x64:
+      return 'x64';
+    default:
+      assert(false);
+      return null;
+  }
 }
 
 HostPlatform getCurrentHostPlatform() {

--- a/packages/flutter_tools/lib/src/commands/build_fuchsia.dart
+++ b/packages/flutter_tools/lib/src/commands/build_fuchsia.dart
@@ -10,6 +10,7 @@ import '../base/platform.dart';
 import '../build_info.dart';
 import '../cache.dart';
 import '../fuchsia/fuchsia_build.dart';
+import '../fuchsia/fuchsia_pm.dart';
 import '../project.dart';
 import '../runner/flutter_command.dart' show FlutterCommandResult;
 import 'build.dart';
@@ -19,6 +20,17 @@ class BuildFuchsiaCommand extends BuildSubCommand {
   BuildFuchsiaCommand({bool verboseHelp = false}) {
     usesTargetOption();
     addBuildModeFlags(verboseHelp: verboseHelp);
+    argParser.addOption(
+      'runner-source',
+      help: 'The package source to use for the flutter_runner. '
+            '"${FuchsiaPackageServer.deviceHost}" implies using a runner already on the device. '
+            '"${FuchsiaPackageServer.toolHost}" implies using a runner distributed with Flutter.',
+      allowed: <String>[
+        FuchsiaPackageServer.deviceHost,
+        FuchsiaPackageServer.toolHost,
+      ],
+      defaultsTo: FuchsiaPackageServer.toolHost,
+    );
   }
 
   @override
@@ -34,7 +46,7 @@ class BuildFuchsiaCommand extends BuildSubCommand {
   };
 
   @override
-  String get description => 'build the Fuchsia target (Experimental).';
+  String get description => 'Build the Fuchsia target (Experimental).';
 
   @override
   Future<FlutterCommandResult> runCommand() async {
@@ -42,22 +54,24 @@ class BuildFuchsiaCommand extends BuildSubCommand {
     final BuildInfo buildInfo = getBuildInfo();
     final FlutterProject flutterProject = FlutterProject.current();
     if (!platform.isLinux && !platform.isMacOS) {
-      throwToolExit('"build Fuchsia" only supported on Linux and MacOS hosts.');
+      throwToolExit('"build fuchsia" is only supported on Linux and MacOS hosts.');
     }
     if (!flutterProject.fuchsia.existsSync()) {
-      throwToolExit('No Fuchsia project configured.');
+      throwToolExit('No Fuchsia project is configured.');
     }
     final String appName = flutterProject.fuchsia.project.manifest.appName;
     final String cmxPath = fs.path.join(
         flutterProject.fuchsia.meta.path, '$appName.cmx');
     final File cmxFile = fs.file(cmxPath);
     if (!cmxFile.existsSync()) {
-      throwToolExit('Fuchsia build requires a .cmx file at $cmxPath for the app');
+      throwToolExit('The Fuchsia build requires a .cmx file at $cmxPath for the app.');
     }
     await buildFuchsia(
-        fuchsiaProject: flutterProject.fuchsia,
-        target: targetFile,
-        buildInfo: buildInfo);
+      fuchsiaProject: flutterProject.fuchsia,
+      target: targetFile,
+      buildInfo: buildInfo,
+      runnerPackageSource: argResults['runner-source'],
+    );
     return null;
   }
 }

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -178,7 +178,8 @@ class DeviceManager {
     if (hasSpecifiedAllDevices) {
       devices = <Device>[
         for (Device device in devices)
-          if (await device.targetPlatform != TargetPlatform.fuchsia &&
+          if (await device.targetPlatform != TargetPlatform.fuchsia_arm64 &&
+              await device.targetPlatform != TargetPlatform.fuchsia_x64 &&
               await device.targetPlatform != TargetPlatform.web_javascript)
             device,
       ];
@@ -339,7 +340,8 @@ abstract class Device {
       case TargetPlatform.darwin_x64:
       case TargetPlatform.linux_x64:
       case TargetPlatform.windows_x64:
-      case TargetPlatform.fuchsia:
+      case TargetPlatform.fuchsia_arm64:
+      case TargetPlatform.fuchsia_x64:
       default:
         return false;
     }

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_build.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_build.dart
@@ -38,7 +38,7 @@ Future<void> buildFuchsia({
   @required FuchsiaProject fuchsiaProject,
   @required String target, // E.g., lib/main.dart
   BuildInfo buildInfo = BuildInfo.debug,
-  String runnerPackageSource = 'flutter_tool',
+  String runnerPackageSource = FuchsiaPackageServer.toolHost,
 }) async {
   final Directory outDir = fs.directory(getFuchsiaBuildDirectory());
   if (!outDir.existsSync()) {

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_build.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_build.dart
@@ -38,6 +38,7 @@ Future<void> buildFuchsia({
   @required FuchsiaProject fuchsiaProject,
   @required String target, // E.g., lib/main.dart
   BuildInfo buildInfo = BuildInfo.debug,
+  String runnerPackageSource = 'flutter_tool',
 }) async {
   final Directory outDir = fs.directory(getFuchsiaBuildDirectory());
   if (!outDir.existsSync()) {
@@ -50,7 +51,7 @@ Future<void> buildFuchsia({
   await _timedBuildStep('fuchsia-build-assets',
     () => _buildAssets(fuchsiaProject, target, buildInfo));
   await _timedBuildStep('fuchsia-build-package',
-    () => _buildPackage(fuchsiaProject, target, buildInfo));
+    () => _buildPackage(fuchsiaProject, target, buildInfo, runnerPackageSource));
 }
 
 Future<void> _buildAssets(
@@ -85,7 +86,7 @@ Future<void> _buildAssets(
   await outFile.close();
 }
 
-void _rewriteCmx(BuildMode mode, File src, File dst) {
+void _rewriteCmx(BuildMode mode, String runnerPackageSource, File src, File dst) {
   final Map<String, dynamic> cmx = json.decode(src.readAsStringSync());
   // If the app author has already specified the runner in the cmx file, then
   // do not override it with something else.
@@ -106,7 +107,7 @@ void _rewriteCmx(BuildMode mode, File src, File dst) {
       throwToolExit('Fuchsia does not support build mode "$mode"');
       break;
   }
-  cmx['runner'] = 'fuchsia-pkg://fuchsia.com/$runner#meta/$runner.cmx';
+  cmx['runner'] = 'fuchsia-pkg://$runnerPackageSource/$runner#meta/$runner.cmx';
   dst.writeAsStringSync(json.encode(cmx));
 }
 
@@ -115,6 +116,7 @@ Future<void> _buildPackage(
   FuchsiaProject fuchsiaProject,
   String target, // lib/main.dart
   BuildInfo buildInfo,
+  String runnerPackageSource,
 ) async {
   final String outDir = getFuchsiaBuildDirectory();
   final String pkgDir = fs.path.join(outDir, 'pkg');
@@ -132,7 +134,7 @@ Future<void> _buildPackage(
   final File srcCmx =
       fs.file(fs.path.join(fuchsiaProject.meta.path, '$appName.cmx'));
   final File dstCmx = fs.file(fs.path.join(outDir, '$appName.cmx'));
-  _rewriteCmx(buildInfo.mode, srcCmx, dstCmx);
+  _rewriteCmx(buildInfo.mode, runnerPackageSource, srcCmx, dstCmx);
 
   // Concatenate dilpmanifest and pkgassets into package_manifest.
   final File manifestFile = fs.file(packageManifest);

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_pm.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_pm.dart
@@ -178,6 +178,9 @@ class FuchsiaPM {
 class FuchsiaPackageServer {
   FuchsiaPackageServer(this._repo, this.name, this._host, this._port);
 
+  static const String deviceHost = 'fuchsia.com';
+  static const String toolHost = 'flutter_tool';
+
   final String _repo;
   final String _host;
   final int _port;

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
@@ -102,9 +102,6 @@ class FuchsiaArtifacts {
   FuchsiaArtifacts({
     this.sshConfig,
     this.devFinder,
-    this.platformKernelDill,
-    this.flutterPatchedSdk,
-    this.kernelCompiler,
     this.pm,
   });
 
@@ -119,19 +116,6 @@ class FuchsiaArtifacts {
       // Don't try to find the artifacts on platforms that are not supported.
       return FuchsiaArtifacts();
     }
-    final String fuchsia = Cache.instance.getArtifactDirectory('fuchsia').path;
-    final String tools = fs.path.join(fuchsia, 'tools');
-    final String dartPrebuilts = fs.path.join(tools, 'dart_prebuilts');
-
-    final File devFinder = fs.file(fs.path.join(tools, 'dev_finder'));
-    final File platformDill = fs.file(fs.path.join(
-          dartPrebuilts, 'flutter_runner', 'platform_strong.dill'));
-    final File patchedSdk = fs.file(fs.path.join(
-          dartPrebuilts, 'flutter_runner'));
-    final File kernelCompiler = fs.file(fs.path.join(
-          dartPrebuilts, 'kernel_compiler.snapshot'));
-    final File pm = fs.file(fs.path.join(tools, 'pm'));
-
     // If FUCHSIA_BUILD_DIR is defined, then look for the ssh_config dir
     // relative to it. Next, if FUCHSIA_SSH_CONFIG is defined, then use it.
     // TODO(zra): Consider passing the ssh config path in with a flag.
@@ -142,12 +126,15 @@ class FuchsiaArtifacts {
     } else if (platform.environment.containsKey(_kFuchsiaSshConfig)) {
       sshConfig = fs.file(platform.environment[_kFuchsiaSshConfig]);
     }
+
+    final String fuchsia = Cache.instance.getArtifactDirectory('fuchsia').path;
+    final String tools = fs.path.join(fuchsia, 'tools');
+    final File devFinder = fs.file(fs.path.join(tools, 'dev_finder'));
+    final File pm = fs.file(fs.path.join(tools, 'pm'));
+
     return FuchsiaArtifacts(
       sshConfig: sshConfig,
       devFinder: devFinder.existsSync() ? devFinder : null,
-      platformKernelDill: platformDill.existsSync() ? platformDill : null,
-      flutterPatchedSdk: patchedSdk.existsSync() ? patchedSdk : null,
-      kernelCompiler: kernelCompiler.existsSync() ? kernelCompiler : null,
       pm: pm.existsSync() ? pm : null,
     );
   }
@@ -162,15 +149,6 @@ class FuchsiaArtifacts {
   /// The location of the dev finder tool used to locate connected
   /// Fuchsia devices.
   final File devFinder;
-
-  /// The location of the Fuchsia-specific platform dill.
-  final File platformKernelDill;
-
-  /// The directory containing [platformKernelDill].
-  final File flutterPatchedSdk;
-
-  /// The snapshot of the Fuchsia kernel compiler.
-  final File kernelCompiler;
 
   /// The pm tool.
   final File pm;

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -734,7 +734,8 @@ DevelopmentArtifact _artifactFromTargetPlatform(TargetPlatform targetPlatform) {
         return DevelopmentArtifact.linux;
       }
       return null;
-    case TargetPlatform.fuchsia:
+    case TargetPlatform.fuchsia_arm64:
+    case TargetPlatform.fuchsia_x64:
     case TargetPlatform.tester:
       // No artifacts currently supported.
       return null;

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_fuchsia_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_fuchsia_test.dart
@@ -27,23 +27,18 @@ void main() {
   MockPlatform linuxPlatform;
   MockPlatform windowsPlatform;
   MockFuchsiaSdk fuchsiaSdk;
-  MockFuchsiaArtifacts fuchsiaArtifacts;
-  MockFuchsiaArtifacts fuchsiaArtifactsNoCompiler;
 
   setUp(() {
     linuxPlatform = MockPlatform();
     windowsPlatform = MockPlatform();
     fuchsiaSdk = MockFuchsiaSdk();
-    fuchsiaArtifacts = MockFuchsiaArtifacts();
-    fuchsiaArtifactsNoCompiler = MockFuchsiaArtifacts();
 
     when(linuxPlatform.isLinux).thenReturn(true);
     when(linuxPlatform.isWindows).thenReturn(false);
+    when(linuxPlatform.isMacOS).thenReturn(false);
     when(windowsPlatform.isWindows).thenReturn(true);
     when(windowsPlatform.isLinux).thenReturn(false);
     when(windowsPlatform.isMacOS).thenReturn(false);
-    when(fuchsiaArtifacts.kernelCompiler).thenReturn(MockFile());
-    when(fuchsiaArtifactsNoCompiler.kernelCompiler).thenReturn(null);
   });
 
   group('Fuchsia build fails gracefully when', () {
@@ -58,7 +53,6 @@ void main() {
       Platform: () => linuxPlatform,
       FileSystem: () => MemoryFileSystem(),
       ProcessManager: () => FakeProcessManager.any(),
-      FuchsiaArtifacts: () => fuchsiaArtifacts,
     });
 
     testUsingContext('there is no cmx file', () async {
@@ -76,7 +70,6 @@ void main() {
       Platform: () => linuxPlatform,
       FileSystem: () => MemoryFileSystem(),
       ProcessManager: () => FakeProcessManager.any(),
-      FuchsiaArtifacts: () => fuchsiaArtifacts,
     });
 
     testUsingContext('on Windows platform', () async {
@@ -99,7 +92,6 @@ void main() {
       Platform: () => windowsPlatform,
       FileSystem: () => MemoryFileSystem(),
       ProcessManager: () => FakeProcessManager.any(),
-      FuchsiaArtifacts: () => fuchsiaArtifacts,
     });
 
     testUsingContext('there is no Fuchsia kernel compiler', () async {
@@ -122,7 +114,6 @@ void main() {
       Platform: () => linuxPlatform,
       FileSystem: () => MemoryFileSystem(),
       ProcessManager: () => FakeProcessManager.any(),
-      FuchsiaArtifacts: () => fuchsiaArtifactsNoCompiler,
     });
   });
 
@@ -233,7 +224,3 @@ class MockFuchsiaSdk extends Mock implements FuchsiaSdk {
   final FuchsiaKernelCompiler fuchsiaKernelCompiler =
       MockFuchsiaKernelCompiler();
 }
-
-class MockFile extends Mock implements File {}
-
-class MockFuchsiaArtifacts extends Mock implements FuchsiaArtifacts {}

--- a/packages/flutter_tools/test/general.shard/device_test.dart
+++ b/packages/flutter_tools/test/general.shard/device_test.dart
@@ -57,7 +57,7 @@ void main() {
       webDevice = _MockDevice('webby', 'webby')
         ..targetPlatform = Future<TargetPlatform>.value(TargetPlatform.web_javascript);
       fuchsiaDevice = _MockDevice('fuchsiay', 'fuchsiay')
-        ..targetPlatform = Future<TargetPlatform>.value(TargetPlatform.fuchsia);
+        ..targetPlatform = Future<TargetPlatform>.value(TargetPlatform.fuchsia_x64);
     });
 
     testUsingContext('chooses ephemeral device', () async {

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/time.dart';
 import 'package:flutter_tools/src/build_info.dart';
@@ -36,8 +37,13 @@ import '../../src/context.dart';
 void main() {
   group('fuchsia device', () {
     MemoryFileSystem memoryFileSystem;
+    MockFile sshConfig;
+    MockProcessUtils mockProcessUtils;
     setUp(() {
       memoryFileSystem = MemoryFileSystem();
+      sshConfig = MockFile();
+      mockProcessUtils = MockProcessUtils();
+      when(sshConfig.absolute).thenReturn(sshConfig);
     });
 
     testUsingContext('stores the requested id and name', () {
@@ -96,44 +102,78 @@ void main() {
       FileSystem: () => memoryFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
     });
+
+    testUsingContext('targetPlatform arm64 works', () async {
+      when(mockProcessUtils.run(any)).thenAnswer((Invocation _) {
+        return Future<RunResult>.value(RunResult(ProcessResult(1, 0, 'aarch64', ''), <String>['']));
+      });
+      final FuchsiaDevice device = FuchsiaDevice('123');
+      expect(await device.targetPlatform, TargetPlatform.fuchsia_arm64);
+    }, overrides: <Type, Generator>{
+      FuchsiaArtifacts: () => FuchsiaArtifacts(sshConfig: sshConfig),
+      ProcessUtils: () => mockProcessUtils,
+    });
+
+    testUsingContext('targetPlatform x64 works', () async {
+      when(mockProcessUtils.run(any)).thenAnswer((Invocation _) {
+        return Future<RunResult>.value(RunResult(ProcessResult(1, 0, 'x86_64', ''), <String>['']));
+      });
+      final FuchsiaDevice device = FuchsiaDevice('123');
+      expect(await device.targetPlatform, TargetPlatform.fuchsia_x64);
+    }, overrides: <Type, Generator>{
+      FuchsiaArtifacts: () => FuchsiaArtifacts(sshConfig: sshConfig),
+      ProcessUtils: () => mockProcessUtils,
+    });
   });
 
   group('Fuchsia device artifact overrides', () {
-    MockFile devFinder;
-    MockFile sshConfig;
-    MockFile platformDill;
-    MockFile patchedSdk;
+    MemoryFileSystem memoryFileSystem;
+    File devFinder;
+    File sshConfig;
+    File platformDill;
+    File patchedSdk;
+    MockArtifacts mockArtifacts;
 
     setUp(() {
-      devFinder = MockFile();
-      sshConfig = MockFile();
-      platformDill = MockFile();
-      patchedSdk = MockFile();
-      when(devFinder.absolute).thenReturn(devFinder);
-      when(sshConfig.absolute).thenReturn(sshConfig);
-      when(platformDill.absolute).thenReturn(platformDill);
-      when(patchedSdk.absolute).thenReturn(patchedSdk);
+      memoryFileSystem = MemoryFileSystem();
+      devFinder = memoryFileSystem.file('dev_finder');
+      sshConfig = memoryFileSystem.file('ssh_config');
+      platformDill = memoryFileSystem.file('platform_strong.dill');
+      patchedSdk = memoryFileSystem.file('flutter_runner_patched_sdk');
+
+      mockArtifacts = MockArtifacts();
+      when(mockArtifacts.getArtifactPath(
+        Artifact.fuchsiaPlatformDill,
+        platform: anyNamed('platform'),
+        mode: anyNamed('mode'),
+      )).thenReturn(platformDill.path);
+      when(mockArtifacts.getArtifactPath(
+        Artifact.fuchsiaPatchedSdk,
+        platform: anyNamed('platform'),
+        mode: anyNamed('mode'),
+      )).thenReturn(patchedSdk.path);
     });
 
     testUsingContext('exist', () async {
       final FuchsiaDevice device = FuchsiaDevice('fuchsia-device');
       expect(device.artifactOverrides, isNotNull);
-      expect(device.artifactOverrides.platformKernelDill, equals(platformDill));
-      expect(device.artifactOverrides.flutterPatchedSdk, equals(patchedSdk));
+      expect(device.artifactOverrides.platformKernelDill.path, equals(platformDill.path));
+      expect(device.artifactOverrides.flutterPatchedSdk.path, equals(patchedSdk.path));
     }, overrides: <Type, Generator>{
+      Artifacts: () => mockArtifacts,
+      FileSystem: () => memoryFileSystem,
       FuchsiaArtifacts: () => FuchsiaArtifacts(
             sshConfig: sshConfig,
             devFinder: devFinder,
-            platformKernelDill: platformDill,
-            flutterPatchedSdk: patchedSdk,
           ),
+      ProcessManager: () => FakeProcessManager.any(),
     });
 
     testUsingContext('are used', () async {
       final FuchsiaDevice device = FuchsiaDevice('fuchsia-device');
       expect(device.artifactOverrides, isNotNull);
-      expect(device.artifactOverrides.platformKernelDill, equals(platformDill));
-      expect(device.artifactOverrides.flutterPatchedSdk, equals(patchedSdk));
+      expect(device.artifactOverrides.platformKernelDill.path, equals(platformDill.path));
+      expect(device.artifactOverrides.flutterPatchedSdk.path, equals(patchedSdk.path));
       await context.run<void>(
         body: () {
           expect(Artifacts.instance.getArtifactPath(Artifact.platformKernelDill),
@@ -146,12 +186,13 @@ void main() {
         },
       );
     }, overrides: <Type, Generator>{
+      Artifacts: () => mockArtifacts,
+      FileSystem: () => memoryFileSystem,
       FuchsiaArtifacts: () => FuchsiaArtifacts(
             sshConfig: sshConfig,
             devFinder: devFinder,
-            platformKernelDill: platformDill,
-            flutterPatchedSdk: patchedSdk,
           ),
+      ProcessManager: () => FakeProcessManager.any(),
     });
   });
 
@@ -339,15 +380,23 @@ void main() {
   });
 
   group(FuchsiaIsolateDiscoveryProtocol, () {
+    MockPortForwarder portForwarder;
+    MockVMService vmService;
+    MockVM vm;
+
+    setUp(() {
+      portForwarder = MockPortForwarder();
+      vmService = MockVMService();
+      vm = MockVM();
+
+      when(vm.vmService).thenReturn(vmService);
+      when(vmService.vm).thenReturn(vm);
+    });
+
     Future<Uri> findUri(List<MockFlutterView> views, String expectedIsolateName) {
-      final MockPortForwarder portForwarder = MockPortForwarder();
-      final MockVMService vmService = MockVMService();
-      final MockVM vm = MockVM();
-      vm.vmService = vmService;
-      vmService.vm = vm;
-      vm.views = views;
+      when(vm.views).thenReturn(views);
       for (MockFlutterView view in views) {
-        view.owner = vm;
+        when(view.owner).thenReturn(vm);
       }
       final MockFuchsiaDevice fuchsiaDevice =
           MockFuchsiaDevice('123', portForwarder, false);
@@ -404,11 +453,47 @@ void main() {
     FakeOperatingSystemUtils osUtils;
     FakeFuchsiaDeviceTools fuchsiaDeviceTools;
     MockFuchsiaSdk fuchsiaSdk;
+    MockFuchsiaArtifacts fuchsiaArtifacts;
+    MockArtifacts mockArtifacts;
+
+    File compilerSnapshot;
+    File platformDill;
+    File patchedSdk;
+    File runner;
+
     setUp(() {
       memoryFileSystem = MemoryFileSystem();
       osUtils = FakeOperatingSystemUtils();
       fuchsiaDeviceTools = FakeFuchsiaDeviceTools();
       fuchsiaSdk = MockFuchsiaSdk();
+      fuchsiaArtifacts = MockFuchsiaArtifacts();
+
+      compilerSnapshot = memoryFileSystem.file('kernel_compiler.snapshot')..createSync();
+      platformDill = memoryFileSystem.file('platform_strong.dill')..createSync();
+      patchedSdk = memoryFileSystem.file('flutter_runner_patched_sdk')..createSync();
+      runner = memoryFileSystem.file('flutter_jit_runner')..createSync();
+
+      mockArtifacts = MockArtifacts();
+      when(mockArtifacts.getArtifactPath(
+        Artifact.fuchsiaKernelCompiler,
+        platform: anyNamed('platform'),
+        mode: anyNamed('mode'),
+      )).thenReturn(compilerSnapshot.path);
+      when(mockArtifacts.getArtifactPath(
+        Artifact.fuchsiaPlatformDill,
+        platform: anyNamed('platform'),
+        mode: anyNamed('mode'),
+      )).thenReturn(platformDill.path);
+      when(mockArtifacts.getArtifactPath(
+        Artifact.fuchsiaPatchedSdk,
+        platform: anyNamed('platform'),
+        mode: anyNamed('mode'),
+      )).thenReturn(patchedSdk.path);
+      when(mockArtifacts.getArtifactPath(
+        Artifact.fuchsiaFlutterJitRunner,
+        platform: anyNamed('platform'),
+        mode: anyNamed('mode'),
+      )).thenReturn(runner.path);
     });
 
     Future<LaunchResult> setupAndStartApp({
@@ -434,11 +519,12 @@ void main() {
         app = BuildableFuchsiaApp(project: FlutterProject.current().fuchsia);
       }
 
-      final DebuggingOptions debuggingOptions =
-          DebuggingOptions.disabled(BuildInfo(mode, null));
-      return await device.startApp(app,
-          prebuiltApplication: prebuilt,
-          debuggingOptions: debuggingOptions);
+      final DebuggingOptions debuggingOptions = DebuggingOptions.disabled(BuildInfo(mode, null));
+      return await device.startApp(
+        app,
+        prebuiltApplication: prebuilt,
+        debuggingOptions: debuggingOptions,
+      );
     }
 
     testUsingContext('start prebuilt in release mode', () async {
@@ -447,9 +533,11 @@ void main() {
       expect(launchResult.started, isTrue);
       expect(launchResult.hasObservatory, isFalse);
     }, overrides: <Type, Generator>{
+      Artifacts: () => mockArtifacts,
       FileSystem: () => memoryFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
       FuchsiaDeviceTools: () => fuchsiaDeviceTools,
+      FuchsiaArtifacts: () => fuchsiaArtifacts,
       FuchsiaSdk: () => fuchsiaSdk,
       OperatingSystemUtils: () => osUtils,
     });
@@ -472,9 +560,11 @@ void main() {
       expect(launchResult.hasObservatory, isFalse);
       expect(await device.stopApp(app), isTrue);
     }, overrides: <Type, Generator>{
+      Artifacts: () => mockArtifacts,
       FileSystem: () => memoryFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
       FuchsiaDeviceTools: () => fuchsiaDeviceTools,
+      FuchsiaArtifacts: () => fuchsiaArtifacts,
       FuchsiaSdk: () => fuchsiaSdk,
       OperatingSystemUtils: () => osUtils,
     });
@@ -485,9 +575,11 @@ void main() {
       expect(launchResult.started, isTrue);
       expect(launchResult.hasObservatory, isTrue);
     }, overrides: <Type, Generator>{
+      Artifacts: () => mockArtifacts,
       FileSystem: () => memoryFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
       FuchsiaDeviceTools: () => fuchsiaDeviceTools,
+      FuchsiaArtifacts: () => fuchsiaArtifacts,
       FuchsiaSdk: () => fuchsiaSdk,
       OperatingSystemUtils: () => osUtils,
     });
@@ -498,9 +590,11 @@ void main() {
       expect(launchResult.started, isTrue);
       expect(launchResult.hasObservatory, isFalse);
     }, overrides: <Type, Generator>{
+      Artifacts: () => mockArtifacts,
       FileSystem: () => memoryFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
       FuchsiaDeviceTools: () => fuchsiaDeviceTools,
+      FuchsiaArtifacts: () => fuchsiaArtifacts,
       FuchsiaSdk: () => fuchsiaSdk,
       OperatingSystemUtils: () => osUtils,
     });
@@ -511,9 +605,11 @@ void main() {
       expect(launchResult.started, isTrue);
       expect(launchResult.hasObservatory, isTrue);
     }, overrides: <Type, Generator>{
+      Artifacts: () => mockArtifacts,
       FileSystem: () => memoryFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
       FuchsiaDeviceTools: () => fuchsiaDeviceTools,
+      FuchsiaArtifacts: () => fuchsiaArtifacts,
       FuchsiaSdk: () => fuchsiaSdk,
       OperatingSystemUtils: () => osUtils,
     });
@@ -524,9 +620,11 @@ void main() {
       expect(launchResult.started, isFalse);
       expect(launchResult.hasObservatory, isFalse);
     }, overrides: <Type, Generator>{
+      Artifacts: () => mockArtifacts,
       FileSystem: () => memoryFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
       FuchsiaDeviceTools: () => fuchsiaDeviceTools,
+      FuchsiaArtifacts: () => fuchsiaArtifacts,
       FuchsiaSdk: () => MockFuchsiaSdk(devFinder: FailingDevFinder()),
       OperatingSystemUtils: () => osUtils,
     });
@@ -537,9 +635,11 @@ void main() {
       expect(launchResult.started, isFalse);
       expect(launchResult.hasObservatory, isFalse);
     }, overrides: <Type, Generator>{
+      Artifacts: () => mockArtifacts,
       FileSystem: () => memoryFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
       FuchsiaDeviceTools: () => fuchsiaDeviceTools,
+      FuchsiaArtifacts: () => fuchsiaArtifacts,
       FuchsiaSdk: () => MockFuchsiaSdk(pm: FailingPM()),
       OperatingSystemUtils: () => osUtils,
     });
@@ -550,9 +650,11 @@ void main() {
       expect(launchResult.started, isFalse);
       expect(launchResult.hasObservatory, isFalse);
     }, overrides: <Type, Generator>{
+      Artifacts: () => mockArtifacts,
       FileSystem: () => memoryFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
       FuchsiaDeviceTools: () => FakeFuchsiaDeviceTools(amber: FailingAmberCtl()),
+      FuchsiaArtifacts: () => fuchsiaArtifacts,
       FuchsiaSdk: () => fuchsiaSdk,
       OperatingSystemUtils: () => osUtils,
     });
@@ -563,9 +665,11 @@ void main() {
       expect(launchResult.started, isFalse);
       expect(launchResult.hasObservatory, isFalse);
     }, overrides: <Type, Generator>{
+      Artifacts: () => mockArtifacts,
       FileSystem: () => memoryFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
       FuchsiaDeviceTools: () => FakeFuchsiaDeviceTools(tiles: FailingTilesCtl()),
+      FuchsiaArtifacts: () => fuchsiaArtifacts,
       FuchsiaSdk: () => fuchsiaSdk,
       OperatingSystemUtils: () => osUtils,
     });
@@ -643,9 +747,15 @@ class FuchsiaModulePackage extends ApplicationPackage {
   final String name;
 }
 
+class MockArtifacts extends Mock implements Artifacts {}
+
+class MockFuchsiaArtifacts extends Mock implements FuchsiaArtifacts {}
+
 class MockProcessManager extends Mock implements ProcessManager {}
 
 class MockProcessResult extends Mock implements ProcessResult {}
+
+class MockProcessUtils extends Mock implements ProcessUtils {}
 
 class MockFile extends Mock implements File {}
 
@@ -690,31 +800,22 @@ class MockFuchsiaDevice extends Mock implements FuchsiaDevice {
   final String id;
   @override
   final DevicePortForwarder portForwarder;
+
+  @override
+  Future<TargetPlatform> get targetPlatform async => TargetPlatform.fuchsia_arm64;
 }
 
 class MockPortForwarder extends Mock implements DevicePortForwarder {}
 
-class MockVMService extends Mock implements VMService {
-  @override
-  VM vm;
-}
+class MockVMService extends Mock implements VMService {}
 
-class MockVM extends Mock implements VM {
-  @override
-  VMService vmService;
-
-  @override
-  List<FlutterView> views;
-}
+class MockVM extends Mock implements VM {}
 
 class MockFlutterView extends Mock implements FlutterView {
   MockFlutterView(this.uiIsolate);
 
   @override
   final Isolate uiIsolate;
-
-  @override
-  ServiceObjectOwner owner;
 }
 
 class MockIsolate extends Mock implements Isolate {
@@ -731,6 +832,9 @@ class FuchsiaDeviceWithFakeDiscovery extends FuchsiaDevice {
   FuchsiaIsolateDiscoveryProtocol getIsolateDiscoveryProtocol(String isolateName) {
     return FakeFuchsiaIsolateDiscoveryProtocol();
   }
+
+  @override
+  Future<TargetPlatform> get targetPlatform async => TargetPlatform.fuchsia_arm64;
 }
 
 class FakeFuchsiaIsolateDiscoveryProtocol implements FuchsiaIsolateDiscoveryProtocol {


### PR DESCRIPTION
## Description

This PR switches Fuchsia targets to use the engine prebuilts instead of the prebuilts bundled with the Fuchsia SDK. The prebuilts bundled with the Fuchsia SDK are to be removed as part of the flutter_runner migration to the engine repo.

## Tests

Updated existing tests, and added tests for querying `FuchsiaDevice.targetPlatform`.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.