### PR TITLE
Gold Performance improvements

### DIFF
--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -233,14 +233,12 @@ class FlutterSkiaGoldFileComparator extends FlutterGoldenFileComparator {
   /// Decides based on the current environment whether goldens tests should be
   /// performed against Skia Gold.
   static bool isAvailableForEnvironment(Platform platform) {
-    final String cirrusCI = platform.environment['CIRRUS_CI'] ?? '';
     final String cirrusPR = platform.environment['CIRRUS_PR'] ?? '';
     final String cirrusBranch = platform.environment['CIRRUS_BRANCH'] ?? '';
-    final String goldServiceAccount = platform.environment['GOLD_SERVICE_ACCOUNT'] ?? '';
-    return cirrusCI.isNotEmpty
+    return platform.environment.containsKey('CIRRUS_CI')
       && cirrusPR.isEmpty
       && cirrusBranch == 'master'
-      && goldServiceAccount.isNotEmpty;
+      && platform.environment.containsKey('GOLD_SERVICE_ACCOUNT');
   }
 }
 
@@ -340,9 +338,68 @@ class FlutterPreSubmitFileComparator extends FlutterGoldenFileComparator {
   /// Decides based on the current environment whether goldens tests should be
   /// performed as pre-submit tests with Skia Gold.
   static bool isAvailableForEnvironment(Platform platform) {
-    final String cirrusCI = platform.environment['CIRRUS_CI'] ?? '';
     final String cirrusPR = platform.environment['CIRRUS_PR'] ?? '';
-    return cirrusCI.isNotEmpty && cirrusPR.isNotEmpty;
+    return platform.environment.containsKey('CIRRUS_CI')
+      && cirrusPR.isNotEmpty;
+  }
+}
+
+/// A [FlutterGoldenFileComparator] for controlling post-submit testing
+/// conditions that do not execute golden file tests.
+///
+/// Currently, this comparator is used in post-submit checks on LUCI and with
+/// some Cirrus shards that do not run framework tests.
+///
+/// See also:
+///
+///  * [FlutterGoldensRepositoryFileComparator], another
+///    [FlutterGoldenFileComparator] that tests golden images using the
+///    flutter/goldens repository.
+///  * [FlutterSkiaGoldFileComparator], another [FlutterGoldenFileComparator]
+///    that tests golden images through Skia Gold.
+///  * [FlutterPreSubmitFileComparator], another
+///    [FlutterGoldenFileComparator] that tests golden images before changes are
+///    merged into the master branch.
+///  * [FlutterLocalFileComparator], another
+///    [FlutterGoldenFileComparator] that tests golden images locally on your
+///    current machine.
+class FlutterSkippingGoldenFileComparator extends FlutterGoldenFileComparator {
+  /// Creates a [FlutterSkippingGoldenFileComparator] that will skip tests that
+  /// are not in the right environment for golden file testing.
+  FlutterSkippingGoldenFileComparator(
+    final Uri basedir,
+    final SkiaGoldClient skiaClient,
+  ) : super(basedir, skiaClient);
+
+  /// Creates a new [FlutterSkippingGoldenFileComparator] that mirrors the
+  /// relative path resolution of the default [goldenFileComparator].
+  static FlutterSkippingGoldenFileComparator fromDefaultComparator({
+    LocalFileComparator defaultComparator,
+  }) {
+    defaultComparator ??= goldenFileComparator;
+    const FileSystem fs = LocalFileSystem();
+    final Uri basedir = defaultComparator.basedir;
+    final SkiaGoldClient skiaClient = SkiaGoldClient(fs.directory(basedir));
+    return FlutterSkippingGoldenFileComparator(basedir, skiaClient);
+  }
+
+  @override
+  Future<bool> compare(Uint8List imageBytes, Uri golden) async {
+    print(
+      'Skipping "$golden" test : Golden file testing is unavailable on LUCI and '
+        'some Cirrus shards.'
+    );
+    return true;
+  }
+
+  @override
+  Future<void> update(Uri golden, Uint8List imageBytes) => null;
+
+  /// Decides based on the current environment whether this comparator should be
+  /// used.
+  static bool isAvailableForEnvironment(Platform platform) {
+    return platform.environment.containsKey('SWARMING_TASK_ID')
+      || platform.environment.containsKey('CIRRUS_CI');
   }
 }
 
