### PR TITLE
Fixed onSort bug in data_table.dart

### DIFF
--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -443,6 +443,11 @@ class DataTable extends StatelessWidget {
         textDirection: numeric ? TextDirection.rtl : null,
         children: <Widget>[ label, arrowPadding, arrow ],
       );
+    } else {
+      label = Row(
+        textDirection: numeric ? TextDirection.rtl : null,
+        children: <Widget>[ label ],
+      );
     }
     label = Container(
       padding: padding,

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -618,7 +618,7 @@ class DataTable extends StatelessWidget {
         label: column.label,
         tooltip: column.tooltip,
         numeric: column.numeric,
-        onSort: () => column.onSort != null ? column.onSort(dataColumnIndex, sortColumnIndex != dataColumnIndex || !sortAscending) : null,
+        onSort: column.onSort != null ? () => column.onSort(dataColumnIndex, sortColumnIndex != dataColumnIndex || !sortAscending) : null,
         sorted: dataColumnIndex == sortColumnIndex,
         ascending: sortAscending,
       );


### PR DESCRIPTION
## Problem
A bad comparison argument on a ternary operator made it impossible for a null value to be passed into `_buildHeadingCell`'s `onSort` parameter causing alignment problems described in the related issues referenced below.

## Description
### Short explanation of my fix
So for the line
```dart
onSort: () => column.onSort != null ? column.onSort(dataColumnIndex, sortColumnIndex != dataColumnIndex || !sortAscending) : null
```
the comparison argument is `column.onSort != null` instead of `() => column.onSort != null`. That is where the problem lies. Because the `onSort` parameter will either take `() => column.onSort(dataColumnIndex, sortColumnIndex != dataColumnIndex || !sortAscending)` or `() => null` and **BOTH** are non-null VoidCallback functions.
If you remove the `() =>` from in front of the comparison argument, you fix that problem; however, you still need to return a callback function or null so change the second argument to `() => column.onSort(dataColumnIndex, sortColumnIndex != dataColumnIndex || !sortAscending)` so that is passes a VoidCallback function.

### Long explanation of my fix

```dart
typedef VoidCallback = void Function();

void myFunction({VoidCallback myCallback}) {
  if (myCallback != null) {
    print("myCallback is NOT null. Calling myCallback now.");
    myCallback();
  } else {
    print("myCallback is null!");
  }
}

void main() {
  VoidCallback callback0;
  VoidCallback callback1 = () => print("callback1");

  /* This is how it should be
   * -------------------------------------------
   * We check if the callback0 has been defined.
   * If it has, then we pass
   * 
   * callback0
   * 
   * as the parameter, if not, we pass
   * 
   * null
   * 
   * as the parameter.
   */
  myFunction(myCallback: callback0 != null ? callback0 : null);

  /* This is the logic data_table.dart implements
   * -------------------------------------------
   * We check if the callback0 has been defined.
   * If it has, then we pass
   * 
   * () => callback0
   * 
   * as the parameter, if not, we pass
   * 
   * () => null
   * 
   * as the parameter.
   * 
   * Regardless of whether callback0 is null or not,
   * this results in a non-null VoidCallback function
   * being passed as the parameter because both
   * 
   * () => callback0
   * 
   * and 
   * 
   * () => null
   * 
   * are non-null VoidCallback functions because
   * they are defined with that line.
   * 
   * This results in the if statement
   * 
   * if (onSort != null) [this is currently on line 435 of data_table.dart]
   * 
   * always evaluating to true.
   */
  myFunction(myCallback: () => callback0 != null ? callback0 : null);
}

```

## Related Issues
- These issues will be fixed by this pull request
  - https://github.com/flutter/flutter/issues/26845
  - https://github.com/flutter/flutter/issues/40526

## Tests

I didn't add any tests as this is already a part of Flutter's code and is an incredibly simple fix.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
