### PR TITLE
Added a null check for ranges in the sourceReport map.

### DIFF
--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -245,24 +245,37 @@ void _buildCoverageMap(
   final Map<String, Map<int, int>> hitMaps = <String, Map<int, int>>{};
   for (String scriptId in scripts.keys) {
     final Map<String, dynamic> sourceReport = sourceReports[scriptId];
+    final Map<String, dynamic> scripts = sourceReport['scripts'];
+    final List<Map<String, Object>> ranges = sourceReport['ranges'];
     // Ranges may sometimes be null for a report.
-    if (sourceReport['ranges'] == null) {
+    if (ranges == null || scripts == null) {
       continue;
     }
-    for (Map<String, dynamic> range in sourceReport['ranges']) {
+    for (Map<String, dynamic> range in ranges) {
       final Map<String, dynamic> coverage = range['coverage'];
+      final String scriptIndex = range['scriptIndex'];
       // Coverage reports may sometimes be null for a Script.
-      if (coverage == null) {
+      if (coverage == null || scriptIndex == null) {
         continue;
       }
-      final Map<String, dynamic> scriptRef = sourceReport['scripts'][range['scriptIndex']];
+      final Map<String, dynamic> scriptRef = scripts[scriptIndex];
+      if (scriptRef == null) {
+        continue;
+      }
       final String uri = scriptRef['uri'];
-
+      final String id = scriptRef['id'];
+      if (uri == null || id == null) {
+        continue;
+      }
+      final Map<String, Object> scriptById = scripts[id];
+      if (scriptById == null) {
+        continue;
+      }
       hitMaps[uri] ??= <int, int>{};
       final Map<int, int> hitMap = hitMaps[uri];
       final List<dynamic> hits = coverage['hits'];
       final List<dynamic> misses = coverage['misses'];
-      final List<dynamic> tokenPositions = scripts[scriptRef['id']]['tokenPosTable'];
+      final List<dynamic> tokenPositions = scriptById['tokenPosTable'];
       // The token positions can be null if the script has no coverable lines.
       if (tokenPositions == null) {
         continue;

--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -245,6 +245,10 @@ void _buildCoverageMap(
   final Map<String, Map<int, int>> hitMaps = <String, Map<int, int>>{};
   for (String scriptId in scripts.keys) {
     final Map<String, dynamic> sourceReport = sourceReports[scriptId];
+    // Ranges may sometimes be null for a report.
+    if (sourceReport['ranges'] == null) {
+      continue;
+    }
     for (Map<String, dynamic> range in sourceReport['ranges']) {
       final Map<String, dynamic> coverage = range['coverage'];
       // Coverage reports may sometimes be null for a Script.

--- a/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
+++ b/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
@@ -20,14 +20,427 @@ void main() {
 
   test('Coverage collector Can handle coverage sentinenl data', () async {
     when(mockVMService.vm.isolates.first.invokeRpcRaw('getScripts', params: anyNamed('params')))
-      .thenAnswer((Invocation invocation) async {
-        return <String, Object>{'type': 'Sentinel', 'kind': 'Collected', 'valueAsString': '<collected>'};
-      });
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{'type': 'Sentinel', 'kind': 'Collected', 'valueAsString': '<collected>'};
+    });
     final Map<String, Object> result = await collect(null, (String predicate) => true, connector: (Uri uri) async {
       return mockVMService;
     });
 
     expect(result, <String, Object>{'type': 'CodeCoverage', 'coverage': <Object>[]});
+  });
+
+  test('Coverage collector can handle null scripts value', () async {
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getScripts', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{
+        'scripts': <Map<String, Object>>[
+          <String, Object>{'uri': 'some_uri', 'id': 'some_id'}
+        ]
+      };
+    });
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getSourceReport', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{
+        'ranges': <Map<String, Object>>[<String, Object>{}]
+      };
+    });
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getObject', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{};
+    });
+    final Map<String, Object> result = await collect(null, (String predicate) => true, connector: (Uri uri) async {
+      return mockVMService;
+    });
+
+    expect(result, <String, Object>{'type': 'CodeCoverage', 'coverage': <Object>[]});
+  });
+
+  test('Coverage collector can handle null ranges value', () async {
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getScripts', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{
+        'scripts': <Map<String, Object>>[
+          <String, Object>{'uri': 'some_uri', 'id': 'some_id'}
+        ]
+      };
+    });
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getSourceReport', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{'scripts': <String, Object>{}};
+    });
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getObject', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{};
+    });
+    final Map<String, Object> result = await collect(null, (String predicate) => true, connector: (Uri uri) async {
+      return mockVMService;
+    });
+
+    expect(result, <String, Object>{'type': 'CodeCoverage', 'coverage': <Object>[]});
+  });
+
+  test('Coverage collector can handle null scriptIndex values', () async {
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getScripts', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{
+        'scripts': <Map<String, Object>>[
+          <String, Object>{'uri': 'some_uri', 'id': 'some_id'}
+        ]
+      };
+    });
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getSourceReport', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{
+        'scripts': <String, Object>{'uri': 'some_uri', 'id': 'some_id'},
+        'ranges': <Map<String, Object>>[
+          <String, Object>{'coverage': <String, Object>{}}
+        ]
+      };
+    });
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getObject', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{};
+    });
+    final Map<String, Object> result = await collect(null, (String predicate) => true, connector: (Uri uri) async {
+      return mockVMService;
+    });
+
+    expect(result, <String, Object>{'type': 'CodeCoverage', 'coverage': <Object>[]});
+  });
+
+  test('Coverage collector can handle null scriptRef values', () async {
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getScripts', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{
+        'scripts': <Map<String, Object>>[
+          <String, Object>{'uri': 'some_uri', 'id': 'some_id'}
+        ]
+      };
+    });
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getSourceReport', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{
+        'scripts': <String, Object>{'uri': 'some_uri', 'id': 'some_id'},
+        'ranges': <Map<String, Object>>[
+          <String, Object>{'coverage': <String, Object>{}, 'scriptIndex': 'some_value'}
+        ]
+      };
+    });
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getObject', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{};
+    });
+    final Map<String, Object> result = await collect(null, (String predicate) => true, connector: (Uri uri) async {
+      return mockVMService;
+    });
+
+    expect(result, <String, Object>{'type': 'CodeCoverage', 'coverage': <Object>[]});
+  });
+
+  test('Coverage collector can handle null scriptRef uri values', () async {
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getScripts', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{
+        'scripts': <Map<String, Object>>[
+          <String, Object>{'uri': 'some_uri', 'id': 'some_id'}
+        ]
+      };
+    });
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getSourceReport', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{
+        'scripts': <String, Object>{'uri': 'some_uri', 'id': 'some_id', 'index_0': <String, Object>{}},
+        'ranges': <Map<String, Object>>[
+          <String, Object>{'coverage': <String, Object>{}, 'scriptIndex': 'index_0'}
+        ]
+      };
+    });
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getObject', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{};
+    });
+    final Map<String, Object> result = await collect(null, (String predicate) => true, connector: (Uri uri) async {
+      return mockVMService;
+    });
+
+    expect(result, <String, Object>{'type': 'CodeCoverage', 'coverage': <Object>[]});
+  });
+
+  test('Coverage collector can handle null scriptRef id values', () async {
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getScripts', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{
+        'scripts': <Map<String, Object>>[
+          <String, Object>{'uri': 'some_uri', 'id': 'some_id'}
+        ]
+      };
+    });
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getSourceReport', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{
+        'scripts': <String, Object>{
+          'uri': 'some_uri',
+          'id': 'some_id',
+          'index_0': <String, Object>{'uri': 'some_uri'}
+        },
+        'ranges': <Map<String, Object>>[
+          <String, Object>{'coverage': <String, Object>{}, 'scriptIndex': 'index_0'}
+        ]
+      };
+    });
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getObject', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{};
+    });
+    final Map<String, Object> result = await collect(null, (String predicate) => true, connector: (Uri uri) async {
+      return mockVMService;
+    });
+
+    expect(result, <String, Object>{'type': 'CodeCoverage', 'coverage': <Object>[]});
+  });
+
+  test('Coverage collector can handle null scriptById values', () async {
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getScripts', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{
+        'scripts': <Map<String, Object>>[
+          <String, Object>{'uri': 'some_uri', 'id': 'some_id'}
+        ]
+      };
+    });
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getSourceReport', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{
+        'scripts': <String, Object>{
+          'uri': 'some_uri',
+          'id': 'some_id',
+          'index_0': <String, Object>{'uri': 'some_uri', 'id': '01'},
+        },
+        'ranges': <Map<String, Object>>[
+          <String, Object>{'coverage': <String, Object>{}, 'scriptIndex': 'index_0'}
+        ]
+      };
+    });
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getObject', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{};
+    });
+    final Map<String, Object> result = await collect(null, (String predicate) => true, connector: (Uri uri) async {
+      return mockVMService;
+    });
+
+    expect(result, <String, Object>{'type': 'CodeCoverage', 'coverage': <Object>[]});
+  });
+
+  test('Coverage collector can handle null tokenPosTable values', () async {
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getScripts', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{
+        'scripts': <Map<String, Object>>[
+          <String, Object>{'uri': 'some_uri', 'id': 'some_id'}
+        ]
+      };
+    });
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getSourceReport', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{
+        'scripts': <String, Object>{
+          'uri': 'some_uri',
+          'id': 'some_id',
+          'index_0': <String, Object>{'uri': 'some_uri', 'id': '01'},
+          '01': <String, Object>{},
+        },
+        'ranges': <Map<String, Object>>[
+          <String, Object>{'coverage': <String, Object>{}, 'scriptIndex': 'index_0'}
+        ]
+      };
+    });
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getObject', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{};
+    });
+    final Map<String, Object> result = await collect(null, (String predicate) => true, connector: (Uri uri) async {
+      return mockVMService;
+    });
+
+    expect(result, <String, Object>{
+      'type': 'CodeCoverage',
+      'coverage': <Map<String, Object>>[
+        <String, Object>{
+          'source': 'some_uri',
+          'script': {
+            'type': '@Script',
+            'fixedId': true,
+            'id': 'libraries/1/scripts/some_uri',
+            'uri': 'some_uri',
+            '_kind': 'library'
+          },
+          'hits': <Map<String, Object>>[]
+        }
+      ]
+    });
+  });
+
+  test('Coverage collector can handle null hits values', () async {
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getScripts', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{
+        'scripts': <Map<String, Object>>[
+          <String, Object>{'uri': 'some_uri', 'id': 'some_id'}
+        ]
+      };
+    });
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getSourceReport', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{
+        'scripts': <String, Object>{
+          'uri': 'some_uri',
+          'id': 'some_id',
+          'index_0': <String, Object>{'uri': 'some_uri', 'id': '01'},
+          '01': <String, Object>{'tokenPosTable': <dynamic>[]},
+        },
+        'ranges': <Map<String, Object>>[
+          <String, Object>{'coverage': <String, Object>{}, 'scriptIndex': 'index_0'}
+        ]
+      };
+    });
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getObject', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{};
+    });
+    final Map<String, Object> result = await collect(null, (String predicate) => true, connector: (Uri uri) async {
+      return mockVMService;
+    });
+
+    expect(result, <String, Object>{
+      'type': 'CodeCoverage',
+      'coverage': <Map<String, Object>>[
+        <String, Object>{
+          'source': 'some_uri',
+          'script': {
+            'type': '@Script',
+            'fixedId': true,
+            'id': 'libraries/1/scripts/some_uri',
+            'uri': 'some_uri',
+            '_kind': 'library'
+          },
+          'hits': <Map<String, Object>>[]
+        }
+      ]
+    });
+  });
+
+  test('Coverage collector can handle null misses values', () async {
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getScripts', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{
+        'scripts': <Map<String, Object>>[
+          <String, Object>{'uri': 'some_uri', 'id': 'some_id'}
+        ]
+      };
+    });
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getSourceReport', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{
+        'scripts': <String, Object>{
+          'uri': 'some_uri',
+          'id': 'some_id',
+          'index_0': <String, Object>{'uri': 'some_uri', 'id': '01'},
+          '01': <String, Object>{'tokenPosTable': <dynamic>[]},
+        },
+        'ranges': <Map<String, Object>>[
+          <String, Object>{
+            'coverage': <String, Object>{'hits': <dynamic>[]},
+            'scriptIndex': 'index_0'
+          }
+        ]
+      };
+    });
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getObject', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{};
+    });
+    final Map<String, Object> result = await collect(null, (String predicate) => true, connector: (Uri uri) async {
+      return mockVMService;
+    });
+
+    expect(result, <String, Object>{
+      'type': 'CodeCoverage',
+      'coverage': <Map<String, Object>>[
+        <String, Object>{
+          'source': 'some_uri',
+          'script': {
+            'type': '@Script',
+            'fixedId': true,
+            'id': 'libraries/1/scripts/some_uri',
+            'uri': 'some_uri',
+            '_kind': 'library'
+          },
+          'hits': <Map<String, Object>>[]
+        }
+      ]
+    });
+  });
+
+  test('Coverage collector should process hits and misses', () async {
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getScripts', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{
+        'scripts': <Map<String, Object>>[
+          <String, Object>{'uri': 'some_uri', 'id': 'some_id'}
+        ]
+      };
+    });
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getSourceReport', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{
+        'scripts': <String, Object>{
+          'uri': 'some_uri',
+          'id': 'some_id',
+          'index_0': <String, Object>{'uri': 'some_uri', 'id': '01'},
+          '01': <String, Object>{
+            'tokenPosTable': <dynamic>[
+              <int>[1, 100, 5, 101, 8],
+              <int>[2, 102, 7],
+            ]
+          },
+        },
+        'ranges': <Map<String, Object>>[
+          <String, Object>{
+            'coverage': <String, Object>{
+              'hits': <dynamic>[100, 101],
+              'misses': <dynamic>[102],
+            },
+            'scriptIndex': 'index_0'
+          }
+        ]
+      };
+    });
+    when(mockVMService.vm.isolates.first.invokeRpcRaw('getObject', params: anyNamed('params')))
+        .thenAnswer((Invocation invocation) async {
+      return <String, Object>{};
+    });
+    final Map<String, Object> result = await collect(null, (String predicate) => true, connector: (Uri uri) async {
+      return mockVMService;
+    });
+
+    expect(result, <String, Object>{
+      'type': 'CodeCoverage',
+      'coverage': <Map<String, Object>>[
+        <String, Object>{
+          'source': 'some_uri',
+          'script': {
+            'type': '@Script',
+            'fixedId': true,
+            'id': 'libraries/1/scripts/some_uri',
+            'uri': 'some_uri',
+            '_kind': 'library'
+          },
+          'hits': <int>[1, 2, 2, 0]
+        }
+      ]
+    });
   });
 }
 
