### PR TITLE
fix: icon should center align vertical

### DIFF
--- a/packages/flutter/lib/src/widgets/icon.dart
+++ b/packages/flutter/lib/src/widgets/icon.dart
@@ -176,6 +176,7 @@ class Icon extends StatelessWidget {
       text: TextSpan(
         text: String.fromCharCode(icon.codePoint),
         style: TextStyle(
+          height: 1, // Line height should be 1 for vertical align center.
           inherit: false,
           color: iconColor,
           fontSize: iconSize,


### PR DESCRIPTION
## Description

Icon no center alignment when it's size larger, because the line height of icon's TextSpan is not 1.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
