### PR TITLE
Sort Localization generation output

### DIFF
--- a/dev/tools/localization/gen_localizations.dart
+++ b/dev/tools/localization/gen_localizations.dart
@@ -99,7 +99,7 @@ String generateArbBasedLocalizationSubclasses({
     }
     languageToLocales[locale.languageCode] ??= <LocaleInfo>[];
     languageToLocales[locale.languageCode].add(locale);
-    allResourceIdentifiers.addAll(localeToResources[locale].keys);
+    allResourceIdentifiers.addAll(localeToResources[locale].keys.toList()..sort());
   }
 
   // We generate one class per supported language (e.g.
@@ -155,7 +155,7 @@ String generateArbBasedLocalizationSubclasses({
         ));
         output.writeln(generateConstructor(scriptBaseLocale));
         final Map<String, String> scriptResources = localeToResources[scriptBaseLocale];
-        for (String key in scriptResources.keys) {
+        for (String key in scriptResources.keys.toList()..sort()) {
           if (languageResources[key] == scriptResources[key])
             continue;
           final Map<String, dynamic> attributes = localeToResourceAttributes[canonicalLocale][key];

--- a/dev/tools/localization/localizations_utils.dart
+++ b/dev/tools/localization/localizations_utils.dart
@@ -12,6 +12,10 @@ import 'package:meta/meta.dart';
 typedef HeaderGenerator = String Function(String regenerateInstructions);
 typedef ConstructorGenerator = String Function(LocaleInfo locale);
 
+int sortFilesByPath (FileSystemEntity a, FileSystemEntity b) {
+  return a.path.compareTo(b.path);
+}
+
 /// Simple data class to hold parsed locale. Does not promise validity of any data.
 class LocaleInfo implements Comparable<LocaleInfo> {
   LocaleInfo({
@@ -153,7 +157,7 @@ void loadMatchingArbsIntoBundleMaps({
   /// overwrite the existing assumed data.
   final Set<LocaleInfo> assumedLocales = <LocaleInfo>{};
 
-  for (FileSystemEntity entity in directory.listSync()) {
+  for (FileSystemEntity entity in directory.listSync().toList()..sort(sortFilesByPath)) {
     final String entityPath = entity.path;
     if (FileSystemEntity.isFileSync(entityPath) && filenamePattern.hasMatch(entityPath)) {
       final String localeString = filenamePattern.firstMatch(entityPath)[1];

--- a/packages/flutter_localizations/lib/src/l10n/generated_cupertino_localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/generated_cupertino_localizations.dart
@@ -10685,19 +10685,19 @@ class CupertinoLocalizationSrLatn extends CupertinoLocalizationSr {
   );
 
   @override
+  String get alertDialogLabel => r'Obaveštenje';
+
+  @override
+  String get anteMeridiemAbbreviation => r'pre podne';
+
+  @override
+  String get copyButtonLabel => r'Kopiraj';
+
+  @override
+  String get cutButtonLabel => r'Iseci';
+
+  @override
   String get datePickerHourSemanticsLabelFew => r'$hour sata';
-
-  @override
-  String get datePickerMinuteSemanticsLabelFew => r'$minute minuta';
-
-  @override
-  String get timerPickerHourLabelFew => r'sata';
-
-  @override
-  String get timerPickerMinuteLabelFew => r'min';
-
-  @override
-  String get timerPickerSecondLabelFew => r'sek';
 
   @override
   String get datePickerHourSemanticsLabelOne => r'$hour sat';
@@ -10706,22 +10706,25 @@ class CupertinoLocalizationSrLatn extends CupertinoLocalizationSr {
   String get datePickerHourSemanticsLabelOther => r'$hour sati';
 
   @override
+  String get datePickerMinuteSemanticsLabelFew => r'$minute minuta';
+
+  @override
   String get datePickerMinuteSemanticsLabelOne => r'1 minut';
 
   @override
   String get datePickerMinuteSemanticsLabelOther => r'$minute minuta';
 
   @override
-  String get anteMeridiemAbbreviation => r'pre podne';
+  String get pasteButtonLabel => r'Nalepi';
 
   @override
   String get postMeridiemAbbreviation => r'po podne';
 
   @override
-  String get todayLabel => r'Danas';
+  String get selectAllButtonLabel => r'Izaberi sve';
 
   @override
-  String get alertDialogLabel => r'Obaveštenje';
+  String get timerPickerHourLabelFew => r'sata';
 
   @override
   String get timerPickerHourLabelOne => r'sat';
@@ -10730,10 +10733,16 @@ class CupertinoLocalizationSrLatn extends CupertinoLocalizationSr {
   String get timerPickerHourLabelOther => r'sati';
 
   @override
+  String get timerPickerMinuteLabelFew => r'min';
+
+  @override
   String get timerPickerMinuteLabelOne => r'min';
 
   @override
   String get timerPickerMinuteLabelOther => r'min';
+
+  @override
+  String get timerPickerSecondLabelFew => r'sek';
 
   @override
   String get timerPickerSecondLabelOne => r'sek';
@@ -10742,16 +10751,7 @@ class CupertinoLocalizationSrLatn extends CupertinoLocalizationSr {
   String get timerPickerSecondLabelOther => r'sek';
 
   @override
-  String get cutButtonLabel => r'Iseci';
-
-  @override
-  String get copyButtonLabel => r'Kopiraj';
-
-  @override
-  String get pasteButtonLabel => r'Nalepi';
-
-  @override
-  String get selectAllButtonLabel => r'Izaberi sve';
+  String get todayLabel => r'Danas';
 }
 
 /// The translations for Swedish (`sv`).
@@ -12586,6 +12586,18 @@ class CupertinoLocalizationZhHant extends CupertinoLocalizationZh {
   );
 
   @override
+  String get alertDialogLabel => r'通知';
+
+  @override
+  String get copyButtonLabel => r'複製';
+
+  @override
+  String get cutButtonLabel => r'剪下';
+
+  @override
+  String get datePickerDateTimeOrderString => r'date_dayPeriod_time';
+
+  @override
   String get datePickerHourSemanticsLabelOne => r'$hour 點';
 
   @override
@@ -12598,10 +12610,10 @@ class CupertinoLocalizationZhHant extends CupertinoLocalizationZh {
   String get datePickerMinuteSemanticsLabelOther => r'$minute 分鐘';
 
   @override
-  String get datePickerDateTimeOrderString => r'date_dayPeriod_time';
+  String get pasteButtonLabel => r'貼上';
 
   @override
-  String get alertDialogLabel => r'通知';
+  String get selectAllButtonLabel => r'全選';
 
   @override
   String get timerPickerHourLabelOne => r'小時';
@@ -12614,18 +12626,6 @@ class CupertinoLocalizationZhHant extends CupertinoLocalizationZh {
 
   @override
   String get timerPickerMinuteLabelOther => r'分鐘';
-
-  @override
-  String get cutButtonLabel => r'剪下';
-
-  @override
-  String get copyButtonLabel => r'複製';
-
-  @override
-  String get pasteButtonLabel => r'貼上';
-
-  @override
-  String get selectAllButtonLabel => r'全選';
 }
 
 /// The translations for Chinese, as used in Hong Kong, using the Han script (`zh_Hant_HK`).

--- a/packages/flutter_localizations/lib/src/l10n/generated_material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/generated_material_localizations.dart
@@ -15255,67 +15255,28 @@ class MaterialLocalizationSrLatn extends MaterialLocalizationSr {
   );
 
   @override
-  String get remainingTextFieldCharacterCountFew => r'Preostala su $remainingCount znaka';
-
-  @override
-  String get selectedRowCountTitleFew => r'Izabrane su $selectedRowCount stavke';
-
-  @override
-  String get openAppDrawerTooltip => r'Otvorite meni za navigaciju';
-
-  @override
-  String get backButtonTooltip => r'Nazad';
-
-  @override
-  String get closeButtonTooltip => r'Zatvorite';
-
-  @override
-  String get deleteButtonTooltip => r'Izbrišite';
-
-  @override
-  String get nextMonthTooltip => r'Sledeći mesec';
-
-  @override
-  String get previousMonthTooltip => r'Prethodni mesec';
-
-  @override
-  String get nextPageTooltip => r'Sledeća stranica';
-
-  @override
-  String get previousPageTooltip => r'Prethodna stranica';
-
-  @override
-  String get showMenuTooltip => r'Prikaži meni';
-
-  @override
   String get aboutListTileTitleRaw => r'O aplikaciji $applicationName';
 
   @override
-  String get licensesPageTitle => r'Licence';
+  String get alertDialogLabel => r'Obaveštenje';
 
   @override
-  String get pageRowsInfoTitleRaw => r'$firstRow – $lastRow od $rowCount';
+  String get anteMeridiemAbbreviation => r'pre podne';
 
   @override
-  String get pageRowsInfoTitleApproximateRaw => r'$firstRow – $lastRow od približno $rowCount';
-
-  @override
-  String get rowsPerPageTitle => r'Redova po stranici:';
-
-  @override
-  String get tabLabelRaw => r'$tabIndex. kartica od $tabCount';
-
-  @override
-  String get selectedRowCountTitleOne => r'Izabrana je 1 stavka';
-
-  @override
-  String get selectedRowCountTitleOther => r'Izabrano je $selectedRowCount stavki';
+  String get backButtonTooltip => r'Nazad';
 
   @override
   String get cancelButtonLabel => r'OTKAŽI';
 
   @override
   String get closeButtonLabel => r'ZATVORI';
+
+  @override
+  String get closeButtonTooltip => r'Zatvorite';
+
+  @override
+  String get collapsedIconTapHint => r'Proširi';
 
   @override
   String get continueButtonLabel => r'NASTAVI';
@@ -15327,64 +15288,70 @@ class MaterialLocalizationSrLatn extends MaterialLocalizationSr {
   String get cutButtonLabel => r'ISECI';
 
   @override
-  String get okButtonLabel => r'Potvrdi';
-
-  @override
-  String get pasteButtonLabel => r'NALEPI';
-
-  @override
-  String get selectAllButtonLabel => r'IZABERI SVE';
-
-  @override
-  String get viewLicensesButtonLabel => r'PRIKAŽI LICENCE';
-
-  @override
-  String get anteMeridiemAbbreviation => r'pre podne';
-
-  @override
-  String get postMeridiemAbbreviation => r'po podne';
-
-  @override
-  String get timePickerHourModeAnnouncement => r'Izaberite sate';
-
-  @override
-  String get timePickerMinuteModeAnnouncement => r'Izaberite minute';
-
-  @override
-  String get modalBarrierDismissLabel => r'Odbaci';
-
-  @override
-  String get signedInLabel => r'Prijavljeni ste';
-
-  @override
-  String get hideAccountsLabel => r'Sakrij naloge';
-
-  @override
-  String get showAccountsLabel => r'Prikaži naloge';
-
-  @override
-  String get drawerLabel => r'Meni za navigaciju';
-
-  @override
-  String get popupMenuLabel => r'Iskačući meni';
+  String get deleteButtonTooltip => r'Izbrišite';
 
   @override
   String get dialogLabel => r'Dijalog';
 
   @override
-  String get alertDialogLabel => r'Obaveštenje';
+  String get drawerLabel => r'Meni za navigaciju';
 
   @override
-  String get searchFieldLabel => r'Pretražite';
+  String get expandedIconTapHint => r'Skupi';
 
   @override
-  String get reorderItemToStart => r'Pomerite na početak';
+  String get hideAccountsLabel => r'Sakrij naloge';
 
   @override
-  String get reorderItemToEnd => r'Pomerite na kraj';
+  String get licensesPageTitle => r'Licence';
 
   @override
-  String get reorderItemUp => r'Pomerite nagore';
+  String get modalBarrierDismissLabel => r'Odbaci';
+
+  @override
+  String get nextMonthTooltip => r'Sledeći mesec';
+
+  @override
+  String get nextPageTooltip => r'Sledeća stranica';
+
+  @override
+  String get okButtonLabel => r'Potvrdi';
+
+  @override
+  String get openAppDrawerTooltip => r'Otvorite meni za navigaciju';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow – $lastRow od $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow – $lastRow od približno $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'NALEPI';
+
+  @override
+  String get popupMenuLabel => r'Iskačući meni';
+
+  @override
+  String get postMeridiemAbbreviation => r'po podne';
+
+  @override
+  String get previousMonthTooltip => r'Prethodni mesec';
+
+  @override
+  String get previousPageTooltip => r'Prethodna stranica';
+
+  @override
+  String get refreshIndicatorSemanticLabel => r'Osveži';
+
+  @override
+  String get remainingTextFieldCharacterCountFew => r'Preostala su $remainingCount znaka';
+
+  @override
+  String get remainingTextFieldCharacterCountOne => r'Preostao je 1 znak';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'Preostalo je $remainingCount znakova';
 
   @override
   String get reorderItemDown => r'Pomerite nadole';
@@ -15396,19 +15363,52 @@ class MaterialLocalizationSrLatn extends MaterialLocalizationSr {
   String get reorderItemRight => r'Pomerite udesno';
 
   @override
-  String get expandedIconTapHint => r'Skupi';
+  String get reorderItemToEnd => r'Pomerite na kraj';
 
   @override
-  String get collapsedIconTapHint => r'Proširi';
+  String get reorderItemToStart => r'Pomerite na početak';
 
   @override
-  String get remainingTextFieldCharacterCountOne => r'Preostao je 1 znak';
+  String get reorderItemUp => r'Pomerite nagore';
 
   @override
-  String get remainingTextFieldCharacterCountOther => r'Preostalo je $remainingCount znakova';
+  String get rowsPerPageTitle => r'Redova po stranici:';
 
   @override
-  String get refreshIndicatorSemanticLabel => r'Osveži';
+  String get searchFieldLabel => r'Pretražite';
+
+  @override
+  String get selectAllButtonLabel => r'IZABERI SVE';
+
+  @override
+  String get selectedRowCountTitleFew => r'Izabrane su $selectedRowCount stavke';
+
+  @override
+  String get selectedRowCountTitleOne => r'Izabrana je 1 stavka';
+
+  @override
+  String get selectedRowCountTitleOther => r'Izabrano je $selectedRowCount stavki';
+
+  @override
+  String get showAccountsLabel => r'Prikaži naloge';
+
+  @override
+  String get showMenuTooltip => r'Prikaži meni';
+
+  @override
+  String get signedInLabel => r'Prijavljeni ste';
+
+  @override
+  String get tabLabelRaw => r'$tabIndex. kartica od $tabCount';
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Izaberite sate';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Izaberite minute';
+
+  @override
+  String get viewLicensesButtonLabel => r'PRIKAŽI LICENCE';
 }
 
 /// The translations for Swedish (`sv`).
@@ -17907,67 +17907,19 @@ class MaterialLocalizationZhHant extends MaterialLocalizationZh {
   );
 
   @override
-  String get tabLabelRaw => r'第 $tabIndex 個標籤，總共 $tabCount 個';
+  String get aboutListTileTitleRaw => r'關於$applicationName';
 
   @override
-  String get showAccountsLabel => r'顯示帳戶';
+  String get alertDialogLabel => r'通知';
 
   @override
-  String get modalBarrierDismissLabel => r'拒絕';
-
-  @override
-  String get hideAccountsLabel => r'隱藏帳戶';
-
-  @override
-  String get signedInLabel => r'已登入';
-
-  @override
-  String get openAppDrawerTooltip => r'開啟導覽選單';
+  String get closeButtonLabel => r'關閉';
 
   @override
   String get closeButtonTooltip => r'關閉';
 
   @override
-  String get deleteButtonTooltip => r'刪除';
-
-  @override
-  String get nextMonthTooltip => r'下個月';
-
-  @override
-  String get previousMonthTooltip => r'上個月';
-
-  @override
-  String get nextPageTooltip => r'下一頁';
-
-  @override
-  String get previousPageTooltip => r'上一頁';
-
-  @override
-  String get showMenuTooltip => r'顯示選單';
-
-  @override
-  String get aboutListTileTitleRaw => r'關於$applicationName';
-
-  @override
-  String get licensesPageTitle => r'授權';
-
-  @override
-  String get pageRowsInfoTitleRaw => r'第 $firstRow 至 $lastRow 列，共 $rowCount 列';
-
-  @override
-  String get pageRowsInfoTitleApproximateRaw => r'第 $firstRow 至 $lastRow 列，共約 $rowCount 列';
-
-  @override
-  String get rowsPerPageTitle => r'每頁列數：';
-
-  @override
-  String get selectedRowCountTitleOne => r'已選取 1 個項目';
-
-  @override
-  String get selectedRowCountTitleOther => r'已選取 $selectedRowCount 個項目';
-
-  @override
-  String get closeButtonLabel => r'關閉';
+  String get collapsedIconTapHint => r'展開';
 
   @override
   String get continueButtonLabel => r'繼續';
@@ -17979,46 +17931,64 @@ class MaterialLocalizationZhHant extends MaterialLocalizationZh {
   String get cutButtonLabel => r'剪下';
 
   @override
-  String get okButtonLabel => r'確定';
-
-  @override
-  String get pasteButtonLabel => r'貼上';
-
-  @override
-  String get selectAllButtonLabel => r'全選';
-
-  @override
-  String get viewLicensesButtonLabel => r'查看授權';
-
-  @override
-  String get timePickerHourModeAnnouncement => r'揀選小時';
-
-  @override
-  String get timePickerMinuteModeAnnouncement => r'揀選分鐘';
-
-  @override
-  String get drawerLabel => r'導覽選單';
-
-  @override
-  String get popupMenuLabel => r'彈出式選單';
+  String get deleteButtonTooltip => r'刪除';
 
   @override
   String get dialogLabel => r'對話方塊';
 
   @override
-  String get alertDialogLabel => r'通知';
+  String get drawerLabel => r'導覽選單';
 
   @override
-  String get searchFieldLabel => r'搜尋';
+  String get expandedIconTapHint => r'收合';
 
   @override
-  String get reorderItemToStart => r'移到開頭';
+  String get hideAccountsLabel => r'隱藏帳戶';
 
   @override
-  String get reorderItemToEnd => r'移到最後';
+  String get licensesPageTitle => r'授權';
 
   @override
-  String get reorderItemUp => r'向上移';
+  String get modalBarrierDismissLabel => r'拒絕';
+
+  @override
+  String get nextMonthTooltip => r'下個月';
+
+  @override
+  String get nextPageTooltip => r'下一頁';
+
+  @override
+  String get okButtonLabel => r'確定';
+
+  @override
+  String get openAppDrawerTooltip => r'開啟導覽選單';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'第 $firstRow 至 $lastRow 列，共 $rowCount 列';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'第 $firstRow 至 $lastRow 列，共約 $rowCount 列';
+
+  @override
+  String get pasteButtonLabel => r'貼上';
+
+  @override
+  String get popupMenuLabel => r'彈出式選單';
+
+  @override
+  String get previousMonthTooltip => r'上個月';
+
+  @override
+  String get previousPageTooltip => r'上一頁';
+
+  @override
+  String get refreshIndicatorSemanticLabel => r'重新整理';
+
+  @override
+  String get remainingTextFieldCharacterCountOne => r'尚餘 1 個字元';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'尚餘 $remainingCount 個字元';
 
   @override
   String get reorderItemDown => r'向下移';
@@ -18030,19 +18000,49 @@ class MaterialLocalizationZhHant extends MaterialLocalizationZh {
   String get reorderItemRight => r'向右移';
 
   @override
-  String get expandedIconTapHint => r'收合';
+  String get reorderItemToEnd => r'移到最後';
 
   @override
-  String get collapsedIconTapHint => r'展開';
+  String get reorderItemToStart => r'移到開頭';
 
   @override
-  String get remainingTextFieldCharacterCountOne => r'尚餘 1 個字元';
+  String get reorderItemUp => r'向上移';
 
   @override
-  String get remainingTextFieldCharacterCountOther => r'尚餘 $remainingCount 個字元';
+  String get rowsPerPageTitle => r'每頁列數：';
 
   @override
-  String get refreshIndicatorSemanticLabel => r'重新整理';
+  String get searchFieldLabel => r'搜尋';
+
+  @override
+  String get selectAllButtonLabel => r'全選';
+
+  @override
+  String get selectedRowCountTitleOne => r'已選取 1 個項目';
+
+  @override
+  String get selectedRowCountTitleOther => r'已選取 $selectedRowCount 個項目';
+
+  @override
+  String get showAccountsLabel => r'顯示帳戶';
+
+  @override
+  String get showMenuTooltip => r'顯示選單';
+
+  @override
+  String get signedInLabel => r'已登入';
+
+  @override
+  String get tabLabelRaw => r'第 $tabIndex 個標籤，總共 $tabCount 個';
+
+  @override
+  String get timePickerHourModeAnnouncement => r'揀選小時';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'揀選分鐘';
+
+  @override
+  String get viewLicensesButtonLabel => r'查看授權';
 }
 
 /// The translations for Chinese, as used in Hong Kong, using the Han script (`zh_Hant_HK`).


### PR DESCRIPTION
## Description

- When creating locales that were assumed from existing locales, the
file that is used is non-deterministic. This adds a sort to the iterator
to ensure that the same existing locale is used to generate the assumed
locale
- When generating material, cupertino and date localizations, the generated getters were not sorted. This introduces an alphabetic sort

## Related Issues
Fixes https://github.com/flutter/flutter/issues/44728

## Tests

I added the following tests:


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
