### PR TITLE
Release startup lock during long-lived build ios framework

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -18,6 +18,7 @@ import '../base/utils.dart';
 import '../build_info.dart';
 import '../build_system/targets/ios.dart';
 import '../bundle.dart';
+import '../cache.dart';
 import '../globals.dart';
 import '../macos/cocoapod_utils.dart';
 import '../macos/xcode.dart';
@@ -131,6 +132,8 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
+    Cache.releaseLockEarly();
+
     final String outputArgument = argResults['output']
         ?? fs.path.join(fs.currentDirectory.path, 'build', 'ios', 'framework');
 


### PR DESCRIPTION
## Description

Avoid `Waiting for another flutter command to release the startup lock...` during long-running `flutter build ios-framework` commands.
