### PR TITLE
Split desktop config fallback variable by platform

### DIFF
--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -97,7 +97,7 @@ const Feature flutterWebFeature = Feature(
 const Feature flutterMacOSDesktopFeature = Feature(
   name: 'Flutter for desktop on macOS',
   configSetting: 'enable-macos-desktop',
-  environmentOverride: 'ENABLE_FLUTTER_DESKTOP',
+  environmentOverride: 'FLUTTER_MACOS',
   master: FeatureChannelSetting(
     available: true,
     enabledByDefault: false,
@@ -108,7 +108,7 @@ const Feature flutterMacOSDesktopFeature = Feature(
 const Feature flutterLinuxDesktopFeature = Feature(
   name: 'Flutter for desktop on Linux',
   configSetting: 'enable-linux-desktop',
-  environmentOverride: 'ENABLE_FLUTTER_DESKTOP',
+  environmentOverride: 'FLUTTER_LINUX',
   master: FeatureChannelSetting(
     available: true,
     enabledByDefault: false,
@@ -119,7 +119,7 @@ const Feature flutterLinuxDesktopFeature = Feature(
 const Feature flutterWindowsDesktopFeature = Feature(
   name: 'Flutter for desktop on Windows',
   configSetting: 'enable-windows-desktop',
-  environmentOverride: 'ENABLE_FLUTTER_DESKTOP',
+  environmentOverride: 'FLUTTER_WINDOWS',
   master: FeatureChannelSetting(
     available: true,
     enabledByDefault: false,

--- a/packages/flutter_tools/test/general.shard/features_test.dart
+++ b/packages/flutter_tools/test/general.shard/features_test.dart
@@ -206,7 +206,7 @@ void main() {
 
     test('flutter macos desktop enabled with environment variable on master', () => testbed.run(() {
       when(mockFlutterVerion.channel).thenReturn('master');
-      when(mockPlatform.environment).thenReturn(<String, String>{'ENABLE_FLUTTER_DESKTOP': 'true'});
+      when(mockPlatform.environment).thenReturn(<String, String>{'FLUTTER_MACOS': 'true'});
 
       expect(featureFlags.isMacOSEnabled, true);
     }));
@@ -226,7 +226,7 @@ void main() {
 
     test('flutter macos desktop not enabled with environment variable on dev', () => testbed.run(() {
       when(mockFlutterVerion.channel).thenReturn('dev');
-      when(mockPlatform.environment).thenReturn(<String, String>{'ENABLE_FLUTTER_DESKTOP': 'true'});
+      when(mockPlatform.environment).thenReturn(<String, String>{'FLUTTER_MACOS': 'true'});
 
       expect(featureFlags.isMacOSEnabled, false);
     }));
@@ -246,7 +246,7 @@ void main() {
 
     test('flutter macos desktop not enabled with environment variable on beta', () => testbed.run(() {
       when(mockFlutterVerion.channel).thenReturn('beta');
-      when(mockPlatform.environment).thenReturn(<String, String>{'ENABLE_FLUTTER_DESKTOP': 'true'});
+      when(mockPlatform.environment).thenReturn(<String, String>{'FLUTTER_MACOS': 'true'});
 
       expect(featureFlags.isMacOSEnabled, false);
     }));
@@ -266,7 +266,7 @@ void main() {
 
     test('flutter macos desktop not enabled with environment variable on stable', () => testbed.run(() {
       when(mockFlutterVerion.channel).thenReturn('stable');
-      when(mockPlatform.environment).thenReturn(<String, String>{'ENABLE_FLUTTER_DESKTOP': 'true'});
+      when(mockPlatform.environment).thenReturn(<String, String>{'FLUTTER_MACOS': 'true'});
 
       expect(featureFlags.isMacOSEnabled, false);
     }));
@@ -287,7 +287,7 @@ void main() {
 
     test('flutter linux desktop enabled with environment variable on master', () => testbed.run(() {
       when(mockFlutterVerion.channel).thenReturn('master');
-      when(mockPlatform.environment).thenReturn(<String, String>{'ENABLE_FLUTTER_DESKTOP': 'true'});
+      when(mockPlatform.environment).thenReturn(<String, String>{'FLUTTER_LINUX': 'true'});
 
       expect(featureFlags.isLinuxEnabled, true);
     }));
@@ -307,7 +307,7 @@ void main() {
 
     test('flutter linux desktop not enabled with environment variable on dev', () => testbed.run(() {
       when(mockFlutterVerion.channel).thenReturn('dev');
-      when(mockPlatform.environment).thenReturn(<String, String>{'ENABLE_FLUTTER_DESKTOP': 'true'});
+      when(mockPlatform.environment).thenReturn(<String, String>{'FLUTTER_LINUX': 'true'});
 
       expect(featureFlags.isLinuxEnabled, false);
     }));
@@ -327,7 +327,7 @@ void main() {
 
     test('flutter linux desktop not enabled with environment variable on beta', () => testbed.run(() {
       when(mockFlutterVerion.channel).thenReturn('beta');
-      when(mockPlatform.environment).thenReturn(<String, String>{'ENABLE_FLUTTER_DESKTOP': 'true'});
+      when(mockPlatform.environment).thenReturn(<String, String>{'FLUTTER_LINUX': 'true'});
 
       expect(featureFlags.isLinuxEnabled, false);
     }));
@@ -347,7 +347,7 @@ void main() {
 
     test('flutter linux desktop not enabled with environment variable on stable', () => testbed.run(() {
       when(mockFlutterVerion.channel).thenReturn('stable');
-      when(mockPlatform.environment).thenReturn(<String, String>{'ENABLE_FLUTTER_DESKTOP': 'true'});
+      when(mockPlatform.environment).thenReturn(<String, String>{'FLUTTER_LINUX': 'true'});
 
       expect(featureFlags.isLinuxEnabled, false);
     }));
@@ -368,7 +368,7 @@ void main() {
 
     test('flutter windows desktop enabled with environment variable on master', () => testbed.run(() {
       when(mockFlutterVerion.channel).thenReturn('master');
-      when(mockPlatform.environment).thenReturn(<String, String>{'ENABLE_FLUTTER_DESKTOP': 'true'});
+      when(mockPlatform.environment).thenReturn(<String, String>{'FLUTTER_WINDOWS': 'true'});
 
       expect(featureFlags.isWindowsEnabled, true);
     }));
@@ -388,7 +388,7 @@ void main() {
 
     test('flutter windows desktop not enabled with environment variable on dev', () => testbed.run(() {
       when(mockFlutterVerion.channel).thenReturn('dev');
-      when(mockPlatform.environment).thenReturn(<String, String>{'ENABLE_FLUTTER_DESKTOP': 'true'});
+      when(mockPlatform.environment).thenReturn(<String, String>{'FLUTTER_WINDOWS': 'true'});
 
       expect(featureFlags.isWindowsEnabled, false);
     }));
@@ -408,7 +408,7 @@ void main() {
 
     test('flutter windows desktop not enabled with environment variable on beta', () => testbed.run(() {
       when(mockFlutterVerion.channel).thenReturn('beta');
-      when(mockPlatform.environment).thenReturn(<String, String>{'ENABLE_FLUTTER_DESKTOP': 'true'});
+      when(mockPlatform.environment).thenReturn(<String, String>{'FLUTTER_WINDOWS': 'true'});
 
       expect(featureFlags.isWindowsEnabled, false);
     }));
@@ -428,7 +428,7 @@ void main() {
 
     test('flutter windows desktop not enabled with environment variable on stable', () => testbed.run(() {
       when(mockFlutterVerion.channel).thenReturn('stable');
-      when(mockPlatform.environment).thenReturn(<String, String>{'ENABLE_FLUTTER_DESKTOP': 'true'});
+      when(mockPlatform.environment).thenReturn(<String, String>{'FLUTTER_WINDOWS': 'true'});
 
       expect(featureFlags.isWindowsEnabled, false);
     }));


### PR DESCRIPTION
## Description

The environment variable for all desktop platforms is currently
ENABLE_FLUTTER_DESKTOP to allow backward compatibility with existing
workflows. However, this is actually causing issues since 'flutter
config' provides a better experience (most importantly, IDEs will work
correctly, which is generally not the case with the environemnt
variable). Currently people following old (third-patry) instructions
don't realize that they are missing available functionality, so aren't
looking for the current instructions.

In adddition, this will be confusing as different platform graduate to
channels other than master at different times.

To resolve both issues, the environment variable fallback is now
separate for each desktop platform, and follows a naming scheme
consistent with the web environment variable.

## Related Issues

None

## Tests

I added the following tests: None. Updated existing tests.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

Technically this is a breaking change for people still using a long-obsolete workflow on desktop, but desktop is not yet subject to the breaking change policy as it is explicitly unstable.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
