### PR TITLE
re-enable system_debug_ios

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -503,13 +503,12 @@ tasks:
     required_agent_capabilities: ["mac/ios"]
     timeout_in_minutes: 20
 
-  # TODO(fujino): does not pass on iOS13 https://github.com/flutter/flutter/issues/41133
-  # system_debug_ios:
-  #   description: >
-  #     Tests that the Engine correctly initializes the system debugger for debug-mode iOS apps.
-  #   stage: devicelab_ios
-  #   required_agent_capabilities: ["mac/ios"]
-  #   timeout_in_minutes: 10
+  system_debug_ios:
+    description: >
+      Tests that the Engine correctly initializes the system debugger for debug-mode iOS apps.
+    stage: devicelab_ios
+    required_agent_capabilities: ["mac/ios"]
+    timeout_in_minutes: 10
 
   ios_sample_catalog_generator:
     description: >


### PR DESCRIPTION
## Description

Re-enable `system_debug_ios`.

## Related Issues

Fixes #43029.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.