### PR TITLE
Fixed bug where we could accidently call a callback twice.

### DIFF
--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -200,6 +200,7 @@ class _DefaultBinaryMessenger extends BinaryMessenger {
         response = await handler(data);
       } else {
         ui.channelBuffers.push(channel, data, callback);
+        callback = null;
       }
     } catch (exception, stack) {
       FlutterError.reportError(FlutterErrorDetails(
@@ -209,7 +210,9 @@ class _DefaultBinaryMessenger extends BinaryMessenger {
         context: ErrorDescription('during a platform message callback'),
       ));
     } finally {
-      callback(response);
+      if (callback != null) {
+        callback(response);
+      }
     }
   }
 

--- a/packages/flutter/test/services/default_binary_messenger_test.dart
+++ b/packages/flutter/test/services/default_binary_messenger_test.dart
@@ -1,0 +1,37 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  ByteData _makeByteData(String str) {
+    final List<int> list = utf8.encode(str);
+    final ByteBuffer buffer =
+        list is Uint8List ? list.buffer : Uint8List.fromList(list).buffer;
+    return ByteData.view(buffer);
+  }
+
+  test('default binary messenger calls callback once', () async {
+    int count = 0;
+    const String channel = 'foo';
+    ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+        channel, _makeByteData('bar'), (ByteData message) async {
+      count += 1;
+      return null;
+    });
+    expect(count, equals(0));
+    await ui.channelBuffers.drain(channel,
+        (ByteData data, ui.PlatformMessageResponseCallback callback) {
+      callback(null);
+      return null;
+    });
+    expect(count, equals(1));
+  });
+}

--- a/packages/flutter_web_plugins/lib/src/plugin_registry.dart
+++ b/packages/flutter_web_plugins/lib/src/plugin_registry.dart
@@ -82,6 +82,7 @@ class _PlatformBinaryMessenger extends BinaryMessenger {
         response = await handler(data);
       } else {
         ui.channelBuffers.push(channel, data, callback);
+        callback = null;
       }
     } catch (exception, stack) {
       FlutterError.reportError(FlutterErrorDetails(
@@ -91,7 +92,9 @@ class _PlatformBinaryMessenger extends BinaryMessenger {
         context: ErrorDescription('during a plugin platform message call'),
       ));
     } finally {
-      callback(response);
+      if (callback != null) {
+        callback(response);
+      }
     }
   }
 


### PR DESCRIPTION
## Description

In the case where we would overflow a buffer channel we would end up calling the callback twice.

## Related Issues

Related Issue: https://github.com/flutter/flutter/issues/42880

## Tests

I added the following tests:

WIP

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
