### PR TITLE
Require awaiting testbed.run

### DIFF
--- a/packages/flutter_tools/test/general.shard/testbed_test.dart
+++ b/packages/flutter_tools/test/general.shard/testbed_test.dart
@@ -77,7 +77,7 @@ void main() {
     test('Doesnt throw a StateError if Timer is left cleaned up', () async {
       final Testbed testbed = Testbed();
 
-      testbed.run(() async {
+      await testbed.run(() async {
         final Timer timer = Timer.periodic(const Duration(seconds: 1), (Timer timer) { });
         timer.cancel();
       });

--- a/packages/flutter_tools/test/src/testbed.dart
+++ b/packages/flutter_tools/test/src/testbed.dart
@@ -90,7 +90,7 @@ class Testbed {
   ///
   /// `overrides` may be used to provide new context values for the single test
   /// case or override any context values from the setup.
-  FutureOr<T> run<T>(FutureOr<T> Function() test, {Map<Type, Generator> overrides}) {
+  Future<T> run<T>(FutureOr<T> Function() test, {Map<Type, Generator> overrides}) {
     final Map<Type, Generator> testOverrides = <Type, Generator>{
       ..._testbedDefaults,
       // Add the initial setUp overrides


### PR DESCRIPTION
## Description

The test failure in https://github.com/flutter/flutter/commit/a192e2960330f7ce980fde58bf866918b1c8b2da would have been easier to catch if we had been required to await the Future. this lint doesn't seem to be triggered on FutureOr