### PR TITLE
Fix NPE in resident runner

### DIFF
--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -198,7 +198,7 @@ class FlutterDevice {
     if (flutterViews.any((FlutterView view) {
       return view != null &&
              view.uiIsolate != null &&
-             view.uiIsolate.pauseEvent.isPauseEvent;
+             view.uiIsolate.pauseEvent?.isPauseEvent == true;
       }
     )) {
       await device.stopApp(package);

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -206,7 +206,6 @@ class FlutterDevice {
     }
     for (FlutterView view in flutterViews) {
       if (view != null && view.uiIsolate != null) {
-        assert(!view.uiIsolate.pauseEvent.isPauseEvent);
         futures.add(view.uiIsolate.flutterExit());
       }
     }

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -448,6 +448,19 @@ void main() {
     verify(mockDevice.stopApp(any)).called(1);
   }));
 
+  test('FlutterDevice will not NPE when checking for a paused isolate', () => testbed.run(() async {
+    final TestFlutterDevice flutterDevice = TestFlutterDevice(
+      mockDevice,
+      <FlutterView>[ mockFlutterView ],
+    );
+    when(mockIsolate.pauseEvent).thenReturn(null);
+    when(mockDevice.supportsFlutterExit).thenReturn(true);
+
+    await flutterDevice.exitApps();
+
+    verify(mockIsolate.flutterExit());
+  }));
+
   test('FlutterDevice will exit an un-paused isolate', () => testbed.run(() async {
     final TestFlutterDevice flutterDevice = TestFlutterDevice(
       mockDevice,


### PR DESCRIPTION
## Description

pause event might be null, causing an NPE:

```
NoSuchMethodError: The getter 'isPauseEvent' was called on null.
Receiver: null
Tried calling: isPauseEvent

  | at Object.noSuchMethod | (object_patch.dart:51 )
-- | -- | --
  | at FlutterDevice.exitApps.<anonymous closure> | (resident_runner.dart:188 )
  | at ListMixin.any | (list.dart:126 )
  | at FlutterDevice.exitApps | (resident_runner.dart:185 )
  | at <asynchronous gap> | (async )
  | at ResidentRunner.exitApp | (resident_runner.dart:911 )
  | at <asynchronous gap> | (async )
  | at ColdRunner.cleanupAfterSignal | (run_cold.dart:168 )
  | at <asynchronous gap> | (async )
  | at TerminalHandler._cleanUp | (resident_runner.dart:1196 )
  | at <asynchronous gap> | (async )
  | at TerminalHandler.processTerminalInput | (resident_runner.dart:1170 )
  | at <asynchronous gap> | (async )
  | at _rootRunUnary | (zone.dart:1132 )
  | at _CustomZone.runUnary | (zone.dart:1029 )
  | at _CustomZone.runUnaryGuarded | (zone.dart:931 )
  | at _BufferingStreamSubscription._sendData | (stream_impl.dart:336 )
  | at _BufferingStreamSubscription._add | (stream_impl.dart:263 )
  | at _SyncBroadcastStreamController._sendData | (broadcast_stream_controller.dart:375 )
  | at _BroadcastStreamController.add | (broadcast_stream_controller.dart:250 )
  | at _AsBroadcastStreamController.add | (broadcast_stream_controller.dart:474 )
  | at _rootRunUnary | (zone.dart:1132 )
  | at _CustomZone.runUnary | (zone.dart:1029 )
  | at _CustomZone.runUnaryGuarded | (zone.dart:931 )
  | at _BufferingStreamSubscription._sendData | (stream_impl.dart:336 )
  | at _BufferingStreamSubscription._add | (stream_impl.dart:263 )
  | at _SinkTransformerStreamSubscription._add | (stream_transformers.dart:68 )
  | at _EventSinkWrapper.add | (stream_transformers.dart:15 )
  | at _StringAdapterSink.add | (string_conversion.dart:236 )
  | at _StringAdapterSink.addSlice | (string_conversion.dart:241 )
  | at _Utf8ConversionSink.addSlice | (string_conversion.dart:312 )
  | at _ErrorHandlingAsciiDecoderSink.addSlice | (ascii.dart:252 )
  | at _ErrorHandlingAsciiDecoderSink.add | (ascii.dart:238 )
  | at _ConverterStreamEventSink.add | (chunked_conversion.dart:72 )
  | at _SinkTransformerStreamSubscription._handleData | (stream_transformers.dart:120 )
  | at _rootRunUnary | (zone.dart:1132 )
  | at _CustomZone.runUnary | (zone.dart:1029 )
  | at _CustomZone.runUnaryGuarded | (zone.dart:931 )
  | at _BufferingStreamSubscription._sendData | (stream_impl.dart:336 )
  | at _BufferingStreamSubscription._add | (stream_impl.dart:263 )
  | at _SyncStreamControllerDispatch._sendData | (stream_controller.dart:764 )
  | at _StreamController._add | (stream_controller.dart:640 )
  | at _StreamController.add | (stream_controller.dart:586 )
  | at _Socket._onData | (socket_patch.dart:1829 )
  | at _rootRunUnary | (zone.dart:1136 )
  | at _CustomZone.runUnary | (zone.dart:1029 )
  | at _CustomZone.runUnaryGuarded | (zone.dart:931 )
  | at _BufferingStreamSubscription._sendData | (stream_impl.dart:336 )
  | at _BufferingStreamSubscription._add | (stream_impl.dart:263 )
  | at _SyncStreamControllerDispatch._sendData | (stream_controller.dart:764 )
  | at _StreamController._add | (stream_controller.dart:640 )
  | at _StreamController.add | (stream_controller.dart:586 )
  | at new _RawSocket.<anonymous closure> | (socket_patch.dart:1377 )
  | at _NativeSocket.issueReadEvent.issue | (socket_patch.dart:897 )
  | at _microtaskLoop | (schedule_microtask.dart:41 )
  | at _startMicrotaskLoop | (schedule_microtask.dart:50 )
  | at _runPendingImmediateCallback | (isolate_patch.dart:116 )
  | at _RawReceivePortImpl._handleMessage | (isolate_patch.dart:173 )


```