### PR TITLE
Alias upgrade-packages => update-packages

### DIFF
--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -81,7 +81,7 @@ class UpdatePackagesCommand extends FlutterCommand {
 
   @override
   final String description = 'Update the packages inside the Flutter repo.';
-  
+
   @override
   final List<String> aliases = <String>['upgrade-packages'];
 

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -81,6 +81,9 @@ class UpdatePackagesCommand extends FlutterCommand {
 
   @override
   final String description = 'Update the packages inside the Flutter repo.';
+  
+  @override
+  final List<String> aliases = <String>['upgrade-packages'];
 
   @override
   final bool hidden;


### PR DESCRIPTION
## Description

Every. time.

## Tests

I don't see any other alias tests, but this worked:
```
$ flutter upgrade-packages -h                     
Update the packages inside the Flutter repo.

Usage: flutter update-packages [arguments]
-h, --help                  Print this usage information.
    --force-upgrade         Attempt to update all the dependencies to their latest versions.
                            This will actually modify the pubspec.yaml files in your checkout.

    --paths                 Finds paths in the dependency chain leading from package specified in --from to package specified in --to.
    --from                  Used with flag --dependency-path. Specifies the package to begin searching dependency path from.
    --to                    Used with flag --dependency-path. Specifies the package that the sought after dependency path leads to.
    --transitive-closure    Prints the dependency graph that is the transitive closure of packages the Flutter SDK depends on.
    --consumer-only         Only prints the dependency graph that is the transitive closurethat a consumer of the Flutter SDK will observe (When combined with transitive-closure)
    --verify-only           verifies the package checksum without changing or updating deps
```

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.