### PR TITLE
Revert "[flutter_runner] Use sky_engine from the topaz tree (#43684)"

### DIFF
--- a/packages/flutter/BUILD.gn
+++ b/packages/flutter/BUILD.gn
@@ -13,15 +13,15 @@ dart_library("flutter") {
   disable_analysis = true
 
   deps = [
+    "//third_party/dart/third_party/pkg/intl",
     "//third_party/dart-pkg/pub/async",
     "//third_party/dart-pkg/pub/collection",
     "//third_party/dart-pkg/pub/meta",
     "//third_party/dart-pkg/pub/typed_data",
     "//third_party/dart-pkg/pub/vector_math",
-    "//third_party/dart/third_party/pkg/intl",
   ]
 
   if (is_fuchsia) {
-    deps += [ "//topaz/runtime/sky_engine:sky_engine_dart" ]
+    deps += [ "$flutter_root/sky/packages/sky_engine:sky_engine_dart" ]
   }
 }

--- a/packages/flutter_driver/BUILD.gn
+++ b/packages/flutter_driver/BUILD.gn
@@ -20,11 +20,11 @@ dart_library("flutter_driver") {
     "//third_party/dart-pkg/pub/json_rpc_2",
     "//third_party/dart-pkg/pub/meta",
     "//third_party/dart-pkg/pub/path",
-    "//third_party/dart-pkg/pub/vm_service_client",
     "//third_party/dart-pkg/pub/web_socket_channel",
+    "//third_party/dart-pkg/pub/vm_service_client",
   ]
 
   if (is_fuchsia) {
-    deps += [ "//topaz/runtime/sky_engine:sky_engine_dart" ]
+    deps += [ "$flutter_root/sky/packages/sky_engine:sky_engine_dart" ]
   }
 }


### PR DESCRIPTION
This reverts commit e091d724f697d78375b9b850b67b6a810daa8f82.

We need to first update the fuchsia roll script to copy over the sky_engine from flutter cache.