### PR TITLE
Adding handling of TextInputClient.onConnectionClosed messages handli…

### DIFF
--- a/packages/flutter/lib/src/services/system_channels.dart
+++ b/packages/flutter/lib/src/services/system_channels.dart
@@ -159,6 +159,14 @@ class SystemChannels {
   ///    second argument is a [String] consisting of the stringification of one
   ///    of the values of the [TextInputAction] enum.
   ///
+  ///  * `TextInputClient.onConnectionClosed`: The text input connection closed
+  ///    on the platform side. For example the application is moved to
+  ///    background or used closed the virtual keyboard. This method informs
+  ///    [TextInputClient] to clear connection and finalize editing.
+  ///    `TextInput.clearClient` and `TextInput.hide` is not called after
+  ///    clearing the connection since on the platform side the connection is
+  ///    already finalized.
+  ///
   /// Calls to methods that are not implemented on the shell side are ignored
   /// (so it is safe to call methods when the relevant plugin might be missing).
   static const MethodChannel textInput = OptionalMethodChannel(

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -633,6 +633,9 @@ abstract class TextInputClient {
 
   /// Updates the floating cursor position and state.
   void updateFloatingCursor(RawFloatingCursorPoint point);
+
+  /// Connection close request is received.
+  void connectionClosed();
 }
 
 /// An interface for interacting with a text input control.
@@ -813,6 +816,9 @@ class _TextInputClientHandler {
         break;
       case 'TextInputClient.updateFloatingCursor':
         _currentConnection._client.updateFloatingCursor(_toTextPoint(_toTextCursorAction(args[1]), args[2]));
+        break;
+      case 'TextInputClient.onConnectionClosed':
+        _currentConnection._client.connectionClosed();
         break;
       default:
         throw MissingPluginException();

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -634,7 +634,7 @@ abstract class TextInputClient {
   /// Updates the floating cursor position and state.
   void updateFloatingCursor(RawFloatingCursorPoint point);
 
-  /// Connection close request is received.
+  /// Platform notified framework of closed connection due to user activity.
   void connectionClosed();
 }
 
@@ -735,6 +735,15 @@ class TextInputConnection {
         .._currentConnection = null
         .._scheduleHide();
     }
+    assert(!attached);
+  }
+
+  /// User closed the connection.
+  ///
+  /// This method cleans up the [TextInputConnection] after platform notifies
+  /// the framework of closed connection.
+  void connectionClosedReceived() {
+    _clientHandler._currentConnection = null;
     assert(!attached);
   }
 }

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -634,7 +634,9 @@ abstract class TextInputClient {
   /// Updates the floating cursor position and state.
   void updateFloatingCursor(RawFloatingCursorPoint point);
 
-  /// Platform notified framework of closed connection due to user activity.
+  /// Platform notified framework of closed connection.
+  ///
+  /// [TextInputClient] should cleanup its connection and finalize editing.
   void connectionClosed();
 }
 
@@ -738,10 +740,9 @@ class TextInputConnection {
     assert(!attached);
   }
 
-  /// User closed the connection.
+  /// Platform sent a notification informing the connection is closed.
   ///
-  /// This method cleans up the [TextInputConnection] after platform notifies
-  /// the framework of closed connection.
+  /// [TextInputConnection] should clean current client connection.
   void connectionClosedReceived() {
     _clientHandler._currentConnection = null;
     assert(!attached);

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1425,21 +1425,22 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     }
   }
 
-  void _closeConnectionReceived() {
-    if (_hasInputConnection) {
-      _textInputConnection.connectionClosedReceived();
-      _textInputConnection = null;
-      _lastKnownRemoteTextEditingValue = null;
-      _finalizeEditing(true);
-    }
-  }
-
   void _openOrCloseInputConnectionIfNeeded() {
     if (_hasFocus && widget.focusNode.consumeKeyboardToken()) {
       _openInputConnection();
     } else if (!_hasFocus) {
       _closeInputConnectionIfNeeded();
       widget.controller.clearComposing();
+    }
+  }
+
+  @override
+  void connectionClosed() {
+    if (_hasInputConnection) {
+      _textInputConnection.connectionClosedReceived();
+      _textInputConnection = null;
+      _lastKnownRemoteTextEditingValue = null;
+      _finalizeEditing(true);
     }
   }
 
