### PR TITLE
Catch unhandled build exceptions

### DIFF
--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -122,22 +122,26 @@ Future<void> buildWithAssemble({
   final Target target = buildMode == BuildMode.debug
     ? const CopyFlutterBundle()
     : const ReleaseCopyFlutterBundle();
-  final BuildResult result = await buildSystem.build(target, environment);
+  try {
+    final BuildResult result = await buildSystem.build(target, environment);
 
-  if (!result.success) {
-    for (ExceptionMeasurement measurement in result.exceptions.values) {
-      printError(measurement.exception.toString());
-      printError(measurement.stackTrace.toString());
+    if (!result.success) {
+      for (ExceptionMeasurement measurement in result.exceptions.values) {
+        printError(measurement.exception.toString());
+        printError(measurement.stackTrace.toString());
+      }
+      throwToolExit('Failed to build bundle.');
     }
-    throwToolExit('Failed to build bundle.');
-  }
-  if (depfilePath != null) {
-    final Depfile depfile = Depfile(result.inputFiles, result.outputFiles);
-    final File outputDepfile = fs.file(depfilePath);
-    if (!outputDepfile.parent.existsSync()) {
-      outputDepfile.parent.createSync(recursive: true);
+    if (depfilePath != null) {
+      final Depfile depfile = Depfile(result.inputFiles, result.outputFiles);
+      final File outputDepfile = fs.file(depfilePath);
+      if (!outputDepfile.parent.existsSync()) {
+        outputDepfile.parent.createSync(recursive: true);
+      }
+      depfile.writeToFile(outputDepfile);
     }
-    depfile.writeToFile(outputDepfile);
+  } catch (err) {
+    throwToolExit('Failed to build bundle.$err');
   }
 }
 

--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -140,8 +140,10 @@ Future<void> buildWithAssemble({
       }
       depfile.writeToFile(outputDepfile);
     }
-  } catch (err) {
-    throwToolExit('Failed to build bundle.$err');
+  } catch (err, stackTrace) {
+    printError(err.toString());
+    printError(stackTrace.toString());
+    throwToolExit('Failed to build bundle.');
   }
 }
 

--- a/packages/flutter_tools/test/commands.shard/permeable/build_bundle_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_bundle_test.dart
@@ -234,6 +234,25 @@ void main() {
     FileSystem: () => MemoryFileSystem(),
     ProcessManager: () => FakeProcessManager.any(),
   });
+
+  testUsingContext('handles unhandled build exceptions', () async {
+    fs.file('lib/main.dart').createSync(recursive: true);
+    fs.file('pubspec.yaml').createSync();
+    fs.file('.packages').createSync();
+    final CommandRunner<void> runner = createTestCommandRunner(BuildBundleCommand());
+    when(buildSystem.build(any, any)).thenThrow(const FileSystemException());
+
+    expect(runner.run(<String>[
+      'bundle',
+      '--no-pub',
+      '--debug',
+      '--target-platform=android-arm',
+    ]), throwsToolExit());
+  }, overrides: <Type, Generator>{
+    BuildSystem: () => MockBuildSystem(),
+    FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager.any(),
+  });
 }
 
 class MockBundleBuilder extends Mock implements BundleBuilder {}


### PR DESCRIPTION
## Description

flutter assemble catches unhandled build exceptions, but the buildAssemble bundle implementation does. Example:

```
	at _Directory._fillWithDirectoryListing	(directory_patch.dart:37 )
at _Directory.listSync	(directory_impl.dart:249 )
at ForwardingDirectory.listSync	(forwarding_directory.dart:45 )
at _AssetDirectoryCache.variantsFor	(asset.dart:517 )
at _parseAssetFromFile	(asset.dart:659 )
at _parseAssets	(asset.dart:583 )
at _ManifestAssetBundle.build	(asset.dart:151 )
at <asynchronous gap>	(async )
at AssetOutputBehavior.outputs	(assets.dart:77 )
at SourceVisitor.visitBehavior	(source.dart:171 )
at _SourceBehavior.accept	(source.dart:247 )
at Target._resolveConfiguration	(build_system.dart:230 )
at Target.resolveOutputs	(build_system.dart:188 )
at Target._toNode	(build_system.dart:132 )
at BuildSystem.build	(build_system.dart:415 )
at _AsyncAwaitCompleter.start	(async_patch.dart:43 )
at BuildSystem.build	(build_system.dart:400 )
at buildWithAssemble	(bundle.dart:125 )
at _AsyncAwaitCompleter.start	(async_patch.dart:43 )
at buildWithAssemble	(bundle.dart:99 )
at BundleBuilder.build	(bundle.dart:75 )
at _AsyncAwaitCompleter.start	(async_patch.dart:43 )
at BundleBuilder.build	(bundle.dart:52 )
at IOSSimulator._sideloadUpdatedAssetsForInstalledApplicationBundle	(simulators.dart:453 )
at IOSSimulator._setupUpdatedApplicationBundle	(simulators.dart:420 )
at _AsyncAwaitCompleter.start	(async_patch.dart:43 )
at IOSSimulator._setupUpdatedApplicationBundle	(simulators.dart:419 )
at IOSSimulator.startApp	(simulators.dart:352 )
at _AsyncAwaitCompleter.start	(async_patch.dart:43 )
at IOSSimulator.startApp	(simulators.dart:339 )
at FlutterDevice.runHot	(resident_runner.dart:393 )
at _asyncThenWrapperHelper.<anonymous closure>	(async_patch.dart:71 )
at _rootRunUnary	(zone.dart:1132 )
at _CustomZone.runUnary	(zone.dart:1029 )
at _FutureListener.handleValue	(future_impl.dart:137 )
at Future._propagateToListeners.handleValueCallback	(future_impl.dart:678 )
at Future._propagateToListeners	(future_impl.dart:707 )
at Future._completeWithValue	(future_impl.dart:522 )
at _AsyncAwaitCompleter.complete	(async_patch.dart:30 )
at _completeOnAsyncReturn	(async_patch.dart:288 )
at BuildableIOSApp.fromProject	(application_package.dart )
at _asyncThenWrapperHelper.<anonymous closure>	(async_patch.dart:71 )
at _rootRunUnary	(zone.dart:1132 )
at _CustomZone.runUnary	(zone.dart:1029 )
at _FutureListener.handleValue	(future_impl.dart:137 )
at Future._propagateToListeners.handleValueCallback	(future_impl.dart:678 )
at Future._propagateToListeners	(future_impl.dart:707 )
at Future._completeWithValue	(future_impl.dart:522 )
at Future._asyncComplete.<anonymous closure>	(future_impl.dart:552 )
at _rootRun	(zone.dart:1124 )
at _CustomZone.run	(zone.dart:1021 )
at _CustomZone.runGuarded	(zone.dart:923 )
at _CustomZone.bindCallbackGuarded.<anonymous closure>	(zone.dart:963 )
at _microtaskLoop	(schedule_microtask.dart:41 )
at _startMicrotaskLoop	(schedule_microtask.dart:50 )
at _runPendingImmediateCallback	(isolate_patch.dart:116 )
at _RawReceivePortImpl._handleMessage	(isolate_patch.dart:173 )
```