### PR TITLE
Fixes bug where route navigation rebuilds all below materialApp

### DIFF
--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -108,7 +108,7 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
     @required this.builder,
     this.title,
     RouteSettings settings,
-    this.opaque = false,
+    this.opaque = true,
     this.maintainState = true,
     bool fullscreenDialog = false,
   }) : assert(builder != null),
@@ -174,6 +174,9 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
   @override
   Color get barrierColor => null;
   
+  /// Allows you to set opaque to false to prevent route reconstruction. 
+  /// The default behavior is true, and declaring false can have side effects. 
+  /// Use caution and awareness that rebuilding is necessary to properly display the back button.
   @override
   final bool opaque;
 

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -108,12 +108,13 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
     @required this.builder,
     this.title,
     RouteSettings settings,
+    this.opaque = false,
     this.maintainState = true,
     bool fullscreenDialog = false,
   }) : assert(builder != null),
        assert(maintainState != null),
        assert(fullscreenDialog != null),
-       assert(opaque),
+       assert(opaque != null),
        super(settings: settings, fullscreenDialog: fullscreenDialog);
 
   /// Builds the primary contents of the route.
@@ -172,6 +173,9 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
 
   @override
   Color get barrierColor => null;
+  
+  @override
+  final bool opaque;
 
   @override
   String get barrierLabel => null;

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -43,7 +43,7 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   MaterialPageRoute({
     @required this.builder,
     RouteSettings settings,
-    this.opaque = false,
+    this.opaque = true,
     this.maintainState = true,
     bool fullscreenDialog = false,
   }) : assert(builder != null),
@@ -58,6 +58,9 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   @override
   final bool maintainState;
   
+  /// Allows you to set opaque to false to prevent route reconstruction. 
+  /// The default behavior is true, and declaring false can have side effects. 
+  /// Use caution and awareness that rebuilding is necessary to properly display the back button.
   @override
   final bool opaque;
 

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -43,12 +43,13 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   MaterialPageRoute({
     @required this.builder,
     RouteSettings settings,
+    this.opaque = false,
     this.maintainState = true,
     bool fullscreenDialog = false,
   }) : assert(builder != null),
        assert(maintainState != null),
        assert(fullscreenDialog != null),
-       assert(opaque),
+       assert(opaque != null),
        super(settings: settings, fullscreenDialog: fullscreenDialog);
 
   /// Builds the primary contents of the route.
@@ -56,6 +57,9 @@ class MaterialPageRoute<T> extends PageRoute<T> {
 
   @override
   final bool maintainState;
+  
+  @override
+  final bool opaque;
 
   @override
   Duration get transitionDuration => const Duration(milliseconds: 300);

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -254,6 +254,7 @@ void main() {
       },
     );
 
+    
     tester.state<NavigatorState>(find.byType(Navigator)).push(route2);
 
     await tester.pump();

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -5,7 +5,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import '../rendering/mock_canvas.dart';
 
 void main() {


### PR DESCRIPTION
## Description

This issue fixes unexpected MaterialApp rebuild errors when MaterialRoutePage or CupertinoRoutePage is called.

## Related Issues

opaque should be false for Screens Navigators, and true only for modals (ShowDialog should darken the rest of the screen).
MaterialPageRoute and CupertinoPageRoute navigation are inheriting "true" from PageRoute <T>, which causes an unexpected app rebuild bug.
For large apps with many routes (+20 Navigator.push) this can greatly degrade performance. Since all previous pages that are still in the widget tree will be rebuilt.
This pull fixes the errors in:

https://github.com/flutter/flutter/issues/39770
https://github.com/flutter/flutter/issues/11655
https://github.com/flutter/flutter/issues/29800
https://github.com/flutter/flutter/issues/16117
https://github.com/flutter/flutter/issues/11655

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behaviour with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
