### PR TITLE
[WIP] Make flutter assemble initialize from dill

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/dart.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/dart.dart
@@ -8,10 +8,8 @@ import '../../artifacts.dart';
 import '../../asset.dart';
 import '../../base/build.dart';
 import '../../base/file_system.dart';
-import '../../base/platform.dart';
 import '../../build_info.dart';
 import '../../compile.dart';
-import '../../dart/package_map.dart';
 import '../../devfs.dart';
 import '../../globals.dart';
 import '../../project.dart';
@@ -41,27 +39,6 @@ const String kTrackWidgetCreation = 'TrackWidgetCreation';
 ///
 /// The other supported value is armv7, the 32-bit iOS architecture.
 const String kIosArchs = 'IosArchs';
-
-/// Finds the locations of all dart files within the project.
-///
-/// This does not attempt to determine if a file is used or imported, so it
-/// may otherwise report more files than strictly necessary.
-List<File> listDartSources(Environment environment) {
-  final Map<String, Uri> packageMap = PackageMap(environment.projectDir.childFile('.packages').path).map;
-  final List<File> dartFiles = <File>[];
-  for (Uri uri in packageMap.values) {
-    final Directory libDirectory = fs.directory(uri.toFilePath(windows: platform.isWindows));
-    if (!libDirectory.existsSync()) {
-      continue;
-    }
-    for (FileSystemEntity entity in libDirectory.listSync(recursive: true)) {
-      if (entity is File && entity.path.endsWith('.dart')) {
-        dartFiles.add(entity);
-      }
-    }
-  }
-  return dartFiles;
-}
 
 /// Copies the prebuilt flutter bundle.
 // This is a one-off rule for implementing build bundle in terms of assemble.
@@ -213,7 +190,7 @@ class KernelSnapshot extends Target {
     final String targetFileAbsolute = fs.file(targetFile).absolute.path;
     // everything besides 'false' is considered to be enabled.
     final bool trackWidgetCreation = environment.defines[kTrackWidgetCreation] != 'false';
-
+    final String dillOutput = environment.buildDir.childFile('app.dill').path;
     final CompilerOutput output = await compiler.compile(
       sdkRoot: artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath, mode: buildMode),
       aot: buildMode != BuildMode.debug,
@@ -225,6 +202,7 @@ class KernelSnapshot extends Target {
       linkPlatformKernelIn: buildMode == BuildMode.release,
       mainPath: targetFileAbsolute,
       depFilePath: environment.buildDir.childFile('kernel_snapshot.d').path,
+      initializeFromDill: dillOutput,
     );
     if (output == null || output.errorCount != 0) {
       throw Exception('Errors during snapshot creation: $output');

--- a/packages/flutter_tools/lib/src/build_system/targets/dart.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/dart.dart
@@ -197,7 +197,7 @@ class KernelSnapshot extends Target {
       buildMode: buildMode,
       trackWidgetCreation: trackWidgetCreation && buildMode == BuildMode.debug,
       targetModel: TargetModel.flutter,
-      outputFilePath: environment.buildDir.childFile('app.dill').path,
+      outputFilePath: dillOutput,
       packagesPath: packagesPath,
       linkPlatformKernelIn: buildMode == BuildMode.release,
       mainPath: targetFileAbsolute,

--- a/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
@@ -355,16 +355,6 @@ flutter_tools:lib/''');
   }, overrides: <Type, Generator>{
     ProcessManager: () => mockProcessManager,
   }));
-
-  test('list dart sources handles packages without lib directories', () => testbed.run(() {
-    fs.file('.packages')
-      ..createSync()
-      ..writeAsStringSync('''
-# Generated
-example:fiz/lib/''');
-    fs.directory('fiz').createSync();
-    expect(listDartSources(androidEnvironment), <File>[]);
-  }));
 }
 
 class MockProcessManager extends Mock implements ProcessManager {}


### PR DESCRIPTION
## Description

Always initialize KernelSnapshot from dill. This might speed up build times slightly.