### PR TITLE
[flutter_tool] Screenshot command must require device only for _kDeviceType

### DIFF
--- a/packages/flutter_tools/lib/src/commands/screenshot.dart
+++ b/packages/flutter_tools/lib/src/commands/screenshot.dart
@@ -64,17 +64,19 @@ class ScreenshotCommand extends FlutterCommand {
   Device device;
 
   static void validateOptions(String screenshotType, Device device, String observatoryUri) {
-    if (screenshotType == _kDeviceType) {
-      if (device == null) {
-        throwToolExit('Must have a connected device for screenshot type $screenshotType');
-      }
-      if (!device.supportsScreenshot) {
-        throwToolExit('Screenshot not supported for ${device.name}.');
-      }
-    } else {
-      if (observatoryUri == null) {
-        throwToolExit('Observatory URI must be specified for screenshot type $screenshotType');
-      }
+    switch (screenshotType) {
+      case _kDeviceType:
+        if (device == null) {
+          throwToolExit('Must have a connected device for screenshot type $screenshotType');
+        }
+        if (!device.supportsScreenshot) {
+          throwToolExit('Screenshot not supported for ${device.name}.');
+        }
+        break;
+      default:
+        if (observatoryUri == null) {
+          throwToolExit('Observatory URI must be specified for screenshot type $screenshotType');
+        }
     }
   }
 

--- a/packages/flutter_tools/lib/src/commands/screenshot.dart
+++ b/packages/flutter_tools/lib/src/commands/screenshot.dart
@@ -66,11 +66,13 @@ class ScreenshotCommand extends FlutterCommand {
   @override
   Future<FlutterCommandResult> verifyThenRunCommand(String commandPath) async {
     device = await findTargetDevice();
-    if (device == null) {
-      throwToolExit('Must have a connected device');
-    }
-    if (argResults[_kType] == _kDeviceType && !device.supportsScreenshot) {
-      throwToolExit('Screenshot not supported for ${device.name}.');
+    if (argResults[_kType] == _kDeviceType) {
+      if (device == null) {
+        throwToolExit('Must have a connected device for screenshot type ${argResults[_kType]}');
+      }
+      if (!device.supportsScreenshot) {
+        throwToolExit('Screenshot not supported for ${device.name}.');
+      }
     }
     if (argResults[_kType] != _kDeviceType && argResults[_kObservatoryUri] == null) {
       throwToolExit('Observatory URI must be specified for screenshot type ${argResults[_kType]}');

--- a/packages/flutter_tools/lib/src/commands/screenshot.dart
+++ b/packages/flutter_tools/lib/src/commands/screenshot.dart
@@ -63,20 +63,25 @@ class ScreenshotCommand extends FlutterCommand {
 
   Device device;
 
-  @override
-  Future<FlutterCommandResult> verifyThenRunCommand(String commandPath) async {
-    device = await findTargetDevice();
-    if (argResults[_kType] == _kDeviceType) {
+  static void validateOptions(String screenshotType, Device device, String observatoryUri) {
+    if (screenshotType == _kDeviceType) {
       if (device == null) {
-        throwToolExit('Must have a connected device for screenshot type ${argResults[_kType]}');
+        throwToolExit('Must have a connected device for screenshot type $screenshotType');
       }
       if (!device.supportsScreenshot) {
         throwToolExit('Screenshot not supported for ${device.name}.');
       }
+    } else {
+      if (observatoryUri == null) {
+        throwToolExit('Observatory URI must be specified for screenshot type $screenshotType');
+      }
     }
-    if (argResults[_kType] != _kDeviceType && argResults[_kObservatoryUri] == null) {
-      throwToolExit('Observatory URI must be specified for screenshot type ${argResults[_kType]}');
-    }
+  }
+
+  @override
+  Future<FlutterCommandResult> verifyThenRunCommand(String commandPath) async {
+    device = await findTargetDevice();
+    validateOptions(argResults[_kType], device, argResults[_kObservatoryUri]);
     return super.verifyThenRunCommand(commandPath);
   }
 

--- a/packages/flutter_tools/test/general.shard/screenshot_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/screenshot_command_test.dart
@@ -1,0 +1,34 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tools/src/base/common.dart';
+import 'package:flutter_tools/src/commands/screenshot.dart';
+import 'package:matcher/matcher.dart';
+
+import '../src/common.dart';
+import '../src/context.dart';
+
+void main() {
+  final Matcher expectToolError = throwsA(const TypeMatcher<ToolExit>());
+
+  setUpAll(() {});
+
+  group('Validate screenshot options', () {
+    setUp(() async {});
+
+    testUsingContext('rasterizer and skia screenshots do not require a device', () async {
+      ScreenshotCommand.validateOptions('rasterizer', null, 'dummy_observatory_uri');
+      ScreenshotCommand.validateOptions('skia', null, 'dummy_observatory_uri');
+    });
+
+    testUsingContext('rasterizer and skia screenshots require observatory uri', () async {
+      expect(() => ScreenshotCommand.validateOptions('rasterizer', null, null), expectToolError);
+      expect(() => ScreenshotCommand.validateOptions('skia', null, null), expectToolError);
+    });
+
+    testUsingContext('device screenshots require device', () async {
+      expect(() => ScreenshotCommand.validateOptions('device', null, null), expectToolError);
+    });
+  });
+}

--- a/packages/flutter_tools/test/general.shard/screenshot_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/screenshot_command_test.dart
@@ -2,33 +2,25 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/commands/screenshot.dart';
-import 'package:matcher/matcher.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
 
 void main() {
-  final Matcher expectToolError = throwsA(const TypeMatcher<ToolExit>());
-
-  setUpAll(() {});
-
   group('Validate screenshot options', () {
-    setUp(() async {});
-
     testUsingContext('rasterizer and skia screenshots do not require a device', () async {
       ScreenshotCommand.validateOptions('rasterizer', null, 'dummy_observatory_uri');
       ScreenshotCommand.validateOptions('skia', null, 'dummy_observatory_uri');
     });
 
     testUsingContext('rasterizer and skia screenshots require observatory uri', () async {
-      expect(() => ScreenshotCommand.validateOptions('rasterizer', null, null), expectToolError);
-      expect(() => ScreenshotCommand.validateOptions('skia', null, null), expectToolError);
+      expect(() => ScreenshotCommand.validateOptions('rasterizer', null, null), throwsToolExit());
+      expect(() => ScreenshotCommand.validateOptions('skia', null, null), throwsToolExit());
     });
 
     testUsingContext('device screenshots require device', () async {
-      expect(() => ScreenshotCommand.validateOptions('device', null, null), expectToolError);
+      expect(() => ScreenshotCommand.validateOptions('device', null, null), throwsToolExit());
     });
   });
 }


### PR DESCRIPTION
There are cases where we have access to the observatory without having a device connection accessible.