### PR TITLE
Sort locales and method/properties/getters alphabetically

### DIFF
--- a/dev/tools/localization/gen_l10n.dart
+++ b/dev/tools/localization/gen_l10n.dart
@@ -149,6 +149,10 @@ const String pluralMethodTemplate = '''
   }
 ''';
 
+int sortFilesByPath (FileSystemEntity a, FileSystemEntity b) {
+  return a.path.compareTo(b.path);
+}
+
 List<String> genMethodParameters(Map<String, dynamic> bundle, String key, String type) {
   final Map<String, dynamic> attributesMap = bundle['@$key'];
   if (attributesMap != null && attributesMap.containsKey('placeholders')) {
@@ -384,7 +388,7 @@ Future<void> main(List<String> arguments) async {
   final Set<String> supportedLanguageCodes = <String>{};
   final Set<LocaleInfo> supportedLocales = <LocaleInfo>{};
 
-  for (FileSystemEntity entity in l10nDirectory.listSync()) {
+  for (FileSystemEntity entity in l10nDirectory.listSync().toList()..sort(sortFilesByPath)) {
     final String entityPath = entity.path;
 
     if (FileSystemEntity.isFileSync(entityPath)) {
@@ -435,7 +439,7 @@ Future<void> main(List<String> arguments) async {
 
   final RegExp pluralValueRE = RegExp(r'^\s*\{[\w\s,]*,\s*plural\s*,');
 
-  for (String key in bundle.keys) {
+  for (String key in bundle.keys.toList()..sort()) {
     if (key.startsWith('@'))
       continue;
     if (!_isValidGetterAndMethodName(key))

--- a/examples/stocks/lib/i18n/messages_all.dart
+++ b/examples/stocks/lib/i18n/messages_all.dart
@@ -15,21 +15,21 @@ import 'package:intl/intl.dart';
 import 'package:intl/message_lookup_by_library.dart';
 import 'package:intl/src/intl_helpers.dart';
 
-import 'messages_es_ES.dart' as messages_es_es;
 import 'messages_en_US.dart' as messages_en_us;
+import 'messages_es_ES.dart' as messages_es_es;
 
 typedef Future<dynamic> LibraryLoader();
 Map<String, LibraryLoader> _deferredLibraries = {
-  'es_ES': () => new Future.value(null),
   'en_US': () => new Future.value(null),
+  'es_ES': () => new Future.value(null),
 };
 
 MessageLookupByLibrary _findExact(String localeName) {
   switch (localeName) {
-    case 'es_ES':
-      return messages_es_es.messages;
     case 'en_US':
       return messages_en_us.messages;
+    case 'es_ES':
+      return messages_es_es.messages;
     default:
       return null;
   }

--- a/examples/stocks/lib/i18n/stock_strings.dart
+++ b/examples/stocks/lib/i18n/stock_strings.dart
@@ -65,7 +65,7 @@ class StockStrings {
 
   static Future<StockStrings> load(Locale locale) {
     return initializeMessages(locale.toString())
-      .then<StockStrings>((void _) => StockStrings(locale));
+      .then<StockStrings>((_) => StockStrings(locale));
   }
 
   static StockStrings of(BuildContext context) {
@@ -89,18 +89,9 @@ class StockStrings {
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
-    Locale('es', 'ES'),
     Locale('en', 'US'),
+    Locale('es', 'ES'),
   ];
-
-  String get title {
-    return Intl.message(
-      r'Stocks',
-      locale: _localeName,
-      name: 'title',
-      desc: r'Title for the Stocks application'
-    );
-  }
 
   String get market {
     return Intl.message(
@@ -120,6 +111,15 @@ class StockStrings {
     );
   }
 
+  String get title {
+    return Intl.message(
+      r'Stocks',
+      locale: _localeName,
+      name: 'title',
+      desc: r'Title for the Stocks application'
+    );
+  }
+
 }
 
 class _StockStringsDelegate extends LocalizationsDelegate<StockStrings> {
@@ -129,7 +129,7 @@ class _StockStringsDelegate extends LocalizationsDelegate<StockStrings> {
   Future<StockStrings> load(Locale locale) => StockStrings.load(locale);
 
   @override
-  bool isSupported(Locale locale) => <String>['es', 'en'].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>['en', 'es'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_StockStringsDelegate old) => false;


### PR DESCRIPTION
## Description

1. Minimize the number of diffs for Flutter developers using this tool by:
- Sorting message properties/methods/getters generated by the `gen_l10n.dart` script alphabetically
- Sorting locales based on .arb String paths alphabetically
2. Update `examples/stocks` to reflect alphabetical sorting