### PR TITLE
Remove TextRange, export it from dart:ui

### DIFF
--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -816,8 +816,15 @@ class TextPainter {
   /// <http://www.unicode.org/reports/tr29/#Word_Boundaries>.
   TextRange getWordBoundary(TextPosition position) {
     assert(!_needsLayout);
-    final List<int> indices = _paragraph.getWordBoundary(position.offset);
-    return TextRange(start: indices[0], end: indices[1]);
+    // TODO(gspencergoog): remove the List<int>-based code when the engine API
+    // returns a TextRange instead of a List<int>.
+    final dynamic boundary = _paragraph.getWordBoundary(position.offset);
+    if (boundary is List<int>) {
+      final List<int> indices = boundary;
+      return TextRange(start: indices[0], end: indices[1]);
+    }
+    final TextRange range = boundary;
+    return range;
   }
 
   /// Returns the full list of [LineMetrics] that describe in detail the various

--- a/packages/flutter/lib/src/services/text_editing.dart
+++ b/packages/flutter/lib/src/services/text_editing.dart
@@ -2,96 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' show hashValues, TextAffinity, TextPosition;
+import 'dart:ui' show hashValues, TextAffinity, TextPosition, TextRange;
 
 import 'package:flutter/foundation.dart';
 
-export 'dart:ui' show TextAffinity, TextPosition;
-
-/// A range of characters in a string of text.
-@immutable
-class TextRange {
-  /// Creates a text range.
-  ///
-  /// The [start] and [end] arguments must not be null. Both the [start] and
-  /// [end] must either be greater than or equal to zero or both exactly -1.
-  ///
-  /// Instead of creating an empty text range, consider using the [empty]
-  /// constant.
-  const TextRange({
-    @required this.start,
-    @required this.end,
-  }) : assert(start != null && start >= -1),
-       assert(end != null && end >= -1);
-
-  /// A text range that starts and ends at offset.
-  ///
-  /// The [offset] argument must be non-null and greater than or equal to -1.
-  const TextRange.collapsed(int offset)
-    : assert(offset != null && offset >= -1),
-      start = offset,
-      end = offset;
-
-  /// A text range that contains nothing and is not in the text.
-  static const TextRange empty = TextRange(start: -1, end: -1);
-
-  /// The index of the first character in the range.
-  ///
-  /// If [start] and [end] are both -1, the text range is empty.
-  final int start;
-
-  /// The next index after the characters in this range.
-  ///
-  /// If [start] and [end] are both -1, the text range is empty.
-  final int end;
-
-  /// Whether this range represents a valid position in the text.
-  bool get isValid => start >= 0 && end >= 0;
-
-  /// Whether this range is empty (but still potentially placed inside the text).
-  bool get isCollapsed => start == end;
-
-  /// Whether the start of this range precedes the end.
-  bool get isNormalized => end >= start;
-
-  /// The text before this range.
-  String textBefore(String text) {
-    assert(isNormalized);
-    return text.substring(0, start);
-  }
-
-  /// The text after this range.
-  String textAfter(String text) {
-    assert(isNormalized);
-    return text.substring(end);
-  }
-
-  /// The text inside this range.
-  String textInside(String text) {
-    assert(isNormalized);
-    return text.substring(start, end);
-  }
-
-  @override
-  bool operator ==(dynamic other) {
-    if (identical(this, other))
-      return true;
-    if (other is! TextRange)
-      return false;
-    final TextRange typedOther = other;
-    return typedOther.start == start
-        && typedOther.end == end;
-  }
-
-  @override
-  int get hashCode => hashValues(
-    start.hashCode,
-    end.hashCode,
-  );
-
-  @override
-  String toString() => 'TextRange(start: $start, end: $end)';
-}
+export 'dart:ui' show TextAffinity, TextPosition, TextRange;
 
 /// A range of text that represents a selection.
 @immutable


### PR DESCRIPTION
## Description

This removes `TextRange` from the framework and moves it to the engine, in preparation for using it to return text ranges from the text extent APIs, and updates the APIs that use `Paragraph.getWordBoundary` (there was only one) to expect a `TextRange` or  a pair of `int`s temporarily until the engine side returns TextRanges, so that I can convert over without breaking the builds.

I'll add the engine roll into this PR as soon as https://github.com/flutter/engine/pull/13747 has landed and is green in the engine.

I have successfully run the CI tests locally with the updated engine.

## Tests

- Wrote new tests, but added them to dart:ui.

## Breaking Change

- [X] No, this is *not* a breaking change.