### PR TITLE
Remove flutter.yaml migration code

### DIFF
--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -224,20 +224,6 @@ class UserMessages {
       'Error: No pubspec.yaml file found.\n'
       'This command should be run from the root of your Flutter project.\n'
       'Do not run this command from the root of your git clone of Flutter.';
-  String get flutterMergeYamlFiles =>
-      'Please merge your flutter.yaml into your pubspec.yaml.\n\n'
-      'We have changed from having separate flutter.yaml and pubspec.yaml\n'
-      'files to having just one pubspec.yaml file. Transitioning is simple:\n'
-      'add a line that just says "flutter:" to your pubspec.yaml file, and\n'
-      'move everything from your current flutter.yaml file into the\n'
-      'pubspec.yaml file, below that line, with everything indented by two\n'
-      'extra spaces compared to how it was in the flutter.yaml file. Then, if\n'
-      'you had a "name:" line, move that to the top of your "pubspec.yaml"\n'
-      'file (you may already have one there), so that there is only one\n'
-      '"name:" line. Finally, delete the flutter.yaml file.\n\n'
-      'For an example of what a new-style pubspec.yaml file might look like,\n'
-      'check out the Flutter Gallery pubspec.yaml:\n'
-      'https://github.com/flutter/flutter/blob/master/examples/flutter_gallery/pubspec.yaml\n';
   String flutterTargetFileMissing(String path) => 'Target file "$path" not found.';
   String get flutterBasePatchFlagsExclusive => 'Error: Only one of --baseline, --patch is allowed.';
   String get flutterBaselineRequiresTraceFile => 'Error: --baseline requires --compilation-trace-file to be specified.';

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -632,10 +632,6 @@ abstract class FlutterCommand extends Command<void> {
         throw ToolExit(userMessages.flutterNoPubspec);
       }
 
-      if (fs.isFileSync('flutter.yaml')) {
-        throw ToolExit(userMessages.flutterMergeYamlFiles);
-      }
-
       // Validate the current package map only if we will not be running "pub get" later.
       if (parent?.name != 'pub' && !(_usesPubOption && argResults['pub'])) {
         final String error = PackageMap(PackageMap.globalPackagesPath).checkValid();


### PR DESCRIPTION
## Description

Once upon a time flutter.yaml and pubspec.yaml were different files, then they were merged. Its been about ~2 years since this migration, so this code should be safe to remove