### PR TITLE
Reland: Migrate examples to the Android embedding v2

### DIFF
--- a/dev/benchmarks/macrobenchmarks/android/app/src/main/AndroidManifest.xml
+++ b/dev/benchmarks/macrobenchmarks/android/app/src/main/AndroidManifest.xml
@@ -23,17 +23,15 @@
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
-            <!-- This keeps the window background of the activity showing
-                 until Flutter renders its first frame. It can be removed if
-                 there is no splash screen (such as the default splash screen
-                 defined in @style/LaunchTheme). -->
-            <meta-data
-                android:name="io.flutter.app.android.SplashScreenUntilFirstFrame"
-                android:value="true" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+    <!-- Don't delete the meta-data below.
+         This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
 </manifest>

--- a/dev/benchmarks/macrobenchmarks/android/app/src/main/java/com/example/macrobenchmarks/MainActivity.java
+++ b/dev/benchmarks/macrobenchmarks/android/app/src/main/java/com/example/macrobenchmarks/MainActivity.java
@@ -1,13 +1,13 @@
 package com.example.macrobenchmarks;
 
-import android.os.Bundle;
-import io.flutter.app.FlutterActivity;
+import androidx.annotation.NonNull;
+import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.plugins.GeneratedPluginRegistrant;
 
 public class MainActivity extends FlutterActivity {
   @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    GeneratedPluginRegistrant.registerWith(this);
+  public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
+    GeneratedPluginRegistrant.registerWith(flutterEngine);
   }
 }

--- a/dev/integration_tests/abstract_method_smoke_test/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/abstract_method_smoke_test/android/app/src/main/AndroidManifest.xml
@@ -17,17 +17,15 @@
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="stateVisible|adjustResize">
-            <!-- This keeps the window background of the activity showing
-                 until Flutter renders its first frame. It can be removed if
-                 there is no splash screen (such as the default splash screen
-                 defined in @style/LaunchTheme). -->
-            <meta-data
-                android:name="io.flutter.app.android.SplashScreenUntilFirstFrame"
-                android:value="true" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+    <!-- Don't delete the meta-data below.
+         This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
 </manifest>

--- a/dev/integration_tests/abstract_method_smoke_test/android/app/src/main/kotlin/com/example/abstract_method_smoke_test/MainActivity.kt
+++ b/dev/integration_tests/abstract_method_smoke_test/android/app/src/main/kotlin/com/example/abstract_method_smoke_test/MainActivity.kt
@@ -5,7 +5,10 @@ import android.graphics.Color
 import android.os.Bundle
 import android.view.View
 import android.view.inputmethod.InputMethodManager
-import io.flutter.app.FlutterActivity
+import androidx.annotation.NonNull
+import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.embedding.engine.plugins.shim.ShimPluginRegistry
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.StandardMessageCodec
 import io.flutter.plugin.platform.PlatformView
@@ -27,11 +30,11 @@ class MainActivity : FlutterActivity() {
         }
     }
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        GeneratedPluginRegistrant.registerWith(this)
+    override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
+        GeneratedPluginRegistrant.registerWith(flutterEngine);
 
