### PR TITLE
Track and use fallback TextAffinity for null affinity platform TextSelections.

### DIFF
--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -82,9 +82,6 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
     if (delegate.selectionEnabled) {
       switch (Theme.of(_state.context).platform) {
         case TargetPlatform.iOS:
-          // Call regular selectPosition to set tap fallback affinity.
-          renderEditable.selectPosition(cause: SelectionChangedCause.tap);
-          // Call selectWordEdge to achieve desired selection.
           renderEditable.selectWordEdge(cause: SelectionChangedCause.tap);
           break;
         case TargetPlatform.android:

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -82,6 +82,9 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
     if (delegate.selectionEnabled) {
       switch (Theme.of(_state.context).platform) {
         case TargetPlatform.iOS:
+          // Call regular selectPosition to set tap fallback affinity.
+          renderEditable.selectPosition(cause: SelectionChangedCause.tap);
+          // Call selectWordEdge to achieve desired selection.
           renderEditable.selectWordEdge(cause: SelectionChangedCause.tap);
           break;
         case TargetPlatform.android:

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -833,7 +833,8 @@ class TextPainter {
   ///
   /// Not valid until after layout.
   ///
-  /// This can potentially be expensive, since it needs to compute the line
+  /// This can potentially be expensive, since it needs to compute the full
+  /// layout before it is available.
   TextRange getLineBoundary(TextPosition position) {
     return _paragraph.getLineBoundary(position);
   }

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -776,7 +776,6 @@ class TextPainter {
         rect = _getRectFromUpstream(offset, caretPrototype) ?? _getRectFromDownstream(offset, caretPrototype);
         break;
       }
-      case TextAffinity.ambiguous: // Treat ambiguous affinity as downstream.
       case TextAffinity.downstream: {
         rect = _getRectFromDownstream(offset, caretPrototype) ??  _getRectFromUpstream(offset, caretPrototype);
         break;

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -776,6 +776,7 @@ class TextPainter {
         rect = _getRectFromUpstream(offset, caretPrototype) ?? _getRectFromDownstream(offset, caretPrototype);
         break;
       }
+      case TextAffinity.ambiguous: // Treat ambiguous affinity as downstream.
       case TextAffinity.downstream: {
         rect = _getRectFromDownstream(offset, caretPrototype) ??  _getRectFromUpstream(offset, caretPrototype);
         break;

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -819,23 +819,16 @@ class TextPainter {
     return _paragraph.getWordBoundary(position);
   }
 
-  /// Returns the text range of the line at the given offset.
-  ///
-  /// The newline, if any, is included in the range.
-  TextRange getLineBoundary(TextPosition position) {
-    assert(!_needsLayout);
-    return _paragraph.getLineBoundary(position);
-  }
-
   /// Returns the [TextRange] of the line at the given [TextPosition].
   ///
-  /// The newline (if any) is returned as part of the range.
+  /// The newline, if any, is returned as part of the range.
   ///
   /// Not valid until after layout.
   ///
   /// This can potentially be expensive, since it needs to compute the full
   /// layout before it is available.
   TextRange getLineBoundary(TextPosition position) {
+    assert(!_needsLayout);
     return _paragraph.getLineBoundary(position);
   }
 

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -827,6 +827,17 @@ class TextPainter {
     return _paragraph.getLineBoundary(position);
   }
 
+  /// Returns the [TextRange] of the line at the given [TextPosition].
+  ///
+  /// The newline (if any) is returned as part of the range.
+  ///
+  /// Not valid until after layout.
+  ///
+  /// This can potentially be expensive, since it needs to compute the line
+  TextRange getLineBoundary(TextPosition position) {
+    return _paragraph.getLineBoundary(position);
+  }
+
   /// Returns the full list of [LineMetrics] that describe in detail the various
   /// metrics of each laid out line.
   ///

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -422,10 +422,18 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     if (onSelectionChanged != null) {
       onSelectionChanged(nextSelection, this, cause);
     }
+  }
+
+  // Sets the fallback affinity to the affinity of the selection.
+  //
+  // Require a full selection as affinity should always be computed with a selection.
+  void _setFallbackAffinity(
+    TextSelection selection,
+  ) {
     // Engine-computed selections will always compute affinity when necessary.
     // We cache this affinity in the case we use a platform supplied selection
-    // that does not provide an affinity .
-    _fallbackAffinity = nextSelection.affinity;
+    // that does not provide an affinity.
+    _fallbackAffinity = selection.affinity;
   }
 
   static final Set<LogicalKeyboardKey> _movementKeys = <LogicalKeyboardKey>{
@@ -1588,6 +1596,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     );
     // Call [onSelectionChanged] only when the selection actually changed.
     _handleSelectionChange(newSelection, cause);
+    _setFallbackAffinity(newSelection);
   }
 
   /// Select a word around the location of the last tap down.

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -425,15 +425,13 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   }
 
   // Sets the fallback affinity to the affinity of the selection.
-  //
-  // Require a full selection as affinity should always be computed with a selection.
   void _setFallbackAffinity(
-    TextSelection selection,
+    TextAffinity affinity,
   ) {
     // Engine-computed selections will always compute affinity when necessary.
     // We cache this affinity in the case we use a platform supplied selection
     // that does not provide an affinity.
-    _fallbackAffinity = selection.affinity;
+    _fallbackAffinity = affinity;
   }
 
   static final Set<LogicalKeyboardKey> _movementKeys = <LogicalKeyboardKey>{
@@ -1592,7 +1590,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     );
     // Call [onSelectionChanged] only when the selection actually changed.
     _handleSelectionChange(newSelection, cause);
-    _setFallbackAffinity(newSelection);
+    _setFallbackAffinity(newSelection.affinity);
   }
 
   /// Select a word around the location of the last tap down.
@@ -1641,6 +1639,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return;
     }
     final TextPosition position = _textPainter.getPositionForOffset(globalToLocal(_lastTapDownPosition - _paintOffset));
+    _setFallbackAffinity(position.affinity);
     final TextRange word = _textPainter.getWordBoundary(position);
     if (position.offset - word.start <= 1) {
       _handleSelectionChange(

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1641,7 +1641,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     final TextPosition position = _textPainter.getPositionForOffset(globalToLocal(_lastTapDownPosition - _paintOffset));
     _setFallbackAffinity(position.affinity);
     final TextRange word = _textPainter.getWordBoundary(position);
-    final lineBoundary = _textPainter.getLineBoundary(position);
+    final TextRange lineBoundary = _textPainter.getLineBoundary(position);
     final bool endOfLine = lineBoundary.end == position.offset && position.affinity != null;
     if (position.offset - word.start <= 1) {
       _handleSelectionChange(

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -402,10 +402,10 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   // down in a multi-line text field when selecting using the keyboard.
   bool _wasSelectingVerticallyWithKeyboard = false;
 
-  // This is the affinity we use when a platform-supplied value has ambiguous
+  // This is the affinity we use when a platform-supplied value has null
   // affinity.
   //
-  // This affinity should never be [TextAffinity.ambiguous].
+  // This affinity should never be null.
   TextAffinity _fallbackAffinity = TextAffinity.downstream;
 
   // Call through to onSelectionChanged.
@@ -424,7 +424,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
     // Engine-computed selections will always compute affinity when necessary.
     // We cache this affinity in the case we use a platform supplied selection
-    // that does not provide an affinity ([TextAffinity.ambiguous]).
+    // that does not provide an affinity .
     _fallbackAffinity = nextSelection.affinity;
   }
 
@@ -973,11 +973,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   set selection(TextSelection value) {
     if (_selection == value)
       return;
-    // We use the _backupAffinity when the set selection has an ambiguous
+    // We use the _fallbackAffinity when the set selection has a null
     // affinity. This happense when the platform does not supply affinity,
-    // in which case using the backup affinity computed from dart:ui will
+    // in which case using the fallback affinity computed from dart:ui will
     // be superior to simply defaulting to TextAffinity.downstream.
-    if (value.affinity == TextAffinity.ambiguous) {
+    if (value.affinity == null) {
       _selection = TextSelection(
         baseOffset: value.baseOffset,
         extentOffset: value.extentOffset,

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -986,11 +986,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     // in which case using the fallback affinity computed from dart:ui will
     // be superior to simply defaulting to TextAffinity.downstream.
     if (value.affinity == null) {
-      _selection = TextSelection(
-        baseOffset: value.baseOffset,
-        extentOffset: value.extentOffset,
-        affinity: _fallbackAffinity,
-      );
+      _selection = value.copyWith(affinity: _fallbackAffinity);
     } else {
       _selection = value;
     }

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1641,14 +1641,16 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     final TextPosition position = _textPainter.getPositionForOffset(globalToLocal(_lastTapDownPosition - _paintOffset));
     _setFallbackAffinity(position.affinity);
     final TextRange word = _textPainter.getWordBoundary(position);
+    final lineBoundary = _textPainter.getLineBoundary(position);
+    final bool endOfLine = lineBoundary.end == position.offset && position.affinity != null;
     if (position.offset - word.start <= 1) {
       _handleSelectionChange(
-        TextSelection.collapsed(offset: word.start, affinity: TextAffinity.downstream),
+        TextSelection.collapsed(offset: word.start, affinity: endOfLine ? position.affinity : TextAffinity.downstream),
         cause,
       );
     } else {
       _handleSelectionChange(
-        TextSelection.collapsed(offset: word.end, affinity: TextAffinity.upstream),
+        TextSelection.collapsed(offset: word.end, affinity: endOfLine ? position.affinity : TextAffinity.upstream),
         cause,
       );
     }

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1642,7 +1642,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     _setFallbackAffinity(position.affinity);
     final TextRange word = _textPainter.getWordBoundary(position);
     final TextRange lineBoundary = _textPainter.getLineBoundary(position);
-    final bool endOfLine = lineBoundary.end == position.offset && position.affinity != null;
+    final bool endOfLine = lineBoundary?.end == position.offset && position.affinity != null;
     if (position.offset - word.start <= 1) {
       _handleSelectionChange(
         TextSelection.collapsed(offset: word.start, affinity: endOfLine ? position.affinity : TextAffinity.downstream),

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -428,9 +428,10 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   void _setFallbackAffinity(
     TextAffinity affinity,
   ) {
+    assert(affinity != null);
     // Engine-computed selections will always compute affinity when necessary.
-    // We cache this affinity in the case we use a platform supplied selection
-    // that does not provide an affinity.
+    // Cache this affinity in the case where the platform supplied selection
+    // does not provide an affinity.
     _fallbackAffinity = affinity;
   }
 
@@ -979,8 +980,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   set selection(TextSelection value) {
     if (_selection == value)
       return;
-    // We use the _fallbackAffinity when the set selection has a null
-    // affinity. This happense when the platform does not supply affinity,
+    // Use the _fallbackAffinity when the set selection has a null
+    // affinity. This happens when the platform does not supply affinity,
     // in which case using the fallback affinity computed from dart:ui will
     // be superior to simply defaulting to TextAffinity.downstream.
     if (value.affinity == null) {

--- a/packages/flutter/lib/src/services/text_editing.dart
+++ b/packages/flutter/lib/src/services/text_editing.dart
@@ -81,7 +81,7 @@ class TextSelection extends TextRange {
   /// The position at which the selection originates.
   ///
   /// Might be larger than, smaller than, or equal to extent.
-  TextPosition get base => TextPosition(offset: baseOffset, affinity: affinity);
+  TextPosition get base => TextPosition(offset: baseOffset, affinity: affinity ?? TextAffinity.downstream);
 
   /// The position at which the selection terminates.
   ///
@@ -90,7 +90,7 @@ class TextSelection extends TextRange {
   /// side of the selection, this is the location at which to paint the caret.
   ///
   /// Might be larger than, smaller than, or equal to base.
-  TextPosition get extent => TextPosition(offset: extentOffset, affinity: affinity);
+  TextPosition get extent => TextPosition(offset: extentOffset, affinity: affinity ?? TextAffinity.downstream);
 
   @override
   String toString() {

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -533,7 +533,7 @@ class TextEditingValue {
       selection: TextSelection(
         baseOffset: encoded['selectionBase'] ?? -1,
         extentOffset: encoded['selectionExtent'] ?? -1,
-        affinity: _toTextAffinity(encoded['selectionAffinity']) ?? TextAffinity.downstream,
+        affinity: _toTextAffinity(encoded['selectionAffinity']) ?? TextAffinity.ambiguous,
         isDirectional: encoded['selectionIsDirectional'] ?? false,
       ),
       composing: TextRange(

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -472,6 +472,9 @@ TextAffinity _toTextAffinity(String affinity) {
     case 'TextAffinity.upstream':
       return TextAffinity.upstream;
   }
+  // Null affinity indicates that the platform did not provide a valid
+  // affinity. We set it to null here to allow the framework to supply
+  // a fallback affinity.
   return null;
 }
 
@@ -533,7 +536,7 @@ class TextEditingValue {
       selection: TextSelection(
         baseOffset: encoded['selectionBase'] ?? -1,
         extentOffset: encoded['selectionExtent'] ?? -1,
-        affinity: _toTextAffinity(encoded['selectionAffinity']) ?? TextAffinity.ambiguous,
+        affinity: _toTextAffinity(encoded['selectionAffinity']),
         isDirectional: encoded['selectionIsDirectional'] ?? false,
       ),
       composing: TextRange(

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -473,7 +473,7 @@ TextAffinity _toTextAffinity(String affinity) {
       return TextAffinity.upstream;
   }
   // Null affinity indicates that the platform did not provide a valid
-  // affinity. We set it to null here to allow the framework to supply
+  // affinity. Set it to null here to allow the framework to supply
   // a fallback affinity.
   return null;
 }

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -790,4 +790,42 @@ void main() {
     expect(lines[2].lineNumber, 2);
     expect(lines[3].lineNumber, 3);
   }, skip: !isLinux);
+
+  test('getLineBoundary', () {
+    final TextPainter painter = TextPainter()
+      ..textDirection = TextDirection.ltr;
+
+    const String text = 'test1\nhello line two really long for soft break\nfinal line 4';
+    painter.text = const TextSpan(
+      text: text,
+    );
+
+    painter.layout(maxWidth: 300);
+
+    final List<ui.LineMetrics> lines = painter.computeLineMetrics();
+
+    expect(lines.length, 4);
+
+    expect(painter.getLineBoundary(TextPosition(offset: -1)), TextRange(start: -1, end: -1));
+    
+    expect(painter.getLineBoundary(TextPosition(offset: 0)), TextRange(start: 0, end: 5));
+    expect(painter.getLineBoundary(TextPosition(offset: 1)), TextRange(start: 0, end: 5));
+    expect(painter.getLineBoundary(TextPosition(offset: 4)), TextRange(start: 0, end: 5));
+    expect(painter.getLineBoundary(TextPosition(offset: 5)), TextRange(start: 0, end: 5));
+
+    expect(painter.getLineBoundary(TextPosition(offset: 10)), TextRange(start: 6, end: 28));
+    expect(painter.getLineBoundary(TextPosition(offset: 15)), TextRange(start: 6, end: 28));
+    expect(painter.getLineBoundary(TextPosition(offset: 21)), TextRange(start: 6, end: 28));
+    expect(painter.getLineBoundary(TextPosition(offset: 28)), TextRange(start: 6, end: 28));
+
+    expect(painter.getLineBoundary(TextPosition(offset: 29)), TextRange(start: 28, end: 47));
+    expect(painter.getLineBoundary(TextPosition(offset: 47)), TextRange(start: 28, end: 47));
+
+    expect(painter.getLineBoundary(TextPosition(offset: 48)), TextRange(start: 48, end: 60));
+    expect(painter.getLineBoundary(TextPosition(offset: 49)), TextRange(start: 48, end: 60));
+    expect(painter.getLineBoundary(TextPosition(offset: 60)), TextRange(start: 48, end: 60));
+
+    expect(painter.getLineBoundary(TextPosition(offset: 61)), TextRange(start: -1, end: -1));
+    expect(painter.getLineBoundary(TextPosition(offset: 100)), TextRange(start: -1, end: -1));
+  }, skip: !isLinux);
 }

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -806,26 +806,26 @@ void main() {
 
     expect(lines.length, 4);
 
-    expect(painter.getLineBoundary(TextPosition(offset: -1)), TextRange(start: -1, end: -1));
-    
-    expect(painter.getLineBoundary(TextPosition(offset: 0)), TextRange(start: 0, end: 5));
-    expect(painter.getLineBoundary(TextPosition(offset: 1)), TextRange(start: 0, end: 5));
-    expect(painter.getLineBoundary(TextPosition(offset: 4)), TextRange(start: 0, end: 5));
-    expect(painter.getLineBoundary(TextPosition(offset: 5)), TextRange(start: 0, end: 5));
+    expect(painter.getLineBoundary(const TextPosition(offset: -1)), const TextRange(start: -1, end: -1));
 
-    expect(painter.getLineBoundary(TextPosition(offset: 10)), TextRange(start: 6, end: 28));
-    expect(painter.getLineBoundary(TextPosition(offset: 15)), TextRange(start: 6, end: 28));
-    expect(painter.getLineBoundary(TextPosition(offset: 21)), TextRange(start: 6, end: 28));
-    expect(painter.getLineBoundary(TextPosition(offset: 28)), TextRange(start: 6, end: 28));
+    expect(painter.getLineBoundary(const TextPosition(offset: 0)), const TextRange(start: 0, end: 5));
+    expect(painter.getLineBoundary(const TextPosition(offset: 1)), const TextRange(start: 0, end: 5));
+    expect(painter.getLineBoundary(const TextPosition(offset: 4)), const TextRange(start: 0, end: 5));
+    expect(painter.getLineBoundary(const TextPosition(offset: 5)), const TextRange(start: 0, end: 5));
 
-    expect(painter.getLineBoundary(TextPosition(offset: 29)), TextRange(start: 28, end: 47));
-    expect(painter.getLineBoundary(TextPosition(offset: 47)), TextRange(start: 28, end: 47));
+    expect(painter.getLineBoundary(const TextPosition(offset: 10)), const TextRange(start: 6, end: 28));
+    expect(painter.getLineBoundary(const TextPosition(offset: 15)), const TextRange(start: 6, end: 28));
+    expect(painter.getLineBoundary(const TextPosition(offset: 21)), const TextRange(start: 6, end: 28));
+    expect(painter.getLineBoundary(const TextPosition(offset: 28)), const TextRange(start: 6, end: 28));
 
-    expect(painter.getLineBoundary(TextPosition(offset: 48)), TextRange(start: 48, end: 60));
-    expect(painter.getLineBoundary(TextPosition(offset: 49)), TextRange(start: 48, end: 60));
-    expect(painter.getLineBoundary(TextPosition(offset: 60)), TextRange(start: 48, end: 60));
+    expect(painter.getLineBoundary(const TextPosition(offset: 29)), const TextRange(start: 28, end: 47));
+    expect(painter.getLineBoundary(const TextPosition(offset: 47)), const TextRange(start: 28, end: 47));
 
-    expect(painter.getLineBoundary(TextPosition(offset: 61)), TextRange(start: -1, end: -1));
-    expect(painter.getLineBoundary(TextPosition(offset: 100)), TextRange(start: -1, end: -1));
+    expect(painter.getLineBoundary(const TextPosition(offset: 48)), const TextRange(start: 48, end: 60));
+    expect(painter.getLineBoundary(const TextPosition(offset: 49)), const TextRange(start: 48, end: 60));
+    expect(painter.getLineBoundary(const TextPosition(offset: 60)), const TextRange(start: 48, end: 60));
+
+    expect(painter.getLineBoundary(const TextPosition(offset: 61)), const TextRange(start: -1, end: -1));
+    expect(painter.getLineBoundary(const TextPosition(offset: 100)), const TextRange(start: -1, end: -1));
   }, skip: !isLinux);
 }

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -611,4 +611,29 @@ void main() {
     editable.layout(BoxConstraints.loose(const Size(1000.0, 1000.0)));
     expect(editable.maxScrollExtent, equals(10));
   }, skip: isBrowser); // TODO(yjbanov): https://github.com/flutter/flutter/issues/42772
+
+  test('selection affinity uses fallback', () {
+    final TextSelectionDelegate delegate = FakeEditableTextState();
+    EditableText.debugDeterministicCursor = true;
+
+    final RenderEditable editable = RenderEditable(
+      textDirection: TextDirection.ltr,
+      cursorColor: const Color.fromARGB(0xFF, 0xFF, 0x00, 0x00),
+      offset: ViewportOffset.zero(),
+      textSelectionDelegate: delegate,
+      startHandleLayerLink: LayerLink(),
+      endHandleLayerLink: LayerLink(),
+    );
+
+    expect(editable.selection, null);
+
+    const TextSelection sel1 = TextSelection(baseOffset: 10, extentOffset: 11);
+    editable.selection = sel1;
+    expect(editable.selection, sel1);
+
+    const TextSelection sel2 = TextSelection(baseOffset: 10, extentOffset: 11, affinity: null);
+    const TextSelection sel3 = TextSelection(baseOffset: 10, extentOffset: 11, affinity: TextAffinity.downstream);
+    editable.selection = sel2;
+    expect(editable.selection, sel3);
+  }, skip: isBrowser);
 }

--- a/packages/flutter/test/services/text_input_test.dart
+++ b/packages/flutter/test/services/text_input_test.dart
@@ -173,6 +173,37 @@ void main() {
       expect(client.latestMethodCall, 'connectionClosed');
     });
   });
+
+  test('TextEditingValue handles JSON affinity', () async {
+    Map<String, dynamic> json = Map<String, dynamic>();
+    json['text'] = 'Xiaomuqiao';
+
+    TextEditingValue val = TextEditingValue.fromJSON(json);
+    expect(val.text, 'Xiaomuqiao');
+    expect(val.selection.baseOffset, -1);
+    expect(val.selection.extentOffset, -1);
+    expect(val.selection.affinity, null);
+    expect(val.selection.isDirectional, false);
+    expect(val.composing.start, -1);
+    expect(val.composing.end, -1);
+
+    json['text'] = 'Xiaomuqiao';
+    json['selectionBase'] = 5;
+    json['selectionExtent'] = 6;
+    json['selectionAffinity'] = 'TextAffinity.upstream';
+    json['selectionIsDirectional'] = true;
+    json['composingBase'] = 7;
+    json['composingExtent'] = 8;
+
+    val = TextEditingValue.fromJSON(json);
+    expect(val.text, 'Xiaomuqiao');
+    expect(val.selection.baseOffset, 5);
+    expect(val.selection.extentOffset, 6);
+    expect(val.selection.affinity, TextAffinity.upstream);
+    expect(val.selection.isDirectional, true);
+    expect(val.composing.start, 7);
+    expect(val.composing.end, 8);
+  });
 }
 
 class FakeTextInputClient implements TextInputClient {

--- a/packages/flutter/test/services/text_input_test.dart
+++ b/packages/flutter/test/services/text_input_test.dart
@@ -175,7 +175,7 @@ void main() {
   });
 
   test('TextEditingValue handles JSON affinity', () async {
-    Map<String, dynamic> json = Map<String, dynamic>();
+    final Map<String, dynamic> json = {};
     json['text'] = 'Xiaomuqiao';
 
     TextEditingValue val = TextEditingValue.fromJSON(json);

--- a/packages/flutter/test/services/text_input_test.dart
+++ b/packages/flutter/test/services/text_input_test.dart
@@ -175,7 +175,7 @@ void main() {
   });
 
   test('TextEditingValue handles JSON affinity', () async {
-    final Map<String, dynamic> json = {};
+    final Map<String, dynamic> json = <String, dynamic>{};
     json['text'] = 'Xiaomuqiao';
 
     TextEditingValue val = TextEditingValue.fromJSON(json);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/40095

When affinity is unknown, we pass null instead of defaulting to `TextAffnity.downstream`. This allows us to supply fallback affinities computed from libtxt.

Since LibTxt tracks affinities in the `getPositionForOffset` call (used in renderEditable in `selectPositionAt` and `selectWordEdge`), we can use the affinity information by falling back to libtxt affinity when the platform provided affinity is null.

This also exposes `getLineBoundary` in `TextPainter`, which is then used to choose the LibTxt affinity when at the end of the line since selections at the end of lines cannot be downstream affinity without jumping to the next line.