### PR TITLE
Fixes widget inspector can transform unmounted element

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2660,6 +2660,11 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   BuildOwner get owner => _owner;
   BuildOwner _owner;
 
+  /// Whether the element is active.
+  ///
+  /// A element will be active if it is mounted and attached to the element
+  /// tree.
+  bool get isActive => _active;
   bool _active = false;
 
   /// {@template flutter.widgets.reassemble}

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -2823,8 +2823,9 @@ Iterable<DiagnosticsNode> _describeRelevantUserCode(Element element) {
     }
     return true;
   }
-  if (processElement(element))
+  if (processElement(element) && element.isActive) {
     element.visitAncestorElements(processElement);
+  }
   return nodes;
 }
 

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -2823,9 +2823,8 @@ Iterable<DiagnosticsNode> _describeRelevantUserCode(Element element) {
     }
     return true;
   }
-  if (processElement(element) && element.isActive) {
+  if (processElement(element) && element.isActive)
     element.visitAncestorElements(processElement);
-  }
   return nodes;
 }
 

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -917,6 +917,7 @@ class TestWidgetInspectorService extends Object with WidgetInspectorService {
     });
 
     testWidgets('test transformDebugCreator can transform unmounted element', (WidgetTester tester) async {
+      final bool widgetTracked = WidgetInspectorService.instance.isWidgetCreationTracked();
       // Clears any mocked pub root.
       service.setPubRootDirectories(<Object>[]);
       final Element elementA = const Text('a').createElement();
@@ -930,9 +931,16 @@ class TestWidgetInspectorService extends Object with WidgetInspectorService {
         // Transforms unmounted element should not raise any exception.
         expect(false, isTrue);
       }
-      expect(nodes.length, 1);
-      expect(nodes[0].runtimeType, StringProperty);
-      expect(nodes[0].name, 'dummy1');
+      if (widgetTracked) {
+        expect(nodes.length, 1);
+        expect(nodes[0].runtimeType, StringProperty);
+        expect(nodes[0].name, 'dummy1');
+      } else {
+        expect(nodes.length, 3);
+        expect(nodes[1].runtimeType, ErrorDescription);
+        final ErrorDescription node = nodes[1];
+        expect(node.valueToString().startsWith('Widget creation tracking is currently disabled.'), true);
+      }
     });
 
     testWidgets('test transformDebugCreator will not re-order if before stack trace', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -916,6 +916,25 @@ class TestWidgetInspectorService extends Object with WidgetInspectorService {
       expect(nodes[4].runtimeType, DiagnosticsStackTrace);
     });
 
+    testWidgets('test transformDebugCreator can transform unmounted element', (WidgetTester tester) async {
+      // Clears any mocked pub root.
+      service.setPubRootDirectories(<Object>[]);
+      final Element elementA = const Text('a').createElement();
+      final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
+      builder.add(StringProperty('dummy1', 'value'));
+      builder.add(DiagnosticsDebugCreator(DebugCreator(elementA)));
+      List<DiagnosticsNode> nodes;
+      try {
+        nodes = List<DiagnosticsNode>.from(transformDebugCreator(builder.properties));
+      } catch(_) {
+        // Transforms unmounted element should not raise any exception.
+        expect(false, isTrue);
+      }
+      expect(nodes.length, 1);
+      expect(nodes[0].runtimeType, StringProperty);
+      expect(nodes[0].name, 'dummy1');
+    });
+
     testWidgets('test transformDebugCreator will not re-order if before stack trace', (WidgetTester tester) async {
       final bool widgetTracked = WidgetInspectorService.instance.isWidgetCreationTracked();
       await tester.pumpWidget(
@@ -977,7 +996,7 @@ class TestWidgetInspectorService extends Object with WidgetInspectorService {
       expect(nodes[3].runtimeType, StringProperty);
       expect(nodes[3].name, 'dummy2');
       expect(nodes[4].runtimeType, DiagnosticsStackTrace);
-    }, skip: WidgetInspectorService.instance.isWidgetCreationTracked());
+    });
 
     testWidgets('WidgetInspectorService setPubRootDirectories', (WidgetTester tester) async {
       await tester.pumpWidget(


### PR DESCRIPTION
## Description

Our current widget inspector will try to visit ancestors of an error cause element in the case of a framework crash. The method that visits the ancestors of an element will throw an assertion error if the element is not mounted which results in another crash.

This pr exposes an api to get element's active state, and the widget inspector will use the api to determine if it should traverse the ancestors of the error causing element.

## Related Issues
https://github.com/flutter/flutter/issues/44485

## Tests

I added the following tests:

"test transformDebugCreator can transform unmounted element"

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
