### PR TITLE
Add --web-define flag to `flutter build web`

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/web_fs.dart
+++ b/packages/flutter_tools/lib/src/build_runner/web_fs.dart
@@ -72,7 +72,7 @@ typedef DwdsFactory = Future<Dwds> Function({
   bool enableDebugExtension,
 });
 
-/// A function with the same signatuure as [WebFs.start].
+/// A function with the same signature as [WebFs.start].
 typedef WebFsFactory = Future<WebFs> Function({
   @required String target,
   @required FlutterProject flutterProject,
@@ -83,7 +83,7 @@ typedef WebFsFactory = Future<WebFs> Function({
   @required String port,
 });
 
-/// The dev filesystem responsible for building and serving  web applications.
+/// The dev filesystem responsible for building and serving web applications.
 class WebFs {
   @visibleForTesting
   WebFs(
@@ -146,7 +146,7 @@ class WebFs {
   /// Recompile the web application and return whether this was successful.
   Future<bool> recompile() async {
     if (!_useBuildRunner) {
-      await buildWeb(_flutterProject, _target, _buildInfo, _initializePlatform);
+      await buildWeb(_flutterProject, _target, _buildInfo, _initializePlatform, <String>[]);
       return true;
     }
     _client.startBuild();
@@ -302,7 +302,7 @@ class WebFs {
         handler = pipeline.addHandler(proxyHandler('http://localhost:$daemonAssetPort/web/'));
       }
     } else {
-      await buildWeb(flutterProject, target, buildInfo, initializePlatform);
+      await buildWeb(flutterProject, target, buildInfo, initializePlatform, <String>[]);
       firstBuildCompleter.complete(true);
     }
 

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -26,6 +26,11 @@ const String kHasWebPlugins = 'HasWebPlugins';
 /// Valid values are O1 (lowest, profile default) to O4 (highest, release default).
 const String kDart2jsOptimization = 'Dart2jsOptimization';
 
+/// A comma-separated list of environment variable definitions.
+///
+/// These take the form of FOO=bar,BAZ=quux. These are passed to the compiler.
+const String kWebDefines = 'WebDefines';
+
 /// Generates an entrypoint for a web target.
 class WebEntrypointTarget extends Target {
   const WebEntrypointTarget();
@@ -124,6 +129,13 @@ class Dart2JSTarget extends Target {
   @override
   Future<void> build(Environment environment) async {
     final String dart2jsOptimization = environment.defines[kDart2jsOptimization];
+    final String webDefines = environment.defines[kWebDefines];
+    List<String> parsedWebDefines;
+    if (webDefines == null || webDefines.isEmpty) {
+      parsedWebDefines = const <String>[];
+    } else {
+      parsedWebDefines = environment.defines[kWebDefines].split(',');
+    }
     final BuildMode buildMode = getBuildModeForName(environment.defines[kBuildMode]);
     final String specPath = fs.path.join(artifacts.getArtifactPath(Artifact.flutterWebSdk), 'libraries.json');
     final String packageFile = FlutterProject.fromDirectory(environment.projectDir).hasBuilders
@@ -147,6 +159,7 @@ class Dart2JSTarget extends Target {
         '-Ddart.vm.profile=true'
       else
         '-Ddart.vm.product=true',
+      for (String define in parsedWebDefines) '-D$define',
       environment.buildDir.childFile('main.dart').path,
     ]);
     if (result.exitCode != 0) {

--- a/packages/flutter_tools/lib/src/commands/build_web.dart
+++ b/packages/flutter_tools/lib/src/commands/build_web.dart
@@ -24,6 +24,13 @@ class BuildWebCommand extends BuildSubCommand {
         hide: true,
         help: 'Whether to automatically invoke webOnlyInitializePlatform.',
     );
+    argParser.addMultiOption('web-define',
+        hide: true,
+        splitCommas: true,
+        help: 'An environment variable to be passed to the web compilers'
+              'when building the Flutter Web app.',
+        valueHelp: 'VARIABLE=value',
+    );
   }
 
   @override
@@ -53,7 +60,7 @@ class BuildWebCommand extends BuildSubCommand {
     if (buildInfo.isDebug) {
       throwToolExit('debug builds cannot be built directly for the web. Try using "flutter run"');
     }
-    await buildWeb(flutterProject, target, buildInfo, argResults['web-initialize-platform']);
+    await buildWeb(flutterProject, target, buildInfo, argResults['web-initialize-platform'], argResults['web-define']);
     return null;
   }
 }

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -510,7 +510,7 @@ class DebuggingOptions {
     this.vmserviceOutFile,
    }) : debuggingEnabled = true;
 
-  DebuggingOptions.disabled(this.buildInfo, { this.initializePlatform = true, this.port, this.hostname, this.cacheSkSL = false, })
+  DebuggingOptions.disabled(this.buildInfo, { this.initializePlatform = true, this.port, this.hostname, this.cacheSkSL = false })
     : debuggingEnabled = false,
       useTestFonts = false,
       startPaused = false,

--- a/packages/flutter_tools/lib/src/web/compile.dart
+++ b/packages/flutter_tools/lib/src/web/compile.dart
@@ -21,7 +21,7 @@ import '../reporting/reporting.dart';
 /// The [WebCompilationProxy] instance.
 WebCompilationProxy get webCompilationProxy => context.get<WebCompilationProxy>();
 
-Future<void> buildWeb(FlutterProject flutterProject, String target, BuildInfo buildInfo, bool initializePlatform) async {
+Future<void> buildWeb(FlutterProject flutterProject, String target, BuildInfo buildInfo, bool initializePlatform, List<String> webDefines) async {
   if (!flutterProject.web.existsSync()) {
     throwToolExit('Missing index.html.');
   }
@@ -42,6 +42,7 @@ Future<void> buildWeb(FlutterProject flutterProject, String target, BuildInfo bu
         kTargetFile: target,
         kInitializePlatform: initializePlatform.toString(),
         kHasWebPlugins: hasWebPlugins.toString(),
+        kWebDefines: webDefines.join(','),
       },
     ));
     if (!result.success) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
@@ -57,6 +57,7 @@ void main() {
       fs.path.join('lib', 'main.dart'),
       BuildInfo.debug,
       false,
+      <String>[],
     ), throwsA(isInstanceOf<ToolExit>()));
   }));
 


### PR DESCRIPTION
## Description

This allows passing environment variables to dart2js. For example, this will let users build a CanvasKit app using: `flutter build web --web-define=FLUTTER_WEB_USE_SKIA=true`

## Issues

This partially addresses https://github.com/flutter/flutter/issues/44226

This only adds support for `flutter build web`, not `flutter run -d web-server --release` or `flutter run -d chrome --release`.

## Tests

I added the following tests:

* a test in `test/general.shard/build_system/targets/web_test.dart` that tests that the environment variables are actually passed to dart2js.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
