### PR TITLE
Make ProjectFileInvalidator injectable

### DIFF
--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -27,6 +27,10 @@ import 'reporting/reporting.dart';
 import 'resident_runner.dart';
 import 'vmservice.dart';
 
+ProjectFileInvalidator get projectFileInvalidator => context.get<ProjectFileInvalidator>() ?? const ProjectFileInvalidator();
+
+HotRunnerConfig get hotRunnerConfig => context.get<HotRunnerConfig>();
+
 class HotRunnerConfig {
   /// Should the hot runner assume that the minimal Dart dependencies do not change?
   bool stableDartDependencies = false;
@@ -45,8 +49,6 @@ class HotRunnerConfig {
     return;
   }
 }
-
-HotRunnerConfig get hotRunnerConfig => context.get<HotRunnerConfig>();
 
 const bool kHotReloadDefault = true;
 
@@ -301,7 +303,7 @@ class HotRunner extends ResidentRunner {
 
     // Picking up first device's compiler as a source of truth - compilers
     // for all devices should be in sync.
-    final List<Uri> invalidatedFiles = await ProjectFileInvalidator.findInvalidated(
+    final List<Uri> invalidatedFiles = await projectFileInvalidator.findInvalidated(
       lastCompiled: flutterDevices[0].devFS.lastCompiled,
       urisToMonitor: flutterDevices[0].devFS.sources,
       packagesPath: packagesFilePath,
@@ -1047,6 +1049,8 @@ class HotRunner extends ResidentRunner {
 }
 
 class ProjectFileInvalidator {
+  const ProjectFileInvalidator();
+
   static const String _pubCachePathLinuxAndMac = '.pub-cache';
   static const String _pubCachePathWindows = 'Pub/Cache';
 
@@ -1058,7 +1062,7 @@ class ProjectFileInvalidator {
   // ~2000 files.
   static const int _kMaxPendingStats = 8;
 
-  static Future<List<Uri>> findInvalidated({
+  Future<List<Uri>> findInvalidated({
     @required DateTime lastCompiled,
     @required List<Uri> urisToMonitor,
     @required String packagesPath,

--- a/packages/flutter_tools/test/general.shard/project_file_invalidator_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_file_invalidator_test.dart
@@ -23,9 +23,11 @@ void main() {
 }
 
 void _testProjectFileInvalidator({@required bool asyncScanning}) {
+  const ProjectFileInvalidator projectFileInvalidator = ProjectFileInvalidator();
+
   testUsingContext('No last compile', () async {
     expect(
-      await ProjectFileInvalidator.findInvalidated(
+      await projectFileInvalidator.findInvalidated(
         lastCompiled: null,
         urisToMonitor: <Uri>[],
         packagesPath: '',
@@ -37,7 +39,7 @@ void _testProjectFileInvalidator({@required bool asyncScanning}) {
 
   testUsingContext('Empty project', () async {
     expect(
-      await ProjectFileInvalidator.findInvalidated(
+      await projectFileInvalidator.findInvalidated(
         lastCompiled: inFuture,
         urisToMonitor: <Uri>[],
         packagesPath: '',
@@ -52,7 +54,7 @@ void _testProjectFileInvalidator({@required bool asyncScanning}) {
 
   testUsingContext('Non-existent files are ignored', () async {
     expect(
-      await ProjectFileInvalidator.findInvalidated(
+      await projectFileInvalidator.findInvalidated(
         lastCompiled: inFuture,
         urisToMonitor: <Uri>[Uri.parse('/not-there-anymore'),],
         packagesPath: '',


### PR DESCRIPTION
Allow `ProjectFileInvalidator` to be overridden with a different
implementation.

I stole this from https://github.com/flutter/flutter/pull/39217.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
