### PR TITLE
Use alphabetic baselines for layout of InputDecorator

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -907,7 +907,12 @@ class _RenderDecoration extends RenderBox {
       return 0.0;
     }
     box.layout(constraints, parentUsesSize: true);
-    final double baseline = box.getDistanceToBaseline(textBaseline);
+    // Since internally, all layout is performed against the alphabetic baseline,
+    // (eg, ascents/descents are all relative to alphabetic, even if the font is
+    // a ideographic or hanging font), we always obtain the reference baseline from
+    // the alphabetic baseline. The ideographic baseline is for reference
+    // post-layout.
+    final double baseline = box.getDistanceToBaseline(TextBaseline.alphabetic);
     assert(baseline != null && baseline >= 0.0);
     return baseline;
   }

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -909,10 +909,10 @@ class _RenderDecoration extends RenderBox {
     box.layout(constraints, parentUsesSize: true);
     // Since internally, all layout is performed against the alphabetic baseline,
     // (eg, ascents/descents are all relative to alphabetic, even if the font is
-    // a ideographic or hanging font), we should always obtain the reference
+    // an ideographic or hanging font), we should always obtain the reference
     // baseline from the alphabetic baseline. The ideographic baseline is for
-    // use post-layout and is derived from the alphabetic baseline and font
-    // metrics.
+    // use post-layout and is derived from the alphabetic baseline combined with
+    // the font metrics.
     final double baseline = box.getDistanceToBaseline(TextBaseline.alphabetic);
     assert(baseline != null && baseline >= 0.0);
     return baseline;

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -909,9 +909,10 @@ class _RenderDecoration extends RenderBox {
     box.layout(constraints, parentUsesSize: true);
     // Since internally, all layout is performed against the alphabetic baseline,
     // (eg, ascents/descents are all relative to alphabetic, even if the font is
-    // a ideographic or hanging font), we always obtain the reference baseline from
-    // the alphabetic baseline. The ideographic baseline is for reference
-    // post-layout.
+    // a ideographic or hanging font), we should always obtain the reference
+    // baseline from the alphabetic baseline. The ideographic baseline is for
+    // use post-layout and is derived from the alphabetic baseline and font
+    // metrics.
     final double baseline = box.getDistanceToBaseline(TextBaseline.alphabetic);
     assert(baseline != null && baseline >= 0.0);
     return baseline;

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -3574,7 +3574,7 @@ void main() {
                 labelText: 'label',
                 alignLabelWithHint: alignLabelWithHint,
                 hintText: 'hint',
-                hintStyle: TextStyle(
+                hintStyle: const TextStyle(
                   fontFamily: 'Cough',
                 ),
               ),
@@ -3586,8 +3586,12 @@ void main() {
 
     await tester.pumpWidget(buildFrame(true));
     await tester.pumpAndSettle();
-    // These numbers should be the values from using alphabetic baselines.
+
+    // These numbers should be the values from using alphabetic baselines:
+    // Ideographic (incorrect) value is 31.299999713897705
     expect(tester.getTopLeft(find.text('hint')).dy, 28.75);
+
+    // Ideographic (incorrect) value is 50.299999713897705
     expect(tester.getBottomLeft(find.text('hint')).dy, 47.75);
   });
 }

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -3551,4 +3551,43 @@ void main() {
       'alignLabelWithHint: true',
     ]);
   });
+
+  testWidgets('uses alphabetic baseline for CJK layout', (WidgetTester tester) async {
+    await tester.binding.setLocale('zh', 'CN');
+    final Typography typography = Typography();
+
+    final FocusNode focusNode = FocusNode();
+    final TextEditingController controller = TextEditingController();
+    // The dense theme uses ideographic baselines
+    Widget buildFrame(bool alignLabelWithHint) {
+      return MaterialApp(
+        theme: ThemeData(
+          textTheme: typography.dense,
+        ),
+        home: Material(
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: TextField(
+              controller: controller,
+              focusNode: focusNode,
+              decoration: InputDecoration(
+                labelText: 'label',
+                alignLabelWithHint: alignLabelWithHint,
+                hintText: 'hint',
+                hintStyle: TextStyle(
+                  fontFamily: 'Cough',
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame(true));
+    await tester.pumpAndSettle();
+    // These numbers should be the values from using alphabetic baselines.
+    expect(tester.getTopLeft(find.text('hint')).dy, 28.75);
+    expect(tester.getBottomLeft(find.text('hint')).dy, 47.75);
+  });
 }


### PR DESCRIPTION
Always use alphabetic when performing layout of InputDecorator.

See explanation in the comment.

```
    // Since internally, all layout is performed against the alphabetic baseline,
    // (eg, ascents/descents are all relative to alphabetic, even if the font is
    // a ideographic or hanging font), we should always obtain the reference
    // baseline from the alphabetic baseline. The ideographic baseline is for
    // use post-layout and is derived from the alphabetic baseline and font
    // metrics.
```
This fixes broken caret alignments in CJK/ideographic languages https://github.com/flutter/flutter/issues/40118

Tests coming soon!