### PR TITLE
Don't allow Disabled InkWells to be focusable

### DIFF
--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -773,39 +773,30 @@ class _InkResponseState<T extends InkResponse> extends State<T> with AutomaticKe
       _highlights[type]?.color = getHighlightColorForType(type);
     }
     _currentSplash?.color = widget.splashColor ?? Theme.of(context).splashColor;
-
-    Widget child = GestureDetector(
-      onTapDown: enabled ? _handleTapDown : null,
-      onTap: enabled ? () => _handleTap(context) : null,
-      onTapCancel: enabled ? _handleTapCancel : null,
-      onDoubleTap: widget.onDoubleTap != null ? _handleDoubleTap : null,
-      onLongPress: widget.onLongPress != null ? () => _handleLongPress(context) : null,
-      behavior: HitTestBehavior.opaque,
-      excludeFromSemantics: widget.excludeFromSemantics,
-      child: widget.child,
-    );
-
-    if (enabled) {
-      child = MouseRegion(
-        onEnter: _handleMouseEnter,
-        onExit: _handleMouseExit,
-        child: child,
-      );
-
-      if (widget.canRequestFocus) {
-        child = Actions(
-          actions: _actionMap,
-          child: Focus(
-            focusNode: widget.focusNode,
-            onFocusChange: _handleFocusUpdate,
-            autofocus: widget.autofocus,
-            child: child,
+    final bool canRequestFocus = enabled && widget.canRequestFocus;
+    return Actions(
+      actions: _actionMap,
+      child: Focus(
+        focusNode: widget.focusNode,
+        canRequestFocus: canRequestFocus,
+        onFocusChange: _handleFocusUpdate,
+        autofocus: widget.autofocus,
+        child: MouseRegion(
+          onEnter: enabled ? _handleMouseEnter : null,
+          onExit: enabled ? _handleMouseExit : null,
+          child: GestureDetector(
+            onTapDown: enabled ? _handleTapDown : null,
+            onTap: enabled ? () => _handleTap(context) : null,
+            onTapCancel: enabled ? _handleTapCancel : null,
+            onDoubleTap: widget.onDoubleTap != null ? _handleDoubleTap : null,
+            onLongPress: widget.onLongPress != null ? () => _handleLongPress(context) : null,
+            behavior: HitTestBehavior.opaque,
+            excludeFromSemantics: widget.excludeFromSemantics,
+            child: widget.child,
           ),
-        );
-      }
-    }
-
-    return child;
+        ),
+      ),
+    );
   }
 }
 

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -773,29 +773,39 @@ class _InkResponseState<T extends InkResponse> extends State<T> with AutomaticKe
       _highlights[type]?.color = getHighlightColorForType(type);
     }
     _currentSplash?.color = widget.splashColor ?? Theme.of(context).splashColor;
