### PR TITLE
pass --no-gen-bytecode to aot kernel compiler invocations

### DIFF
--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -324,6 +324,8 @@ class KernelCompiler {
       if (aot) ...<String>[
         '--aot',
         '--tfa',
+        // TODO(jonahwilliams): remove when https://github.com/flutter/flutter/issues/43751 is resolved.
+        '--no-gen-bytecode',
       ],
       if (packagesPath != null) ...<String>[
         '--packages',

--- a/packages/flutter_tools/test/general.shard/compile_batch_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_batch_test.dart
@@ -66,6 +66,31 @@ void main() {
     Platform: kNoColorTerminalPlatform,
   });
 
+  testUsingContext('passes no-gen-bytecode to kernel compiler in aot/release mode', () async {
+    when(mockFrontendServer.stdout)
+      .thenAnswer((Invocation invocation) => Stream<List<int>>.fromFuture(
+        Future<List<int>>.value(utf8.encode(
+          'result abc\nline1\nline2\nabc\nabc /path/to/main.dart.dill 0'
+        ))
+      ));
+    final KernelCompiler kernelCompiler = await kernelCompilerFactory.create(null);
+    await kernelCompiler.compile(sdkRoot: '/path/to/sdkroot',
+      mainPath: '/path/to/main.dart',
+      buildMode: BuildMode.release,
+      trackWidgetCreation: false,
+      aot: true,
+    );
+
+    expect(mockFrontendServerStdIn.getAndClear(), isEmpty);
+    final VerificationResult argVerification = verify(mockProcessManager.start(captureAny));
+    expect(argVerification.captured.single, contains('--no-gen-bytecode'));
+  }, overrides: <Type, Generator>{
+    ProcessManager: () => mockProcessManager,
+    OutputPreferences: () => OutputPreferences(showColor: false),
+    Platform: kNoColorTerminalPlatform,
+  });
+
+
   testUsingContext('batch compile single dart failed compilation', () async {
     final BufferLogger bufferLogger = logger;
     when(mockFrontendServer.stdout)

--- a/packages/flutter_tools/test/general.shard/compile_batch_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_batch_test.dart
@@ -90,7 +90,6 @@ void main() {
     Platform: kNoColorTerminalPlatform,
   });
 
-
   testUsingContext('batch compile single dart failed compilation', () async {
     final BufferLogger bufferLogger = logger;
     when(mockFrontendServer.stdout)


### PR DESCRIPTION
## Description

Do not generate bytecode until  https://github.com/flutter/flutter/issues/43751 is resolved