### PR TITLE
Reducing Gold requests on post-submit Cirrus shards

### DIFF
--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -451,8 +451,11 @@ class FlutterLocalFileComparator extends FlutterGoldenFileComparator with LocalC
 }
 
 /// A [FlutterGoldenFileComparator] for skipping golden image tests when the
-/// current environment is not supported. This comparator is used in post-submit
-/// checks on LUCI.
+/// current environment is not supported.
+///
+/// The [FlutterLocalFileComparator] is a catch-all for testing environments not
+/// covered by the other [FlutterGoldenFileComparator]s. This comparator is used
+/// in post-submit checks on LUCI and with some Cirrus shards.
 ///
 /// See also:
 ///
@@ -490,8 +493,8 @@ class FlutterSkippingGoldenFileComparator extends FlutterGoldenFileComparator {
   @override
   Future<bool> compare(Uint8List imageBytes, Uri golden) async {
     print(
-      'Skipping "$golden" test : Golden file testing is unavailble in LUCI'
-        'environment.'
+      'Skipping "$golden" test : Golden file testing is unavailable on LUCI and '
+        'some Cirrus shards.'
     );
     return true;
   }
@@ -503,6 +506,7 @@ class FlutterSkippingGoldenFileComparator extends FlutterGoldenFileComparator {
   /// skipped.
   static bool isAvailableForEnvironment(Platform platform) {
     final String luci = platform.environment['SWARMING_TASK_ID'] ?? '';
-    return luci.isNotEmpty;
+    final String cirrus = platform.environment['CIRRUS_CI'] ?? '';
+    return luci.isNotEmpty || cirrus.isNotEmpty;
   }
 }

--- a/packages/flutter_goldens/test/flutter_goldens_test.dart
+++ b/packages/flutter_goldens/test/flutter_goldens_test.dart
@@ -519,7 +519,7 @@ void main() {
     });
 
     group('Skipping', () {
-      test('correctly determines testing environment', () {
+      test('correctly determines testing environment on LUCI', () {
         platform = FakePlatform(
           environment: <String, String>{
             'FLUTTER_ROOT': _kFlutterRoot,
@@ -530,6 +530,33 @@ void main() {
         expect(
           FlutterSkippingGoldenFileComparator.isAvailableForEnvironment(platform),
           isTrue,
+        );
+      });
+
+      test('correctly determines testing environment on Cirrus', () {
+        platform = FakePlatform(
+          environment: <String, String>{
+            'FLUTTER_ROOT': _kFlutterRoot,
+            'CIRRUS_CI' : 'yep',
+          },
+          operatingSystem: 'macos'
+        );
+        expect(
+          FlutterSkippingGoldenFileComparator.isAvailableForEnvironment(platform),
+          isTrue,
+        );
+      });
+
+      test('correctly determines not a testing environment', () {
+        platform = FakePlatform(
+          environment: <String, String>{
+            'FLUTTER_ROOT': _kFlutterRoot,
+          },
+          operatingSystem: 'macos'
+        );
+        expect(
+          FlutterSkippingGoldenFileComparator.isAvailableForEnvironment(platform),
+          isFalse,
         );
       });
     });


### PR DESCRIPTION
## Description

This PR adds another condition for the `FlutterSkippingGoldenFileComparator`. 

Prior to https://github.com/flutter/flutter/pull/43371 landing, the `FlutterSkippingGoldenFileComparator` was a catch-all for tests that did not meet the conditions of post-submit testing. Now that Gold is supported locally, the `FlutterLocalFileComparator` is the catch-all, and is running unnecessarily on some Cirrus shards in post-submit.

## Tests

`FlutterSkippingGoldenFileComparator` determines the correct testing environment.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
