### PR TITLE
Adjust and refactor all `RaisedButton` tests into its respective file

### DIFF
--- a/packages/flutter/test/material/buttons_test.dart
+++ b/packages/flutter/test/material/buttons_test.dart
@@ -9,88 +9,10 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../rendering/mock_canvas.dart';
-import '../widgets/semantics_tester.dart';
 
 void main() {
   setUp(() {
     debugResetSemanticsIdCounter();
-  });
-
-  testWidgets('RaisedButton defaults', (WidgetTester tester) async {
-    final Finder rawButtonMaterial = find.descendant(
-      of: find.byType(RaisedButton),
-      matching: find.byType(Material),
-    );
-
-    // Enabled RaisedButton
-    await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: RaisedButton(
-          onPressed: () { },
-          child: const Text('button'),
-        ),
-      ),
-    );
-    Material material = tester.widget<Material>(rawButtonMaterial);
-    expect(material.animationDuration, const Duration(milliseconds: 200));
-    expect(material.borderOnForeground, true);
-    expect(material.borderRadius, null);
-    expect(material.clipBehavior, Clip.none);
-    expect(material.color, const Color(0xffe0e0e0));
-    expect(material.elevation, 2.0);
-    expect(material.shadowColor, const Color(0xff000000));
-    expect(material.shape, RoundedRectangleBorder(borderRadius: BorderRadius.circular(2.0)));
-    expect(material.textStyle.color, const Color(0xdd000000));
-    expect(material.textStyle.fontFamily, 'Roboto');
-    expect(material.textStyle.fontSize, 14);
-    expect(material.textStyle.fontWeight, FontWeight.w500);
-    expect(material.type, MaterialType.button);
-
-    final Offset center = tester.getCenter(find.byType(RaisedButton));
-    await tester.startGesture(center);
-    await tester.pumpAndSettle();
-
-    // Only elevation changes when enabled and pressed.
-    material = tester.widget<Material>(rawButtonMaterial);
-    expect(material.animationDuration, const Duration(milliseconds: 200));
-    expect(material.borderOnForeground, true);
-    expect(material.borderRadius, null);
-    expect(material.clipBehavior, Clip.none);
-    expect(material.color, const Color(0xffe0e0e0));
-    expect(material.elevation, 8.0);
-    expect(material.shadowColor, const Color(0xff000000));
-    expect(material.shape, RoundedRectangleBorder(borderRadius: BorderRadius.circular(2.0)));
-    expect(material.textStyle.color, const Color(0xdd000000));
-    expect(material.textStyle.fontFamily, 'Roboto');
-    expect(material.textStyle.fontSize, 14);
-    expect(material.textStyle.fontWeight, FontWeight.w500);
-    expect(material.type, MaterialType.button);
-
-    // Disabled RaisedButton
-    await tester.pumpWidget(
-      const Directionality(
-        textDirection: TextDirection.ltr,
-        child: RaisedButton(
-          onPressed: null,
-          child: Text('button'),
-        ),
-      ),
-    );
-    material = tester.widget<Material>(rawButtonMaterial);
-    expect(material.animationDuration, const Duration(milliseconds: 200));
-    expect(material.borderOnForeground, true);
-    expect(material.borderRadius, null);
-    expect(material.clipBehavior, Clip.none);
-    expect(material.color, const Color(0x61000000));
-    expect(material.elevation, 0.0);
-    expect(material.shadowColor, const Color(0xff000000));
-    expect(material.shape, RoundedRectangleBorder(borderRadius: BorderRadius.circular(2.0)));
-    expect(material.textStyle.color, const Color(0x61000000));
-    expect(material.textStyle.fontFamily, 'Roboto');
-    expect(material.textStyle.fontSize, 14);
-    expect(material.textStyle.fontWeight, FontWeight.w500);
-    expect(material.type, MaterialType.button);
   });
 
   testWidgets('OutlineButton defaults', (WidgetTester tester) async {
@@ -185,22 +107,7 @@ void main() {
     await gesture.addPointer();
     await gesture.moveTo(tester.getCenter(find.byType(OutlineButton)));
     await tester.pumpAndSettle();
-    RenderObject inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
-    expect(inkFeatures, paints..rect(color: hoverColor));
-
-    await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: RaisedButton(
-          hoverColor: hoverColor,
-          onPressed: () { },
-          child: const Text('button'),
-        ),
-      ),
-    );
-
-    await tester.pumpAndSettle();
-    inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
+    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
     expect(inkFeatures, paints..rect(color: hoverColor));
 
     gesture.removePointer();
@@ -209,11 +116,11 @@ void main() {
   testWidgets('Do buttons work with focus', (WidgetTester tester) async {
     const Color focusColor = Color(0xff001122);
 
-    FocusNode focusNode = FocusNode(debugLabel: 'RaisedButton Node');
+    final FocusNode focusNode = FocusNode(debugLabel: 'OutlineButton Node');
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: RaisedButton(
+        child: OutlineButton(
           focusColor: focusColor,
           focusNode: focusNode,
           onPressed: () { },
@@ -226,127 +133,7 @@ void main() {
     focusNode.requestFocus();
     await tester.pumpAndSettle();
 
-    RenderObject inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
+    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
     expect(inkFeatures, paints..rect(color: focusColor));
-
-    focusNode = FocusNode(debugLabel: 'OutlineButton Node');
-    await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: OutlineButton(
-          focusColor: focusColor,
-          focusNode: focusNode,
-          onPressed: () { },
-          child: const Text('button'),
-        ),
-      ),
-    );
-    focusNode.requestFocus();
-    await tester.pumpAndSettle();
-    inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
-    expect(inkFeatures, paints..rect(color: focusColor));
-  });
-
-  testWidgets('Does RaisedButton contribute semantics', (WidgetTester tester) async {
-    final SemanticsTester semantics = SemanticsTester(tester);
-    await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: Material(
-          child: Center(
-            child: RaisedButton(
-              onPressed: () { },
-              child: const Text('ABC'),
-            ),
-          ),
-        ),
-      ),
-    );
-
-    expect(semantics, hasSemantics(
-      TestSemantics.root(
-        children: <TestSemantics>[
-          TestSemantics.rootChild(
-            actions: <SemanticsAction>[
-              SemanticsAction.tap,
-            ],
-            label: 'ABC',
-            rect: const Rect.fromLTRB(0.0, 0.0, 88.0, 48.0),
-            transform: Matrix4.translationValues(356.0, 276.0, 0.0),
-            flags: <SemanticsFlag>[
-              SemanticsFlag.hasEnabledState,
-              SemanticsFlag.isButton,
-              SemanticsFlag.isEnabled,
-              SemanticsFlag.isFocusable,
-            ],
-          ),
-        ],
-      ),
-      ignoreId: true,
-    ));
-
-    semantics.dispose();
-  });
-
-  testWidgets('RaisedButton size is configurable by ThemeData.materialTapTargetSize', (WidgetTester tester) async {
-    final Key key1 = UniqueKey();
-    await tester.pumpWidget(
-      Theme(
-        data: ThemeData(materialTapTargetSize: MaterialTapTargetSize.padded),
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: Material(
-            child: Center(
-              child: RaisedButton(
-                key: key1,
-                child: const SizedBox(width: 50.0, height: 8.0),
-                onPressed: () { },
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-
-    expect(tester.getSize(find.byKey(key1)), const Size(88.0, 48.0));
-
-    final Key key2 = UniqueKey();
-    await tester.pumpWidget(
-      Theme(
-        data: ThemeData(materialTapTargetSize: MaterialTapTargetSize.shrinkWrap),
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: Material(
-            child: Center(
-              child: RaisedButton(
-                key: key2,
-                child: const SizedBox(width: 50.0, height: 8.0),
-                onPressed: () { },
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-
-    expect(tester.getSize(find.byKey(key2)), const Size(88.0, 36.0));
-  });
-
-  testWidgets('RaisedButton has no clip by default', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      Directionality(
-          textDirection: TextDirection.ltr,
-          child: Material(
-            child: RaisedButton(
-              onPressed: () { /* to make sure the button is enabled */ },
-            ),
-          ),
-      ),
-    );
-
-    expect(
-        tester.renderObject(find.byType(RaisedButton)),
-        paintsExactlyCountTimes(#clipPath, 0),
-    );
   });
 }

--- a/packages/flutter/test/material/raised_button_test.dart
+++ b/packages/flutter/test/material/raised_button_test.dart
@@ -7,7 +7,87 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/rendering.dart';
 
+import '../rendering/mock_canvas.dart';
+import '../widgets/semantics_tester.dart';
+
 void main() {
+  testWidgets('RaisedButton defaults', (WidgetTester tester) async {
+    final Finder rawButtonMaterial = find.descendant(
+      of: find.byType(RaisedButton),
+      matching: find.byType(Material),
+    );
+
+    // Enabled RaisedButton
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: RaisedButton(
+          onPressed: () { },
+          child: const Text('button'),
+        ),
+      ),
+    );
+    Material material = tester.widget<Material>(rawButtonMaterial);
+    expect(material.animationDuration, const Duration(milliseconds: 200));
+    expect(material.borderOnForeground, true);
+    expect(material.borderRadius, null);
+    expect(material.clipBehavior, Clip.none);
+    expect(material.color, const Color(0xffe0e0e0));
+    expect(material.elevation, 2.0);
+    expect(material.shadowColor, const Color(0xff000000));
+    expect(material.shape, RoundedRectangleBorder(borderRadius: BorderRadius.circular(2.0)));
+    expect(material.textStyle.color, const Color(0xdd000000));
+    expect(material.textStyle.fontFamily, 'Roboto');
+    expect(material.textStyle.fontSize, 14);
+    expect(material.textStyle.fontWeight, FontWeight.w500);
+    expect(material.type, MaterialType.button);
+
+    final Offset center = tester.getCenter(find.byType(RaisedButton));
+    await tester.startGesture(center);
+    await tester.pumpAndSettle();
+
+    // Only elevation changes when enabled and pressed.
+    material = tester.widget<Material>(rawButtonMaterial);
+    expect(material.animationDuration, const Duration(milliseconds: 200));
+    expect(material.borderOnForeground, true);
+    expect(material.borderRadius, null);
+    expect(material.clipBehavior, Clip.none);
+    expect(material.color, const Color(0xffe0e0e0));
+    expect(material.elevation, 8.0);
+    expect(material.shadowColor, const Color(0xff000000));
+    expect(material.shape, RoundedRectangleBorder(borderRadius: BorderRadius.circular(2.0)));
+    expect(material.textStyle.color, const Color(0xdd000000));
+    expect(material.textStyle.fontFamily, 'Roboto');
+    expect(material.textStyle.fontSize, 14);
+    expect(material.textStyle.fontWeight, FontWeight.w500);
+    expect(material.type, MaterialType.button);
+
+    // Disabled RaisedButton
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: RaisedButton(
+          onPressed: null,
+          child: Text('button'),
+        ),
+      ),
+    );
+    material = tester.widget<Material>(rawButtonMaterial);
+    expect(material.animationDuration, const Duration(milliseconds: 200));
+    expect(material.borderOnForeground, true);
+    expect(material.borderRadius, null);
+    expect(material.clipBehavior, Clip.none);
+    expect(material.color, const Color(0x61000000));
+    expect(material.elevation, 0.0);
+    expect(material.shadowColor, const Color(0xff000000));
+    expect(material.shape, RoundedRectangleBorder(borderRadius: BorderRadius.circular(2.0)));
+    expect(material.textStyle.color, const Color(0x61000000));
+    expect(material.textStyle.fontFamily, 'Roboto');
+    expect(material.textStyle.fontSize, 14);
+    expect(material.textStyle.fontWeight, FontWeight.w500);
+    expect(material.type, MaterialType.button);
+  });
+
   testWidgets('RaisedButton implements debugFillProperties', (WidgetTester tester) async {
     final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
     RaisedButton(
@@ -324,6 +404,158 @@ void main() {
     expect(didLongPressButton, isFalse);
     await tester.longPress(raisedButton);
     expect(didLongPressButton, isTrue);
+  });
+
+  testWidgets('Does RaisedButton work with hover', (WidgetTester tester) async {
+    const Color hoverColor = Color(0xff001122);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: RaisedButton(
+          hoverColor: hoverColor,
+          onPressed: () { },
+          child: const Text('button'),
+        ),
+      ),
+    );
+
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer();
+    await gesture.moveTo(tester.getCenter(find.byType(RaisedButton)));
+    await tester.pumpAndSettle();
+
+    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
+    expect(inkFeatures, paints..rect(color: hoverColor));
+
+    await gesture.removePointer();
+  });
+
+  testWidgets('Does RaisedButton work with focus', (WidgetTester tester) async {
+    const Color focusColor = Color(0xff001122);
+
+    final FocusNode focusNode = FocusNode(debugLabel: 'RaisedButton Node');
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: RaisedButton(
+          focusColor: focusColor,
+          focusNode: focusNode,
+          onPressed: () { },
+          child: const Text('button'),
+        ),
+      ),
+    );
+
+    FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+    focusNode.requestFocus();
+    await tester.pumpAndSettle();
+
+    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
+    expect(inkFeatures, paints..rect(color: focusColor));
+  });
+
+  testWidgets('Does RaisedButton contribute semantics', (WidgetTester tester) async {
+    final SemanticsTester semantics = SemanticsTester(tester);
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Material(
+          child: Center(
+            child: RaisedButton(
+              onPressed: () { },
+              child: const Text('ABC'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(semantics, hasSemantics(
+      TestSemantics.root(
+        children: <TestSemantics>[
+          TestSemantics.rootChild(
+            actions: <SemanticsAction>[
+              SemanticsAction.tap,
+            ],
+            label: 'ABC',
+            rect: const Rect.fromLTRB(0.0, 0.0, 88.0, 48.0),
+            transform: Matrix4.translationValues(356.0, 276.0, 0.0),
+            flags: <SemanticsFlag>[
+              SemanticsFlag.hasEnabledState,
+              SemanticsFlag.isButton,
+              SemanticsFlag.isEnabled,
+              SemanticsFlag.isFocusable,
+            ],
+          ),
+        ],
+      ),
+      ignoreId: true,
+    ));
+
+    semantics.dispose();
+  });
+
+  testWidgets('RaisedButton size is configurable by ThemeData.materialTapTargetSize', (WidgetTester tester) async {
+    final Key key1 = UniqueKey();
+    await tester.pumpWidget(
+      Theme(
+        data: ThemeData(materialTapTargetSize: MaterialTapTargetSize.padded),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Material(
+            child: Center(
+              child: RaisedButton(
+                key: key1,
+                child: const SizedBox(width: 50.0, height: 8.0),
+                onPressed: () { },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byKey(key1)), const Size(88.0, 48.0));
+
+    final Key key2 = UniqueKey();
+    await tester.pumpWidget(
+      Theme(
+        data: ThemeData(materialTapTargetSize: MaterialTapTargetSize.shrinkWrap),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Material(
+            child: Center(
+              child: RaisedButton(
+                key: key2,
+                child: const SizedBox(width: 50.0, height: 8.0),
+                onPressed: () { },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byKey(key2)), const Size(88.0, 36.0));
+  });
+
+  testWidgets('RaisedButton has no clip by default', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Directionality(
+          textDirection: TextDirection.ltr,
+          child: Material(
+            child: RaisedButton(
+              onPressed: () { /* to make sure the button is enabled */ },
+            ),
+          ),
+      ),
+    );
+
+    expect(
+        tester.renderObject(find.byType(RaisedButton)),
+        paintsExactlyCountTimes(#clipPath, 0),
+    );
   });
 }
 


### PR DESCRIPTION
## Description

The existing monolithic `buttons_tests.dart` file contains tests for different buttons like `FlatButton`, `RaisedButton`, `OutlineButton` and `MaterialButton`, even though `flat_button_test.dart`, `raised_button_test.dart`, `outline_button_test.dart`, and `material_button_test.dart` exists.

This PR splits up and adjusts `RaisedButton` tests properly into its respective file.

## Related Issues

 #42798

## Tests

I added the following tests:

- Refactors existing

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
