### PR TITLE
check if libimobiledevice executables exist

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -1102,6 +1102,10 @@ class IosUsbArtifacts extends CachedArtifact {
     'ios-deploy',
   ];
 
+  // For unknown reasons, users are getting into bad states where libimobiledevice is
+  // downloaded but some executables are missing from the zip. The names here are
+  // used for additional download checks below, so we can redownload if they are
+  // missing.
   static const Map<String, List<String>> _kExecutables = <String, List<String>>{
     'libimobiledevice': <String>[
       'idevice_id',

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -1102,6 +1102,13 @@ class IosUsbArtifacts extends CachedArtifact {
     'ios-deploy',
   ];
 
+  static const Map<String, List<String>> _kExecutables = <String, List<String>>{
+    'libimobiledevice': <String>[
+      'idevice_id',
+      'ideviceinfo',
+    ],
+  };
+
   @override
   Map<String, String> get environment {
     return <String, String>{
@@ -1110,9 +1117,26 @@ class IosUsbArtifacts extends CachedArtifact {
   }
 
   @override
+  bool isUpToDateInner() {
+    final List<String> executables =_kExecutables[name];
+    if (executables == null) {
+      return true;
+    }
+    for (String executable in executables) {
+      if (!location.childFile(executable).existsSync()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @override
   Future<void> updateInner() {
     if (!platform.isMacOS && !cache.includeAllPlatforms) {
       return Future<void>.value();
+    }
+    if (location.existsSync()) {
+      location.deleteSync(recursive: true);
     }
     return _downloadZipArchive('Downloading $name...', archiveUri, location);
   }

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -330,11 +330,43 @@ void main() {
     });
   });
 
-  group('Unsigned mac artifacts', () {
+  group('macOS artifacts', () {
     MockCache mockCache;
 
     setUp(() {
       mockCache = MockCache();
+    });
+
+    testUsingContext('verifies executables for libimobiledeivce in isUpToDateInner', () async {
+      final IosUsbArtifacts iosUsbArtifacts = IosUsbArtifacts('libimobiledevice', mockCache);
+      when(mockCache.getArtifactDirectory(any)).thenReturn(fs.currentDirectory);
+      iosUsbArtifacts.location.createSync();
+      final File ideviceIdFile = iosUsbArtifacts.location.childFile('idevice_id')
+        ..createSync();
+      iosUsbArtifacts.location.childFile('ideviceinfo')
+        ..createSync();
+
+      expect(iosUsbArtifacts.isUpToDateInner(), true);
+
+      ideviceIdFile.deleteSync();
+
+      expect(iosUsbArtifacts.isUpToDateInner(), false);
+    }, overrides: <Type, Generator>{
+      Cache: () => mockCache,
+      FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager.any(),
+    });
+
+    testUsingContext('Does not verify executables for openssl in isUpToDateInner', () async {
+      final IosUsbArtifacts iosUsbArtifacts = IosUsbArtifacts('openssl', mockCache);
+      when(mockCache.getArtifactDirectory(any)).thenReturn(fs.currentDirectory);
+      iosUsbArtifacts.location.createSync();
+
+      expect(iosUsbArtifacts.isUpToDateInner(), true);
+    }, overrides: <Type, Generator>{
+      Cache: () => mockCache,
+      FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager.any(),
     });
 
     testUsingContext('use unsigned when specified', () async {

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -337,7 +337,7 @@ void main() {
       mockCache = MockCache();
     });
 
-    testUsingContext('verifies executables for libimobiledeivce in isUpToDateInner', () async {
+    testUsingContext('verifies executables for libimobiledevice in isUpToDateInner', () async {
       final IosUsbArtifacts iosUsbArtifacts = IosUsbArtifacts('libimobiledevice', mockCache);
       when(mockCache.getArtifactDirectory(any)).thenReturn(fs.currentDirectory);
       iosUsbArtifacts.location.createSync();


### PR DESCRIPTION
## Description

We've been noticing several ArgumentErrors in crash logs from missing libimobiledevice artifacts. In place of a full solution (checksums, cache verification), we can add a check that the specific artifacts exist on disk to the cache update logic.