### PR TITLE
Observe logging from VM service on iOS 13

### DIFF
--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -23,6 +23,7 @@ import 'linux/linux_device.dart';
 import 'macos/macos_device.dart';
 import 'project.dart';
 import 'tester/flutter_tester.dart';
+import 'vmservice.dart';
 import 'web/web_device.dart';
 import 'windows/windows_device.dart';
 
@@ -618,6 +619,10 @@ abstract class DeviceLogReader {
   /// A broadcast stream where each element in the string is a line of log output.
   Stream<String> get logLines;
 
+  /// Some logs can be obtained from a VM service stream.
+  /// Set this after the VM services are connected.
+  List<VMService> connectedVMServices;
+
   @override
   String toString() => name;
 
@@ -644,6 +649,9 @@ class NoOpDeviceLogReader implements DeviceLogReader {
 
   @override
   int appPid;
+
+  @override
+  List<VMService> connectedVMServices;
 
   @override
   Stream<String> get logLines => const Stream<String>.empty();

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -600,12 +600,12 @@ class IOSDeviceLogReader extends DeviceLogReader {
     _connectedVMServices = connectedVMServices;
   }
 
-  Future<void> _listenToSysLog () async {
+  void _listenToSysLog () {
     // syslog is not written on iOS 13+.
     if (device.majorSdkVersion >= _minimumUniversalLoggingSdkVersion) {
       return;
     }
-    unawaited(iMobileDevice.startLogger(device.id).then<void>((Process process) {
+    iMobileDevice.startLogger(device.id).then<void>((Process process) {
       process.stdout.transform<String>(utf8.decoder).transform<String>(const LineSplitter()).listen(_newSyslogLineHandler());
       process.stderr.transform<String>(utf8.decoder).transform<String>(const LineSplitter()).listen(_newSyslogLineHandler());
       process.exitCode.whenComplete(() {
@@ -615,7 +615,7 @@ class IOSDeviceLogReader extends DeviceLogReader {
       });
       assert(_idevicesyslogProcess == null);
       _idevicesyslogProcess = process;
-    }));
+    });
   }
 
   @visibleForTesting

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -163,6 +163,7 @@ class FlutterDevice {
       printTrace('Successfully connected to service protocol: ${observatoryUris[i]}');
     }
     vmServices = localVmServices;
+    device.getLogReader(app: package).connectedVMServices = vmServices;
   }
 
   Future<void> refreshViews() async {

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -68,6 +68,16 @@ void main() {
       Platform: () => macPlatform,
     });
 
+    testUsingContext('parses major version', () {
+      expect(IOSDevice('device-123', sdkVersion: '1.0.0').majorSdkVersion, 1);
+      expect(IOSDevice('device-123', sdkVersion: '13.1.1').majorSdkVersion, 13);
+      expect(IOSDevice('device-123', sdkVersion: '10').majorSdkVersion, 10);
+      expect(IOSDevice('device-123', sdkVersion: '0').majorSdkVersion, 0);
+      expect(IOSDevice('device-123', sdkVersion: 'bogus').majorSdkVersion, null);
+    }, overrides: <Type, Generator>{
+      Platform: () => macPlatform,
+    });
+
     for (Platform platform in unsupportedPlatforms) {
       testUsingContext('throws UnsupportedError exception if instantiated on ${platform.operatingSystem}', () {
         expect(

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -73,7 +73,7 @@ void main() {
       expect(IOSDevice('device-123', sdkVersion: '13.1.1').majorSdkVersion, 13);
       expect(IOSDevice('device-123', sdkVersion: '10').majorSdkVersion, 10);
       expect(IOSDevice('device-123', sdkVersion: '0').majorSdkVersion, 0);
-      expect(IOSDevice('device-123', sdkVersion: 'bogus').majorSdkVersion, null);
+      expect(IOSDevice('device-123', sdkVersion: 'bogus').majorSdkVersion, 0);
     }, overrides: <Type, Generator>{
       Platform: () => macPlatform,
     });


### PR DESCRIPTION
## Description

IOSDeviceLogReader observes Stdout stream from VMService if version is iOS 13+ to print dart and engine logs.  Keep using syslog on older versions since that will additionally provide logs if the app crashes.

Similar to resident_web_runner behavior:
https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart#L295

## Related Issues

Fixes https://github.com/flutter/flutter/issues/41133.

## Tests

New resident_runner_test and devices_test.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.