### PR TITLE
Ensure Chrome is closed on tab close

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -122,7 +122,7 @@ class ResidentWebRunner extends ResidentRunner {
 
   Future<void> _cleanupAndExit() async {
     await _cleanup();
-    exit(0);
+    appFinished();
   }
 
   @override

--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -113,7 +113,16 @@ class ResidentWebRunner extends ResidentRunner {
     await _stdOutSub?.cancel();
     await _webFs?.stop();
     await device.stopApp(null);
+    if (ChromeLauncher.hasChromeInstance) {
+      final Chrome chrome = await ChromeLauncher.connectedInstance;
+      await chrome.close();
+    }
     _exited = true;
+  }
+
+  Future<void> _cleanupAndExit() async {
+    await _cleanup();
+    exit(0);
   }
 
   @override
@@ -201,7 +210,7 @@ class ResidentWebRunner extends ResidentRunner {
         );
         if (supportsServiceProtocol) {
           _connectionResult = await _webFs.connect(debuggingOptions);
-          unawaited(_connectionResult.debugConnection.onDone.whenComplete(() => exit(0)));
+          unawaited(_connectionResult.debugConnection.onDone.whenComplete(_cleanupAndExit));
         }
         if (statusActive) {
           buildStatus.stop();

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -69,6 +69,8 @@ String findChromeExecutable() {
 class ChromeLauncher {
   const ChromeLauncher();
 
+  static bool get hasChromeInstance => _currentCompleter.isCompleted;
+
   static final Completer<Chrome> _currentCompleter = Completer<Chrome>();
 
   /// Whether we can locate the chrome executable.

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -532,6 +532,23 @@ void main() {
     verifyNever(mockDebugConnection.close());
   }));
 
+  test('cleans up Chrome if tab is closed', () => testbed.run(() async {
+    _setupMocks();
+    final Completer<void> onDone = Completer<void>();
+    when(mockDebugConnection.onDone).thenAnswer((Invocation invocation) {
+      return onDone.future;
+    });
+    final Completer<DebugConnectionInfo> connectionInfoCompleter = Completer<DebugConnectionInfo>();
+    final Future<int> result = residentWebRunner.run(
+      connectionInfoCompleter: connectionInfoCompleter,
+    );
+    await connectionInfoCompleter.future;
+    onDone.complete();
+
+    await result;
+    verify(mockWebFs.stop()).called(1);
+  }));
+
   test('Prints target and device name on run', () => testbed.run(() async {
     _setupMocks();
     when(mockWebDevice.name).thenReturn('Chromez');


### PR DESCRIPTION
## Description

If the browser exit is initiated by the browser, we don't properly clean up chrome. Ensure we use the exit notification to use the existing cleanup mechanism.

Fixes #43486