### PR TITLE
Exit tool if a plugin only supports the embedding v2 but the app doesn't

### DIFF
--- a/packages/flutter_tools/lib/src/platform_plugins.dart
+++ b/packages/flutter_tools/lib/src/platform_plugins.dart
@@ -64,17 +64,20 @@ class AndroidPlugin extends PluginPlatform {
       'name': name,
       'package': package,
       'class': pluginClass,
-      'usesEmbedding2': _embeddingVersion == '2',
+      // Mustache doesn't support complex types.
+      'supportsEmbeddingV1': _supportedEmbedings.contains('1'),
+      'supportsEmbeddingV2': _supportedEmbedings.contains('2'),
     };
   }
 
-  String _cachedEmbeddingVersion;
+  Set<String> _cachedEmbeddingVersion;
 
   /// Returns the version of the Android embedding.
-  String get _embeddingVersion => _cachedEmbeddingVersion ??= _getEmbeddingVersion();
+  Set<String> get _supportedEmbedings => _cachedEmbeddingVersion ??= _getSupportedEmbeddings();
 
-  String _getEmbeddingVersion() {
+  Set<String> _getSupportedEmbeddings() {
     assert(pluginPath != null);
+    final Set<String> supportedEmbeddings = <String>{};
     final String baseMainPath = fs.path.join(
       pluginPath,
       'android',
@@ -113,9 +116,15 @@ class AndroidPlugin extends PluginPlatform {
     }
     if (mainClassContent
         .contains('io.flutter.embedding.engine.plugins.FlutterPlugin')) {
-      return '2';
+      supportedEmbeddings.add('2');
+    } else {
+      supportedEmbeddings.add('1');
     }
-    return '1';
+    if (mainClassContent.contains('registerWith(Registrar registrar)') ||
+        mainClassContent.contains('registerWith(registrar: Registrar)')) {
+      supportedEmbeddings.add('1');
+    }
+    return supportedEmbeddings;
   }
 }
 

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -299,6 +299,111 @@ plugin3:${pluginUsingOldEmbeddingDir.childDirectory('lib').uri.toString()}
         XcodeProjectInterpreter: () => xcodeProjectInterpreter,
       });
 
+      testUsingContext('exits the tool if an app uses the v1 embedding and a plugin only supports the v2 embedding', () async {
+        when(flutterProject.isModule).thenReturn(false);
+
+        final File androidManifest = flutterProject.directory
+          .childDirectory('android')
+          .childFile('AndroidManifest.xml')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(kAndroidManifestUsingOldEmbedding);
+        when(androidProject.appManifestFile).thenReturn(androidManifest);
+
+        final Directory pluginUsingJavaAndNewEmbeddingDir =
+          fs.systemTempDirectory.createTempSync('flutter_plugin_using_java_and_new_embedding_dir.');
+        pluginUsingJavaAndNewEmbeddingDir
+          .childFile('pubspec.yaml')
+          .writeAsStringSync('''
+  flutter:
+    plugin:
+      androidPackage: plugin1
+      pluginClass: UseNewEmbedding
+  ''');
+        pluginUsingJavaAndNewEmbeddingDir
+          .childDirectory('android')
+          .childDirectory('src')
+          .childDirectory('main')
+          .childDirectory('java')
+          .childDirectory('plugin1')
+          .childFile('UseNewEmbedding.java')
+          ..createSync(recursive: true)
+          ..writeAsStringSync('import io.flutter.embedding.engine.plugins.FlutterPlugin;');
+
+        flutterProject.directory
+          .childFile('.packages')
+          .writeAsStringSync('''
+plugin1:${pluginUsingJavaAndNewEmbeddingDir.childDirectory('lib').uri.toString()}
+''');
+        await expectLater(
+          () async {
+            await injectPlugins(flutterProject);
+          },
+          throwsToolExit(
+            message: 'The plugin `plugin1` requires your app to be migrated to the Android embedding v2. '
+                     'Follow the steps on https://flutter.dev/go/android-project-migration and re-run this command.'
+          ),
+        );
+      }, overrides: <Type, Generator>{
+        FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager.any(),
+        FeatureFlags: () => featureFlags,
+        XcodeProjectInterpreter: () => xcodeProjectInterpreter,
+      });
+
+      testUsingContext('allows app use a plugin that supports v1 and v2 embedding', () async {
+        when(flutterProject.isModule).thenReturn(false);
+
+        final File androidManifest = flutterProject.directory
+          .childDirectory('android')
+          .childFile('AndroidManifest.xml')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(kAndroidManifestUsingOldEmbedding);
+        when(androidProject.appManifestFile).thenReturn(androidManifest);
+
+        final Directory pluginUsingJavaAndNewEmbeddingDir =
+          fs.systemTempDirectory.createTempSync('flutter_plugin_using_java_and_new_embedding_dir.');
+        pluginUsingJavaAndNewEmbeddingDir
+          .childFile('pubspec.yaml')
+          .writeAsStringSync('''
+  flutter:
+    plugin:
+      androidPackage: plugin1
+      pluginClass: UseNewEmbedding
+  ''');
+        pluginUsingJavaAndNewEmbeddingDir
+          .childDirectory('android')
+          .childDirectory('src')
+          .childDirectory('main')
+          .childDirectory('java')
+          .childDirectory('plugin1')
+          .childFile('UseNewEmbedding.java')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(
+            'import io.flutter.embedding.engine.plugins.FlutterPlugin;'
+            'registerWith(Registrar registrar)'
+          );
+
+        flutterProject.directory
+          .childFile('.packages')
+          .writeAsStringSync('''
+plugin1:${pluginUsingJavaAndNewEmbeddingDir.childDirectory('lib').uri.toString()}
+''');
+        await injectPlugins(flutterProject);
+
+        final File registrant = flutterProject.directory
+          .childDirectory(fs.path.join('android', 'app', 'src', 'main', 'java', 'io', 'flutter', 'plugins'))
+          .childFile('GeneratedPluginRegistrant.java');
+
+        expect(registrant.existsSync(), isTrue);
+        expect(registrant.readAsStringSync(), contains('package io.flutter.plugins'));
+        expect(registrant.readAsStringSync(), contains('class GeneratedPluginRegistrant'));
+      }, overrides: <Type, Generator>{
+        FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager.any(),
+        FeatureFlags: () => featureFlags,
+        XcodeProjectInterpreter: () => xcodeProjectInterpreter,
+      });
+
       testUsingContext('Registrant doesn\'t use new embedding if app doesn\'t use new embedding', () async {
         when(flutterProject.isModule).thenReturn(false);
 


### PR DESCRIPTION
## Description
If a plugin only supports the embedding v2, but the app only supports the v1 embedding, then the tool exits.

After discussing with @amirh offline, it was decided that the plugin template should be backward compatible. That change will be done in a separate PR.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/43779

## Tests

I added the following tests: Unit test.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
