### PR TITLE
[flutter_tool] Stream artifact downloads to files

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -1242,8 +1242,7 @@ String flattenNameSubdirs(Uri url) {
 /// Download a file from the given [url] and write it to [location].
 Future<void> _downloadFile(Uri url, File location) async {
   _ensureExists(location.parent);
-  final List<int> fileBytes = await fetchUrl(url);
-  location.writeAsBytesSync(fileBytes, flush: true);
+  await fetchUrl(url, destFile: location);
 }
 
 Future<bool> _doesRemoteExist(String message, Uri url) async {

--- a/packages/flutter_tools/test/general.shard/base/net_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/net_test.dart
@@ -3,8 +3,12 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart' as io;
 import 'package:flutter_tools/src/base/net.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -14,6 +18,36 @@ import '../../src/common.dart';
 import '../../src/context.dart';
 
 void main() {
+  group('successful fetch', () {
+    const String responseString = 'response string';
+    List<int> responseData;
+
+    setUp(() {
+      responseData = utf8.encode(responseString);
+    });
+
+    testUsingContext('fetchUrl() gets the data', () async {
+      final List<int> data = await fetchUrl(Uri.parse('http://example.invalid/'));
+      expect(data, equals(responseData));
+    }, overrides: <Type, Generator>{
+      HttpClientFactory: () => () => FakeHttpClient(200, data: responseString),
+    });
+
+    testUsingContext('fetchUrl(destFile) writes the data to a file', () async {
+      final File destFile = fs.file('dest_file')..createSync();
+      final List<int> data = await fetchUrl(
+        Uri.parse('http://example.invalid/'),
+        destFile: destFile,
+      );
+      expect(data, equals(<int>[]));
+      expect(destFile.readAsStringSync(), equals(responseString));
+    }, overrides: <Type, Generator>{
+      FileSystem: () => MemoryFileSystem(),
+      HttpClientFactory: () => () => FakeHttpClient(200, data: responseString),
+      ProcessManager: () => FakeProcessManager.any(),
+    });
+  });
+
   testUsingContext('retry from 500', () async {
     String error;
     FakeAsync().run((FakeAsync time) {
@@ -249,13 +283,14 @@ class FakeHttpClientThrowing implements io.HttpClient {
 }
 
 class FakeHttpClient implements io.HttpClient {
-  FakeHttpClient(this.statusCode);
+  FakeHttpClient(this.statusCode, { this.data });
 
   final int statusCode;
+  final String data;
 
   @override
   Future<io.HttpClientRequest> getUrl(Uri url) async {
-    return FakeHttpClientRequest(statusCode);
+    return FakeHttpClientRequest(statusCode, data: data);
   }
 
   @override
@@ -286,13 +321,14 @@ class FakeHttpClientThrowingRequest implements io.HttpClient {
 }
 
 class FakeHttpClientRequest implements io.HttpClientRequest {
-  FakeHttpClientRequest(this.statusCode);
+  FakeHttpClientRequest(this.statusCode, { this.data });
 
   final int statusCode;
+  final String data;
 
   @override
   Future<io.HttpClientResponse> close() async {
-    return FakeHttpClientResponse(statusCode);
+    return FakeHttpClientResponse(statusCode, data: data);
   }
 
   @override
@@ -318,10 +354,12 @@ class FakeHttpClientRequestThrowing implements io.HttpClientRequest {
 }
 
 class FakeHttpClientResponse implements io.HttpClientResponse {
-  FakeHttpClientResponse(this.statusCode);
+  FakeHttpClientResponse(this.statusCode, { this.data });
 
   @override
   final int statusCode;
+
+  final String data;
 
   @override
   String get reasonPhrase => '<reason phrase>';
@@ -333,13 +371,24 @@ class FakeHttpClientResponse implements io.HttpClientResponse {
     void onDone(),
     bool cancelOnError,
   }) {
-    return Stream<Uint8List>.fromFuture(Future<Uint8List>.error(const io.SocketException('test')))
-      .listen(onData, onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+    if (data == null) {
+      return Stream<Uint8List>.fromFuture(Future<Uint8List>.error(
+        const io.SocketException('test'),
+      )).listen(onData, onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+    } else {
+      return Stream<Uint8List>.fromFuture(Future<Uint8List>.value(
+        utf8.encode(data) as Uint8List,
+      )).listen(onData, onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+    }
   }
 
   @override
-  Future<dynamic> forEach(void Function(Uint8List element) action) {
-    return Future<void>.error(const io.SocketException('test'));
+  Future<dynamic> forEach(void Function(Uint8List element) action) async {
+    if (data == null) {
+      return Future<void>.error(const io.SocketException('test'));
+    } else {
+      return Future<void>.microtask(() => action(utf8.encode(data)));
+    }
   }
 
   @override


### PR DESCRIPTION
## Description

When downloading artifacts, the tool would bring the artifacts into the Dart heap before writing them to files. This PR streams them directly to files.

On Windows, the artifacts are still brought into the Dart heap for decompression, but fixing that is more difficult since the API is synchronous.

## Related Issues

Analytics showing >1GB RSS for the tool on artifact download.

## Tests

I added the following tests:

Added tests for `fetchUrl`.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.