### PR TITLE
Pass environment variables through to xcodebuild

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -464,6 +464,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   // e.g. `flutter build bundle`.
   buildCommands.add('FLUTTER_SUPPRESS_ANALYTICS=true');
   buildCommands.add('COMPILER_INDEX_STORE_ENABLE=NO');
+  buildCommands.addAll(environmentVariablesAsXcodeBuildSettings());
 
   final Stopwatch sw = Stopwatch()..start();
   initialBuildStatus = logger.startProgress('Running Xcode build...', timeout: timeoutConfiguration.fastOperation);

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -293,9 +293,10 @@ class XcodeProjectInterpreter {
       '-target',
       target,
       '-showBuildSettings',
+      ...environmentVariablesAsXcodeBuildSettings()
     ];
     try {
-      // showBuildSettings is reported to ocassionally timeout. Here, we give it
+      // showBuildSettings is reported to occasionally timeout. Here, we give it
       // a lot of wiggle room (locally on Flutter Gallery, this takes ~1s).
       // When there is a timeout, we retry once.
       final RunResult result = await processUtils.run(
@@ -329,6 +330,7 @@ class XcodeProjectInterpreter {
       scheme,
       '-quiet',
       'clean',
+      ...environmentVariablesAsXcodeBuildSettings()
     ], workingDirectory: fs.currentDirectory.path);
   }
 
@@ -352,6 +354,20 @@ class XcodeProjectInterpreter {
     }
     return XcodeProjectInfo.fromXcodeBuildOutput(result.toString());
   }
