### PR TITLE
Add command key bindings to macOS text editing and fix selection.

### DIFF
--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -816,15 +816,7 @@ class TextPainter {
   /// <http://www.unicode.org/reports/tr29/#Word_Boundaries>.
   TextRange getWordBoundary(TextPosition position) {
     assert(!_needsLayout);
-    // TODO(gspencergoog): remove the List<int>-based code when the engine API
-    // returns a TextRange instead of a List<int>.
-    final dynamic boundary = _paragraph.getWordBoundary(position);
-    if (boundary is List<int>) {
-      final List<int> indices = boundary;
-      return TextRange(start: indices[0], end: indices[1]);
-    }
-    final TextRange range = boundary;
-    return range;
+    return _paragraph.getWordBoundary(position);
   }
 
   /// Returns the text range of the line at the given offset.
@@ -832,8 +824,7 @@ class TextPainter {
   /// The newline, if any, is included in the range.
   TextRange getLineBoundary(TextPosition position) {
     assert(!_needsLayout);
-    final List<int> indices = _paragraph.getLineBoundary(position.offset);
-    return TextRange(start: indices[0], end: indices[1]);
+    return _paragraph.getLineBoundary(position);
   }
 
   /// Returns the full list of [LineMetrics] that describe in detail the various

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -827,6 +827,15 @@ class TextPainter {
     return range;
   }
 
+  /// Returns the text range of the line at the given offset.
+  ///
+  /// The newline, if any, is included in the range.
+  TextRange getLineBoundary(TextPosition position) {
+    assert(!_needsLayout);
+    final List<int> indices = _paragraph.getLineBoundary(position.offset);
+    return TextRange(start: indices[0], end: indices[1]);
+  }
+
   /// Returns the full list of [LineMetrics] that describe in detail the various
   /// metrics of each laid out line.
   ///

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -485,10 +485,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     if (lineModifier) {
       // If control/command is pressed, we will decide which way to expand to
       // the beginning/end of the line based on which arrow is pressed.
+      final TextSelection textSelection = _selectLineAtOffset(TextPosition(offset: newSelection.extentOffset));
       if (leftArrow) {
-        newSelection = newSelection.copyWith(extentOffset: 0);
+        newSelection = newSelection.copyWith(extentOffset: textSelection.baseOffset);
       } else if (rightArrow) {
-        newSelection = newSelection.copyWith(extentOffset: text.text.length);
+        newSelection = newSelection.copyWith(extentOffset: textSelection.extentOffset);
       }
     }
 
@@ -1581,6 +1582,18 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return TextSelection(baseOffset: 0, extentOffset: text.toPlainText().length);
     }
     return TextSelection(baseOffset: word.start, extentOffset: word.end);
+  }
+
+  TextSelection _selectLineAtOffset(TextPosition position) {
+    assert(_textLayoutLastMaxWidth == constraints.maxWidth &&
+        _textLayoutLastMinWidth == constraints.minWidth,
+    'Last width ($_textLayoutLastMinWidth, $_textLayoutLastMaxWidth) not the same as max width constraint (${constraints.minWidth}, ${constraints.maxWidth}).');
+    final TextRange line = _textPainter.getLineBoundary(position);
+    // If text is obscured, the entire string should be treated as one line.
+    if (obscureText) {
+      return TextSelection(baseOffset: 0, extentOffset: text.toPlainText().length);
+    }
+    return TextSelection(baseOffset: line.start, extentOffset: line.end);
   }
 
   Rect _caretPrototype;

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -525,58 +525,59 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return result;
     }
 
