### PR TITLE
Allow web server device to use extension if started with --start-paused

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -104,6 +104,8 @@ abstract class ResidentWebRunner extends ResidentRunner {
   /// WebServer device is debuggable when running with --start-paused.
   bool get deviceIsDebuggable => device.device is! WebServerDevice || debuggingOptions.startPaused;
 
+  bool get _enableDwds => debuggingEnabled;
+
   WebFs _webFs;
   ConnectionResult _connectionResult;
   StreamSubscription<vmservice.Event> _stdOutSub;
@@ -603,7 +605,7 @@ class _DwdsResidentWebRunner extends ResidentWebRunner {
           initializePlatform: debuggingOptions.initializePlatform,
           hostname: debuggingOptions.hostname,
           port: debuggingOptions.port,
-          skipDwds: !deviceIsDebuggable || !debuggingOptions.buildInfo.isDebug,
+          skipDwds: !_enableDwds,
           dartDefines: dartDefines,
         );
         // When connecting to a browser, update the message with a seemsSlow notification
@@ -625,7 +627,7 @@ class _DwdsResidentWebRunner extends ResidentWebRunner {
             'uri': _webFs.uri,
           },
         );
-        if (supportsServiceProtocol) {
+        if (_enableDwds) {
           final bool useDebugExtension = device.device is WebServerDevice && debuggingOptions.startPaused;
           _connectionResult = await _webFs.connect(useDebugExtension);
           unawaited(_connectionResult.debugConnection.onDone.whenComplete(_cleanupAndExit));

--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -743,7 +743,7 @@ class _DwdsResidentWebRunner extends ResidentWebRunner {
       }
     }
     // Allows browser refresh hot restart on non-debug builds.
-    if (device is ChromeDevice) {
+    if (device is ChromeDevice && !isRunningDebug) {
       try {
         final Chrome chrome = await ChromeLauncher.connectedInstance;
         final ChromeTab chromeTab = await chrome.chromeConnection.getTab((ChromeTab chromeTab) {

--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -102,7 +102,7 @@ abstract class ResidentWebRunner extends ResidentRunner {
   bool get debuggingEnabled => isRunningDebug && deviceIsDebuggable;
 
   /// WebServer device is debuggable when running with --start-paused.
-  bool get deviceIsDebuggable => device is! WebServerDevice || debuggingOptions.startPaused;
+  bool get deviceIsDebuggable => device.device is! WebServerDevice || debuggingOptions.startPaused;
 
   WebFs _webFs;
   ConnectionResult _connectionResult;
@@ -626,7 +626,7 @@ class _DwdsResidentWebRunner extends ResidentWebRunner {
           },
         );
         if (supportsServiceProtocol) {
-          final bool useDebugExtension = device is WebServerDevice && debuggingOptions.startPaused;
+          final bool useDebugExtension = device.device is WebServerDevice && debuggingOptions.startPaused;
           _connectionResult = await _webFs.connect(useDebugExtension);
           unawaited(_connectionResult.debugConnection.onDone.whenComplete(_cleanupAndExit));
         }

--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -610,7 +610,7 @@ class _DwdsResidentWebRunner extends ResidentWebRunner {
         // to handle the case where we fail to connect.
         buildStatus.stop();
         statusActive = false;
-        if (debuggingOptions.browserLaunch && supportsServiceProtocol) {
+        if (supportsServiceProtocol) {
           buildStatus = logger.startProgress(
             'Attempting to connect to browser instance..',
             timeout: const Duration(seconds: 30),
@@ -626,9 +626,7 @@ class _DwdsResidentWebRunner extends ResidentWebRunner {
           },
         );
         if (supportsServiceProtocol) {
-          final bool useDebugExtension = device is WebServerDevice
-            ? debuggingOptions.startPaused
-            : !debuggingOptions.browserLaunch;
+          final bool useDebugExtension = device is WebServerDevice && debuggingOptions.startPaused;
           _connectionResult = await _webFs.connect(useDebugExtension);
           unawaited(_connectionResult.debugConnection.onDone.whenComplete(_cleanupAndExit));
         }
@@ -745,7 +743,7 @@ class _DwdsResidentWebRunner extends ResidentWebRunner {
       }
     }
     // Allows browser refresh hot restart on non-debug builds.
-    if (device is ChromeDevice && debuggingOptions.browserLaunch) {
+    if (device is ChromeDevice) {
       try {
         final Chrome chrome = await ChromeLauncher.connectedInstance;
         final ChromeTab chromeTab = await chrome.chromeConnection.getTab((ChromeTab chromeTab) {

--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -745,7 +745,7 @@ class _DwdsResidentWebRunner extends ResidentWebRunner {
       }
     }
     // Allows browser refresh hot restart on non-debug builds.
-    if (device is ChromeDevice && !isRunningDebug) {
+    if (device.device is ChromeDevice && !isRunningDebug) {
       try {
         final Chrome chrome = await ChromeLauncher.connectedInstance;
         final ChromeTab chromeTab = await chrome.chromeConnection.getTab((ChromeTab chromeTab) {

--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -101,7 +101,7 @@ abstract class ResidentWebRunner extends ResidentRunner {
   @override
   bool get debuggingEnabled => isRunningDebug && deviceIsDebuggable;
 
-  // WebServer device is debuggable when running with --start-paused.
+  /// WebServer device is debuggable when running with --start-paused.
   bool get deviceIsDebuggable => device is! WebServerDevice || debuggingOptions.startPaused;
 
   WebFs _webFs;

--- a/packages/flutter_tools/lib/src/build_runner/web_fs.dart
+++ b/packages/flutter_tools/lib/src/build_runner/web_fs.dart
@@ -33,7 +33,6 @@ import '../bundle.dart';
 import '../cache.dart';
 import '../dart/package_map.dart';
 import '../dart/pub.dart';
-import '../device.dart';
 import '../globals.dart';
 import '../platform_plugins.dart';
 import '../plugins.dart';
@@ -131,12 +130,12 @@ class WebFs {
   /// Connect and retrieve the [DebugConnection] for the current application.
   ///
   /// Only calls [AppConnection.runMain] on the subsequent connections.
-  Future<ConnectionResult> connect(DebuggingOptions debuggingOptions) {
+  Future<ConnectionResult> connect(bool useDebugExtension) {
     final Completer<ConnectionResult> firstConnection = Completer<ConnectionResult>();
     _connectedApps = _dwds.connectedApps.listen((AppConnection appConnection) async {
-      final DebugConnection debugConnection = debuggingOptions.browserLaunch
-        ? await _dwds.debugConnection(appConnection)
-        : await (_cachedExtensionFuture ??= _dwds.extensionDebugConnections.stream.first);
+      final DebugConnection debugConnection = useDebugExtension
+        ? await (_cachedExtensionFuture ??= _dwds.extensionDebugConnections.stream.first)
+        : await _dwds.debugConnection(appConnection);
       if (!firstConnection.isCompleted) {
         firstConnection.complete(ConnectionResult(appConnection, debugConnection));
       } else {

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -321,7 +321,6 @@ class RunCommand extends RunCommandBase {
         initializePlatform: boolArg('web-initialize-platform'),
         hostname: featureFlags.isWebEnabled ? stringArg('web-hostname') : '',
         port: featureFlags.isWebEnabled ? stringArg('web-port') : '',
-        browserLaunch: featureFlags.isWebEnabled ? boolArg('web-browser-launch') : null,
         vmserviceOutFile: stringArg('vmservice-out-file'),
       );
     }

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -506,7 +506,6 @@ class DebuggingOptions {
     this.initializePlatform = true,
     this.hostname,
     this.port,
-    this.browserLaunch = true,
     this.vmserviceOutFile,
    }) : debuggingEnabled = true;
 
@@ -524,7 +523,6 @@ class DebuggingOptions {
       verboseSystemLogs = false,
       hostVmServicePort = null,
       deviceVmServicePort = null,
-      browserLaunch = true,
       vmserviceOutFile = null;
 
   final bool debuggingEnabled;
@@ -547,7 +545,6 @@ class DebuggingOptions {
   final int deviceVmServicePort;
   final String port;
   final String hostname;
-  final bool browserLaunch;
   /// A file where the vmservice uri should be written after the application is started.
   final String vmserviceOutFile;
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -150,14 +150,6 @@ abstract class FlutterCommand extends Command<void> {
         'will select a random open port on the host.',
       hide: hide,
     );
-    argParser.addFlag('web-browser-launch',
-      defaultsTo: true,
-      negatable: true,
-      help: 'Whether to automatically launch browsers for web devices '
-        'that do so. Setting this to true allows using the Dart debug extension '
-        'on Chrome and other browsers which support extensions.',
-      hide: hide,
-    );
   }
 
   void usesTargetOption() {

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -250,7 +250,11 @@ class WebServerDevice extends Device {
     bool ipv6 = false,
   }) async {
     final String url = platformArgs['uri'] as String;
-    printStatus('$mainPath is being served at $url', emphasis: true);
+    if (debuggingOptions.startPaused) {
+      printStatus('Waiting for connection from Dart debug extension at $url', emphasis: true);
+    } else {
+      printStatus('$mainPath is being served at $url', emphasis: true);
+    }
     logger.sendEvent('app.webLaunchUrl', <String, dynamic>{'url': url, 'launched': false});
     return LaunchResult.succeeded(observatoryUri: null);
   }

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -131,16 +131,13 @@ class ChromeDevice extends Device {
     // See [ResidentWebRunner.run] in flutter_tools/lib/src/resident_web_runner.dart
     // for the web initialization and server logic.
     final String url = platformArgs['uri'] as String;
-    if (debuggingOptions.browserLaunch) {
-      _chrome = await chromeLauncher.launch(url,
-        dataDir: fs.currentDirectory
-          .childDirectory('.dart_tool')
-          .childDirectory('chrome-device'));
-      logger.sendEvent('app.webLaunchUrl', <String, dynamic>{'url': url, 'launched': true});
-    } else {
-      printStatus('Waiting for connection from Dart debug extension at $url', emphasis: true);
-      logger.sendEvent('app.webLaunchUrl', <String, dynamic>{'url': url, 'launched': false});
-    }
+    _chrome = await chromeLauncher.launch(url,
+      dataDir: fs.currentDirectory
+        .childDirectory('.dart_tool')
+        .childDirectory('chrome-device'));
+
+    logger.sendEvent('app.webLaunchUrl', <String, dynamic>{'url': url, 'launched': true});
+
     return LaunchResult.succeeded(observatoryUri: null);
   }
 

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -39,8 +39,6 @@ void main() {
   MockDebugConnection mockDebugConnection;
   MockVmService mockVmService;
   MockChromeDevice mockChromeDevice;
-  MockWebDevice mockWebDevice;
-  MockWebServerDevice mockWebServerDevice;
   MockAppConnection mockAppConnection;
   MockFlutterDevice mockFlutterDevice;
   MockWebDevFS mockWebDevFS;
@@ -58,8 +56,6 @@ void main() {
     mockDebugConnection = MockDebugConnection();
     mockVmService = MockVmService();
     mockChromeDevice = MockChromeDevice();
-    mockWebDevice = MockWebDevice();
-    mockWebServerDevice = MockWebServerDevice();
     mockAppConnection = MockAppConnection();
     mockFlutterDevice = MockFlutterDevice();
     mockWebDevFS = MockWebDevFS();
@@ -166,11 +162,14 @@ void main() {
   }));
 
   test('runner with web server device supports debugging with --start-paused', () => testbed.run(() {
-    final ResidentRunner profileResidentWebRunner = ResidentWebRunner(
-      WebServerDevice(),
+    when(mockFlutterDevice.device).thenReturn(WebServerDevice());
+    final ResidentRunner profileResidentWebRunner = DwdsWebRunnerFactory().createWebRunner(
+      mockFlutterDevice,
       flutterProject: FlutterProject.current(),
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, startPaused: true),
       ipv6: true,
+      stayResident: true,
+      dartDefines: <String>[],
     );
 
     expect(profileResidentWebRunner.debuggingEnabled, true);
@@ -179,13 +178,16 @@ void main() {
 
   test('runner with web server device uses debug extension with --start-paused', () => testbed.run(() async {
     _setupMocks();
+    when(mockFlutterDevice.device).thenReturn(WebServerDevice());
     final BufferLogger bufferLogger = logger;
 
-    final ResidentWebRunner runner = ResidentWebRunner(
-      mockWebServerDevice,
+    final ResidentWebRunner runner = DwdsWebRunnerFactory().createWebRunner(
+      mockFlutterDevice,
       flutterProject: FlutterProject.current(),
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, startPaused: true),
       ipv6: true,
+      stayResident: true,
+      dartDefines: <String>[],
     );
 
     final Completer<DebugConnectionInfo> connectionInfoCompleter = Completer<DebugConnectionInfo>();

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -144,7 +144,6 @@ void main() {
     expect(profileResidentWebRunner.debuggingEnabled, false);
 
     when(mockFlutterDevice.device).thenReturn(MockChromeDevice());
-
     expect(residentWebRunner.debuggingEnabled, true);
   }));
 
@@ -173,7 +172,6 @@ void main() {
     );
 
     expect(profileResidentWebRunner.debuggingEnabled, true);
-    expect(residentWebRunner.debuggingEnabled, true);
   }));
 
   test('runner with web server device uses debug extension with --start-paused', () => testbed.run(() async {
@@ -1021,8 +1019,6 @@ void main() {
 class MockChromeLauncher extends Mock implements ChromeLauncher {}
 class MockFlutterUsage extends Mock implements Usage {}
 class MockChromeDevice extends Mock implements ChromeDevice {}
-class MockWebDevice extends Mock implements ChromeDevice {}
-class MockWebServerDevice extends Mock implements WebServerDevice {}
 class MockBuildDaemonCreator extends Mock implements BuildDaemonCreator {}
 class MockFlutterWebFs extends Mock implements WebFs {}
 class MockDebugConnection extends Mock implements DebugConnection {}

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -189,7 +189,7 @@ void main() {
     );
 
     final Completer<DebugConnectionInfo> connectionInfoCompleter = Completer<DebugConnectionInfo>();
-     unawaited(residentWebRunner.run(
+     unawaited(runner.run(
       connectionInfoCompleter: connectionInfoCompleter,
     ));
     await connectionInfoCompleter.future;


### PR DESCRIPTION
@jonahwilliams This enables using the Dart debug extension using the web-server device when `--start-paused` is used. This is to support running in remote environments where there's no Chrome installed (and the Chrome device is not available) but you still want to be able to debug.

## Tests

@jonahwilliams do we have any ability to test with the Debug extension? I looked but couldn't find anything. I tested manually from the terminal by:

- running `flutter run -d web-server --start-paused`
- When the URL was printed, opened it in Chrome and clicked the Debug extension icon
- When DevTools launched, switched to the Debugger tab and clicked Resume
- When the counter app rendered, clicked the + button a few times
- Pressed `r` in the terminal to confirm hot reload worked (counter reset - since it's a restart right now)

I also tested from VS Code with a fork of DWDS that does not spawn the DevTools and confirmed I could launch the app and hot-reload-on-save worked:

<img width="1680" alt="Screenshot 2019-11-06 at 10 40 53 am" src="https://user-images.githubusercontent.com/1078012/68291511-ee7a6000-0081-11ea-92e4-a9cab1200f1a.png">

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
