### PR TITLE
Change PopupMenuButton.icon type to Widget

### DIFF
--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -979,10 +979,12 @@ class PopupMenuButton<T> extends StatefulWidget {
   final EdgeInsetsGeometry padding;
 
   /// If provided, the widget used for this button.
+  /// The widget will use an [InkWell] for taps.
   final Widget child;
 
   /// If provided, the icon used for this button.
-  final Icon icon;
+  /// The widget will behave like an [IconButton].
+  final Widget icon;
 
   /// The offset applied to the Popup Menu Button.
   ///

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -978,12 +978,12 @@ class PopupMenuButton<T> extends StatefulWidget {
   /// to set the padding to zero.
   final EdgeInsetsGeometry padding;
 
-  /// If provided, the widget used for this button.
-  /// The widget will use an [InkWell] for taps.
+  /// If provided, [child] is the widget used for this button
+  /// and the button will use an [InkWell] for taps.
   final Widget child;
 
-  /// If provided, the icon used for this button.
-  /// The widget will behave like an [IconButton].
+  /// If provided, [icon] used for this button
+  /// and the button will behave like an [IconButton].
   final Widget icon;
 
   /// The offset applied to the Popup Menu Button.

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -979,10 +979,10 @@ class PopupMenuButton<T> extends StatefulWidget {
   final EdgeInsetsGeometry padding;
 
   /// If provided, [child] is the widget used for this button
-  /// and the button will use an [InkWell] for taps.
+  /// and the button will utilize an [InkWell] for taps.
   final Widget child;
 
-  /// If provided, [icon] used for this button
+  /// If provided, the [icon] is used for this button
   /// and the button will behave like an [IconButton].
   final Widget icon;
 

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -974,6 +974,29 @@ void main() {
     expect(find.byType(Tooltip), findsNWidgets(3));
     expect(find.byTooltip('Test tooltip',), findsNWidgets(3));
   });
+
+  testWidgets('Allow Widget for PopupMenuButton.icon', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: PopupMenuButton<int>(
+            itemBuilder: (BuildContext context) {
+              return <PopupMenuEntry<int>>[
+                const PopupMenuItem<int>(
+                  value: 1,
+                  child: Text('Tap me please!'),
+                ),
+              ];
+            },
+            tooltip: 'Test tooltip',
+            icon: const Text('PopupMenuButton icon'),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('PopupMenuButton icon'), findsOneWidget);
+  });
 }
 
 class TestApp extends StatefulWidget {


### PR DESCRIPTION
## Description

[`IconButton.icon`](https://api.flutter.dev/flutter/material/IconButton/icon.html) is a `Widget` and since `PopupMenuButton.icon` is directly passed to that, it should also be `Widget` and not be restricted to `Icon`s.

## Tests

This pull request should not require any tests as this change is safe and completely backwards compatible as `Icon` is a subclass of `Widget`.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.