@@ -350,11 +407,14 @@ class FlutterPreSubmitFileComparator extends FlutterGoldenFileComparator {
 /// current machine.
 ///
 /// This comparator utilizes the [SkiaGoldClient] to request baseline images for
-/// the given device under test for comparison. This comparator is only
-/// initialized when running tests locally, and is intended to serve as a smoke
-/// test during development. As such, it will not be able to detect unintended
-/// changes on other machines until it they are tested using the
-/// [FlutterPreSubmitFileComparator].
+/// the given device under test for comparison. This comparator is initialized
+/// when conditions for all other [FlutterGoldenFileComparators] have not been
+/// met, see the `isAvailableForEnvironment` method for each one listed below.
+///
+/// The [FlutterLocalFileComparator] is intended to run on local machines and
+/// serve as a smoke test during development. As such, it will not be able to
+/// detect unintended changes on other machines until it they are tested using
+/// the [FlutterPreSubmitFileComparator].
 ///
 /// See also:
 ///
@@ -366,6 +426,8 @@ class FlutterPreSubmitFileComparator extends FlutterGoldenFileComparator {
 ///  * [FlutterPreSubmitFileComparator], another
 ///    [FlutterGoldenFileComparator] that tests golden images before changes are
 ///    merged into the master branch.
+///  * [FlutterSkippingGoldenFileComparator], another
+///    [FlutterGoldenFileComparator] that controls .
 class FlutterLocalFileComparator extends FlutterGoldenFileComparator with LocalComparisonOutput {
   /// Creates a [FlutterLocalFileComparator] that will test golden file
   /// images against baselines requested from Flutter Gold.
@@ -375,9 +437,9 @@ class FlutterLocalFileComparator extends FlutterGoldenFileComparator with LocalC
   FlutterLocalFileComparator(
     final Uri basedir,
     final SkiaGoldClient skiaClient, {
-    final FileSystem fs = const LocalFileSystem(),
-    final Platform platform = const LocalPlatform(),
-  }) : super(
+      final FileSystem fs = const LocalFileSystem(),
+      final Platform platform = const LocalPlatform(),
+    }) : super(
     basedir,
     skiaClient,
     fs: fs,
@@ -391,9 +453,9 @@ class FlutterLocalFileComparator extends FlutterGoldenFileComparator with LocalC
   /// purposes only.
   static Future<FlutterGoldenFileComparator> fromDefaultComparator(
     final Platform platform, {
-    SkiaGoldClient goldens,
-    LocalFileComparator defaultComparator,
-  }) async {
+      SkiaGoldClient goldens,
+      LocalFileComparator defaultComparator,
+    }) async {
 
     defaultComparator ??= goldenFileComparator;
     final Directory baseDirectory = FlutterGoldenFileComparator.getBaseDirectory(
@@ -447,66 +509,5 @@ class FlutterLocalFileComparator extends FlutterGoldenFileComparator with LocalC
         generateFailureOutput(result, golden, basedir, key: expectation);
     });
     return false;
-  }
-}
-
-/// A [FlutterGoldenFileComparator] for skipping golden image tests when the
-/// current environment is not supported.
-///
-/// The [FlutterLocalFileComparator] is a catch-all for testing environments not
-/// covered by the other [FlutterGoldenFileComparator]s. This comparator is used
-/// in post-submit checks on LUCI and with some Cirrus shards.
-///
-/// See also:
-///
-///  * [FlutterGoldensRepositoryFileComparator], another
-///    [FlutterGoldenFileComparator] that tests golden images using the
-///    flutter/goldens repository.
-///  * [FlutterSkiaGoldFileComparator], another [FlutterGoldenFileComparator]
-///    that tests golden images through Skia Gold.
-///  * [FlutterPreSubmitFileComparator], another
-///    [FlutterGoldenFileComparator] that tests golden images before changes are
-///    merged into the master branch.
-///  * [FlutterLocalFileComparator], another
-///    [FlutterGoldenFileComparator] that tests golden images locally on your
-///    current machine.
-class FlutterSkippingGoldenFileComparator extends FlutterGoldenFileComparator {
-  /// Creates a [FlutterSkippingGoldenFileComparator] that will skip tests that
-  /// are not in the right environment for golden file testing.
-  FlutterSkippingGoldenFileComparator(
-    final Uri basedir,
-    final SkiaGoldClient skiaClient,
-  ) : super(basedir, skiaClient);
-
-  /// Creates a new [FlutterSkippingGoldenFileComparator] that mirrors the
-  /// relative path resolution of the default [goldenFileComparator].
-  static FlutterSkippingGoldenFileComparator fromDefaultComparator({
-    LocalFileComparator defaultComparator,
-  }) {
-    defaultComparator ??= goldenFileComparator;
-    const FileSystem fs = LocalFileSystem();
-    final Uri basedir = defaultComparator.basedir;
-    final SkiaGoldClient skiaClient = SkiaGoldClient(fs.directory(basedir));
-    return FlutterSkippingGoldenFileComparator(basedir, skiaClient);
-  }
-
-  @override
-  Future<bool> compare(Uint8List imageBytes, Uri golden) async {
-    print(
-      'Skipping "$golden" test : Golden file testing is unavailable on LUCI and '
-        'some Cirrus shards.'
-    );
-    return true;
-  }
-
-  @override
-  Future<void> update(Uri golden, Uint8List imageBytes) => null;
-
-  /// Decides based on the current environment whether goldens tests should be
-  /// skipped.
-  static bool isAvailableForEnvironment(Platform platform) {
-    final String luci = platform.environment['SWARMING_TASK_ID'] ?? '';
-    final String cirrus = platform.environment['CIRRUS_CI'] ?? '';
-    return luci.isNotEmpty || cirrus.isNotEmpty;
   }
 }

