### PR TITLE
Don't print how to consume AARs when building plugins as AARs

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_builder.dart
+++ b/packages/flutter_tools/lib/src/android/android_builder.dart
@@ -70,6 +70,7 @@ class _AndroidBuilderImpl extends AndroidBuilder {
         androidBuildInfo: androidBuildInfo,
         target: target,
         outputDir: outputDirectory,
+        printHowToConsumeAaar: true,
       );
     } finally {
       androidSdk.reinitialize();

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -472,7 +472,14 @@ Future<void> buildGradleAar({
   @required AndroidBuildInfo androidBuildInfo,
   @required String target,
   @required Directory outputDir,
+  @required bool printHowToConsumeAaar,
 }) async {
+  assert(project != null);
+  assert(androidBuildInfo != null);
+  assert(target != null);
+  assert(outputDir != null);
+  assert(printHowToConsumeAaar != null);
+
   if (androidSdk == null) {
     exitWithNoSdkMessage();
   }
@@ -564,11 +571,13 @@ Future<void> buildGradleAar({
     '$successMark Built ${fs.path.relative(repoDirectory.path)}.',
     color: TerminalColor.green,
   );
-  _printHowToConsumeAar(
-    buildMode: androidBuildInfo.buildInfo.modeName,
-    androidPackage: project.manifest.androidPackage,
-    repoPath: repoDirectory.path,
-  );
+  if (printHowToConsumeAaar) {
+    _printHowToConsumeAar(
+      buildMode: androidBuildInfo.buildInfo.modeName,
+      androidPackage: project.manifest.androidPackage,
+      repoPath: repoDirectory.path,
+    );
+  }
 }
 
 /// Prints how to consume the AAR from a host app.
@@ -688,6 +697,7 @@ Future<void> buildPluginsAsAar(
         ),
         target: '',
         outputDir: buildDirectory,
+        printHowToConsumeAaar: false,
       );
     } on ToolExit {
       // Log the entire plugin entry in `.flutter-plugins` since it


### PR DESCRIPTION
It isn't desired to display how to consume an AAR when the tool is building the plugins as AARs to fix AndroidX failures.