### PR TITLE
Allow TextStyle.lerp to lerp TextStyles with different inherit settings

### DIFF
--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -913,7 +913,8 @@ class TextStyle extends Diagnosticable {
 
   /// Interpolate between two text styles.
   ///
-  /// This will not work well if the styles don't set the same fields.
+  /// This will not work well if the styles don't set the same fields, or if
+  /// the [inherit] fields are different.
   ///
   /// {@macro dart.ui.shadow.lerp}
   ///
@@ -926,7 +927,6 @@ class TextStyle extends Diagnosticable {
   /// based on the [backgroundColor] property).
   static TextStyle lerp(TextStyle a, TextStyle b, double t) {
     assert(t != null);
-    assert(a == null || b == null || a.inherit == b.inherit);
     if (a == null && b == null) {
       return null;
     }
@@ -992,7 +992,7 @@ class TextStyle extends Diagnosticable {
     }
 
     return TextStyle(
-      inherit: b.inherit,
+      inherit: t < 0.5 ? a.inherit : b.inherit,
       color: a.foreground == null && b.foreground == null ? Color.lerp(a.color, b.color, t) : null,
       backgroundColor: a.background == null && b.background == null ? Color.lerp(a.backgroundColor, b.backgroundColor, t) : null,
       fontFamily: t < 0.5 ? a.fontFamily : b.fontFamily,

--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -167,6 +167,10 @@ void main() {
     expect(s9.height, isNull);
     expect(s9.color, isNull);
 
+    // Check that we can lerp with different inherit flags
+    final TextStyle s10 = TextStyle.lerp(s1, const TextStyle(inherit: false), 0.75);
+    expect(s10.inherit, isFalse);
+
     final ui.TextStyle ts5 = s5.getTextStyle();
     expect(ts5, equals(ui.TextStyle(fontWeight: FontWeight.w700, fontSize: 12.0, height: 123.0)));
     expect(ts5.toString(), 'TextStyle(color: unspecified, decoration: unspecified, decorationColor: unspecified, decorationStyle: unspecified, decorationThickness: unspecified, fontWeight: FontWeight.w700, fontStyle: unspecified, textBaseline: unspecified, fontFamily: unspecified, fontFamilyFallback: unspecified, fontSize: 12.0, letterSpacing: unspecified, wordSpacing: unspecified, height: 123.0x, locale: unspecified, background: unspecified, foreground: unspecified, shadows: unspecified, fontFeatures: unspecified)');


### PR DESCRIPTION
## Description

Currently the `TextStyle.lerp` function asserts if the two TextStyles do not have the same `inherit` field. It is a not exactly clear what the outcome of a lerp between two styles that where one is inheriting part of its properties from its parents and the other isn't should be. However, this does lead to the case were certain TextStyle combinations can't be lerp'd which can cause failures when trying to lerp between our default Themes. (See #43358).

We already allow for some weirdness in this when lerping between two styles that have different sets of fields set. It would be better to allow this with some possibly weird intermittent results rather than failing altogether. This PR just allows the function to lerp the 'inherit' field like we do other boolean fields (i.e. swap them at 0.5). 

## Related Issues

Fixes: #43358 

## Tests

I added a test to the existing `TextStyle` unit tests to verify that `lerp` works with different `inherit` settings.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
