### PR TITLE
Remove Poller class from flutter_tools

### DIFF
--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -8,7 +8,6 @@ import 'dart:math' show Random, max;
 import 'package:intl/intl.dart';
 
 import '../convert.dart';
-import '../globals.dart';
 import 'context.dart';
 import 'file_system.dart';
 import 'io.dart' as io;
@@ -257,45 +256,6 @@ Map<String, dynamic> castStringKeyedMap(dynamic untyped) {
 }
 
 typedef AsyncCallback = Future<void> Function();
-
-/// A [Timer] inspired class that:
-///   - has a different initial value for the first callback delay
-///   - waits for a callback to be complete before it starts the next timer
-class Poller {
-  Poller(this.callback, this.pollingInterval, { this.initialDelay = Duration.zero }) {
-    Future<void>.delayed(initialDelay, _handleCallback);
-  }
-
-  final AsyncCallback callback;
-  final Duration initialDelay;
-  final Duration pollingInterval;
-
-  bool _canceled = false;
-  Timer _timer;
-
-  Future<void> _handleCallback() async {
-    if (_canceled) {
-      return;
-    }
-
-    try {
-      await callback();
-    } catch (error) {
-      printTrace('Error from poller: $error');
-    }
-
-    if (!_canceled) {
-      _timer = Timer(pollingInterval, _handleCallback);
-    }
-  }
-
-  /// Cancels the poller.
-  void cancel() {
-    _canceled = true;
-    _timer?.cancel();
-    _timer = null;
-  }
-}
 
 /// Returns a [Future] that completes when all given [Future]s complete.
 ///

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -250,28 +250,32 @@ abstract class PollingDeviceDiscovery extends DeviceDiscovery {
 
   final String name;
   ItemListNotifier<Device> _items;
-  Poller _poller;
+  Timer _timer;
 
   Future<List<Device>> pollingGetDevices();
 
   void startPolling() {
-    if (_poller == null) {
+    if (_timer == null) {
       _items ??= ItemListNotifier<Device>();
-
-      _poller = Poller(() async {
-        try {
-          final List<Device> devices = await pollingGetDevices().timeout(_pollingTimeout);
-          _items.updateWithNewList(devices);
-        } on TimeoutException {
-          printTrace('Device poll timed out. Will retry.');
-        }
-      }, _pollingInterval);
+      _timer = _initTimer();
     }
   }
 
+  Timer _initTimer() {
+    return Timer(_pollingInterval, () async {
+      try {
+        final List<Device> devices = await pollingGetDevices().timeout(_pollingTimeout);
+        _items.updateWithNewList(devices);
+      } on TimeoutException {
+        printTrace('Device poll timed out. Will retry.');
+      }
+      _timer = _initTimer();
+    });
+  }
+
   void stopPolling() {
-    _poller?.cancel();
-    _poller = null;
+    _timer?.cancel();
+    _timer = null;
   }
 
   @override

--- a/packages/flutter_tools/test/general.shard/utils_test.dart
+++ b/packages/flutter_tools/test/general.shard/utils_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/utils.dart';
 import 'package:flutter_tools/src/base/version.dart';
@@ -119,56 +117,6 @@ baz=qux
       expect(v5, equals(v2));
 
       expect(Version.parse('Preview2.2'), isNull);
-    });
-  });
-
-  group('Poller', () {
-    const Duration kShortDelay = Duration(milliseconds: 100);
-
-    Poller poller;
-
-    tearDown(() {
-      poller?.cancel();
-    });
-
-    test('fires at start', () async {
-      bool called = false;
-      poller = Poller(() async {
-        called = true;
-      }, const Duration(seconds: 1));
-      expect(called, false);
-      await Future<void>.delayed(kShortDelay);
-      expect(called, true);
-    });
-
-    test('runs periodically', () async {
-      // Ensure we get the first (no-delay) callback, and one of the periodic callbacks.
-      int callCount = 0;
-      poller = Poller(() async {
-        callCount++;
-      }, Duration(milliseconds: kShortDelay.inMilliseconds ~/ 2));
-      expect(callCount, 0);
-      await Future<void>.delayed(kShortDelay);
-      expect(callCount, greaterThanOrEqualTo(2));
-    });
-
-    test('no quicker then the periodic delay', () async {
-      // Make sure that the poller polls at delay + the time it took to run the callback.
-      final Completer<Duration> completer = Completer<Duration>();
-      DateTime firstTime;
-      poller = Poller(() async {
-        if (firstTime == null) {
-          firstTime = DateTime.now();
-        } else {
-          completer.complete(DateTime.now().difference(firstTime));
-        }
-
-        // introduce a delay
-        await Future<void>.delayed(kShortDelay);
-      }, kShortDelay);
-      final Duration duration = await completer.future;
-      expect(
-          duration, greaterThanOrEqualTo(Duration(milliseconds: kShortDelay.inMilliseconds * 2)));
     });
   });
 


### PR DESCRIPTION
## Description

This class was only used a single place in PollingDeviceDiscovery. The semantics of poller can be achieved using a recursively scheduled non-periodic timer. The ability to specify a different starting delay was not used.

Fixes https://github.com/flutter/flutter/issues/43664