### PR TITLE
Reorder show and setEditingState calls to the IMM

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1409,6 +1409,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
               keyboardAppearance: widget.keyboardAppearance,
           ),
       );
+      _textInputConnection.show();
 
       _updateSizeAndTransform();
       final TextStyle style = widget.style;
@@ -1421,8 +1422,9 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
           textAlign: widget.textAlign,
         )
         ..setEditingState(localValue);
+    } else {
+      _textInputConnection.show();
     }
-    _textInputConnection.show();
   }
 
   void _closeInputConnectionIfNeeded() {

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -3421,7 +3421,7 @@ void main() {
     });
     const String testText = 'flutter is the best!';
     final TextEditingController controller = TextEditingController(text: testText);
-    EditableText et = EditableText(
+    final EditableText et = EditableText(
       showSelectionHandles: true,
       maxLines: 2,
       controller: controller,
@@ -3445,7 +3445,7 @@ void main() {
     await tester.showKeyboard(find.byType(EditableText));
     expect(log.length, 7);
     // TextInput.show should be before TextInput.setEditingState
-    List<String> logOrder = ['TextInput.setClient', 'TextInput.show', 'TextInput.setEditableSizeAndTransform', 'TextInput.setStyle', 'TextInput.setEditingState', 'TextInput.setEditingState', 'TextInput.show'];
+    final List<String> logOrder = <String>['TextInput.setClient', 'TextInput.show', 'TextInput.setEditableSizeAndTransform', 'TextInput.setStyle', 'TextInput.setEditingState', 'TextInput.setEditingState', 'TextInput.show'];
     int index = 0;
     for (MethodCall m in log) {
       expect(m.method, logOrder[index]);

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -3413,6 +3413,45 @@ void main() {
       throwsAssertionError,
     );
   });
+
+  testWidgets('input imm channel calls are ordered correctly', (WidgetTester tester) async {
+    final List<MethodCall> log = <MethodCall>[];
+    SystemChannels.textInput.setMockMethodCallHandler((MethodCall methodCall) async {
+      log.add(methodCall);
+    });
+    const String testText = 'flutter is the best!';
+    final TextEditingController controller = TextEditingController(text: testText);
+    EditableText et = EditableText(
+      showSelectionHandles: true,
+      maxLines: 2,
+      controller: controller,
+      focusNode: FocusNode(),
+      cursorColor: Colors.red,
+      backgroundCursorColor: Colors.blue,
+      style: Typography(platform: TargetPlatform.android).black.subhead.copyWith(fontFamily: 'Roboto'),
+      keyboardType: TextInputType.text,
+    );
+
+    await tester.pumpWidget(MaterialApp(
+      home: Align(
+        alignment: Alignment.topLeft,
+        child: SizedBox(
+          width: 100,
+          child: et,
+        ),
+      ),
+    ));
+
+    await tester.showKeyboard(find.byType(EditableText));
+    expect(log.length, 7);
+    // TextInput.show should be before TextInput.setEditingState
+    List<String> logOrder = ['TextInput.setClient', 'TextInput.show', 'TextInput.setEditableSizeAndTransform', 'TextInput.setStyle', 'TextInput.setEditingState', 'TextInput.setEditingState', 'TextInput.show'];
+    int index = 0;
+    for (MethodCall m in log) {
+      expect(m.method, logOrder[index]);
+      index++;
+    }
+  });
 }
 
 class MockTextSelectionControls extends Mock implements TextSelectionControls {


### PR DESCRIPTION
This ensures `_textInputConnection.show()` is called before `_textInputConnection.setEditingState()`.

This makes it consistent with the order of other platforms, and is aimed at possibly resolving https://github.com/flutter/flutter/issues/41990 (pending confirmation from Samsung).

b/141639086 reports that a possible cause of the Samsung keyboard bugs we are seeing is a reversed call order of onShowInputRequested() and onUpdateSelection(). This change should flip it to the expected order.

In practice, this reorder does not seem to have any impact on Flutter.