### PR TITLE
Move integration test to commands

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/flutter_run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/flutter_run_test.dart
@@ -1,0 +1,52 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:args/command_runner.dart';
+
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/commands/run.dart';
+import 'package:flutter_tools/src/doctor.dart';
+import 'package:flutter_tools/src/globals.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../src/common.dart';
+import '../../src/mocks.dart';
+import '../../src/testbed.dart';
+
+void main() {
+  setUpAll(() {
+    Cache.disableLocking();
+    Cache.flutterRoot = '';
+  });
+
+  final Testbed testbed = Testbed(setup: () {
+    when(doctor.canLaunchAnything).thenReturn(true);
+
+    fs.file('pubspec.yaml').createSync();
+    fs.file('.packages').createSync();
+    fs.file(fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    fs.directory('android').createSync();
+    fs.directory('ios').createSync();
+  }, overrides: <Type, Generator>{
+    Doctor: () => MockFlutterDoctor(),
+  });
+
+  // This test forces flutter to check for all possible devices to catch issues
+  // like https://github.com/flutter/flutter/issues/21418 which were skipped
+  // over because other integration tests run using flutter-tester which short-cuts
+  // some of the checks for devices.
+  test('flutter run handles invalid device id', () => testbed.run(() async {
+    final BufferLogger bufferLogger = logger;
+    final RunCommand command = RunCommand();
+    applyMocksToCommand(command);
+    final CommandRunner<void> commandRunner = createTestCommandRunner(command);
+
+    await expectLater(commandRunner.run(<String>['run', '-d', 'invalid-device-id', '--no-pub']), throwsToolExit());
+    expect(bufferLogger.statusText, contains('No devices found with name or id matching'));
+  }));
+}
+
+class MockFlutterDoctor extends Mock implements Doctor {}

--- a/packages/flutter_tools/test/integration.shard/flutter_run_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_run_test.dart
@@ -4,8 +4,6 @@
 
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/base/io.dart';
-import 'package:process/process.dart';
 
 import '../src/common.dart';
 import 'test_data/basic_project.dart';
@@ -26,27 +24,6 @@ void main() {
   tearDown(() async {
     await _flutter.stop();
     tryToDelete(tempDir);
-  });
-
-  test('flutter run reports an error if an invalid device is supplied', () async {
-    // This test forces flutter to check for all possible devices to catch issues
-    // like https://github.com/flutter/flutter/issues/21418 which were skipped
-    // over because other integration tests run using flutter-tester which short-cuts
-    // some of the checks for devices.
-    final String flutterBin = fs.path.join(getFlutterRoot(), 'bin', 'flutter');
-
-    const ProcessManager _processManager = LocalProcessManager();
-    final ProcessResult _proc = await _processManager.run(
-      <String>[flutterBin, 'run', '-d', 'invalid-device-id'],
-      workingDirectory: tempDir.path,
-    );
-
-    expect(_proc.stdout, isNot(contains('flutter has exited unexpectedly')));
-    expect(_proc.stderr, isNot(contains('flutter has exited unexpectedly')));
-    if (!_proc.stderr.toString().contains('Unable to locate a development')
-        && !_proc.stdout.toString().contains('No devices found with name or id matching')) {
-      fail("'flutter run -d invalid-device-id' did not produce the expected error");
-    }
   });
 
   test('flutter run writes pid-file', () async {


### PR DESCRIPTION
## Description

Refactor an integration test to work in the commands shard. Uses fewer resources and gives us codecoverage