### PR TITLE
[WIP] Track element instances in running application

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3210,7 +3210,6 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
     assert(() {
       _debugLifecycleState = _ElementLifecycle.active;
       WidgetInspectorService.instance.activateElement(this);
-      // _debugElementLocations['something'] = this;
       return true;
     }());
     if (_dirty)
@@ -3250,7 +3249,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
     _inheritedWidgets = null;
     _active = false;
     assert(() {
-       WidgetInspectorService.instance.deactivateElement(this);
+      WidgetInspectorService.instance.activateElement(this);
       _debugLifecycleState = _ElementLifecycle.inactive;
       return true;
     }());

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -11,6 +11,7 @@ import 'package:flutter/rendering.dart';
 
 import 'debug.dart';
 import 'focus_manager.dart';
+import 'widget_inspector.dart';
 
 export 'dart:ui' show hashValues, hashList;
 
@@ -3208,6 +3209,8 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
     _updateInheritance();
     assert(() {
       _debugLifecycleState = _ElementLifecycle.active;
+      WidgetInspectorService.instance.activateElement(this);
+      // _debugElementLocations['something'] = this;
       return true;
     }());
     if (_dirty)
@@ -3247,6 +3250,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
     _inheritedWidgets = null;
     _active = false;
     assert(() {
+       WidgetInspectorService.instance.deactivateElement(this);
       _debugLifecycleState = _ElementLifecycle.inactive;
       return true;
     }());


### PR DESCRIPTION
## Description

Allows invalidation of a subset of the widget tree, when provided with file/line/column information. Currently registered in the WidgetInspector extensions due to the visibility constraints on `_Location`. Probably doesn't quite work yet


cc @jacob314 