### PR TITLE
Remove plugin imports from module_test_ios

### DIFF
--- a/dev/integration_tests/ios_host_app_swift/Host/AppDelegate.swift
+++ b/dev/integration_tests/ios_host_app_swift/Host/AppDelegate.swift
@@ -1,9 +1,5 @@
 import UIKit
 
-// Prove plugins can be module-imported from the host app.
-import device_info
-import google_maps_flutter
-
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
   func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {


### PR DESCRIPTION
## Description

I missed the module_test_ios imports when I was reverting https://github.com/flutter/flutter/pull/42204.

## Tests

```
dart bin/run.dart -t module_test_ios 
```
now passes.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.