### PR TITLE
Build AAR for all build variants by default

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_builder.dart
+++ b/packages/flutter_tools/lib/src/android/android_builder.dart
@@ -27,6 +27,7 @@ abstract class AndroidBuilder {
   Future<void> buildAar({
     @required FlutterProject project,
     @required Set<AndroidBuildInfo> androidBuildInfo,
+    @required String target,
     @required String outputDirectoryPath,
   });
 
@@ -54,6 +55,7 @@ class _AndroidBuilderImpl extends AndroidBuilder {
   Future<void> buildAar({
     @required FlutterProject project,
     @required Set<AndroidBuildInfo> androidBuildInfo,
+    @required String target,
     @required String outputDirectoryPath,
   }) async {
     try {
@@ -67,6 +69,7 @@ class _AndroidBuilderImpl extends AndroidBuilder {
         await buildGradleAar(
           project: project,
           androidBuildInfo: androidBuildInfo,
+          target: target,
           outputDirectory: outputDirectory,
         );
       }

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -57,7 +57,6 @@ Directory getBundleDirectory(FlutterProject project) {
 
 /// The directory where the repo is generated.
 /// Only applicable to AARs.
-@visibleForTesting
 Directory getRepoDirectory(Directory buildDirectory) {
   return buildDirectory
     .childDirectory('outputs')
@@ -465,20 +464,15 @@ Future<void> buildGradleApp({
 ///
 /// * [project] is typically [FlutterProject.current()].
 /// * [androidBuildInfo] is the build configuration.
-/// * [target] is the target dart entrypoint. Typically, `lib/main.dart`.
 /// * [outputDir] is the destination of the artifacts,
 Future<void> buildGradleAar({
   @required FlutterProject project,
   @required AndroidBuildInfo androidBuildInfo,
-  @required String target,
-  @required Directory outputDir,
-  @required bool printHowToConsumeAaar,
+  @required Directory outputDirectory,
 }) async {
   assert(project != null);
   assert(androidBuildInfo != null);
-  assert(target != null);
-  assert(outputDir != null);
-  assert(printHowToConsumeAaar != null);
+  assert(outputDirectory != null);
 
   if (androidSdk == null) {
     exitWithNoSdkMessage();
@@ -507,13 +501,10 @@ Future<void> buildGradleAar({
     gradleUtils.getExecutable(project),
     '-I=$initScript',
     '-Pflutter-root=$flutterRoot',
-    '-Poutput-dir=${outputDir.path}',
+    '-Poutput-dir=${outputDirectory.path}',
     '-Pis-plugin=${manifest.isPlugin}',
   ];
 
-  if (target != null && target.isNotEmpty) {
-    command.add('-Ptarget=$target');
-  }
   if (androidBuildInfo.targetArchs.isNotEmpty) {
     final String targetPlatforms = androidBuildInfo.targetArchs
         .map(getPlatformNameForAndroidArch).join(',');
@@ -558,7 +549,7 @@ Future<void> buildGradleAar({
       exitCode: exitCode,
     );
   }
-  final Directory repoDirectory = getRepoDirectory(outputDir);
+  final Directory repoDirectory = getRepoDirectory(outputDirectory);
   if (!repoDirectory.existsSync()) {
     printStatus(result.stdout, wrap: false);
     printError(result.stderr, wrap: false);
@@ -571,24 +562,17 @@ Future<void> buildGradleAar({
     '$successMark Built ${fs.path.relative(repoDirectory.path)}.',
     color: TerminalColor.green,
   );
-  if (printHowToConsumeAaar) {
-    _printHowToConsumeAar(
-      buildMode: androidBuildInfo.buildInfo.modeName,
-      androidPackage: project.manifest.androidPackage,
-      repoPath: repoDirectory.path,
-    );
-  }
 }
 
 /// Prints how to consume the AAR from a host app.
-void _printHowToConsumeAar({
-  @required String buildMode,
+void printHowToConsumeAar({
+  @required Set<String> buildModes,
   @required String androidPackage,
-  @required String repoPath,
+  @required Directory repoDirectory,
 }) {
-  assert(buildMode != null);
+  assert(buildModes != null && buildModes.isNotEmpty);
   assert(androidPackage != null);
-  assert(repoPath != null);
+  assert(repoDirectory != null);
 
   printStatus('''
 
@@ -598,20 +582,42 @@ ${terminal.bolden('Consuming the Module')}
 
       repositories {
         maven {
-            url '$repoPath'
+            url '${repoDirectory.path}'
         }
         maven {
             url 'http://download.flutter.io'
         }
       }
 
-  3. Make the host app depend on the $buildMode module:
+  3. Make the host app depend on the Flutter module:
 
-      dependencies {
-        ${buildMode}Implementation '$androidPackage:flutter_$buildMode:1.0'
+    dependencies {''');
+
+  for (String buildMode in buildModes) {
+    printStatus('''
+      ${buildMode}Implementation '$androidPackage:flutter_$buildMode:1.0''');
+  }
+
+printStatus('''
+    }
+''');
+
+  if (buildModes.contains('profile')) {
+    printStatus('''
+
+  4. Add the `profile` build type:
+
+    android {
+      buildTypes {
+        profile {
+          initWith debug
+        }
       }
+    }
+''');
+  }
 
-To learn more, visit https://flutter.dev/go/build-aar''');
+printStatus('To learn more, visit https://flutter.dev/go/build-aar''');
 }
 
 String _hex(List<int> bytes) {
@@ -695,9 +701,7 @@ Future<void> buildPluginsAsAar(
             null, // Plugins don't define flavors.
           ),
         ),
-        target: '',
-        outputDir: buildDirectory,
-        printHowToConsumeAaar: false,
+        outputDirectory: buildDirectory,
       );
     } on ToolExit {
       // Log the entire plugin entry in `.flutter-plugins` since it

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -468,9 +468,11 @@ Future<void> buildGradleApp({
 Future<void> buildGradleAar({
   @required FlutterProject project,
   @required AndroidBuildInfo androidBuildInfo,
+  @required String target,
   @required Directory outputDirectory,
 }) async {
   assert(project != null);
+  assert(target != null);
   assert(androidBuildInfo != null);
   assert(outputDirectory != null);
 
@@ -504,6 +506,10 @@ Future<void> buildGradleAar({
     '-Poutput-dir=${outputDirectory.path}',
     '-Pis-plugin=${manifest.isPlugin}',
   ];
+
+  if (target != null && target.isNotEmpty) {
+    command.add('-Ptarget=$target');
+  }
 
   if (androidBuildInfo.targetArchs.isNotEmpty) {
     final String targetPlatforms = androidBuildInfo.targetArchs
@@ -701,6 +707,7 @@ Future<void> buildPluginsAsAar(
             null, // Plugins don't define flavors.
           ),
         ),
+        target: '',
         outputDirectory: buildDirectory,
       );
     } on ToolExit {

--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -21,7 +21,7 @@ import 'build_web.dart';
 
 class BuildCommand extends FlutterCommand {
   BuildCommand({bool verboseHelp = false}) {
-    addSubcommand(BuildAarCommand(verboseHelp: verboseHelp));
+    addSubcommand(BuildAarCommand());
     addSubcommand(BuildApkCommand(verboseHelp: verboseHelp));
     addSubcommand(BuildAppBundleCommand(verboseHelp: verboseHelp));
     addSubcommand(BuildAotCommand(verboseHelp: verboseHelp));

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -1532,6 +1532,7 @@ plugin2=${plugin2.path}
         androidBuildInfo: const AndroidBuildInfo(BuildInfo(BuildMode.release, null)),
         project: FlutterProject.current(),
         outputDirectory: fs.directory('build/'),
+        target: '',
       );
 
       final BufferLogger logger = context.get<Logger>();
@@ -1694,6 +1695,7 @@ plugin2=${plugin2.path}
         androidBuildInfo: const AndroidBuildInfo(BuildInfo(BuildMode.release, null)),
         project: FlutterProject.current(),
         outputDirectory: fs.directory('build/'),
+        target: '',
       );
 
       final List<String> actualGradlewCall = verify(
@@ -1769,7 +1771,9 @@ plugin2=${plugin2.path}
         )
       );
     }, overrides: <Type, Generator>{
+      FileSystem: () => MemoryFileSystem(),
       Platform: () => fakePlatform('android'),
+      ProcessManager: () => FakeProcessManager.any(),
     });
 
     testUsingContext('stdout contains release', () async {
@@ -1807,7 +1811,9 @@ plugin2=${plugin2.path}
         )
       );
     }, overrides: <Type, Generator>{
+      FileSystem: () => MemoryFileSystem(),
       Platform: () => fakePlatform('android'),
+      ProcessManager: () => FakeProcessManager.any(),
     });
 
     testUsingContext('stdout contains debug', () async {
@@ -1845,7 +1851,9 @@ plugin2=${plugin2.path}
         )
       );
     }, overrides: <Type, Generator>{
+      FileSystem: () => MemoryFileSystem(),
       Platform: () => fakePlatform('android'),
+      ProcessManager: () => FakeProcessManager.any(),
     });
 
     testUsingContext('stdout contains profile', () async {
@@ -1894,7 +1902,9 @@ plugin2=${plugin2.path}
         )
       );
     }, overrides: <Type, Generator>{
+      FileSystem: () => MemoryFileSystem(),
       Platform: () => fakePlatform('android'),
+      ProcessManager: () => FakeProcessManager.any(),
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -1501,79 +1501,6 @@ plugin2=${plugin2.path}
       ProcessManager: () => mockProcessManager,
     });
 
-    testUsingContext('indicates how to consume an AAR when printHowToConsumeAaar is true', () async {
-      final File manifestFile = fs.file('pubspec.yaml');
-      manifestFile.createSync(recursive: true);
-      manifestFile.writeAsStringSync('''
-        flutter:
-          module:
-            androidPackage: com.example.test
-        '''
-      );
-
-      fs.file('.android/gradlew').createSync(recursive: true);
-
-      fs.file('.android/gradle.properties')
-        .writeAsStringSync('irrelevant');
-
-      fs.file('.android/build.gradle')
-        .createSync(recursive: true);
-
-      // Let any process start. Assert after.
-      when(mockProcessManager.run(
-        any,
-        environment: anyNamed('environment'),
-        workingDirectory: anyNamed('workingDirectory'),
-      )).thenAnswer((_) async => ProcessResult(1, 0, '', ''));
-
-      fs.directory('build/outputs/repo').createSync(recursive: true);
-
-      await buildGradleAar(
-        androidBuildInfo: const AndroidBuildInfo(BuildInfo(BuildMode.release, null)),
-        project: FlutterProject.current(),
-        outputDir: fs.directory('build/'),
-        target: '',
-        printHowToConsumeAaar: true,
-      );
-
-      final BufferLogger logger = context.get<Logger>();
-      expect(
-        logger.statusText,
-        contains('Built build/outputs/repo'),
-      );
-      expect(
-        logger.statusText,
-        contains('''
-Consuming the Module
-  1. Open <host>/app/build.gradle
-  2. Ensure you have the repositories configured, otherwise add them:
-
-      repositories {
-        maven {
-            url 'build/outputs/repo'
-        }
-        maven {
-            url 'http://download.flutter.io'
-        }
-      }
-
-  3. Make the host app depend on the release module:
-
-      dependencies {
-        releaseImplementation 'com.example.test:flutter_release:1.0'
-      }
-
-To learn more, visit https://flutter.dev/go/build-aar'''));
-
-    }, overrides: <Type, Generator>{
-      AndroidSdk: () => mockAndroidSdk,
-      AndroidStudio: () => mockAndroidStudio,
-      Cache: () => cache,
-      Platform: () => android,
-      FileSystem: () => fs,
-      ProcessManager: () => mockProcessManager,
-    });
-
     testUsingContext('doesn\'t indicate how to consume an AAR when printHowToConsumeAaar is false', () async {
       final File manifestFile = fs.file('pubspec.yaml');
       manifestFile.createSync(recursive: true);
@@ -1604,9 +1531,7 @@ To learn more, visit https://flutter.dev/go/build-aar'''));
       await buildGradleAar(
         androidBuildInfo: const AndroidBuildInfo(BuildInfo(BuildMode.release, null)),
         project: FlutterProject.current(),
-        outputDir: fs.directory('build/'),
-        target: '',
-        printHowToConsumeAaar: false,
+        outputDirectory: fs.directory('build/'),
       );
 
       final BufferLogger logger = context.get<Logger>();
@@ -1768,9 +1693,7 @@ To learn more, visit https://flutter.dev/go/build-aar'''));
       await buildGradleAar(
         androidBuildInfo: const AndroidBuildInfo(BuildInfo(BuildMode.release, null)),
         project: FlutterProject.current(),
-        outputDir: fs.directory('build/'),
-        target: '',
-        printHowToConsumeAaar: false,
+        outputDirectory: fs.directory('build/'),
       );
 
       final List<String> actualGradlewCall = verify(
@@ -1794,6 +1717,184 @@ To learn more, visit https://flutter.dev/go/build-aar'''));
       Platform: () => android,
       FileSystem: () => fs,
       ProcessManager: () => mockProcessManager,
+    });
+  });
+
+  group('printHowToConsumeAar', () {
+    testUsingContext('stdout contains release, debug and profile', () async {
+      printHowToConsumeAar(
+        buildModes: const <String>{'release', 'debug', 'profile'},
+        androidPackage: 'com.mycompany',
+        repoDirectory: fs.directory('build/'),
+      );
+
+      final BufferLogger logger = context.get<Logger>();
+      expect(
+        logger.statusText,
+        contains(
+          '\n'
+          'Consuming the Module\n'
+          '  1. Open <host>/app/build.gradle\n'
+          '  2. Ensure you have the repositories configured, otherwise add them:\n'
+          '\n'
+          '      repositories {\n'
+          '        maven {\n'
+          '            url \'build/\'\n'
+          '        }\n'
+          '        maven {\n'
+          '            url \'http://download.flutter.io\'\n'
+          '        }\n'
+          '      }\n'
+          '\n'
+          '  3. Make the host app depend on the Flutter module:\n'
+          '\n'
+          '    dependencies {\n'
+          '      releaseImplementation \'com.mycompany:flutter_release:1.0\n'
+          '      debugImplementation \'com.mycompany:flutter_debug:1.0\n'
+          '      profileImplementation \'com.mycompany:flutter_profile:1.0\n'
+          '    }\n'
+          '\n'
+          '\n'
+          '  4. Add the `profile` build type:\n'
+          '\n'
+          '    android {\n'
+          '      buildTypes {\n'
+          '        profile {\n'
+          '          initWith debug\n'
+          '        }\n'
+          '      }\n'
+          '    }\n'
+          '\n'
+          'To learn more, visit https://flutter.dev/go/build-aar\n'
+        )
+      );
+    }, overrides: <Type, Generator>{
+      Platform: () => fakePlatform('android'),
+    });
+
+    testUsingContext('stdout contains release', () async {
+      printHowToConsumeAar(
+        buildModes: const <String>{'release'},
+        androidPackage: 'com.mycompany',
+        repoDirectory: fs.directory('build/'),
+      );
+
+      final BufferLogger logger = context.get<Logger>();
+      expect(
+        logger.statusText,
+        contains(
+          '\n'
+          'Consuming the Module\n'
+          '  1. Open <host>/app/build.gradle\n'
+          '  2. Ensure you have the repositories configured, otherwise add them:\n'
+          '\n'
+          '      repositories {\n'
+          '        maven {\n'
+          '            url \'build/\'\n'
+          '        }\n'
+          '        maven {\n'
+          '            url \'http://download.flutter.io\'\n'
+          '        }\n'
+          '      }\n'
+          '\n'
+          '  3. Make the host app depend on the Flutter module:\n'
+          '\n'
+          '    dependencies {\n'
+          '      releaseImplementation \'com.mycompany:flutter_release:1.0\n'
+          '    }\n'
+          '\n'
+          'To learn more, visit https://flutter.dev/go/build-aar\n'
+        )
+      );
+    }, overrides: <Type, Generator>{
+      Platform: () => fakePlatform('android'),
+    });
+
+    testUsingContext('stdout contains debug', () async {
+      printHowToConsumeAar(
+        buildModes: const <String>{'debug'},
+        androidPackage: 'com.mycompany',
+        repoDirectory: fs.directory('build/'),
+      );
+
+      final BufferLogger logger = context.get<Logger>();
+      expect(
+        logger.statusText,
+        contains(
+          '\n'
+          'Consuming the Module\n'
+          '  1. Open <host>/app/build.gradle\n'
+          '  2. Ensure you have the repositories configured, otherwise add them:\n'
+          '\n'
+          '      repositories {\n'
+          '        maven {\n'
+          '            url \'build/\'\n'
+          '        }\n'
+          '        maven {\n'
+          '            url \'http://download.flutter.io\'\n'
+          '        }\n'
+          '      }\n'
+          '\n'
+          '  3. Make the host app depend on the Flutter module:\n'
+          '\n'
+          '    dependencies {\n'
+          '      debugImplementation \'com.mycompany:flutter_debug:1.0\n'
+          '    }\n'
+          '\n'
+          'To learn more, visit https://flutter.dev/go/build-aar\n'
+        )
+      );
+    }, overrides: <Type, Generator>{
+      Platform: () => fakePlatform('android'),
+    });
+
+    testUsingContext('stdout contains profile', () async {
+      printHowToConsumeAar(
+        buildModes: const <String>{'profile'},
+        androidPackage: 'com.mycompany',
+        repoDirectory: fs.directory('build/'),
+      );
+
+      final BufferLogger logger = context.get<Logger>();
+      expect(
+        logger.statusText,
+        contains(
+          '\n'
+          'Consuming the Module\n'
+          '  1. Open <host>/app/build.gradle\n'
+          '  2. Ensure you have the repositories configured, otherwise add them:\n'
+          '\n'
+          '      repositories {\n'
+          '        maven {\n'
+          '            url \'build/\'\n'
+          '        }\n'
+          '        maven {\n'
+          '            url \'http://download.flutter.io\'\n'
+          '        }\n'
+          '      }\n'
+          '\n'
+          '  3. Make the host app depend on the Flutter module:\n'
+          '\n'
+          '    dependencies {\n'
+          '      profileImplementation \'com.mycompany:flutter_profile:1.0\n'
+          '    }\n'
+          '\n'
+          '\n'
+          '  4. Add the `profile` build type:\n'
+          '\n'
+          '    android {\n'
+          '      buildTypes {\n'
+          '        profile {\n'
+          '          initWith debug\n'
+          '        }\n'
+          '      }\n'
+          '    }\n'
+          '\n'
+          'To learn more, visit https://flutter.dev/go/build-aar\n'
+        )
+      );
+    }, overrides: <Type, Generator>{
+      Platform: () => fakePlatform('android'),
     });
   });
 }

--- a/packages/flutter_tools/test/src/android_common.dart
+++ b/packages/flutter_tools/test/src/android_common.dart
@@ -14,6 +14,7 @@ class FakeAndroidBuilder implements AndroidBuilder {
   Future<void> buildAar({
     @required FlutterProject project,
     @required Set<AndroidBuildInfo> androidBuildInfo,
+    @required String target,
     @required String outputDirectoryPath,
   }) async {}
 

--- a/packages/flutter_tools/test/src/android_common.dart
+++ b/packages/flutter_tools/test/src/android_common.dart
@@ -13,9 +13,8 @@ class FakeAndroidBuilder implements AndroidBuilder {
   @override
   Future<void> buildAar({
     @required FlutterProject project,
-    @required AndroidBuildInfo androidBuildInfo,
-    @required String target,
-    @required String outputDir,
+    @required Set<AndroidBuildInfo> androidBuildInfo,
+    @required String outputDirectoryPath,
   }) async {}
 
   @override


### PR DESCRIPTION
This will be the new default of `flutter build aar`:

```
$ flutter build aar
Building flutter tool...
Running "flutter pub get" in flutter_module...                      0.4s
Running Gradle task 'assembleAarRelease'...
Running Gradle task 'assembleAarRelease'... Done                   56.4s
✓ Built build/host/outputs/repo.
Running Gradle task 'assembleAarDebug'...
Running Gradle task 'assembleAarDebug'... Done                     29.5s
✓ Built build/host/outputs/repo.
Running Gradle task 'assembleAarProfile'...
Running Gradle task 'assembleAarProfile'... Done                   71.9s
✓ Built build/host/outputs/repo.

Consuming the Module
  1. Open <host>/app/build.gradle
  2. Ensure you have the repositories configured, otherwise add them:

      repositories {
        maven {
            url '/Users/egarciad/p/flutter_apps/add2app/flutter_module/build/host/outputs/repo'
        }
        maven {
            url 'http://download.flutter.io'
        }
      }

  3. Make the host app depend on the Flutter module:

    dependencies {
      releaseImplementation 'com.example.flutter_module:flutter_release:1.0
      debugImplementation 'com.example.flutter_module:flutter_debug:1.0
      profileImplementation 'com.example.flutter_module:flutter_profile:1.0
    }


  4. Add the `profile` build type:

    android {
      buildTypes {
        profile {
          initWith debug
        }
      }
    }

To learn more, visit https://flutter.dev/go/build-aar
```