@@ -38,13 +451,13 @@ class MockVMService extends Mock implements VMService {
 
 class MockVM extends Mock implements VM {
   @override
-  final List<MockIsolate> isolates = <MockIsolate>[ MockIsolate() ];
+  final List<MockIsolate> isolates = <MockIsolate>[MockIsolate()];
 }
 
 class MockIsolate extends Mock implements Isolate {}
 
 class MockProcess extends Mock implements Process {
-  final Completer<int>completer = Completer<int>();
+  final Completer<int> completer = Completer<int>();
 
   @override
   Future<int> get exitCode => completer.future;

--- a/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
+++ b/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
@@ -269,7 +269,7 @@ void main() {
       'coverage': <Map<String, Object>>[
         <String, Object>{
           'source': 'some_uri',
-          'script': {
+          'script': <String, Object>{
             'type': '@Script',
             'fixedId': true,
             'id': 'libraries/1/scripts/some_uri',
@@ -318,7 +318,7 @@ void main() {
       'coverage': <Map<String, Object>>[
         <String, Object>{
           'source': 'some_uri',
-          'script': {
+          'script': <String, Object>{
             'type': '@Script',
             'fixedId': true,
             'id': 'libraries/1/scripts/some_uri',
@@ -370,7 +370,7 @@ void main() {
       'coverage': <Map<String, Object>>[
         <String, Object>{
           'source': 'some_uri',
-          'script': {
+          'script': <String, Object>{
             'type': '@Script',
             'fixedId': true,
             'id': 'libraries/1/scripts/some_uri',
@@ -430,7 +430,7 @@ void main() {
       'coverage': <Map<String, Object>>[
         <String, Object>{
           'source': 'some_uri',
-          'script': {
+          'script': <String, Object>{
             'type': '@Script',
             'fixedId': true,
             'id': 'libraries/1/scripts/some_uri',


### PR DESCRIPTION
## Description

I am adding a null checking throughout the functions that build the test coverage map. 

## Related Issues

This is related to https://github.com/flutter/flutter/issues/35907.

## Tests

I have added test cases for all of the null checks and the happy path.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [-] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
