### PR TITLE
Use raw string for l10n description 

### DIFF
--- a/dev/tools/localization/gen_l10n.dart
+++ b/dev/tools/localization/gen_l10n.dart
@@ -164,7 +164,7 @@ List<String> genIntlMethodArgs(Map<String, dynamic> bundle, String key) {
   if (attributesMap != null) {
     if (attributesMap.containsKey('description')) {
       final String description = attributesMap['description'];
-      attributes.add('desc: \'$description\'');
+      attributes.add('desc: ${generateString(description)}');
     }
     if (attributesMap.containsKey('placeholders')) {
       final Map<String, dynamic> placeholders = attributesMap['placeholders'];

--- a/examples/stocks/lib/i18n/messages_all.dart
+++ b/examples/stocks/lib/i18n/messages_all.dart
@@ -15,21 +15,21 @@ import 'package:intl/intl.dart';
 import 'package:intl/message_lookup_by_library.dart';
 import 'package:intl/src/intl_helpers.dart';
 
-import 'messages_en_US.dart' as messages_en_us;
 import 'messages_es_ES.dart' as messages_es_es;
+import 'messages_en_US.dart' as messages_en_us;
 
 typedef Future<dynamic> LibraryLoader();
 Map<String, LibraryLoader> _deferredLibraries = {
-  'en_US': () => new Future.value(null),
   'es_ES': () => new Future.value(null),
+  'en_US': () => new Future.value(null),
 };
 
 MessageLookupByLibrary _findExact(String localeName) {
   switch (localeName) {
-    case 'en_US':
-      return messages_en_us.messages;
     case 'es_ES':
       return messages_es_es.messages;
+    case 'en_US':
+      return messages_en_us.messages;
     default:
       return null;
   }

--- a/examples/stocks/lib/i18n/stock_strings.dart
+++ b/examples/stocks/lib/i18n/stock_strings.dart
@@ -30,8 +30,7 @@ import 'messages_all.dart';
 ///
 /// ```
 /// dependencies:
-///   # rest of dependencies
-///
+///   # Internationalization support.
 ///   flutter_localizations:
 ///     sdk: flutter
 ///   intl: 0.16.0
@@ -90,8 +89,8 @@ class StockStrings {
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
-    Locale('en', 'US'),
     Locale('es', 'ES'),
+    Locale('en', 'US'),
   ];
 
   String title() {
@@ -99,7 +98,7 @@ class StockStrings {
       r'Stocks',
       locale: _localeName,
       name: 'title',
-      desc: 'Title for the Stocks application',
+      desc: r'Title for the Stocks application',
       args: <Object>[]
     );
   }
@@ -109,7 +108,7 @@ class StockStrings {
       r'MARKET',
       locale: _localeName,
       name: 'market',
-      desc: 'Label for the Market tab',
+      desc: r'Label for the Market tab',
       args: <Object>[]
     );
   }
@@ -119,7 +118,7 @@ class StockStrings {
       r'PORTFOLIO',
       locale: _localeName,
       name: 'portfolio',
-      desc: 'Label for the Portfolio tab',
+      desc: r'Label for the Portfolio tab',
       args: <Object>[]
     );
   }
@@ -133,7 +132,7 @@ class _StockStringsDelegate extends LocalizationsDelegate<StockStrings> {
   Future<StockStrings> load(Locale locale) => StockStrings.load(locale);
 
   @override
-  bool isSupported(Locale locale) => <String>['en', 'es'].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>['es', 'en'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_StockStringsDelegate old) => false;


### PR DESCRIPTION
## Description

The `gen_l10n.dart` tool does not properly handle escapable characters. This corrects that problem if the template arb file has messages with descriptions that contain escapable characters like single quote or double quote.