### PR TITLE
Catch failure to delete directory

### DIFF
--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -451,7 +451,12 @@ class IosProject implements XcodeBasedProject {
     if (!pubspecChanged && !toolingChanged) {
       return;
     }
-    _deleteIfExistsSync(ephemeralDirectory);
+    try {
+      _deleteIfExistsSync(ephemeralDirectory);
+    } on FileSystemException catch (err) {
+      printError('Failed to regnerate module directory $ephemeralDirectory:\n$err');
+      return;
+    }
     _overwriteFromTemplate(fs.path.join('module', 'ios', 'library'), ephemeralDirectory);
     // Add ephemeral host app, if a editable host app does not already exist.
     if (!_editableDirectory.existsSync()) {


### PR DESCRIPTION
## Description

TODO: test...

StackTrace:

```
  | at _Directory._deleteSync | (directory_impl.dart:206 )
-- | -- | --
  | at FileSystemEntity.deleteSync | (file_system_entity.dart:464 )
  | at ForwardingFileSystemEntity.deleteSync | (forwarding_file_system_entity.dart:72 )
  | at _deleteIfExistsSync | (project.dart:665 )
  | at IosProject._regenerateFromTemplateIfNeeded | (project.dart:448 )
  | at IosProject.ensureReadyForPlatformSpecificTooling | (project.dart:422 )
  | at <asynchronous gap> | (async )
  | at FlutterProject.ensureReadyForPlatformSpecificTooling | (project.dart:208 )
  | at <asynchronous gap> | (async )
  | at PackagesGetCommand.runCommand | (packages.dart:128 )
  | at <asynchronous gap> | (async )
  | at FlutterCommand.verifyThenRunCommand | (flutter_command.dart:557 )
  | at _asyncThenWrapperHelper.<anonymous closure> | (async_patch.dart:71 )
  | at _rootRunUnary | (zone.dart:1132 )
  | at _CustomZone.runUnary | (zone.dart:1029 )
  | at _FutureListener.handleValue | (future_impl.dart:137 )
  | at Future._propagateToListeners.handleValueCallback | (future_impl.dart:678 )
  | at Future._propagateToListeners | (future_impl.dart:707 )
  | at Future._completeWithValue | (future_impl.dart:522 )
  | at Future._asyncComplete.<anonymous closure> | (future_impl.dart:552 )
  | at _rootRun | (zone.dart:1124 )
  | at _CustomZone.run | (zone.dart:1021 )
  | at _CustomZone.runGuarded | (zone.dart:923 )
  | at _CustomZone.bindCallbackGuarded.<anonymous closure> | (zone.dart:963 )
  | at _microtaskLoop | (schedule_microtask.dart:41 )
  | at _startMicrotaskLoop | (schedule_microtask.dart:50 )
  | at _runPendingImmediateCallback | (isolate_patch.dart:116 )
  | at _RawReceivePortImpl._handleMessage | (isolate_patch.dart:173 )


```