### PR TITLE
Fix test for null flutter root

### DIFF
--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -87,11 +87,16 @@ class AssembleCommand extends FlutterCommand {
     if (futterProject == null) {
       return const <CustomDimensions, String>{};
     }
-    final Environment localEnvironment = environment;
-    return <CustomDimensions, String>{
-      CustomDimensions.commandBuildBundleTargetPlatform: localEnvironment.defines['TargetPlatform'],
-      CustomDimensions.commandBuildBundleIsModule: '${futterProject.isModule}',
-    };
+    try {
+      final Environment localEnvironment = environment;
+      return <CustomDimensions, String>{
+        CustomDimensions.commandBuildBundleTargetPlatform: localEnvironment.defines['TargetPlatform'],
+        CustomDimensions.commandBuildBundleIsModule: '${futterProject.isModule}',
+      };
+    } catch (err) {
+      // We've failed to send usage.
+    }
+    return const <CustomDimensions, String>{};
   }
 
   /// The target we are building.

--- a/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
@@ -18,15 +18,13 @@ import '../../src/testbed.dart';
 void main() {
   Testbed testbed;
   MockBuildSystem mockBuildSystem;
-
-  setUpAll(() {
-    Cache.disableLocking();
-  });
+  Cache.disableLocking();
 
   setUp(() {
     mockBuildSystem = MockBuildSystem();
     testbed = Testbed(overrides: <Type, Generator>{
       BuildSystem: ()  => mockBuildSystem,
+      Cache: () => FakeCache(),
     });
   });
 


### PR DESCRIPTION
## Description

With the usageValues added we can fail to find a flutter root and crash, though this is only in tests.