### PR TITLE
catch failure to parse FLUTTER_STORAGE_BASE_URL

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -482,8 +482,15 @@ abstract class CachedArtifact extends ArtifactSet {
   /// Template method to perform artifact update.
   Future<void> updateInner();
 
-  String get _storageBaseUrl {
+  @visibleForTesting
+  String get storageBaseUrl {
     final String overrideUrl = platform.environment['FLUTTER_STORAGE_BASE_URL'];
+    // verify that this is a valid URI.
+    try {
+      Uri.parse(overrideUrl);
+    } on FormatException catch (err) {
+      throwToolExit('"FLUTTER_STORAGE_BASE_URL" contains an invalid URI:\n$err');
+    }
     if (overrideUrl == null) {
       return 'https://storage.googleapis.com';
     }
@@ -491,7 +498,7 @@ abstract class CachedArtifact extends ArtifactSet {
     return overrideUrl;
   }
 
-  Uri _toStorageUri(String path) => Uri.parse('$_storageBaseUrl/$path');
+  Uri _toStorageUri(String path) => Uri.parse('$storageBaseUrl/$path');
 
   /// Download an archive from the given [url] and unzip it to [location].
   Future<void> _downloadArchive(String message, Uri url, Directory location, bool verifier(File f), void extractor(File f, Directory d)) {
@@ -587,7 +594,7 @@ class FlutterWebSdk extends CachedArtifact {
     } else if (platform.isWindows) {
       platformName += 'windows-x64';
     }
-    final Uri url = Uri.parse('$_storageBaseUrl/flutter_infra/flutter/$version/$platformName.zip');
+    final Uri url = Uri.parse('$storageBaseUrl/flutter_infra/flutter/$version/$platformName.zip');
     await _downloadZipArchive('Downloading Web SDK...', url, location);
     // This is a temporary work-around for not being able to safely download into a shared directory.
     for (FileSystemEntity entity in location.listSync(recursive: true)) {
@@ -652,7 +659,7 @@ abstract class EngineCachedArtifact extends CachedArtifact {
 
   @override
   Future<void> updateInner() async {
-    final String url = '$_storageBaseUrl/flutter_infra/flutter/$version/';
+    final String url = '$storageBaseUrl/flutter_infra/flutter/$version/';
 
     final Directory pkgDir = cache.getCacheDir('pkg');
     for (String pkgName in getPackageDirs()) {
@@ -687,7 +694,7 @@ abstract class EngineCachedArtifact extends CachedArtifact {
 
   Future<bool> checkForArtifacts(String engineVersion) async {
     engineVersion ??= version;
-    final String url = '$_storageBaseUrl/flutter_infra/flutter/$engineVersion/';
+    final String url = '$storageBaseUrl/flutter_infra/flutter/$engineVersion/';
 
     bool exists = false;
     for (String pkgName in getPackageDirs()) {
@@ -1111,7 +1118,7 @@ class IosUsbArtifacts extends CachedArtifact {
   }
 
   @visibleForTesting
-  Uri get archiveUri => Uri.parse('$_storageBaseUrl/flutter_infra/ios-usb-dependencies${cache.useUnsignedMacBinaries ? '/unsigned' : ''}/$name/$version/$name.zip');
+  Uri get archiveUri => Uri.parse('$storageBaseUrl/flutter_infra/ios-usb-dependencies${cache.useUnsignedMacBinaries ? '/unsigned' : ''}/$name/$version/$name.zip');
 }
 
 // Many characters are problematic in filenames, especially on Windows.

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -485,14 +485,14 @@ abstract class CachedArtifact extends ArtifactSet {
   @visibleForTesting
   String get storageBaseUrl {
     final String overrideUrl = platform.environment['FLUTTER_STORAGE_BASE_URL'];
+    if (overrideUrl == null) {
+      return 'https://storage.googleapis.com';
+    }
     // verify that this is a valid URI.
     try {
       Uri.parse(overrideUrl);
     } on FormatException catch (err) {
       throwToolExit('"FLUTTER_STORAGE_BASE_URL" contains an invalid URI:\n$err');
-    }
-    if (overrideUrl == null) {
-      return 'https://storage.googleapis.com';
     }
     _maybeWarnAboutStorageOverride(overrideUrl);
     return overrideUrl;

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -5,6 +5,7 @@
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
+import 'package:flutter_tools/src/base/platform.dart';
 import 'package:meta/meta.dart';
 import 'package:mockito/mockito.dart';
 import 'package:platform/platform.dart';
@@ -202,6 +203,18 @@ void main() {
         );
       }
     });
+
+    testUsingContext('Invalid URI for FLUTTER_STORAGE_BASE_URL throws ToolExit', () async {
+      when(platform.environment).thenReturn(const <String, String>{
+        'FLUTTER_STORAGE_BASE_URL': ' http://foo',
+      });
+      final Cache cache = Cache();
+      final CachedArtifact artifact = MaterialFonts(cache);
+
+      expect(() => artifact.storageBaseUrl, throwsA(isInstanceOf<ToolExit>()));
+    }, overrides: <Type, Generator>{
+      Platform: () => MockPlatform(),
+    });
   });
 
   testUsingContext('flattenNameSubdirs', () {
@@ -379,3 +392,4 @@ class MockIosUsbArtifacts extends Mock implements IosUsbArtifacts {}
 class MockInternetAddress extends Mock implements InternetAddress {}
 class MockCache extends Mock implements Cache {}
 class MockOperatingSystemUtils extends Mock implements OperatingSystemUtils {}
+class MockPlatform extends Mock implements Platform {}


### PR DESCRIPTION
## Description

If the URI has a leading space or other invalid characters, then currently we'll crash with a FormatException.

```
FormatException: Scheme not starting with alphabetic character (at character 1)
 https://storage.flutter-io.cn/flutter_infra/flutter/3ebf0069041803955fc002

  | at _Uri._fail | (uri.dart:1623 )
-- | -- | --
  | at _Uri._makeScheme | (uri.dart:2184 )
  | at new _Uri.notSimple | (uri.dart:1465 )
  | at Uri.parse | (uri.dart:1022 )
  | at EngineCachedArtifact.updateInner | (cache.dart:666 )
  | at <asynchronous gap> | (async )
  | at CachedArtifact.update | (cache.dart:460 )
  | at <asynchronous gap> | (async )
  | at Cache.updateAll | (cache.dart:359 )
  | at <asynchronous gap> | (async )
  | at FlutterCommand.verifyThenRunCommand | (flutter_command.dart:537 )
  | at <asynchronous gap> | (async )
  | at FlutterCommand.run.<anonymous closure> | (flutter_command.dart:457 )
  | at <asynchronous gap> | (async )
  | at AppContext.run.<anonymous closure> | (context.dart:157 )
  | at <asynchronous gap> | (async )
  | at _rootRun | (zone.dart:1124 )
  | at _CustomZone.run | (zone.dart:1021 )
  | at _runZoned | (zone.dart:1516 )
  | at runZoned | (zone.dart:1463 )
  | at AppContext.run | (context.dart:156 )
  | at <asynchronous gap> | (async )
  | at FlutterCommand.run | (flutter_command.dart:446 )
  | at CommandRunner.runCommand | (command_runner.dart:197 )
  | at <asynchronous gap> | (async )
  | at FlutterCommandRunner.runCommand.<anonymous closure> | (flutter_command_runner.dart:416 )
  | at <asynchronous gap> | (async )
  | at AppContext.run.<anonymous closure> | (context.dart:157 )
  | at <asynchronous gap> | (async )
  | at _rootRun | (zone.dart:1124 )
  | at _CustomZone.run | (zone.dart:1021 )
  | at _runZoned | (zone.dart:1516 )
  | at runZoned | (zone.dart:1463 )
  | at AppContext.run | (context.dart:156 )
  | at <asynchronous gap> | (async )
  | at FlutterCommandRunner.runCommand | (flutter_command_runner.dart:367 )
  | at <asynchronous gap> | (async )
  | at CommandRunner.run.<anonymous closure> | (command_runner.dart:112 )


```