### PR TITLE
dont catch dynamic and force Exception

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -253,7 +253,7 @@ Future<GradleProject> _readGradleProject(
       environment: gradleEnv,
     );
     project = GradleProject.fromAppProperties(propertiesRunResult.stdout, tasksRunResult.stdout);
-  } catch (exception) {
+  } on Exception catch (exception) {
     if (getFlutterPluginVersion(flutterProject.android) == FlutterPluginVersion.managed) {
       status.cancel();
       // Handle known exceptions.
@@ -276,7 +276,7 @@ Future<GradleProject> _readGradleProject(
 /// Handle Gradle error thrown when Gradle needs to download additional
 /// Android SDK components (e.g. Platform Tools), and the license
 /// for that component has not been accepted.
-void throwToolExitIfLicenseNotAccepted(dynamic exception) {
+void throwToolExitIfLicenseNotAccepted(Exception exception) {
   const String licenseNotAcceptedMatcher =
     r'You have not accepted the license agreements of the following SDK components:'
     r'\s*\[(.+)\]';

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -253,9 +253,10 @@ Future<GradleProject> _readGradleProject(
       environment: gradleEnv,
     );
     project = GradleProject.fromAppProperties(propertiesRunResult.stdout, tasksRunResult.stdout);
+    status.stop(); 
   } on ProcessException catch (exception) {
+    status.cancel();
     if (getFlutterPluginVersion(flutterProject.android) == FlutterPluginVersion.managed) {
-      status.cancel();
       // Handle known exceptions.
       throwToolExitIfLicenseNotAccepted(exception);
       // Print a general Gradle error and exit.
@@ -268,8 +269,6 @@ Future<GradleProject> _readGradleProject(
       <String>[],
       fs.path.join(flutterProject.android.hostAppGradleRoot.path, 'app', 'build'),
     );
-  } finally {
-    status.stop(); 
   }
   return project;
 }

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -276,7 +276,7 @@ Future<GradleProject> _readGradleProject(
 /// Handle Gradle error thrown when Gradle needs to download additional
 /// Android SDK components (e.g. Platform Tools), and the license
 /// for that component has not been accepted.
-void throwToolExitIfLicenseNotAccepted(Exception exception) {
+void throwToolExitIfLicenseNotAccepted(dynamic exception) {
   const String licenseNotAcceptedMatcher =
     r'You have not accepted the license agreements of the following SDK components:'
     r'\s*\[(.+)\]';

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -253,7 +253,7 @@ Future<GradleProject> _readGradleProject(
       environment: gradleEnv,
     );
     project = GradleProject.fromAppProperties(propertiesRunResult.stdout, tasksRunResult.stdout);
-  } on Exception catch (exception) {
+  } on ProcessException catch (exception) {
     if (getFlutterPluginVersion(flutterProject.android) == FlutterPluginVersion.managed) {
       status.cancel();
       // Handle known exceptions.
@@ -268,8 +268,9 @@ Future<GradleProject> _readGradleProject(
       <String>[],
       fs.path.join(flutterProject.android.hostAppGradleRoot.path, 'app', 'build'),
     );
+  } finally {
+    status.stop(); 
   }
-  status.stop();
   return project;
 }
 


### PR DESCRIPTION
## Description
The catch here catches any thrown type as dynamic, but passes it to a function that expects an Exception - this is unsound and unnecessary. Widen throwToolExitIfLicenseNotAccepted to accept any type..

```
_TypeError: type 'StateError' is not a subtype of type 'Exception

  | at _readGradleProject | (gradle.dart:260 )
-- | -- | --
  | at <asynchronous gap> | (async )
  | at GradleUtils.getAppProject | (gradle.dart:55 )
  | at <asynchronous gap> | (async )
  | at getGradleAppOut | (gradle.dart:143 )
  | at <asynchronous gap> | (async )
  | at AndroidApk.fromAndroidProject | (application_package.dart:168 )
  | at <asynchronous gap> | (async )
  | at ApplicationPackageFactory.getPackageForPlatform | (application_package.dart:47 )
  | at <asynchronous gap> | (async )
  | at FlutterDevice.runHot | (resident_runner.dart:357 )
  | at <asynchronous gap> | (async )
  | at HotRunner.run | (run_hot.dart:258 )
  | at <asynchronous gap> | (async )
  | at RunCommand.runCommand | (run.dart:481 )
  | at <asynchronous gap> | (async )
  | at FlutterCommand.verifyThenRunCommand | (flutter_command.dart:553 )
  | at _asyncThenWrapperHelper.<anonymous closure> | (async_patch.dart:71 )
  | at _rootRunUnary | (zone.dart:1132 )
  | at _CustomZone.runUnary | (zone.dart:1029 )
  | at _FutureListener.handleValue | (future_impl.dart:137 )
  | at Future._propagateToListeners.handleValueCallback | (future_impl.dart:678 )
  | at Future._propagateToListeners | (future_impl.dart:707 )
  | at Future._completeWithValue | (future_impl.dart:522 )
  | at _AsyncAwaitCompleter.complete | (async_patch.dart:30 )
  | at _completeOnAsyncReturn | (async_patch.dart:288 )
  | at RunCommand.usageValues | (run.dart )
  | at _asyncThenWrapperHelper.<anonymous closure> | (async_patch.dart:71 )
  | at _rootRunUnary | (zone.dart:1132 )
  | at _CustomZone.runUnary | (zone.dart:1029 )
  | at _FutureListener.handleValue | (future_impl.dart:137 )
  | at Future._propagateToListeners.handleValueCallback | (future_impl.dart:678 )
  | at Future._propagateToListeners | (future_impl.dart:707 )
  | at Future._completeWithValue | (future_impl.dart:522 )
  | at _AsyncAwaitCompleter.complete | (async_patch.dart:30 )
  | at _completeOnAsyncReturn | (async_patch.dart:288 )
  | at IosProject.isSwift | (project.dart )
  | at _asyncThenWrapperHelper.<anonymous closure> | (async_patch.dart:71 )
  | at _rootRunUnary | (zone.dart:1132 )
  | at _CustomZone.runUnary | (zone.dart:1029 )
  | at _FutureListener.handleValue | (future_impl.dart:137 )
  | at Future._propagateToListeners.handleValueCallback | (future_impl.dart:678 )
  | at Future._propagateToListeners | (future_impl.dart:707 )
  | at Future._completeWithValue | (future_impl.dart:522 )
  | at _AsyncAwaitCompleter.complete | (async_patch.dart:30 )
  | at _completeOnAsyncReturn | (async_patch.dart:288 )
  | at IosProject.buildSettings | (project.dart )
  | at _asyncThenWrapperHelper.<anonymous closure> | (async_patch.dart:71 )
  | at _rootRunUnary | (zone.dart:1132 )
  | at _CustomZone.runUnary | (zone.dart:1029 )
  | at _FutureListener.handleValue | (future_impl.dart:137 )
  | at Future._propagateToListeners.handleValueCallback | (future_impl.dart:678 )
  | at Future._propagateToListeners | (future_impl.dart:707 )
  | at Future._completeWithValue | (future_impl.dart:522 )
  | at _AsyncAwaitCompleter.complete | (async_patch.dart:30 )
  | at _completeOnAsyncReturn | (async_patch.dart:288 )
  | at XcodeProjectInterpreter.getBuildSettings | (xcodeproj.dart )
  | at _asyncThenWrapperHelper.<anonymous closure> | (async_patch.dart:71 )
  | at _rootRunUnary | (zone.dart:1132 )
  | at _CustomZone.runUnary | (zone.dart:1029 )
  | at _FutureListener.handleValue | (future_impl.dart:137 )
  | at Future._propagateToListeners.handleValueCallback | (future_impl.dart:678 )
  | at Future._propagateToListeners | (future_impl.dart:707 )
  | at Future._completeWithValue | (future_impl.dart:522 )
  | at _AsyncAwaitCompleter.complete | (async_patch.dart:30 )
  | at _completeOnAsyncReturn | (async_patch.dart:288 )
  | at _DefaultProcessUtils.run | (process.dart )
  | at _asyncThenWrapperHelper.<anonymous closure> | (async_patch.dart:71 )
  | at _rootRunUnary | (zone.dart:1132 )
  | at _CustomZone.runUnary | (zone.dart:1029 )
  | at _FutureListener.handleValue | (future_impl.dart:137 )
  | at Future._propagateToListeners.handleValueCallback | (future_impl.dart:678 )
  | at Future._propagateToListeners | (future_impl.dart:707 )
  | at Future._completeWithValue | (future_impl.dart:522 )
  | at Future.wait.<anonymous closure> | (future.dart:400 )
  | at _rootRunUnary | (zone.dart:1132 )
  | at _CustomZone.runUnary | (zone.dart:1029 )
  | at _FutureListener.handleValue | (future_impl.dart:137 )
  | at Future._propagateToListeners.handleValueCallback | (future_impl.dart:678 )
  | at Future._propagateToListeners | (future_impl.dart:707 )
  | at Future._complete | (future_impl.dart:512 )
  | at _BufferingStreamSubscription.asFuture.<anonymous closure> | (stream_impl.dart:204 )
  | at _rootRun | (zone.dart:1120 )
  | at _CustomZone.run | (zone.dart:1021 )
  | at _CustomZone.runGuarded | (zone.dart:923 )
  | at _BufferingStreamSubscription._sendDone.sendDone | (stream_impl.dart:389 )
  | at _BufferingStreamSubscription._sendDone | (stream_impl.dart:399 )
  | at _BufferingStreamSubscription._close | (stream_impl.dart:283 )
  | at _SinkTransformerStreamSubscription._close | (stream_transformers.dart:96 )
  | at _EventSinkWrapper.close | (stream_transformers.dart:23 )
  | at _StringAdapterSink.close | (string_conversion.dart:249 )
  | at _Utf8ConversionSink.close | (string_conversion.dart:300 )
  | at _ConverterStreamEventSink.close | (chunked_conversion.dart:80 )
  | at _SinkTransformerStreamSubscription._handleDone | (stream_transformers.dart:141 )
  | at _rootRun | (zone.dart:1120 )
  | at _CustomZone.run | (zone.dart:1021 )
  | at _CustomZone.runGuarded | (zone.dart:923 )
  | at _BufferingStreamSubscription._sendDone.sendDone | (stream_impl.dart:389 )
  | at _BufferingStreamSubscription._sendDone | (stream_impl.dart:399 )
  | at _BufferingStreamSubscription._close | (stream_impl.dart:283 )
  | at _SyncStreamControllerDispatch._sendDone | (stream_controller.dart:772 )
  | at _StreamController._closeUnchecked | (stream_controller.dart:629 )
  | at _StreamController.close | (stream_controller.dart:622 )
  | at _Socket._onData | (socket_patch.dart:1836 )
  | at _rootRunUnary | (zone.dart:1136 )
  | at _CustomZone.runUnary | (zone.dart:1029 )
  | at _CustomZone.runUnaryGuarded | (zone.dart:931 )
  | at _BufferingStreamSubscription._sendData | (stream_impl.dart:336 )
  | at _BufferingStreamSubscription._add | (stream_impl.dart:263 )
  | at _SyncStreamControllerDispatch._sendData | (stream_controller.dart:764 )
  | at _StreamController._add | (stream_controller.dart:640 )
  | at _StreamController.add | (stream_controller.dart:586 )
  | at new _RawSocket.<anonymous closure> | (socket_patch.dart:1384 )
  | at _NativeSocket.issueReadEvent.issue | (socket_patch.dart:890 )
  | at _microtaskLoop | (schedule_microtask.dart:41 )
  | at _startMicrotaskLoop | (schedule_microtask.dart:50 )
  | at _runPendingImmediateCallback | (isolate_patch.dart:116 )
  | at _RawReceivePortImpl._handleMessage | (isolate_patch.dart:173 )
```