@@ -1887,11 +1888,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       style: widget.style,
       withComposing: !widget.readOnly,
     );
-  }
-
-  @override
-  void connectionClosed() {
-    _closeConnectionReceived();
   }
 }
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1425,6 +1425,15 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     }
   }
 
+  void _closeConnectionReceived() {
+    if (_hasInputConnection) {
+      _textInputConnection.connectionClosedReceived();
+      _textInputConnection = null;
+      _lastKnownRemoteTextEditingValue = null;
+      _finalizeEditing(true);
+    }
+  }
+
   void _openOrCloseInputConnectionIfNeeded() {
     if (_hasFocus && widget.focusNode.consumeKeyboardToken()) {
       _openInputConnection();
@@ -1882,7 +1891,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
 
   @override
   void connectionClosed() {
-    _closeInputConnectionIfNeeded();
+    _closeConnectionReceived();
   }
 }
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1879,6 +1879,11 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       withComposing: !widget.readOnly,
     );
   }
+
+  @override
+  void connectionClosed() {
+    _closeInputConnectionIfNeeded();
+  }
 }
 
 class _Editable extends LeafRenderObjectWidget {

--- a/packages/flutter/test/services/text_input_test.dart
+++ b/packages/flutter/test/services/text_input_test.dart
@@ -98,8 +98,7 @@ void main() {
       expect(client.latestMethodCall, isEmpty);
 
       // Send onConnectionClosed message.
-      final ByteData messageBytes =
-          const JSONMessageCodec().encodeMessage(<String, dynamic>{
+      final ByteData messageBytes = const JSONMessageCodec().encodeMessage(<String, dynamic>{
         'args': <dynamic>[1],
         'method': 'TextInputClient.onConnectionClosed',
       });

--- a/packages/flutter/test/services/text_input_test.dart
+++ b/packages/flutter/test/services/text_input_test.dart
@@ -88,5 +88,52 @@ void main() {
       expect(signed.hashCode == signedDecimal.hashCode, false);
       expect(decimal.hashCode == signedDecimal.hashCode, false);
     });
+
+    test('TextInputClient onConnectionClosed method is called', () async {
+      // Assemble a TextInputConnection so we can verify its change in state.
+      final FakeTextInputClient client = FakeTextInputClient();
+      const TextInputConfiguration configuration = TextInputConfiguration();
+      TextInput.attach(client, configuration);
+
+      expect(client.latestMethodCall, isEmpty);
+
+      // Send onConnectionClosed message.
+      final ByteData messageBytes =
+          const JSONMessageCodec().encodeMessage(<String, dynamic>{
+        'args': <dynamic>[1],
+        'method': 'TextInputClient.onConnectionClosed',
+      });
+      await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+        'flutter/textinput',
+        messageBytes,
+        (ByteData _) {},
+      );
+
+      expect(client.latestMethodCall, 'connectionClosed');
+    });
   });
