### PR TITLE
Add reloadMethod RPC

### DIFF
--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -123,16 +123,9 @@ class VMService {
         final bool force = params.asMap['force'] ?? false;
         final bool pause = params.asMap['pause'] ?? false;
 
-        if (isolateId is! String || isolateId.isEmpty) {
+        if (isolateId.isEmpty) {
           throw rpc.RpcException.invalidParams('Invalid \'isolateId\': $isolateId');
         }
-        if (force is! bool) {
-          throw rpc.RpcException.invalidParams('Invalid \'force\': $force');
-        }
-        if (pause is! bool) {
-          throw rpc.RpcException.invalidParams('Invalid \'pause\': $pause');
-        }
-
         try {
           await reloadSources(isolateId, force: force, pause: pause);
           return <String, String>{'type': 'Success'};
@@ -154,13 +147,10 @@ class VMService {
       // to change to a more efficient implementation in the future.
       _peer.registerMethod('reloadMethod', (rpc.Parameters params) async {
         final String isolateId = params['isolateId'].value;
-        final bool force = params.asMap['force'] ?? false;
-        final bool pause = params.asMap['pause'] ?? false;
-
         printTrace('reloadMethod not yet supported, falling back to hot reload');
 
         try {
-          await reloadSources(isolateId, force: force, pause: pause);
+          await reloadSources(isolateId);
           return <String, String>{'type': 'Success'};
         } on rpc.RpcException {
           rethrow;

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -147,6 +147,24 @@ class VMService {
       // to change to a more efficient implementation in the future.
       _peer.registerMethod('reloadMethod', (rpc.Parameters params) async {
         final String isolateId = params['isolateId'].value;
+        final String libraryId = params['library'].value;
+        final String classId = params['class'].value;
+        final String methodId = params['method'].value;
+        final String methodBody = params['methodBody'].value;
+
+        if (libraryId.isEmpty) {
+          throw rpc.RpcException.invalidParams('Invalid \'libraryId\': $libraryId');
+        }
+        if (classId.isEmpty) {
+          throw rpc.RpcException.invalidParams('Invalid \'classId\': $classId');
+        }
+        if (methodId.isEmpty) {
+          throw rpc.RpcException.invalidParams('Invalid \'methodId\': $methodId');
+        }
+        if (methodBody.isEmpty) {
+          throw rpc.RpcException.invalidParams('Invalid \'methodBody\': $methodBody');
+        }
+
         printTrace('reloadMethod not yet supported, falling back to hot reload');
 
         try {

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -148,6 +148,31 @@ class VMService {
         'service': 'reloadSources',
         'alias': 'Flutter Tools',
       });
+
+      // Register a special method for hot UI. while this is implemented
+      // currently in the same way as hot reload, it leaves the tool free
+      // to change to a more efficient implementation in the future.
+      _peer.registerMethod('reloadMethod', (rpc.Parameters params) async {
+        final String isolateId = params['isolateId'].value;
+        final bool force = params.asMap['force'] ?? false;
+        final bool pause = params.asMap['pause'] ?? false;
+
+        printTrace('reloadMethod not yet supported, falling back to hot reload');
+
+        try {
+          await reloadSources(isolateId, force: force, pause: pause);
+          return <String, String>{'type': 'Success'};
+        } on rpc.RpcException {
+          rethrow;
+        } catch (e, st) {
+          throw rpc.RpcException(rpc_error_code.SERVER_ERROR,
+              'Error during Sources Reload: $e\n$st');
+        }
+      });
+      _peer.sendNotification('registerService', <String, String>{
+        'service': 'reloadMethod',
+        'alias': 'Flutter Tools',
+      });
     }
 
     if (restart != null) {

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -47,7 +47,7 @@ class MockPeer implements rpc.Peer {
 
   @override
   void registerMethod(String name, Function callback) {
-    // this does get called
+    registeredMethods.add(name);
   }
 
   @override
@@ -57,6 +57,7 @@ class MockPeer implements rpc.Peer {
   }
 
   Map<String, List<dynamic>> sentNotifications = <String, List<dynamic>>{};
+  List<String> registeredMethods = <String>[];
 
   bool isolatesEnabled = false;
 
@@ -258,6 +259,19 @@ void main() {
         expect(done, isTrue);
         expect(mockStdio.writtenToStdout.join(''), message);
         expect(mockStdio.writtenToStderr.join(''), '');
+      });
+    }, overrides: <Type, Generator>{
+      Logger: () => StdoutLogger(),
+      Stdio: () => mockStdio,
+    });
+
+     testUsingContext('registers hot UI method', () {
+      FakeAsync().run((FakeAsync time) {
+        final MockPeer mockPeer = MockPeer();
+        Future<void> reloadSources(String isolateId, { bool pause, bool force}) async {}
+        VMService(mockPeer, null, null, reloadSources, null, null);
+
+        expect(mockPeer.registeredMethods, contains('reloadMethod'));
       });
     }, overrides: <Type, Generator>{
       Logger: () => StdoutLogger(),


### PR DESCRIPTION
## Description

This method will allow the tool to replace hot reload with a more efficient implementation specifically for hot UI in the future. For now it delegates to reloadSources.

Note: removed unreachable type error checking