### PR TITLE
Support --no-resident on the web

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -435,6 +435,7 @@ class AppDomain extends Domain {
         target: target,
         debuggingOptions: options,
         ipv6: ipv6,
+        stayResident: true,
       );
     } else if (enableHotReload) {
       runner = HotRunner(

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -457,6 +457,7 @@ class RunCommand extends RunCommandBase {
         flutterProject: flutterProject,
         ipv6: ipv6,
         debuggingOptions: _createDebuggingOptions(),
+        stayResident: stayResident,
       );
     } else {
       runner = ColdRunner(

--- a/packages/flutter_tools/lib/src/web/web_runner.dart
+++ b/packages/flutter_tools/lib/src/web/web_runner.dart
@@ -19,6 +19,7 @@ abstract class WebRunnerFactory {
   ResidentRunner createWebRunner(
     Device device, {
     String target,
+    @required bool stayResident,
     @required FlutterProject flutterProject,
     @required bool ipv6,
     @required DebuggingOptions debuggingOptions,

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -154,6 +154,19 @@ void main() {
     Logger: () => DelegateLogger(BufferLogger()),
   }));
 
+  test('Can successfully run and disconnect with --no-resident', () => testbed.run(() async {
+    _setupMocks();
+    residentWebRunner = ResidentWebRunner(
+      mockWebDevice,
+      flutterProject: FlutterProject.current(),
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      ipv6: true,
+      stayResident: false,
+    );
+
+    expect(await residentWebRunner.run(), 0);
+  }));
+
   test('Listens to stdout streams before running main', () => testbed.run(() async {
     _setupMocks();
     final BufferLogger bufferLogger = logger;


### PR DESCRIPTION
## Description

Attempts to match the behavior of mobile flutter for --no-resident. Slightly due different semantics due to the vmservice running host side. This means no-resident can't be used to connect/reconnect to an existing application yet, but can be used to ensure the build is reasonably up to date.