### PR TITLE
Add module to create template help text

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -85,8 +85,8 @@ class CreateCommand extends FlutterCommand {
         getEnumName(_ProjectType.plugin): 'Generate a shareable Flutter project containing an API '
             'in Dart code with a platform-specific implementation for Android, for iOS code, or '
             'for both.',
-        getEnumName(_ProjectType.module): 'Generate a project to add a Flutter module to existing '
-            'Android or iOS applications.',
+        getEnumName(_ProjectType.module): 'Generate a project to add a Flutter module to an '
+            'existing Android or iOS application.',
       },
       defaultsTo: null,
     );

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -85,6 +85,8 @@ class CreateCommand extends FlutterCommand {
         getEnumName(_ProjectType.plugin): 'Generate a shareable Flutter project containing an API '
             'in Dart code with a platform-specific implementation for Android, for iOS code, or '
             'for both.',
+        getEnumName(_ProjectType.module): 'Generate a Flutter project to add Flutter views to a non-'
+          'Flutter Android or iOS application.',
       },
       defaultsTo: null,
     );

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -85,8 +85,8 @@ class CreateCommand extends FlutterCommand {
         getEnumName(_ProjectType.plugin): 'Generate a shareable Flutter project containing an API '
             'in Dart code with a platform-specific implementation for Android, for iOS code, or '
             'for both.',
-        getEnumName(_ProjectType.module): 'Generate a Flutter project to add Flutter views to a non-'
-          'Flutter Android or iOS application.',
+        getEnumName(_ProjectType.module): 'Generate a project to add a Flutter module to existing '
+            'Android or iOS applications.',
       },
       defaultsTo: null,
     );


### PR DESCRIPTION
## Description
Add module to help text.
```
$ flutter create -h
...
-t, --template=<type>          Specify the type of project to create.

          [app]                (default) Generate a Flutter application.
          [module]             Generate a Flutter project to add Flutter views to a non-Flutter Android or iOS application.
          [package]            Generate a shareable Flutter project containing modular Dart code.
          [plugin]             Generate a shareable Flutter project containing an API in Dart code with a platform-specific implementation for Android, for iOS code, or for both.
...
```

## Related Issues

Fixes https://github.com/flutter/flutter/issues/32259.
