### PR TITLE
Attach looks at future observatory URIs

### DIFF
--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -293,34 +293,34 @@ class AttachCommand extends FlutterCommand {
         }
         result = await app.runner.waitForAppToFinish();
         assert(result != null);
-      } else {
-        while (true) {
-          final ResidentRunner runner = await createResidentRunner(
-            observatoryUris: observatoryUri,
-            device: device,
-            flutterProject: flutterProject,
-            usesIpv6: usesIpv6,
-          );
-          final Completer<void> onAppStart = Completer<void>.sync();
-          TerminalHandler terminalHandler;
-          unawaited(onAppStart.future.whenComplete(() {
-            terminalHandler = TerminalHandler(runner)
-              ..setupTerminal()
-              ..registerSignalHandlers();
-          }));
-          result = await runner.attach(
-            appStartedCompleter: onAppStart,
-          );
-          if (result != 0) {
-            throwToolExit(null, exitCode: result);
-          }
-          terminalHandler?.stop();
-          assert(result != null);
-          if (runner.exited || !runner.isStreamingNewObservatoryUris) {
-            break;
-          }
-          printStatus('Waiting for a new connection from Flutter on ${device.name}...');
+        return;
+      }
+      while (true) {
+        final ResidentRunner runner = await createResidentRunner(
+          observatoryUris: observatoryUri,
+          device: device,
+          flutterProject: flutterProject,
+          usesIpv6: usesIpv6,
+        );
+        final Completer<void> onAppStart = Completer<void>.sync();
+        TerminalHandler terminalHandler;
+        unawaited(onAppStart.future.whenComplete(() {
+          terminalHandler = TerminalHandler(runner)
+            ..setupTerminal()
+            ..registerSignalHandlers();
+        }));
+        result = await runner.attach(
+          appStartedCompleter: onAppStart,
+        );
+        if (result != 0) {
+          throwToolExit(null, exitCode: result);
         }
+        terminalHandler?.stop();
+        assert(result != null);
+        if (runner.exited || !runner.isStreamingNewObservatoryUris) {
+          break;
+        }
+        printStatus('Waiting for a new connection from Flutter on ${device.name}...');
       }
     } finally {
       final List<ForwardedPort> ports = device.portForwarder.forwardedPorts.toList();

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -344,7 +344,7 @@ class AttachCommand extends FlutterCommand {
           );
           terminalHandler?.stop();
           assert(result != null);
-          if (runner.exited) {
+          if (runner.exited || !runner.isStreamingNewObservatoryUris) {
             break;
           }
           printStatus('Waiting for a new connection from Flutter on ${device.name}...');

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -317,7 +317,7 @@ class AttachCommand extends FlutterCommand {
         }
         terminalHandler?.stop();
         assert(result != null);
-        if (runner.exited || !runner.isStreamingNewObservatoryUris) {
+        if (runner.exited || !runner.isWaitingForObservatory) {
           break;
         }
         printStatus('Waiting for a new connection from Flutter on ${device.name}...');

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -11,6 +11,7 @@ import 'asset.dart';
 import 'base/context.dart';
 import 'base/file_system.dart';
 import 'base/io.dart';
+import 'base/net.dart';
 import 'build_info.dart';
 import 'bundle.dart';
 import 'compile.dart';
@@ -263,7 +264,12 @@ class DevFSException implements Exception {
   final StackTrace stackTrace;
 }
 
-HttpClient get httpClient => context.get<HttpClient>() ?? HttpClient();
+HttpClient get httpClient {
+  if (context.get<HttpClientFactory>() != null) {
+    return context.get<HttpClientFactory>()();
+  }
+  return HttpClient();
+}
 
 class _DevFSHttpWriter {
   _DevFSHttpWriter(this.fsName, VMService serviceProtocol)

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -263,6 +263,8 @@ class DevFSException implements Exception {
   final StackTrace stackTrace;
 }
 
+HttpClient get httpClient => context.get<HttpClient>() ?? HttpClient();
+
 class _DevFSHttpWriter {
   _DevFSHttpWriter(this.fsName, VMService serviceProtocol)
     : httpAddress = serviceProtocol.httpAddress;
@@ -275,7 +277,7 @@ class _DevFSHttpWriter {
   int _inFlight = 0;
   Map<Uri, DevFSContent> _outstanding;
   Completer<void> _completer;
-  final HttpClient _client = HttpClient();
+  final HttpClient _client = httpClient;
 
   Future<void> write(Map<Uri, DevFSContent> entries) async {
     _client.maxConnectionsPerHost = kMaxInFlight;

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -264,26 +264,22 @@ class DevFSException implements Exception {
   final StackTrace stackTrace;
 }
 
-HttpClient get httpClient {
-  if (context.get<HttpClientFactory>() != null) {
-    return context.get<HttpClientFactory>()();
-  }
-  return HttpClient();
-}
-
 class _DevFSHttpWriter {
   _DevFSHttpWriter(this.fsName, VMService serviceProtocol)
-    : httpAddress = serviceProtocol.httpAddress;
+    : httpAddress = serviceProtocol.httpAddress,
+      _client = (context.get<HttpClientFactory>() == null)
+        ? HttpClient()
+        : context.get<HttpClientFactory>()();
 
   final String fsName;
   final Uri httpAddress;
+  final HttpClient _client;
 
   static const int kMaxInFlight = 6;
 
   int _inFlight = 0;
   Map<Uri, DevFSContent> _outstanding;
   Completer<void> _completer;
-  final HttpClient _client = httpClient;
 
   Future<void> write(Map<Uri, DevFSContent> entries) async {
     _client.maxConnectionsPerHost = kMaxInFlight;

--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -88,9 +88,7 @@ class ProtocolDiscovery {
       .transform(_throttle<Uri>(
         timeInMilliseconds: throttleTimeInMilliseconds,
       ))
-      .asyncMap<Uri>((Uri observatoryUri) async {
-        return await _forwardPort(observatoryUri);
-      });
+      .asyncMap<Uri>((Uri observatoryUri) => _forwardPort(observatoryUri));
   }
 
   Future<void> cancel() => _stopScrapingLogs();

--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -82,7 +82,7 @@ class ProtocolDiscovery {
       .transform(_throttle<Uri>(
         waitDuration: throttleDuration,
       ))
-      .asyncMap<Uri>((Uri observatoryUri) => _forwardPort(observatoryUri));
+      .asyncMap<Uri>(_forwardPort);
   }
 
   Future<void> cancel() => _stopScrapingLogs();

--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -70,7 +70,7 @@ class ProtocolDiscovery {
   /// a new observatory URI may be assigned to the app.
   Stream<Uri> get uris {
     return logReader.logLines
-      .where((String line) => _getObservatoryUri(line) != null)
+      .where((String line) => _getPatternMatch(line) != null)
       // Throttle the logs, so the stream forwards the most recent logs.
       .transform(throttle<String>(
         timeInMilliseconds: 200,
@@ -89,15 +89,17 @@ class ProtocolDiscovery {
     _deviceLogSubscription = null;
   }
 
-  Uri _getObservatoryUri(String line) {
-    Uri uri;
+  Match _getPatternMatch(String line) {
     final RegExp r = RegExp('${RegExp.escape(serviceName)} listening on ((http|\/\/)[a-zA-Z0-9:/=_\\-\.\\[\\]]+)');
-    final Match match = r.firstMatch(line);
+    return r.firstMatch(line);
+  }
 
+  Uri _getObservatoryUri(String line) {
+    final Match match = _getPatternMatch(line);
     if (match != null) {
       return Uri.parse(match[1]);
     }
-    return uri;
+    return null;
   }
 
   void _handleLine(String line) {

--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -62,15 +62,11 @@ class ProtocolDiscovery {
 
   StreamSubscription<String> _deviceLogSubscription;
   StreamController<Uri> _uriStreamController;
-  bool _isUriStreamEmpty = false;
 
   /// The discovered service URI.
   /// Use [uris] instead.
   // TODO(egarciad): replace `uri` for `uris`.
   Future<Uri> get uri {
-    if (_uriStreamController.isClosed && _isUriStreamEmpty) {
-      return Future<Uri>.error('No observatory URI available');
-    }
     return uris.first;
   }
 
@@ -116,7 +112,6 @@ class ProtocolDiscovery {
       uri = _getObservatoryUri(line);
     } on FormatException catch(error, stackTrace) {
       _uriStreamController.addError(error, stackTrace);
-      _isUriStreamEmpty = false;
     }
     if (uri == null) {
       return;
@@ -126,7 +121,6 @@ class ProtocolDiscovery {
       return;
     }
     _uriStreamController.add(uri);
-    _isUriStreamEmpty = false;
   }
 
   Future<Uri> _forwardPort(Uri deviceUri) async {

--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -70,13 +70,13 @@ class ProtocolDiscovery {
     return uris.first;
   }
 
-  /// The discovered service URI stream.
+  /// The discovered service URIs.
   ///
-  /// Port forwarding is only attempted when this is invoked, in case we never
-  /// need to port forward.
+  /// When a new observatory URI is available in [logReader],
+  /// the URIs are forwarded at most once every [throttleDuration].
   ///
-  /// Dependending on the lifespan of the app running the observatory,
-  /// a new observatory URI may be assigned to the app.
+  /// Port forwarding is only attempted when this is invoked,
+  /// for each observatory URI in the stream.
   Stream<Uri> get uris {
     return _uriStreamController.stream
       .transform(_throttle<Uri>(

--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -155,6 +155,7 @@ StreamTransformer<S, S> _throttle<S>({
   @required int timeInMilliseconds,
 }) {
   assert(timeInMilliseconds != null);
+
   S latestLine;
   int lastExecution;
   Future<void> throttleFuture;

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -131,7 +131,7 @@ class FlutterDevice {
 
   final Device device;
   final ResidentCompiler generator;
-  List<Uri> observatoryUris;
+  Stream<Uri> observatoryUris;
   List<VMService> vmServices;
   DevFS devFS;
   ApplicationPackage package;
@@ -154,23 +154,31 @@ class FlutterDevice {
     ReloadSources reloadSources,
     Restart restart,
     CompileExpression compileExpression,
-  }) async {
-    if (vmServices != null) {
-      return;
-    }
-    final List<VMService> localVmServices = List<VMService>(observatoryUris.length);
-    for (int i = 0; i < observatoryUris.length; i += 1) {
-      printTrace('Connecting to service protocol: ${observatoryUris[i]}');
-      localVmServices[i] = await VMService.connect(
-        observatoryUris[i],
-        reloadSources: reloadSources,
-        restart: restart,
-        compileExpression: compileExpression,
-      );
-      printTrace('Successfully connected to service protocol: ${observatoryUris[i]}');
-    }
-    vmServices = localVmServices;
-    device.getLogReader(app: package).connectedVMServices = vmServices;
+  }) {
+    final Completer<void> completer = Completer<void>();
+    StreamSubscription<void> subscription;
+    subscription = observatoryUris.listen((Uri observatoryUri) async {
+      try {
+        final VMService service = await VMService.connect(
+          observatoryUri,
+          reloadSources: reloadSources,
+          restart: restart,
+          compileExpression: compileExpression,
+        );
+        if (completer.isCompleted) {
+          return;
+        }
+        printTrace('Successfully connected to service protocol: $observatoryUri');
+
+        vmServices = <VMService>[service];
+        device.getLogReader(app: package).connectedVMServices = vmServices;
+        completer.complete();
+        await subscription.cancel();
+      } catch (exception) {
+        printTrace('Fail to connect to service protocol: $observatoryUri: $exception');
+      }
+    });
+    return completer.future;
   }
 
   Future<void> refreshViews() async {
@@ -431,9 +439,13 @@ class FlutterDevice {
       return 2;
     }
     if (result.hasObservatory) {
-      observatoryUris = <Uri>[result.observatoryUri];
+      observatoryUris = Stream<Uri>
+        .value(result.observatoryUri)
+        .asBroadcastStream();
     } else {
-      observatoryUris = <Uri>[];
+      observatoryUris = const Stream<Uri>
+        .empty()
+        .asBroadcastStream();
     }
     return 0;
   }
@@ -491,9 +503,13 @@ class FlutterDevice {
       return 2;
     }
     if (result.hasObservatory) {
-      observatoryUris = <Uri>[result.observatoryUri];
+      observatoryUris = Stream<Uri>
+        .value(result.observatoryUri)
+        .asBroadcastStream();
     } else {
-      observatoryUris = <Uri>[];
+      observatoryUris = const Stream<Uri>
+        .empty()
+        .asBroadcastStream();
     }
     return 0;
   }
@@ -613,14 +629,14 @@ abstract class ResidentRunner {
   /// The parent location of the incremental artifacts.
   @visibleForTesting
   final Directory artifactDirectory;
-  final Completer<int> _finished = Completer<int>();
   final String packagesFilePath;
   final String projectRootPath;
   final String mainPath;
   final AssetBundle assetBundle;
 
   bool _exited = false;
-  bool hotMode ;
+  Completer<int> _finished = Completer<int>();
+  bool hotMode;
 
   String get dillOutputPath => _dillOutputPath ?? fs.path.join(artifactDirectory.path, 'app.dill');
   String getReloadPath({ bool fullRestart }) => mainPath + (fullRestart ? '' : '.incremental') + '.dill';
@@ -630,6 +646,9 @@ abstract class ResidentRunner {
   bool get isRunningProfile => debuggingOptions.buildInfo.isProfile;
   bool get isRunningRelease => debuggingOptions.buildInfo.isRelease;
   bool get supportsServiceProtocol => isRunningDebug || isRunningProfile;
+
+  /// Returns [true] if the resident runner exited after invoking [exit()].
+  bool get exited => _exited;
 
   /// Whether this runner can hot restart.
   ///
@@ -862,6 +881,8 @@ abstract class ResidentRunner {
       throw 'The service protocol is not enabled.';
     }
 
+    _finished ??= Completer<int>();
+
     bool viewFound = false;
     for (FlutterDevice device in flutterDevices) {
       await device.connect(
@@ -912,22 +933,25 @@ abstract class ResidentRunner {
       // User requested the application exit.
       return;
     }
-    if (_finished.isCompleted) {
+    if (_finished == null || _finished.isCompleted) {
       return;
     }
     printStatus('Lost connection to device.');
     _finished.complete(0);
+    _finished = null;
   }
 
   void appFinished() {
-    if (_finished.isCompleted) {
+    if (_finished == null || _finished.isCompleted) {
       return;
     }
     printStatus('Application finished.');
     _finished.complete(0);
+    _finished = null;
   }
 
   Future<int> waitForAppToFinish() async {
+    _finished ??= Completer<int>();
     final int exitCode = await _finished.future;
     assert(exitCode != null);
     await cleanupAtFinish();
@@ -1045,15 +1069,33 @@ class TerminalHandler {
     subscription = terminal.keystrokes.listen(processTerminalInput);
   }
 
+
+  final Map<io.ProcessSignal, Object> _signalTokens = <io.ProcessSignal, Object>{};
+
+  void _addSignalHandler(io.ProcessSignal signal, SignalHandler handler) {
+    _signalTokens[signal] = signals.addHandler(signal, handler);
+  }
+
   void registerSignalHandlers() {
     assert(residentRunner.stayResident);
-    signals.addHandler(io.ProcessSignal.SIGINT, _cleanUp);
-    signals.addHandler(io.ProcessSignal.SIGTERM, _cleanUp);
+
+    _addSignalHandler(io.ProcessSignal.SIGINT, _cleanUp);
+    _addSignalHandler(io.ProcessSignal.SIGTERM, _cleanUp);
     if (!residentRunner.supportsServiceProtocol || !residentRunner.supportsRestart) {
       return;
     }
-    signals.addHandler(io.ProcessSignal.SIGUSR1, _handleSignal);
-    signals.addHandler(io.ProcessSignal.SIGUSR2, _handleSignal);
+    _addSignalHandler(io.ProcessSignal.SIGUSR1, _handleSignal);
+    _addSignalHandler(io.ProcessSignal.SIGUSR2, _handleSignal);
+  }
+
+  /// Unregisters terminal signal and keystroke handlers.
+  void stop() {
+    assert(residentRunner.stayResident);
+    for (MapEntry<io.ProcessSignal, Object> entry in _signalTokens.entries) {
+      signals.removeHandler(entry.key, entry.value);
+    }
+    _signalTokens.clear();
+    subscription.cancel();
   }
 
   /// Returns [true] if the input has been handled by this function.

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -194,6 +194,8 @@ class FlutterDevice {
       device.getLogReader(app: package).connectedVMServices = vmServices;
       completer.complete();
       await subscription.cancel();
+    }, onError: (dynamic error) {
+      printTrace('Fail to handle observatory URI: $error');
     }, onDone: () {
       _isStreamingNewObservatoryUri = false;
       if (!completer.isCompleted && !isWaitingForVm) {

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -176,7 +176,7 @@ class FlutterDevice {
           restart: restart,
           compileExpression: compileExpression,
         );
-      } catch (exception) {
+      } on Exception catch (exception) {
         printTrace('Fail to connect to service protocol: $observatoryUri: $exception');
         if (!completer.isCompleted && !_isListeningForObservatoryUri) {
           completer.completeError('failed to connect to $observatoryUri');

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -83,7 +83,7 @@ class ColdRunner extends ResidentRunner {
     if (flutterDevices.first.observatoryUris != null) {
       // For now, only support one debugger connection.
       connectionInfoCompleter?.complete(DebugConnectionInfo(
-        httpUri: flutterDevices.first.observatoryUris.first,
+        httpUri: flutterDevices.first.vmServices.first.httpAddress,
         wsUri: flutterDevices.first.vmServices.first.wsAddress,
       ));
     }
@@ -184,9 +184,8 @@ class ColdRunner extends ResidentRunner {
     for (FlutterDevice device in flutterDevices) {
       final String dname = device.device.name;
       if (device.observatoryUris != null) {
-        for (Uri uri in device.observatoryUris) {
-          printStatus('An Observatory debugger and profiler on $dname is available at $uri');
-          haveAnything = true;
+        for (VMService vm in device.vmServices) {
+          printStatus('An Observatory debugger and profiler on $dname is available at: ${vm.wsAddress}');
         }
       }
     }

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -180,7 +180,7 @@ class HotRunner extends ResidentRunner {
         // Only handle one debugger connection.
         connectionInfoCompleter.complete(
           DebugConnectionInfo(
-            httpUri: flutterDevices.first.observatoryUris.first,
+            httpUri: flutterDevices.first.vmServices.first.httpAddress,
             wsUri: flutterDevices.first.vmServices.first.wsAddress,
             baseUri: baseUris.first.toString(),
           ),
@@ -987,8 +987,8 @@ class HotRunner extends ResidentRunner {
     printStatus(message);
     for (FlutterDevice device in flutterDevices) {
       final String dname = device.device.name;
-      for (Uri uri in device.observatoryUris) {
-        printStatus('An Observatory debugger and profiler on $dname is available at: $uri');
+      for (VMService vm in device.vmServices) {
+        printStatus('An Observatory debugger and profiler on $dname is available at: ${vm.wsAddress}');
       }
     }
     final String quitMessage = _didAttach

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -247,10 +247,8 @@ void main() {
       testUsingContext('accepts filesystem parameters', () async {
         when(device.getLogReader()).thenAnswer((_) {
           // Now that the reader is used, start writing messages to it.
-          Timer.run(() {
-            mockLogReader.addLine('Foo');
-            mockLogReader.addLine('Observatory listening on http://127.0.0.1:$devicePort');
-          });
+          mockLogReader.addLine('Foo');
+          mockLogReader.addLine('Observatory listening on http://127.0.0.1:$devicePort');
           return mockLogReader;
         });
         testDeviceManager.addDevice(device);

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -84,7 +84,7 @@ void main() {
         testDeviceManager.addDevice(device);
         final Completer<void> completer = Completer<void>();
         final StreamSubscription<String> loggerSubscription = logger.stream.listen((String message) {
-          if (message == '[verbose] Observatory URL on device: http://127.0.0.1:499') {
+          if (message == '[verbose] Observatory URL on device: http://127.0.0.1:$devicePort') {
             // The "Observatory URL on device" message is output by the ProtocolDiscovery when it found the observatory.
             completer.complete();
           }

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -7,16 +7,20 @@ import 'dart:async';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/attach.dart';
+import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
 import 'package:flutter_tools/src/mdns_discovery.dart';
+import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:flutter_tools/src/run_hot.dart';
+import 'package:flutter_tools/src/vmservice.dart';
 import 'package:meta/meta.dart';
 import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
@@ -25,6 +29,7 @@ import 'package:quiver/testing/async.dart';
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/mocks.dart';
+
 
 void main() {
   group('attach', () {
@@ -50,11 +55,16 @@ void main() {
       MockDeviceLogReader mockLogReader;
       MockPortForwarder portForwarder;
       MockAndroidDevice device;
+      MockProcessManager mockProcessManager;
+      MockHttpClient httpClient;
+      Completer<void> vmServiceDoneCompleter;
 
       setUp(() {
+        mockProcessManager = MockProcessManager();
         mockLogReader = MockDeviceLogReader();
         portForwarder = MockPortForwarder();
         device = MockAndroidDevice();
+        vmServiceDoneCompleter = Completer<void>();
         when(device.portForwarder)
           .thenReturn(portForwarder);
         when(portForwarder.forward(devicePort, hostPort: anyNamed('hostPort')))
@@ -63,6 +73,14 @@ void main() {
           .thenReturn(<ForwardedPort>[ForwardedPort(hostPort, devicePort)]);
         when(portForwarder.unforward(any))
           .thenAnswer((_) async => null);
+
+        final HttpClientRequest httpClientRequest = MockHttpClientRequest();
+        httpClient = MockHttpClient();
+        when(httpClient.putUrl(any))
+          .thenAnswer((_) => Future<HttpClientRequest>.value(httpClientRequest));
+        when(httpClientRequest.headers).thenReturn(MockHttpHeaders());
+        when(httpClientRequest.close())
+          .thenAnswer((_) => Future<HttpClientResponse>.value(MockHttpClientResponse()));
 
         // We cannot add the device to a device manager because that is
         // only enabled by the context of each testUsingContext call.
@@ -105,53 +123,108 @@ void main() {
       });
 
       testUsingContext('finds all observatory ports and forwards them', () async {
+        testFileSystem.file(testFileSystem.path.join('.packages')).createSync();
+        testFileSystem.file(testFileSystem.path.join('lib', 'main.dart')).createSync();
+        testFileSystem
+          .file(testFileSystem.path.join('build', 'flutter_assets', 'AssetManifest.json'))
+          ..createSync(recursive: true)
+          ..writeAsStringSync('{}');
+
+        when(device.name).thenReturn('MockAndroidDevice');
         when(device.getLogReader()).thenReturn(mockLogReader);
+
+        final Process dartProcess = MockProcess();
+        final StreamController<List<int>> compilerStdoutController = StreamController<List<int>>();
+
+        when(dartProcess.stdout).thenAnswer((_) => compilerStdoutController.stream);
+        when(dartProcess.stderr)
+          .thenAnswer((_) => Stream<List<int>>.fromFuture(Future<List<int>>.value(const <int>[])));
+
+        when(dartProcess.stdin).thenAnswer((_) => MockStdIn());
+
+        final Completer<int> dartProcessExitCode = Completer<int>();
+        when(dartProcess.exitCode).thenAnswer((_) => dartProcessExitCode.future);
+        when(mockProcessManager.start(any)).thenAnswer((_) => Future<Process>.value(dartProcess));
+
         testDeviceManager.addDevice(device);
 
         final List<String> observatoryLogs = <String>[];
-        final StreamSubscription<String> loggerSubscription = logger.stream.listen((String message) {
-          if (message.startsWith('[verbose] Observatory URL on device')) {
-            observatoryLogs.add(message);
-          }
-        });
 
-        FakeAsync().run((FakeAsync time) {
+        await FakeAsync().run((FakeAsync time) {
           unawaited(runZoned(() async {
-            final Future<void> task = createTestCommandRunner(AttachCommand()).run(<String>['attach']);
+            final StreamSubscription<String> loggerSubscription = logger.stream.listen((String message) {
+              // The "Observatory URL on device" message is output by the ProtocolDiscovery when it found the observatory.
+              if (message.startsWith('[verbose] Observatory URL on device')) {
+                observatoryLogs.add(message);
+              }
+              if (message == '[stdout] Waiting for a connection from Flutter on MockAndroidDevice...') {
+                observatoryLogs.add(message);
+              }
+              if (message == '[stdout] Lost connection to device.') {
+                observatoryLogs.add(message);
+              }
+              if (message.contains('To hot reload changes while running, press "r". To hot restart (and rebuild state), press "R".')) {
+                observatoryLogs.add(message);
+              }
+            });
 
+            final TestHotRunnerFactory testHotRunnerFactory = TestHotRunnerFactory();
+            final Future<void> task = createTestCommandRunner(
+              AttachCommand(hotRunnerFactory: testHotRunnerFactory)
+            ).run(<String>['attach']);
+
+            // First iteration of the attach loop.
             mockLogReader.addLine('Observatory listening on http://127.0.0.1:0001');
             mockLogReader.addLine('Observatory listening on http://127.0.0.1:1234');
 
             time.elapse(const Duration(milliseconds: 200));
 
+            compilerStdoutController
+              .add(utf8.encode('result abc\nline1\nline2\nabc\nabc /path/to/main.dart.dill 0\n'));
+            time.flushMicrotasks();
+
+            testHotRunnerFactory.fakeAppFinishedUnexpectedly();
+            time.flushMicrotasks();
+
+            // Second iteration of the attach loop.
             mockLogReader.addLine('Observatory listening on http://127.0.0.1:0002');
             mockLogReader.addLine('Observatory listening on http://127.0.0.1:1235');
 
             time.elapse(const Duration(milliseconds: 200));
 
-            expect(observatoryLogs.length, 2);
-            expect(observatoryLogs[0], '[verbose] Observatory URL on device: http://127.0.0.1:1234');
-            expect(observatoryLogs[1], '[verbose] Observatory URL on device: http://127.0.0.1:1235');
+            compilerStdoutController
+              .add(utf8.encode('result abc\nline1\nline2\nabc\nabc /path/to/main.dart.dill 0\n'));
+            time.flushMicrotasks();
 
-            verify(
-              portForwarder.forward(1234, hostPort: anyNamed('hostPort')),
-            ).called(1);
+            dartProcessExitCode.complete(0);
 
-            verify(
-              portForwarder.forward(1235, hostPort: anyNamed('hostPort')),
-            ).called(1);
-
-            await mockLogReader.dispose();
-            await expectLoggerInterruptEndsTask(task, logger);
             await loggerSubscription.cancel();
+            await testHotRunnerFactory.exitApp();
+            await task;
           }));
         });
+
+        expect(observatoryLogs.length, 7);
+        expect(observatoryLogs[0], '[stdout] Waiting for a connection from Flutter on MockAndroidDevice...');
+        expect(observatoryLogs[1], '[verbose] Observatory URL on device: http://127.0.0.1:1234');
+        expect(observatoryLogs[2], '[stdout] Lost connection to device.');
+        expect(observatoryLogs[3].contains('To hot reload changes while running, press "r". To hot restart (and rebuild state), press "R"'), isTrue);
+        expect(observatoryLogs[4], '[verbose] Observatory URL on device: http://127.0.0.1:1235');
+        expect(observatoryLogs[5], '[stdout] Lost connection to device.');
+        expect(observatoryLogs[6].contains('To hot reload changes while running, press "r". To hot restart (and rebuild state), press "R"'), isTrue);
+
+        verify(portForwarder.forward(1234, hostPort: anyNamed('hostPort'))).called(1);
+        verify(portForwarder.forward(1235, hostPort: anyNamed('hostPort'))).called(1);
+
       }, overrides: <Type, Generator>{
         FileSystem: () => testFileSystem,
-        ProcessManager: () => FakeProcessManager.any(),
+        HttpClient: () => httpClient,
+        ProcessManager: () => mockProcessManager,
         Logger: () => logger,
+        VMServiceConnector: () => getFakeVmServiceFactory(
+          vmServiceDoneCompleter: vmServiceDoneCompleter,
+        ),
       });
-
 
       testUsingContext('Fails with tool exit on bad Observatory uri', () async {
         when(device.getLogReader()).thenAnswer((_) {
@@ -615,3 +688,89 @@ Future<void> expectLoggerInterruptEndsTask(Future<void> task, StreamLogger logge
     expect(error.exitCode, 2); // ...with exit code 2.
   }
 }
+
+VMServiceConnector getFakeVmServiceFactory({
+  @required Completer<void> vmServiceDoneCompleter,
+}) {
+  assert(vmServiceDoneCompleter != null);
+
+  return (
+    Uri httpUri, {
+    ReloadSources reloadSources,
+    Restart restart,
+    CompileExpression compileExpression,
+    CompressionOptions compression,
+  }) async {
+    final VMService vmService = VMServiceMock();
+    final VM vm = VMMock();
+
+    when(vmService.vm).thenReturn(vm);
+    when(vmService.isClosed).thenReturn(false);
+    when(vmService.done).thenAnswer((_) {
+      return Future<void>.value(null);
+    });
+
+    when(vm.refreshViews(waitForViews: anyNamed('waitForViews')))
+      .thenAnswer((_) => Future<void>.value(null));
+    when(vm.views)
+      .thenReturn(<FlutterView>[FlutterViewMock()]);
+    when(vm.createDevFS(any))
+      .thenAnswer((_) => Future<Map<String, dynamic>>.value(<String, dynamic>{'uri': '/',}));
+
+    return vmService;
+  };
+}
+
+class TestHotRunnerFactory extends HotRunnerFactory {
+  HotRunner _runner;
+
+  @override
+  HotRunner build(
+    List<FlutterDevice> devices, {
+    String target,
+    DebuggingOptions debuggingOptions,
+    bool benchmarkMode = false,
+    File applicationBinary,
+    bool hostIsIde = false,
+    String projectRootPath,
+    String packagesFilePath,
+    String dillOutputPath,
+    bool stayResident = true,
+    bool ipv6 = false,
+    FlutterProject flutterProject,
+  }) {
+    _runner ??= HotRunner(
+      devices,
+      target: target,
+      debuggingOptions: debuggingOptions,
+      benchmarkMode: benchmarkMode,
+      applicationBinary: applicationBinary,
+      hostIsIde: hostIsIde,
+      projectRootPath: projectRootPath,
+      packagesFilePath: packagesFilePath,
+      dillOutputPath: dillOutputPath,
+      stayResident: stayResident,
+      ipv6: ipv6,
+    );
+    return _runner;
+  }
+
+  void fakeAppFinishedUnexpectedly() {
+    assert(_runner != null);
+    _runner.appFinished();
+  }
+
+  Future<void> exitApp() async {
+    assert(_runner != null);
+    await _runner.exit();
+  }
+}
+
+class VMMock extends Mock implements VM {}
+class VMServiceMock extends Mock implements VMService {}
+class FlutterViewMock extends Mock implements FlutterView {}
+class MockProcessManager extends Mock implements ProcessManager {}
+class MockProcess extends Mock implements Process {}
+class MockHttpClientRequest extends Mock implements HttpClientRequest {}
+class MockHttpClientResponse extends Mock implements HttpClientResponse {}
+class MockHttpHeaders extends Mock implements HttpHeaders {}

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/net.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/cache.dart';
@@ -218,7 +219,7 @@ void main() {
 
       }, overrides: <Type, Generator>{
         FileSystem: () => testFileSystem,
-        HttpClient: () => httpClient,
+        HttpClientFactory: () => () => httpClient,
         ProcessManager: () => mockProcessManager,
         Logger: () => logger,
         VMServiceConnector: () => getFakeVmServiceFactory(
@@ -263,7 +264,7 @@ void main() {
         when(mockHotRunner.attach(appStartedCompleter: anyNamed('appStartedCompleter')))
             .thenAnswer((_) async => 0);
         when(mockHotRunner.exited).thenReturn(false);
-        when(mockHotRunner.isStreamingNewObservatoryUris).thenReturn(false);
+        when(mockHotRunner.isWaitingForObservatory).thenReturn(false);
 
         final MockHotRunnerFactory mockHotRunnerFactory = MockHotRunnerFactory();
         when(
@@ -396,7 +397,7 @@ void main() {
         ipv6: false,
       )).thenReturn(mockHotRunner);
       when(mockHotRunner.exited).thenReturn(false);
-      when(mockHotRunner.isStreamingNewObservatoryUris).thenReturn(false);
+      when(mockHotRunner.isWaitingForObservatory).thenReturn(false);
 
       testDeviceManager.addDevice(device);
       when(device.getLogReader())

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -10,6 +10,7 @@ import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/net.dart';
 import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/vmservice.dart';
@@ -159,7 +160,7 @@ void main() {
       verify(httpRequest.close()).called(kFailedAttempts + 1);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
-      HttpClient: () => httpClient,
+      HttpClientFactory: () => () => httpClient,
       ProcessManager: () => FakeProcessManager.any(),
     });
   });
@@ -209,7 +210,7 @@ void main() {
       expect(report.success, true);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
-      HttpClient: () => HttpClient(),
+      HttpClient: () => () => HttpClient(),
       ProcessManager: () => FakeProcessManager.any(),
     });
 
@@ -312,7 +313,7 @@ void main() {
       expect(devFS.lastCompiled, isNot(previousCompile));
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
-      HttpClient: () => HttpClient(),
+      HttpClient: () => () => HttpClient(),
       ProcessManager: () => FakeProcessManager.any(),
     });
   });

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -159,6 +159,7 @@ void main() {
       verify(httpRequest.close()).called(kFailedAttempts + 1);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      HttpClient: () => httpClient,
       ProcessManager: () => FakeProcessManager.any(),
     });
   });
@@ -208,6 +209,7 @@ void main() {
       expect(report.success, true);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      HttpClient: () => HttpClient(),
       ProcessManager: () => FakeProcessManager.any(),
     });
 
@@ -310,6 +312,7 @@ void main() {
       expect(devFS.lastCompiled, isNot(previousCompile));
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
+      HttpClient: () => HttpClient(),
       ProcessManager: () => FakeProcessManager.any(),
     });
   });

--- a/packages/flutter_tools/test/general.shard/protocol_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/protocol_discovery_test.dart
@@ -17,37 +17,42 @@ void main() {
     MockDeviceLogReader logReader;
     ProtocolDiscovery discoverer;
 
-    group('no port forwarding', () {
-      /// Performs test set-up functionality that must be performed as part of
-      /// the `test()` pass and not part of the `setUp()` pass.
-      ///
-      /// This exists to make sure we're not creating an error that tries to
-      /// cross an error-zone boundary. Our use of `testUsingContext()` runs the
-      /// test code inside an error zone, but the `setUp()` code is not run in
-      /// any zone. This creates the potential for errors that try to cross
-      /// error-zone boundaries, which are considered uncaught.
-      ///
-      /// This also exists for cases where our initialization requires access to
-      /// a `Context` object, which is only set up inside the zone.
-      ///
-      /// These issues do not pertain to real code and are a test-only concern,
-      /// because in real code, the zone is set up in `main()`.
-      ///
-      /// See also: [runZoned]
-      void initialize({
-        int devicePort,
-        int throttleTimeInMilliseconds = 200,
-      }) {
-        logReader = MockDeviceLogReader();
-        discoverer = ProtocolDiscovery.observatory(
-          logReader,
-          ipv6: false,
-          hostPort: null,
-          devicePort: devicePort,
-          throttleTimeInMilliseconds: throttleTimeInMilliseconds,
-        );
-      }
+    /// Performs test set-up functionality that must be performed as part of
+    /// the `test()` pass and not part of the `setUp()` pass.
+    ///
+    /// This exists to make sure we're not creating an error that tries to
+    /// cross an error-zone boundary. Our use of `testUsingContext()` runs the
+    /// test code inside an error zone, but the `setUp()` code is not run in
+    /// any zone. This creates the potential for errors that try to cross
+    /// error-zone boundaries, which are considered uncaught.
+    ///
+    /// This also exists for cases where our initialization requires access to
+    /// a `Context` object, which is only set up inside the zone.
+    ///
+    /// These issues do not pertain to real code and are a test-only concern,
+    /// because in real code, the zone is set up in `main()`.
+    ///
+    /// See also: [runZoned]
+    void initialize({
+      int devicePort,
+      int throttleTimeInMilliseconds = 200,
+    }) {
+      logReader = MockDeviceLogReader();
+      discoverer = ProtocolDiscovery.observatory(
+        logReader,
+        ipv6: false,
+        hostPort: null,
+        devicePort: devicePort,
+        throttleTimeInMilliseconds: throttleTimeInMilliseconds,
+      );
+    }
 
+    testUsingContext('returns non-null uri future', () async {
+      initialize();
+      expect(discoverer.uri, isNotNull);
+    });
+
+    group('no port forwarding', () {
       tearDown(() {
         discoverer.cancel();
         logReader.dispose();

--- a/packages/flutter_tools/test/general.shard/protocol_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/protocol_discovery_test.dart
@@ -35,7 +35,7 @@ void main() {
     /// See also: [runZoned]
     void initialize({
       int devicePort,
-      int throttleTimeInMilliseconds = 200,
+      Duration throttleDuration = const Duration(milliseconds: 200),
     }) {
       logReader = MockDeviceLogReader();
       discoverer = ProtocolDiscovery.observatory(
@@ -43,7 +43,7 @@ void main() {
         ipv6: false,
         hostPort: null,
         devicePort: devicePort,
-        throttleTimeInMilliseconds: throttleTimeInMilliseconds,
+        throttleDuration: throttleDuration,
       );
     }
 
@@ -170,10 +170,10 @@ void main() {
       });
 
       testUsingContext('uris in the stream are throttled', () async {
-        const int kThrottleTimeInMilliseconds = 10;
+        const Duration kThrottleDuration = Duration(milliseconds: 10);
 
         FakeAsync().run((FakeAsync time) {
-          initialize(throttleTimeInMilliseconds: kThrottleTimeInMilliseconds);
+          initialize(throttleDuration: kThrottleDuration);
 
           final List<Uri> discoveredUris = <Uri>[];
           discoverer.uris.listen((Uri uri) {
@@ -183,12 +183,12 @@ void main() {
           logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
           logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
 
-          time.elapse(const Duration(milliseconds: kThrottleTimeInMilliseconds));
+          time.elapse(kThrottleDuration);
 
           logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:12344/PTwjm8Ii8qg=/');
           logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:12343/PTwjm8Ii8qg=/');
 
-          time.elapse(const Duration(milliseconds: kThrottleTimeInMilliseconds));
+          time.elapse(kThrottleDuration);
 
           expect(discoveredUris.length, 2);
           expect(discoveredUris[0].port, 12345);
@@ -199,12 +199,12 @@ void main() {
       });
 
       testUsingContext('uris in the stream are throttled when they match the port', () async {
-        const int kThrottleTimeInMilliseconds = 10;
+        const Duration kThrottleTimeInMilliseconds = Duration(milliseconds: 10);
 
         FakeAsync().run((FakeAsync time) {
           initialize(
             devicePort: 12345,
-            throttleTimeInMilliseconds: kThrottleTimeInMilliseconds,
+            throttleDuration: kThrottleTimeInMilliseconds,
           );
 
           final List<Uri> discoveredUris = <Uri>[];
@@ -215,12 +215,12 @@ void main() {
           logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
           logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
 
-          time.elapse(const Duration(milliseconds: kThrottleTimeInMilliseconds));
+          time.elapse(kThrottleTimeInMilliseconds);
 
           logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:12345/PTwjm8Ii8qc=/');
           logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:12344/PTwjm8Ii8qf=/');
 
-          time.elapse(const Duration(milliseconds: kThrottleTimeInMilliseconds));
+          time.elapse(kThrottleTimeInMilliseconds);
 
           expect(discoveredUris.length, 2);
           expect(discoveredUris[0].port, 12345);

--- a/packages/flutter_tools/test/general.shard/protocol_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/protocol_discovery_test.dart
@@ -86,9 +86,7 @@ void main() {
 
       testUsingContext('uri throws if logs produce bad line', () async {
         initialize();
-        Timer.run(() {
-          logReader.addLine('Observatory listening on http://127.0.0.1:apple');
-        });
+        logReader.addLine('Observatory listening on http://127.0.0.1:apple');
         expect(discoverer.uri, throwsA(isFormatException));
       });
 

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -95,9 +95,7 @@ void main() {
     when(mockFlutterView.uiIsolate).thenReturn(mockIsolate);
     when(mockFlutterView.runFromSource(any, any, any)).thenAnswer((Invocation invocation) async {});
     when(mockFlutterDevice.stopEchoingDeviceLog()).thenAnswer((Invocation invocation) async { });
-    when(mockFlutterDevice.observatoryUris).thenReturn(<Uri>[
-      testUri,
-    ]);
+    when(mockFlutterDevice.observatoryUris).thenAnswer((_) => Stream<Uri>.value(testUri));
     when(mockFlutterDevice.connect(
       reloadSources: anyNamed('reloadSources'),
       restart: anyNamed('restart'),
@@ -636,7 +634,7 @@ void main() {
     final TestFlutterDevice flutterDevice = TestFlutterDevice(
       mockDevice,
       <FlutterView>[],
-      observatoryUris: <Uri>[ testUri ]
+      observatoryUris: Stream<Uri>.value(testUri),
     );
 
     await flutterDevice.connect();
@@ -657,7 +655,7 @@ class MockUsage extends Mock implements Usage {}
 class MockProcessManager extends Mock implements ProcessManager {}
 class MockServiceEvent extends Mock implements ServiceEvent {}
 class TestFlutterDevice extends FlutterDevice {
-  TestFlutterDevice(Device device, this.views, { List<Uri> observatoryUris })
+  TestFlutterDevice(Device device, this.views, { Stream<Uri> observatoryUris })
     : super(device, buildMode: BuildMode.debug, trackWidgetCreation: false) {
     _observatoryUris = observatoryUris;
   }
@@ -666,8 +664,8 @@ class TestFlutterDevice extends FlutterDevice {
   final List<FlutterView> views;
 
   @override
-  List<Uri> get observatoryUris => _observatoryUris;
-  List<Uri> _observatoryUris;
+  Stream<Uri> get observatoryUris => _observatoryUris;
+  Stream<Uri> _observatoryUris;
 }
 
 class ThrowingForwardingFileSystem extends ForwardingFileSystem {

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -563,16 +563,33 @@ class MockDeviceLogReader extends DeviceLogReader {
   @override
   String get name => 'MockLogReader';
 
-  final StreamController<String> _linesController = StreamController<String>.broadcast();
+  StreamController<String> _cachedLinesController;
+
+  final List<String> _lineQueue = <String>[];
+  StreamController<String> get _linesController {
+    _cachedLinesController ??= StreamController<String>
+      .broadcast(onListen: () {
+        _lineQueue.forEach(_linesController.add);
+        _lineQueue.clear();
+     });
+    return _cachedLinesController;
+  }
 
   @override
   Stream<String> get logLines => _linesController.stream;
 
-  void addLine(String line) => _linesController.add(line);
+  void addLine(String line) {
+    if (_linesController.hasListener) {
+      _linesController.add(line);
+    } else {
+      _lineQueue.add(line);
+    }
+  }
 
   @override
-  void dispose() {
-    _linesController.close();
+  Future<void> dispose() async {
+    _lineQueue.clear();
+    await _linesController.close();
   }
 }
 

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -534,6 +534,12 @@ class MockAndroidDevice extends Mock implements AndroidDevice {
   bool isSupported() => true;
 
   @override
+  bool get supportsHotRestart => true;
+
+  @override
+  bool get supportsFlutterExit => false;
+
+  @override
   bool isSupportedForProject(FlutterProject flutterProject) => true;
 }
 


### PR DESCRIPTION
## Description

I refactored the the protocol discovery mechanism, so it looks at future observatory URIs instead of old ones.  I'm sending this PR to get early feedback. I will then add unit tests.

The main change is that `observatoryUri` becomes a `Stream` of `Uri`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
