### PR TITLE
Forward experimental Skia for web environment variable to engine

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/web_fs.dart
+++ b/packages/flutter_tools/lib/src/build_runner/web_fs.dart
@@ -97,6 +97,7 @@ class WebFs {
     this._target,
     this._buildInfo,
     this._initializePlatform,
+    this._useSkia,
   );
 
   /// The server uri.
@@ -111,6 +112,7 @@ class WebFs {
   final String _target;
   final BuildInfo _buildInfo;
   final bool _initializePlatform;
+  final bool _useSkia;
   StreamSubscription<void> _connectedApps;
 
   static const String _kHostName = 'localhost';
@@ -146,7 +148,7 @@ class WebFs {
   /// Recompile the web application and return whether this was successful.
   Future<bool> recompile() async {
     if (!_useBuildRunner) {
-      await buildWeb(_flutterProject, _target, _buildInfo, _initializePlatform);
+      await buildWeb(_flutterProject, _target, _buildInfo, _initializePlatform, _useSkia);
       return true;
     }
     _client.startBuild();
@@ -171,6 +173,7 @@ class WebFs {
     @required BuildInfo buildInfo,
     @required bool skipDwds,
     @required bool initializePlatform,
+    @required bool useSkia,
     @required String hostname,
     @required String port,
   }) async {
@@ -302,7 +305,7 @@ class WebFs {
         handler = pipeline.addHandler(proxyHandler('http://localhost:$daemonAssetPort/web/'));
       }
     } else {
-      await buildWeb(flutterProject, target, buildInfo, initializePlatform);
+      await buildWeb(flutterProject, target, buildInfo, initializePlatform, useSkia);
       firstBuildCompleter.complete(true);
     }
 
@@ -325,6 +328,7 @@ class WebFs {
       target,
       buildInfo,
       initializePlatform,
+      useSkia,
     );
     if (!await firstBuildCompleter.future) {
       throw const BuildException();

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import '../../artifacts.dart';
 import '../../asset.dart';
 import '../../base/file_system.dart';
@@ -133,9 +131,7 @@ class Dart2JSTarget extends Target {
       ? PackageMap.globalGeneratedPackagesPath
       : PackageMap.globalPackagesPath;
     final File outputFile = environment.buildDir.childFile('main.dart.js');
-    if (Platform.environment.containsKey('FLUTTER_WEB_USE_SKIA')) {
-      environment.defines['FLUTTER_WEB_USE_SKIA'] = Platform.environment['FLUTTER_WEB_USE_SKIA'];
-    }
+    final bool useSkia = environment.defines['FLUTTER_WEB_USE_SKIA'] == 'true';
     
     final ProcessResult result = await processManager.run(<String>[
       artifacts.getArtifactPath(Artifact.engineDartBinary),
@@ -154,8 +150,9 @@ class Dart2JSTarget extends Target {
         '-Ddart.vm.profile=true'
       else
         '-Ddart.vm.product=true',
-      if (Platform.environment.containsKey('FLUTTER_WEB_USE_SKIA'))
-        environment.defines['FLUTTER_WEB_USE_SKIA'] = Platform.environment['FLUTTER_WEB_USE_SKIA'],
+      if (useSkia)
+        '-DFLUTTER_WEB_USE_SKIA=true',
+
       environment.buildDir.childFile('main.dart').path,
     ]);
     if (result.exitCode != 0) {

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -133,6 +133,10 @@ class Dart2JSTarget extends Target {
       ? PackageMap.globalGeneratedPackagesPath
       : PackageMap.globalPackagesPath;
     final File outputFile = environment.buildDir.childFile('main.dart.js');
+    if (Platform.environment.containsKey('FLUTTER_WEB_USE_SKIA')) {
+      environment.defines['FLUTTER_WEB_USE_SKIA'] = Platform.environment['FLUTTER_WEB_USE_SKIA'];
+    }
+    
     final ProcessResult result = await processManager.run(<String>[
       artifacts.getArtifactPath(Artifact.engineDartBinary),
       artifacts.getArtifactPath(Artifact.dart2jsSnapshot),

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -131,7 +131,7 @@ class Dart2JSTarget extends Target {
       ? PackageMap.globalGeneratedPackagesPath
       : PackageMap.globalPackagesPath;
     final File outputFile = environment.buildDir.childFile('main.dart.js');
-    final bool useSkia = environment.defines['FLUTTER_WEB_USE_SKIA'] == 'true';
+    final bool useSkia = environment.defines['WebUseSkia'] == 'true';
     
     final ProcessResult result = await processManager.run(<String>[
       artifacts.getArtifactPath(Artifact.engineDartBinary),

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
 import '../../artifacts.dart';
 import '../../asset.dart';
 import '../../base/file_system.dart';
@@ -148,6 +150,8 @@ class Dart2JSTarget extends Target {
         '-Ddart.vm.profile=true'
       else
         '-Ddart.vm.product=true',
+      if (Platform.environment.containsKey('FLUTTER_WEB_USE_SKIA'))
+        environment.defines['FLUTTER_WEB_USE_SKIA'] = Platform.environment['FLUTTER_WEB_USE_SKIA'],
       environment.buildDir.childFile('main.dart').path,
     ]);
     if (result.exitCode != 0) {

--- a/packages/flutter_tools/lib/src/commands/build_web.dart
+++ b/packages/flutter_tools/lib/src/commands/build_web.dart
@@ -24,6 +24,14 @@ class BuildWebCommand extends BuildSubCommand {
         hide: true,
         help: 'Whether to automatically invoke webOnlyInitializePlatform.',
     );
+
+    argParser.addFlag('web-use-skia',
+      defaultsTo: false,
+      negatable: false,
+      hide: true,
+      help:
+      'Whether to use Skia rendering engine for web (EXPERIMENTAL)',
+    );
   }
 
   @override
@@ -53,7 +61,7 @@ class BuildWebCommand extends BuildSubCommand {
     if (buildInfo.isDebug) {
       throwToolExit('debug builds cannot be built directly for the web. Try using "flutter run"');
     }
-    await buildWeb(flutterProject, target, buildInfo, argResults['web-initialize-platform']);
+    await buildWeb(flutterProject, target, buildInfo, argResults['web-initialize-platform'], argResults['web-use-skia']);
     return null;
   }
 }

--- a/packages/flutter_tools/lib/src/web/compile.dart
+++ b/packages/flutter_tools/lib/src/web/compile.dart
@@ -21,7 +21,7 @@ import '../reporting/reporting.dart';
 /// The [WebCompilationProxy] instance.
 WebCompilationProxy get webCompilationProxy => context.get<WebCompilationProxy>();
 
-Future<void> buildWeb(FlutterProject flutterProject, String target, BuildInfo buildInfo, bool initializePlatform) async {
+Future<void> buildWeb(FlutterProject flutterProject, String target, BuildInfo buildInfo, bool initializePlatform, bool useSkia) async {
   if (!flutterProject.web.existsSync()) {
     throwToolExit('Missing index.html.');
   }
@@ -42,6 +42,7 @@ Future<void> buildWeb(FlutterProject flutterProject, String target, BuildInfo bu
         kTargetFile: target,
         kInitializePlatform: initializePlatform.toString(),
         kHasWebPlugins: hasWebPlugins.toString(),
+        'WebUseSkia': useSkia.toString(), 
       },
     ));
     if (!result.success) {

--- a/packages/flutter_tools/lib/src/web/compile.dart
+++ b/packages/flutter_tools/lib/src/web/compile.dart
@@ -42,7 +42,7 @@ Future<void> buildWeb(FlutterProject flutterProject, String target, BuildInfo bu
         kTargetFile: target,
         kInitializePlatform: initializePlatform.toString(),
         kHasWebPlugins: hasWebPlugins.toString(),
-        'WebUseSkia': useSkia.toString(), 
+        'WebUseSkia': useSkia.toString(),
       },
     ));
     if (!result.success) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
@@ -57,6 +57,7 @@ void main() {
       fs.path.join('lib', 'main.dart'),
       BuildInfo.debug,
       false,
+      false,
     ), throwsA(isInstanceOf<ToolExit>()));
   }));
 

--- a/packages/flutter_tools/test/general.shard/web/web_fs_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/web_fs_test.dart
@@ -124,6 +124,7 @@ void main() {
       buildInfo: BuildInfo.debug,
       flutterProject: flutterProject,
       initializePlatform: true,
+      useSkia: false,
       hostname: null,
       port: null,
     );
@@ -153,6 +154,7 @@ void main() {
       buildInfo: BuildInfo.debug,
       flutterProject: flutterProject,
       initializePlatform: false,
+      useSkia: false,
       hostname: null,
       port: null,
     );
@@ -173,6 +175,7 @@ void main() {
       buildInfo: BuildInfo.debug,
       flutterProject: flutterProject,
       initializePlatform: false,
+      useSkia: false,
       hostname: 'foo',
       port: '1234',
     );
@@ -205,6 +208,7 @@ void main() {
       buildInfo: BuildInfo.debug,
       flutterProject: flutterProject,
       initializePlatform: false,
+      useSkia: false,
       hostname: 'foo',
       port: '1234',
     ), throwsA(isInstanceOf<Exception>()));


### PR DESCRIPTION
## Description

Flutter for Web has an experimental flag for using the Skia engine. It requires the environment variable `FLUTTER_WEB_USE_SKIA` to be set [(source)](https://github.com/flutter/engine/blob/master/lib/web_ui/lib/src/engine/compositor/initialization.dart).

Forwarding from tools does not require a custom build of the engine to try this experimental feature.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from our [issue database]. Indicate, which of these issues are resolved or fixed by this PR.*

## Tests

WIP

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
