### PR TITLE
Always link desktop platforms

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/dart.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/dart.dart
@@ -204,6 +204,7 @@ class KernelSnapshot extends Target {
         forceLinkPlatform = true;
         break;
       default:
+        forceLinkPlatform = false;
     }
 
     final CompilerOutput output = await compiler.compile(
@@ -218,7 +219,7 @@ class KernelSnapshot extends Target {
       targetModel: targetModel,
       outputFilePath: environment.buildDir.childFile('app.dill').path,
       packagesPath: packagesPath,
-      linkPlatformKernelIn: forceLinkPlatform ?? buildMode.isPrecompiled,
+      linkPlatformKernelIn: forceLinkPlatform || buildMode.isPrecompiled,
       mainPath: targetFileAbsolute,
       depFilePath: environment.buildDir.childFile('kernel_snapshot.d').path,
       extraFrontEndOptions: extraFrontEndOptions,

--- a/packages/flutter_tools/lib/src/build_system/targets/dart.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/dart.dart
@@ -193,6 +193,18 @@ class KernelSnapshot extends Target {
         targetPlatform == TargetPlatform.fuchsia_arm64) {
       targetModel = TargetModel.flutterRunner;
     }
+    // Force linking of the platform for desktop embedder targets since these
+    // do not correctly load the core snapshots in debug mode.
+    // See https://github.com/flutter/flutter/issues/44724
+    bool forceLinkPlatform;
+    switch (targetPlatform) {
+      case TargetPlatform.darwin_x64:
+      case TargetPlatform.windows_x64:
+      case TargetPlatform.linux_x64:
+        forceLinkPlatform = true;
+        break;
+      default:
+    }
 
     final CompilerOutput output = await compiler.compile(
       sdkRoot: artifacts.getArtifactPath(
@@ -206,7 +218,7 @@ class KernelSnapshot extends Target {
       targetModel: targetModel,
       outputFilePath: environment.buildDir.childFile('app.dill').path,
       packagesPath: packagesPath,
-      linkPlatformKernelIn: buildMode.isPrecompiled,
+      linkPlatformKernelIn: forceLinkPlatform ?? buildMode.isPrecompiled,
       mainPath: targetFileAbsolute,
       depFilePath: environment.buildDir.childFile('kernel_snapshot.d').path,
       extraFrontEndOptions: extraFrontEndOptions,

--- a/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
@@ -214,7 +214,7 @@ flutter_tools:lib/''');
       sdkRoot: anyNamed('sdkRoot'),
       aot: anyNamed('aot'),
       buildMode: anyNamed('buildMode'),
-      trackWidgetCreation: false,
+      trackWidgetCreation: anyNamed('trackWidgetCreation'),
       targetModel: anyNamed('targetModel'),
       outputFilePath: anyNamed('outputFilePath'),
       depFilePath: anyNamed('depFilePath'),

--- a/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
@@ -205,6 +205,39 @@ flutter_tools:lib/''');
     KernelCompilerFactory: () => MockKernelCompilerFactory(),
   }));
 
+  test('kernel_snapshot forces platform linking on debug for darwin target platforms', () => testbed.run(() async {
+    final MockKernelCompiler mockKernelCompiler = MockKernelCompiler();
+    when(kernelCompilerFactory.create(any)).thenAnswer((Invocation _) async {
+      return mockKernelCompiler;
+    });
+    when(mockKernelCompiler.compile(
+      sdkRoot: anyNamed('sdkRoot'),
+      aot: anyNamed('aot'),
+      buildMode: anyNamed('buildMode'),
+      trackWidgetCreation: false,
+      targetModel: anyNamed('targetModel'),
+      outputFilePath: anyNamed('outputFilePath'),
+      depFilePath: anyNamed('depFilePath'),
+      packagesPath: anyNamed('packagesPath'),
+      mainPath: anyNamed('mainPath'),
+      extraFrontEndOptions: anyNamed('extraFrontEndOptions'),
+      fileSystemRoots: anyNamed('fileSystemRoots'),
+      fileSystemScheme: anyNamed('fileSystemScheme'),
+      linkPlatformKernelIn: true,
+      dartDefines: anyNamed('dartDefines'),
+    )).thenAnswer((Invocation _) async {
+      return const CompilerOutput('example', 0, <Uri>[]);
+    });
+
+    await const KernelSnapshot().build(androidEnvironment
+      ..defines[kTargetPlatform]  = 'darwin-x64'
+      ..defines[kBuildMode] = 'debug'
+    );
+  }, overrides: <Type, Generator>{
+    KernelCompilerFactory: () => MockKernelCompilerFactory(),
+  }));
+
+
   test('kernel_snapshot does use track widget creation on debug builds', () => testbed.run(() async {
     final MockKernelCompiler mockKernelCompiler = MockKernelCompiler();
     when(kernelCompilerFactory.create(any)).thenAnswer((Invocation _) async {


### PR DESCRIPTION
## Description

The desktop shells are not correctly loading the prebuilt core snapshots. This requires the platform to be linked in order to work in debug mode.

See https://github.com/flutter/flutter/issues/44724