### PR TITLE
Make selected item get focus when dropdown is opened

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -100,6 +100,7 @@ class _DropdownScrollBehavior extends ScrollBehavior {
   ScrollPhysics getScrollPhysics(BuildContext context) => const ClampingScrollPhysics();
 }
 
+// The widget that is the button wrapping the menu items.
 class _DropdownMenuItemButton<T> extends StatefulWidget {
   const _DropdownMenuItemButton({
     Key key,
@@ -133,7 +134,8 @@ class _DropdownMenuItemButtonState<T> extends State<_DropdownMenuItemButton<T>> 
     }
 
     if (focused && inTraditionalMode) {
-      final _MenuLimits menuLimits = widget.route.getMenuLimits(widget.buttonRect, widget.constraints.maxHeight, widget.itemIndex);
+      final _MenuLimits menuLimits = widget.route.getMenuLimits(
+          widget.buttonRect, widget.constraints.maxHeight, widget.itemIndex);
       widget.route.scrollController.animateTo(
         menuLimits.scrollOffset,
         curve: Curves.easeInOut,
@@ -149,8 +151,6 @@ class _DropdownMenuItemButtonState<T> extends State<_DropdownMenuItemButton<T>> 
     );
   }
 
-  // On the web, enter doesn't select things, *except* in a <select>
-  // element, which is what a dropdown emulates.
   static final Map<LogicalKeySet, Intent> _webShortcuts =<LogicalKeySet, Intent>{
     LogicalKeySet(LogicalKeyboardKey.enter): const Intent(SelectAction.key),
   };
@@ -244,19 +244,16 @@ class _DropdownMenuState<T> extends State<_DropdownMenu<T>> {
     assert(debugCheckHasMaterialLocalizations(context));
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
     final _DropdownRoute<T> route = widget.route;
-    final double unit = 0.5 / (route.items.length + 1.5);
-    final List<Widget> children = <Widget>[];
-    for (int itemIndex = 0; itemIndex < route.items.length; ++itemIndex) {
-      children.add(
-          _DropdownMenuItemButton<T>(
-            route: widget.route,
-            padding: widget.padding,
-            buttonRect: widget.buttonRect,
-            constraints: widget.constraints,
-            itemIndex: itemIndex,
-          ),
-      );
-    }
+    final List<Widget> children = <Widget>[
+      for (int itemIndex = 0; itemIndex < route.items.length; ++itemIndex)
+        _DropdownMenuItemButton<T>(
+          route: widget.route,
+          padding: widget.padding,
+          buttonRect: widget.buttonRect,
+          constraints: widget.constraints,
+          itemIndex: itemIndex,
+        ),
+      ];
 
     return FadeTransition(
       opacity: _fadeOpacity,

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -2056,7 +2056,7 @@ void main() {
     final Element element = tester.element(find.byKey(const ValueKey<String>('two')).last);
     final FocusNode node = Focus.of(element);
     expect(node.hasFocus, isTrue);
-  });
+  }, skip: kIsWeb);
 
   testWidgets('Selected element is correctly focused with dropdown that more items than fit on the screen', (WidgetTester tester) async {
     final FocusNode focusNode = FocusNode(debugLabel: 'DropdownButton');
@@ -2119,7 +2119,7 @@ void main() {
     final Element element = tester.element(find.byKey(const ValueKey<int>(42)).last);
     final FocusNode node = Focus.of(element);
     expect(node.hasFocus, isTrue);
-  });
+  }, skip: kIsWeb);
 
   testWidgets("Having a focused element doesn't interrupt scroll when flung by touch", (WidgetTester tester) async {
     final FocusNode focusNode = FocusNode(debugLabel: 'DropdownButton');
@@ -2193,5 +2193,5 @@ void main() {
     // Scrolling to the top again has removed the one the focus was on from the
     // tree, causing it to lose focus.
     expect(Focus.of(tester.element(find.byKey(const ValueKey<int>(91)).last)).hasPrimaryFocus, isFalse);
-  });
+  }, skip: kIsWeb);
 }

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -7,6 +7,7 @@ import 'dart:ui' show window;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
@@ -2000,36 +2001,34 @@ void main() {
   testWidgets('Selected element is focused when dropdown is opened', (WidgetTester tester) async {
     final FocusNode focusNode = FocusNode(debugLabel: 'DropdownButton');
     String value = 'one';
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: Center(
-            child: StatefulBuilder(
-              builder: (BuildContext context, StateSetter setState) {
-                return DropdownButton<String>(
-                  focusNode: focusNode,
-                  autofocus: true,
-                  onChanged: (String newValue) {
-                    setState(() {
-                      value = newValue;
-                    });
-                  },
-                  value: value,
-                  itemHeight: null,
-                  items: menuItems.map<DropdownMenuItem<String>>((String item) {
-                    return DropdownMenuItem<String>(
-                      key: ValueKey<String>(item),
-                      value: item,
-                      child: Text(item, key: ValueKey<String>('Text $item')),
-                    );
-                  }).toList(),
-                );
-              },
-            ),
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return DropdownButton<String>(
+                focusNode: focusNode,
+                autofocus: true,
+                onChanged: (String newValue) {
+                  setState(() {
+                    value = newValue;
+                  });
+                },
+                value: value,
+                itemHeight: null,
+                items: menuItems.map<DropdownMenuItem<String>>((String item) {
+                  return DropdownMenuItem<String>(
+                    key: ValueKey<String>(item),
+                    value: item,
+                    child: Text(item, key: ValueKey<String>('Text $item')),
+                  );
+                }).toList(),
+              );
+            },
           ),
         ),
-      )
-    );
+      ),
+    ));
 
     await tester.pump(); // Pump a frame for autofocus to take effect.
     expect(focusNode.hasPrimaryFocus, isTrue);
