### PR TITLE
Catch failure to list asset

### DIFF
--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:flutter_tools/src/base/common.dart';
 import 'package:yaml/yaml.dart';
 
 import 'base/context.dart';
@@ -514,7 +515,17 @@ class _AssetDirectoryCache {
 
     if (_cache[directory] == null) {
       final List<String> paths = <String>[];
-      for (FileSystemEntity entity in fs.directory(directory).listSync(recursive: true)) {
+      List<FileSystemEntity> entities;
+      try {
+        entities = fs.directory(directory).listSync(recursive: true);
+      } on FileSystemException catch (err) {
+        throwToolExit('Failed to list directory $directory.\n$err\n'
+          'This might happen if the directory is missing read permissions or is '
+          'incorrectly specified in the asset manifest.'
+        );
+      }
+
+      for (FileSystemEntity entity in entities) {
         final String path = entity.path;
         if (fs.isFileSync(path) && !_excluded.any((String exclude) => path.startsWith(exclude))) {
           paths.add(path);

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -4,9 +4,9 @@
 
 import 'dart:async';
 
-import 'package:flutter_tools/src/base/common.dart';
 import 'package:yaml/yaml.dart';
 
+import 'base/common.dart';
 import 'base/context.dart';
 import 'base/file_system.dart';
 import 'base/platform.dart';


### PR DESCRIPTION
## Description

In general, this could happen if an incorrectly specified asset path is pointing users to a directory that is missing read permissions.

Stack Trace:

```

  | at _Directory._fillWithDirectoryListing | (directory_patch.dart:37 )
-- | -- | --
  | at _Directory.listSync | (directory_impl.dart:249 )
  | at ForwardingDirectory.listSync | (forwarding_directory.dart:45 )
  | at _AssetDirectoryCache.variantsFor | (asset.dart:517 )
  | at _parseAssetFromFile | (asset.dart:659 )
  | at _parseAssets | (asset.dart:583 )
  | at _ManifestAssetBundle.build | (asset.dart:151 )
  | at <asynchronous gap> | (async )
  | at AssetOutputBehavior.inputs | (assets.dart:60 )
  | at SourceVisitor.visitBehavior | (source.dart:169 )
  | at _SourceBehavior.accept | (source.dart:247 )
  | at Target._resolveConfiguration | (build_system.dart:230 )
  | at Target.resolveInputs | (build_system.dart:180 )
  | at Target._toNode | (build_system.dart:131 )
  | at BuildSystem.build | (build_system.dart:415 )
  | at <asynchronous gap> | (async )
  | at buildWithAssemble | (bundle.dart:125 )
  | at <asynchronous gap> | (async )
  | at BundleBuilder.build | (bundle.dart:75 )
  | at <asynchronous gap> | (async )
  | at IOSSimulator._sideloadUpdatedAssetsForInstalledApplicationBundle | (simulators.dart:453 )
  | at IOSSimulator._setupUpdatedApplicationBundle | (simulators.dart:420 )
  | at <asynchronous gap> | (async )
  | at IOSSimulator.startApp | (simulators.dart:352 )
  | at <asynchronous gap> | (async )
  | at FlutterDevice.runHot | (resident_runner.dart:393 )
  | at _asyncThenWrapperHelper.<anonymous closure> | (async_patch.dart:71 )
  | at _rootRunUnary | (zone.dart:1132 )
  | at _CustomZone.runUnary | (zone.dart:1029 )
  | at _FutureListener.handleValue | (future_impl.dart:137 )
  | at Future._propagateToListeners.handleValueCallback | (future_impl.dart:678 )
  | at Future._propagateToListeners | (future_impl.dart:707 )
  | at Future._completeWithValue | (future_impl.dart:522 )
  | at _AsyncAwaitCompleter.complete | (async_patch.dart:30 )
  | at _completeOnAsyncReturn | (async_patch.dart:288 )
  | at BuildableIOSApp.fromProject | (application_package.dart )
  | at _asyncThenWrapperHelper.<anonymous closure> | (async_patch.dart:71 )
  | at _rootRunUnary | (zone.dart:1132 )
  | at _CustomZone.runUnary | (zone.dart:1029 )
  | at _FutureListener.handleValue | (future_impl.dart:137 )
  | at Future._propagateToListeners.handleValueCallback | (future_impl.dart:678 )
  | at Future._propagateToListeners | (future_impl.dart:707 )
  | at Future._completeWithValue | (future_impl.dart:522 )
  | at Future._asyncComplete.<anonymous closure> | (future_impl.dart:552 )
  | at _rootRun | (zone.dart:1124 )
  | at _CustomZone.run | (zone.dart:1021 )
  | at _CustomZone.runGuarded | (zone.dart:923 )
  | at _CustomZone.bindCallbackGuarded.<anonymous closure> | (zone.dart:963 )
  | at _microtaskLoop | (schedule_microtask.dart:41 )
  | at _startMicrotaskLoop | (schedule_microtask.dart:50 )
  | at _runPendingImmediateCallback | (isolate_patch.dart:116 )
  | at _RawReceivePortImpl._handleMessage | (isolate_patch.dart:173 )
```