### PR TITLE
check for instanceof instead of runtimeType

### DIFF
--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -341,7 +341,7 @@ void main() {
       expect(testLogger.errorText, startsWith(
         'Warning: File "/pubspec.yaml" was created in the future. Optimizations that rely on '
         'comparing time stamps will be unreliable. Check your system clock for accuracy.\n'
-        'The timestamp was: 2000-01-01 00:00:00.000\n'
+        'The timestamp was:'
       ));
       testLogger.clear();
     }, overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -278,6 +278,14 @@ void main() {
             ..setLastModifiedSync(DateTime(2002));
         }
       ),
+      const FakeCommand(
+        command: <String>[
+          '/bin/cache/dart-sdk/bin/pub',
+          '--verbosity=warning',
+          'get',
+          '--no-precompile',
+        ],
+      ),
     ]);
     await Testbed().run(() async {
       // the good scenario: .packages is old, pub updates the file.

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -315,7 +315,7 @@ void main() {
         await pub.get(context: PubContext.flutterTests, checkLastModified: true);
         expect(true, isFalse, reason: 'pub.get did not throw');
       } catch (error) {
-        expect(error.runtimeType, Exception);
+        expect(error, isInstanceOf<Exception>());
         expect(error.message, '/: unexpected concurrent modification of pubspec.yaml while running pub.');
       }
       expect(testLogger.statusText, 'Running "flutter pub get" in /...\n');

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -337,7 +337,7 @@ void main() {
         ..setLastModifiedSync(DateTime(9999));
       assert(DateTime(9999).isAfter(DateTime.now()));
       await pub.get(context: PubContext.flutterTests, checkLastModified: true); // pub does nothing
-      expect(testLogger.statusText, 'Running "flutter pub get" in /...\n');
+      expect(testLogger.statusText, contains('Running "flutter pub get" in /...\n'));
       expect(testLogger.errorText, startsWith(
         'Warning: File "/pubspec.yaml" was created in the future. Optimizations that rely on '
         'comparing time stamps will be unreliable. Check your system clock for accuracy.\n'

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -243,7 +243,7 @@ void main() {
     Pub: () => const Pub(),
   });
 
-  test('Pub error handling', () {
+  test('Pub error handling', () async {
     final MemoryFileSystem fileSystem = MemoryFileSystem();
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
@@ -279,7 +279,7 @@ void main() {
         }
       ),
     ]);
-    Testbed().run(() async {
+    await Testbed().run(() async {
       // the good scenario: .packages is old, pub updates the file.
       fs.file('.packages')
         ..createSync()


### PR DESCRIPTION
## Description

This is an attempt at fixing https://github.com/flutter/flutter/issues/43866. I'm not sure why runtime type would sometimes not work. 

EDIT: this test was not flaky due to runtime types, but due to timing some of the later asserts would only run if they could be hit before the test isolate was torn down. Currently looking into why await Futures has failed me