### PR TITLE
Copy chrome preferences to seeded data dir

### DIFF
--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -132,7 +132,10 @@ class ChromeDevice extends Device {
     // for the web initialization and server logic.
     final String url = platformArgs['uri'];
     if (debuggingOptions.browserLaunch) {
-      _chrome = await chromeLauncher.launch(url);
+      _chrome = await chromeLauncher.launch(url,
+        dataDir: fs.currentDirectory
+          .childDirectory('.dart_tool')
+          .childDirectory('chrome-device'));
     } else {
       printStatus('Waiting for connection from Dart debug extension at $url', emphasis: true);
       logger.sendNotification(url, progressId: 'debugExtension');

--- a/packages/flutter_tools/test/general.shard/web/chrome_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/chrome_test.dart
@@ -19,33 +19,43 @@ import '../../src/testbed.dart';
 
 void main() {
   Testbed testbed;
+  Completer<int> exitCompleter;
 
   setUp(() {
     final MockPlatform platform = MockPlatform();
+    exitCompleter = Completer<int>.sync();
     when(platform.isWindows).thenReturn(false);
-    final MockFileSystem mockFileSystem = MockFileSystem();
     testbed = Testbed(overrides: <Type, Generator>{
       ProcessManager: () => MockProcessManager(),
       Platform: () => platform,
       OperatingSystemUtils: () => MockOperatingSystemUtils(),
-      FileSystem: () => mockFileSystem,
+    }, setup: () {
+      when(os.findFreePort()).thenAnswer((Invocation invocation) async {
+        return 1234;
+      });
+      when(platform.environment).thenReturn(<String, String>{
+        kChromeEnvironment: 'example_chrome',
+      });
+      when(processManager.start(any))
+        .thenAnswer((Invocation invocation) async {
+        return FakeProcess(
+          exitCode: exitCompleter.future,
+          stdout: const Stream<List<int>>.empty(),
+          stderr: Stream<List<int>>.fromIterable(<List<int>>[
+            utf8.encode('\n\nDevTools listening\n\n'),
+          ]),
+        );
+      });
     });
   });
 
+  tearDown(() {
+    resetChromeForTesting();
+  });
+
   test('can launch chrome and connect to the devtools', () => testbed.run(() async {
-    when(os.findFreePort()).thenAnswer((Invocation invocation) async {
-      return 1234;
-    });
-    when(platform.environment).thenReturn(<String, String>{
-      kChromeEnvironment: 'example_chrome',
-    });
-    final Directory mockDirectory = MockDirectory();
-    when(fs.systemTempDirectory).thenReturn(mockDirectory);
-    when(mockDirectory.createTempSync(any)).thenReturn(mockDirectory);
-    when(mockDirectory.path).thenReturn('example');
-    when(processManager.start(<String>[
+    const List<String> expected = <String>[
       'example_chrome',
-      '--user-data-dir=example',
       '--remote-debugging-port=1234',
       '--disable-background-timer-throttling',
       '--disable-extensions',
@@ -56,22 +66,45 @@ void main() {
       '--disable-default-apps',
       '--disable-translate',
       'example_url',
-    ])).thenAnswer((Invocation invocation) async {
-      return FakeProcess(
-        exitCode: Completer<int>().future,
-        stdout: const Stream<List<int>>.empty(),
-        stderr: Stream<List<int>>.fromIterable(<List<int>>[
-          utf8.encode('\n\nDevTools listening\n\n'),
-        ]),
-      );
-    });
+    ];
 
     await chromeLauncher.launch('example_url', skipCheck: true);
+    final VerificationResult result = verify(processManager.start(captureAny));
+
+    expect(result.captured.single, containsAll(expected));
+  }));
+
+  test('can seed chrome temp directory with existing preferences', () => testbed.run(() async {
+    final Directory dataDir = fs.directory('chrome-stuff');
+    final File preferencesFile = dataDir
+      .childDirectory('Default')
+      .childFile('preferences');
+    preferencesFile
+      ..createSync(recursive: true)
+      ..writeAsStringSync('example');
+
+    await chromeLauncher.launch('example_url', skipCheck: true, dataDir: dataDir);
+    final VerificationResult result = verify(processManager.start(captureAny));
+    final String arg = result.captured.single
+      .firstWhere((String arg) => arg.startsWith('--user-data-dir='));
+    final Directory tempDirectory = fs.directory(arg.split('=')[1]);
+    final File tempFile = tempDirectory
+      .childDirectory('Default')
+      .childFile('preferences');
+
+    expect(tempFile.existsSync(), true);
+    expect(tempFile.readAsStringSync(), 'example');
+
+    // write crash to file:
+    tempFile.writeAsStringSync('"exit_type":"Crashed"');
+    exitCompleter.complete(0);
+
+    // writes non-crash back to dart_tool
+    expect(preferencesFile.readAsStringSync(), '"exit_type":"Normal"');
   }));
 }
 
 class MockProcessManager extends Mock implements ProcessManager {}
 class MockPlatform extends Mock implements Platform {}
 class MockOperatingSystemUtils extends Mock implements OperatingSystemUtils {}
-class MockFileSystem extends Mock implements FileSystem {}
-class MockDirectory extends Mock implements Directory {}
+


### PR DESCRIPTION
## Description

Chrome stores preferences such as window size in data-dir/Default/preferences. This is occasionally updated by a running chrome process, seems like every few seconds. To allow multiple chrome instances to run while still keeping them in temp directories, we can save the preferences file under .dart_tool, and copy it back and forth between the temp/project dir.

Sometime this file will indicate that the browser crashed. This also removes that info to prevent the warning popup on next run.

Fixes https://github.com/flutter/flutter/issues/38537