### PR TITLE
Revert "[Chip] Make sure InkResponse is in the foreground on delete f…

### DIFF
--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -15,7 +15,6 @@ import 'constants.dart';
 import 'debug.dart';
 import 'feedback.dart';
 import 'icons.dart';
-import 'ink_decoration.dart';
 import 'ink_well.dart';
 import 'material.dart';
 import 'material_localizations.dart';
@@ -1814,7 +1813,7 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
         child: AnimatedBuilder(
           animation: Listenable.merge(<Listenable>[selectController, enableController]),
           builder: (BuildContext context, Widget child) {
-            return Ink(
+            return Container(
               decoration: ShapeDecoration(
                 shape: shape,
                 color: getBackgroundColor(chipTheme),

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -236,11 +236,6 @@ class _RenderLayoutBuilder extends RenderBox with RenderObjectWithChildMixin<Ren
   }
 
   @override
-  double computeDistanceToActualBaseline(TextBaseline baseline) {
-    return child?.getDistanceToActualBaseline(baseline);
-  }
-
-  @override
   void performLayout() {
     layoutAndBuildChild();
     if (child != null) {

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -2179,35 +2179,6 @@ void main() {
     await gesture.removePointer();
   });
 
-  testWidgets('Chips with background color should have delete icon ripple and splash in the foreground', (WidgetTester tester) async {
-    // Regression test for https://github.com/flutter/flutter/issues/41461
-    await tester.pumpWidget(
-      _wrapForChip(
-        child: Chip(
-          onDeleted: () { },
-          backgroundColor: Colors.pink,
-          label: const Text('Chip with delete icon'),
-          deleteIcon: const Icon(Icons.cancel),
-        ),
-      ),
-    );
-    final Offset center = tester.getCenter(find.byType(Icon));
-
-    final TestGesture gesture = await tester.startGesture(center);
-    await tester.pump(); // start gesture
-    await tester.pump(const Duration(milliseconds: 200)); // wait for splash to be well under way
-    final RenderBox box = Material.of(tester.element(find.byType(InkResponse))) as dynamic;
-    expect(
-      box,
-      paints
-        ..clipRect(rect: const Rect.fromLTRB(0.0, 0.0, 342.0, 32.0))
-        ..path(color: Colors.pink[500])
-        ..circle(x: 12.0, y: 12.0, radius: 0.0, color: const Color(0x66c8c8c8))
-        ..circle(x: 326.0, y: 16.0, radius: 35.0, color: const Color(0x00bcbcbc))
-    );
-    await gesture.up();
-  });
-
   testWidgets('loses focus when disabled', (WidgetTester tester) async {
     final FocusNode focusNode = FocusNode(debugLabel: 'InputChip');
     await tester.pumpWidget(

--- a/packages/flutter/test/widgets/layout_builder_test.dart
+++ b/packages/flutter/test/widgets/layout_builder_test.dart
@@ -587,40 +587,4 @@ void main() {
     await tester.pump();
     expect(hitCounts, const <int> [0, 0, 0]);
   });
-
-  testWidgets('LayoutBuilder calculates baseline from child', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.baseline,
-          textBaseline: TextBaseline.alphabetic,
-          children: <Widget>[
-            LayoutBuilder(
-              builder: (BuildContext context, BoxConstraints constraints) {
-                return const Text('First', style: TextStyle(fontSize: 10));
-              },
-            ),
-            LayoutBuilder(
-              builder: (BuildContext context, BoxConstraints constraints) {
-                return const Text('Second', style: TextStyle(fontSize: 30));
-              },
-            ),
-          ],
-        ),
-      ),
-    );
-
-    // The Ahem font extends 0.2 * fontSize below the baseline.
-    // So the two row elements line up like this:
-    //
-    //  First  Second
-    //  -------------   baseline
-    //    2      6      space below the baseline = 0.2 * fontSize
-    //  -------------   widget text dy values
-
-    final double firstTextDy = tester.getBottomLeft(find.text('First')).dy;
-    final double secondTextDy = tester.getBottomLeft(find.text('Second')).dy;
-    expect(firstTextDy, closeTo(secondTextDy - 4.0, 0.001));
-  }, skip: isBrowser);
 }


### PR DESCRIPTION
Failures:

```
03:43 +2170 ~12: /tmp/flutter sdk/packages/flutter/test/material/chip_test.dart: Chips with background color should have delete icon ripple and splash in the foreground                               
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
The following StateError was thrown running a test:
Bad state: No element
When the exception was thrown, this was the stack:
#0      Iterable.single (dart:core/iterable.dart:552:25)
#1      WidgetController.element (package:flutter_test/src/controller.dart:110:30)
#2      main.<anonymous closure> (file:///tmp/flutter%20sdk/packages/flutter/test/material/chip_test.dart:2199:46)
<asynchronous suspension>
#3      testWidgets.<anonymous closure>.<anonymous closure> (package:flutter_test/src/widget_tester.dart:121:25)
<asynchronous suspension>
#4      TestWidgetsFlutterBinding._runTestBody (package:flutter_test/src/binding.dart:695:19)
<asynchronous suspension>
#7      TestWidgetsFlutterBinding._runTest (package:flutter_test/src/binding.dart:678:14)
#8      AutomatedTestWidgetsFlutterBinding.runTest.<anonymous closure> (package:flutter_test/src/binding.dart:1051:24)
#14     AutomatedTestWidgetsFlutterBinding.runTest (package:flutter_test/src/binding.dart:1048:15)
#15     testWidgets.<anonymous closure> (package:flutter_test/src/widget_tester.dart:118:22)
#16     Declarer.test.<anonymous closure>.<anonymous closure>.<anonymous closure> (package:test_api/src/backend/declarer.dart:168:27)
<asynchronous suspension>
#17     Invoker.waitForOutstandingCallbacks.<anonymous closure> (package:test_api/src/backend/invoker.dart:250:15)
<asynchronous suspension>
#22     Invoker.waitForOutstandingCallbacks (package:test_api/src/backend/invoker.dart:247:5)
#23     Declarer.test.<anonymous closure>.<anonymous closure> (package:test_api/src/backend/declarer.dart:166:33)
#28     Declarer.test.<anonymous closure> (package:test_api/src/backend/declarer.dart:165:13)
<asynchronous suspension>
#29     Invoker._onRun.<anonymous closure>.<anonymous closure>.<anonymous closure>.<anonymous closure> (package:test_api/src/backend/invoker.dart:400:25)
<asynchronous suspension>
#43     _Timer._runTimers (dart:isolate-patch/timer_impl.dart:382:19)
#44     _Timer._handleMessage (dart:isolate-patch/timer_impl.dart:416:5)
#45     _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:172:12)
(elided 28 frames from class _FakeAsync, package dart:async, package dart:async-patch, and package stack_trace)
The test description was:
  Chips with background color should have delete icon ripple and splash in the foreground
════════════════════════════════════════════════════════════════════════════════════════════════════
03:43 +2170 ~12 -1: /tmp/flutter sdk/packages/flutter/test/material/chip_test.dart: Chips with background color should have delete icon ripple and splash in the foreground [E]                        
  Test failed. See exception logs above.
  The test description was: Chips with background color should have delete icon ripple and splash in the foreground

```