### PR TITLE
flutter build aar should also build plugins as AARs

### DIFF
--- a/dev/devicelab/bin/tasks/build_aar_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_aar_module_test.dart
@@ -42,7 +42,7 @@ Future<void> main() async {
       String content = pubspec.readAsStringSync();
       content = content.replaceFirst(
         '\ndependencies:\n',
-        '\ndependencies:\n  device_info:\n  package_info:\n',
+        '\ndependencies:\n  device_info: 0.4.1\n  package_info: 0.4.0+9\n',
       );
       pubspec.writeAsStringSync(content, flush: true);
       await inDirectory(projectDir, () async {
@@ -69,6 +69,8 @@ Future<void> main() async {
         'repo',
       );
 
+      section('Check release Maven artifacts');
+
       checkFileExists(path.join(
         repoPath,
         'io',
@@ -93,12 +95,59 @@ Future<void> main() async {
 
       checkFileExists(releasePom);
 
+      checkFileExists(path.join(
+        repoPath,
+        'io',
+        'flutter',
+        'plugins',
+        'deviceinfo',
+        'device_info_release',
+        '1.0',
+        'device_info_release-1.0.aar',
+      ));
+
+      checkFileExists(path.join(
+        repoPath,
+        'io',
+        'flutter',
+        'plugins',
+        'deviceinfo',
+        'device_info_release',
+        '1.0',
+        'device_info_release-1.0.pom',
+      ));
+
+      checkFileExists(path.join(
+        repoPath,
+        'io',
+        'flutter',
+        'plugins',
+        'packageinfo',
+        'package_info_release',
+        '1.0',
+        'package_info_release-1.0.aar',
+      ));
+
+      checkFileExists(path.join(
+        repoPath,
+        'io',
+        'flutter',
+        'plugins',
+        'packageinfo',
+        'package_info_release',
+        '1.0',
+        'package_info_release-1.0.pom',
+      ));
+
       section('Check AOT blobs in release POM');
 
       checkFileContains(<String>[
         'flutter_embedding_release',
         'armeabi_v7a_release',
         'arm64_v8a_release',
+        'x86_64_release',
+        'package_info_release',
+        'device_info_release',
       ], releasePom);
 
       section('Check assets in release AAR');
@@ -109,6 +158,7 @@ Future<void> main() async {
           // AOT snapshots
           'jni/arm64-v8a/libapp.so',
           'jni/armeabi-v7a/libapp.so',
+          'jni/x86_64/libapp.so',
         ],
         await getFilesInAar(
           path.join(
@@ -132,6 +182,8 @@ Future<void> main() async {
           options: <String>['aar', '--verbose', '--debug'],
         );
       });
+
+      section('Check debug Maven artifacts');
 
       checkFileExists(path.join(
         repoPath,
@@ -157,6 +209,50 @@ Future<void> main() async {
 
       checkFileExists(debugPom);
 
+      checkFileExists(path.join(
+        repoPath,
+        'io',
+        'flutter',
+        'plugins',
+        'deviceinfo',
+        'device_info_debug',
+        '1.0',
+        'device_info_debug-1.0.aar',
+      ));
+
+      checkFileExists(path.join(
+        repoPath,
+        'io',
+        'flutter',
+        'plugins',
+        'deviceinfo',
+        'device_info_debug',
+        '1.0',
+        'device_info_debug-1.0.pom',
+      ));
+
+      checkFileExists(path.join(
+        repoPath,
+        'io',
+        'flutter',
+        'plugins',
+        'packageinfo',
+        'package_info_debug',
+        '1.0',
+        'package_info_debug-1.0.aar',
+      ));
+
+      checkFileExists(path.join(
+        repoPath,
+        'io',
+        'flutter',
+        'plugins',
+        'packageinfo',
+        'package_info_debug',
+        '1.0',
+        'package_info_debug-1.0.pom',
+      ));
+
       section('Check AOT blobs in debug POM');
 
       checkFileContains(<String>[
@@ -165,6 +261,8 @@ Future<void> main() async {
         'x86_64_debug',
         'armeabi_v7a_debug',
         'arm64_v8a_debug',
+        'package_info_debug',
+        'device_info_debug',
       ], debugPom);
 
       section('Check assets in debug AAR');

--- a/packages/flutter_tools/gradle/aar_init_script.gradle
+++ b/packages/flutter_tools/gradle/aar_init_script.gradle
@@ -79,7 +79,7 @@ String getFlutterRoot(Project project) {
 
 void addAarTask(Project project, variant) {
     String variantName = variant.name.capitalize()
-    String taskName = "assembleAar${variantName}"
+    String taskName = "assembleAar$variantName"
     project.tasks.create(name: taskName) {
         // This check is required to be able to configure the archives before `uploadArchives` runs.
         if (!project.gradle.startParameter.taskNames.contains(taskName)) {
@@ -136,13 +136,32 @@ projectsEvaluated {
     assert rootProject.hasProperty("is-plugin")
     if (rootProject.property("is-plugin").toBoolean()) {
         assert rootProject.hasProperty("output-dir")
-        // In plugin projects, the Android library is the root project.
+        // In plugin projects, the root project is the plugin.
         configureProject(rootProject, rootProject.property("output-dir"))
         return
     }
-    // In module projects, the Android library project is the `:flutter` subproject.
-    Project androidLibraryProject = rootProject.subprojects.find { it.name == "flutter" }
-    assert androidLibraryProject != null
-    assert androidLibraryProject.hasProperty("output-dir")
-    configureProject(androidLibraryProject, androidLibraryProject.property("output-dir"))
+    // The module project is the `:flutter` subproject.
+    Project moduleProject = rootProject.subprojects.find { it.name == "flutter" }
+    assert moduleProject != null
+    assert moduleProject.hasProperty("output-dir")
+    configureProject(moduleProject, moduleProject.property("output-dir"))
+
+    // Gets the plugin subprojects.
+    Set<Project> modulePlugins = rootProject.subprojects.findAll {
+        it.name != "flutter" && it.name != "app"
+    }
+    // When a module is built as a Maven artifacts, plugins must also be built this way
+    // because the module POM's file will include a dependency on the plugin Maven artifact.
+    // This is due to the Android Gradle Plugin expecting all library subprojects to be published
+    // as Maven artifacts.
+    modulePlugins.each { pluginProject ->
+        configureProject(pluginProject, moduleProject.property("output-dir"))
+        moduleProject.android.libraryVariants.all { variant ->
+            // Configure the `assembleAar<variantName>` task for each plugin's projects and make
+            // the module's equivalent task depend on the plugin's task.
+            String variantName = variant.name.capitalize()
+            moduleProject.tasks.findByPath("assembleAar$variantName")
+                .dependsOn(pluginProject.tasks.findByPath("assembleAar$variantName"))
+        }
+    }
 }

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -264,18 +264,9 @@ class FlutterPlugin implements Plugin<Project> {
         if (useLocalEngine()) {
             throw new GradleException("Local engine isn't supported when building the plugins as AAR")
         }
-        List<Project> projects = [project]
-        // Module projects set the `hostProjects` extra property in `include_flutter.groovy`.
-        // This is required to set the local repository in each host app project.
-        if (project.ext.has("hostProjects")) {
-            projects.addAll(project.ext.get("hostProjects"))
-        }
-        // Configure the repository for the plugins.
-        projects.each { hostProject ->
-            hostProject.repositories {
-                maven {
-                    url "${getPluginBuildDir()}/outputs/repo"
-                }
+        project.repositories {
+            maven {
+                url "${getPluginBuildDir()}/outputs/repo"
             }
         }
         getPluginList().each { pluginName, pluginPath ->

--- a/packages/flutter_tools/templates/module/android/library/include_flutter.groovy.copy.tmpl
+++ b/packages/flutter_tools/templates/module/android/library/include_flutter.groovy.copy.tmpl
@@ -6,37 +6,24 @@ def flutterProjectRoot = new File(scriptFile).parentFile.parentFile
 gradle.include ':flutter'
 gradle.project(':flutter').projectDir = new File(flutterProjectRoot, '.android/Flutter')
 
-if (System.getProperty('build-plugins-as-aars') != 'true') {
-    def plugins = new Properties()
-    def pluginsFile = new File(flutterProjectRoot, '.flutter-plugins')
-    if (pluginsFile.exists()) {
-        pluginsFile.withReader('UTF-8') { reader -> plugins.load(reader) }
-    }
-
-    plugins.each { name, path ->
-        def pluginDirectory = flutterProjectRoot.toPath().resolve(path).resolve('android').toFile()
-        gradle.include ":$name"
-        gradle.project(":$name").projectDir = pluginDirectory
-    }
+def plugins = new Properties()
+def pluginsFile = new File(flutterProjectRoot, '.flutter-plugins')
+if (pluginsFile.exists()) {
+    pluginsFile.withReader('UTF-8') { reader -> plugins.load(reader) }
 }
+
+plugins.each { name, path ->
+    def pluginDirectory = flutterProjectRoot.toPath().resolve(path).resolve('android').toFile()
+    gradle.include ":$name"
+    gradle.project(":$name").projectDir = pluginDirectory
+}
+
 gradle.getGradle().projectsLoaded { g ->
     g.rootProject.beforeEvaluate { p ->
         _mainModuleName = binding.variables['mainModuleName']
         if (_mainModuleName != null && !_mainModuleName.empty) {
             p.ext.mainModuleName = _mainModuleName
         }
-        def subprojects = []
-        def flutterProject
-        p.subprojects { sp ->
-            if (sp.name == 'flutter') {
-                flutterProject = sp
-            } else {
-                subprojects.add(sp)
-            }
-        }
-        assert flutterProject != null
-        flutterProject.ext.hostProjects = subprojects
-        flutterProject.ext.pluginBuildDir = new File(flutterProjectRoot, 'build/host')
     }
     g.rootProject.afterEvaluate { p ->
         p.subprojects { sp ->

--- a/packages/flutter_tools/templates/module/android/library_new_embedding/include_flutter.groovy.copy.tmpl
+++ b/packages/flutter_tools/templates/module/android/library_new_embedding/include_flutter.groovy.copy.tmpl
@@ -6,37 +6,24 @@ def flutterProjectRoot = new File(scriptFile).parentFile.parentFile
 gradle.include ':flutter'
 gradle.project(':flutter').projectDir = new File(flutterProjectRoot, '.android/Flutter')
 
-if (System.getProperty('build-plugins-as-aars') != 'true') {
-    def plugins = new Properties()
-    def pluginsFile = new File(flutterProjectRoot, '.flutter-plugins')
-    if (pluginsFile.exists()) {
-        pluginsFile.withReader('UTF-8') { reader -> plugins.load(reader) }
-    }
-
-    plugins.each { name, path ->
-        def pluginDirectory = flutterProjectRoot.toPath().resolve(path).resolve('android').toFile()
-        gradle.include ":$name"
-        gradle.project(":$name").projectDir = pluginDirectory
-    }
+def plugins = new Properties()
+def pluginsFile = new File(flutterProjectRoot, '.flutter-plugins')
+if (pluginsFile.exists()) {
+    pluginsFile.withReader('UTF-8') { reader -> plugins.load(reader) }
 }
+
+plugins.each { name, path ->
+    def pluginDirectory = flutterProjectRoot.toPath().resolve(path).resolve('android').toFile()
+    gradle.include ":$name"
+    gradle.project(":$name").projectDir = pluginDirectory
+}
+
 gradle.getGradle().projectsLoaded { g ->
     g.rootProject.beforeEvaluate { p ->
         _mainModuleName = binding.variables['mainModuleName']
         if (_mainModuleName != null && !_mainModuleName.empty) {
             p.ext.mainModuleName = _mainModuleName
         }
-        def subprojects = []
-        def flutterProject
-        p.subprojects { sp ->
-            if (sp.name == 'flutter') {
-                flutterProject = sp
-            } else {
-                subprojects.add(sp)
-            }
-        }
-        assert flutterProject != null
-        flutterProject.ext.hostProjects = subprojects
-        flutterProject.ext.pluginBuildDir = new File(flutterProjectRoot, 'build/host')
     }
     g.rootProject.afterEvaluate { p ->
         p.subprojects { sp ->


### PR DESCRIPTION
## Description
Currently, `flutter build aar` doesn't build the plugins as Maven artifacts. AGP requires all libraries subprojects such as Flutter plugins to be published as Maven artifacts. 

I broke this behavior when I removed the sync `execute(..)` call from the Flutter Gradle plugin.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/43919#event-2761279931

## Tests

I added the following tests: integration test `build_aar_module_test.dart`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
