### PR TITLE
Revert "Turn off docs upload temporarily (#44365)"

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -121,10 +121,6 @@ fi
 # Ensure google webmaster tools can verify our site.
 cp "$FLUTTER_ROOT/dev/docs/google2ed1af765c529f57.html" "$FLUTTER_ROOT/dev/docs/doc"
 
-# TEMPORARILY EXIT WITHOUT UPLOADING
-# TODO(gspencergoog): Renable once Firebase outage is resolved.
-exit 0
-
 # Upload new API docs when running on Cirrus
 if [[ -n "$CIRRUS_CI" && -z "$CIRRUS_PR" ]]; then
   echo "This is not a pull request; considering whether to upload docs... (branch=$CIRRUS_BRANCH)"

--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -14,6 +14,7 @@ function deploy {
 
   [[ "$remaining_tries" == 0 ]] && {
     echo "Command still failed after $total_tries tries: '$@'"
+    cat firebase-debug.log || echo "Unable to show contents of firebase-debug.log."
     return 1
   }
   return 0

--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -123,8 +123,7 @@ fi
 cp "$FLUTTER_ROOT/dev/docs/google2ed1af765c529f57.html" "$FLUTTER_ROOT/dev/docs/doc"
 
 # Upload new API docs when running on Cirrus
-# TODO(jackson): Temporarily enabling this for PRs, revert before landing
-if [[ -n "$CIRRUS_CI" ]]; then
+if [[ -n "$CIRRUS_CI" && -z "$CIRRUS_PR" ]]; then
   echo "This is not a pull request; considering whether to upload docs... (branch=$CIRRUS_BRANCH)"
   if [[ "$CIRRUS_BRANCH" == "master" ]]; then
     echo "Updating $CIRRUS_BRANCH docs: https://master-api.flutter.dev/"

--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -123,19 +123,17 @@ fi
 cp "$FLUTTER_ROOT/dev/docs/google2ed1af765c529f57.html" "$FLUTTER_ROOT/dev/docs/doc"
 
 # Upload new API docs when running on Cirrus
-# TODO(jackson): Temporarily enabling upload for PRs, revert before landing
+# TODO(jackson): Temporarily enabling this for PRs, revert before landing
 if [[ -n "$CIRRUS_CI" ]]; then
   echo "This is not a pull request; considering whether to upload docs... (branch=$CIRRUS_BRANCH)"
-  # TODO(jackson): Temporarily enabling upload for PRs, revert before landing
-  # if [[ "$CIRRUS_BRANCH" == "master" ]]; then
+  if [[ "$CIRRUS_BRANCH" == "master" ]]; then
     echo "Updating $CIRRUS_BRANCH docs: https://master-api.flutter.dev/"
     # Disable search indexing on the master staging site so searches get only
     # the stable site.
     echo -e "User-agent: *\nDisallow: /" > "$FLUTTER_ROOT/dev/docs/doc/robots.txt"
     export FIREBASE_TOKEN="$FIREBASE_MASTER_TOKEN"
     deploy 5 master-docs-flutter-dev
-  # TODO(jackson): Temporarily enabling upload for PRs, revert before landing
-  # fi
+  fi
 
   if [[ "$CIRRUS_BRANCH" == "stable" ]]; then
     # Enable search indexing on the master staging site so searches get only

--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -123,7 +123,8 @@ fi
 cp "$FLUTTER_ROOT/dev/docs/google2ed1af765c529f57.html" "$FLUTTER_ROOT/dev/docs/doc"
 
 # Upload new API docs when running on Cirrus
-if [[ -n "$CIRRUS_CI" && -z "$CIRRUS_PR" ]]; then
+# TODO(jackson): Temporarily enabling this for PRs, revert before landing
+if [[ -n "$CIRRUS_CI" ]]; then
   echo "This is not a pull request; considering whether to upload docs... (branch=$CIRRUS_BRANCH)"
   if [[ "$CIRRUS_BRANCH" == "master" ]]; then
     echo "Updating $CIRRUS_BRANCH docs: https://master-api.flutter.dev/"

--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -123,17 +123,19 @@ fi
 cp "$FLUTTER_ROOT/dev/docs/google2ed1af765c529f57.html" "$FLUTTER_ROOT/dev/docs/doc"
 
 # Upload new API docs when running on Cirrus
-# TODO(jackson): Temporarily enabling this for PRs, revert before landing
+# TODO(jackson): Temporarily enabling upload for PRs, revert before landing
 if [[ -n "$CIRRUS_CI" ]]; then
   echo "This is not a pull request; considering whether to upload docs... (branch=$CIRRUS_BRANCH)"
-  if [[ "$CIRRUS_BRANCH" == "master" ]]; then
+  # TODO(jackson): Temporarily enabling upload for PRs, revert before landing
+  # if [[ "$CIRRUS_BRANCH" == "master" ]]; then
     echo "Updating $CIRRUS_BRANCH docs: https://master-api.flutter.dev/"
     # Disable search indexing on the master staging site so searches get only
     # the stable site.
     echo -e "User-agent: *\nDisallow: /" > "$FLUTTER_ROOT/dev/docs/doc/robots.txt"
     export FIREBASE_TOKEN="$FIREBASE_MASTER_TOKEN"
     deploy 5 master-docs-flutter-dev
-  fi
+  # TODO(jackson): Temporarily enabling upload for PRs, revert before landing
+  # fi
 
   if [[ "$CIRRUS_BRANCH" == "stable" ]]; then
     # Enable search indexing on the master staging site so searches get only


### PR DESCRIPTION
This reverts commit 3dd67410787e918774f052121963086f0ef777a9.

Here's the docs upload build failure that @gspencergoog skipped in #44365:

https://cirrus-ci.com/task/5617336584765440

In this PR I've reverted the disabled docs upload so that we can see if the Firebase 503 error issue persists. I've updated the Cirrus script so that it prints out the contents of firebase-debug.log.

I also temporarily made it so docs upload happens for PRs that aren't on master, so we can see if this passes before landing.

Here's the new CI run:

https://cirrus-ci.com/task/6320256838008832

I suspect that this issue will resolve on its own and we'll have to decide if we want to turn the upload back on and hope it never happens again, or come up with some other solution. If this is the first time we've seen it, my inclination would be to just turn it back on because it might be a long time before Firebase goes down in the same way again.