### PR TITLE
Print a message when modifying settings that you may need to reload IDE/editor

### DIFF
--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -154,6 +154,8 @@ class ConfigCommand extends FlutterCommand {
 
     if (argResults.arguments.isEmpty) {
       printStatus(usage);
+    } else {
+      printStatus('\nYou may need to restart any open editors for them to read new settings.');
     }
 
     return null;

--- a/packages/flutter_tools/test/commands.shard/hermetic/config_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/config_test.dart
@@ -166,7 +166,6 @@ void main() {
       ]);
 
       expect(logger.statusText, contains('You may need to restart any open editors'));
-
     }, overrides: <Type, Generator>{
       Usage: () => mockUsage,
     });

--- a/packages/flutter_tools/test/commands.shard/hermetic/config_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/config_test.dart
@@ -155,6 +155,22 @@ void main() {
       Usage: () => mockUsage,
     });
 
+    testUsingContext('warns the user to reload IDE', () async {
+      final BufferLogger logger = context.get<Logger>();
+      final ConfigCommand configCommand = ConfigCommand();
+      final CommandRunner<void> commandRunner = createTestCommandRunner(configCommand);
+
+      await commandRunner.run(<String>[
+        'config',
+        '--enable-web'
+      ]);
+
+      expect(logger.statusText, contains('You may need to restart any open editors'));
+
+    }, overrides: <Type, Generator>{
+      Usage: () => mockUsage,
+    });
+
     testUsingContext('displays which config settings are available on stable', () async {
       final BufferLogger logger = context.get<Logger>();
       when(mockFlutterVersion.channel).thenReturn('stable');


### PR DESCRIPTION
This just adds a note about needing to reload editors if you make changes using `flutter config`.

Fixes https://github.com/Dart-Code/Dart-Code/issues/2090 (or at least, gives the user the solution).