### PR TITLE
de-flake logger test

### DIFF
--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -359,12 +359,12 @@ class BufferLogger extends Logger {
 
 class VerboseLogger extends Logger {
   VerboseLogger(this.parent) : assert(terminal != null) {
-    stopwatch.start();
+    _stopwatch.start();
   }
 
   final Logger parent;
 
-  Stopwatch stopwatch = Stopwatch();
+  final Stopwatch _stopwatch = context.get<Stopwatch>() ?? Stopwatch();
 
   @override
   bool get isVerbose => true;
@@ -438,8 +438,8 @@ class VerboseLogger extends Logger {
       return;
     }
 
-    final int millis = stopwatch.elapsedMilliseconds;
-    stopwatch.reset();
+    final int millis = _stopwatch.elapsedMilliseconds;
+    _stopwatch.reset();
 
     String prefix;
     const int prefixWidth = 8;

--- a/packages/flutter_tools/test/general.shard/base/logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/logger_test.dart
@@ -24,6 +24,11 @@ void main() {
   final String resetColor = RegExp.escape(AnsiTerminal.resetColor);
 
   group('AppContext', () {
+    FakeStopwatch fakeStopWatch;
+
+    setUp(() {
+      fakeStopWatch = FakeStopwatch();
+    });
     testUsingContext('error', () async {
       final BufferLogger mockLogger = BufferLogger();
       final VerboseLogger verboseLogger = VerboseLogger(mockLogger);
@@ -39,6 +44,7 @@ void main() {
     }, overrides: <Type, Generator>{
       OutputPreferences: () => OutputPreferences(showColor: false),
       Platform: _kNoAnsiPlatform,
+      Stopwatch: () => fakeStopWatch,
     });
 
     testUsingContext('ANSI colored errors', () async {
@@ -60,6 +66,7 @@ void main() {
     }, overrides: <Type, Generator>{
       OutputPreferences: () => OutputPreferences(showColor: true),
       Platform: () => FakePlatform()..stdoutSupportsAnsi = true,
+      Stopwatch: () => fakeStopWatch,
     });
   });
 


### PR DESCRIPTION
## Description

This test was using a real stopwatch. It would happen to work if test execution took less that 1 millisecond, but CI machines are slow. Apply a similar injection strategy that was used in the Status.

Fixes https://github.com/flutter/flutter/issues/43797