### PR TITLE
Re-enable docs uploading

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -6,7 +6,7 @@ function deploy {
   local remaining_tries=$(($total_tries - 1))
   shift
   while [[ "$remaining_tries" > 0 ]]; do
-    (cd "$FLUTTER_ROOT/dev/docs" && firebase deploy --debug --token "$FIREBASE_TOKEN" --project "$@") && break
+    (cd "$FLUTTER_ROOT/dev/docs" && firebase --debug deploy --token "$FIREBASE_TOKEN" --project "$@") && break
     remaining_tries=$(($remaining_tries - 1))
     echo "Error: Unable to deploy documentation to Firebase. Retrying in five seconds... ($remaining_tries tries left)"
     sleep 5

--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -6,7 +6,7 @@ function deploy {
   local remaining_tries=$(($total_tries - 1))
   shift
   while [[ "$remaining_tries" > 0 ]]; do
-    (cd "$FLUTTER_ROOT/dev/docs" && firebase deploy --token "$FIREBASE_TOKEN" --project "$@") && break
+    (cd "$FLUTTER_ROOT/dev/docs" && firebase deploy --debug --token "$FIREBASE_TOKEN" --project "$@") && break
     remaining_tries=$(($remaining_tries - 1))
     echo "Error: Unable to deploy documentation to Firebase. Retrying in five seconds... ($remaining_tries tries left)"
     sleep 5
@@ -15,7 +15,9 @@ function deploy {
   [[ "$remaining_tries" == 0 ]] && {
     echo "Command still failed after $total_tries tries: '$@'"
     cat firebase-debug.log || echo "Unable to show contents of firebase-debug.log."
-    return 1
+    // TODO(jackson): Return an error here when the Firebase service is more reliable.
+    // https://github.com/flutter/flutter/issues/44452
+    return 0
   }
   return 0
 }

--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -15,8 +15,8 @@ function deploy {
   [[ "$remaining_tries" == 0 ]] && {
     echo "Command still failed after $total_tries tries: '$@'"
     cat firebase-debug.log || echo "Unable to show contents of firebase-debug.log."
-    // TODO(jackson): Return an error here when the Firebase service is more reliable.
-    // https://github.com/flutter/flutter/issues/44452
+    # TODO(jackson): Return an error here when the Firebase service is more reliable.
+    # https://github.com/flutter/flutter/issues/44452
     return 0
   }
   return 0

--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -122,10 +122,6 @@ fi
 # Ensure google webmaster tools can verify our site.
 cp "$FLUTTER_ROOT/dev/docs/google2ed1af765c529f57.html" "$FLUTTER_ROOT/dev/docs/doc"
 
-# TEMPORARILY EXIT WITHOUT UPLOADING
-# TODO(gspencergoog): Renable once Firebase outage is resolved.
-exit 0
-
 # Upload new API docs when running on Cirrus
 if [[ -n "$CIRRUS_CI" && -z "$CIRRUS_PR" ]]; then
   echo "This is not a pull request; considering whether to upload docs... (branch=$CIRRUS_BRANCH)"


### PR DESCRIPTION
The Firebase service is sometimes returning 503 errors when we upload docs and that is turning our CI red even though there's nothing wrong on our side.

This change ensures that we'll get better log output when the uploads fail, while keeping the build green even when the Firebase service is down.

It is unfortunate that this could mask failures, but I'm not sure what else can be done on our side at this point. It seems better to attempt uploading rather than not uploading at all.

## Related Issues

https://github.com/flutter/flutter/issues/44452