### PR TITLE
Do not pass obsolete --strong option to front-end server

### DIFF
--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -315,7 +315,6 @@ class KernelCompiler {
       frontendServer,
       '--sdk-root',
       sdkRoot,
-      '--strong',
       '--target=$targetModel',
       '-Ddart.developer.causal_async_stacks=$causalAsyncStacks',
       ..._buildModeOptions(buildMode),
@@ -648,7 +647,6 @@ class DefaultResidentCompiler implements ResidentCompiler {
       '--sdk-root',
       sdkRoot,
       '--incremental',
-      '--strong',
       '--target=$targetModel',
       '-Ddart.developer.causal_async_stacks=$causalAsyncStacks',
       if (outputPath != null) ...<String>[


### PR DESCRIPTION
Option `--strong` is obsolete since Dart 2 and it's ignored by front-end server.
This change removes flutter tools code which passes `--strong` to the front-end server.