### PR TITLE
Handle permission error during flutter clean

### DIFF
--- a/packages/flutter_tools/lib/src/commands/clean.dart
+++ b/packages/flutter_tools/lib/src/commands/clean.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import 'package:flutter_tools/src/base/common.dart';
 import 'package:meta/meta.dart';
 
 import '../base/file_system.dart';

--- a/packages/flutter_tools/lib/src/commands/clean.dart
+++ b/packages/flutter_tools/lib/src/commands/clean.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:flutter_tools/src/base/common.dart';
 import 'package:meta/meta.dart';
 
 import '../base/file_system.dart';
@@ -83,7 +84,13 @@ class CleanCommand extends FlutterCommand {
 
   @visibleForTesting
   void deleteFile(FileSystemEntity file) {
-    if (!file.existsSync()) {
+    // This will throw a FileSystemException if the directory is missing permissions.
+    try {
+      if (!file.existsSync()) {
+        return;
+      }
+    } on FileSystemException catch (err) {
+      printError('Cannot clean ${file.path}.\n$err');
       return;
     }
     final Status deletionStatus = logger.startProgress('Deleting ${file.basename}...', timeout: timeoutConfiguration.fastOperation);

--- a/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
@@ -80,6 +80,24 @@ void main() {
       Logger: () => BufferLogger(),
       Xcode: () => mockXcode,
     });
+
+    testUsingContext('$CleanCommand handles missing permissions;', () async {
+      when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(false);
+
+      final MockFile mockFile = MockFile();
+      when(mockFile.existsSync()).thenThrow(const FileSystemException('OS error: Access Denied'));
+      when(mockFile.path).thenReturn('foo.dart');
+
+      final BufferLogger logger = context.get<Logger>();
+      final CleanCommand command = CleanCommand();
+      command.deleteFile(mockFile);
+      expect(logger.errorText, contains('Cannot clean foo.dart'));
+      verifyNever(mockFile.deleteSync(recursive: true));
+    }, overrides: <Type, Generator>{
+      Platform: () => windowsPlatform,
+      Logger: () => BufferLogger(),
+      Xcode: () => mockXcode,
+    });
   }
 
   test1();


### PR DESCRIPTION
## Description

If a Directory is missing read permissions then flutter clean with crash:

```
FileSystemException: Exists failed, path = 'PROJECT\.dart_tool' (OS Error: Accesso negato., errno = 5)

  | at _Directory.existsSync | (directory_impl.dart:99 )
-- | -- | --
  | at ForwardingFileSystemEntity.existsSync | (forwarding_file_system_entity.dart:45 )
  | at CleanCommand.deleteFile | (clean.dart:86 )
  | at CleanCommand.runCommand | (clean.dart:46 )
  | at <asynchronous gap> | (async )
  | at FlutterCommand.verifyThenRunCommand | (flutter_command.dart:557 )
  | at _asyncThenWrapperHelper.<anonymous closure> | (async_patch.dart:71 )
  | at _rootRunUnary | (zone.dart:1132 )
  | at _CustomZone.runUnary | (zone.dart:1029 )
  | at _FutureListener.handleValue | (future_impl.dart:137 )
  | at Future._propagateToListeners.handleValueCallback | (future_impl.dart:678 )
  | at Future._propagateToListeners | (future_impl.dart:707 )
  | at Future._completeWithValue | (future_impl.dart:522 )
  | at Future._asyncComplete.<anonymous closure> | (future_impl.dart:552 )
  | at _rootRun | (zone.dart:1124 )
  | at _CustomZone.run | (zone.dart:1021 )
  | at _CustomZone.runGuarded | (zone.dart:923 )
  | at _CustomZone.bindCallbackGuarded.<anonymous closure> | (zone.dart:963 )
  | at _microtaskLoop | (schedule_microtask.dart:41 )
  | at _startMicrotaskLoop | (schedule_microtask.dart:50 )
  | at _runPendingImmediateCallback | (isolate_patch.dart:116 )
  | at _RawReceivePortImpl._handleMessage | (isolate_patch.dart:173 )


```