### PR TITLE
FocusableActionDetector widget

### DIFF
--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -159,7 +159,6 @@ class Checkbox extends StatefulWidget {
 class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin {
   bool get enabled => widget.onChanged != null;
   Map<LocalKey, ActionFactory> _actionMap;
-  bool _showHighlight = false;
 
   @override
   void initState() {
@@ -168,8 +167,6 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin {
       SelectAction.key: _createAction,
       if (!kIsWeb) ActivateAction.key: _createAction,
     };
-    _updateHighlightMode(FocusManager.instance.highlightMode);
-    FocusManager.instance.addHighlightModeListener(_handleFocusHighlightModeChange);
   }
 
   void _actionHandler(FocusNode node, Intent intent){
@@ -197,27 +194,11 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin {
     );
   }
 
-  void _updateHighlightMode(FocusHighlightMode mode) {
-    switch (FocusManager.instance.highlightMode) {
-      case FocusHighlightMode.touch:
-        _showHighlight = false;
-        break;
-      case FocusHighlightMode.traditional:
-        _showHighlight = true;
-        break;
-    }
-  }
-
-  void _handleFocusHighlightModeChange(FocusHighlightMode mode) {
-    if (!mounted) {
-      return;
-    }
-    setState(() { _updateHighlightMode(mode); });
-  }
+  bool _showHighlight = false;
+  void _handleHighlightChanged(bool show) => setState(() { _showHighlight = show; });
 
   bool hovering = false;
-  void _handleMouseEnter(PointerEnterEvent event) => setState(() { hovering = true; });
-  void _handleMouseExit(PointerExitEvent event) => setState(() { hovering = false; });
+  void _handleHoverChanged(bool show) => setState(() { hovering = show; });
 
   @override
   Widget build(BuildContext context) {
@@ -233,35 +214,30 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin {
         break;
     }
     final BoxConstraints additionalConstraints = BoxConstraints.tight(size);
-    return MouseRegion(
-      onEnter: enabled ? _handleMouseEnter : null,
-      onExit: enabled ? _handleMouseExit : null,
-      child: Actions(
-        actions: _actionMap,
-        child: Focus(
-          focusNode: widget.focusNode,
-          autofocus: widget.autofocus,
-          canRequestFocus: enabled,
-          debugLabel: '${describeIdentity(widget)}(${widget.value})',
-          child: Builder(
-            builder: (BuildContext context) {
-              return _CheckboxRenderObjectWidget(
-                value: widget.value,
-                tristate: widget.tristate,
-                activeColor: widget.activeColor ?? themeData.toggleableActiveColor,
-                checkColor: widget.checkColor ?? const Color(0xFFFFFFFF),
-                inactiveColor: enabled ? themeData.unselectedWidgetColor : themeData.disabledColor,
-                focusColor: widget.focusColor ?? themeData.focusColor,
-                hoverColor: widget.hoverColor ?? themeData.hoverColor,
-                onChanged: widget.onChanged,
-                additionalConstraints: additionalConstraints,
-                vsync: this,
-                hasFocus: enabled && _showHighlight && Focus.of(context).hasFocus,
-                hovering: enabled && _showHighlight && hovering,
-              );
-            },
-          ),
-        ),
+    return FocusableActionDetector(
+      actions: _actionMap,
+      focusNode: widget.focusNode,
+      autofocus: widget.autofocus,
+      enabled: enabled,
+      onShowFocusHighlight: _handleHighlightChanged,
+      onShowHoverHighlight: _handleHoverChanged,
+      child: Builder(
+        builder: (BuildContext context) {
+          return _CheckboxRenderObjectWidget(
+            value: widget.value,
+            tristate: widget.tristate,
+            activeColor: widget.activeColor ?? themeData.toggleableActiveColor,
+            checkColor: widget.checkColor ?? const Color(0xFFFFFFFF),
+            inactiveColor: enabled ? themeData.unselectedWidgetColor : themeData.disabledColor,
+            focusColor: widget.focusColor ?? themeData.focusColor,
+            hoverColor: widget.hoverColor ?? themeData.hoverColor,
+            onChanged: widget.onChanged,
+            additionalConstraints: additionalConstraints,
+            vsync: this,
+            hasFocus: enabled && _showHighlight && Focus.of(context).hasFocus,
+            hovering: enabled && _showHighlight && hovering,
+          );
+        },
       ),
     );
   }

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -194,11 +194,19 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin {
     );
   }
 
-  bool _showHighlight = false;
-  void _handleHighlightChanged(bool show) => setState(() { _showHighlight = show; });
+  bool _focused = false;
+  void _handleFocusHighlightChanged(bool focused) {
+    if (focused != _focused) {
+      setState(() { _focused = focused; });
+    }
+  }
 
-  bool hovering = false;
-  void _handleHoverChanged(bool show) => setState(() { hovering = show; });
+  bool _hovering = false;
+  void _handleHoverChanged(bool hovering) {
+    if (hovering != _hovering) {
+      setState(() { _hovering = hovering; });
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -219,7 +227,7 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin {
       focusNode: widget.focusNode,
       autofocus: widget.autofocus,
       enabled: enabled,
-      onShowFocusHighlight: _handleHighlightChanged,
+      onShowFocusHighlight: _handleFocusHighlightChanged,
       onShowHoverHighlight: _handleHoverChanged,
       child: Builder(
         builder: (BuildContext context) {
@@ -234,8 +242,8 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin {
             onChanged: widget.onChanged,
             additionalConstraints: additionalConstraints,
             vsync: this,
-            hasFocus: enabled && _showHighlight && Focus.of(context).hasFocus,
-            hovering: enabled && _showHighlight && hovering,
+            hasFocus: _focused,
+            hovering: _hovering,
           );
         },
       ),

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -187,7 +187,6 @@ class Radio<T> extends StatefulWidget {
 class _RadioState<T> extends State<Radio<T>> with TickerProviderStateMixin {
   bool get enabled => widget.onChanged != null;
   Map<LocalKey, ActionFactory> _actionMap;
-  bool _showHighlight = false;
 
   @override
   void initState() {
@@ -196,8 +195,6 @@ class _RadioState<T> extends State<Radio<T>> with TickerProviderStateMixin {
       SelectAction.key: _createAction,
       if (!kIsWeb) ActivateAction.key: _createAction,
     };
-    _updateHighlightMode(FocusManager.instance.highlightMode);
-    FocusManager.instance.addHighlightModeListener(_handleFocusHighlightModeChange);
   }
 
   void _actionHandler(FocusNode node, Intent intent){
@@ -215,27 +212,11 @@ class _RadioState<T> extends State<Radio<T>> with TickerProviderStateMixin {
     );
   }
 
-  void _updateHighlightMode(FocusHighlightMode mode) {
-    switch (FocusManager.instance.highlightMode) {
-      case FocusHighlightMode.touch:
-        _showHighlight = false;
-        break;
-      case FocusHighlightMode.traditional:
-        _showHighlight = true;
-        break;
-    }
-  }
-
-  void _handleFocusHighlightModeChange(FocusHighlightMode mode) {
-    if (!mounted) {
-      return;
-    }
-    setState(() { _updateHighlightMode(mode); });
-  }
+  bool _showHighlight = false;
+  void _handleHighlightChanged(bool show) => setState(() { _showHighlight = show; });
 
   bool hovering = false;
-  void _handleMouseEnter(PointerEnterEvent event) => setState(() { hovering = true; });
-  void _handleMouseExit(PointerExitEvent event) => setState(() { hovering = false; });
+  void _handleHoverChanged(bool show) => setState(() { hovering = show; });
 
   Color _getInactiveColor(ThemeData themeData) {
     return enabled ? themeData.unselectedWidgetColor : themeData.disabledColor;
@@ -260,33 +241,28 @@ class _RadioState<T> extends State<Radio<T>> with TickerProviderStateMixin {
         break;
     }
     final BoxConstraints additionalConstraints = BoxConstraints.tight(size);
-    return MouseRegion(
-      onEnter: enabled ? _handleMouseEnter : null,
-      onExit: enabled ? _handleMouseExit : null,
-      child: Actions(
-        actions: _actionMap,
-        child: Focus(
-          focusNode: widget.focusNode,
-          autofocus: widget.autofocus,
-          canRequestFocus: enabled,
-          debugLabel: '${describeIdentity(widget)}(${widget.value})',
-          child: Builder(
-            builder: (BuildContext context) {
-              return _RadioRenderObjectWidget(
-                selected: widget.value == widget.groupValue,
-                activeColor: widget.activeColor ?? themeData.toggleableActiveColor,
-                inactiveColor: _getInactiveColor(themeData),
-                focusColor: widget.focusColor ?? themeData.focusColor,
-                hoverColor: widget.hoverColor ?? themeData.hoverColor,
-                onChanged: enabled ? _handleChanged : null,
-                additionalConstraints: additionalConstraints,
-                vsync: this,
-                hasFocus: enabled && _showHighlight && Focus.of(context).hasFocus,
-                hovering: enabled && _showHighlight && hovering,
-              );
-            },
-          ),
-        ),
+    return FocusableActionDetector(
+      actions: _actionMap,
+      focusNode: widget.focusNode,
+      autofocus: widget.autofocus,
+      enabled: enabled,
+      onShowFocusHighlight: _handleHighlightChanged,
+      onShowHoverHighlight: _handleHoverChanged,
+      child: Builder(
+        builder: (BuildContext context) {
+          return _RadioRenderObjectWidget(
+            selected: widget.value == widget.groupValue,
+            activeColor: widget.activeColor ?? themeData.toggleableActiveColor,
+            inactiveColor: _getInactiveColor(themeData),
+            focusColor: widget.focusColor ?? themeData.focusColor,
+            hoverColor: widget.hoverColor ?? themeData.hoverColor,
+            onChanged: enabled ? _handleChanged : null,
+            additionalConstraints: additionalConstraints,
+            vsync: this,
+            hasFocus: enabled && _showHighlight && Focus.of(context).hasFocus,
+            hovering: enabled && _showHighlight && hovering,
+          );
+        },
       ),
     );
   }

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -212,11 +212,19 @@ class _RadioState<T> extends State<Radio<T>> with TickerProviderStateMixin {
     );
   }
 
-  bool _showHighlight = false;
-  void _handleHighlightChanged(bool show) => setState(() { _showHighlight = show; });
+  bool _focused = false;
+  void _handleHighlightChanged(bool focused) {
+    if (_focused != focused) {
+      setState(() { _focused = focused; });
+    }
+  }
 
-  bool hovering = false;
-  void _handleHoverChanged(bool show) => setState(() { hovering = show; });
+  bool _hovering = false;
+  void _handleHoverChanged(bool hovering) {
+    if (_hovering != hovering) {
+      setState(() { _hovering = hovering; });
+    }
+  }
 
   Color _getInactiveColor(ThemeData themeData) {
     return enabled ? themeData.unselectedWidgetColor : themeData.disabledColor;
@@ -259,8 +267,8 @@ class _RadioState<T> extends State<Radio<T>> with TickerProviderStateMixin {
             onChanged: enabled ? _handleChanged : null,
             additionalConstraints: additionalConstraints,
             vsync: this,
-            hasFocus: enabled && _showHighlight && Focus.of(context).hasFocus,
-            hovering: enabled && _showHighlight && hovering,
+            hasFocus: _focused,
+            hovering: _hovering,
           );
         },
       ),

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -239,11 +239,19 @@ class _SwitchState extends State<Switch> with TickerProviderStateMixin {
     );
   }
 
-  bool _showHighlight = false;
-  void _handleHighlightChanged(bool show) => setState(() { _showHighlight = show; });
+  bool _focused = false;
+  void _handleFocusHighlightChanged(bool focused) {
+    if (focused != _focused) {
+      setState(() { _focused = focused; });
+    }
+  }
 
-  bool hovering = false;
-  void _handleHoverChanged(bool show) => setState(() { hovering = show; });
+  bool _hovering = false;
+  void _handleHoverChanged(bool hovering) {
+    if (hovering != _hovering) {
+      setState(() { _hovering = hovering; });
+    }
+  }
 
   Size getSwitchSize(ThemeData theme) {
     switch (widget.materialTapTargetSize ?? theme.materialTapTargetSize) {
@@ -286,11 +294,10 @@ class _SwitchState extends State<Switch> with TickerProviderStateMixin {
       focusNode: widget.focusNode,
       autofocus: widget.autofocus,
       enabled: enabled,
-      onShowFocusHighlight: _handleHighlightChanged,
+      onShowFocusHighlight: _handleFocusHighlightChanged,
       onShowHoverHighlight: _handleHoverChanged,
       child: Builder(
         builder: (BuildContext context) {
-          final bool hasFocus = Focus.of(context).hasFocus;
           return _SwitchRenderObjectWidget(
             dragStartBehavior: widget.dragStartBehavior,
             value: widget.value,
@@ -305,8 +312,8 @@ class _SwitchState extends State<Switch> with TickerProviderStateMixin {
             configuration: createLocalImageConfiguration(context),
             onChanged: widget.onChanged,
             additionalConstraints: BoxConstraints.tight(getSwitchSize(theme)),
-            hasFocus: enabled && _showHighlight && hasFocus,
-            hovering: enabled && _showHighlight && hovering,
+            hasFocus: _focused,
+            hovering: _hovering,
             vsync: this,
           );
         },

--- a/packages/flutter/lib/src/material/toggleable.dart
+++ b/packages/flutter/lib/src/material/toggleable.dart
@@ -474,7 +474,9 @@ abstract class RenderToggleable extends RenderConstrainedBox {
       final double reactionRadius = hasFocus || hovering
           ? kRadialReactionRadius
           : _kRadialReactionRadiusTween.evaluate(_reaction);
-      canvas.drawCircle(center + offset, reactionRadius, reactionPaint);
+      if (reactionRadius > 0.0) {
+        canvas.drawCircle(center + offset, reactionRadius, reactionPaint);
+      }
     }
   }
 

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -368,7 +368,142 @@ class Actions extends InheritedWidget {
 /// highlights.
 ///
 /// This widget can be used to give a control the required detection modes for
-/// focus and hover handling.
+/// focus and hover handling. It is most often used when authoring a new control
+/// widget, and the new control should be enabled for keyboard traversal and
+/// activation.
+///
+/// {@tool snippet --template=stateful_widget_material}
+/// This example shows how keyboard interaction can be added to a custom control
+/// that changes color when hovered and focused, and can toggle a light when
+/// activated, either by touch or by hitting the `X` key on the keyboard.
+///
+/// This example defines its own key binding for the `X` key, but in this case,
+/// there is also a default key binding for [ActivateAction] in the default key
+/// bindings created by [WidgetsApp] (the parent for [MaterialApp], and
+/// [CupertinoApp]), so the `ENTER` key will also activate the control.
+///
+/// ```dart imports
+/// import 'package:flutter/services.dart';
+/// ```
+///
+/// ```dart preamble
+/// class FadButton extends StatefulWidget {
+///   const FadButton({Key key, this.onPressed, this.child}) : super(key: key);
+///
+///   final VoidCallback onPressed;
+///   final Widget child;
+///
+///   @override
+///   _FadButtonState createState() => _FadButtonState();
+/// }
+///
+/// class _FadButtonState extends State<FadButton> {
+///   bool _focused = false;
+///   bool _hovering = false;
+///   bool _on = false;
+///   Map<LocalKey, ActionFactory> _actionMap;
+///   Map<LogicalKeySet, Intent> _shortcutMap;
+///
+///   @override
+///   void initState() {
+///     super.initState();
+///     _actionMap = <LocalKey, ActionFactory>{
+///       ActivateAction.key: () {
+///         return CallbackAction(
+///           ActivateAction.key,
+///           onInvoke: (FocusNode node, Intent intent) => _toggleState(),
+///         );
+///       },
+///     };
+///     _shortcutMap = <LogicalKeySet, Intent>{
+///       LogicalKeySet(LogicalKeyboardKey.keyX): Intent(ActivateAction.key),
+///     };
+///   }
+///
+///   Color get color {
+///     Color baseColor = Colors.lightBlue;
+///     if (_focused) {
+///       baseColor = Color.alphaBlend(Colors.black.withOpacity(0.25), baseColor);
+///     }
+///     if (_hovering) {
+///       baseColor = Color.alphaBlend(Colors.black.withOpacity(0.1), baseColor);
+///     }
+///     return baseColor;
+///   }
+///
+///   void _toggleState() {
+///     setState(() {
+///       _on = !_on;
+///     });
+///   }
+///
+///   void _handleFocusHighlight(bool value) {
+///     setState(() {
+///       _focused = value;
+///     });
+///   }
+///
+///   void _handleHoveHighlight(bool value) {
+///     setState(() {
+///       _hovering = value;
+///     });
+///   }
+///
+///   @override
+///   Widget build(BuildContext context) {
+///     return GestureDetector(
+///       onTap: _toggleState,
+///       child: FocusableActionDetector(
+///         actions: _actionMap,
+///         shortcuts: _shortcutMap,
+///         onShowFocusHighlight: _handleFocusHighlight,
+///         onShowHoverHighlight: _handleHoveHighlight,
+///         child: Row(
+///           children: <Widget>[
+///             Container(
+///               padding: EdgeInsets.all(10.0),
+///               color: color,
+///               child: widget.child,
+///             ),
+///             Container(
+///               width: 30,
+///               height: 30,
+///               margin: EdgeInsets.all(10.0),
+///               color: _on ? Colors.red : Colors.transparent,
+///             ),
+///           ],
+///         ),
+///       ),
+///     );
+///   }
+/// }
+/// ```
+///
+/// ```dart
+/// Widget build(BuildContext context) {
+///   return Scaffold(
+///     appBar: AppBar(
+///       title: Text('FocusableActionDetector Example'),
+///     ),
+///     body: Center(
+///       child: Row(
+///         mainAxisAlignment: MainAxisAlignment.center,
+///         children: <Widget>[
+///           Padding(
+///             padding: const EdgeInsets.all(8.0),
+///             child: FlatButton(onPressed: () {}, child: Text('Press Me')),
+///           ),
+///           Padding(
+///             padding: const EdgeInsets.all(8.0),
+///             child: FadButton(onPressed: () {}, child: Text('And Me')),
+///           ),
+///         ],
+///       ),
+///     ),
+///   );
+/// }
+/// ```
+/// {@end-tool}
 ///
 /// This widget doesn't have any visual representation, it is just a detector that
 /// provides focus and hover capabilities.

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -364,8 +364,8 @@ class Actions extends InheritedWidget {
 
 /// A widget that combines the functionality of [Actions], [Shortcuts],
 /// [MouseRegion] and a [Focus] widget to create a detector that defines actions
-/// and key bindings, and will notify that the focus or hover highlights should
-/// be shown or not.
+/// and key bindings, and provides callbacks for handling focus and hover
+/// highlights.
 ///
 /// This widget can be used to give a control the required detection modes for
 /// focus and hover handling.
@@ -527,7 +527,9 @@ class _FocusableActionDetectorState extends State<FocusableActionDetector> {
     if (widget.enabled && widget.actions != null && widget.actions.isNotEmpty) {
       child = Actions(actions: widget.actions, child: child);
     }
-    child = Shortcuts(shortcuts: widget.enabled && widget.shortcuts != null ? widget.shortcuts : const <LogicalKeySet, Intent>{}, child: child);
+    if (widget.enabled && widget.shortcuts != null && widget.shortcuts.isNotEmpty) {
+      child = Shortcuts(shortcuts: widget.shortcuts, child: child);
+    }
     return child;
   }
 }

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -1,6 +1,7 @@
 // Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -478,25 +479,27 @@ class _FocusableActionDetectorState extends State<FocusableActionDetector> {
   void _handleMouseEnter(PointerEnterEvent event) {
     assert(widget.onShowHoverHighlight != null);
     if (!_hovering) {
-      _hovering = true;
-      _handleShowHoverHighlight();
+      // TODO(gspencergoog): remove scheduleMicrotask once MouseRegion event timing has changed.
+      scheduleMicrotask(() { setState(() { _hovering = true; _handleShowHoverHighlight(); }); });
     }
   }
 
   void _handleMouseExit(PointerExitEvent event) {
     assert(widget.onShowHoverHighlight != null);
     if (_hovering) {
-      _hovering = false;
-      _handleShowHoverHighlight();
+      // TODO(gspencergoog): remove scheduleMicrotask once MouseRegion event timing has changed.
+      scheduleMicrotask(() { setState(() { _hovering = false; _handleShowHoverHighlight(); }); });
     }
   }
 
   bool _focused = false;
   void _handleFocusChange(bool focused) {
     if (_focused != focused) {
-      _focused = focused;
-      _handleShowFocusHighlight();
-      widget.onFocusChange?.call(_focused);
+      setState(() {
+        _focused = focused;
+        _handleShowFocusHighlight();
+        widget.onFocusChange?.call(_focused);
+      });
     }
   }
 
@@ -506,15 +509,6 @@ class _FocusableActionDetectorState extends State<FocusableActionDetector> {
 
   void _handleShowFocusHighlight() {
     widget.onShowFocusHighlight?.call(_focused && widget.enabled && _canShowHighlight);
-  }
-
-  @override
-  void didUpdateWidget(FocusableActionDetector oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (widget.enabled != oldWidget.enabled) {
-      _handleShowFocusHighlight();
-      _handleShowHoverHighlight();
-    }
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -325,7 +325,6 @@ class Focus extends StatefulWidget {
 class _FocusState extends State<Focus> {
   FocusNode _internalNode;
   FocusNode get focusNode => widget.focusNode ?? _internalNode;
-  bool _hasFocus;
   bool _hasPrimaryFocus;
   bool _canRequestFocus;
   bool _didAutofocus = false;
@@ -347,7 +346,6 @@ class _FocusState extends State<Focus> {
     _focusAttachment = focusNode.attach(context, onKey: widget.onKey);
     focusNode.skipTraversal = widget.skipTraversal ?? focusNode.skipTraversal;
     focusNode.canRequestFocus = widget.canRequestFocus ?? focusNode.canRequestFocus;
-    _hasFocus = focusNode.hasFocus;
     _canRequestFocus = focusNode.canRequestFocus;
     _hasPrimaryFocus = focusNode.hasPrimaryFocus;
 
@@ -425,22 +423,19 @@ class _FocusState extends State<Focus> {
   }
 
   void _handleFocusChanged() {
-    if (_hasFocus != focusNode.hasFocus) {
-      setState(() {
-        _hasFocus = focusNode.hasFocus;
-      });
-      if (widget.onFocusChange != null) {
-        widget.onFocusChange(focusNode.hasFocus);
-      }
+    final bool hasPrimaryFocus = focusNode.hasPrimaryFocus;
+    final bool canRequestFocus = focusNode.canRequestFocus;
+    if (widget.onFocusChange != null) {
+      widget.onFocusChange(focusNode.hasFocus);
     }
-    if (_hasPrimaryFocus != focusNode.hasPrimaryFocus) {
+    if (_hasPrimaryFocus != hasPrimaryFocus) {
       setState(() {
-        _hasPrimaryFocus = focusNode.hasPrimaryFocus;
+        _hasPrimaryFocus = hasPrimaryFocus;
       });
     }
-    if (_canRequestFocus != focusNode.canRequestFocus) {
+    if (_canRequestFocus != canRequestFocus) {
       setState(() {
-        _canRequestFocus = focusNode.canRequestFocus;
+        _canRequestFocus = canRequestFocus;
       });
     }
   }

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -254,11 +254,13 @@ class Shortcuts extends StatefulWidget {
   /// [shortcuts] change materially.
   final ShortcutManager manager;
 
-  /// The map of shortcuts that the [manager] will be given to manage.
+  /// {@template flutter.widgets.shortcuts.shortcuts}
+  /// The map of shortcuts that the [ShortcutManager] will be given to manage.
   ///
   /// For performance reasons, it is recommended that a pre-built map is passed
   /// in here (e.g. a final variable from your widget class) instead of defining
   /// it inline in the build function.
+  /// {@endtemplate}
   final Map<LogicalKeySet, Intent> shortcuts;
 
   /// The child widget for this [Shortcuts] widget.

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -68,7 +68,7 @@ void main() {
       ),
     ));
 
-    expect(tester.getSemantics(find.byType(Focus)), matchesSemantics(
+    expect(tester.getSemantics(find.byType(Focus).last), matchesSemantics(
       hasCheckedState: true,
       hasEnabledState: true,
       isEnabled: true,
@@ -83,7 +83,7 @@ void main() {
       ),
     ));
 
-    expect(tester.getSemantics(find.byType(Focus)), matchesSemantics(
+    expect(tester.getSemantics(find.byType(Focus).last), matchesSemantics(
       hasCheckedState: true,
       hasEnabledState: true,
       isChecked: true,
@@ -99,10 +99,9 @@ void main() {
       ),
     ));
 
-    expect(tester.getSemantics(find.byType(Focus)), matchesSemantics(
+    expect(tester.getSemantics(find.byType(Focus).last), matchesSemantics(
       hasCheckedState: true,
       hasEnabledState: true,
-      isFocusable: true,
     ));
 
     await tester.pumpWidget(const Material(
@@ -112,7 +111,7 @@ void main() {
       ),
     ));
 
-    expect(tester.getSemantics(find.byType(Focus)), matchesSemantics(
+    expect(tester.getSemantics(find.byType(Focus).last), matchesSemantics(
       hasCheckedState: true,
       hasEnabledState: true,
       isChecked: true,
@@ -134,7 +133,7 @@ void main() {
       ),
     ));
 
-    expect(tester.getSemantics(find.byType(Focus)), matchesSemantics(
+    expect(tester.getSemantics(find.byType(Focus).last), matchesSemantics(
       label: 'foo',
       textDirection: TextDirection.ltr,
       hasCheckedState: true,

--- a/packages/flutter/test/material/radio_test.dart
+++ b/packages/flutter/test/material/radio_test.dart
@@ -180,11 +180,11 @@ void main() {
     expect(semantics, hasSemantics(TestSemantics.root(
       children: <TestSemantics>[
         TestSemantics.rootChild(
-          id: 1,
+          id: 2,
           flags: <SemanticsFlag>[
-            SemanticsFlag.isInMutuallyExclusiveGroup,
             SemanticsFlag.hasCheckedState,
             SemanticsFlag.hasEnabledState,
+            SemanticsFlag.isInMutuallyExclusiveGroup,
           ],
         ),
       ],
@@ -201,12 +201,12 @@ void main() {
     expect(semantics, hasSemantics(TestSemantics.root(
       children: <TestSemantics>[
         TestSemantics.rootChild(
-          id: 1,
+          id: 2,
           flags: <SemanticsFlag>[
-            SemanticsFlag.isInMutuallyExclusiveGroup,
             SemanticsFlag.hasCheckedState,
             SemanticsFlag.isChecked,
             SemanticsFlag.hasEnabledState,
+            SemanticsFlag.isInMutuallyExclusiveGroup,
           ],
         ),
       ],

--- a/packages/flutter/test/material/radio_test.dart
+++ b/packages/flutter/test/material/radio_test.dart
@@ -185,7 +185,6 @@ void main() {
             SemanticsFlag.isInMutuallyExclusiveGroup,
             SemanticsFlag.hasCheckedState,
             SemanticsFlag.hasEnabledState,
-            SemanticsFlag.isFocusable,
           ],
         ),
       ],
@@ -396,6 +395,7 @@ void main() {
     }
     await tester.pumpWidget(buildApp());
 
+    await tester.pump();
     await tester.pumpAndSettle();
     expect(
       Material.of(tester.element(find.byKey(radioKey))),
@@ -415,6 +415,7 @@ void main() {
     // Check when the radio isn't selected.
     groupValue = 1;
     await tester.pumpWidget(buildApp());
+    await tester.pump();
     await tester.pumpAndSettle();
     expect(
         Material.of(tester.element(find.byKey(radioKey))),
@@ -429,6 +430,7 @@ void main() {
     // Check when the radio is selected, but disabled.
     groupValue = 0;
     await tester.pumpWidget(buildApp(enabled: false));
+    await tester.pump();
     await tester.pumpAndSettle();
     expect(
       Material.of(tester.element(find.byKey(radioKey))),


### PR DESCRIPTION
## Description

This adds a `FocusableActionDetector`, a widget which combines the functionality of `Actions`, `Shortcuts`, `MouseRegion` and a `Focus` widget to create a detector that defines actions and key bindings, and will notify that the focus or hover highlights should be shown or not. This widget can be used to give a control the required detection modes for focus and hover handling on desktop and web platforms.

I replaced a bunch of similar code in many of our widgets with this widget, and found that pretty much any control that wants to be focusable wants all of these features as well: focus highlights, hover highlights, and actions to activate it.

Also eliminated an extra `_hasFocus` variable in `FocusState` that wasn't being used.

## Tests

- Added tests for the new widget.

## Breaking Change

- [X] No, this is *not* a breaking change.