### PR TITLE
Enable tests that failed due to CupertinoDynamicColor

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -74,10 +74,6 @@ const List<String> kWebTestFileBlacklist = <String>[
   'test/widgets/shortcuts_test.dart',
   'test/material/text_form_field_test.dart',
   'test/material/data_table_test.dart',
-
-  // TODO(yjbanov): CupertinoDynamicColor breaks the web engine. The fix
-  //                is on the engine side: https://github.com/flutter/engine/pull/13359
-  'test/cupertino/colors_test.dart',
   'test/cupertino/dialog_test.dart',
   'test/cupertino/nav_bar_test.dart',
   'test/cupertino/nav_bar_transition_test.dart',
@@ -88,8 +84,6 @@ const List<String> kWebTestFileBlacklist = <String>[
   'test/cupertino/slider_test.dart',
   'test/cupertino/text_field_test.dart',
   'test/cupertino/segmented_control_test.dart',
-  'test/cupertino/scaffold_test.dart',
-  'test/cupertino/route_test.dart',
   'test/cupertino/route_test.dart',
   'test/cupertino/activity_indicator_test.dart',
 ];


### PR DESCRIPTION
## Description

Enable tests that were waiting for https://github.com/flutter/engine/pull/13359, which has landed in flutter/flutter.

## Related Issues

Progress towards https://github.com/flutter/flutter/issues/41920 and https://github.com/flutter/flutter/projects/60.
