### PR TITLE
Simplification of build_runner integration

### DIFF
--- a/dev/integration_tests/simple_codegen/build.yaml
+++ b/dev/integration_tests/simple_codegen/build.yaml
@@ -5,4 +5,5 @@ builders:
     builder_factories:
       - simpleBuilder
     build_extensions: {'.spec':['.dart']}
-    auto_apply: all_packages
+    build_to: source
+    auto_apply: root_package

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -9,7 +9,6 @@ import '../../base/process_manager.dart';
 import '../../build_info.dart';
 import '../../dart/package_map.dart';
 import '../../globals.dart';
-import '../../project.dart';
 import '../build_system.dart';
 import '../depfile.dart';
 import 'assets.dart';
@@ -126,9 +125,7 @@ class Dart2JSTarget extends Target {
     final String dart2jsOptimization = environment.defines[kDart2jsOptimization];
     final BuildMode buildMode = getBuildModeForName(environment.defines[kBuildMode]);
     final String specPath = fs.path.join(artifacts.getArtifactPath(Artifact.flutterWebSdk), 'libraries.json');
-    final String packageFile = FlutterProject.fromDirectory(environment.projectDir).hasBuilders
-      ? PackageMap.globalGeneratedPackagesPath
-      : PackageMap.globalPackagesPath;
+    final String packageFile = PackageMap.globalPackagesPath;
     final File outputFile = environment.buildDir.childFile('main.dart.js');
     final ProcessResult result = await processManager.run(<String>[
       artifacts.getArtifactPath(Artifact.engineDartBinary),

--- a/packages/flutter_tools/lib/src/codegen.dart
+++ b/packages/flutter_tools/lib/src/codegen.dart
@@ -2,22 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:meta/meta.dart';
-
-import 'artifacts.dart';
 import 'base/context.dart';
-import 'base/file_system.dart';
-import 'base/platform.dart';
-import 'build_info.dart';
-import 'compile.dart';
-import 'dart/package_map.dart';
-import 'globals.dart';
 import 'project.dart';
-
-// Arbitrarily chosen multi-root file scheme. This is used to configure the
-// frontend_server to resolve a package uri to multiple filesystem directories.
-// In this case, the source directory and a generated directory.
-const String kMultiRootScheme = 'org-dartlang-app';
 
 /// The [CodeGenerator] instance.
 ///
@@ -42,18 +28,6 @@ abstract class CodeGenerator {
   // Generates a synthetic package under .dart_tool/flutter_tool which is in turn
   // used to generate a build script.
   Future<void> generateBuildScript(FlutterProject flutterProject);
-
-  /// Create generated packages file which adds a multi-root scheme to the user's
-  /// project directory. Currently we only replace the root package with a multiroot
-  /// scheme. To support codegen on arbitrary packages we would need to do
-  /// this for each dependency.
-  void updatePackages(FlutterProject flutterProject) {
-    final String oldPackagesContents = fs.file(PackageMap.globalPackagesPath).readAsStringSync();
-    final String appName = flutterProject.manifest.appName;
-    final String newPackagesContents = oldPackagesContents.replaceFirst('$appName:lib/', '$appName:$kMultiRootScheme:/');
-    final String generatedPackagesPath = fs.path.setExtension(PackageMap.globalPackagesPath, '.generated');
-    fs.file(generatedPackagesPath).writeAsStringSync(newPackagesContents);
-  }
 }
 
 class UnsupportedCodeGenerator extends CodeGenerator {
@@ -78,186 +52,6 @@ abstract class CodegenDaemon {
 
   /// Starts a new build.
   void startBuild();
-}
-
-/// An implementation of the [KernelCompiler] which delegates to build_runner.
-///
-/// Only a subset of the arguments provided to the [KernelCompiler] are
-/// supported here. Using the build pipeline implies a fixed multiroot
-/// filesystem and requires a pubspec.
-class CodeGeneratingKernelCompiler implements KernelCompiler {
-  const CodeGeneratingKernelCompiler();
-
-  static const KernelCompiler _delegate = KernelCompiler();
-
-  @override
-  Future<CompilerOutput> compile({
-    String mainPath,
-    String outputFilePath,
-    bool linkPlatformKernelIn = false,
-    bool aot = false,
-    @required BuildMode buildMode,
-    bool causalAsyncStacks = true,
-    bool trackWidgetCreation,
-    List<String> extraFrontEndOptions,
-    // These arguments are currently unused.
-    String sdkRoot,
-    String packagesPath,
-    List<String> fileSystemRoots,
-    String fileSystemScheme,
-    String depFilePath,
-    TargetModel targetModel = TargetModel.flutter,
-    String initializeFromDill,
-    String platformDill,
-  }) async {
-    if (fileSystemRoots != null || fileSystemScheme != null || depFilePath != null || targetModel != null || sdkRoot != null || packagesPath != null) {
-      printTrace('fileSystemRoots, fileSystemScheme, depFilePath, targetModel,'
-        'sdkRoot, packagesPath are not supported when using the experimental '
-        'build* pipeline');
-    }
-    final FlutterProject flutterProject = FlutterProject.current();
-    codeGenerator.updatePackages(flutterProject);
-    final CodegenDaemon codegenDaemon = await codeGenerator.daemon(flutterProject);
-    codegenDaemon.startBuild();
-    await for (CodegenStatus codegenStatus in codegenDaemon.buildResults) {
-      if (codegenStatus == CodegenStatus.Failed) {
-        printError('Code generation failed, build may have compile errors.');
-        break;
-      }
-      if (codegenStatus == CodegenStatus.Succeeded) {
-        break;
-      }
-    }
-    return _delegate.compile(
-      mainPath: mainPath,
-      outputFilePath: outputFilePath,
-      linkPlatformKernelIn: linkPlatformKernelIn,
-      aot: aot,
-      buildMode: buildMode,
-      causalAsyncStacks: causalAsyncStacks,
-      trackWidgetCreation: trackWidgetCreation,
-      extraFrontEndOptions: extraFrontEndOptions,
-      sdkRoot: sdkRoot,
-      packagesPath: PackageMap.globalGeneratedPackagesPath,
-      fileSystemRoots: <String>[
-        fs.path.join(flutterProject.generated.path, 'lib${platform.pathSeparator}'),
-        fs.path.join(flutterProject.directory.path, 'lib${platform.pathSeparator}'),
-      ],
-      fileSystemScheme: kMultiRootScheme,
-      depFilePath: depFilePath,
-      targetModel: targetModel,
-      initializeFromDill: initializeFromDill,
-    );
-  }
-}
-
-/// An implementation of a [ResidentCompiler] which runs a [BuildRunner] before
-/// talking to the CFE.
-class CodeGeneratingResidentCompiler implements ResidentCompiler {
-  CodeGeneratingResidentCompiler._(this._residentCompiler, this._codegenDaemon, this._flutterProject);
-
-  /// Creates a new [ResidentCompiler] and configures a [BuildDaemonClient] to
-  /// run builds.
-  ///
-  /// If `runCold` is true, then no codegen daemon will be created. Instead the
-  /// compiler will only be initialized with the correct configuration for
-  /// codegen mode.
-  static Future<ResidentCompiler> create({
-    @required FlutterProject flutterProject,
-    @required BuildMode buildMode,
-    bool trackWidgetCreation = false,
-    CompilerMessageConsumer compilerMessageConsumer = printError,
-    bool unsafePackageSerialization = false,
-    String outputPath,
-    String initializeFromDill,
-    bool runCold = false,
-    TargetPlatform targetPlatform,
-  }) async {
-    codeGenerator.updatePackages(flutterProject);
-    final ResidentCompiler residentCompiler = ResidentCompiler(
-      artifacts.getArtifactPath(
-        Artifact.flutterPatchedSdkPath,
-        platform: targetPlatform,
-        mode: buildMode,
-      ),
-      buildMode: buildMode,
-      trackWidgetCreation: trackWidgetCreation,
-      packagesPath: PackageMap.globalGeneratedPackagesPath,
-      fileSystemRoots: <String>[
-        fs.path.join(flutterProject.generated.path, 'lib${platform.pathSeparator}'),
-        fs.path.join(flutterProject.directory.path, 'lib${platform.pathSeparator}'),
-      ],
-      fileSystemScheme: kMultiRootScheme,
-      targetModel: TargetModel.flutter,
-      unsafePackageSerialization: unsafePackageSerialization,
-      initializeFromDill: initializeFromDill,
-    );
-    if (runCold) {
-      return residentCompiler;
-    }
-    final CodegenDaemon codegenDaemon = await codeGenerator.daemon(flutterProject);
-    codegenDaemon.startBuild();
-    final CodegenStatus status = await codegenDaemon.buildResults.firstWhere((CodegenStatus status) {
-      return status == CodegenStatus.Succeeded || status == CodegenStatus.Failed;
-    });
-    if (status == CodegenStatus.Failed) {
-      printError('Code generation failed, build may have compile errors.');
-    }
-    return CodeGeneratingResidentCompiler._(residentCompiler, codegenDaemon, flutterProject);
-  }
-
-  final ResidentCompiler _residentCompiler;
-  final CodegenDaemon _codegenDaemon;
-  final FlutterProject _flutterProject;
-
-  @override
-  void accept() {
-    _residentCompiler.accept();
-  }
-
-  @override
-  Future<CompilerOutput> compileExpression(String expression, List<String> definitions, List<String> typeDefinitions, String libraryUri, String klass, bool isStatic) {
-    return _residentCompiler.compileExpression(expression, definitions, typeDefinitions, libraryUri, klass, isStatic);
-  }
-
-  @override
-  Future<CompilerOutput> recompile(String mainPath, List<Uri> invalidatedFiles, {String outputPath, String packagesFilePath}) async {
-    if (_codegenDaemon.lastStatus != CodegenStatus.Succeeded && _codegenDaemon.lastStatus != CodegenStatus.Failed) {
-      await _codegenDaemon.buildResults.firstWhere((CodegenStatus status) {
-        return status == CodegenStatus.Succeeded || status == CodegenStatus.Failed;
-      });
-    }
-    if (_codegenDaemon.lastStatus == CodegenStatus.Failed) {
-      printError('Code generation failed, build may have compile errors.');
-    }
-    // Update the generated packages file if the original packages file has changes.
-    if (fs.statSync(PackageMap.globalPackagesPath).modified.millisecondsSinceEpoch >
-        fs.statSync(PackageMap.globalGeneratedPackagesPath).modified.millisecondsSinceEpoch) {
-      codeGenerator.updatePackages(_flutterProject);
-      invalidatedFiles.add(fs.file(PackageMap.globalGeneratedPackagesPath).uri);
-    }
-    return _residentCompiler.recompile(
-      mainPath,
-      invalidatedFiles,
-      outputPath: outputPath,
-      packagesFilePath: PackageMap.globalGeneratedPackagesPath,
-    );
-  }
-
-  @override
-  Future<CompilerOutput> reject() {
-    return _residentCompiler.reject();
-  }
-
-  @override
-  void reset() {
-    _residentCompiler.reset();
-  }
-
-  @override
-  Future<void> shutdown() {
-    return _residentCompiler.shutdown();
-  }
 }
 
 /// The current status of a codegen build.

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -153,7 +153,7 @@ class RunCommand extends RunCommandBase {
       )
       ..addFlag('hot',
         negatable: true,
-        defaultsTo: kHotReloadDefault,
+        defaultsTo: true,
         help: 'Run with support for hot reloading. Only available for debug mode. Not available with "--trace-startup".',
       )
       ..addFlag('resident',

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -28,7 +28,7 @@ class KernelCompilerFactory {
   const KernelCompilerFactory();
 
   Future<KernelCompiler> create(FlutterProject flutterProject) async {
-    if (flutterProject.hasBuilders) {
+    if (flutterProject?.hasBuilders == true) {
       final CodegenDaemon codegenDaemon = await codeGenerator
         .daemon(flutterProject);
       codegenDaemon.startBuild();

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -49,7 +49,7 @@ import 'macos/xcode.dart';
 import 'macos/xcode_validator.dart';
 import 'mdns_discovery.dart';
 import 'reporting/reporting.dart';
-import 'run_hot.dart';
+import 'resident_runner.dart';
 import 'version.dart';
 import 'web/chrome.dart';
 import 'web/workflow.dart';

--- a/packages/flutter_tools/lib/src/dart/package_map.dart
+++ b/packages/flutter_tools/lib/src/dart/package_map.dart
@@ -20,8 +20,6 @@ class PackageMap {
 
   static String get globalPackagesPath => _globalPackagesPath ?? kPackagesFileName;
 
-  static String get globalGeneratedPackagesPath => fs.path.setExtension(globalPackagesPath, '.generated');
-
   static set globalPackagesPath(String value) {
     _globalPackagesPath = value;
   }


### PR DESCRIPTION
## Description

Currently build_runner is integrated by wrapping the kernel and resident compilers, proxying the underlying calls and applying some existing configuration to support a multiroot scheme. This is fairly complex, and the only benefit is supporting build_to: cache, which isn't widely used since the generated code is hard to discover.

By removing this functionality, we can simplify the integration to a hook that verifies that all builds are up to date before running.