### PR TITLE
[ci] Use the latest Cirrus Image for macOS 

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -430,7 +430,7 @@ task:
 # than just fetching the data in the first place.
 task:
   osx_instance:
-    image: mojave-xcode-11.2.1-flutter # see https://cirrus-ci.org/guide/macOS/ for list of images (we should update regularly)
+    image: mojave-flutter # see https://cirrus-ci.org/guide/macOS/ for list of images (we should update regularly)
     # cpu is always 2
     # memory is always 8G
   environment:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -443,8 +443,8 @@ task:
   setup_script:
     - date
     - which flutter
-    - sudo gem install bundler -v 2.0.2 -N
-    - bundle install --system --gemfile=dev/ci/mac/Gemfile
+    - bundle --version
+    - sudo bundle install --system --gemfile=dev/ci/mac/Gemfile
     - git clean -xffd
     - git fetch origin
     - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -430,7 +430,7 @@ task:
 # than just fetching the data in the first place.
 task:
   osx_instance:
-    image: mojave-xcode-10.2-flutter # see https://cirrus-ci.org/guide/macOS/ for list of images (we should update regularly)
+    image: mojave-xcode-11.2.1-flutter # see https://cirrus-ci.org/guide/macOS/ for list of images (we should update regularly)
     # cpu is always 2
     # memory is always 8G
   environment:


### PR DESCRIPTION
## Description

`mojave-flutter` is an alias to the latest image with Xcode and Flutter preinstalled. Right now it points to `mojave-xcode-11.2.1-flutter` images which has Xcode 11.2.1 and the latest stable Flutter.

## Tests

All CI checks

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