+}
+
+/// Environment variables prefixed by FLUTTER_XCODE_ will be passed as build configurations to xcodebuild.
+/// This allows developers to pass arbitrary build settings in without the tool needing to make a flag
+/// for or be aware of each one. This could be used to set code signing build settings in a CI
+/// environment without requiring settings changes in the Xcode project.
+List<String> environmentVariablesAsXcodeBuildSettings() {
+  const String xcodeBuildSettingPrefix = 'FLUTTER_XCODE_';
+  return platform.environment.entries
+    .where(
+      (MapEntry<String, String> mapEntry) => mapEntry.key.startsWith(xcodeBuildSettingPrefix))
+    .expand<String>(
+      (MapEntry<String, String> mapEntry) => <String>['${mapEntry.key.substring(xcodeBuildSettingPrefix.length)}=${mapEntry.value}'])
+    .toList();
 }
 
 Map<String, String> parseXcodeBuildSettings(String showBuildSettingsOutput) {

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -360,17 +360,15 @@ class XcodeProjectInterpreter {
 /// This allows developers to pass arbitrary build settings in without the tool needing to make a flag
 /// for or be aware of each one. This could be used to set code signing build settings in a CI
 /// environment without requiring settings changes in the Xcode project.
-List<String> environmentVariablesAsXcodeBuildSettings() {
+Iterable<String> environmentVariablesAsXcodeBuildSettings() {
   const String xcodeBuildSettingPrefix = 'FLUTTER_XCODE_';
-  final Iterable<MapEntry<String, String>> xcodeEnvironmentVariables = platform.environment.entries.where((MapEntry<String, String> mapEntry) {
+  return platform.environment.entries.where((MapEntry<String, String> mapEntry) {
     return mapEntry.key.startsWith(xcodeBuildSettingPrefix);
-  });
-  final Iterable<String> xcodeBuildSettingsKeyValue = xcodeEnvironmentVariables.expand<String>((MapEntry<String, String> mapEntry) {
+  }).expand<String>((MapEntry<String, String> mapEntry) {
     // Remove FLUTTER_XCODE_ prefix from the environment variable to get the build setting.
     final String trimmedBuildSettingKey = mapEntry.key.substring(xcodeBuildSettingPrefix.length);
     return <String>['$trimmedBuildSettingKey=${mapEntry.value}'];
   });
-  return xcodeBuildSettingsKeyValue.toList();
 }
 
 Map<String, String> parseXcodeBuildSettings(String showBuildSettingsOutput) {

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -362,12 +362,15 @@ class XcodeProjectInterpreter {
 /// environment without requiring settings changes in the Xcode project.
 List<String> environmentVariablesAsXcodeBuildSettings() {
   const String xcodeBuildSettingPrefix = 'FLUTTER_XCODE_';
-  return platform.environment.entries
-    .where(
-      (MapEntry<String, String> mapEntry) => mapEntry.key.startsWith(xcodeBuildSettingPrefix))
-    .expand<String>(
-      (MapEntry<String, String> mapEntry) => <String>['${mapEntry.key.substring(xcodeBuildSettingPrefix.length)}=${mapEntry.value}'])
-    .toList();
+  final Iterable<MapEntry<String, String>> xcodeEnvironmentVariables = platform.environment.entries.where((MapEntry<String, String> mapEntry) {
+    return mapEntry.key.startsWith(xcodeBuildSettingPrefix);
+  });
+  final Iterable<String> xcodeBuildSettingsKeyValue = xcodeEnvironmentVariables.expand<String>((MapEntry<String, String> mapEntry) {
+    // Remove FLUTTER_XCODE_ prefix from the environment variable to get the build setting.
+    final String trimmedBuildSettingKey = mapEntry.key.substring(xcodeBuildSettingPrefix.length);
+    return <String>['$trimmedBuildSettingKey=${mapEntry.value}'];
+  });
+  return xcodeBuildSettingsKeyValue.toList();
 }
 
 Map<String, String> parseXcodeBuildSettings(String showBuildSettingsOutput) {

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -360,7 +360,7 @@ class XcodeProjectInterpreter {
 /// This allows developers to pass arbitrary build settings in without the tool needing to make a flag
 /// for or be aware of each one. This could be used to set code signing build settings in a CI
 /// environment without requiring settings changes in the Xcode project.
-Iterable<String> environmentVariablesAsXcodeBuildSettings() {
+List<String> environmentVariablesAsXcodeBuildSettings() {
   const String xcodeBuildSettingPrefix = 'FLUTTER_XCODE_';
   return platform.environment.entries.where((MapEntry<String, String> mapEntry) {
     return mapEntry.key.startsWith(xcodeBuildSettingPrefix);
@@ -368,7 +368,7 @@ Iterable<String> environmentVariablesAsXcodeBuildSettings() {
     // Remove FLUTTER_XCODE_ prefix from the environment variable to get the build setting.
     final String trimmedBuildSettingKey = mapEntry.key.substring(xcodeBuildSettingPrefix.length);
     return <String>['$trimmedBuildSettingKey=${mapEntry.value}'];
-  });
+  }).toList();
 }
 
 Map<String, String> parseXcodeBuildSettings(String showBuildSettingsOutput) {

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -79,6 +79,7 @@ Future<void> buildMacOS({
       'OBJROOT=${fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Intermediates.noindex')}',
       'SYMROOT=${fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Products')}',
       'COMPILER_INDEX_STORE_ENABLE=NO',
+      ...environmentVariablesAsXcodeBuildSettings()
     ], trace: true);
   } finally {
     status.cancel();

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -23,7 +23,7 @@ import '../../src/pubspec_schema.dart';
 const String xcodebuild = '/usr/bin/xcodebuild';
 
 void main() {
-  group('xcodebuild versioning', () {
+  group('xcodebuild commands', () {
     mocks.MockProcessManager mockProcessManager;
     XcodeProjectInterpreter xcodeProjectInterpreter;
     FakePlatform macOS;
@@ -171,6 +171,54 @@ void main() {
       Platform: () => macOS,
       FileSystem: () => fs,
       ProcessManager: () => mockProcessManager,
+    });
+
+    testUsingOsxContext('build settings contains Flutter Xcode environment variables', () async {
+      macOS.environment = <String, String>{
+        'FLUTTER_XCODE_CODE_SIGN_STYLE': 'Manual',
+        'FLUTTER_XCODE_ARCHS': 'arm64'
+      };
+      when(mockProcessManager.runSync(<String>[
+        xcodebuild,
+        '-project',
+        macOS.pathSeparator,
+        '-target',
+        '',
+        '-showBuildSettings',
+        'CODE_SIGN_STYLE=Manual',
+        'ARCHS=arm64'
+      ],
+        workingDirectory: anyNamed('workingDirectory'),
+        environment: anyNamed('environment')))
+        .thenReturn(ProcessResult(1, 0, '', ''));
+      expect(await xcodeProjectInterpreter.getBuildSettings('', ''), const <String, String>{});
+    });
+
+    testUsingOsxContext('clean contains Flutter Xcode environment variables', () async {
+      macOS.environment = <String, String>{
+        'FLUTTER_XCODE_CODE_SIGN_STYLE': 'Manual',
+        'FLUTTER_XCODE_ARCHS': 'arm64'
+      };
+      when(mockProcessManager.runSync(
+        any,
+        workingDirectory: anyNamed('workingDirectory')))
+        .thenReturn(ProcessResult(1, 0, '', ''));
+      xcodeProjectInterpreter.cleanWorkspace('workspace_path', 'Runner');
+      final List<dynamic> captured = verify(mockProcessManager.runSync(
+        captureAny,
+        workingDirectory: anyNamed('workingDirectory'),
+        environment: anyNamed('environment'))).captured;
+      expect(captured.first, <String>[
+        xcodebuild,
+        '-workspace',
+        'workspace_path',
+        '-scheme',
+        'Runner',
+        '-quiet',
+        'clean',
+        'CODE_SIGN_STYLE=Manual',
+        'ARCHS=arm64'
+      ]);
     });
   });
 
@@ -335,6 +383,27 @@ Information about project "Runner":
       expect(info.buildConfigurationFor(const BuildInfo(BuildMode.debug, 'Free'), 'Free'), null);
       expect(info.buildConfigurationFor(const BuildInfo(BuildMode.profile, 'Free'), 'Free'), null);
       expect(info.buildConfigurationFor(const BuildInfo(BuildMode.release, 'Paid'), 'Paid'), null);
+    });
+  });
+
+  group('environmentVariablesAsXcodeBuildSettings', () {
+    FakePlatform platform;
+
+    setUp(() {
+      platform = fakePlatform('ignored');
+    });
+
+    testUsingContext('environment variables as Xcode build settings', () {
+      platform.environment = <String, String>{
+        'Ignored': 'Bogus',
+        'FLUTTER_NOT_XCODE': 'Bogus',
+        'FLUTTER_XCODE_CODE_SIGN_STYLE': 'Manual',
+        'FLUTTER_XCODE_ARCHS': 'arm64'
+      };
+      final List<String> environmentVariablesAsBuildSettings = environmentVariablesAsXcodeBuildSettings();
+      expect(environmentVariablesAsBuildSettings, <String>['CODE_SIGN_STYLE=Manual', 'ARCHS=arm64']);
+    }, overrides: <Type, Generator>{
+      Platform: () => platform
     });
   });
 

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -174,10 +174,10 @@ void main() {
     });
 
     testUsingOsxContext('build settings contains Flutter Xcode environment variables', () async {
-      macOS.environment = <String, String>{
+      macOS.environment = Map<String, String>.unmodifiable(<String, String>{
         'FLUTTER_XCODE_CODE_SIGN_STYLE': 'Manual',
         'FLUTTER_XCODE_ARCHS': 'arm64'
-      };
+      });
       when(mockProcessManager.runSync(<String>[
         xcodebuild,
         '-project',
@@ -195,10 +195,10 @@ void main() {
     });
 
     testUsingOsxContext('clean contains Flutter Xcode environment variables', () async {
-      macOS.environment = <String, String>{
+      macOS.environment = Map<String, String>.unmodifiable(<String, String>{
         'FLUTTER_XCODE_CODE_SIGN_STYLE': 'Manual',
         'FLUTTER_XCODE_ARCHS': 'arm64'
-      };
+      });
       when(mockProcessManager.runSync(
         any,
         workingDirectory: anyNamed('workingDirectory')))
@@ -394,12 +394,12 @@ Information about project "Runner":
     });
 
     testUsingContext('environment variables as Xcode build settings', () {
-      platform.environment = <String, String>{
+      platform.environment = Map<String, String>.unmodifiable(<String, String>{
         'Ignored': 'Bogus',
         'FLUTTER_NOT_XCODE': 'Bogus',
         'FLUTTER_XCODE_CODE_SIGN_STYLE': 'Manual',
         'FLUTTER_XCODE_ARCHS': 'arm64'
-      };
+      });
       final List<String> environmentVariablesAsBuildSettings = environmentVariablesAsXcodeBuildSettings();
       expect(environmentVariablesAsBuildSettings, <String>['CODE_SIGN_STYLE=Manual', 'ARCHS=arm64']);
     }, overrides: <Type, Generator>{


### PR DESCRIPTION
## Description

Allow developers to pass in arbitrary Xcode build settings via environment variables prefixed with `FLUTTER_XCODE_`.  This will prevent the need for a new `flutter` flag for every build setting a developer may want to change.

We can use this in our device lab to override code signing Xcode settings without needing to edit every integration test Xcode project, for example.

Removes the need for patterns like FLUTTER_DEVICELAB_XCODE_PROVISIONING_CONFIG that inject xcconfig files into Generated files (see https://github.com/flutter/flutter/pull/10736/files)

## Related Issues

See proposal in https://github.com/flutter/flutter/issues/37231#issue-474518955.

## Tests

Added a few `xcodebuild commands` tests.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.