### PR TITLE
Catch exception from setting last modified time

### DIFF
--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -208,7 +208,11 @@ class _DefaultPub implements Pub {
         'The time now is: $now'
       );
     } else {
-      dotPackages.setLastModifiedSync(now);
+      try {
+        dotPackages.setLastModifiedSync(now);
+      } on FileSystemException {
+        // We don't have permission to change this file.
+      }
       final DateTime newDotPackagesTimestamp = dotPackages.lastModifiedSync();
       if (newDotPackagesTimestamp.isBefore(originalPubspecYamlModificationTime)) {
         printError(


### PR DESCRIPTION
## Description

This operation can fail due to permission issues that are not necessarily fatal.

```

at _File.setLastModifiedSync | (file_impl.dart:471 )
-- | --
  | at ForwardingFile.setLastModifiedSync | (forwarding_file.dart:62 )
  | at _DefaultPub.get | (pub.dart:211 )
  | at <asynchronous gap> | (async )
  | at FlutterCommand.verifyThenRunCommand | (flutter_command.dart:541 )
  | at <asynchronous gap> | (async )
  | at FlutterCommand.run.<anonymous closure> | (flutter_command.dart:457 )
  | at <asynchronous gap> | (async )
  | at AppContext.run.<anonymous closure> | (context.dart:157 )
  | at <asynchronous gap> | (async )
  | at _rootRun | (zone.dart:1124 )
  | at _CustomZone.run | (zone.dart:1021 )
  | at _runZoned | (zone.dart:1516 )
  | at runZoned | (zone.dart:1463 )
  | at AppContext.run | (context.dart:156 )
  | at <asynchronous gap> | (async )
  | at FlutterCommand.run | (flutter_command.dart:446 )
  | at CommandRunner.runCommand | (command_runner.dart:197 )
  | at <asynchronous gap> | (async )
  | at FlutterCommandRunner.runCommand.<anonymous closure> | (flutter_command_runner.dart:416 )
  | at <asynchronous gap> | (async )
  | at AppContext.run.<anonymous closure> | (context.dart:157 )
  | at <asynchronous gap> | (async )
  | at _rootRun | (zone.dart:1124 )
  | at _CustomZone.run | (zone.dart:1021 )
  | at _runZoned | (zone.dart:1516 )
  | at runZoned | (zone.dart:1463 )
  | at AppContext.run | (context.dart:156 )
  | at <asynchronous gap> | (async )
  | at FlutterCommandRunner.runCommand | (flutter_command_runner.dart:367 )
  | at <asynchronous gap> | (async )
  | at CommandRunner.run.<anonymous closure> | (command_runner.dart:112 )
  | at new Future.sync | (future.dart:222 )
  | at CommandRunner.run | (command_runner.dart:112 )
  | at FlutterCommandRunner.run | (flutter_command_runner.dart:251 )
  | at run.<anonymous closure>.<anonymous closure> | (runner.dart:63 )
  | at <asynchronous gap> | (async )
  | at _rootRun | (zone.dart:1124 )
  | at _CustomZone.run | (zone.dart:1021 )
  | at _runZoned | (zone.dart:1516 )
  | at runZoned | (zone.dart:1500 )
  | at run.<anonymous closure> | (runner.dart:61 )
  | at <asynchronous gap> | (async )
  | at AppContext.run.<anonymous closure> | (context.dart:157 )
  | at <asynchronous gap> | (async )
  | at _rootRun | (zone.dart:1124 )
  | at _CustomZone.run | (zone.dart:1021 )


```