### PR TITLE
Fixing local golden output flake

### DIFF
--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -509,7 +509,7 @@ class FlutterLocalFileComparator extends FlutterGoldenFileComparator with LocalC
 
     for (MapEntry<String, ComparisonResult> entry in failureDiffs.entries) {
       if (await skiaClient.isValidDigestForExpectation(entry.key, golden.path))
-        await generateFailureOutput(entry.value, golden, basedir, key: entry.key);
+        generateFailureOutput(entry.value, golden, basedir, key: entry.key);
     }
     return false;
   }

--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -506,10 +506,11 @@ class FlutterLocalFileComparator extends FlutterGoldenFileComparator with LocalC
       }
       failureDiffs[expectation] = result;
     }
-    failureDiffs.forEach((String expectation, ComparisonResult result) async {
-      if (await skiaClient.isValidDigestForExpectation(expectation, golden.path))
-        generateFailureOutput(result, golden, basedir, key: expectation);
-    });
+
+    for (MapEntry<String, ComparisonResult> entry in failureDiffs.entries) {
+      if (await skiaClient.isValidDigestForExpectation(entry.key, golden.path))
+        await generateFailureOutput(entry.value, golden, basedir, key: entry.key);
+    }
     return false;
   }
 }

--- a/packages/flutter_goldens/test/flutter_goldens_test.dart
+++ b/packages/flutter_goldens/test/flutter_goldens_test.dart
@@ -741,6 +741,27 @@ void main() {
           isTrue,
         );
       });
+
+      test('compare properly awaits validation & output before failing.', () async {
+        final Completer<bool> completer = Completer<bool>();
+        when(mockSkiaClient.isValidDigestForExpectation(
+          '55109a4bed52acc780530f7a9aeff6c0',
+          'library.flutter.golden_test.1.png',
+        ))
+          .thenAnswer((_) => completer.future);
+        final Future<bool> result = comparator.compare(
+          Uint8List.fromList(_kFailPngBytes),
+          Uri.parse('flutter.golden_test.1.png'),
+        );
+        bool shouldThrow = true;
+        result.then((_) {
+          if (shouldThrow)
+            fail('Compare completed before validation completed!');
+        });
+        await Future<void>.value();
+        shouldThrow = false;
+        completer.complete(Future<bool>.value(false));
+      });
     });
   });
 }

--- a/packages/flutter_test/lib/src/_goldens_io.dart
+++ b/packages/flutter_test/lib/src/_goldens_io.dart
@@ -101,7 +101,7 @@ class LocalFileComparator extends GoldenFileComparator with LocalComparisonOutpu
     );
 
     if (!result.passed) {
-      await generateFailureOutput(result, golden, basedir);
+      generateFailureOutput(result, golden, basedir);
     }
     return result.passed;
   }
@@ -124,12 +124,12 @@ class LocalComparisonOutput {
   /// Writes out diffs from the [ComparisonResult] of a golden file test.
   ///
   /// Will throw an error if a null result is provided.
-  Future<void> generateFailureOutput(
+  void generateFailureOutput(
     ComparisonResult result,
     Uri golden,
     Uri basedir, {
     String key = '',
-  }) async {
+  }) {
     String additionalFeedback = '';
     if (result.diffs != null) {
       additionalFeedback = '\nFailure feedback can be found at '

--- a/packages/flutter_test/lib/src/_goldens_io.dart
+++ b/packages/flutter_test/lib/src/_goldens_io.dart
@@ -101,7 +101,7 @@ class LocalFileComparator extends GoldenFileComparator with LocalComparisonOutpu
     );
 
     if (!result.passed) {
-      generateFailureOutput(result, golden, basedir);
+      await generateFailureOutput(result, golden, basedir);
     }
     return result.passed;
   }
@@ -124,12 +124,12 @@ class LocalComparisonOutput {
   /// Writes out diffs from the [ComparisonResult] of a golden file test.
   ///
   /// Will throw an error if a null result is provided.
-  void generateFailureOutput(
+  Future<void> generateFailureOutput(
     ComparisonResult result,
     Uri golden,
     Uri basedir, {
     String key = '',
-  }) {
+  }) async {
     String additionalFeedback = '';
     if (result.diffs != null) {
       additionalFeedback = '\nFailure feedback can be found at '


### PR DESCRIPTION
## Description

This fixes the async-related issue that made output from golden file test failures flaky. If a failing golden file test executed shortly before program execution, output would not finish, and the information error messaging not provided.

## Related Issues

Fixes #44306 

## Tests

Compare properly awaits validation & output before failing.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
