### PR TITLE
Moving pointer event sanitizing to engine.

### DIFF
--- a/packages/flutter/lib/src/gestures/converter.dart
+++ b/packages/flutter/lib/src/gestures/converter.dart
@@ -99,7 +99,7 @@ class PointerEventConverter {
           case ui.PointerChange.down:
             yield PointerDownEvent(
               timeStamp: timeStamp,
-              pointer: datum.pointer,
+              pointer: datum.pointerIdentifier,
               kind: kind,
               device: datum.device,
               position: position,
@@ -121,7 +121,7 @@ class PointerEventConverter {
           case ui.PointerChange.move:
             yield PointerMoveEvent(
               timeStamp: timeStamp,
-              pointer: datum.pointer,
+              pointer: datum.pointerIdentifier,
               kind: kind,
               device: datum.device,
               position: position,
@@ -146,7 +146,7 @@ class PointerEventConverter {
           case ui.PointerChange.up:
             yield PointerUpEvent(
               timeStamp: timeStamp,
-              pointer: datum.pointer,
+              pointer: datum.pointerIdentifier,
               kind: kind,
               device: datum.device,
               position: position,
@@ -169,7 +169,7 @@ class PointerEventConverter {
           case ui.PointerChange.cancel:
             yield PointerCancelEvent(
               timeStamp: timeStamp,
-              pointer: datum.pointer,
+              pointer: datum.pointerIdentifier,
               kind: kind,
               device: datum.device,
               position: position,

--- a/packages/flutter/lib/src/gestures/converter.dart
+++ b/packages/flutter/lib/src/gestures/converter.dart
@@ -96,7 +96,9 @@ class PointerEventConverter {
   /// [PointerEvent] for more details on the [PointerEvent] coordinate space.
   static Iterable<PointerEvent> expand(Iterable<ui.PointerData> data, double devicePixelRatio) sync* {
     for (ui.PointerData datum in data) {
+      print('even ${datum.toStringFull()}');
       final Offset position = Offset(datum.physicalX, datum.physicalY) / devicePixelRatio;
+      final Offset delta = Offset(datum.physicalDeltaX, datum.physicalDeltaY) / devicePixelRatio;
       final double radiusMinor = _toLogicalPixels(datum.radiusMinor, devicePixelRatio);
       final double radiusMajor = _toLogicalPixels(datum.radiusMajor, devicePixelRatio);
       final double radiusMin = _toLogicalPixels(datum.radiusMin, devicePixelRatio);
@@ -107,9 +109,6 @@ class PointerEventConverter {
       if (datum.signalKind == null || datum.signalKind == ui.PointerSignalKind.none) {
         switch (datum.change) {
           case ui.PointerChange.add:
-            assert(!_pointers.containsKey(datum.device));
-            final _PointerState state = _ensureStateForPointer(datum, position);
-            assert(state.lastPosition == position);
             yield PointerAddedEvent(
               timeStamp: timeStamp,
               kind: kind,
@@ -127,33 +126,12 @@ class PointerEventConverter {
             );
             break;
           case ui.PointerChange.hover:
-            final bool alreadyAdded = _pointers.containsKey(datum.device);
-            final _PointerState state = _ensureStateForPointer(datum, position);
-            assert(!state.down);
-            if (!alreadyAdded) {
-              assert(state.lastPosition == position);
-              yield PointerAddedEvent(
-                timeStamp: timeStamp,
-                kind: kind,
-                device: datum.device,
-                position: position,
-                obscured: datum.obscured,
-                pressureMin: datum.pressureMin,
-                pressureMax: datum.pressureMax,
-                distance: datum.distance,
-                distanceMax: datum.distanceMax,
-                radiusMin: radiusMin,
-                radiusMax: radiusMax,
-                orientation: datum.orientation,
-                tilt: datum.tilt,
-              );
-            }
             yield PointerHoverEvent(
               timeStamp: timeStamp,
               kind: kind,
               device: datum.device,
               position: position,
-              delta: state.deltaTo(position),
+              delta: delta,
               buttons: datum.buttons,
               obscured: datum.obscured,
               pressureMin: datum.pressureMin,
@@ -168,62 +146,11 @@ class PointerEventConverter {
               orientation: datum.orientation,
               tilt: datum.tilt,
             );
-            state.lastPosition = position;
             break;
           case ui.PointerChange.down:
-            final bool alreadyAdded = _pointers.containsKey(datum.device);
-            final _PointerState state = _ensureStateForPointer(datum, position);
-            assert(!state.down);
-            if (!alreadyAdded) {
-              assert(state.lastPosition == position);
-              yield PointerAddedEvent(
-                timeStamp: timeStamp,
-                kind: kind,
-                device: datum.device,
-                position: position,
-                obscured: datum.obscured,
-                pressureMin: datum.pressureMin,
-                pressureMax: datum.pressureMax,
-                distance: datum.distance,
-                distanceMax: datum.distanceMax,
-                radiusMin: radiusMin,
-                radiusMax: radiusMax,
-                orientation: datum.orientation,
-                tilt: datum.tilt,
-              );
-            }
-            if (state.lastPosition != position) {
-              // Not all sources of pointer packets respect the invariant that
-              // they hover the pointer to the down location before sending the
-              // down event. We restore the invariant here for our clients.
-              yield PointerHoverEvent(
-                timeStamp: timeStamp,
-                kind: kind,
-                device: datum.device,
-                position: position,
-                delta: state.deltaTo(position),
-                buttons: datum.buttons,
-                obscured: datum.obscured,
-                pressureMin: datum.pressureMin,
-                pressureMax: datum.pressureMax,
-                distance: datum.distance,
-                distanceMax: datum.distanceMax,
-                size: datum.size,
-                radiusMajor: radiusMajor,
-                radiusMinor: radiusMinor,
-                radiusMin: radiusMin,
-                radiusMax: radiusMax,
-                orientation: datum.orientation,
-                tilt: datum.tilt,
-                synthesized: true,
-              );
-              state.lastPosition = position;
-            }
-            state.startNewPointer();
-            state.setDown();
             yield PointerDownEvent(
               timeStamp: timeStamp,
-              pointer: state.pointer,
+              pointer: datum.pointer,
               kind: kind,
               device: datum.device,
               position: position,
@@ -243,19 +170,13 @@ class PointerEventConverter {
             );
             break;
           case ui.PointerChange.move:
-            // If the service starts supporting hover pointers, then it must also
-            // start sending us ADDED and REMOVED data points.
-            // See also: https://github.com/flutter/flutter/issues/720
-            assert(_pointers.containsKey(datum.device));
-            final _PointerState state = _pointers[datum.device];
-            assert(state.down);
             yield PointerMoveEvent(
               timeStamp: timeStamp,
-              pointer: state.pointer,
+              pointer: datum.pointer,
               kind: kind,
               device: datum.device,
               position: position,
-              delta: state.deltaTo(position),
+              delta: delta,
               buttons: _synthesiseDownButtons(datum.buttons, kind),
               obscured: datum.obscured,
               pressure: datum.pressure,
@@ -271,139 +192,53 @@ class PointerEventConverter {
               tilt: datum.tilt,
               platformData: datum.platformData,
             );
-            state.lastPosition = position;
             break;
           case ui.PointerChange.up:
+            yield PointerUpEvent(
+              timeStamp: timeStamp,
+              pointer: datum.pointer,
+              kind: kind,
+              device: datum.device,
+              position: position,
+              buttons: datum.buttons,
+              obscured: datum.obscured,
+              pressure: datum.pressure,
+              pressureMin: datum.pressureMin,
+              pressureMax: datum.pressureMax,
+              distance: datum.distance,
+              distanceMax: datum.distanceMax,
+              size: datum.size,
+              radiusMajor: radiusMajor,
+              radiusMinor: radiusMinor,
+              radiusMin: radiusMin,
+              radiusMax: radiusMax,
+              orientation: datum.orientation,
+              tilt: datum.tilt,
+            );
+            break;
           case ui.PointerChange.cancel:
-            assert(_pointers.containsKey(datum.device));
-            final _PointerState state = _pointers[datum.device];
-            assert(state.down);
-            if (position != state.lastPosition) {
-              // Not all sources of pointer packets respect the invariant that
-              // they move the pointer to the up location before sending the up
-              // event. For example, in the iOS simulator, of you drag outside the
-              // window, you'll get a stream of pointers that violates that
-              // invariant. We restore the invariant here for our clients.
-              yield PointerMoveEvent(
-                timeStamp: timeStamp,
-                pointer: state.pointer,
-                kind: kind,
-                device: datum.device,
-                position: position,
-                delta: state.deltaTo(position),
-                buttons: _synthesiseDownButtons(datum.buttons, kind),
-                obscured: datum.obscured,
-                pressure: datum.pressure,
-                pressureMin: datum.pressureMin,
-                pressureMax: datum.pressureMax,
-                distanceMax: datum.distanceMax,
-                size: datum.size,
-                radiusMajor: radiusMajor,
-                radiusMinor: radiusMinor,
-                radiusMin: radiusMin,
-                radiusMax: radiusMax,
-                orientation: datum.orientation,
-                tilt: datum.tilt,
-                synthesized: true,
-              );
-              state.lastPosition = position;
-            }
-            assert(position == state.lastPosition);
-            state.setUp();
-            if (datum.change == ui.PointerChange.up) {
-              yield PointerUpEvent(
-                timeStamp: timeStamp,
-                pointer: state.pointer,
-                kind: kind,
-                device: datum.device,
-                position: position,
-                buttons: datum.buttons,
-                obscured: datum.obscured,
-                pressure: datum.pressure,
-                pressureMin: datum.pressureMin,
-                pressureMax: datum.pressureMax,
-                distance: datum.distance,
-                distanceMax: datum.distanceMax,
-                size: datum.size,
-                radiusMajor: radiusMajor,
-                radiusMinor: radiusMinor,
-                radiusMin: radiusMin,
-                radiusMax: radiusMax,
-                orientation: datum.orientation,
-                tilt: datum.tilt,
-              );
-            } else {
-              yield PointerCancelEvent(
-                timeStamp: timeStamp,
-                pointer: state.pointer,
-                kind: kind,
-                device: datum.device,
-                position: position,
-                buttons: datum.buttons,
-                obscured: datum.obscured,
-                pressureMin: datum.pressureMin,
-                pressureMax: datum.pressureMax,
-                distance: datum.distance,
-                distanceMax: datum.distanceMax,
-                size: datum.size,
-                radiusMajor: radiusMajor,
-                radiusMinor: radiusMinor,
-                radiusMin: radiusMin,
-                radiusMax: radiusMax,
-                orientation: datum.orientation,
-                tilt: datum.tilt,
-              );
-            }
+            yield PointerCancelEvent(
+              timeStamp: timeStamp,
+              pointer: datum.pointer,
+              kind: kind,
+              device: datum.device,
+              position: position,
+              buttons: datum.buttons,
+              obscured: datum.obscured,
+              pressureMin: datum.pressureMin,
+              pressureMax: datum.pressureMax,
+              distance: datum.distance,
+              distanceMax: datum.distanceMax,
+              size: datum.size,
+              radiusMajor: radiusMajor,
+              radiusMinor: radiusMinor,
+              radiusMin: radiusMin,
+              radiusMax: radiusMax,
+              orientation: datum.orientation,
+              tilt: datum.tilt,
+            );
             break;
           case ui.PointerChange.remove:
-            assert(_pointers.containsKey(datum.device));
-            final _PointerState state = _pointers[datum.device];
-            if (state.down) {
-              yield PointerCancelEvent(
-                timeStamp: timeStamp,
-                pointer: state.pointer,
-                kind: kind,
-                device: datum.device,
-                position: state.lastPosition, // Change position in Hover
-                buttons: datum.buttons,
-                obscured: datum.obscured,
-                pressureMin: datum.pressureMin,
-                pressureMax: datum.pressureMax,
-                distance: datum.distance,
-                distanceMax: datum.distanceMax,
-                size: datum.size,
-                radiusMajor: radiusMajor,
-                radiusMinor: radiusMinor,
-                radiusMin: radiusMin,
-                radiusMax: radiusMax,
-                orientation: datum.orientation,
-                tilt: datum.tilt,
-              );
-            }
-            if (position != state.lastPosition) {
-              yield PointerHoverEvent(
-                timeStamp: timeStamp,
-                kind: kind,
-                device: datum.device,
-                position: position,
-                delta: state.deltaTo(position),
-                buttons: datum.buttons,
-                obscured: datum.obscured,
-                pressureMin: datum.pressureMin,
-                pressureMax: datum.pressureMax,
-                distance: datum.distance,
-                distanceMax: datum.distanceMax,
-                size: datum.size,
-                radiusMajor: radiusMajor,
-                radiusMinor: radiusMinor,
-                radiusMin: radiusMin,
-                radiusMax: radiusMax,
-                orientation: datum.orientation,
-                tilt: datum.tilt,
-                synthesized: true,
-              );
-            }
-            _pointers.remove(datum.device);
             yield PointerRemovedEvent(
               timeStamp: timeStamp,
               kind: kind,

--- a/packages/flutter/lib/src/gestures/converter.dart
+++ b/packages/flutter/lib/src/gestures/converter.dart
@@ -45,6 +45,7 @@ class PointerEventConverter {
   /// [PointerEvent] for more details on the [PointerEvent] coordinate space.
   static Iterable<PointerEvent> expand(Iterable<ui.PointerData> data, double devicePixelRatio) sync* {
     for (ui.PointerData datum in data) {
+      print('event ${datum.toStringFull()}');
       final Offset position = Offset(datum.physicalX, datum.physicalY) / devicePixelRatio;
       final Offset delta = Offset(datum.physicalDeltaX, datum.physicalDeltaY) / devicePixelRatio;
       final double radiusMinor = _toLogicalPixels(datum.radiusMinor, devicePixelRatio);
@@ -93,6 +94,7 @@ class PointerEventConverter {
               radiusMax: radiusMax,
               orientation: datum.orientation,
               tilt: datum.tilt,
+              synthesized: datum.synthesized,
             );
             break;
           case ui.PointerChange.down:
@@ -139,6 +141,7 @@ class PointerEventConverter {
               orientation: datum.orientation,
               tilt: datum.tilt,
               platformData: datum.platformData,
+              synthesized: datum.synthesized,
             );
             break;
           case ui.PointerChange.up:

--- a/packages/flutter/lib/src/gestures/converter.dart
+++ b/packages/flutter/lib/src/gestures/converter.dart
@@ -45,7 +45,6 @@ class PointerEventConverter {
   /// [PointerEvent] for more details on the [PointerEvent] coordinate space.
   static Iterable<PointerEvent> expand(Iterable<ui.PointerData> data, double devicePixelRatio) sync* {
     for (ui.PointerData datum in data) {
-      print('event ${datum.toStringFull()}');
       final Offset position = Offset(datum.physicalX, datum.physicalY) / devicePixelRatio;
       final Offset delta = Offset(datum.physicalDeltaX, datum.physicalDeltaY) / devicePixelRatio;
       final double radiusMinor = _toLogicalPixels(datum.radiusMinor, devicePixelRatio);

--- a/packages/flutter/lib/src/gestures/converter.dart
+++ b/packages/flutter/lib/src/gestures/converter.dart
@@ -4,8 +4,6 @@
 
 import 'dart:ui' as ui show PointerData, PointerChange, PointerSignalKind;
 
-import 'package:flutter/foundation.dart' show visibleForTesting;
-
 import 'events.dart';
 
 // Add `kPrimaryButton` to [buttons] when a pointer of certain devices is down.

--- a/packages/flutter/lib/src/gestures/converter.dart
+++ b/packages/flutter/lib/src/gestures/converter.dart
@@ -45,7 +45,6 @@ class PointerEventConverter {
   /// [PointerEvent] for more details on the [PointerEvent] coordinate space.
   static Iterable<PointerEvent> expand(Iterable<ui.PointerData> data, double devicePixelRatio) sync* {
     for (ui.PointerData datum in data) {
-      print('even ${datum.toStringFull()}');
       final Offset position = Offset(datum.physicalX, datum.physicalY) / devicePixelRatio;
       final Offset delta = Offset(datum.physicalDeltaX, datum.physicalDeltaY) / devicePixelRatio;
       final double radiusMinor = _toLogicalPixels(datum.radiusMinor, devicePixelRatio);

--- a/packages/flutter/test/gestures/gesture_binding_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_test.dart
@@ -71,9 +71,11 @@ void main() {
   test('Pointer hover events', () {
     const ui.PointerDataPacket packet = ui.PointerDataPacket(
         data: <ui.PointerData>[
+          ui.PointerData(change: ui.PointerChange.add),
           ui.PointerData(change: ui.PointerChange.hover),
           ui.PointerData(change: ui.PointerChange.hover),
           ui.PointerData(change: ui.PointerChange.remove),
+          ui.PointerData(change: ui.PointerChange.add),
           ui.PointerData(change: ui.PointerChange.hover),
         ],
     );
@@ -94,33 +96,6 @@ void main() {
     expect(pointerRouterEvents[3].runtimeType, equals(PointerRemovedEvent));
     expect(pointerRouterEvents[4].runtimeType, equals(PointerAddedEvent));
     expect(pointerRouterEvents[5].runtimeType, equals(PointerHoverEvent));
-  });
-
-  test('Synthetic move events', () {
-    final ui.PointerDataPacket packet = ui.PointerDataPacket(
-      data: <ui.PointerData>[
-        ui.PointerData(
-          change: ui.PointerChange.down,
-          physicalX: 1.0 * ui.window.devicePixelRatio,
-          physicalY: 3.0 * ui.window.devicePixelRatio,
-        ),
-        ui.PointerData(
-          change: ui.PointerChange.up,
-          physicalX: 10.0 * ui.window.devicePixelRatio,
-          physicalY: 15.0 * ui.window.devicePixelRatio,
-        ),
-      ],
-    );
-
-    final List<PointerEvent> events = <PointerEvent>[];
-    _binding.callback = events.add;
-
-    ui.window.onPointerDataPacket(packet);
-    expect(events.length, 3);
-    expect(events[0].runtimeType, equals(PointerDownEvent));
-    expect(events[1].runtimeType, equals(PointerMoveEvent));
-    expect(events[1].delta, equals(const Offset(9.0, 12.0)));
-    expect(events[2].runtimeType, equals(PointerUpEvent));
   });
 
   test('Pointer cancel events', () {
@@ -167,6 +142,7 @@ void main() {
         ui.PointerData(change: ui.PointerChange.add, device: 24),
         ui.PointerData(change: ui.PointerChange.hover, device: 24),
         ui.PointerData(change: ui.PointerChange.remove, device: 24),
+        ui.PointerData(change: ui.PointerChange.add, device: 24),
         ui.PointerData(change: ui.PointerChange.hover, device: 24),
       ],
     );
@@ -180,28 +156,6 @@ void main() {
     expect(events[2].runtimeType, equals(PointerRemovedEvent));
     expect(events[3].runtimeType, equals(PointerAddedEvent));
     expect(events[4].runtimeType, equals(PointerHoverEvent));
-  });
-
-  test('Synthetic hover and cancel for misplaced down and remove', () {
-    final ui.PointerDataPacket packet = ui.PointerDataPacket(
-      data: <ui.PointerData>[
-        ui.PointerData(change: ui.PointerChange.add, device: 25, physicalX: 10.0 * ui.window.devicePixelRatio, physicalY: 10.0 * ui.window.devicePixelRatio),
-        ui.PointerData(change: ui.PointerChange.down, device: 25, physicalX: 15.0 * ui.window.devicePixelRatio, physicalY: 17.0 * ui.window.devicePixelRatio),
-        const ui.PointerData(change: ui.PointerChange.remove, device: 25),
-      ],
-    );
-
-    final List<PointerEvent> events = PointerEventConverter.expand(
-      packet.data, ui.window.devicePixelRatio).toList();
-
-    expect(events.length, 6);
-    expect(events[0].runtimeType, equals(PointerAddedEvent));
-    expect(events[1].runtimeType, equals(PointerHoverEvent));
-    expect(events[1].delta, equals(const Offset(5.0, 7.0)));
-    expect(events[2].runtimeType, equals(PointerDownEvent));
-    expect(events[3].runtimeType, equals(PointerCancelEvent));
-    expect(events[4].runtimeType, equals(PointerHoverEvent));
-    expect(events[5].runtimeType, equals(PointerRemovedEvent));
   });
 
   test('Can expand pointer scroll events', () {
@@ -218,36 +172,6 @@ void main() {
     expect(events.length, 2);
     expect(events[0].runtimeType, equals(PointerAddedEvent));
     expect(events[1].runtimeType, equals(PointerScrollEvent));
-  });
-
-  test('Synthetic hover/move for misplaced scrolls', () {
-    final Offset lastLocation = const Offset(10.0, 10.0) * ui.window.devicePixelRatio;
-    const Offset unexpectedOffset = Offset(5.0, 7.0);
-    final Offset scrollLocation = lastLocation + unexpectedOffset * ui.window.devicePixelRatio;
-    final ui.PointerDataPacket packet = ui.PointerDataPacket(
-      data: <ui.PointerData>[
-        ui.PointerData(change: ui.PointerChange.add, physicalX: lastLocation.dx, physicalY: lastLocation.dy),
-        ui.PointerData(change: ui.PointerChange.hover, physicalX: scrollLocation.dx, physicalY: scrollLocation.dy, signalKind: ui.PointerSignalKind.scroll),
-        // Move back to starting location, click, and repeat to test mouse-down version.
-        ui.PointerData(change: ui.PointerChange.hover, physicalX: lastLocation.dx, physicalY: lastLocation.dy),
-        ui.PointerData(change: ui.PointerChange.down, physicalX: lastLocation.dx, physicalY: lastLocation.dy),
-        ui.PointerData(change: ui.PointerChange.hover, physicalX: scrollLocation.dx, physicalY: scrollLocation.dy, signalKind: ui.PointerSignalKind.scroll),
-      ],
-    );
-
-    final List<PointerEvent> events = PointerEventConverter.expand(
-      packet.data, ui.window.devicePixelRatio).toList();
-
-    expect(events.length, 7);
-    expect(events[0].runtimeType, equals(PointerAddedEvent));
-    expect(events[1].runtimeType, equals(PointerHoverEvent));
-    expect(events[1].delta, equals(unexpectedOffset));
-    expect(events[2].runtimeType, equals(PointerScrollEvent));
-    expect(events[3].runtimeType, equals(PointerHoverEvent));
-    expect(events[4].runtimeType, equals(PointerDownEvent));
-    expect(events[5].runtimeType, equals(PointerMoveEvent));
-    expect(events[5].delta, equals(unexpectedOffset));
-    expect(events[6].runtimeType, equals(PointerScrollEvent));
   });
 
   test('Should synthesize kPrimaryButton for touch', () {

--- a/packages/flutter/test/gestures/gesture_binding_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_test.dart
@@ -26,7 +26,6 @@ TestGestureFlutterBinding _binding = TestGestureFlutterBinding();
 
 void ensureTestGestureBinding() {
   _binding ??= TestGestureFlutterBinding();
-  PointerEventConverter.clearPointers();
   assert(GestureBinding.instance != null);
 }
 
@@ -278,8 +277,6 @@ void main() {
     expect(events[3].buttons, equals(kPrimaryButton));
     expect(events[4].runtimeType, equals(PointerUpEvent));
     expect(events[4].buttons, equals(0));
-
-    PointerEventConverter.clearPointers();
   });
 
   test('Should synthesize kPrimaryButton for stylus', () {
@@ -313,8 +310,6 @@ void main() {
       expect(events[3].buttons, equals(kPrimaryButton | kSecondaryStylusButton));
       expect(events[4].runtimeType, equals(PointerUpEvent));
       expect(events[4].buttons, equals(0));
-
-      PointerEventConverter.clearPointers();
     }
   });
 
@@ -345,8 +340,6 @@ void main() {
     expect(events[3].buttons, equals(kPrimaryButton));
     expect(events[4].runtimeType, equals(PointerUpEvent));
     expect(events[4].buttons, equals(0));
-
-    PointerEventConverter.clearPointers();
   });
 
   test('Should not synthesize kPrimaryButton for mouse', () {
@@ -378,8 +371,6 @@ void main() {
       expect(events[3].buttons, equals(kMiddleMouseButton | kSecondaryMouseButton));
       expect(events[4].runtimeType, equals(PointerUpEvent));
       expect(events[4].buttons, equals(0));
-
-      PointerEventConverter.clearPointers();
     }
   });
 }

--- a/packages/flutter/test/gestures/mouse_tracking_test.dart
+++ b/packages/flutter/test/gestures/mouse_tracking_test.dart
@@ -77,7 +77,6 @@ void main() {
   setUp(() {
     _ensureTestGestureBinding();
     _binding.postFrameCallbacks.clear();
-    PointerEventConverter.clearPointers();
   });
 
   test('MouseTrackerAnnotation has correct toString', () {
@@ -134,11 +133,10 @@ void main() {
 
     // Remove
     ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
-      _pointerData(PointerChange.remove, const Offset(1.0, 201.0)),
+      _pointerData(PointerChange.remove, const Offset(1.0, 101.0)),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<PointerEvent>[
-      const PointerHoverEvent(position: Offset(1.0, 201.0)),
-      const PointerExitEvent(position: Offset(1.0, 201.0)),
+      const PointerExitEvent(position: Offset(1.0, 101.0)),
     ]));
     expect(listenerLogs, <bool>[false]);
     events.clear();
@@ -286,12 +284,12 @@ void main() {
     _setUpWithOneAnnotation(logEvents: events);
 
     ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+      _pointerData(PointerChange.add, const Offset(0.0, 101.0)),
       _pointerData(PointerChange.down, const Offset(0.0, 101.0)),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<PointerEvent>[
-      // This Enter event is triggered by the [PointerAddedEvent] that was
-      // synthesized during the event normalization of pointer event converter.
-      // The [PointerDownEvent] is ignored by [MouseTracker].
+      // This Enter event is triggered by the [PointerAddedEvent] The
+      // [PointerDownEvent] is ignored by [MouseTracker].
       const PointerEnterEvent(position: Offset(0.0, 101.0)),
     ]));
     events.clear();

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -808,8 +808,6 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
         'active mouse gesture to remove the mouse pointer.');
     // ignore: invalid_use_of_visible_for_testing_member
     RendererBinding.instance.initMouseTracker();
-    // ignore: invalid_use_of_visible_for_testing_member
-    PointerEventConverter.clearPointers();
   }
 }
 


### PR DESCRIPTION
## Description

This pr moves the pointer event sanitizing away from framework, as well as test code.

## Related Issues

https://github.com/flutter/flutter/issues/20517

## Tests

I removed a bunch of unused test.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
