### PR TITLE
Enable heroes_test.dart on the web matrix

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -62,7 +62,6 @@ const int kWebBatchSize = 20;
 // TODO(yjbanov): we're getting rid of this blacklist as part of https://github.com/flutter/flutter/projects/60
 const List<String> kWebTestFileBlacklist = <String>[
   'test/examples/sector_layout_test.dart',
-  'test/widgets/heroes_test.dart',
   'test/widgets/text_test.dart',
   'test/widgets/selectable_text_test.dart',
   'test/widgets/color_filter_test.dart',

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -186,6 +186,7 @@ class MyStatefulWidgetState extends State<MyStatefulWidget> {
 
 Future<void> main() async {
   final ui.Image testImage = await createTestImage();
+  assert(testImage != null);
 
   setUp(() {
     transitionFromUserGestures = false;


### PR DESCRIPTION
## Description

Enable the heroes_test.dart after https://github.com/flutter/engine/pull/13391 lands.

## Related Issues

Progress towards https://github.com/flutter/flutter/projects/60
