### PR TITLE
Handle format error from vswhere

### DIFF
--- a/packages/flutter_tools/lib/src/windows/visual_studio.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio.dart
@@ -208,6 +208,8 @@ class VisualStudio {
       // Thrown if vswhere doesnt' exist; ignore and return null below.
     } on ProcessException {
       // Ignored, return null below.
+    } on FormatException {
+      // may be thrown if invalid JSON is returned.
     }
     return null;
   }


### PR DESCRIPTION
## Description

From crash logging, this can throw if we're given invalid JSON. Example stacktrace:

```
at _ChunkedJsonParser.fail	(convert_patch.dart:1392 )
at _ChunkedJsonParser.parseStringEscape	(convert_patch.dart:1172 )
at _ChunkedJsonParser.parseStringToBuffer	(convert_patch.dart:1111 )
at _ChunkedJsonParser.parseString	(convert_patch.dart:1026 )
at _ChunkedJsonParser.parse	(convert_patch.dart:847 )
at _parseJson	(convert_patch.dart:29 )
at JsonDecoder.convert	(json.dart:493 )
at JsonCodec.decode	(json.dart:151 )
at VisualStudio._visualStudioDetails	(visual_studio.dart:202 )
at VisualStudio._usableVisualStudioDetails	(visual_studio.dart:247 )
at VisualStudio.vcvarsPath	(visual_studio.dart:95 )
at buildWindows	(build_windows.dart:37 )
at <asynchronous gap>	(async )
at WindowsDevice.buildForDevice	(windows_device.dart:46 )
at <asynchronous gap>	(async )
at DesktopDevice.startApp	(desktop_device.dart:87 )
at <asynchronous gap>	(async )
at FlutterDevice.runHot	(resident_runner.dart:393 )
at <asynchronous gap>	(async )
at HotRunner.run	(run_hot.dart:264 )
at <asynchronous gap>	(async )
at RunCommand.runCommand	(run.dart:492 )
at <asynchronous gap>	(async )
at FlutterCommand.verifyThenRunCommand	(flutter_command.dart:557 )
at _asyncThenWrapperHelper.<anonymous closure>	(async_patch.dart:71 )
at _rootRunUnary	(zone.dart:1132 )
at _CustomZone.runUnary	(zone.dart:1029 )
at _FutureListener.handleValue	(future_impl.dart:137 )
at Future._propagateToListeners.handleValueCallback	(future_impl.dart:678 )
at Future._propagateToListeners	(future_impl.dart:707 )
at Future._completeWithValue	(future_impl.dart:522 )
at _AsyncAwaitCompleter.complete	(async_patch.dart:30 )
at _completeOnAsyncReturn	(async_patch.dart:288 )
at RunCommand.usageValues	(run.dart )
at _asyncThenWrapperHelper.<anonymous closure>	(async_patch.dart:71 )
at _rootRunUnary	(zone.dart:1132 )
at _CustomZone.runUnary	(zone.dart:1029 )
at _FutureListener.handleValue	(future_impl.dart:137 )
at Future._propagateToListeners.handleValueCallback	(future_impl.dart:678 )
at Future._propagateToListeners	(future_impl.dart:707 )
at Future._completeWithValue	(future_impl.dart:522 )
at Future._asyncComplete.<anonymous closure>	(future_impl.dart:552 )
at _rootRun	(zone.dart:1124 )
at _CustomZone.run	(zone.dart:1021 )
at _CustomZone.runGuarded	(zone.dart:923 )
at _CustomZone.bindCallbackGuarded.<anonymous closure>	(zone.dart:963 )
at _microtaskLoop	(schedule_microtask.dart:41 )
at _startMicrotaskLoop	(schedule_microtask.dart:50 )
at _runPendingImmediateCallback	(isolate_patch.dart:116 )
at _RawReceivePortImpl._handleMessage	(isolate_patch.dart:173 )
```