-    // Jump to begin/end of word.
-    if (wordModifier) {
-      // If control/option is pressed, we will decide which way to look for a
-      // word based on which arrow is pressed.
-      if (leftArrow) {
-        // When going left, we want to skip over any whitespace before the word,
-        // so we go back to the first non-whitespace before asking for the word
-        // boundary, since _selectWordAtOffset finds the word boundaries without
-        // including whitespace.
-        final int startPoint = previousNonWhitespace(newSelection.extentOffset);
-        final TextSelection textSelection = _selectWordAtOffset(TextPosition(offset: startPoint));
-        newSelection = newSelection.copyWith(extentOffset: textSelection.baseOffset);
-      } else if (rightArrow) {
-        // When going right, we want to skip over any whitespace after the word,
-        // so we go forward to the first non-whitespace character before asking
-        // for the word bounds, since _selectWordAtOffset finds the word
-        // boundaries without including whitespace.
-        final int startPoint = nextNonWhitespace(newSelection.extentOffset);
-        final TextSelection textSelection = _selectWordAtOffset(TextPosition(offset: startPoint));
-        newSelection = newSelection.copyWith(extentOffset: textSelection.extentOffset);
-      }
-    } else if (lineModifier) {
-      // If control/command is pressed, we will decide which way to expand to
-      // the beginning/end of the line based on which arrow is pressed.
-      if (leftArrow) {
-        // When going left, we want to skip over any whitespace before the line,
-        // so we go back to the first non-whitespace before asking for the line
-        // bounds, since _selectLineAtOffset finds the line boundaries without
-        // including whitespace (like the newline).
-        final int startPoint = previousNonWhitespace(newSelection.extentOffset);
-        final TextSelection textSelection = _selectLineAtOffset(TextPosition(offset: startPoint));
-        newSelection = newSelection.copyWith(extentOffset: textSelection.baseOffset);
-      } else if (rightArrow) {
-        // When going right, we want to skip over any whitespace after the line,
-        // so we go forward to the first non-whitespace character before asking
-        // for the line bounds, since _selectLineAtOffset finds the line
-        // boundaries without including whitespace (like the newline).
-        final int startPoint = nextNonWhitespace(newSelection.extentOffset);
-        final TextSelection textSelection = _selectLineAtOffset(TextPosition(offset: startPoint));
-        newSelection = newSelection.copyWith(extentOffset: textSelection.extentOffset);
-      }
-    } else {
-      if (rightArrow && newSelection.extentOffset < _plainText.length) {
-        newSelection = newSelection.copyWith(extentOffset: newSelection.extentOffset + 1);
-        if (shift) {
-          _cursorResetLocation += 1;
+    if ((rightArrow || leftArrow) && !(rightArrow && leftArrow)) {
+      // Jump to begin/end of word.
+      if (wordModifier) {
+        // If control/option is pressed, we will decide which way to look for a
+        // word based on which arrow is pressed.
+        if (leftArrow) {
+          // When going left, we want to skip over any whitespace before the word,
+          // so we go back to the first non-whitespace before asking for the word
+          // boundary, since _selectWordAtOffset finds the word boundaries without
+          // including whitespace.
+          final int startPoint = previousNonWhitespace(newSelection.extentOffset);
+          final TextSelection textSelection = _selectWordAtOffset(TextPosition(offset: startPoint));
+          newSelection = newSelection.copyWith(extentOffset: textSelection.baseOffset);
+        } else {
+          // When going right, we want to skip over any whitespace after the word,
+          // so we go forward to the first non-whitespace character before asking
+          // for the word bounds, since _selectWordAtOffset finds the word
+          // boundaries without including whitespace.
+          final int startPoint = nextNonWhitespace(newSelection.extentOffset);
+          final TextSelection textSelection = _selectWordAtOffset(TextPosition(offset: startPoint));
+          newSelection = newSelection.copyWith(extentOffset: textSelection.extentOffset);
         }
-      }
-      if (leftArrow && newSelection.extentOffset > 0) {
-        newSelection = newSelection.copyWith(extentOffset: newSelection.extentOffset - 1);
-        if (shift) {
-          _cursorResetLocation -= 1;
+      } else if (lineModifier) {
+        // If control/command is pressed, we will decide which way to expand to
+        // the beginning/end of the line based on which arrow is pressed.
+        if (leftArrow) {
+          // When going left, we want to skip over any whitespace before the line,
+          // so we go back to the first non-whitespace before asking for the line
+          // bounds, since _selectLineAtOffset finds the line boundaries without
+          // including whitespace (like the newline).
+          final int startPoint = previousNonWhitespace(newSelection.extentOffset);
+          final TextSelection textSelection = _selectLineAtOffset(TextPosition(offset: startPoint));
+          newSelection = newSelection.copyWith(extentOffset: textSelection.baseOffset);
+        } else {
+          // When going right, we want to skip over any whitespace after the line,
+          // so we go forward to the first non-whitespace character before asking
+          // for the line bounds, since _selectLineAtOffset finds the line
+          // boundaries without including whitespace (like the newline).
+          final int startPoint = nextNonWhitespace(newSelection.extentOffset);
+          final TextSelection textSelection = _selectLineAtOffset(TextPosition(offset: startPoint));
+          newSelection = newSelection.copyWith(extentOffset: textSelection.extentOffset);
+        }
+      } else {
+        if (rightArrow && newSelection.extentOffset < _plainText.length) {
+          newSelection = newSelection.copyWith(extentOffset: newSelection.extentOffset + 1);
+          if (shift) {
+            _cursorResetLocation += 1;
+          }
+        } else if (leftArrow && newSelection.extentOffset > 0) {
+          newSelection = newSelection.copyWith(extentOffset: newSelection.extentOffset - 1);
+          if (shift) {
+            _cursorResetLocation -= 1;
+          }
         }
       }
     }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1482,7 +1482,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   }
 
   void _handleSelectionChanged(TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {
-    print('EditableText handling selection change: $selection');
     widget.controller.selection = selection;
 
     // This will show the keyboard for all selection changes on the

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1482,6 +1482,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   }
 
   void _handleSelectionChanged(TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {
+    print('EditableText handling selection change: $selection');
     widget.controller.selection = selection;
 
     // This will show the keyboard for all selection changes on the

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -3301,7 +3301,7 @@ void main() {
       reason: 'on $platform',
     );
 
-    // Select to the end of the line.
+    // Select to the end of the selection.
     await sendKeys(
       tester,
       <LogicalKeyboardKey>[
@@ -3340,7 +3340,7 @@ void main() {
       equals(
         const TextSelection(
           baseOffset: 21,
-          extentOffset: 0,
+          extentOffset: 55,
           affinity: TextAffinity.downstream,
         ),
       ),

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io' show Platform;
 
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -3017,24 +3018,24 @@ void main() {
 
     await tester.pump(); // Wait for autofocus to take effect.
 
-    Future<void> sendKeys(List<LogicalKeyboardKey> keys, {bool shift = false, bool control = false}) async {
+    Future<void> sendKeys(List<LogicalKeyboardKey> keys, {bool shift = false, bool modifier = false}) async {
       if (shift) {
         await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
       }
-      if (control) {
-        await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      if (modifier) {
+        await tester.sendKeyDownEvent(Platform.isMacOS ? LogicalKeyboardKey.meta : LogicalKeyboardKey.controlLeft);
       }
       for (LogicalKeyboardKey key in keys) {
         await tester.sendKeyEvent(key);
         await tester.pump();
       }
-      if (control) {
-        await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      if (modifier) {
+        await tester.sendKeyUpEvent(Platform.isMacOS ? LogicalKeyboardKey.meta : LogicalKeyboardKey.controlLeft);
       }
       if (shift) {
         await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
       }
-      if (shift || control) {
+      if (shift || modifier) {
         await tester.pump();
       }
     }
@@ -3093,7 +3094,7 @@ void main() {
         LogicalKeyboardKey.arrowRight,
       ],
       shift: true,
-      control: true,
+      modifier: true,
     );
 
     expect(selection, equals(const TextSelection(
@@ -3108,7 +3109,7 @@ void main() {
         LogicalKeyboardKey.arrowLeft,
       ],
       shift: true,
-      control: true,
+      modifier: true,
     );
 
     expect(selection, equals(const TextSelection(
@@ -3194,7 +3195,7 @@ void main() {
       <LogicalKeyboardKey>[
         LogicalKeyboardKey.keyA,
       ],
-      control: true,
+      modifier: true,
     );
 
     expect(selection, equals(const TextSelection(
@@ -3223,7 +3224,7 @@ void main() {
         LogicalKeyboardKey.arrowRight,
         LogicalKeyboardKey.arrowRight,
       ],
-      control: true,
+      modifier: true,
     );
 
     expect(selection, equals(const TextSelection(
@@ -3254,7 +3255,7 @@ void main() {
         LogicalKeyboardKey.arrowLeft,
       ],
       shift: true,
-      control: true,
+      modifier: true,
     );
 
     expect(selection, equals(const TextSelection(
@@ -3269,7 +3270,7 @@ void main() {
       <LogicalKeyboardKey>[
         LogicalKeyboardKey.keyX,
       ],
-      control: true,
+      modifier: true,
     );
 
     expect(selection, equals(const TextSelection(
@@ -3288,7 +3289,7 @@ void main() {
       <LogicalKeyboardKey>[
         LogicalKeyboardKey.keyV,
       ],
-      control: true,
+      modifier: true,
     );
 
     expect(selection, equals(const TextSelection(
@@ -3304,7 +3305,7 @@ void main() {
         LogicalKeyboardKey.keyA,
         LogicalKeyboardKey.keyC,
       ],
-      control: true,
+      modifier: true,
     );
 
     expect(selection, equals(const TextSelection(

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -2984,30 +2984,52 @@ void main() {
       WidgetTester tester,
       List<LogicalKeyboardKey> keys, {
         bool shift = false,
-        bool modifier = false,
+        bool wordModifier = false,
+        bool lineModifier = false,
+        bool shortcutModifier = false,
         String platform,
       }) async {
     if (shift) {
       await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft, platform: platform);
     }
-    if (modifier) {
+    if (shortcutModifier) {
       await tester.sendKeyDownEvent(
-          platform == 'macos' ? LogicalKeyboardKey.meta : LogicalKeyboardKey.controlLeft,
+          platform == 'macos' ? LogicalKeyboardKey.metaLeft : LogicalKeyboardKey.controlLeft,
+          platform: platform);
+    }
+    if (wordModifier) {
+      await tester.sendKeyDownEvent(
+          platform == 'macos' ? LogicalKeyboardKey.altLeft : LogicalKeyboardKey.controlLeft,
+          platform: platform);
+    }
+    if (lineModifier) {
+      await tester.sendKeyDownEvent(
+          platform == 'macos' ? LogicalKeyboardKey.metaLeft : LogicalKeyboardKey.altLeft,
           platform: platform);
     }
     for (LogicalKeyboardKey key in keys) {
       await tester.sendKeyEvent(key, platform: platform);
       await tester.pump();
     }
-    if (modifier) {
+    if (lineModifier) {
       await tester.sendKeyUpEvent(
-          platform == 'macos' ? LogicalKeyboardKey.meta : LogicalKeyboardKey.controlLeft,
+          platform == 'macos' ? LogicalKeyboardKey.metaLeft : LogicalKeyboardKey.altLeft,
+          platform: platform);
+    }
+    if (wordModifier) {
+      await tester.sendKeyUpEvent(
+          platform == 'macos' ? LogicalKeyboardKey.altLeft : LogicalKeyboardKey.controlLeft,
+          platform: platform);
+    }
+    if (shortcutModifier) {
+      await tester.sendKeyUpEvent(
+          platform == 'macos' ? LogicalKeyboardKey.metaLeft : LogicalKeyboardKey.controlLeft,
           platform: platform);
     }
     if (shift) {
       await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft, platform: platform);
     }
-    if (shift || modifier) {
+    if (shift || wordModifier || lineModifier) {
       await tester.pump();
     }
   }
@@ -3128,7 +3150,7 @@ void main() {
         LogicalKeyboardKey.arrowRight,
       ],
       shift: true,
-      modifier: true,
+      wordModifier: true,
       platform: platform,
     );
 
@@ -3151,7 +3173,7 @@ void main() {
         LogicalKeyboardKey.arrowLeft,
       ],
       shift: true,
-      modifier: true,
+      wordModifier: true,
       platform: platform,
     );
 
@@ -3279,13 +3301,59 @@ void main() {
       reason: 'on $platform',
     );
 
+    // Select to the end of the line.
+    await sendKeys(
+      tester,
+      <LogicalKeyboardKey>[
+        LogicalKeyboardKey.arrowRight,
+      ],
+      lineModifier: true,
+      shift: true,
+      platform: platform,
+    );
+
+    expect(
+      selection,
+      equals(
+        const TextSelection(
+          baseOffset: 21,
+          extentOffset: 72,
+          affinity: TextAffinity.downstream,
+        ),
+      ),
+      reason: 'on $platform',
+    );
+
+    // Select to the beginning of the line.
+    await sendKeys(
+      tester,
+      <LogicalKeyboardKey>[
+        LogicalKeyboardKey.arrowLeft,
+      ],
+      lineModifier: true,
+      shift: true,
+      platform: platform,
+    );
+
+    expect(
+      selection,
+      equals(
+        const TextSelection(
+          baseOffset: 21,
+          extentOffset: 0,
+          affinity: TextAffinity.downstream,
+        ),
+      ),
+      reason: 'on $platform',
+    );
+
     // Select All
     await sendKeys(
       tester,
       <LogicalKeyboardKey>[
         LogicalKeyboardKey.keyA,
       ],
-      modifier: true,
+      shortcutModifier: true,
       platform: platform,
     );
 
@@ -3330,7 +3398,7 @@ void main() {
         LogicalKeyboardKey.arrowRight,
         LogicalKeyboardKey.arrowRight,
       ],
-      modifier: true,
+      wordModifier: true,
       platform: platform,
     );
 
@@ -3377,7 +3445,7 @@ void main() {
         LogicalKeyboardKey.arrowLeft,
       ],
       shift: true,
-      modifier: true,
+      wordModifier: true,
       platform: platform,
     );
 
@@ -3400,7 +3468,7 @@ void main() {
       <LogicalKeyboardKey>[
         LogicalKeyboardKey.keyX,
       ],
-      modifier: true,
+      shortcutModifier: true,
       platform: platform,
     );
 
@@ -3435,7 +3503,7 @@ void main() {
       <LogicalKeyboardKey>[
         LogicalKeyboardKey.keyV,
       ],
-      modifier: true,
+      shortcutModifier: true,
       platform: platform,
     );
 
@@ -3459,7 +3527,7 @@ void main() {
         LogicalKeyboardKey.keyA,
         LogicalKeyboardKey.keyC,
       ],
-      modifier: true,
+      shortcutModifier: true,
       platform: platform,
     );
 


### PR DESCRIPTION
## Description

This adds support for the command key for text selection/editing on macOS. I had ported the text editing code (in https://github.com/flutter/flutter/pull/42879), but forgot to add support for the command key itself.  This also adds a test that tests the text editing on multiple platforms instead of just testing Android.

There appears to still be a bug (filed https://github.com/flutter/flutter/issues/44135) where we're losing key events sometimes on macOS, leaving some keys "stuck" on, but this PR at least allows the right key combinations to be used.

## Related Issues

Addresses https://github.com/flutter/flutter/issues/30709
Fixes https://github.com/flutter/flutter/issues/36316

## Tests

- Added tests for multiple platforms to make sure that editing works there.

## Breaking Change

- [X] No, this is *not* a breaking change.