--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -331,7 +331,7 @@ class FlutterPreSubmitFileComparator extends FlutterGoldenFileComparator {
       }
     }
 
-    return skiaClient.testIsIgnored(
+    return skiaClient.testIsIgnoredForPullRequest(
       platform.environment['CIRRUS_PR'] ?? '',
       golden.path,
     );

--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -388,7 +388,7 @@ class FlutterSkippingGoldenFileComparator extends FlutterGoldenFileComparator {
   Future<bool> compare(Uint8List imageBytes, Uri golden) async {
     print(
       'Skipping "$golden" test : Golden file testing is unavailable on LUCI and '
-        'some Cirrus shards.'
+      'some Cirrus shards.'
     );
     return true;
   }
@@ -414,8 +414,8 @@ class FlutterSkippingGoldenFileComparator extends FlutterGoldenFileComparator {
 ///
 /// The [FlutterLocalFileComparator] is intended to run on local machines and
 /// serve as a smoke test during development. As such, it will not be able to
-/// detect unintended changes on other machines until it they are tested using
-/// the [FlutterPreSubmitFileComparator].
+/// detect unintended changes on environments other than the currently executing
+/// machine, until it they are tested using the [FlutterPreSubmitFileComparator].
 ///
 /// See also:
 ///
@@ -428,7 +428,8 @@ class FlutterSkippingGoldenFileComparator extends FlutterGoldenFileComparator {
 ///    [FlutterGoldenFileComparator] that tests golden images before changes are
 ///    merged into the master branch.
 ///  * [FlutterSkippingGoldenFileComparator], another
-///    [FlutterGoldenFileComparator] that controls .
+///    [FlutterGoldenFileComparator] that controls post-submit testing
+///    conditions that do not execute golden file tests.
 class FlutterLocalFileComparator extends FlutterGoldenFileComparator with LocalComparisonOutput {
   /// Creates a [FlutterLocalFileComparator] that will test golden file
   /// images against baselines requested from Flutter Gold.

--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -331,7 +331,7 @@ class FlutterPreSubmitFileComparator extends FlutterGoldenFileComparator {
       }
     }
 
-    return skiaClient.testIsIgnoredForPullRequest(
+    return skiaClient.testIsIgnored(
       platform.environment['CIRRUS_PR'] ?? '',
       golden.path,
     );
@@ -342,7 +342,10 @@ class FlutterPreSubmitFileComparator extends FlutterGoldenFileComparator {
   static bool isAvailableForEnvironment(Platform platform) {
     final String cirrusCI = platform.environment['CIRRUS_CI'] ?? '';
     final String cirrusPR = platform.environment['CIRRUS_PR'] ?? '';
-    return cirrusCI.isNotEmpty && cirrusPR.isNotEmpty;
+    final String goldServiceAccount = platform.environment['GOLD_SERVICE_ACCOUNT'] ?? '';
+    return cirrusCI.isNotEmpty
+      && cirrusPR.isNotEmpty
+      && goldServiceAccount.isNotEmpty;
   }
 }
 
@@ -490,7 +493,7 @@ class FlutterSkippingGoldenFileComparator extends FlutterGoldenFileComparator {
   @override
   Future<bool> compare(Uint8List imageBytes, Uri golden) async {
     print(
-      'Skipping "$golden" test : Golden file testing is unavailble in LUCI'
+      'Skipping "$golden" test : Golden file testing is unavailable in LUCI '
         'environment.'
     );
     return true;

--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -438,9 +438,9 @@ class FlutterLocalFileComparator extends FlutterGoldenFileComparator with LocalC
   FlutterLocalFileComparator(
     final Uri basedir,
     final SkiaGoldClient skiaClient, {
-      final FileSystem fs = const LocalFileSystem(),
-      final Platform platform = const LocalPlatform(),
-    }) : super(
+    final FileSystem fs = const LocalFileSystem(),
+    final Platform platform = const LocalPlatform(),
+  }) : super(
     basedir,
     skiaClient,
     fs: fs,
@@ -454,9 +454,9 @@ class FlutterLocalFileComparator extends FlutterGoldenFileComparator with LocalC
   /// purposes only.
   static Future<FlutterGoldenFileComparator> fromDefaultComparator(
     final Platform platform, {
-      SkiaGoldClient goldens,
-      LocalFileComparator defaultComparator,
-    }) async {
+    SkiaGoldClient goldens,
+    LocalFileComparator defaultComparator,
+  }) async {
 
     defaultComparator ??= goldenFileComparator;
     final Directory baseDirectory = FlutterGoldenFileComparator.getBaseDirectory(

--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -451,8 +451,11 @@ class FlutterLocalFileComparator extends FlutterGoldenFileComparator with LocalC
 }
 
 /// A [FlutterGoldenFileComparator] for skipping golden image tests when the
-/// current environment is not supported. This comparator is used in post-submit
-/// checks on LUCI.
+/// current environment is not supported.
+///
+/// The [FlutterLocalFileComparator] is a catch-all for testing environments not
+/// covered by the other [FlutterGoldenFileComparator]s. This comparator is used
+/// in post-submit checks on LUCI and with some Cirrus shards.
 ///
 /// See also:
 ///
@@ -490,8 +493,8 @@ class FlutterSkippingGoldenFileComparator extends FlutterGoldenFileComparator {
   @override
   Future<bool> compare(Uint8List imageBytes, Uri golden) async {
     print(
-      'Skipping "$golden" test : Golden file testing is unavailble in LUCI'
-        'environment.'
+      'Skipping "$golden" test : Golden file testing is unavailable on LUCI and '
+        'some Cirrus shards.'
     );
     return true;
   }
@@ -503,6 +506,7 @@ class FlutterSkippingGoldenFileComparator extends FlutterGoldenFileComparator {
   /// skipped.
   static bool isAvailableForEnvironment(Platform platform) {
     final String luci = platform.environment['SWARMING_TASK_ID'] ?? '';
-    return luci.isNotEmpty;
+    final String cirrus = platform.environment['CIRRUS_CI'] ?? '';
+    return luci.isNotEmpty || cirrus.isNotEmpty;
   }
 }

--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -415,7 +415,7 @@ class FlutterSkippingGoldenFileComparator extends FlutterGoldenFileComparator {
 /// The [FlutterLocalFileComparator] is intended to run on local machines and
 /// serve as a smoke test during development. As such, it will not be able to
 /// detect unintended changes on environments other than the currently executing
-/// machine, until it they are tested using the [FlutterPreSubmitFileComparator].
+/// machine, until they are tested using the [FlutterPreSubmitFileComparator].
 ///
 /// See also:
 ///

--- a/packages/flutter_goldens/test/flutter_goldens_test.dart
+++ b/packages/flutter_goldens/test/flutter_goldens_test.dart
@@ -226,6 +226,7 @@ void main() {
                 expires: DateTime.now()
                   .add(const Duration(days: 1))
                   .toString(),
+                otherTestName: 'unrelatedTest.1'
               )
           ));
           when(mockHttpClient.getUrl(url))
@@ -268,6 +269,48 @@ void main() {
           mockHttpResponse = MockHttpClientResponse(utf8.encode(
             ignoreResponseTemplate(
               pullRequestNumber: pullRequestNumber,
+            )
+          ));
+          when(mockHttpRequest.close())
+            .thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
+          final Future<bool> test = skiaClient.testIsIgnoredForPullRequest(
+            pullRequestNumber,
+            testName,
+          );
+          expect(
+            test,
+            throwsException,
+          );
+        });
+
+        test('throws exception for first expired ignore among multiple', () async {
+          mockHttpResponse = MockHttpClientResponse(utf8.encode(
+            ignoreResponseTemplate(
+              pullRequestNumber: pullRequestNumber,
+              otherExpires: DateTime.now()
+                .add(const Duration(days: 1))
+                .toString(),
+            )
+          ));
+          when(mockHttpRequest.close())
+            .thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
+          final Future<bool> test = skiaClient.testIsIgnoredForPullRequest(
+            pullRequestNumber,
+            testName,
+          );
+          expect(
+            test,
+            throwsException,
+          );
+        });
+
+        test('throws exception for later expired ignore among multiple', () async {
+          mockHttpResponse = MockHttpClientResponse(utf8.encode(
+            ignoreResponseTemplate(
+              pullRequestNumber: pullRequestNumber,
+              expires: DateTime.now()
+                .add(const Duration(days: 1))
+                .toString(),
             )
           ));
           when(mockHttpRequest.close())

--- a/packages/flutter_goldens/test/flutter_goldens_test.dart
+++ b/packages/flutter_goldens/test/flutter_goldens_test.dart
@@ -264,7 +264,7 @@ void main() {
           );
         });
 
-        test('returns false for expired ignore', () async {
+        test('provides informative exception for expired ignore', () async {
           mockHttpResponse = MockHttpClientResponse(utf8.encode(
             ignoreResponseTemplate(
               pullRequestNumber: pullRequestNumber,
@@ -272,12 +272,13 @@ void main() {
           ));
           when(mockHttpRequest.close())
             .thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
+          final Future<bool> test = skiaClient.testIsIgnoredForPullRequest(
+            pullRequestNumber,
+            testName,
+          );
           expect(
-            await skiaClient.testIsIgnoredForPullRequest(
-              pullRequestNumber,
-              testName,
-            ),
-            isFalse,
+            test,
+            throwsException,
           );
         });
       });

--- a/packages/flutter_goldens/test/flutter_goldens_test.dart
+++ b/packages/flutter_goldens/test/flutter_goldens_test.dart
@@ -519,7 +519,7 @@ void main() {
     });
 
     group('Skipping', () {
-      test('correctly determines testing environment', () {
+      test('correctly determines testing environment on LUCI', () {
         platform = FakePlatform(
           environment: <String, String>{
             'FLUTTER_ROOT': _kFlutterRoot,
@@ -530,6 +530,33 @@ void main() {
         expect(
           FlutterSkippingGoldenFileComparator.isAvailableForEnvironment(platform),
           isTrue,
+        );
+      });
+
+      test('correctly determines testing environment on Cirrus', () {
+        platform = FakePlatform(
+          environment: <String, String>{
+            'FLUTTER_ROOT': _kFlutterRoot,
+            'CIRRUS_CI' : 'yep',
+          },
+          operatingSystem: 'macos'
+        );
+        expect(
+          FlutterSkippingGoldenFileComparator.isAvailableForEnvironment(platform),
+          isTrue,
+        );
+      });
+
+      test('correctly determines not a testing environment', () {
+        platform = FakePlatform(
+          environment: <String, String>{
+            'FLUTTER_ROOT': _kFlutterRoot,
+          },
+          operatingSystem: 'macos'
+        );
+        expect(
+          FlutterSkippingGoldenFileComparator.isAvailableForEnvironment(platform),
+          isFalse,
         );
       });
     });

--- a/packages/flutter_goldens/test/json_templates.dart
+++ b/packages/flutter_goldens/test/json_templates.dart
@@ -174,6 +174,7 @@ String digestResponseTemplate({
 String ignoreResponseTemplate({
   String pullRequestNumber = '0000',
   String testName = 'flutter.golden_test.1',
+  String expires = '2019-09-06T21:28:18.815336Z',
 }) {
   return '''
     [
@@ -181,7 +182,7 @@ String ignoreResponseTemplate({
         "id": "7579425228619212078",
         "name": "contributor@getMail.com",
         "updatedBy": "contributor@getMail.com",
-        "expires": "2019-09-06T21:28:18.815336Z",
+        "expires": "$expires",
         "query": "ext=png&name=$testName",
         "note": "https://github.com/flutter/flutter/pull/$pullRequestNumber"
       }

--- a/packages/flutter_goldens/test/json_templates.dart
+++ b/packages/flutter_goldens/test/json_templates.dart
@@ -174,7 +174,9 @@ String digestResponseTemplate({
 String ignoreResponseTemplate({
   String pullRequestNumber = '0000',
   String testName = 'flutter.golden_test.1',
+  String otherTestName = 'flutter.golden_test.1',
   String expires = '2019-09-06T21:28:18.815336Z',
+  String otherExpires = '2019-09-06T21:28:18.815336Z',
 }) {
   return '''
     [
@@ -185,6 +187,14 @@ String ignoreResponseTemplate({
         "expires": "$expires",
         "query": "ext=png&name=$testName",
         "note": "https://github.com/flutter/flutter/pull/$pullRequestNumber"
+      },
+      {
+        "id": "7579425228619212078",
+        "name": "contributor@getMail.com",
+        "updatedBy": "contributor@getMail.com",
+        "expires": "$otherExpires",
+        "query": "ext=png&name=$otherTestName",
+        "note": "https://github.com/flutter/flutter/pull/99999"
       }
     ]
   ''';

--- a/packages/flutter_goldens_client/lib/skia_client.dart
+++ b/packages/flutter_goldens_client/lib/skia_client.dart
@@ -276,8 +276,9 @@ class SkiaGoldClient {
           if (ignoredQueries.contains('name=$testName')) {
             if (expiration.isAfter(DateTime.now())) {
               ignoreIsActive = true;
-              break;
             } else {
+              // If any ignore is expired for the given test, throw with
+              // guidance.
               final StringBuffer buf = StringBuffer()
                 ..writeln('This test has an expired ignore in place, and the')
                 ..writeln('change has not been triaged.')

--- a/packages/flutter_goldens_client/lib/skia_client.dart
+++ b/packages/flutter_goldens_client/lib/skia_client.dart
@@ -272,12 +272,12 @@ class SkiaGoldClient {
           final String ignoredPullRequest = ignore['note'].split('/').last;
           final DateTime expiration = DateTime.parse(ignore['expires']);
           if (ignoredQueries.contains('name=$testName') &&
-            expiration.isBefore(DateTime.now())) {
+            expiration.isAfter(DateTime.now())) {
             ignoreIsActive = true;
             if (ignoredPullRequest != pullRequest) {
-              print('An ignore is active for this test for pull reqest:');
-              print('');
-              print('https://flutter-gold.skia.org/ignores');
+              print('An `ignore` is active for this test for pull request:');
+              print('https://github.com/flutter/flutter/pull/$ignoredPullRequest');
+              print('See also: https://flutter-gold.skia.org/ignores for details.');
             }
             break;
           }

--- a/packages/flutter_goldens_client/lib/skia_client.dart
+++ b/packages/flutter_goldens_client/lib/skia_client.dart
@@ -278,7 +278,6 @@ class SkiaGoldClient {
               ignoreIsActive = true;
               break;
             } else {
-              // If the ignore has expired, then the failing test
               final StringBuffer buf = StringBuffer()
                 ..writeln('This test has an expired ignore in place, and the')
                 ..writeln('change has not been triaged.')


### PR DESCRIPTION
## Description

This PR applies performance adjustments on Gold after pilot feedback.

Changes include: 
- tightening control of which shards golden file tests are executing on, this reduces the number of requests to the Gold apis and unnecessary test runs beyond those shards that are specified.
- Better error messaging around pre-submit failures that are attributed to triage failures.
- Updates to the ignore functionality that controls making changes to existing golden files.

Gold-side performance enhancements: https://skia-review.googlesource.com/c/buildbot/+/251459

## Tests

I added the following tests:
- ignores
  - returns true for ignored test and not ignored pull request number
  - returns false for not ignored test and ignored pull request number
  - throws exception for expired ignore
- post-submit
  - correctly determines testing environment
    - returns true
    - returns false - PR active
    - returns false - no service account
    - returns false - not on Cirrus
    - returns false - not on master
- pre-submit
  - correctly determines testing environment
    - returns true
    - returns false - no PR
    - returns false - no service account
    - returns false - not on cirrus
  - fails test that is not ignored
- Skipping
  - correctly determines testing environment
    - returns true on luci
    - returns true on cirrus
    - returns false

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
