### PR TITLE
Add Android embedding version analytics

### DIFF
--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -87,6 +87,8 @@ class PackagesGetCommand extends FlutterCommand {
       usageValues[CustomDimensions.commandPackagesNumberPlugins] = '0';
     }
     usageValues[CustomDimensions.commandPackagesProjectModule] = '${rootProject.isModule}';
+    usageValues[CustomDimensions.commandPackagesAndroidEmbeddingVersion] =
+        rootProject.android.getEmbeddingVersion().toString().split('.').last;
     return usageValues;
   }
 

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -250,6 +250,7 @@ class RunCommand extends RunCommandBase {
       CustomDimensions.commandRunModeName: modeName,
       CustomDimensions.commandRunProjectModule: '${FlutterProject.current().isModule}',
       CustomDimensions.commandRunProjectHostLanguage: hostLanguage.join(','),
+      CustomDimensions.commandRunAndroidEmbeddingVersion: androidProject.getEmbeddingVersion().toString().split('.').last,
     };
   }
 

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -406,6 +406,7 @@ Future<void> _writeAndroidPluginRegistrant(FlutterProject project, List<Plugin> 
       templateContent = _androidPluginRegistryTemplateNewEmbedding;
       break;
     case AndroidEmbeddingVersion.v1:
+    default:
       for (Map<String, dynamic> plugin in androidPlugins) {
         if (!plugin['supportsEmbeddingV1'] && plugin['supportsEmbeddingV2']) {
           throwToolExit(

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:mustache/mustache.dart' as mustache;
-import 'package:xml/xml.dart' as xml;
 import 'package:yaml/yaml.dart';
 
 import 'android/gradle.dart';
@@ -364,30 +363,10 @@ List<Map<String, dynamic>> _extractPlatformMaps(List<Plugin> plugins, String typ
 
 /// Returns the version of the Android embedding that the current
 /// [project] is using.
-String _getAndroidEmbeddingVersion(FlutterProject project) {
+AndroidEmbeddingVersion _getAndroidEmbeddingVersion(FlutterProject project) {
   assert(project.android != null);
 
-  final File androidManifest = project.android.appManifestFile;
-  if (androidManifest == null || !androidManifest.existsSync()) {
-    return '1';
-  }
-  xml.XmlDocument document;
-  try {
-    document = xml.parse(androidManifest.readAsStringSync());
-  } on xml.XmlParserException {
-    throwToolExit('Error parsing ${project.android.appManifestFile} '
-                  'Please ensure that the android manifest is a valid XML document and try again.');
-  } on FileSystemException {
-    throwToolExit('Error reading ${project.android.appManifestFile} even though it exists. '
-                  'Please ensure that you have read permission to this file and try again.');
-  }
-  for (xml.XmlElement metaData in document.findAllElements('meta-data')) {
-    final String name = metaData.getAttribute('android:name');
-    if (name == 'flutterEmbedding') {
-      return metaData.getAttribute('android:value');
-    }
-  }
-  return '1';
+  return project.android.getEmbeddingVersion();
 }
 
 Future<void> _writeAndroidPluginRegistrant(FlutterProject project, List<Plugin> plugins) async {
@@ -412,9 +391,9 @@ Future<void> _writeAndroidPluginRegistrant(FlutterProject project, List<Plugin> 
     'GeneratedPluginRegistrant.java',
   );
   String templateContent;
-  final String appEmbeddingVersion = _getAndroidEmbeddingVersion(project);
+  final AndroidEmbeddingVersion appEmbeddingVersion = _getAndroidEmbeddingVersion(project);
   switch (appEmbeddingVersion) {
-    case '2':
+    case AndroidEmbeddingVersion.v2:
       templateContext['needsShim'] = false;
       // If a plugin is using an embedding version older than 2.0 and the app is using 2.0,
       // then add  shim for the old plugins.
@@ -426,7 +405,7 @@ Future<void> _writeAndroidPluginRegistrant(FlutterProject project, List<Plugin> 
       }
       templateContent = _androidPluginRegistryTemplateNewEmbedding;
     break;
-    case '1':
+    case AndroidEmbeddingVersion.v1:
       for (Map<String, dynamic> plugin in androidPlugins) {
         if (!plugin['supportsEmbeddingV1'] && plugin['supportsEmbeddingV2']) {
           throwToolExit(

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -404,7 +404,7 @@ Future<void> _writeAndroidPluginRegistrant(FlutterProject project, List<Plugin> 
         }
       }
       templateContent = _androidPluginRegistryTemplateNewEmbedding;
-    break;
+      break;
     case AndroidEmbeddingVersion.v1:
       for (Map<String, dynamic> plugin in androidPlugins) {
         if (!plugin['supportsEmbeddingV1'] && plugin['supportsEmbeddingV2']) {
@@ -416,9 +416,7 @@ Future<void> _writeAndroidPluginRegistrant(FlutterProject project, List<Plugin> 
         }
       }
       templateContent = _androidPluginRegistryTemplateOldEmbedding;
-    break;
-    default:
-      throwToolExit('Unsupported Android embedding');
+      break;
   }
   printTrace('Generating $registryPath');
   _renderTemplateToFile(

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -671,7 +671,7 @@ class AndroidProject {
       }
     }
     return AndroidEmbeddingVersion.v1;
-    }
+  }
 }
 
 /// Iteration of the embedding Java API in the engine used by the Android project.

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:meta/meta.dart';
+import 'package:xml/xml.dart' as xml;
 import 'package:yaml/yaml.dart';
 
 import 'android/gradle_utils.dart' as gradle;
@@ -642,6 +643,43 @@ class AndroidProject {
       overwriteExisting: true,
     );
   }
+
+  AndroidEmbeddingVersion getEmbeddingVersion() {
+    if (appManifestFile == null || !appManifestFile.existsSync()) {
+      return AndroidEmbeddingVersion.v1;
+    }
+    xml.XmlDocument document;
+    try {
+      document = xml.parse(appManifestFile.readAsStringSync());
+    } on xml.XmlParserException {
+      throwToolExit('Error parsing $appManifestFile '
+                    'Please ensure that the android manifest is a valid XML document and try again.');
+    } on FileSystemException {
+      throwToolExit('Error reading $appManifestFile even though it exists. '
+                    'Please ensure that you have read permission to this file and try again.');
+    }
+    for (xml.XmlElement metaData in document.findAllElements('meta-data')) {
+      final String name = metaData.getAttribute('android:name');
+      if (name == 'flutterEmbedding') {
+        final String embeddingVersionString = metaData.getAttribute('android:value');
+        if (embeddingVersionString == '1') {
+          return AndroidEmbeddingVersion.v1;
+        }
+        if (embeddingVersionString == '2') {
+          return AndroidEmbeddingVersion.v2;
+        }
+      }
+    }
+    return AndroidEmbeddingVersion.v1;
+    }
+}
+
+/// Iteration of the embedding Java API in the engine used by the Android project.
+enum AndroidEmbeddingVersion {
+  /// V1 APIs based on io.flutter.app.FlutterActivity.
+  v1,
+  /// V2 APIs based on io.flutter.embedding.android.FlutterActivity.
+  v2,
 }
 
 /// Represents the web sub-project of a Flutter project.

--- a/packages/flutter_tools/lib/src/reporting/usage.dart
+++ b/packages/flutter_tools/lib/src/reporting/usage.dart
@@ -55,6 +55,8 @@ enum CustomDimensions {
   commandBuildAppBundleBuildMode, // cd42
   buildEventError,  // cd43
   commandResultEventMaxRss,  // cd44
+  commandRunAndroidEmbeddingVersion, // cd45
+  commandPackagesAndroidEmbeddingVersion, // cd46
 }
 
 String cdKey(CustomDimensions cd) => 'cd${cd.index + 1}';

--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -11,12 +11,14 @@ import 'package:flutter_tools/src/base/utils.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/packages.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
+import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:process/process.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/mocks.dart' show MockProcessManager, MockStdio, PromptingProcess;
+import '../../src/testbed.dart';
 
 class AlwaysTrueBotDetector implements BotDetector {
   const AlwaysTrueBotDetector();
@@ -263,6 +265,36 @@ void main() {
       expect(await getCommand.usageValues,
              containsPair(CustomDimensions.commandPackagesProjectModule, 'true'));
     }, overrides: <Type, Generator>{
+      Pub: () => const Pub(),
+    });
+
+    testUsingContext('indicate that Android project reports v1 in usage value', () async {
+      final String projectPath = await createProject(tempDir,
+        arguments: <String>['--no-pub']);
+      removeGeneratedFiles(projectPath);
+
+      final PackagesCommand command = await runCommandIn(projectPath, 'get');
+      final PackagesGetCommand getCommand = command.subcommands['get'] as PackagesGetCommand;
+
+      expect(await getCommand.usageValues,
+             containsPair(CustomDimensions.commandPackagesAndroidEmbeddingVersion, 'v1'));
+    }, overrides: <Type, Generator>{
+      FeatureFlags: () => TestFeatureFlags(isAndroidEmbeddingV2Enabled: false),
+      Pub: () => const Pub(),
+    });
+
+    testUsingContext('indicate that Android project reports v2 in usage value', () async {
+      final String projectPath = await createProject(tempDir,
+        arguments: <String>['--no-pub']);
+      removeGeneratedFiles(projectPath);
+
+      final PackagesCommand command = await runCommandIn(projectPath, 'get');
+      final PackagesGetCommand getCommand = command.subcommands['get'] as PackagesGetCommand;
+
+      expect(await getCommand.usageValues,
+             containsPair(CustomDimensions.commandPackagesAndroidEmbeddingVersion, 'v2'));
+    }, overrides: <Type, Generator>{
+      FeatureFlags: () => TestFeatureFlags(isAndroidEmbeddingV2Enabled: true),
       Pub: () => const Pub(),
     });
 

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -154,13 +154,7 @@ void main() {
 
       testUsingContext('Registrant uses old embedding in app project', () async {
         when(flutterProject.isModule).thenReturn(false);
-
-        final File androidManifest = flutterProject.directory
-          .childDirectory('android')
-          .childFile('AndroidManifest.xml')
-          ..createSync(recursive: true)
-          ..writeAsStringSync(kAndroidManifestUsingOldEmbedding);
-        when(androidProject.appManifestFile).thenReturn(androidManifest);
+        when(androidProject.getEmbeddingVersion()).thenReturn(AndroidEmbeddingVersion.v1);
 
         await injectPlugins(flutterProject);
 
@@ -179,13 +173,7 @@ void main() {
 
       testUsingContext('Registrant uses new embedding if app uses new embedding', () async {
         when(flutterProject.isModule).thenReturn(false);
-
-        final File androidManifest = flutterProject.directory
-          .childDirectory('android')
-          .childFile('AndroidManifest.xml')
-          ..createSync(recursive: true)
-          ..writeAsStringSync(kAndroidManifestUsingNewEmbedding);
-        when(androidProject.appManifestFile).thenReturn(androidManifest);
+        when(androidProject.getEmbeddingVersion()).thenReturn(AndroidEmbeddingVersion.v2);
 
         await injectPlugins(flutterProject);
 
@@ -204,13 +192,7 @@ void main() {
 
       testUsingContext('Registrant uses shim for plugins using old embedding if app uses new embedding', () async {
         when(flutterProject.isModule).thenReturn(false);
-
-        final File androidManifest = flutterProject.directory
-          .childDirectory('android')
-          .childFile('AndroidManifest.xml')
-          ..createSync(recursive: true)
-          ..writeAsStringSync(kAndroidManifestUsingNewEmbedding);
-        when(androidProject.appManifestFile).thenReturn(androidManifest);
+        when(androidProject.getEmbeddingVersion()).thenReturn(AndroidEmbeddingVersion.v2);
 
         final Directory pluginUsingJavaAndNewEmbeddingDir =
           fs.systemTempDirectory.createTempSync('flutter_plugin_using_java_and_new_embedding_dir.');
@@ -301,13 +283,7 @@ plugin3:${pluginUsingOldEmbeddingDir.childDirectory('lib').uri.toString()}
 
       testUsingContext('exits the tool if an app uses the v1 embedding and a plugin only supports the v2 embedding', () async {
         when(flutterProject.isModule).thenReturn(false);
-
-        final File androidManifest = flutterProject.directory
-          .childDirectory('android')
-          .childFile('AndroidManifest.xml')
-          ..createSync(recursive: true)
-          ..writeAsStringSync(kAndroidManifestUsingOldEmbedding);
-        when(androidProject.appManifestFile).thenReturn(androidManifest);
+        when(androidProject.getEmbeddingVersion()).thenReturn(AndroidEmbeddingVersion.v1);
 
         final Directory pluginUsingJavaAndNewEmbeddingDir =
           fs.systemTempDirectory.createTempSync('flutter_plugin_using_java_and_new_embedding_dir.');
@@ -352,13 +328,7 @@ plugin1:${pluginUsingJavaAndNewEmbeddingDir.childDirectory('lib').uri.toString()
 
       testUsingContext('allows app use a plugin that supports v1 and v2 embedding', () async {
         when(flutterProject.isModule).thenReturn(false);
-
-        final File androidManifest = flutterProject.directory
-          .childDirectory('android')
-          .childFile('AndroidManifest.xml')
-          ..createSync(recursive: true)
-          ..writeAsStringSync(kAndroidManifestUsingOldEmbedding);
-        when(androidProject.appManifestFile).thenReturn(androidManifest);
+        when(androidProject.getEmbeddingVersion()).thenReturn(AndroidEmbeddingVersion.v1);
 
         final Directory pluginUsingJavaAndNewEmbeddingDir =
           fs.systemTempDirectory.createTempSync('flutter_plugin_using_java_and_new_embedding_dir.');
@@ -406,13 +376,7 @@ plugin1:${pluginUsingJavaAndNewEmbeddingDir.childDirectory('lib').uri.toString()
 
       testUsingContext('Registrant doesn\'t use new embedding if app doesn\'t use new embedding', () async {
         when(flutterProject.isModule).thenReturn(false);
-
-        final File androidManifest = flutterProject.directory
-          .childDirectory('android')
-          .childFile('AndroidManifest.xml')
-          ..createSync(recursive: true)
-          ..writeAsStringSync(kAndroidManifestUsingOldEmbedding);
-        when(androidProject.appManifestFile).thenReturn(androidManifest);
+        when(androidProject.getEmbeddingVersion()).thenReturn(AndroidEmbeddingVersion.v1);
 
         await injectPlugins(flutterProject);
 
@@ -431,13 +395,7 @@ plugin1:${pluginUsingJavaAndNewEmbeddingDir.childDirectory('lib').uri.toString()
 
       testUsingContext('Registrant uses old embedding in module project', () async {
         when(flutterProject.isModule).thenReturn(true);
-
-        final File androidManifest = flutterProject.directory
-          .childDirectory('android')
-          .childFile('AndroidManifest.xml')
-          ..createSync(recursive: true)
-          ..writeAsStringSync(kAndroidManifestUsingOldEmbedding);
-        when(androidProject.appManifestFile).thenReturn(androidManifest);
+        when(androidProject.getEmbeddingVersion()).thenReturn(AndroidEmbeddingVersion.v1);
 
         await injectPlugins(flutterProject);
 
@@ -456,13 +414,7 @@ plugin1:${pluginUsingJavaAndNewEmbeddingDir.childDirectory('lib').uri.toString()
 
       testUsingContext('Registrant uses new embedding if module uses new embedding', () async {
         when(flutterProject.isModule).thenReturn(true);
-
-        final File androidManifest = flutterProject.directory
-          .childDirectory('android')
-          .childFile('AndroidManifest.xml')
-          ..createSync(recursive: true)
-          ..writeAsStringSync(kAndroidManifestUsingNewEmbedding);
-        when(androidProject.appManifestFile).thenReturn(androidManifest);
+        when(androidProject.getEmbeddingVersion()).thenReturn(AndroidEmbeddingVersion.v2);
 
         await injectPlugins(flutterProject);
 
@@ -481,13 +433,7 @@ plugin1:${pluginUsingJavaAndNewEmbeddingDir.childDirectory('lib').uri.toString()
 
       testUsingContext('Registrant doesn\'t use new embedding if module doesn\'t use new embedding', () async {
         when(flutterProject.isModule).thenReturn(true);
-
-        final File androidManifest = flutterProject.directory
-          .childDirectory('android')
-          .childFile('AndroidManifest.xml')
-          ..createSync(recursive: true)
-          ..writeAsStringSync(kAndroidManifestUsingOldEmbedding);
-        when(androidProject.appManifestFile).thenReturn(androidManifest);
+        when(androidProject.getEmbeddingVersion()).thenReturn(AndroidEmbeddingVersion.v1);
 
         await injectPlugins(flutterProject);
 
@@ -521,14 +467,6 @@ plugin1:${pluginUsingJavaAndNewEmbeddingDir.childDirectory('lib').uri.toString()
       testUsingContext('Registrant for web doesn\'t escape slashes in imports', () async {
         when(flutterProject.isModule).thenReturn(true);
         when(featureFlags.isWebEnabled).thenReturn(true);
-
-        // injectPlugins will crash if there is no AndroidManifest
-        final File androidManifest = flutterProject.directory
-          .childDirectory('android')
-          .childFile('AndroidManifest.xml')
-          ..createSync(recursive: true)
-          ..writeAsStringSync(kAndroidManifestUsingOldEmbedding);
-        when(androidProject.appManifestFile).thenReturn(androidManifest);
 
         final Directory webPluginWithNestedFile =
             fs.systemTempDirectory.createTempSync('web_plugin_with_nested');

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -125,22 +125,6 @@ void main() {
       MockFeatureFlags featureFlags;
       MockXcodeProjectInterpreter xcodeProjectInterpreter;
 
-      const String kAndroidManifestUsingOldEmbedding = '''
-  <manifest>
-      <application>
-      </application>
-  </manifest>
-  ''';
-      const String kAndroidManifestUsingNewEmbedding = '''
-  <manifest>
-      <application>
-          <meta-data
-              android:name="flutterEmbedding"
-              android:value="2" />
-      </application>
-  </manifest>
-  ''';
-
       setUp(() {
         featureFlags = MockFeatureFlags();
         when(featureFlags.isLinuxEnabled).thenReturn(false);


### PR DESCRIPTION
## Description

Let GA have Android embedding versions on flutter run and flutter packages get

## Related Issues


## Tests

packages_test

I want to add a run test but as far as I can tell, in its current state, the run command is untestable. 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