-    return Actions(
-      actions: _actionMap,
-      child: Focus(
-        focusNode: widget.focusNode,
-        canRequestFocus: widget.canRequestFocus,
-        onFocusChange: _handleFocusUpdate,
-        autofocus: widget.autofocus,
-        child: MouseRegion(
-          onEnter: enabled ? _handleMouseEnter : null,
-          onExit: enabled ? _handleMouseExit : null,
-          child: GestureDetector(
-            onTapDown: enabled ? _handleTapDown : null,
-            onTap: enabled ? () => _handleTap(context) : null,
-            onTapCancel: enabled ? _handleTapCancel : null,
-            onDoubleTap: widget.onDoubleTap != null ? _handleDoubleTap : null,
-            onLongPress: widget.onLongPress != null ? () => _handleLongPress(context) : null,
-            behavior: HitTestBehavior.opaque,
-            excludeFromSemantics: widget.excludeFromSemantics,
-            child: widget.child,
-          ),
-        ),
-      ),
+
+    Widget child = GestureDetector(
+      onTapDown: enabled ? _handleTapDown : null,
+      onTap: enabled ? () => _handleTap(context) : null,
+      onTapCancel: enabled ? _handleTapCancel : null,
+      onDoubleTap: widget.onDoubleTap != null ? _handleDoubleTap : null,
+      onLongPress: widget.onLongPress != null ? () => _handleLongPress(context) : null,
+      behavior: HitTestBehavior.opaque,
+      excludeFromSemantics: widget.excludeFromSemantics,
+      child: widget.child,
     );
+
+    if (enabled) {
+      child = MouseRegion(
+        onEnter: _handleMouseEnter,
+        onExit: _handleMouseExit,
+        child: child,
+      );
+
+      if (widget.canRequestFocus) {
+        child = Actions(
+          actions: _actionMap,
+          child: Focus(
+            focusNode: widget.focusNode,
+            onFocusChange: _handleFocusUpdate,
+            autofocus: widget.autofocus,
+            child: child,
+          ),
+        );
+      }
+    }
+
+    return child;
   }
 }
 

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -880,6 +880,7 @@ class ListTile extends StatelessWidget {
     return InkWell(
       onTap: enabled ? onTap : null,
       onLongPress: enabled ? onLongPress : null,
+      canRequestFocus: enabled,
       child: Semantics(
         selected: selected,
         enabled: enabled,

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -323,6 +323,7 @@ class PopupMenuItemState<T, W extends PopupMenuItem<T>> extends State<W> {
 
     return InkWell(
       onTap: widget.enabled ? handleTap : null,
+      canRequestFocus: widget.enabled,
       child: item,
     );
   }
@@ -1090,6 +1091,7 @@ class _PopupMenuButtonState<T> extends State<PopupMenuButton<T>> {
         message: widget.tooltip ?? MaterialLocalizations.of(context).showMenuTooltip,
         child: InkWell(
           onTap: widget.enabled ? showButtonMenu : null,
+          canRequestFocus: widget.enabled,
           child: widget.child,
         ),
       );

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -593,6 +593,7 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
                   if (widget.onStepTapped != null)
                     widget.onStepTapped(i);
                 } : null,
+                canRequestFocus: widget.steps[i].state != StepState.disabled,
                 child: _buildVerticalHeader(i),
               ),
               _buildVerticalBody(i),
@@ -610,6 +611,7 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
             if (widget.onStepTapped != null)
               widget.onStepTapped(i);
           } : null,
