### PR TITLE
Allow ThemeData to merge the result of ThemeData.from() with the previous ThemeData.

### DIFF
--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -630,6 +630,48 @@ class ThemeData extends Diagnosticable {
     );
   }
 
+  /// Merge a [ThemeData] with colors with another [ThemeData] with styles.
+  ///
+  /// [ThemeData.from] does not retain the base theme information, it only sets up
+  /// the colors. With [ThemeData.mergeThemes], you can merge the colors generated
+  /// from [ThemeData.from] with an existing theme.
+  factory ThemeData.mergeThemes({
+    @required ThemeData coloredTheme,
+    @required ThemeData baseTheme,
+  }) {
+    assert(coloredTheme != null);
+    assert(baseTheme != null);
+
+    return coloredTheme.copyWith(
+      buttonTheme: baseTheme.buttonTheme,
+      textTheme: baseTheme.textTheme,
+      cardTheme: baseTheme.cardTheme,
+      iconTheme: baseTheme.iconTheme,
+      accentIconTheme: baseTheme.accentIconTheme,
+      accentTextTheme: baseTheme.accentTextTheme,
+      appBarTheme: baseTheme.appBarTheme,
+      tabBarTheme: baseTheme.tabBarTheme,
+      toggleButtonsTheme: baseTheme.toggleButtonsTheme,
+      bannerTheme: baseTheme.bannerTheme,
+      tooltipTheme: baseTheme.tooltipTheme,
+      bottomAppBarTheme: baseTheme.bottomAppBarTheme,
+      bottomSheetTheme: baseTheme.bottomSheetTheme,
+      buttonBarTheme: baseTheme.buttonBarTheme,
+      chipTheme: baseTheme.chipTheme,
+      cupertinoOverrideTheme: baseTheme.cupertinoOverrideTheme,
+      dialogTheme: baseTheme.dialogTheme,
+      dividerTheme: baseTheme.dividerTheme,
+      floatingActionButtonTheme: baseTheme.floatingActionButtonTheme,
+      inputDecorationTheme: baseTheme.inputDecorationTheme,
+      pageTransitionsTheme: baseTheme.pageTransitionsTheme,
+      popupMenuTheme: baseTheme.popupMenuTheme,
+      primaryIconTheme: baseTheme.primaryIconTheme,
+      primaryTextTheme: baseTheme.primaryTextTheme,
+      sliderTheme: baseTheme.sliderTheme,
+      snackBarTheme: baseTheme.snackBarTheme,
+    );
+  }
+
   /// A default light blue theme.
   ///
   /// This theme does not contain text geometry. Instead, it is expected that

--- a/packages/flutter/test/material/theme_data_test.dart
+++ b/packages/flutter/test/material/theme_data_test.dart
@@ -475,9 +475,9 @@ void main() {
 
   testWidgets('ThemeData.mergeThemes merges correctly', (WidgetTester tester) async {
 
-    final cardTheme = CardTheme(elevation: 24);
-    final dialogTheme = DialogTheme(elevation: 24);
-    final buttonTheme = ButtonThemeData(
+    const CardTheme cardTheme = CardTheme(elevation: 24);
+    const DialogTheme dialogTheme = DialogTheme(elevation: 24);
+    final ButtonThemeData buttonTheme = ButtonThemeData(
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(8),
       ),

--- a/packages/flutter/test/material/theme_data_test.dart
+++ b/packages/flutter/test/material/theme_data_test.dart
@@ -473,4 +473,31 @@ void main() {
     expect(themeDataCopy.buttonBarTheme, equals(otherTheme.buttonBarTheme));
   });
 
+  testWidgets('ThemeData.mergeThemes merges correctly', (WidgetTester tester) async {
+
+    final cardTheme = CardTheme(elevation: 24);
+    final dialogTheme = DialogTheme(elevation: 24);
+    final buttonTheme = ButtonThemeData(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(8),
+      ),
+    );
+
+    const ColorScheme lightColors = ColorScheme.light();
+    final ThemeData coloredTheme = ThemeData.from(colorScheme: lightColors);
+    final ThemeData baseTheme = ThemeData.light().copyWith(
+      cardTheme: cardTheme,
+      dialogTheme: dialogTheme,
+      buttonTheme: buttonTheme,
+    );
+    final ThemeData theme = ThemeData.mergeThemes(baseTheme: baseTheme, coloredTheme: coloredTheme);
+
+    expect(theme.brightness, equals(Brightness.light));
+    expect(theme.primaryColor, equals(lightColors.primary));
+    expect(theme.accentColor, equals(lightColors.secondary));
+    expect(theme.cardColor, equals(lightColors.surface));
+    expect(theme.cardTheme, equals(cardTheme));
+    expect(theme.buttonTheme, equals(buttonTheme));
+    expect(theme.dialogTheme, equals(dialogTheme));
+  });
 }


### PR DESCRIPTION
## Description

It is currently a lot of trouble when you use `ThemeData.from()` in the middle of an app. It generates a theme with colors, but ignore the rest of the theme. For example, if you have a card with custom elevation and shape, `ThemeData.from()` will ignore it and only set-up the color. You then need to call `copyWith` to re-theme the theme. This becomes more and more boilerplate as your code grows bigger and the app gets deeper.
For additional info, read https://github.com/flutter/flutter/issues/43823.

![image](https://user-images.githubusercontent.com/351125/67884399-86c59180-fb24-11e9-8bfc-6a280f436871.png)

If you then modify the Slider theme in `main()`, you need to come back and also add it there.

I am open to discussions. We could:
- Add this to the inside of `ThemeData.from()`. More performant, since you don't need to create some themes and discard them in sequence. But will make ThemeData.from() bigger and less readable.
- Add this as an extension, it could become baseTheme.fromColors() or something like that.
- We could also change the name from `mergeThemes` to something else, like `applyTheme` or `addColorsTo`.

## Related Issues

https://github.com/flutter/flutter/issues/43823

## Tests

I added the following test:
"ThemeData.mergeThemes merges correctly"

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
