### PR TITLE
Refactorings to testbed.run and testbed.test

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
@@ -16,20 +16,14 @@ import '../../src/common.dart';
 import '../../src/testbed.dart';
 
 void main() {
-  Testbed testbed;
-  MockBuildSystem mockBuildSystem;
   Cache.disableLocking();
-
-  setUp(() {
-    mockBuildSystem = MockBuildSystem();
-    testbed = Testbed(overrides: <Type, Generator>{
-      BuildSystem: ()  => mockBuildSystem,
-      Cache: () => FakeCache(),
-    });
+  final Testbed testbed = Testbed(overrides: <Type, Generator>{
+    BuildSystem: ()  => MockBuildSystem(),
+    Cache: () => FakeCache(),
   });
 
-  test('Can run a build', () => testbed.run(() async {
-    when(mockBuildSystem.build(any, any, buildSystemConfig: anyNamed('buildSystemConfig')))
+  testbed.test('Can run a build', () async {
+    when(buildSystem.build(any, any, buildSystemConfig: anyNamed('buildSystemConfig')))
       .thenAnswer((Invocation invocation) async {
         return BuildResult(success: true);
       });
@@ -38,30 +32,30 @@ void main() {
     final BufferLogger bufferLogger = logger;
 
     expect(bufferLogger.traceText, contains('build succeeded.'));
-  }));
+  });
 
-  test('Throws ToolExit if not provided with output', () => testbed.run(() async {
-    when(mockBuildSystem.build(any, any, buildSystemConfig: anyNamed('buildSystemConfig')))
+  testbed.test('Throws ToolExit if not provided with output', () async {
+    when(buildSystem.build(any, any, buildSystemConfig: anyNamed('buildSystemConfig')))
       .thenAnswer((Invocation invocation) async {
         return BuildResult(success: true);
       });
     final CommandRunner<void> commandRunner = createTestCommandRunner(AssembleCommand());
 
     expect(commandRunner.run(<String>['assemble', 'debug_macos_bundle_flutter_assets']), throwsA(isInstanceOf<ToolExit>()));
-  }));
+  });
 
-  test('Throws ToolExit if called with non-existent rule', () => testbed.run(() async {
-    when(mockBuildSystem.build(any, any, buildSystemConfig: anyNamed('buildSystemConfig')))
+  testbed.test('Throws ToolExit if called with non-existent rule', () async {
+    when(buildSystem.build(any, any, buildSystemConfig: anyNamed('buildSystemConfig')))
       .thenAnswer((Invocation invocation) async {
         return BuildResult(success: true);
       });
     final CommandRunner<void> commandRunner = createTestCommandRunner(AssembleCommand());
 
     expect(commandRunner.run(<String>['assemble', '-o Output', 'undefined']), throwsA(isInstanceOf<ToolExit>()));
-  }));
+  });
 
-  test('Only writes input and output files when the values change', () => testbed.run(() async {
-    when(mockBuildSystem.build(any, any, buildSystemConfig: anyNamed('buildSystemConfig')))
+  testbed.test('Only writes input and output files when the values change', () async {
+    when(buildSystem.build(any, any, buildSystemConfig: anyNamed('buildSystemConfig')))
       .thenAnswer((Invocation invocation) async {
         return BuildResult(
           success: true,
@@ -86,8 +80,7 @@ void main() {
     expect(inputs.lastModifiedSync(), theDistantPast);
     expect(outputs.lastModifiedSync(), theDistantPast);
 
-
-    when(mockBuildSystem.build(any, any, buildSystemConfig: anyNamed('buildSystemConfig')))
+    when(buildSystem.build(any, any, buildSystemConfig: anyNamed('buildSystemConfig')))
       .thenAnswer((Invocation invocation) async {
         return BuildResult(
           success: true,
@@ -99,7 +92,7 @@ void main() {
     expect(inputs.readAsStringSync(), contains('foo'));
     expect(inputs.readAsStringSync(), contains('fizz'));
     expect(inputs.lastModifiedSync(), isNot(theDistantPast));
-  }));
+  });
 }
 
 class MockBuildSystem extends Mock implements BuildSystem {}


### PR DESCRIPTION
## Description

Attempts to reduce testing and simplify how tests are declared and setup, especially in the presence of NNBD. Changes: 

- (1) Create testbed in main instead of setup. Rationale: creating a testbed does not perform any additional work beyond object creation. Moving into setup to avoid work for the case where we only want to run a single test doesn't buy us much, and would force us to either declare testbed as `late` or `nullable` - both of which introduce potential for runtime exceptions and overhead.

- (2) Remove top level fields referenced in `setUp`. The mockito APIs do not require access to instance itself - we can use the typed context getters instead.

- (3) Remove nested closure and provide test method on testbed itself. Reduces nesting, looks cleaner, and no regression in functionality due to annotation. Requires (1).

If this seems like a nicer approach to take, I'll convert the reset of the APIs and remove `run`.