+          canRequestFocus: widget.steps[i].state != StepState.disabled,
           child: Row(
             children: <Widget>[
               Container(

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -1620,7 +1620,6 @@ void main() {
                       TestSemantics(
                         label: 'test',
                         textDirection: TextDirection.ltr,
-                        flags: <SemanticsFlag>[SemanticsFlag.isFocusable],
                       ),
                     ],
                   ),

--- a/packages/flutter/test/material/ink_well_test.dart
+++ b/packages/flutter/test/material/ink_well_test.dart
@@ -322,4 +322,92 @@ void main() {
 
     semantics.dispose();
   });
+  testWidgets("ink response doesn't focus when disabled", (WidgetTester tester) async {
+    WidgetsBinding.instance.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTouch;
+    final FocusNode focusNode = FocusNode(debugLabel: 'Ink Focus');
+    final GlobalKey childKey = GlobalKey();
+    await tester.pumpWidget(
+      Material(
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: InkWell(
+            autofocus: true,
+            onTap: () {},
+            onLongPress: () {},
+            onHover: (bool hover) {},
+            focusNode: focusNode,
+            child: Container(key: childKey),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(focusNode.hasPrimaryFocus, isTrue);
+    await tester.pumpWidget(
+      Material(
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: InkWell(
+            focusNode: focusNode,
+            child: Container(key: childKey),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(focusNode.hasPrimaryFocus, isFalse);
+  });
+
+  testWidgets("ink response doesn't hover when disabled", (WidgetTester tester) async {
+    WidgetsBinding.instance.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTouch;
+    final FocusNode focusNode = FocusNode(debugLabel: 'Ink Focus');
+    final GlobalKey childKey = GlobalKey();
+    bool hovering = false;
+    await tester.pumpWidget(
+      Material(
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Container(
+            width: 100,
+            height: 100,
+            child: InkWell(
+              autofocus: true,
+              onTap: () {},
+              onLongPress: () {},
+              onHover: (bool value) { hovering = value; },
+              focusNode: focusNode,
+              child: Container(key: childKey),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(focusNode.hasPrimaryFocus, isTrue);
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(gesture.removePointer);
+    await gesture.moveTo(tester.getCenter(find.byKey(childKey)));
+    await tester.pumpAndSettle();
+    expect(hovering, isTrue);
+
+    await tester.pumpWidget(
+      Material(
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Container(
+            width: 100,
+            height: 100,
+            child: InkWell(
+              focusNode: focusNode,
+              onHover: (bool value) { hovering = value; },
+              child: Container(key: childKey),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+    expect(focusNode.hasPrimaryFocus, isFalse);
+  });
 }

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -1127,4 +1127,51 @@ void main() {
     expect(tester.getRect(find.byType(Placeholder).at(0)), const Rect.fromLTWH(800.0 - 16.0 - 24.0,        16.0, 24.0, 56.0));
     expect(tester.getRect(find.byType(Placeholder).at(1)), const Rect.fromLTWH(800.0 - 16.0 - 24.0, 88.0 + 16.0, 24.0, 56.0));
   });
+  testWidgets("ListTile doesn't accept focus when disabled", (WidgetTester tester) async {
+    final GlobalKey childKey = GlobalKey();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ListView(
+            children: <Widget>[
+              ListTile(
+                title: Text('A', key: childKey),
+                dense: true,
+                enabled: true,
+                onTap: () {},
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pump(); // Let the focus take effect.
+
+    final FocusNode tileNode = Focus.of(childKey.currentContext);
+    tileNode.requestFocus();
+    await tester.pump(); // Let the focus take effect.
+    expect(Focus.of(childKey.currentContext, nullOk: true).hasPrimaryFocus, isTrue);
+
+    expect(tileNode.hasPrimaryFocus, isTrue);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ListView(
+            children: <Widget>[
+              ListTile(
+                title: Text('A', key: childKey),
+                dense: true,
+                enabled: false,
+                onTap: () {},
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.binding.focusManager.primaryFocus, isNot(equals(tileNode)));
+    expect(Focus.of(childKey.currentContext, nullOk: true).hasPrimaryFocus, isFalse);
+  });
 }

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -349,16 +349,20 @@ void main() {
           child: MediaQuery(
             data: const MediaQueryData(),
             child: Column(
-              children: const <Widget>[
-                ListTile(
+              children: <Widget>[
+                const ListTile(
                   title: Text('one'),
                 ),
                 ListTile(
-                  title: Text('two'),
+                  title: const Text('two'),
+                  onTap: () {},
+                ),
+                const ListTile(
+                  title: Text('three'),
                   selected: true,
                 ),
-                ListTile(
-                  title: Text('three'),
+                const ListTile(
+                  title: Text('four'),
                   enabled: false,
                 ),
               ],
@@ -377,25 +381,31 @@ void main() {
               flags: <SemanticsFlag>[
                 SemanticsFlag.hasEnabledState,
                 SemanticsFlag.isEnabled,
-                SemanticsFlag.isFocusable,
               ],
               label: 'one',
+            ),
+            TestSemantics.rootChild(
+              flags: <SemanticsFlag>[
+                SemanticsFlag.hasEnabledState,
+                SemanticsFlag.isEnabled,
+                SemanticsFlag.isFocusable,
+              ],
+              actions: <SemanticsAction>[SemanticsAction.tap],
+              label: 'two',
             ),
             TestSemantics.rootChild(
               flags: <SemanticsFlag>[
                 SemanticsFlag.isSelected,
                 SemanticsFlag.hasEnabledState,
                 SemanticsFlag.isEnabled,
-                SemanticsFlag.isFocusable,
               ],
-              label: 'two',
+              label: 'three',
             ),
             TestSemantics.rootChild(
               flags: <SemanticsFlag>[
                 SemanticsFlag.hasEnabledState,
-                SemanticsFlag.isFocusable,
               ],
-              label: 'three',
+              label: 'four',
             ),
           ],
         ),

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -1137,7 +1137,7 @@ void main() {
     expect(tester.getRect(find.byType(Placeholder).at(0)), const Rect.fromLTWH(800.0 - 16.0 - 24.0,        16.0, 24.0, 56.0));
     expect(tester.getRect(find.byType(Placeholder).at(1)), const Rect.fromLTWH(800.0 - 16.0 - 24.0, 88.0 + 16.0, 24.0, 56.0));
   });
-  testWidgets("ListTile doesn't accept focus when disabled", (WidgetTester tester) async {
+  testWidgets('ListTile only accepts focus when enabled', (WidgetTester tester) async {
     final GlobalKey childKey = GlobalKey();
 
     await tester.pumpWidget(

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -175,7 +175,7 @@ void main() {
     expect(onCanceledCalled, isFalse);
   });
 
-  testWidgets('disabled PopupMenuButton is not focusabled', (WidgetTester tester) async {
+  testWidgets('disabled PopupMenuButton is not focusable', (WidgetTester tester) async {
     final Key popupButtonKey = UniqueKey();
     final GlobalKey childKey = GlobalKey();
     bool itemBuilderCalled = false;
@@ -214,7 +214,7 @@ void main() {
     expect(onSelectedCalled, isFalse);
   });
 
-  testWidgets('disabled PopupMenuItem is not focusabled', (WidgetTester tester) async {
+  testWidgets('PopupMenuItem is only focusable when enabled', (WidgetTester tester) async {
     final Key popupButtonKey = UniqueKey();
     final GlobalKey childKey = GlobalKey();
     bool itemBuilderCalled = false;
@@ -237,21 +237,22 @@ void main() {
                   ];
                 },
               ),
-              Container(),
             ],
           ),
         ),
       ),
     );
 
-    // Open the popup.
+    // Open the popup to build and show the menu contents.
     await tester.tap(find.byKey(popupButtonKey));
     await tester.pumpAndSettle();
     final FocusNode childNode = Focus.of(childKey.currentContext, nullOk: true);
+    // Now that the contents are shown, request focus on the child text.
     childNode.requestFocus();
     await tester.pumpAndSettle();
     expect(itemBuilderCalled, isTrue);
 
+    // Make sure that the focus went where we expected it to.
     expect(childNode.hasPrimaryFocus, isTrue);
     itemBuilderCalled = false;
 
@@ -264,7 +265,6 @@ void main() {
         home: Material(
           child: Column(
             children: <Widget>[
-              Container(),
               PopupMenuButton<int>(
                 key: popupButtonKey,
                 itemBuilder: (BuildContext context) {
@@ -284,7 +284,7 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    // Open the popup again to rebuild the contents.
+    // Open the popup again to rebuild the contents with enabled == false.
     await tester.tap(find.byKey(popupButtonKey));
     await tester.pumpAndSettle();
 

--- a/packages/flutter/test/material/stepper_test.dart
+++ b/packages/flutter/test/material/stepper_test.dart
@@ -605,4 +605,56 @@ void main() {
 
     expect(find.text('Text After Stepper'), findsNothing);
   });
+
+  testWidgets("Vertical Stepper can't be focused when disabled.", (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Stepper(
+            currentStep: 0,
+            type: StepperType.vertical,
+            steps: const <Step>[
+              Step(
+                title: Text('Step 0'),
+                state: StepState.disabled,
+                content: Text('Text 0'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final FocusNode disabledNode = Focus.of(tester.element(find.text('Step 0')), nullOk: true, scopeOk: true);
+    disabledNode.requestFocus();
+    await tester.pump();
+    expect(disabledNode.hasPrimaryFocus, isFalse);
+  });
+
+  testWidgets("Horizontal Stepper can't be focused when disabled.", (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Stepper(
+            currentStep: 0,
+            type: StepperType.horizontal,
+            steps: const <Step>[
+              Step(
+                title: Text('Step 0'),
+                state: StepState.disabled,
+                content: Text('Text 0'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final FocusNode disabledNode = Focus.of(tester.element(find.text('Step 0')), nullOk: true, scopeOk: true);
+    disabledNode.requestFocus();
+    await tester.pump();
+    expect(disabledNode.hasPrimaryFocus, isFalse);
+  });
 }


### PR DESCRIPTION
## Description

Makes sure that disabled `InkWell`/`InkResponse` and widgets that use them don't allow themselves 
to be focused.

`ListTile`, `PopupMenu`, and `Stepper` were not setting `canRequestFocus` properly on the `InkWell`, and `InkWell` was allowing focus even if it was disabled (it was basically just relying on the containing widget to set `canRequestFocus` properly).  Now `InkWell` must both be enabled (have an `onTap` or similar) and have `canRequestFocus` set to true.

## Related Issues

## Tests

- Added tests for `InkWell`, `ListTile`, `PopupMenu`, and `Stepper`. 

## Breaking Change

- [X] No, this is *not* a breaking change.