### PR TITLE
Re-Land: Add focus nodes, hover, and shortcuts to switches, checkboxes, and radio buttons.

### DIFF
--- a/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
+++ b/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
@@ -198,8 +198,16 @@ void main() {
       });
 
       test('Checkbox has correct Android semantics', () async {
+        Future<AndroidSemanticsNode> getCheckboxSemantics(String key) async {
+          return getSemantics(
+            find.descendant(
+              of: find.byValueKey(key),
+              matching: find.byType('_CheckboxRenderObjectWidget'),
+            ),
+          );
+        }
         expect(
-          await getSemantics(find.byValueKey(checkboxKeyValue)),
+          await getCheckboxSemantics(checkboxKeyValue),
           hasAndroidSemantics(
             className: AndroidClassName.checkBox,
             isChecked: false,
@@ -216,7 +224,7 @@ void main() {
         await driver.tap(find.byValueKey(checkboxKeyValue));
 
         expect(
-          await getSemantics(find.byValueKey(checkboxKeyValue)),
+          await getCheckboxSemantics(checkboxKeyValue),
           hasAndroidSemantics(
             className: AndroidClassName.checkBox,
             isChecked: true,
@@ -230,7 +238,7 @@ void main() {
           ),
         );
         expect(
-          await getSemantics(find.byValueKey(disabledCheckboxKeyValue)),
+          await getCheckboxSemantics(disabledCheckboxKeyValue),
           hasAndroidSemantics(
             className: AndroidClassName.checkBox,
             isCheckable: true,
@@ -242,8 +250,16 @@ void main() {
         );
       });
       test('Radio has correct Android semantics', () async {
+        Future<AndroidSemanticsNode> getRadioSemantics(String key) async {
+          return getSemantics(
+            find.descendant(
+              of: find.byValueKey(key),
+              matching: find.byType('_RadioRenderObjectWidget'),
+            ),
+          );
+        }
         expect(
-          await getSemantics(find.byValueKey(radio2KeyValue)),
+          await getRadioSemantics(radio2KeyValue),
           hasAndroidSemantics(
             className: AndroidClassName.radio,
             isChecked: false,
@@ -260,7 +276,7 @@ void main() {
         await driver.tap(find.byValueKey(radio2KeyValue));
 
         expect(
-          await getSemantics(find.byValueKey(radio2KeyValue)),
+          await getRadioSemantics(radio2KeyValue),
           hasAndroidSemantics(
             className: AndroidClassName.radio,
             isChecked: true,
@@ -275,8 +291,16 @@ void main() {
         );
       });
       test('Switch has correct Android semantics', () async {
+        Future<AndroidSemanticsNode> getSwitchSemantics(String key) async {
+          return getSemantics(
+            find.descendant(
+              of: find.byValueKey(key),
+              matching: find.byType('_SwitchRenderObjectWidget'),
+            ),
+          );
+        }
         expect(
-          await getSemantics(find.byValueKey(switchKeyValue)),
+          await getSwitchSemantics(switchKeyValue),
           hasAndroidSemantics(
             className: AndroidClassName.toggleSwitch,
             isChecked: false,
@@ -293,7 +317,7 @@ void main() {
         await driver.tap(find.byValueKey(switchKeyValue));
 
         expect(
-          await getSemantics(find.byValueKey(switchKeyValue)),
+          await getSwitchSemantics(switchKeyValue),
           hasAndroidSemantics(
             className: AndroidClassName.toggleSwitch,
             isChecked: true,
@@ -310,8 +334,16 @@ void main() {
 
       // Regression test for https://github.com/flutter/flutter/issues/20820.
       test('Switch can be labeled', () async {
+        Future<AndroidSemanticsNode> getSwitchSemantics(String key) async {
+          return getSemantics(
+            find.descendant(
+              of: find.byValueKey(key),
+              matching: find.byType('_SwitchRenderObjectWidget'),
+            ),
+          );
+        }
         expect(
-          await getSemantics(find.byValueKey(labeledSwitchKeyValue)),
+          await getSwitchSemantics(labeledSwitchKeyValue),
           hasAndroidSemantics(
             className: AndroidClassName.toggleSwitch,
             isChecked: false,

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -489,20 +489,25 @@ class _InkResponseState<T extends InkResponse> extends State<T> with AutomaticKe
 
   bool get highlightsExist => _highlights.values.where((InkHighlight highlight) => highlight != null).isNotEmpty;
 
+  void _handleAction(FocusNode node, Intent intent) {
+    _startSplash(context: node.context);
+    _handleTap(node.context);
+  }
+
   Action _createAction() {
     return CallbackAction(
       ActivateAction.key,
-      onInvoke: (FocusNode node, Intent intent) {
-        _startSplash(context: node.context);
-        _handleTap(node.context);
-      },
+      onInvoke:  _handleAction,
     );
   }
 
   @override
   void initState() {
     super.initState();
-    _actionMap = <LocalKey, ActionFactory>{ ActivateAction.key: _createAction };
+    _actionMap = <LocalKey, ActionFactory>{
+      SelectAction.key: _createAction,
+      if (!kIsWeb) ActivateAction.key: _createAction,
+    };
     WidgetsBinding.instance.focusManager.addHighlightModeListener(_handleFocusHighlightModeChange);
   }
 

--- a/packages/flutter/lib/src/material/toggleable.dart
+++ b/packages/flutter/lib/src/material/toggleable.dart
@@ -10,8 +10,14 @@ import 'package:flutter/scheduler.dart';
 
 import 'constants.dart';
 
+// Duration of the animation that moves the toggle from one state to another.
 const Duration _kToggleDuration = Duration(milliseconds: 200);
+
+// Radius of the radial reaction over time.
 final Animatable<double> _kRadialReactionRadiusTween = Tween<double>(begin: 0.0, end: kRadialReactionRadius);
+
+// Duration of the fade animation for the reaction when focus and hover occur.
+const Duration _kReactionFadeDuration = Duration(milliseconds: 50);
 
 /// A base class for material style toggleable controls with toggle animations.
 ///
@@ -28,9 +34,13 @@ abstract class RenderToggleable extends RenderConstrainedBox {
     bool tristate = false,
     @required Color activeColor,
     @required Color inactiveColor,
+    Color hoverColor,
+    Color focusColor,
     ValueChanged<bool> onChanged,
     BoxConstraints additionalConstraints,
     @required TickerProvider vsync,
+    bool hasFocus = false,
+    bool hovering = false,
   }) : assert(tristate != null),
        assert(tristate || value != null),
        assert(activeColor != null),
@@ -40,7 +50,11 @@ abstract class RenderToggleable extends RenderConstrainedBox {
        _tristate = tristate,
        _activeColor = activeColor,
        _inactiveColor = inactiveColor,
+       _hoverColor = hoverColor ?? activeColor.withAlpha(kRadialReactionAlpha),
+       _focusColor = focusColor ?? activeColor.withAlpha(kRadialReactionAlpha),
        _onChanged = onChanged,
+       _hasFocus = hasFocus,
+       _hovering = hovering,
        _vsync = vsync,
        super(additionalConstraints: additionalConstraints) {
     _tap = TapGestureRecognizer()
@@ -64,6 +78,24 @@ abstract class RenderToggleable extends RenderConstrainedBox {
     );
     _reaction = CurvedAnimation(
       parent: _reactionController,
+      curve: Curves.fastOutSlowIn,
+    )..addListener(markNeedsPaint);
+    _reactionHoverFadeController = AnimationController(
+      duration: _kReactionFadeDuration,
+      value: hovering || hasFocus ? 1.0 : 0.0,
+      vsync: vsync,
+    );
+    _reactionHoverFade = CurvedAnimation(
+      parent: _reactionHoverFadeController,
+      curve: Curves.fastOutSlowIn,
+    )..addListener(markNeedsPaint);
+    _reactionFocusFadeController = AnimationController(
+      duration: _kReactionFadeDuration,
+      value: hovering || hasFocus ? 1.0 : 0.0,
+      vsync: vsync,
+    );
+    _reactionFocusFade = CurvedAnimation(
+      parent: _reactionFocusFadeController,
       curve: Curves.fastOutSlowIn,
     )..addListener(markNeedsPaint);
   }
@@ -101,6 +133,66 @@ abstract class RenderToggleable extends RenderConstrainedBox {
   AnimationController get reactionController => _reactionController;
   AnimationController _reactionController;
   Animation<double> _reaction;
+
+  /// Used by subclasses to control the radial reaction's opacity animation for
+  /// [hasFocus] changes.
+  ///
+  /// Some controls have a radial ink reaction to focus. This animation
+  /// controller can be used to start or stop these ink reaction fade-ins and
+  /// fade-outs.
+  ///
+  /// Subclasses should call [paintRadialReaction] to actually paint the radial
+  /// reaction.
+  @protected
+  AnimationController get reactionFocusFadeController => _reactionFocusFadeController;
+  AnimationController _reactionFocusFadeController;
+  Animation<double> _reactionFocusFade;
+
+  /// Used by subclasses to control the radial reaction's opacity animation for
+  /// [hovering] changes.
+  ///
+  /// Some controls have a radial ink reaction to pointer hover. This animation
+  /// controller can be used to start or stop these ink reaction fade-ins and
+  /// fade-outs.
+  ///
+  /// Subclasses should call [paintRadialReaction] to actually paint the radial
+  /// reaction.
+  @protected
+  AnimationController get reactionHoverFadeController => _reactionHoverFadeController;
+  AnimationController _reactionHoverFadeController;
+  Animation<double> _reactionHoverFade;
+
+  /// True if this toggleable has the input focus.
+  bool get hasFocus => _hasFocus;
+  bool _hasFocus;
+  set hasFocus(bool value) {
+    assert(value != null);
+    if (value == _hasFocus)
+      return;
+    _hasFocus = value;
+    if (_hasFocus) {
+      _reactionFocusFadeController.forward();
+    } else {
+      _reactionFocusFadeController.reverse();
+    }
+    markNeedsPaint();
+  }
+
+  /// True if this toggleable is being hovered over by a pointer.
+  bool get hovering => _hovering;
+  bool _hovering;
+  set hovering(bool value) {
+    assert(value != null);
+    if (value == _hovering)
+      return;
+    _hovering = value;
+    if (_hovering) {
+      _reactionHoverFadeController.forward();
+    } else {
+      _reactionHoverFadeController.reverse();
+    }
+    markNeedsPaint();
+  }
 
   /// The [TickerProvider] for the [AnimationController]s that run the animations.
   TickerProvider get vsync => _vsync;
@@ -189,6 +281,54 @@ abstract class RenderToggleable extends RenderConstrainedBox {
     if (value == _inactiveColor)
       return;
     _inactiveColor = value;
+    markNeedsPaint();
+  }
+
+  /// The color that should be used for the reaction when [hovering] is true.
+  ///
+  /// Used when the toggleable needs to change the reaction color/transparency,
+  /// when it is being hovered over.
+  ///
+  /// Defaults to the [activeColor] at alpha [kRadialReactionAlpha].
+  Color get hoverColor => _hoverColor;
+  Color _hoverColor;
+  set hoverColor(Color value) {
+    assert(value != null);
+    if (value == _hoverColor)
+      return;
+    _hoverColor = value;
+    markNeedsPaint();
+  }
+
+  /// The color that should be used for the reaction when [hasFocus] is true.
+  ///
+  /// Used when the toggleable needs to change the reaction color/transparency,
+  /// when it has focus.
+  ///
+  /// Defaults to the [activeColor] at alpha [kRadialReactionAlpha].
+  Color get focusColor => _focusColor;
+  Color _focusColor;
+  set focusColor(Color value) {
+    assert(value != null);
+    if (value == _focusColor)
+      return;
+    _focusColor = value;
+    markNeedsPaint();
+  }
+
+  /// The color that should be used for the reaction when drawn.
+  ///
+  /// Used when the toggleable needs to change the reaction color/transparency
+  /// that is displayed when the toggleable is toggled by a tap.
+  ///
+  /// Defaults to the [activeColor] at alpha [kRadialReactionAlpha].
+  Color get reactionColor => _reactionColor;
+  Color _reactionColor;
+  set reactionColor(Color value) {
+    assert(value != null);
+    if (value == _reactionColor)
+      return;
+    _reactionColor = value;
     markNeedsPaint();
   }
 
@@ -323,12 +463,18 @@ abstract class RenderToggleable extends RenderConstrainedBox {
   /// point at which the user interacted with the control, which is handled
   /// automatically).
   void paintRadialReaction(Canvas canvas, Offset offset, Offset origin) {
-    if (!_reaction.isDismissed) {
-      // TODO(abarth): We should have a different reaction color when position is zero.
-      final Paint reactionPaint = Paint()..color = activeColor.withAlpha(kRadialReactionAlpha);
+    if (!_reaction.isDismissed || !_reactionFocusFade.isDismissed || !_reactionHoverFade.isDismissed) {
+      final Paint reactionPaint = Paint()
+        ..color = Color.lerp(
+          Color.lerp(activeColor.withAlpha(kRadialReactionAlpha), hoverColor, _reactionHoverFade.value),
+          focusColor,
+          _reactionFocusFade.value,
+        );
       final Offset center = Offset.lerp(_downPosition ?? origin, origin, _reaction.value);
-      final double radius = _kRadialReactionRadiusTween.evaluate(_reaction);
-      canvas.drawCircle(center + offset, radius, reactionPaint);
+      final double reactionRadius = hasFocus || hovering
+          ? kRadialReactionRadius
+          : _kRadialReactionRadiusTween.evaluate(_reaction);
+      canvas.drawCircle(center + offset, reactionRadius, reactionPaint);
     }
   }
 

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -376,12 +376,25 @@ class DoNothingAction extends Action {
 /// An action that invokes the currently focused control.
 ///
 /// This is an abstract class that serves as a base class for actions that
-/// activate a control. It is bound to [LogicalKeyboardKey.enter] in the default
-/// keyboard map in [WidgetsApp].
+/// activate a control. By default, is bound to [LogicalKeyboardKey.enter] in
+/// the default keyboard map in [WidgetsApp].
 abstract class ActivateAction extends Action {
   /// Creates a [ActivateAction] with a fixed [key];
   const ActivateAction() : super(key);
 
   /// The [LocalKey] that uniquely identifies this action.
   static const LocalKey key = ValueKey<Type>(ActivateAction);
+}
+
+/// An action that selects the currently focused control.
+///
+/// This is an abstract class that serves as a base class for actions that
+/// select something, like a checkbox or a radio button. By default, it is bound
+/// to [LogicalKeyboardKey.space] in the default keyboard map in [WidgetsApp].
+abstract class SelectAction extends Action {
+  /// Creates a [SelectAction] with a fixed [key];
+  const SelectAction() : super(key);
+
+  /// The [LocalKey] that uniquely identifies this action.
+  static const LocalKey key = ValueKey<Type>(SelectAction);
 }

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1046,6 +1046,7 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
     LogicalKeySet(LogicalKeyboardKey.arrowDown): const DirectionalFocusIntent(TraversalDirection.down),
     LogicalKeySet(LogicalKeyboardKey.arrowUp): const DirectionalFocusIntent(TraversalDirection.up),
     LogicalKeySet(LogicalKeyboardKey.enter): const Intent(ActivateAction.key),
+    LogicalKeySet(LogicalKeyboardKey.space): const Intent(SelectAction.key),
   };
 
   final Map<LocalKey, ActionFactory> _actionMap = <LocalKey, ActionFactory>{

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -897,8 +897,8 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<BuildContext>('context', context, defaultValue: null));
     properties.add(FlagProperty('canRequestFocus', value: canRequestFocus, ifFalse: 'NOT FOCUSABLE', defaultValue: true));
-    properties.add(FlagProperty('hasFocus', value: hasFocus, ifTrue: 'FOCUSED', defaultValue: false));
-    properties.add(StringProperty('debugLabel', debugLabel, defaultValue: null));
+    properties.add(FlagProperty('hasFocus', value: hasFocus && !hasPrimaryFocus, ifTrue: 'IN FOCUS PATH', defaultValue: false));
+    properties.add(FlagProperty('hasPrimaryFocus', value: hasPrimaryFocus, ifTrue: 'PRIMARY FOCUS', defaultValue: false));
   }
 
   @override

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -67,11 +67,12 @@ void main() {
       ),
     ));
 
-    expect(tester.getSemantics(find.byType(Checkbox)), matchesSemantics(
+    expect(tester.getSemantics(find.byType(Focus)), matchesSemantics(
       hasCheckedState: true,
       hasEnabledState: true,
       isEnabled: true,
       hasTapAction: true,
+      isFocusable: true,
     ));
 
     await tester.pumpWidget(Material(
@@ -81,12 +82,13 @@ void main() {
       ),
     ));
 
-    expect(tester.getSemantics(find.byType(Checkbox)), matchesSemantics(
+    expect(tester.getSemantics(find.byType(Focus)), matchesSemantics(
       hasCheckedState: true,
       hasEnabledState: true,
       isChecked: true,
       isEnabled: true,
       hasTapAction: true,
+      isFocusable: true,
     ));
 
     await tester.pumpWidget(const Material(
@@ -96,9 +98,10 @@ void main() {
       ),
     ));
 
-    expect(tester.getSemantics(find.byType(Checkbox)), matchesSemantics(
+    expect(tester.getSemantics(find.byType(Focus)), matchesSemantics(
       hasCheckedState: true,
       hasEnabledState: true,
+      isFocusable: true,
     ));
 
     await tester.pumpWidget(const Material(
@@ -108,7 +111,7 @@ void main() {
       ),
     ));
 
-    expect(tester.getSemantics(find.byType(Checkbox)), matchesSemantics(
+    expect(tester.getSemantics(find.byType(Focus)), matchesSemantics(
       hasCheckedState: true,
       hasEnabledState: true,
       isChecked: true,
@@ -130,13 +133,14 @@ void main() {
       ),
     ));
 
-    expect(tester.getSemantics(find.byType(Checkbox)), matchesSemantics(
+    expect(tester.getSemantics(find.byType(Focus)), matchesSemantics(
       label: 'foo',
       textDirection: TextDirection.ltr,
       hasCheckedState: true,
       hasEnabledState: true,
       isEnabled: true,
       hasTapAction: true,
+      isFocusable: true,
     ));
     handle.dispose();
   });
@@ -202,6 +206,7 @@ void main() {
         SemanticsFlag.hasCheckedState,
         SemanticsFlag.hasEnabledState,
         SemanticsFlag.isEnabled,
+        SemanticsFlag.isFocusable,
       ],
       actions: <SemanticsAction>[SemanticsAction.tap],
     ), hasLength(1));
@@ -222,6 +227,7 @@ void main() {
         SemanticsFlag.hasEnabledState,
         SemanticsFlag.isEnabled,
         SemanticsFlag.isChecked,
+        SemanticsFlag.isFocusable,
       ],
       actions: <SemanticsAction>[SemanticsAction.tap],
     ), hasLength(1));
@@ -241,6 +247,7 @@ void main() {
         SemanticsFlag.hasCheckedState,
         SemanticsFlag.hasEnabledState,
         SemanticsFlag.isEnabled,
+        SemanticsFlag.isFocusable,
       ],
       actions: <SemanticsAction>[SemanticsAction.tap],
     ), hasLength(1));
@@ -274,7 +281,7 @@ void main() {
     );
 
     await tester.tap(find.byType(Checkbox));
-    final RenderObject object = tester.firstRenderObject(find.byType(Checkbox));
+    final RenderObject object = tester.firstRenderObject(find.byType(Focus));
 
     expect(checkboxValue, true);
     expect(semanticEvent, <String, dynamic>{
@@ -304,7 +311,9 @@ void main() {
     }
 
     RenderToggleable getCheckboxRenderer() {
-      return tester.renderObject<RenderToggleable>(find.byType(Checkbox));
+      return tester.renderObject<RenderToggleable>(find.byWidgetPredicate((Widget widget) {
+        return widget.runtimeType.toString() == '_CheckboxRenderObjectWidget';
+      }));
     }
 
     await tester.pumpWidget(buildFrame(false));
@@ -356,7 +365,9 @@ void main() {
     }
 
     RenderToggleable getCheckboxRenderer() {
-      return tester.renderObject<RenderToggleable>(find.byType(Checkbox));
+      return tester.renderObject<RenderToggleable>(find.byWidgetPredicate((Widget widget) {
+        return widget.runtimeType.toString() == '_CheckboxRenderObjectWidget';
+      }));
     }
 
     await tester.pumpWidget(buildFrame(checkColor: const Color(0xFFFFFFFF)));
@@ -376,4 +387,181 @@ void main() {
     expect(getCheckboxRenderer(), paints..rrect(color: const Color(0xFF000000))); // paints's color is 0xFF000000 (params)
   });
 
+  testWidgets('Checkbox is focusable and has correct focus color', (WidgetTester tester) async {
+    final FocusNode focusNode = FocusNode(debugLabel: 'Checkbox');
+    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+    bool value = true;
+    Widget buildApp({bool enabled = true}) {
+      return MaterialApp(
+        home: Material(
+          child: Center(
+            child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+              return Checkbox(
+                value: value,
+                onChanged: enabled ? (bool newValue) {
+                  setState(() {
+                    value = newValue;
+                  });
+                } : null,
+                focusColor: Colors.orange[500],
+                autofocus: true,
+                focusNode: focusNode,
+              );
+            }),
+          ),
+        ),
+      );
+    }
+    await tester.pumpWidget(buildApp());
+
+    await tester.pumpAndSettle();
+    expect(focusNode.hasPrimaryFocus, isTrue);
+    expect(
+      Material.of(tester.element(find.byType(Checkbox))),
+      paints
+        ..circle(color: Colors.orange[500])
+        ..rrect(
+            color: const Color(0xff1e88e5),
+            rrect: RRect.fromLTRBR(
+                391.0, 291.0, 409.0, 309.0, const Radius.circular(1.0)))
+        ..path(color: Colors.white),
+    );
+
+    // Check the false value.
+    value = false;
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+    expect(focusNode.hasPrimaryFocus, isTrue);
+    expect(
+      Material.of(tester.element(find.byType(Checkbox))),
+      paints
+        ..circle(color: Colors.orange[500])
+        ..drrect(
+            color: const Color(0x8a000000),
+            outer: RRect.fromLTRBR(
+                391.0, 291.0, 409.0, 309.0, const Radius.circular(1.0)),
+        inner: RRect.fromLTRBR(393.0,
+            293.0, 407.0, 307.0, const Radius.circular(-1.0))),
+    );
+
+    // Check what happens when disabled.
+    value = false;
+    await tester.pumpWidget(buildApp(enabled: false));
+    await tester.pumpAndSettle();
+    expect(focusNode.hasPrimaryFocus, isFalse);
+    expect(
+      Material.of(tester.element(find.byType(Checkbox))),
+      paints
+        ..drrect(
+            color: const Color(0x61000000),
+            outer: RRect.fromLTRBR(
+                391.0, 291.0, 409.0, 309.0, const Radius.circular(1.0)),
+            inner: RRect.fromLTRBR(393.0,
+                293.0, 407.0, 307.0, const Radius.circular(-1.0))),
+    );
+  });
+
+  testWidgets('Checkbox can be hovered and has correct hover color', (WidgetTester tester) async {
+    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+    bool value = true;
+    Widget buildApp({bool enabled = true}) {
+      return MaterialApp(
+        home: Material(
+          child: Center(
+            child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+              return Checkbox(
+                value: value,
+                onChanged: enabled ? (bool newValue) {
+                  setState(() {
+                    value = newValue;
+                  });
+                } : null,
+                hoverColor: Colors.orange[500],
+              );
+            }),
+          ),
+        ),
+      );
+    }
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+    expect(
+      Material.of(tester.element(find.byType(Checkbox))),
+      paints
+        ..rrect(
+            color: const Color(0xff1e88e5),
+            rrect: RRect.fromLTRBR(
+                391.0, 291.0, 409.0, 309.0, const Radius.circular(1.0)))
+        ..path(color: const Color(0xffffffff), style: PaintingStyle.stroke, strokeWidth: 2.0),
+    );
+
+    // Start hovering
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(gesture.removePointer);
+    await gesture.moveTo(tester.getCenter(find.byType(Checkbox)));
+
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+    expect(
+      Material.of(tester.element(find.byType(Checkbox))),
+      paints
+        ..rrect(
+            color: const Color(0xff1e88e5),
+            rrect: RRect.fromLTRBR(
+                391.0, 291.0, 409.0, 309.0, const Radius.circular(1.0)))
+        ..path(color: const Color(0xffffffff), style: PaintingStyle.stroke, strokeWidth: 2.0),
+    );
+
+    // Check what happens when disabled.
+    await tester.pumpWidget(buildApp(enabled: false));
+    await tester.pumpAndSettle();
+    expect(
+      Material.of(tester.element(find.byType(Checkbox))),
+      paints
+        ..rrect(
+            color: const Color(0x61000000),
+            rrect: RRect.fromLTRBR(
+                391.0, 291.0, 409.0, 309.0, const Radius.circular(1.0)))
+        ..path(color: const Color(0xffffffff), style: PaintingStyle.stroke, strokeWidth: 2.0),
+    );
+  });
+
+  testWidgets('Checkbox can be toggled by keyboard shortcuts', (WidgetTester tester) async {
+    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+    bool value = true;
+    Widget buildApp({bool enabled = true}) {
+      return MaterialApp(
+        home: Material(
+          child: Center(
+            child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+              return Checkbox(
+                value: value,
+                onChanged: enabled ? (bool newValue) {
+                  setState(() {
+                    value = newValue;
+                  });
+                } : null,
+                focusColor: Colors.orange[500],
+                autofocus: true,
+              );
+            }),
+          ),
+        ),
+      );
+    }
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+    expect(value, isFalse);
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+    expect(value, isTrue);
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.pumpAndSettle();
+    expect(value, isFalse);
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.pumpAndSettle();
+    expect(value, isTrue);
+  });
 }

--- a/packages/flutter/test/material/radio_test.dart
+++ b/packages/flutter/test/material/radio_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 
+import '../rendering/mock_canvas.dart';
 import '../widgets/semantics_tester.dart';
 
 void main() {
@@ -131,6 +132,7 @@ void main() {
             SemanticsFlag.hasCheckedState,
             SemanticsFlag.hasEnabledState,
             SemanticsFlag.isEnabled,
+            SemanticsFlag.isFocusable,
           ],
           actions: <SemanticsAction>[
             SemanticsAction.tap,
@@ -157,6 +159,7 @@ void main() {
             SemanticsFlag.isChecked,
             SemanticsFlag.hasEnabledState,
             SemanticsFlag.isEnabled,
+            SemanticsFlag.isFocusable,
           ],
           actions: <SemanticsAction>[
             SemanticsAction.tap,
@@ -181,6 +184,7 @@ void main() {
             SemanticsFlag.isInMutuallyExclusiveGroup,
             SemanticsFlag.hasCheckedState,
             SemanticsFlag.hasEnabledState,
+            SemanticsFlag.isFocusable,
           ],
         ),
       ],
@@ -232,7 +236,7 @@ void main() {
     ));
 
     await tester.tap(find.byKey(key));
-    final RenderObject object = tester.firstRenderObject(find.byKey(key));
+    final RenderObject object = tester.firstRenderObject(find.byType(Focus));
 
     expect(radioValue, 1);
     expect(semanticEvent, <String, dynamic>{
@@ -282,5 +286,227 @@ void main() {
       ),
     );
   }, skip: isBrowser);
+
+  testWidgets('Radio is focusable and has correct focus color', (WidgetTester tester) async {
+    final FocusNode focusNode = FocusNode(debugLabel: 'Radio');
+    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+    int groupValue = 0;
+    const Key radioKey = Key('radio');
+    Widget buildApp({bool enabled = true}) {
+      return MaterialApp(
+        home: Material(
+          child: Center(
+            child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+              return Container(
+                width: 100,
+                height: 100,
+                color: Colors.white,
+                child: Radio<int>(
+                  key: radioKey,
+                  value: 0,
+                  onChanged: enabled ? (int newValue) {
+                    setState(() {
+                      groupValue = newValue;
+                    });
+                  } : null,
+                  focusColor: Colors.orange[500],
+                  autofocus: true,
+                  focusNode: focusNode,
+                  groupValue: groupValue,
+                ),
+              );
+            }),
+          ),
+        ),
+      );
+    }
+    await tester.pumpWidget(buildApp());
+
+    await tester.pumpAndSettle();
+    expect(focusNode.hasPrimaryFocus, isTrue);
+    expect(
+      Material.of(tester.element(find.byKey(radioKey))),
+      paints
+        ..rect(
+            color: const Color(0xffffffff),
+            rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0))
+        ..circle(color: Colors.orange[500])
+        ..circle(color: const Color(0xff1e88e5))
+        ..circle(color: const Color(0xff1e88e5)),
+    );
+
+    // Check when the radio isn't selected.
+    groupValue = 1;
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+    expect(focusNode.hasPrimaryFocus, isTrue);
+    expect(
+      Material.of(tester.element(find.byKey(radioKey))),
+      paints
+        ..rect(
+            color: const Color(0xffffffff),
+            rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0))
+        ..circle(color: Colors.orange[500])
+        ..circle(color: const Color(0x8a000000), style: PaintingStyle.stroke, strokeWidth: 2.0)
+    );
+
+    // Check when the radio is selected, but disabled.
+    groupValue = 0;
+    await tester.pumpWidget(buildApp(enabled: false));
+    await tester.pumpAndSettle();
+    expect(focusNode.hasPrimaryFocus, isFalse);
+    expect(
+      Material.of(tester.element(find.byKey(radioKey))),
+      paints
+        ..rect(
+            color: const Color(0xffffffff),
+            rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0))
+        ..circle(color: const Color(0x61000000))
+        ..circle(color: const Color(0x61000000)),
+    );
+  });
+
+  testWidgets('Radio can be hovered and has correct focus color', (WidgetTester tester) async {
+    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+    int groupValue = 0;
+    const Key radioKey = Key('radio');
+    Widget buildApp({bool enabled = true}) {
+      return MaterialApp(
+        home: Material(
+          child: Center(
+            child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+              return Container(
+                width: 100,
+                height: 100,
+                color: Colors.white,
+                child: Radio<int>(
+                  key: radioKey,
+                  value: 0,
+                  onChanged: enabled ? (int newValue) {
+                    setState(() {
+                      groupValue = newValue;
+                    });
+                  } : null,
+                  hoverColor: Colors.orange[500],
+                  groupValue: groupValue,
+                ),
+              );
+            }),
+          ),
+        ),
+      );
+    }
+    await tester.pumpWidget(buildApp());
+
+    await tester.pumpAndSettle();
+    expect(
+      Material.of(tester.element(find.byKey(radioKey))),
+      paints
+        ..rect(
+            color: const Color(0xffffffff),
+            rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0))
+        ..circle(color: const Color(0xff1e88e5))
+        ..circle(color: const Color(0xff1e88e5)),
+    );
+
+    // Start hovering
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(gesture.removePointer);
+    await gesture.moveTo(tester.getCenter(find.byKey(radioKey)));
+
+    // Check when the radio isn't selected.
+    groupValue = 1;
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+    expect(
+        Material.of(tester.element(find.byKey(radioKey))),
+        paints
+          ..rect(
+              color: const Color(0xffffffff),
+              rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0))
+          ..circle(color: Colors.orange[500])
+          ..circle(color: const Color(0x8a000000), style: PaintingStyle.stroke, strokeWidth: 2.0)
+    );
+
+    // Check when the radio is selected, but disabled.
+    groupValue = 0;
+    await tester.pumpWidget(buildApp(enabled: false));
+    await tester.pumpAndSettle();
+    expect(
+      Material.of(tester.element(find.byKey(radioKey))),
+      paints
+        ..rect(
+            color: const Color(0xffffffff),
+            rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0))
+        ..circle(color: const Color(0x61000000))
+        ..circle(color: const Color(0x61000000)),
+    );
+  });
+
+  testWidgets('Radio can be toggled by keyboard shortcuts', (WidgetTester tester) async {
+    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+    int groupValue = 1;
+    const Key radioKey0 = Key('radio0');
+    const Key radioKey1 = Key('radio1');
+    final FocusNode focusNode1 = FocusNode(debugLabel: 'radio1');
+    Widget buildApp({bool enabled = true}) {
+      return MaterialApp(
+        home: Material(
+          child: Center(
+            child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+              return Container(
+                width: 100,
+                height: 100,
+                color: Colors.white,
+                child: Row(
+                  children: <Widget>[
+                    Radio<int>(
+                      key: radioKey0,
+                      value: 0,
+                      onChanged: enabled ? (int newValue) {
+                        setState(() {
+                          groupValue = newValue;
+                        });
+                      } : null,
+                      hoverColor: Colors.orange[500],
+                      groupValue: groupValue,
+                      autofocus: true,
+                    ),
+                    Radio<int>(
+                      key: radioKey1,
+                      value: 1,
+                      onChanged: enabled ? (int newValue) {
+                        setState(() {
+                          groupValue = newValue;
+                        });
+                      } : null,
+                      hoverColor: Colors.orange[500],
+                      groupValue: groupValue,
+                      focusNode: focusNode1,
+                    ),
+                  ],
+                ),
+              );
+            }),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+    expect(groupValue, equals(0));
+
+    focusNode1.requestFocus();
+    await tester.pumpAndSettle();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.pumpAndSettle();
+    expect(groupValue, equals(1));
+  });
+
 }
 

--- a/packages/flutter/test/material/raw_material_button_test.dart
+++ b/packages/flutter/test/material/raw_material_button_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -47,6 +48,7 @@ void main() {
       Shortcuts(
         shortcuts: <LogicalKeySet, Intent>{
           LogicalKeySet(LogicalKeyboardKey.enter): const Intent(ActivateAction.key),
+          LogicalKeySet(LogicalKeyboardKey.space): const Intent(SelectAction.key),
         },
         child: Directionality(
           textDirection: TextDirection.ltr,
@@ -74,6 +76,12 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(pressed, isTrue);
+
+    pressed = false;
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.pumpAndSettle();
+
+    expect(pressed, kIsWeb ? isFalse : isTrue);
   });
 
   testWidgets('materialTapTargetSize.padded expands hit test area', (WidgetTester tester) async {

--- a/packages/flutter/test/material/switch_test.dart
+++ b/packages/flutter/test/material/switch_test.dart
@@ -518,7 +518,7 @@ void main() {
       ),
     );
     await tester.tap(find.byType(Switch));
-    final RenderObject object = tester.firstRenderObject(find.byType(Switch));
+    final RenderObject object = tester.firstRenderObject(find.byType(Focus));
 
     expect(value, true);
     expect(semanticEvent, <String, dynamic>{
@@ -623,4 +623,198 @@ void main() {
 
   });
 
+  testWidgets('Switch is focusable and has correct focus color', (WidgetTester tester) async {
+    final FocusNode focusNode = FocusNode(debugLabel: 'Switch');
+    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+    bool value = true;
+    Widget buildApp({bool enabled = true}) {
+      return MaterialApp(
+        home: Material(
+          child: Center(
+            child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+              return Switch(
+                value: value,
+                onChanged: enabled ? (bool newValue) {
+                  setState(() {
+                    value = newValue;
+                  });
+                } : null,
+                focusColor: Colors.orange[500],
+                autofocus: true,
+                focusNode: focusNode,
+              );
+            }),
+          ),
+        ),
+      );
+    }
+    await tester.pumpWidget(buildApp());
+
+    await tester.pumpAndSettle();
+    expect(focusNode.hasPrimaryFocus, isTrue);
+    expect(
+      Material.of(tester.element(find.byType(Switch))),
+      paints
+        ..rrect(
+            color: const Color(0x801e88e5),
+            rrect: RRect.fromLTRBR(
+                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+        ..circle(color: Colors.orange[500])
+        ..circle(color: const Color(0x33000000))
+        ..circle(color: const Color(0x24000000))
+        ..circle(color: const Color(0x1f000000))
+        ..circle(color: const Color(0xff1e88e5)),
+    );
+
+    // Check the false value.
+    value = false;
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+    expect(focusNode.hasPrimaryFocus, isTrue);
+    expect(
+      Material.of(tester.element(find.byType(Switch))),
+      paints
+        ..rrect(
+            color: const Color(0x52000000),
+            rrect: RRect.fromLTRBR(
+                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+        ..circle(color: Colors.orange[500])
+        ..circle(color: const Color(0x33000000))
+        ..circle(color: const Color(0x24000000))
+        ..circle(color: const Color(0x1f000000))
+        ..circle(color: const Color(0xfffafafa)),
+    );
+
+    // Check what happens when disabled.
+    value = false;
+    await tester.pumpWidget(buildApp(enabled: false));
+    await tester.pumpAndSettle();
+    expect(focusNode.hasPrimaryFocus, isFalse);
+    expect(
+      Material.of(tester.element(find.byType(Switch))),
+      paints
+        ..rrect(
+            color: const Color(0x1f000000),
+            rrect: RRect.fromLTRBR(
+                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+        ..circle(color: const Color(0x33000000))
+        ..circle(color: const Color(0x24000000))
+        ..circle(color: const Color(0x1f000000))
+        ..circle(color: const Color(0xffbdbdbd)),
+    );
+  });
+
+  testWidgets('Switch can be hovered and has correct hover color', (WidgetTester tester) async {
+    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+    bool value = true;
+    Widget buildApp({bool enabled = true}) {
+      return MaterialApp(
+        home: Material(
+          child: Center(
+            child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+              return Switch(
+                value: value,
+                onChanged: enabled ? (bool newValue) {
+                  setState(() {
+                    value = newValue;
+                  });
+                } : null,
+                hoverColor: Colors.orange[500],
+              );
+            }),
+          ),
+        ),
+      );
+    }
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+    expect(
+      Material.of(tester.element(find.byType(Switch))),
+      paints
+        ..rrect(
+            color: const Color(0x801e88e5),
+            rrect: RRect.fromLTRBR(
+                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+        ..circle(color: const Color(0x33000000))
+        ..circle(color: const Color(0x24000000))
+        ..circle(color: const Color(0x1f000000))
+        ..circle(color: const Color(0xff1e88e5)),
+    );
+
+    // Start hovering
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(gesture.removePointer);
+    await gesture.moveTo(tester.getCenter(find.byType(Switch)));
+
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+    expect(
+      Material.of(tester.element(find.byType(Switch))),
+      paints
+        ..rrect(
+            color: const Color(0x801e88e5),
+            rrect: RRect.fromLTRBR(
+                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+        ..circle(color: Colors.orange[500])
+        ..circle(color: const Color(0x33000000))
+        ..circle(color: const Color(0x24000000))
+        ..circle(color: const Color(0x1f000000))
+        ..circle(color: const Color(0xff1e88e5)),
+    );
+
+    // Check what happens when disabled.
+    await tester.pumpWidget(buildApp(enabled: false));
+    await tester.pumpAndSettle();
+    expect(
+      Material.of(tester.element(find.byType(Switch))),
+      paints
+        ..rrect(
+            color: const Color(0x1f000000),
+            rrect: RRect.fromLTRBR(
+                383.5, 293.0, 416.5, 307.0, const Radius.circular(7.0)))
+        ..circle(color: const Color(0x33000000))
+        ..circle(color: const Color(0x24000000))
+        ..circle(color: const Color(0x1f000000))
+        ..circle(color: const Color(0xffbdbdbd)),
+    );
+  });
+
+  testWidgets('Switch can be toggled by keyboard shortcuts', (WidgetTester tester) async {
+    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+    bool value = true;
+    Widget buildApp({bool enabled = true}) {
+      return MaterialApp(
+        home: Material(
+          child: Center(
+            child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+              return Switch(
+                value: value,
+                onChanged: enabled ? (bool newValue) {
+                  setState(() {
+                    value = newValue;
+                  });
+                } : null,
+                focusColor: Colors.orange[500],
+                autofocus: true,
+              );
+            }),
+          ),
+        ),
+      );
+    }
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+    expect(value, isFalse);
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+    expect(value, isTrue);
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.pumpAndSettle();
+    expect(value, isFalse);
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.pumpAndSettle();
+    expect(value, isTrue);
+  });
 }

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -66,9 +66,12 @@ void main() {
       FocusNode(
         debugLabel: 'Label',
       ).debugFillProperties(builder);
-      final List<String> description = builder.properties.where((DiagnosticsNode n) => !n.isFiltered(DiagnosticLevel.info)).map((DiagnosticsNode n) => n.toString()).toList();
+      final List<String> description = builder.properties.map((DiagnosticsNode n) => n.toString()).toList();
       expect(description, <String>[
-        'debugLabel: "Label"',
+        'context: null',
+        'canRequestFocus: true',
+        'hasFocus: false',
+        'hasPrimaryFocus: false'
       ]);
     });
   });
@@ -621,9 +624,12 @@ void main() {
       FocusScopeNode(
         debugLabel: 'Scope Label',
       ).debugFillProperties(builder);
-      final List<String> description = builder.properties.where((DiagnosticsNode n) => !n.isFiltered(DiagnosticLevel.info)).map((DiagnosticsNode n) => n.toString()).toList();
+      final List<String> description = builder.properties.map((DiagnosticsNode n) => n.toString()).toList();
       expect(description, <String>[
-        'debugLabel: "Scope Label"',
+        'context: null',
+        'canRequestFocus: true',
+        'hasFocus: false',
+        'hasPrimaryFocus: false'
       ]);
     });
     testWidgets('debugDescribeFocusTree produces correct output', (WidgetTester tester) async {
@@ -663,43 +669,36 @@ void main() {
           ' │ primaryFocusCreator: Container-[GlobalKey#00000] ← [root]\n'
           ' │\n'
           ' └─rootScope: FocusScopeNode#00000(Root Focus Scope)\n'
-          '   │ FOCUSED\n'
-          '   │ debugLabel: "Root Focus Scope"\n'
+          '   │ IN FOCUS PATH\n'
           '   │ focusedChildren: FocusScopeNode#00000\n'
           '   │\n'
           '   ├─Child 1: FocusScopeNode#00000(Scope 1)\n'
           '   │ │ context: Container-[GlobalKey#00000]\n'
-          '   │ │ debugLabel: "Scope 1"\n'
           '   │ │\n'
           '   │ └─Child 1: FocusNode#00000(Parent 1)\n'
           '   │   │ context: Container-[GlobalKey#00000]\n'
-          '   │   │ debugLabel: "Parent 1"\n'
           '   │   │\n'
           '   │   ├─Child 1: FocusNode#00000(Child 1)\n'
           '   │   │   context: Container-[GlobalKey#00000]\n'
-          '   │   │   debugLabel: "Child 1"\n'
           '   │   │\n'
           '   │   └─Child 2: FocusNode#00000\n'
           '   │       context: Container-[GlobalKey#00000]\n'
           '   │\n'
           '   └─Child 2: FocusScopeNode#00000\n'
           '     │ context: Container-[GlobalKey#00000]\n'
-          '     │ FOCUSED\n'
+          '     │ IN FOCUS PATH\n'
           '     │ focusedChildren: FocusNode#00000(Child 4)\n'
           '     │\n'
           '     └─Child 1: FocusNode#00000(Parent 2)\n'
           '       │ context: Container-[GlobalKey#00000]\n'
-          '       │ FOCUSED\n'
-          '       │ debugLabel: "Parent 2"\n'
+          '       │ IN FOCUS PATH\n'
           '       │\n'
           '       ├─Child 1: FocusNode#00000(Child 3)\n'
           '       │   context: Container-[GlobalKey#00000]\n'
-          '       │   debugLabel: "Child 3"\n'
           '       │\n'
           '       └─Child 2: FocusNode#00000(Child 4)\n'
           '           context: Container-[GlobalKey#00000]\n'
-          '           FOCUSED\n'
-          '           debugLabel: "Child 4"\n'
+          '           PRIMARY FOCUS\n'
         ));
     });
   });

--- a/packages/flutter/test/widgets/focus_scope_test.dart
+++ b/packages/flutter/test/widgets/focus_scope_test.dart
@@ -229,34 +229,29 @@ void main() {
         parentFocusScope.toStringDeep(),
         equalsIgnoringHashCodes('FocusScopeNode#00000(Parent Scope Node)\n'
             ' │ context: FocusScope\n'
-            ' │ FOCUSED\n'
-            ' │ debugLabel: "Parent Scope Node"\n'
+            ' │ IN FOCUS PATH\n'
             ' │ focusedChildren: FocusNode#00000(Child)\n'
             ' │\n'
             ' └─Child 1: FocusNode#00000(Child)\n'
             '     context: Focus\n'
-            '     FOCUSED\n'
-            '     debugLabel: "Child"\n'),
+            '     PRIMARY FOCUS\n'),
       );
 
       expect(WidgetsBinding.instance.focusManager.rootScope, hasAGoodToStringDeep);
       expect(
         WidgetsBinding.instance.focusManager.rootScope.toStringDeep(minLevel: DiagnosticLevel.info),
         equalsIgnoringHashCodes('FocusScopeNode#00000(Root Focus Scope)\n'
-            ' │ FOCUSED\n'
-            ' │ debugLabel: "Root Focus Scope"\n'
+            ' │ IN FOCUS PATH\n'
             ' │ focusedChildren: FocusScopeNode#00000(Parent Scope Node)\n'
             ' │\n'
             ' └─Child 1: FocusScopeNode#00000(Parent Scope Node)\n'
             '   │ context: FocusScope\n'
-            '   │ FOCUSED\n'
-            '   │ debugLabel: "Parent Scope Node"\n'
+            '   │ IN FOCUS PATH\n'
             '   │ focusedChildren: FocusNode#00000(Child)\n'
             '   │\n'
             '   └─Child 1: FocusNode#00000(Child)\n'
             '       context: Focus\n'
-            '       FOCUSED\n'
-            '       debugLabel: "Child"\n'),
+            '       PRIMARY FOCUS\n'),
       );
 
       // Add the child focus scope to the focus tree.


### PR DESCRIPTION
## Description

This re-lands the change that adds focus nodes, hover, and shortcuts to switches, checkboxes, and radio buttons. (#43213)

No changes from original, except for finding the right `RenderBox` in `dev/integration_tests/android_semantics_testing/test_driver/main_test.dart`.

## Breaking Change

- [X] No, this is *not* a breaking change.