+}
+
+class FakeTextInputClient extends TextInputClient {
+  String latestMethodCall = '';
+
+  @override
+  void performAction(TextInputAction action) {
+    latestMethodCall = 'performAction';
+  }
+
+  @override
+  void updateEditingValue(TextEditingValue value) {
+    latestMethodCall = 'updateEditingValue';
+  }
+
+  @override
+  void updateFloatingCursor(RawFloatingCursorPoint point) {
+    latestMethodCall = 'updateFloatingCursor';
+  }
+
+  @override
+  void connectionClosed() {
+    latestMethodCall = 'connectionClosed';
+  }
 }

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -634,7 +634,7 @@ void main() {
   });
 
   testWidgets('closed connection reopened when user focused on another field', (WidgetTester tester) async {
-    final EditableText testNameField = 
+    final EditableText testNameField =
       EditableText(
         backgroundCursorColor: Colors.grey,
         controller: controller,

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -586,16 +586,16 @@ void main() {
     expect(tester.testTextInput.editingState['text'], equals('test'));
     expect(state.wantKeepAlive, true);
 
+    tester.testTextInput.log.clear();
     tester.testTextInput.closeConnection();
     await tester.idle();
 
     // Widget does not have focus anymore.
     expect(state.wantKeepAlive, false);
-    // testTextInput.isVisible is false if the clearClient/hideClient TextInput
-    // messages are sent. For onConnectionClosed message framework does not send
-    // clearClient/hideClient since the platform already informed the framework
-    // of a closed connection.
-    expect(tester.testTextInput.isVisible, true);
+    // No method calls are sent from the framework.
+    // This makes sure hide/clearClient methods are not called after connection
+    // closed.
+    expect(tester.testTextInput.log, isEmpty);
   });
 
   testWidgets('closed connection reopened when user focused', (WidgetTester tester) async {
@@ -630,18 +630,23 @@ void main() {
     expect(tester.testTextInput.editingState['text'], equals('test3'));
     expect(state.wantKeepAlive, true);
 
+    tester.testTextInput.log.clear();
     tester.testTextInput.closeConnection();
     await tester.pumpAndSettle();
 
     // Widget does not have focus anymore.
     expect(state.wantKeepAlive, false);
+    // No method calls are sent from the framework.
+    // This makes sure hide/clearClient methods are not called after connection
+    // closed.
+    expect(tester.testTextInput.log, isEmpty);
 
     await tester.tap(find.byType(EditableText));
     await tester.showKeyboard(find.byType(EditableText));
     await tester.pump();
     controller.text = 'test2';
     expect(tester.testTextInput.editingState['text'], equals('test2'));
-    // // Widget regained the focus.
+    // Widget regained the focus.
     expect(state.wantKeepAlive, true);
   });
 
@@ -698,10 +703,15 @@ void main() {
         tester.state<EditableTextState>(find.byWidget(testNameField));
     expect(state.wantKeepAlive, true);
 
+    tester.testTextInput.log.clear();
     tester.testTextInput.closeConnection();
 
     // Widget does not have focus anymore.
     expect(state.wantKeepAlive, false);
+    // No method calls are sent from the framework.
+    // This makes sure hide/clearClient methods are not called after connection
+    // closed.
+    expect(tester.testTextInput.log, isEmpty);
 
     // For the next fields, tap, enter text.
     await tester.tap(find.byWidget(testPhoneField));

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -554,6 +554,46 @@ void main() {
         equals('TextInputAction.done'));
   });
 
+  testWidgets('connection is closed when TextInputClient.onConnectionClosed message received', (WidgetTester tester) async {
+    Future<void> verifyVisibility(bool expectedVisibility) async {
+      expect(tester.testTextInput.isVisible, expectedVisibility);
+    }
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(devicePixelRatio: 1.0),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: FocusScope(
+            node: focusScopeNode,
+            autofocus: true,
+            child: EditableText(
+              backgroundCursorColor: Colors.grey,
+              controller: controller,
+              focusNode: focusNode,
+              maxLines: 1, // Sets text keyboard implicitly.
+              style: textStyle,
+              cursorColor: cursorColor,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(EditableText));
+    await tester.showKeyboard(find.byType(EditableText));
+    controller.text = 'test';
+    await tester.idle();
+    expect(tester.testTextInput.editingState['text'], equals('test'));
+    await verifyVisibility(true);
+
+    tester.testTextInput.closeConnection();
+
+    await tester.idle();
+
+    await verifyVisibility(false);
+  });
+
   /// Toolbar is not used in Flutter Web. Skip this check.
   ///
   /// Web is using native dom elements (it is also used as platform input)

--- a/packages/flutter_test/lib/src/test_text_input.dart
+++ b/packages/flutter_test/lib/src/test_text_input.dart
@@ -122,7 +122,7 @@ class TestTextInput {
       (ByteData data) { /* response from framework is discarded */ },
     );
   }
-
+  
   /// Simulates the user closing the text input connection.
   ///
   /// Example via sending the application to the backend or closing a virtual

--- a/packages/flutter_test/lib/src/test_text_input.dart
+++ b/packages/flutter_test/lib/src/test_text_input.dart
@@ -125,8 +125,9 @@ class TestTextInput {
   
   /// Simulates the user closing the text input connection.
   ///
-  /// Example via sending the application to the backend or closing a virtual
-  /// keyboard.
+  /// For example:
+  /// - User pressed the home button and sent the application to background.
+  /// - User closed the virtual keyboard.
   void closeConnection() {
     // Not using the `expect` function because in the case of a FlutterDriver
     // test this code does not run in a package:test test zone.

--- a/packages/flutter_test/lib/src/test_text_input.dart
+++ b/packages/flutter_test/lib/src/test_text_input.dart
@@ -55,6 +55,12 @@ class TestTextInput {
     _isRegistered = false;
   }
 
+  /// Log for method calls.
+  ///
+  /// For all registered channels, handled calls are added to the list. Can
+  /// be cleaned using [clearLog].
+  final List<MethodCall> log = <MethodCall>[];
+
   /// Whether this [TestTextInput] is registered with [SystemChannels.textInput].
   ///
   /// Use [register] and [unregister] methods to control this value.
@@ -78,6 +84,7 @@ class TestTextInput {
   Map<String, dynamic> editingState;
 
   Future<dynamic> _handleTextInputCall(MethodCall methodCall) async {
+    log.add(methodCall);
     switch (methodCall.method) {
       case 'TextInput.setClient':
         _client = methodCall.arguments[0];
@@ -138,7 +145,7 @@ class TestTextInput {
       SystemChannels.textInput.codec.encodeMethodCall(
         MethodCall(
           'TextInputClient.onConnectionClosed',
-           <dynamic>[_client,],
+           <dynamic>[_client,]
         ),
       ),
       (ByteData data) { /* response from framework is discarded */ },

--- a/packages/flutter_test/lib/src/test_text_input.dart
+++ b/packages/flutter_test/lib/src/test_text_input.dart
@@ -123,6 +123,27 @@ class TestTextInput {
     );
   }
 
+  /// Simulates the user closing the text input connection.
+  ///
+  /// Example via sending the application to the backend or closing a virtual
+  /// keyboard.
+  void closeConnection() {
+    // Not using the `expect` function because in the case of a FlutterDriver
+    // test this code does not run in a package:test test zone.
+    if (_client == 0)
+      throw TestFailure('Tried to use TestTextInput with no keyboard attached. You must use WidgetTester.showKeyboard() first.');
+    _binaryMessenger.handlePlatformMessage(
+      SystemChannels.textInput.name,
+      SystemChannels.textInput.codec.encodeMethodCall(
+        MethodCall(
+          'TextInputClient.onConnectionClosed',
+           <dynamic>[_client,],
+        ),
+      ),
+      (ByteData data) { /* response from framework is discarded */ },
+    );
+  }
+
   /// Simulates the user typing the given text.
   void enterText(String text) {
     updateEditingValue(TextEditingValue(

--- a/packages/flutter_test/lib/src/test_text_input.dart
+++ b/packages/flutter_test/lib/src/test_text_input.dart
@@ -122,7 +122,7 @@ class TestTextInput {
       (ByteData data) { /* response from framework is discarded */ },
     );
   }
-  
+
   /// Simulates the user closing the text input connection.
   ///
   /// For example:


### PR DESCRIPTION
Adding handling of TextInputClient.onConnectionClosed messages handling to Framework

## Description

Adding a message to the Flutter Framework for clients to call if a connection is closed.

Information in following situations can be synced with the framework using this method call.

- if the mobile browser is sent to background by pressing the home button on a mobile device.
- If the blur event is triggered on an input element in a web browser.
- the user closed the virtual keyboard indication they stopped editing.

This PR is merged and rolled back before: https://github.com/flutter/flutter/pull/35100

## Related Issues

https://github.com/flutter/flutter/issues/43034

## Tests

I added the following tests:

- Unit tests for editable_text_test.dart
- Unit tests for text_input.dart

Manually tested with the Flutter Web Engine.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes

Announcement: https://groups.google.com/forum/#!topic/flutter-announce/IwG8xGA7Kmo