### PR TITLE
Add v1 plugin register function into v2 plugin template

### DIFF
--- a/dev/devicelab/bin/tasks/plugin_test.dart
+++ b/dev/devicelab/bin/tasks/plugin_test.dart
@@ -14,7 +14,9 @@ Future<void> main() async {
     // These create the plugins using the new v2 plugin templates but create the
     // apps using the old v1 embedding app templates to make sure new plugins
     // are by default backward compatible.
-    PluginTest('apk', <String>['-a', 'java'], pluginCreateEnvs: {'ENABLE_ANDROID_EMBEDDING_V2': 'true'}),
-    PluginTest('apk', <String>['-a', 'kotlin'], pluginCreateEnvs: {'ENABLE_ANDROID_EMBEDDING_V2': 'true'}),
+    PluginTest('apk', <String>['-a', 'java'], pluginCreateEnvironment:
+        <String, String>{'ENABLE_ANDROID_EMBEDDING_V2': 'true'}),
+    PluginTest('apk', <String>['-a', 'kotlin'], pluginCreateEnvironment:
+        <String, String>{'ENABLE_ANDROID_EMBEDDING_V2': 'true'}),
   ]));
 }

--- a/dev/devicelab/bin/tasks/plugin_test.dart
+++ b/dev/devicelab/bin/tasks/plugin_test.dart
@@ -11,5 +11,10 @@ Future<void> main() async {
   await task(combine(<TaskFunction>[
     PluginTest('apk', <String>['-a', 'java']),
     PluginTest('apk', <String>['-a', 'kotlin']),
+    // These create the plugins using the new v2 plugin templates but create the
+    // apps using the old v1 embedding app templates to make sure new plugins
+    // are by default backward compatible.
+    PluginTest('apk', <String>['-a', 'java'], pluginCreateEnvs: {'ENABLE_ANDROID_EMBEDDING_V2': 'true'}),
+    PluginTest('apk', <String>['-a', 'kotlin'], pluginCreateEnvs: {'ENABLE_ANDROID_EMBEDDING_V2': 'true'}),
   ]));
 }

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -256,7 +256,8 @@ Future<Process> startProcess(
   assert(isBot != null);
   final String command = '$executable ${arguments?.join(" ") ?? ""}';
   final String finalWorkingDirectory = workingDirectory ?? cwd;
-  print('\nExecuting: $command in $finalWorkingDirectory');
+  print('\nExecuting: $command in $finalWorkingDirectory'
+      + (environment != null ? ' with environment $environment' : ''));
   environment ??= <String, String>{};
   environment['BOT'] = isBot ? 'true' : 'false';
   final Process process = await _processManager.start(

--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -26,10 +26,12 @@ TaskFunction combine(List<TaskFunction> tasks) {
 /// Defines task that creates new Flutter project, adds a local and remote
 /// plugin, and then builds the specified [buildTarget].
 class PluginTest {
-  PluginTest(this.buildTarget, this.options);
+  PluginTest(this.buildTarget, this.options, { this.pluginCreateEnvs, this.appCreateEnvs });
 
   final String buildTarget;
   final List<String> options;
+  final Map<String, String> pluginCreateEnvs;
+  final Map<String, String> appCreateEnvs;
 
   Future<TaskResult> call() async {
     final Directory tempDir =
@@ -38,12 +40,12 @@ class PluginTest {
       section('Create plugin');
       final _FlutterProject plugin = await _FlutterProject.create(
           tempDir, options,
-          name: 'plugintest', template: 'plugin');
+          name: 'plugintest', template: 'plugin', environment: pluginCreateEnvs);
       section('Test plugin');
       await plugin.test();
       section('Create Flutter app');
       final _FlutterProject app = await _FlutterProject.create(tempDir, options,
-          name: 'plugintestapp', template: 'app');
+          name: 'plugintestapp', template: 'app', environment: appCreateEnvs);
       try {
         if (buildTarget == 'ios')
           await prepareProvisioningCertificates(app.rootPath);
@@ -95,8 +97,13 @@ class _FlutterProject {
   }
 
   static Future<_FlutterProject> create(
-      Directory directory, List<String> options,
-      {String name, String template}) async {
+      Directory directory,
+      List<String> options,
+      {
+        String name,
+        String template,
+        Map<String, String> environment,
+      }) async {
     await inDirectory(directory, () async {
       await flutter(
         'create',
@@ -107,6 +114,7 @@ class _FlutterProject {
           ...options,
           name,
         ],
+        environment: environment,
       );
     });
     return _FlutterProject(directory, name);

--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -26,12 +26,12 @@ TaskFunction combine(List<TaskFunction> tasks) {
 /// Defines task that creates new Flutter project, adds a local and remote
 /// plugin, and then builds the specified [buildTarget].
 class PluginTest {
-  PluginTest(this.buildTarget, this.options, { this.pluginCreateEnvs, this.appCreateEnvs });
+  PluginTest(this.buildTarget, this.options, { this.pluginCreateEnvironment, this.appCreateEnvironment });
 
   final String buildTarget;
   final List<String> options;
-  final Map<String, String> pluginCreateEnvs;
-  final Map<String, String> appCreateEnvs;
+  final Map<String, String> pluginCreateEnvironment;
+  final Map<String, String> appCreateEnvironment;
 
   Future<TaskResult> call() async {
     final Directory tempDir =
@@ -40,12 +40,12 @@ class PluginTest {
       section('Create plugin');
       final _FlutterProject plugin = await _FlutterProject.create(
           tempDir, options,
-          name: 'plugintest', template: 'plugin', environment: pluginCreateEnvs);
+          name: 'plugintest', template: 'plugin', environment: pluginCreateEnvironment);
       section('Test plugin');
       await plugin.test();
       section('Create Flutter app');
       final _FlutterProject app = await _FlutterProject.create(tempDir, options,
-          name: 'plugintestapp', template: 'app', environment: appCreateEnvs);
+          name: 'plugintestapp', template: 'app', environment: appCreateEnvironment);
       try {
         if (buildTarget == 'ios')
           await prepareProvisioningCertificates(app.rootPath);

--- a/packages/flutter_tools/templates/plugin/android-java.tmpl/src/main/java/androidIdentifier/pluginClass.java.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-java.tmpl/src/main/java/androidIdentifier/pluginClass.java.tmpl
@@ -22,13 +22,13 @@ public class {{pluginClass}} implements FlutterPlugin, MethodCallHandler {
     channel.setMethodCallHandler(new {{pluginClass}}());
   }
 
-  // This function is optional and equivalent to onAttachedToEngine. It supports the old
-  // pre-Flutter-1.12 Android projects. Plugin developers are encouraged to continue supporting
+  // This static function is optional and equivalent to onAttachedToEngine. It supports the old
+  // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
   // plugin registration via this function while apps migrate to use the new Android APIs
-  // post-flutter-1.12.
+  // post-flutter-1.12 via https://flutter.dev/go/android-project-migration.
   //
-  // Developers are encouraged to share logic between onAttachedToEngine and registerWith to keep
-  // them functionaly equivalent. Only one of onAttachedToEngine or registerWith will be called
+  // It is encouraged to share logic between onAttachedToEngine and registerWith to keep
+  // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
   // depending on the user's project. onAttachedToEngine or registerWith must both be defined
   // in the same class.
   public static void registerWith(Registrar registrar) {

--- a/packages/flutter_tools/templates/plugin/android-java.tmpl/src/main/java/androidIdentifier/pluginClass.java.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-java.tmpl/src/main/java/androidIdentifier/pluginClass.java.tmpl
@@ -12,12 +12,27 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
+import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /** {{pluginClass}} */
 public class {{pluginClass}} implements FlutterPlugin, MethodCallHandler {
   @Override
   public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
     final MethodChannel channel = new MethodChannel(flutterPluginBinding.getFlutterEngine().getDartExecutor(), "{{projectName}}");
+    channel.setMethodCallHandler(new {{pluginClass}}());
+  }
+
+  // This function is optional and equivalent to onAttachedToEngine. It supports the old
+  // pre-Flutter-1.12 Android projects. Plugin developers are encouraged to continue supporting
+  // plugin registration via this function while apps migrate to use the new Android APIs
+  // post-flutter-1.12.
+  //
+  // Developers are encouraged to share logic between onAttachedToEngine and registerWith to keep
+  // them functionaly equivalent. Only one of onAttachedToEngine or registerWith will be called
+  // depending on the user's project. onAttachedToEngine or registerWith must both be defined
+  // in the same class.
+  public static void registerWith(Registrar registrar) {
+    final MethodChannel channel = new MethodChannel(registrar.messenger(), "{{projectName}}");
     channel.setMethodCallHandler(new {{pluginClass}}());
   }
 

--- a/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/src/main/kotlin/androidIdentifier/pluginClass.kt.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/src/main/kotlin/androidIdentifier/pluginClass.kt.tmpl
@@ -12,12 +12,30 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
+import io.flutter.plugin.common.PluginRegistry.Registrar
 
 /** {{pluginClass}} */
 public class {{pluginClass}}: FlutterPlugin, MethodCallHandler {
   override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     val channel = MethodChannel(flutterPluginBinding.getFlutterEngine().getDartExecutor(), "{{projectName}}")
     channel.setMethodCallHandler({{pluginClass}}());
+  }
+
+  // This static function is optional and equivalent to onAttachedToEngine. It supports the old
+  // pre-Flutter-1.12 Android projects. Plugin developers are encouraged to continue supporting
+  // plugin registration via this function while apps migrate to use the new Android APIs
+  // post-flutter-1.12.
+  //
+  // Developers are encouraged to share logic between onAttachedToEngine and registerWith to keep
+  // them functionaly equivalent. Only one of onAttachedToEngine or registerWith will be called
+  // depending on the user's project. onAttachedToEngine or registerWith must both be defined
+  // in the same class.
+  companion object {
+    @JvmStatic
+    fun registerWith(registrar: Registrar) {
+      val channel = MethodChannel(registrar.messenger(), "{{projectName}}")
+      channel.setMethodCallHandler({{pluginClass}}())
+    }
   }
 
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {

--- a/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/src/main/kotlin/androidIdentifier/pluginClass.kt.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/src/main/kotlin/androidIdentifier/pluginClass.kt.tmpl
@@ -22,12 +22,12 @@ public class {{pluginClass}}: FlutterPlugin, MethodCallHandler {
   }
 
   // This static function is optional and equivalent to onAttachedToEngine. It supports the old
-  // pre-Flutter-1.12 Android projects. Plugin developers are encouraged to continue supporting
+  // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
   // plugin registration via this function while apps migrate to use the new Android APIs
-  // post-flutter-1.12.
+  // post-flutter-1.12 via https://flutter.dev/go/android-project-migration.
   //
-  // Developers are encouraged to share logic between onAttachedToEngine and registerWith to keep
-  // them functionaly equivalent. Only one of onAttachedToEngine or registerWith will be called
+  // It is encouraged to share logic between onAttachedToEngine and registerWith to keep
+  // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
   // depending on the user's project. onAttachedToEngine or registerWith must both be defined
   // in the same class.
   companion object {


### PR DESCRIPTION
## Description

Let the ecosystem plugin developer continue to support both embeddings for now. 

## Related Issues

Fixes https://github.com/flutter/flutter/issues/44022

## Tests

Devicelab tests added in plugin_test

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
