### PR TITLE
Fix hot reload support for typical usage of CupertinoTabView.

### DIFF
--- a/packages/flutter/lib/src/cupertino/tab_view.dart
+++ b/packages/flutter/lib/src/cupertino/tab_view.dart
@@ -172,10 +172,19 @@ class _CupertinoTabViewState extends State<CupertinoTabView> {
     WidgetBuilder routeBuilder;
     String title;
     if (name == Navigator.defaultRouteName && widget.builder != null) {
-      routeBuilder = widget.builder;
+      // We wrap the builder in a closure so that if the builder associated with
+      // the widget changes, the routeBuilder we pass to the PageRoute will
+      // reflect the new builder and not the old builder.
+      // Without wrapping the builder, hot reload will run the old builder
+      // instead of the new builder.
+      routeBuilder = (BuildContext context) {
+        return widget.builder(context);
+      };
       title = widget.defaultTitle;
     } else if (widget.routes != null) {
-      routeBuilder = widget.routes[name];
+      routeBuilder = (BuildContext context) {
+        return widget.routes[name](context);
+      };
     }
     if (routeBuilder != null) {
       return CupertinoPageRoute<dynamic>(

--- a/packages/flutter/test/cupertino/tab_test.dart
+++ b/packages/flutter/test/cupertino/tab_test.dart
@@ -118,6 +118,33 @@ void main() {
     expect(find.text('second route'), findsOneWidget);
   });
 
+  testWidgets('Test tab view hot reload', (WidgetTester tester) async {
+    final GlobalKey<NavigatorState> key = GlobalKey();
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: CupertinoTabView(
+          navigatorKey: key,
+          builder: (BuildContext context) => const Text('first route'),
+        ),
+      ),
+    );
+
+
+    await tester.pump();
+    expect(find.text('first route'), findsOneWidget);
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: CupertinoTabView(
+          navigatorKey: key,
+          builder: (BuildContext context) => const Text('hot reload succeeded'),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(find.text('hot reload succeeded'), findsOneWidget);
+  });
+
   testWidgets('Changing the key resets the navigator', (WidgetTester tester) async {
     final GlobalKey<NavigatorState> key = GlobalKey();
     await tester.pumpWidget(


### PR DESCRIPTION
## Description

CupertinoTabView does not currently handle hot reload as well as it could.
This CL fixes a common case triggered by Cupertino apps that breaks hot reload unless users know the common workaround to fix closures that don't update on hot-reload.


## Related Issues

This PR fixes
https://github.com/flutter/flutter/issues/43574

## Tests

I added the following tests:

I've added a test that simulates a hot reload of the CupertinoTabView. Without this CL the test fails.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
