### PR TITLE
Convert to TextPosition for getWordBoundary

### DIFF
--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -818,7 +818,7 @@ class TextPainter {
     assert(!_needsLayout);
     // TODO(gspencergoog): remove the List<int>-based code when the engine API
     // returns a TextRange instead of a List<int>.
-    final dynamic boundary = _paragraph.getWordBoundary(position.offset);
+    final dynamic boundary = _paragraph.getWordBoundary(position);
     if (boundary is List<int>) {
       final List<int> indices = boundary;
       return TextRange(start: indices[0], end: indices[1]);


### PR DESCRIPTION
## Description

Convert the call to `getWordBoundary` to use a `TextPosition`, in preparation for landing https://github.com/flutter/engine/pull/13727, which switches the desired API to the final desired API.

## Tests

- No testing changes needed.

## Breaking Change

- [X] No, this is *not* a breaking change.