### PR TITLE
Make test case use mockStopwatch

### DIFF
--- a/packages/flutter_tools/test/general.shard/base/logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/logger_test.dart
@@ -90,6 +90,7 @@ void main() {
 
     void doWhileAsync(FakeAsync time, bool doThis()) {
       do {
+        mockStopwatch.elapsed += const Duration(milliseconds: 1);
         time.elapse(const Duration(milliseconds: 1));
       } while (doThis());
     }
@@ -97,6 +98,7 @@ void main() {
     for (String testOs in testPlatforms) {
       testUsingContext('AnsiSpinner works for $testOs (1)', () async {
         bool done = false;
+        mockStopwatch = FakeStopwatch();
         FakeAsync().run((FakeAsync time) {
           final AnsiSpinner ansiSpinner = AnsiSpinner(
             timeout: const Duration(hours: 10),
@@ -129,6 +131,7 @@ void main() {
       }, overrides: <Type, Generator>{
         Platform: () => FakePlatform(operatingSystem: testOs),
         Stdio: () => mockStdio,
+        Stopwatch: () => mockStopwatch,
       });
 
       testUsingContext('AnsiSpinner works for $testOs (2)', () async {


### PR DESCRIPTION
## Description

fixes https://github.com/flutter/flutter/issues/43754

FakeAsync does not effect StopWatches, so we were relying on real time.