### PR TITLE
Don't add x86 nor x64 when building a local engine in debug mode

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -220,7 +220,7 @@ class FlutterPlugin implements Plugin<Project> {
 
         List<String> platforms = getTargetPlatforms().collect()
         // Debug mode includes x86 and x64, which are commonly used in emulators.
-        if (flutterBuildMode == "debug") {
+        if (flutterBuildMode == "debug" && !useLocalEngine()) {
             platforms.add("android-x86")
             platforms.add("android-x64")
         }


### PR DESCRIPTION
In a non-local-engine flow, x86 and x64 are automatically added when building debug.