-        registrarFor("com.example.abstract_method_smoke_test")
+        val shimPluginRegistry = ShimPluginRegistry(flutterEngine);
+        shimPluginRegistry.registrarFor("com.example.abstract_method_smoke_test")
                 .platformViewRegistry()
                 .registerViewFactory("simple", object : PlatformViewFactory(StandardMessageCodec.INSTANCE) {
                     override fun create(context: Context?, viewId: Int, args: Any?): PlatformView {
@@ -41,7 +44,7 @@ class MainActivity : FlutterActivity() {
 
         // Triggers the Android keyboard, which causes the resize of the Flutter view.
         // We need to wait for the app to complete.
-        MethodChannel(flutterView, "com.example.abstract_method_smoke_test")
+        MethodChannel(flutterEngine.getDartExecutor(), "com.example.abstract_method_smoke_test")
                 .setMethodCallHandler { _, result ->
                     toggleInput()
                     result.success(null)

--- a/dev/integration_tests/android_splash_screens/splash_screen_kitchen_sink/android/app/src/main/java/io/flutter/splash_screen_kitchen_sink/MainActivity.java
+++ b/dev/integration_tests/android_splash_screens/splash_screen_kitchen_sink/android/app/src/main/java/io/flutter/splash_screen_kitchen_sink/MainActivity.java
@@ -5,12 +5,9 @@ import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
-
 import androidx.annotation.Nullable;
-
 import java.util.ArrayList;
 import java.util.List;
-
 import io.flutter.embedding.android.FlutterActivity;
 import io.flutter.embedding.android.FlutterView;
 import io.flutter.embedding.android.SplashScreen;

--- a/dev/integration_tests/channels/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/channels/android/app/src/main/AndroidManifest.xml
@@ -24,5 +24,10 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+    <!-- Don't delete the meta-data below.
+         This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
 </manifest>

--- a/dev/integration_tests/channels/android/app/src/main/java/com/yourcompany/channels/MainActivity.java
+++ b/dev/integration_tests/channels/android/app/src/main/java/com/yourcompany/channels/MainActivity.java
@@ -9,22 +9,26 @@ import java.nio.ByteBuffer;
 import java.util.Date;
 
 import android.os.Bundle;
+import androidx.annotation.NonNull;
 
-import io.flutter.app.FlutterActivity;
+import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.engine.dart.DartExecutor;
+import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.plugin.common.*;
 import io.flutter.plugins.GeneratedPluginRegistrant;
 
 public class MainActivity extends FlutterActivity {
   @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    GeneratedPluginRegistrant.registerWith(this);
-    setupMessageHandshake(new BasicMessageChannel<>(getFlutterView(), "binary-msg", BinaryCodec.INSTANCE));
-    setupMessageHandshake(new BasicMessageChannel<>(getFlutterView(), "string-msg", StringCodec.INSTANCE));
-    setupMessageHandshake(new BasicMessageChannel<>(getFlutterView(), "json-msg", JSONMessageCodec.INSTANCE));
-    setupMessageHandshake(new BasicMessageChannel<>(getFlutterView(), "std-msg", ExtendedStandardMessageCodec.INSTANCE));
-    setupMethodHandshake(new MethodChannel(getFlutterView(), "json-method", JSONMethodCodec.INSTANCE));
-    setupMethodHandshake(new MethodChannel(getFlutterView(), "std-method", new StandardMethodCodec(ExtendedStandardMessageCodec.INSTANCE)));
+  public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
+    GeneratedPluginRegistrant.registerWith(flutterEngine);
+
+    DartExecutor dartExecutor = flutterEngine.getDartExecutor();
+    setupMessageHandshake(new BasicMessageChannel<>(dartExecutor, "binary-msg", BinaryCodec.INSTANCE));
+    setupMessageHandshake(new BasicMessageChannel<>(dartExecutor, "string-msg", StringCodec.INSTANCE));
+    setupMessageHandshake(new BasicMessageChannel<>(dartExecutor, "json-msg", JSONMessageCodec.INSTANCE));
+    setupMessageHandshake(new BasicMessageChannel<>(dartExecutor, "std-msg", ExtendedStandardMessageCodec.INSTANCE));
+    setupMethodHandshake(new MethodChannel(dartExecutor, "json-method", JSONMethodCodec.INSTANCE));
+    setupMethodHandshake(new MethodChannel(dartExecutor, "std-method", new StandardMethodCodec(ExtendedStandardMessageCodec.INSTANCE)));
   }
 
   private <T> void setupMessageHandshake(final BasicMessageChannel<T> channel) {

--- a/dev/integration_tests/codegen/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/codegen/android/app/src/main/AndroidManifest.xml
@@ -24,5 +24,10 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+    <!-- Don't delete the meta-data below.
+         This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
 </manifest>

--- a/dev/integration_tests/codegen/android/app/src/main/java/com/yourcompany/platforminteraction/MainActivity.java
+++ b/dev/integration_tests/codegen/android/app/src/main/java/com/yourcompany/platforminteraction/MainActivity.java
@@ -4,14 +4,14 @@
 
 package com.yourcompany.platforminteraction;
 
-import android.os.Bundle;
-import io.flutter.app.FlutterActivity;
+import androidx.annotation.NonNull;
+import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.plugins.GeneratedPluginRegistrant;
 
 public class MainActivity extends FlutterActivity {
   @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    GeneratedPluginRegistrant.registerWith(this);
+  public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
+    GeneratedPluginRegistrant.registerWith(flutterEngine);
   }
 }

--- a/examples/catalog/android/app/src/main/AndroidManifest.xml
+++ b/examples/catalog/android/app/src/main/AndroidManifest.xml
@@ -24,5 +24,10 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <!-- Don't delete the meta-data below.
+             This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
 </manifest>

--- a/examples/catalog/android/app/src/main/java/com/yourcompany/animated_list/MainActivity.java
+++ b/examples/catalog/android/app/src/main/java/com/yourcompany/animated_list/MainActivity.java
@@ -1,13 +1,13 @@
 package com.yourcompany.animated_list;
 
-import android.os.Bundle;
-import io.flutter.app.FlutterActivity;
+import androidx.annotation.NonNull;
+import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.plugins.GeneratedPluginRegistrant;
 
 public class MainActivity extends FlutterActivity {
   @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    GeneratedPluginRegistrant.registerWith(this);
+  public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
+    GeneratedPluginRegistrant.registerWith(flutterEngine);
   }
 }

--- a/examples/flutter_gallery/android/app/src/main/AndroidManifest.xml
+++ b/examples/flutter_gallery/android/app/src/main/AndroidManifest.xml
@@ -29,5 +29,10 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+    <!-- Don't delete the meta-data below.
+         This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
 </manifest>

--- a/examples/flutter_gallery/android/app/src/main/java/io/flutter/demo/gallery/FlutterGalleryInstrumentation.java
+++ b/examples/flutter_gallery/android/app/src/main/java/io/flutter/demo/gallery/FlutterGalleryInstrumentation.java
@@ -5,25 +5,26 @@
 package io.flutter.demo.gallery;
 
 import android.os.ConditionVariable;
+import androidx.annotation.NonNull;
+
+import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.view.FlutterView;
 
 /** Instrumentation for testing using Android Espresso framework. */
 public class FlutterGalleryInstrumentation implements MethodCallHandler {
-
   private final ConditionVariable testFinished = new ConditionVariable();
   private volatile boolean testSuccessful;
 
-  FlutterGalleryInstrumentation(FlutterView view) {
-    new MethodChannel(view, "io.flutter.demo.gallery/TestLifecycleListener")
+  FlutterGalleryInstrumentation(@NonNull BinaryMessenger messenger) {
+    new MethodChannel(messenger, "io.flutter.demo.gallery/TestLifecycleListener")
         .setMethodCallHandler(this);
   }
 
   @Override
-  public void onMethodCall(MethodCall call, Result result) {
+  public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {
     testSuccessful = call.method.equals("success");
     testFinished.open();
     result.success(null);

--- a/examples/flutter_gallery/android/app/src/main/java/io/flutter/demo/gallery/MainActivity.java
+++ b/examples/flutter_gallery/android/app/src/main/java/io/flutter/demo/gallery/MainActivity.java
@@ -4,15 +4,12 @@
 
 package io.flutter.demo.gallery;
 
-import android.os.Build;
-import android.os.Bundle;
-
-import io.flutter.app.FlutterActivity;
-import io.flutter.view.FlutterView;
+import androidx.annotation.NonNull;
+import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.plugins.GeneratedPluginRegistrant;
 
 public class MainActivity extends FlutterActivity {
-
     private FlutterGalleryInstrumentation instrumentation;
 
     /** Instrumentation for testing. */
@@ -21,19 +18,8 @@ public class MainActivity extends FlutterActivity {
     }
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        GeneratedPluginRegistrant.registerWith(this);
-        instrumentation = new FlutterGalleryInstrumentation(this.getFlutterView());
-        getFlutterView().addFirstFrameListener(new FlutterView.FirstFrameListener() {
-            @Override
-            public void onFirstFrame() {
-                // Report fully drawn time for Play Store Console.
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                    MainActivity.this.reportFullyDrawn();
-                }
-                MainActivity.this.getFlutterView().removeFirstFrameListener(this);
-            }
-          });
+    public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
+        GeneratedPluginRegistrant.registerWith(flutterEngine);
+        instrumentation = new FlutterGalleryInstrumentation(flutterEngine.getDartExecutor());
     }
 }

--- a/examples/hello_world/android/app/src/main/AndroidManifest.xml
+++ b/examples/hello_world/android/app/src/main/AndroidManifest.xml
@@ -29,5 +29,10 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+    <!-- Don't delete the meta-data below.
+         This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
 </manifest>

--- a/examples/hello_world/android/app/src/main/java/io/flutter/examples/hello_world/MainActivity.java
+++ b/examples/hello_world/android/app/src/main/java/io/flutter/examples/hello_world/MainActivity.java
@@ -1,13 +1,13 @@
 package io.flutter.examples.hello_world;
 
-import android.os.Bundle;
-import io.flutter.app.FlutterActivity;
+import androidx.annotation.NonNull;
+import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.plugins.GeneratedPluginRegistrant;
 
 public class MainActivity extends FlutterActivity {
   @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    GeneratedPluginRegistrant.registerWith(this);
+  public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
+    GeneratedPluginRegistrant.registerWith(flutterEngine);
   }
 }

--- a/examples/image_list/android/app/src/main/AndroidManifest.xml
+++ b/examples/image_list/android/app/src/main/AndroidManifest.xml
@@ -18,17 +18,15 @@
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
-            <!-- This keeps the window background of the activity showing
-                 until Flutter renders its first frame. It can be removed if
-                 there is no splash screen (such as the default splash screen
-                 defined in @style/LaunchTheme). -->
-            <meta-data
-                android:name="io.flutter.app.android.SplashScreenUntilFirstFrame"
-                android:value="true" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+    <!-- Don't delete the meta-data below.
+         This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
 </manifest>

--- a/examples/image_list/android/app/src/main/java/com/example/image_list/MainActivity.java
+++ b/examples/image_list/android/app/src/main/java/com/example/image_list/MainActivity.java
@@ -1,13 +1,13 @@
 package com.example.image_list;
 
-import android.os.Bundle;
-import io.flutter.app.FlutterActivity;
+import androidx.annotation.NonNull;
+import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.plugins.GeneratedPluginRegistrant;
 
 public class MainActivity extends FlutterActivity {
   @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    GeneratedPluginRegistrant.registerWith(this);
+  public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
+    GeneratedPluginRegistrant.registerWith(flutterEngine);
   }
 }

--- a/examples/layers/android/app/src/main/AndroidManifest.xml
+++ b/examples/layers/android/app/src/main/AndroidManifest.xml
@@ -24,5 +24,10 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+    <!-- Don't delete the meta-data below.
+         This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
 </manifest>

--- a/examples/layers/android/app/src/main/java/io/flutter/examples/Layers/MainActivity.java
+++ b/examples/layers/android/app/src/main/java/io/flutter/examples/Layers/MainActivity.java
@@ -4,15 +4,14 @@
 
 package io.flutter.examples.Layers;
 
-import android.os.Bundle;
-import io.flutter.app.FlutterActivity;
+import androidx.annotation.NonNull;
+import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.plugins.GeneratedPluginRegistrant;
 
 public class MainActivity extends FlutterActivity {
   @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    GeneratedPluginRegistrant.registerWith(this);
+  public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
+    GeneratedPluginRegistrant.registerWith(flutterEngine);
   }
 }
-

--- a/examples/platform_channel/android/app/src/main/AndroidManifest.xml
+++ b/examples/platform_channel/android/app/src/main/AndroidManifest.xml
@@ -21,5 +21,10 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+    <!-- Don't delete the meta-data below.
+         This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
 </manifest>

--- a/examples/platform_channel/android/app/src/main/java/com/example/platformchannel/MainActivity.java
+++ b/examples/platform_channel/android/app/src/main/java/com/example/platformchannel/MainActivity.java
@@ -13,8 +13,9 @@ import android.os.BatteryManager;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
-
-import io.flutter.app.FlutterActivity;
+import androidx.annotation.NonNull;
+import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.EventChannel.EventSink;
 import io.flutter.plugin.common.EventChannel.StreamHandler;
@@ -29,44 +30,44 @@ public class MainActivity extends FlutterActivity {
   private static final String CHARGING_CHANNEL = "samples.flutter.io/charging";
 
   @Override
-  public void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    GeneratedPluginRegistrant.registerWith(this);
-    new EventChannel(getFlutterView(), CHARGING_CHANNEL).setStreamHandler(
-        new StreamHandler() {
-          private BroadcastReceiver chargingStateChangeReceiver;
-          @Override
-          public void onListen(Object arguments, EventSink events) {
-            chargingStateChangeReceiver = createChargingStateChangeReceiver(events);
-            registerReceiver(
-                chargingStateChangeReceiver, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
-          }
+  public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
+    GeneratedPluginRegistrant.registerWith(flutterEngine);
 
-          @Override
-          public void onCancel(Object arguments) {
-            unregisterReceiver(chargingStateChangeReceiver);
-            chargingStateChangeReceiver = null;
-          }
+    new EventChannel(flutterEngine.getDartExecutor(), CHARGING_CHANNEL).setStreamHandler(
+      new StreamHandler() {
+        private BroadcastReceiver chargingStateChangeReceiver;
+        @Override
+        public void onListen(Object arguments, EventSink events) {
+          chargingStateChangeReceiver = createChargingStateChangeReceiver(events);
+          registerReceiver(
+              chargingStateChangeReceiver, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
         }
+
+        @Override
+        public void onCancel(Object arguments) {
+          unregisterReceiver(chargingStateChangeReceiver);
+          chargingStateChangeReceiver = null;
+        }
+      }
     );
 
-    new MethodChannel(getFlutterView(), BATTERY_CHANNEL).setMethodCallHandler(
-        new MethodCallHandler() {
-          @Override
-          public void onMethodCall(MethodCall call, Result result) {
-            if (call.method.equals("getBatteryLevel")) {
-              int batteryLevel = getBatteryLevel();
+    new MethodChannel(flutterEngine.getDartExecutor(), BATTERY_CHANNEL).setMethodCallHandler(
+      new MethodCallHandler() {
+        @Override
+        public void onMethodCall(MethodCall call, Result result) {
+          if (call.method.equals("getBatteryLevel")) {
+            int batteryLevel = getBatteryLevel();
 
-              if (batteryLevel != -1) {
-                result.success(batteryLevel);
-              } else {
-                result.error("UNAVAILABLE", "Battery level not available.", null);
-              }
+            if (batteryLevel != -1) {
+              result.success(batteryLevel);
             } else {
-              result.notImplemented();
+              result.error("UNAVAILABLE", "Battery level not available.", null);
             }
+          } else {
+            result.notImplemented();
           }
         }
+      }
     );
   }
 

--- a/examples/platform_channel_swift/android/app/src/androidTest/java/com/example/platformchannel/ExampleInstrumentedTest.java
+++ b/examples/platform_channel_swift/android/app/src/androidTest/java/com/example/platformchannel/ExampleInstrumentedTest.java
@@ -1,20 +1,18 @@
 package com.example.platformchannel;
 
+import static org.junit.Assert.*;
+
+import android.app.Instrumentation;
 import android.graphics.Bitmap;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
-
 import io.flutter.view.FlutterView;
-
-import android.app.Instrumentation;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import static org.junit.Assert.*;
 
 @RunWith(AndroidJUnit4.class)
 public class ExampleInstrumentedTest {

--- a/examples/platform_channel_swift/android/app/src/main/AndroidManifest.xml
+++ b/examples/platform_channel_swift/android/app/src/main/AndroidManifest.xml
@@ -21,5 +21,10 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+    <!-- Don't delete the meta-data below.
+         This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
 </manifest>

--- a/examples/platform_channel_swift/android/app/src/main/java/com/example/platformchannel/MainActivity.java
+++ b/examples/platform_channel_swift/android/app/src/main/java/com/example/platformchannel/MainActivity.java
@@ -13,8 +13,9 @@ import android.os.BatteryManager;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
-
-import io.flutter.app.FlutterActivity;
+import androidx.annotation.NonNull;
+import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.EventChannel.EventSink;
 import io.flutter.plugin.common.EventChannel.StreamHandler;
@@ -29,44 +30,44 @@ public class MainActivity extends FlutterActivity {
   private static final String CHARGING_CHANNEL = "samples.flutter.io/charging";
 
   @Override
-  public void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    GeneratedPluginRegistrant.registerWith(this);
-    new EventChannel(getFlutterView(), CHARGING_CHANNEL).setStreamHandler(
-        new StreamHandler() {
-          private BroadcastReceiver chargingStateChangeReceiver;
-          @Override
-          public void onListen(Object arguments, EventSink events) {
-            chargingStateChangeReceiver = createChargingStateChangeReceiver(events);
-            registerReceiver(
-                chargingStateChangeReceiver, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
-          }
+  public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
+    GeneratedPluginRegistrant.registerWith(flutterEngine);
 
-          @Override
-          public void onCancel(Object arguments) {
-            unregisterReceiver(chargingStateChangeReceiver);
-            chargingStateChangeReceiver = null;
-          }
+    new EventChannel(flutterEngine.getDartExecutor(), CHARGING_CHANNEL).setStreamHandler(
+      new StreamHandler() {
+        private BroadcastReceiver chargingStateChangeReceiver;
+        @Override
+        public void onListen(Object arguments, EventSink events) {
+          chargingStateChangeReceiver = createChargingStateChangeReceiver(events);
+          registerReceiver(
+              chargingStateChangeReceiver, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
         }
+
+        @Override
+        public void onCancel(Object arguments) {
+          unregisterReceiver(chargingStateChangeReceiver);
+          chargingStateChangeReceiver = null;
+        }
+      }
     );
 
-    new MethodChannel(getFlutterView(), BATTERY_CHANNEL).setMethodCallHandler(
-        new MethodCallHandler() {
-          @Override
-          public void onMethodCall(MethodCall call, Result result) {
-            if (call.method.equals("getBatteryLevel")) {
-              int batteryLevel = getBatteryLevel();
+    new MethodChannel(flutterEngine.getDartExecutor(), BATTERY_CHANNEL).setMethodCallHandler(
+      new MethodCallHandler() {
+        @Override
+        public void onMethodCall(MethodCall call, Result result) {
+          if (call.method.equals("getBatteryLevel")) {
+            int batteryLevel = getBatteryLevel();
 
-              if (batteryLevel != -1) {
-                result.success(batteryLevel);
-              } else {
-                result.error("UNAVAILABLE", "Battery level not available.", null);
-              }
+            if (batteryLevel != -1) {
+              result.success(batteryLevel);
             } else {
-              result.notImplemented();
+              result.error("UNAVAILABLE", "Battery level not available.", null);
             }
+          } else {
+            result.notImplemented();
           }
         }
+      }
     );
   }
 

--- a/examples/platform_view/android/app/src/main/AndroidManifest.xml
+++ b/examples/platform_view/android/app/src/main/AndroidManifest.xml
@@ -33,5 +33,10 @@
             android:parentActivityName="io.flutter.examples.platform_view.MainActivity"
             android:theme="@style/Theme.AppCompat.NoActionBar"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale"></activity>
+    <!-- Don't delete the meta-data below.
+         This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
 </manifest>

--- a/examples/platform_view/android/app/src/main/java/io/flutter/examples/platform_view/MainActivity.java
+++ b/examples/platform_view/android/app/src/main/java/io/flutter/examples/platform_view/MainActivity.java
@@ -5,13 +5,12 @@
 package io.flutter.examples.platform_view;
 
 import android.content.Intent;
-import android.os.Bundle;
-
-import io.flutter.plugins.GeneratedPluginRegistrant;
-
-import io.flutter.app.FlutterActivity;
+import androidx.annotation.NonNull;
+import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
+import io.flutter.plugins.GeneratedPluginRegistrant;
 
 public class MainActivity extends FlutterActivity {
   private static final String CHANNEL = "samples.flutter.io/platform_view";
@@ -21,23 +20,22 @@ public class MainActivity extends FlutterActivity {
   private MethodChannel.Result result;
 
   @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    GeneratedPluginRegistrant.registerWith(this);
+  public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
+    GeneratedPluginRegistrant.registerWith(flutterEngine);
 
-    new MethodChannel(getFlutterView(), CHANNEL).setMethodCallHandler(
-            new MethodChannel.MethodCallHandler() {
-              @Override
-              public void onMethodCall(MethodCall methodCall, MethodChannel.Result result) {
-                MainActivity.this.result = result;
-                int count = methodCall.arguments();
-                if (methodCall.method.equals(METHOD_SWITCH_VIEW)) {
-                  onLaunchFullScreen(count);
-                } else {
-                  result.notImplemented();
-                }
-              }
-            }
+    new MethodChannel(flutterEngine.getDartExecutor(), CHANNEL).setMethodCallHandler(
+      new MethodChannel.MethodCallHandler() {
+        @Override
+        public void onMethodCall(MethodCall methodCall, MethodChannel.Result result) {
+          MainActivity.this.result = result;
+          int count = methodCall.arguments();
+          if (methodCall.method.equals(METHOD_SWITCH_VIEW)) {
+            onLaunchFullScreen(count);
+          } else {
+            result.notImplemented();
+          }
+        }
+      }
     );
   }
 

--- a/examples/stocks/android/app/src/main/AndroidManifest.xml
+++ b/examples/stocks/android/app/src/main/AndroidManifest.xml
@@ -29,5 +29,10 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+   <!-- Don't delete the meta-data below.
+        This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
 </manifest>

--- a/examples/stocks/android/app/src/main/java/io/flutter/examples/stocks/MainActivity.java
+++ b/examples/stocks/android/app/src/main/java/io/flutter/examples/stocks/MainActivity.java
@@ -4,14 +4,14 @@
 
 package io.flutter.examples.stocks;
 
-import android.os.Bundle;
-import io.flutter.app.FlutterActivity;
+import androidx.annotation.NonNull;
+import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.plugins.GeneratedPluginRegistrant;
 
 public class MainActivity extends FlutterActivity {
   @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    GeneratedPluginRegistrant.registerWith(this);
+  public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
+    GeneratedPluginRegistrant.registerWith(flutterEngine);
   }
 }


### PR DESCRIPTION
Once https://github.com/flutter/cocoon/pull/509 is merged and rolled out, then this change can be relanded.