### PR TITLE
Export platformViewRegistry from package:flutter_web_plugins.

### DIFF
--- a/packages/flutter_web_plugins/lib/flutter_web_plugins.dart
+++ b/packages/flutter_web_plugins/lib/flutter_web_plugins.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-export 'src/plugin_event_channel.dart';
-export 'src/plugin_registry.dart';
-
 // This is only in the Web Flutter SDK
 // ignore: undefined_shown_name
 export 'dart:ui' show platformViewRegistry;
+
+export 'src/plugin_event_channel.dart';
+export 'src/plugin_registry.dart';

--- a/packages/flutter_web_plugins/lib/flutter_web_plugins.dart
+++ b/packages/flutter_web_plugins/lib/flutter_web_plugins.dart
@@ -4,3 +4,7 @@
 
 export 'src/plugin_event_channel.dart';
 export 'src/plugin_registry.dart';
+
+// This is only in the Web Flutter SDK
+// ignore: undefined_shown_name
+export 'dart:ui' show platformViewRegistry;


### PR DESCRIPTION
## Description

By exporting `platformViewRegistry` in `package:flutter_web_plugins` and ignoring the warning, users can use `platformViewRegistry` without seeing the warning themselves.

## Issues

Addresses https://github.com/flutter/flutter/issues/41563

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
