### PR TITLE
[flutter_tool] Teach the tool about local engine Fuchsia artifacts

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/build_system.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_system.dart
@@ -575,6 +575,9 @@ class ExceptionMeasurement {
   final String target;
   final dynamic exception;
   final StackTrace stackTrace;
+
+  @override
+  String toString() => 'target: $target\nexception:$exception\n$stackTrace';
 }
 
 /// Helper class to collect measurement data.

--- a/packages/flutter_tools/lib/src/codegen.dart
+++ b/packages/flutter_tools/lib/src/codegen.dart
@@ -171,10 +171,15 @@ class CodeGeneratingResidentCompiler implements ResidentCompiler {
     String outputPath,
     String initializeFromDill,
     bool runCold = false,
+    TargetPlatform targetPlatform,
   }) async {
     codeGenerator.updatePackages(flutterProject);
     final ResidentCompiler residentCompiler = ResidentCompiler(
-      artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath),
+      artifacts.getArtifactPath(
+        Artifact.flutterPatchedSdkPath,
+        platform: targetPlatform,
+        mode: buildMode,
+      ),
       buildMode: buildMode,
       trackWidgetCreation: trackWidgetCreation,
       packagesPath: PackageMap.globalGeneratedPackagesPath,

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -433,24 +433,6 @@ class FuchsiaDevice extends Device {
   void clearLogs() {}
 
   @override
-  OverrideArtifacts get artifactOverrides {
-    return _artifactOverrides ??= OverrideArtifacts(
-      parent: Artifacts.instance,
-      platformKernelDill: fs.file(artifacts.getArtifactPath(
-        Artifact.fuchsiaPlatformDill,
-        platform: TargetPlatform.fuchsia_x64,
-        mode: BuildMode.debug,
-      )),
-      flutterPatchedSdk: fs.file(artifacts.getArtifactPath(
-        Artifact.fuchsiaPatchedSdk,
-        platform: TargetPlatform.fuchsia_x64,
-        mode: BuildMode.debug,
-      )),
-    );
-  }
-  OverrideArtifacts _artifactOverrides;
-
-  @override
   bool get supportsScreenshot => false;
 
   bool get ipv6 {

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_kernel_compiler.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_kernel_compiler.dart
@@ -38,13 +38,13 @@ class FuchsiaKernelCompiler {
     final String kernelCompiler = artifacts.getArtifactPath(
       Artifact.fuchsiaKernelCompiler,
       platform: TargetPlatform.fuchsia_x64,  // This file is not arch-specific.
-      mode: BuildMode.debug,
+      mode: buildInfo.mode,
     );
     if (!fs.isFileSync(kernelCompiler)) {
       throwToolExit('Fuchisa kernel compiler not found at "$kernelCompiler"');
     }
     final String platformDill = artifacts.getArtifactPath(
-      Artifact.fuchsiaPlatformDill,
+      Artifact.platformKernelDill,
       platform: TargetPlatform.fuchsia_x64,  // This file is not arch-specific.
       mode: buildInfo.mode,
     );
@@ -92,7 +92,7 @@ class FuchsiaKernelCompiler {
 
     final List<String> command = <String>[
       artifacts.getArtifactPath(Artifact.engineDartBinary),
-      artifacts.getArtifactPath(Artifact.fuchsiaKernelCompiler),
+      kernelCompiler,
       ...flags,
     ];
     final Process process = await processUtils.start(command);

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -37,12 +37,17 @@ class FlutterDevice {
     this.fileSystemScheme,
     this.viewFilter,
     TargetModel targetModel = TargetModel.flutter,
+    TargetPlatform targetPlatform,
     List<String> experimentalFlags,
     ResidentCompiler generator,
     @required BuildMode buildMode,
   }) : assert(trackWidgetCreation != null),
        generator = generator ?? ResidentCompiler(
-         artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath, mode: buildMode),
+         artifacts.getArtifactPath(
+           Artifact.flutterPatchedSdkPath,
+           platform: targetPlatform,
+           mode: buildMode,
+         ),
          buildMode: buildMode,
          trackWidgetCreation: trackWidgetCreation,
          fileSystemRoots: fileSystemRoots,
@@ -66,8 +71,12 @@ class FlutterDevice {
     ResidentCompiler generator,
   }) async {
     ResidentCompiler generator;
+    final TargetPlatform targetPlatform = await device.targetPlatform;
+    if (device.platformType == PlatformType.fuchsia) {
+      targetModel = TargetModel.flutterRunner;
+    }
     if (featureFlags.isWebIncrementalCompilerEnabled &&
-        await device.targetPlatform == TargetPlatform.web_javascript) {
+        targetPlatform == TargetPlatform.web_javascript) {
       generator = ResidentCompiler(
         artifacts.getArtifactPath(Artifact.flutterWebSdk, mode: buildMode),
         buildMode: buildMode,
@@ -80,12 +89,17 @@ class FlutterDevice {
       );
     } else if (flutterProject.hasBuilders) {
       generator = await CodeGeneratingResidentCompiler.create(
+        targetPlatform: targetPlatform,
         buildMode: buildMode,
         flutterProject: flutterProject,
       );
     } else {
       generator = ResidentCompiler(
-        artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath, mode: buildMode),
+        artifacts.getArtifactPath(
+          Artifact.flutterPatchedSdkPath,
+          platform: targetPlatform,
+          mode: buildMode,
+        ),
         buildMode: buildMode,
         trackWidgetCreation: trackWidgetCreation,
         fileSystemRoots: fileSystemRoots,
@@ -102,6 +116,7 @@ class FlutterDevice {
       viewFilter: viewFilter,
       experimentalFlags: experimentalFlags,
       targetModel: targetModel,
+      targetPlatform: targetPlatform,
       generator: generator,
       buildMode: buildMode,
     );

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -232,6 +232,9 @@ class FakeDevice extends Fake implements Device {
   Future<TargetPlatform> get targetPlatform async => _targetPlatform;
 
   @override
+  final PlatformType platformType = PlatformType.ios;
+
+  @override
   Future<LaunchResult> startApp(
     ApplicationPackage package, {
     String mainPath,

--- a/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
@@ -236,14 +236,12 @@ flutter_tools:lib/''');
     expect(result.exceptions.values.single.exception, isInstanceOf<MissingDefineException>());
   }));
 
-
   test('aot_elf_profile throws error if missing target platform', () => testbed.run(() async {
     final BuildResult result = await buildSystem.build(const AotElfProfile(),
         androidEnvironment..defines.remove(kTargetPlatform));
 
     expect(result.exceptions.values.single.exception, isInstanceOf<MissingDefineException>());
   }));
-
 
   test('aot_assembly_profile throws error if missing build mode', () => testbed.run(() async {
     final BuildResult result = await buildSystem.build(const AotAssemblyProfile(),

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
@@ -126,76 +126,6 @@ void main() {
     });
   });
 
-  group('Fuchsia device artifact overrides', () {
-    MemoryFileSystem memoryFileSystem;
-    File devFinder;
-    File sshConfig;
-    File platformDill;
-    File patchedSdk;
-    MockArtifacts mockArtifacts;
-
-    setUp(() {
-      memoryFileSystem = MemoryFileSystem();
-      devFinder = memoryFileSystem.file('dev_finder');
-      sshConfig = memoryFileSystem.file('ssh_config');
-      platformDill = memoryFileSystem.file('platform_strong.dill');
-      patchedSdk = memoryFileSystem.file('flutter_runner_patched_sdk');
-
-      mockArtifacts = MockArtifacts();
-      when(mockArtifacts.getArtifactPath(
-        Artifact.fuchsiaPlatformDill,
-        platform: anyNamed('platform'),
-        mode: anyNamed('mode'),
-      )).thenReturn(platformDill.path);
-      when(mockArtifacts.getArtifactPath(
-        Artifact.fuchsiaPatchedSdk,
-        platform: anyNamed('platform'),
-        mode: anyNamed('mode'),
-      )).thenReturn(patchedSdk.path);
-    });
-
-    testUsingContext('exist', () async {
-      final FuchsiaDevice device = FuchsiaDevice('fuchsia-device');
-      expect(device.artifactOverrides, isNotNull);
-      expect(device.artifactOverrides.platformKernelDill.path, equals(platformDill.path));
-      expect(device.artifactOverrides.flutterPatchedSdk.path, equals(patchedSdk.path));
-    }, overrides: <Type, Generator>{
-      Artifacts: () => mockArtifacts,
-      FileSystem: () => memoryFileSystem,
-      FuchsiaArtifacts: () => FuchsiaArtifacts(
-            sshConfig: sshConfig,
-            devFinder: devFinder,
-          ),
-      ProcessManager: () => FakeProcessManager.any(),
-    });
-
-    testUsingContext('are used', () async {
-      final FuchsiaDevice device = FuchsiaDevice('fuchsia-device');
-      expect(device.artifactOverrides, isNotNull);
-      expect(device.artifactOverrides.platformKernelDill.path, equals(platformDill.path));
-      expect(device.artifactOverrides.flutterPatchedSdk.path, equals(patchedSdk.path));
-      await context.run<void>(
-        body: () {
-          expect(Artifacts.instance.getArtifactPath(Artifact.platformKernelDill),
-                 equals(platformDill.path));
-          expect(Artifacts.instance.getArtifactPath(Artifact.flutterPatchedSdkPath),
-                 equals(patchedSdk.path));
-        },
-        overrides: <Type, Generator>{
-          Artifacts: () => device.artifactOverrides,
-        },
-      );
-    }, overrides: <Type, Generator>{
-      Artifacts: () => mockArtifacts,
-      FileSystem: () => memoryFileSystem,
-      FuchsiaArtifacts: () => FuchsiaArtifacts(
-            sshConfig: sshConfig,
-            devFinder: devFinder,
-          ),
-      ProcessManager: () => FakeProcessManager.any(),
-    });
-  });
-
   group('displays friendly error when', () {
     MockProcessManager mockProcessManager;
     MockProcessResult mockProcessResult;
@@ -480,12 +410,12 @@ void main() {
         mode: anyNamed('mode'),
       )).thenReturn(compilerSnapshot.path);
       when(mockArtifacts.getArtifactPath(
-        Artifact.fuchsiaPlatformDill,
+        Artifact.platformKernelDill,
         platform: anyNamed('platform'),
         mode: anyNamed('mode'),
       )).thenReturn(platformDill.path);
       when(mockArtifacts.getArtifactPath(
-        Artifact.fuchsiaPatchedSdk,
+        Artifact.flutterPatchedSdkPath,
         platform: anyNamed('platform'),
         mode: anyNamed('mode'),
       )).thenReturn(patchedSdk.path);


### PR DESCRIPTION
## Description

This PR makes --local-engine work when using 'flutter run' to target a Fuchsia device.

It removes `Artifact.fuchsiaPlatformDill` and `Artifact.fuchsiaPatchedSdk`, and instead uses the platform-generic entries. To make that work, the PR ensures that a `TargetPlatform` is passed to `getArtifactPath` whenever the platform dill and patched SDK path are requested.

It fixes a bug in Fuchsia hot reload in which the wrong platform dill and `TargetModel` were passed to the incremental compiler.

It removes `artifactOverrides` from `FuchsiaDevice`, which are no longer needed.

## Tests

This needs an integration test.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.