### PR TITLE
Make disposing a ScrollPosition with pixels=null legal

### DIFF
--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -333,29 +333,6 @@ class _PagePosition extends ScrollPositionWithSingleContext implements PageMetri
   final int initialPage;
   double _pageToUseOnStartup;
 
-  /// If [pixels] isn't set by [applyViewportDimension] before [dispose] is
-  /// called, this could throw an assert as [pixels] will be set to null.
-  ///
-  /// With [Tab]s, this happens when there are nested [TabBarView]s and there
-  /// is an attempt to warp over the nested tab to a tab adjacent to it.
-  ///
-  /// This flag will be set to true once the dimensions have been established
-  /// and [pixels] is set.
-  bool isInitialPixelsValueSet = false;
-
-  @override
-  void dispose() {
-    // TODO(shihaohong): remove workaround once these issues have been
-    // resolved, https://github.com/flutter/flutter/issues/32054,
-    // https://github.com/flutter/flutter/issues/32056
-    // Sets `pixels` to a non-null value before `ScrollPosition.dispose` is
-    // invoked if it was never set by `applyViewportDimension`.
-    if (pixels == null && !isInitialPixelsValueSet) {
-      correctPixels(0);
-    }
-    super.dispose();
-  }
-
   @override
   double get viewportFraction => _viewportFraction;
   double _viewportFraction;
@@ -422,7 +399,6 @@ class _PagePosition extends ScrollPositionWithSingleContext implements PageMetri
 
     if (newPixels != oldPixels) {
       correctPixels(newPixels);
-      isInitialPixelsValueSet = true;
       return false;
     }
     return result;

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -693,7 +693,6 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
 
   @override
   void dispose() {
-    assert(pixels != null);
     activity?.dispose(); // it will be null if it got absorbed by another ScrollPosition
     _activity = null;
     super.dispose();

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -978,8 +978,7 @@ void main() {
     expect(tabController.index, 0);
   });
 
-  testWidgets('Nested TabBarView sets ScrollController pixels to non-null value '
-  'when disposed before it is set by the applyViewportDimension', (WidgetTester tester) async {
+  testWidgets('Can switch to non-neighboring tab in nested TabBarView without crashing', (WidgetTester tester) async {
     // This is a regression test for https://github.com/flutter/flutter/issues/18756
     final TabController _mainTabController = TabController(length: 4, vsync: const TestVSync());
     final TabController _nestedTabController = TabController(length: 2, vsync: const TestVSync());

--- a/packages/flutter/test/widgets/scrollable_in_overlay_test.dart
+++ b/packages/flutter/test/widgets/scrollable_in_overlay_test.dart
@@ -1,0 +1,64 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+
+void main() {
+  test('Can dispose ScrollPosition when pixels is null', () {
+    final ScrollPosition position = ScrollPositionWithSingleContext(
+      initialPixels: null,
+      keepScrollOffset: false,
+      physics: const AlwaysScrollableScrollPhysics(),
+      context: ScrollableState(),
+    );
+
+    expect(position.pixels, isNull);
+    position.dispose(); // Should not throw/assert.
+  });
+
+  testWidgets('scrollable in hidden overlay does not crash when unhidden', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/44269.
+    final TabController controller = TabController(vsync: const TestVSync(), length: 1);
+
+    final OverlayEntry entry1 = OverlayEntry(
+      maintainState: true,
+      opaque: true,
+      builder: (BuildContext context) {
+        return TabBar(
+          isScrollable: true,
+          controller: controller,
+          tabs: const <Tab>[
+            Tab(text: 'Main'),
+          ],
+        );
+      }
+    );
+    final OverlayEntry entry2 = OverlayEntry(
+        maintainState: true,
+        opaque: true,
+        builder: (BuildContext context) {
+          return const Text('number2');
+        }
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Overlay(
+            initialEntries: <OverlayEntry>[
+              entry1,
+              entry2,
+            ],
+          ),
+        ),
+      ),
+    );
+
+    entry2.remove();
+    await tester.pump();
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/packages/flutter/test/widgets/scrollable_in_overlay_test.dart
+++ b/packages/flutter/test/widgets/scrollable_in_overlay_test.dart
@@ -34,14 +34,14 @@ void main() {
             Tab(text: 'Main'),
           ],
         );
-      }
+      },
     );
     final OverlayEntry entry2 = OverlayEntry(
-        maintainState: true,
-        opaque: true,
-        builder: (BuildContext context) {
-          return const Text('number2');
-        }
+      maintainState: true,
+      opaque: true,
+      builder: (BuildContext context) {
+        return const Text('number2');
+      },
     );
 
     await tester.pumpWidget(


### PR DESCRIPTION
## Description

Certain subclass of ScrollPosition (namely _TabBarScrollPosition and _PagePosition) are initialized with initialPixels = null because the initial scroll offset cannot be determined when the ScrollPosition is first constructed. To determine the scroll offset for these subclasses, the viewport dimensions need to be known. Therefore, determining the initial pixels value is deferred until layout when applyViewportDimension is called.

This creates a problem when such a ScrollPosition is disposed without ever doing a layout run: Prior to this change, ScrollPosition.dispose used to assert(pixels != null), which would fire for the aforementioned ScrollPosition if their associated Viewport has never been layed out.

There's a common scenario for this situation: A (scrollable) TabBar or PageView is part of an OverlayEntry that's covered by another opaque OverlayEntry. The covered OverlayEntry is never layed out because its not visible on screen (it is considered to be offstage). When the covering OverlayEntry is removed, the other OverlayEntry is moved in the RenderTree from its offstage to the onstage position. Since the content of the moved OverlayEntry is associated with a global key the containing Scrollable is deactivated at the old position and re-activated at the new position in the RenderTree. This reactivation at a new position in the tree causes didUpdateDependencies to be called on the State of Scrollable, which calls ScrollableState._updatePosition [1]. This method builds a new ScrollPosition based on ScrollConfiguration and ScrollPhysics inherited from the new position in the RenderTree. The old ScrollPosition is disposed (which used to throw since it still has pixels set to null, see above).

This change makes it legal to dispose a ScrollPosition that has pixels still set to null.

Alternatives considered:
 - Just initialize the subclasses with a non-null initial pixels value. This seems less then ideal as this would indicate that the ScrollPosition is valid when in fact it is not until first layout.
 - Defer creation/recreation of ScrollPosition until layout when initial value for pixels is known. This adds a lot of complexity and also breaks the current contract of the Scrollable API, which currently makes the ScrollPosition available before layout.

Side node: For the _PagePosition a work-around for this problem had been implemented in https://github.com/flutter/flutter/pull/31581. This change makes the work-around unnecessary and its therefore removed.

[1] https://github.com/flutter/flutter/blob/35de8d527842f99e30240a7fbf08cd4638ba7a5d/packages/flutter/lib/src/widgets/scrollable.dart#L314-L333

## Related Issues

Fixes https://github.com/flutter/flutter/issues/44269.

## Tests

I added the following tests:

* Can dispose ScrollPosition when pixels is null
* Scrollable in hidden overlay does not crash when unhidden

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
