### PR TITLE
fix text tests on the web

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -61,8 +61,8 @@ const int kWebBatchSize = 20;
 //
 // TODO(yjbanov): we're getting rid of this blacklist as part of https://github.com/flutter/flutter/projects/60
 const List<String> kWebTestFileBlacklist = <String>[
+  // This test doesn't compile because it depends on code outside the flutter package.
   'test/examples/sector_layout_test.dart',
-  'test/widgets/text_test.dart',
   'test/widgets/selectable_text_test.dart',
   'test/widgets/color_filter_test.dart',
   'test/widgets/editable_text_cursor_test.dart',

--- a/packages/flutter/test/widgets/text_test.dart
+++ b/packages/flutter/test/widgets/text_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui' as ui;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -59,7 +61,7 @@ void main() {
     final Size largeSize = tester.getSize(find.byType(RichText));
     expect(largeSize.width, 105.0);
     expect(largeSize.height, equals(21.0));
-  }, skip: isBrowser);
+  });
 
   testWidgets('Text respects textScaleFactor with explicit font size', (WidgetTester tester) async {
     await tester.pumpWidget(const Center(
@@ -87,7 +89,7 @@ void main() {
     final Size largeSize = tester.getSize(find.byType(RichText));
     expect(largeSize.width, anyOf(131.0, 130.0));
     expect(largeSize.height, equals(26.0));
-  }, skip: isBrowser);
+  });
 
   testWidgets('Text throws a nice error message if there\'s no Directionality', (WidgetTester tester) async {
     await tester.pumpWidget(const Text('Hello'));
@@ -157,7 +159,7 @@ void main() {
       ),
     );
     expect(tester.takeException(), null);
-  });
+  }, skip: isBrowser); // TODO(yjbanov): https://github.com/flutter/flutter/issues/42086
 
   testWidgets('semanticsLabel can override text label', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
@@ -411,7 +413,7 @@ void main() {
       ),
     );
     semantics.dispose();
-  }, skip: isBrowser);
+  });
 
 
   testWidgets('recognizers split semantic node - bidi', (WidgetTester tester) async {
@@ -602,7 +604,7 @@ void main() {
       ),
     );
     semantics.dispose();
-  }, skip: isBrowser);
+  }, skip: isBrowser); // TODO(yjbanov): https://github.com/flutter/flutter/issues/42086
 
   testWidgets('inline widgets semantic nodes scale', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
@@ -682,7 +684,7 @@ void main() {
       ),
     );
     semantics.dispose();
-  }, skip: isBrowser);
+  }, skip: isBrowser); // TODO(yjbanov): https://github.com/flutter/flutter/issues/42086
 
   testWidgets('Overflow is clipping correctly - short text with overflow: clip', (WidgetTester tester) async {
     await _pumpTextWidget(
@@ -797,7 +799,15 @@ void main() {
     final Size textSizeLongestLine = tester.getSize(find.byType(Text));
     expect(textSizeLongestLine.width, equals(630.0));
     expect(textSizeLongestLine.height, equals(fontHeight * 2));
-  }, skip: isBrowser);
+  }, skip: isBrowser);  // TODO(yjbanov): https://github.com/flutter/flutter/issues/44020
+
+  testWidgets('Paragraph.getBoxesForRange returns nothing when selection range is zero length', (WidgetTester tester) async {
+    final ui.ParagraphBuilder builder = ui.ParagraphBuilder(ui.ParagraphStyle());
+    builder.addText('hello');
+    final ui.Paragraph paragraph = builder.build();
+    paragraph.layout(const ui.ParagraphConstraints(width: 1000));
+    expect(paragraph.getBoxesForRange(2, 2), isEmpty);
+  });
 }
 
 Future<void> _pumpTextWidget({ WidgetTester tester, String text, TextOverflow overflow }) {


### PR DESCRIPTION
## Description

Enable and unskip many of `text_test.dart` tests. Requires https://github.com/flutter/engine/pull/13483 to land before submitting.

## Related Issues

Progress towards https://github.com/flutter/flutter/projects/60
