### PR TITLE
l10n tool improvements, stocks app refresh

### DIFF
--- a/dev/tools/localization/gen_l10n.dart
+++ b/dev/tools/localization/gen_l10n.dart
@@ -44,8 +44,7 @@ import 'messages_all.dart';
 ///
 /// ```
 /// dependencies:
-///   # rest of dependencies
-///
+///   # Internationalization support.
 ///   flutter_localizations:
 ///     sdk: flutter
 ///   intl: 0.16.0

--- a/dev/tools/localization/gen_l10n.dart
+++ b/dev/tools/localization/gen_l10n.dart
@@ -37,6 +37,23 @@ import 'messages_all.dart';
 /// );
 /// ```
 ///
+/// ## Update pubspec.yaml
+///
+/// Please make sure to update your pubspec.yaml to include the following
+/// packages:
+///
+/// ```
+/// dependencies:
+///   # rest of dependencies
+///
+///   flutter_localizations:
+///     sdk: flutter
+///   intl: 0.16.0
+///   intl_translation: 0.17.7
+///
+///   # rest of dependencies
+/// ```
+///
 /// ## iOS Applications
 ///
 /// iOS applications define key application metadata, including supported
@@ -56,7 +73,6 @@ import 'messages_all.dart';
 /// you wish to add from the pop-up menu in the Value field. This list should
 /// be consistent with the languages listed in the @className.supportedLocales
 /// property.
-
 class @className {
   @className(Locale locale) : _localeName = locale.toString();
 
@@ -294,10 +310,32 @@ String _importFilePath(String path, String fileName) {
 
 Future<void> main(List<String> args) async {
   final argslib.ArgParser parser = argslib.ArgParser();
-  parser.addOption('arb-dir', defaultsTo: path.join('lib', 'l10n'));
-  parser.addOption('template-arb-file', defaultsTo: 'app_en.arb');
-  parser.addOption('output-localization-file', defaultsTo: 'app_localizations.dart');
-  parser.addOption('output-class', defaultsTo: 'AppLocalizations');
+  parser.addOption(
+    'arb-dir',
+    defaultsTo: path.join('lib', 'l10n'),
+    help: 'The directory where all localization files should reside. For '
+      'example, the template and translated arb files should be located here. '
+      'Also, the generated output messages Dart files for each locale and the '
+      'generated localizations classes will be created here.',
+  );
+  parser.addOption(
+    'template-arb-file',
+    defaultsTo: 'app_en.arb',
+    help: 'The template arb file that will be used as the basis for '
+      'generating the Dart localization and messages files.',
+  );
+  parser.addOption(
+    'output-localization-file',
+    defaultsTo: 'app_localizations.dart',
+    help: 'The filename for the output localization and localizations '
+      'delegate classes.',
+  );
+  parser.addOption(
+    'output-class',
+    defaultsTo: 'AppLocalizations',
+    help: 'The Dart class name to use for the output localization and '
+      'localizations delegate classes.',
+  );
   final argslib.ArgResults results = parser.parse(args);
 
   final String arbPathString = results['arb-dir'];

--- a/dev/tools/localization/gen_l10n.dart
+++ b/dev/tools/localization/gen_l10n.dart
@@ -308,8 +308,14 @@ String _importFilePath(String path, String fileName) {
   return '$replaceLib/$fileName';
 }
 
-Future<void> main(List<String> args) async {
+Future<void> main(List<String> arguments) async {
   final argslib.ArgParser parser = argslib.ArgParser();
+  parser.addFlag(
+    'help',
+    defaultsTo: false,
+    negatable: false,
+    help: 'Print this help message.',
+  );
   parser.addOption(
     'arb-dir',
     defaultsTo: path.join('lib', 'l10n'),
@@ -336,7 +342,12 @@ Future<void> main(List<String> args) async {
     help: 'The Dart class name to use for the output localization and '
       'localizations delegate classes.',
   );
-  final argslib.ArgResults results = parser.parse(args);
+
+  final argslib.ArgResults results = parser.parse(arguments);
+  if (results['help'] == true) {
+    print(parser.usage);
+    exit(0);
+  }
 
   final String arbPathString = results['arb-dir'];
   final String outputFileString = results['output-localization-file'];

--- a/examples/stocks/lib/i18n/regenerate.md
+++ b/examples/stocks/lib/i18n/regenerate.md
@@ -15,8 +15,8 @@ for more info.
 `messages_all.dart`, and `stock_strings.dart` with the following command:
 
 ```dart
-dart ${FLUTTER_PATH}/dev/tools/localization/gen_l10n.dart --arb-dir=lib/i18n
-  --template-arb-file=stocks_en_EN.arb --output-localization-file=stock_strings.dart
+dart ${FLUTTER_PATH}/dev/tools/localization/gen_l10n.dart --arb-dir=lib/i18n \
+  --template-arb-file=stocks_en_US.arb --output-localization-file=stock_strings.dart \
   --output-class=StockStrings
 ```
 

--- a/examples/stocks/lib/i18n/stock_strings.dart
+++ b/examples/stocks/lib/i18n/stock_strings.dart
@@ -23,6 +23,23 @@ import 'messages_all.dart';
 /// );
 /// ```
 ///
+/// ## Update pubspec.yaml
+///
+/// Please make sure to update your pubspec.yaml to include the following
+/// packages:
+///
+/// ```
+/// dependencies:
+///   # rest of dependencies
+///
+///   flutter_localizations:
+///     sdk: flutter
+///   intl: 0.16.0
+///   intl_translation: 0.17.7
+///
+///   # rest of dependencies
+/// ```
+///
 /// ## iOS Applications
 ///
 /// iOS applications define key application metadata, including supported
@@ -42,7 +59,6 @@ import 'messages_all.dart';
 /// you wish to add from the pop-up menu in the Value field. This list should
 /// be consistent with the languages listed in the StockStrings.supportedLocales
 /// property.
-
 class StockStrings {
   StockStrings(Locale locale) : _localeName = locale.toString();
 


### PR DESCRIPTION
## Description

Adds a help flag, as well as help messages to the `gen_l10n.dart` tool. This also refreshes the stocks app to reflect the new changes to the tool, while fixing a typo in the `regenerate.md` tutorial.

```
~/dev/flutter$ dart ${FLUTTER}/dev/tools/localization/gen_l10n.dart --help
--help                        Print this help message.
--arb-dir                     The directory where all localization files should reside. For example, the template and translated arb files should be located here. Also, the generated output messages Dart files for each locale and the generated localizations classes will be created here.
                              (defaults to "lib/l10n")

--template-arb-file           The template arb file that will be used as the basis for generating the Dart localization and messages files.
                              (defaults to "app_en.arb")

--output-localization-file    The filename for the output localization and localizations delegate classes.
                              (defaults to "app_localizations.dart")

--output-class                The Dart class name to use for the output localization and localizations delegate classes.
                              (defaults to "AppLocalizations")
```

## Issues
Related to https://github.com/flutter/flutter/issues/41437