@@ -2054,12 +2053,12 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(seconds: 1)); // finish the menu open animation
     expect(value, equals('two'));
-    final Element element =tester.element(find.byKey(const ValueKey<String>('two')).last);
+    final Element element = tester.element(find.byKey(const ValueKey<String>('two')).last);
     final FocusNode node = Focus.of(element);
     expect(node.hasFocus, isTrue);
   });
 
-  testWidgets('Selected element is correctly focused with a large dropdown', (WidgetTester tester) async {
+  testWidgets('Selected element is correctly focused with dropdown that more items than fit on the screen', (WidgetTester tester) async {
     final FocusNode focusNode = FocusNode(debugLabel: 'DropdownButton');
     int value = 1;
     final List<int> hugeMenuItems = List<int>.generate(50, (int index) => index);
@@ -2117,8 +2116,82 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(seconds: 1)); // finish the menu open animation
     expect(value, equals(42));
-    final Element element =tester.element(find.byKey(const ValueKey<int>(42)).last);
+    final Element element = tester.element(find.byKey(const ValueKey<int>(42)).last);
     final FocusNode node = Focus.of(element);
     expect(node.hasFocus, isTrue);
+  });
+
+  testWidgets("Having a focused element doesn't interrupt scroll when flung by touch", (WidgetTester tester) async {
+    final FocusNode focusNode = FocusNode(debugLabel: 'DropdownButton');
+    int value = 1;
+    final List<int> hugeMenuItems = List<int>.generate(100, (int index) => index);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: StatefulBuilder(
+              builder: (BuildContext context, StateSetter setState) {
+                return DropdownButton<int>(
+                  focusNode: focusNode,
+                  autofocus: true,
+                  onChanged: (int newValue) {
+                    setState(() {
+                      value = newValue;
+                    });
+                  },
+                  value: value,
+                  itemHeight: null,
+                  items: hugeMenuItems.map<DropdownMenuItem<int>>((int item) {
+                    return DropdownMenuItem<int>(
+                      key: ValueKey<int>(item),
+                      value: item,
+                      child: Text(item.toString(), key: ValueKey<String>('Text $item')),
+                    );
+                  }).toList(),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump(); // Pump a frame for autofocus to take effect.
+    expect(focusNode.hasPrimaryFocus, isTrue);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+    expect(value, equals(1));
+    expect(Focus.of(tester.element(find.byKey(const ValueKey<int>(1)).last)).hasPrimaryFocus, isTrue);
+
+    // Move to an item very far down the menu.
+    for (int i = 0; i < 90; ++i) {
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab); // Move to the next one.
+      await tester.pumpAndSettle(); // Wait for it to animate the menu.
+    }
+    expect(Focus.of(tester.element(find.byKey(const ValueKey<int>(91)).last)).hasPrimaryFocus, isTrue);
+
+    // Scroll back to the top using touch, and make sure we end up there.
+    final Finder menu = find.byWidgetPredicate((Widget widget) {
+      return widget.runtimeType.toString().startsWith('_DropdownMenu<');
+    });
+    final Rect menuRect = tester.getRect(menu).shift(tester.getTopLeft(menu));
+    for (int i = 0; i < 10; ++i) {
+      await tester.fling(menu, Offset(0.0, menuRect.height), 10.0);
+    }
+    await tester.pumpAndSettle();
+
+    // Make sure that we made it to the top and something didn't stop the
+    // scroll.
+    expect(find.byKey(const ValueKey<int>(1)), findsNWidgets(2));
+    expect(
+      tester.getRect(find.byKey(const ValueKey<int>(1)).last),
+      equals(const Rect.fromLTRB(372.0, 104.0, 436.0, 152.0)),
+    );
+
+    // Scrolling to the top again has removed the one the focus was on from the
+    // tree, causing it to lose focus.
+    expect(Focus.of(tester.element(find.byKey(const ValueKey<int>(91)).last)).hasPrimaryFocus, isFalse);
   });
 }


### PR DESCRIPTION
## Description

As it stands, dropdowns currently do not focus the item that is selected, so if you select something on a dropdown, and then close it, and re-open it, then the new item is not auto-focused. This PR changes that so that selected value is focused by default when the dropdown is re-opened.

## Tests

- Added tests for making sure that the right element is focused when a dropdown opens, and that the dropdown itself is focused when the dropdown is closed.

## Breaking Change

- [X] Yes, this is a breaking change, because it changes the focus behavior of dropdowns. Only dropdowns that expect to control focus themselves are affected.