### PR TITLE
Cupertino web tests

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -59,10 +59,7 @@ const int kWebBatchSize = 20;
 
 /// Tests that we don't run on Web for various reasons.
 //
-// TODO(yjbanov): we're getting rid of these blacklists as part of https://github.com/flutter/flutter/projects/60
-const List<String> kWebTestDirectoryBlacklist = <String>[
-  'cupertino',
-];
+// TODO(yjbanov): we're getting rid of this blacklist as part of https://github.com/flutter/flutter/projects/60
 const List<String> kWebTestFileBlacklist = <String>[
   'test/examples/sector_layout_test.dart',
   'test/widgets/heroes_test.dart',
@@ -77,6 +74,24 @@ const List<String> kWebTestFileBlacklist = <String>[
   'test/widgets/shortcuts_test.dart',
   'test/material/text_form_field_test.dart',
   'test/material/data_table_test.dart',
+
+  // TODO(yjbanov): CupertinoDynamicColor breaks the web engine. The fix
+  //                is on the engine side: https://github.com/flutter/engine/pull/13359
+  'test/cupertino/colors_test.dart',
+  'test/cupertino/dialog_test.dart',
+  'test/cupertino/nav_bar_test.dart',
+  'test/cupertino/nav_bar_transition_test.dart',
+  'test/cupertino/refresh_test.dart',
+  'test/cupertino/switch_test.dart',
+  'test/cupertino/text_field_test.dart',
+  'test/cupertino/date_picker_test.dart',
+  'test/cupertino/slider_test.dart',
+  'test/cupertino/text_field_test.dart',
+  'test/cupertino/segmented_control_test.dart',
+  'test/cupertino/scaffold_test.dart',
+  'test/cupertino/route_test.dart',
+  'test/cupertino/route_test.dart',
+  'test/cupertino/activity_indicator_test.dart',
 ];
 
 /// When you call this, you can pass additional arguments to pass custom
@@ -455,7 +470,6 @@ Future<void> _runWebTests() async {
   final List<String> allTests = flutterPackageTestDirectory
     .listSync()
     .whereType<Directory>()
-    .where((Directory directory) => !kWebTestDirectoryBlacklist.contains(path.basename(directory.path)))
     .expand((Directory directory) => directory
       .listSync(recursive: true)
       .where((FileSystemEntity entity) => entity.path.endsWith('_test.dart'))

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -62,9 +62,9 @@ const int kWebBatchSize = 20;
 // TODO(yjbanov): we're getting rid of these blacklists as part of https://github.com/flutter/flutter/projects/60
 const List<String> kWebTestDirectoryBlacklist = <String>[
   'cupertino',
-  'examples',
 ];
 const List<String> kWebTestFileBlacklist = <String>[
+  'test/examples/sector_layout_test.dart',
   'test/widgets/heroes_test.dart',
   'test/widgets/text_test.dart',
   'test/widgets/selectable_text_test.dart',
@@ -74,13 +74,9 @@ const List<String> kWebTestFileBlacklist = <String>[
   'test/widgets/raw_keyboard_listener_test.dart',
   'test/widgets/editable_text_test.dart',
   'test/widgets/widget_inspector_test.dart',
-  'test/widgets/draggable_test.dart',
   'test/widgets/shortcuts_test.dart',
   'test/material/text_form_field_test.dart',
-  'test/material/banner_theme_test.dart',
-  'test/material/popup_menu_test.dart',
   'test/material/data_table_test.dart',
-  'test/material/toggle_buttons_test.dart',
 ];
 
 /// When you call this, you can pass additional arguments to pass custom

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-@TestOn('!chrome') // flaky on CI
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/flutter/test/widgets/center_test.dart
+++ b/packages/flutter/test/widgets/center_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-@TestOn('!chrome') // flaky on web
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 


### PR DESCRIPTION
## Description

* Remove the directory blacklist. File blacklist if sufficient as the number of tests we skip is now pretty low.
* Enable many of the Cupertino and other tests.

## Related Issues

A step towards fixing https://github.com/flutter/flutter/issues/41920
