### PR TITLE
Catch and display version check errors during doctor

### DIFF
--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -10,7 +10,7 @@ UserMessages get userMessages => context.get<UserMessages>();
 class UserMessages {
   // Messages used in FlutterValidator
   String flutterStatusInfo(String channel, String version, String os, String locale) =>
-      'Channel $channel, v$version, on $os, locale $locale';
+      'Channel ${channel ?? 'unknown'}, v${version ?? 'Unknown'}, on $os, locale $locale';
   String flutterVersion(String version, String flutterRoot) =>
       'Flutter version $version at $flutterRoot';
   String flutterRevision(String revision, String age, String date) =>

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -587,13 +587,22 @@ class FlutterValidator extends DoctorValidator {
   Future<ValidationResult> validate() async {
     final List<ValidationMessage> messages = <ValidationMessage>[];
     ValidationType valid = ValidationType.installed;
+    String versionChannel;
+    String frameworkVersion;
 
-    final FlutterVersion version = FlutterVersion.instance;
+    try {
+      final FlutterVersion version = FlutterVersion.instance;
+      versionChannel = version.channel;
+      frameworkVersion = version.frameworkVersion;
+      messages.add(ValidationMessage(userMessages.flutterVersion(frameworkVersion, Cache.flutterRoot)));
+      messages.add(ValidationMessage(userMessages.flutterRevision(version.frameworkRevisionShort, version.frameworkAge, version.frameworkDate)));
+      messages.add(ValidationMessage(userMessages.engineRevision(version.engineRevisionShort)));
+      messages.add(ValidationMessage(userMessages.dartRevision(version.dartSdkVersion)));
+    } on VersionCheckError catch (e) {
+      messages.add(ValidationMessage.error(e.message));
+      valid = ValidationType.partial;
+    }
 
-    messages.add(ValidationMessage(userMessages.flutterVersion(version.frameworkVersion, Cache.flutterRoot)));
-    messages.add(ValidationMessage(userMessages.flutterRevision(version.frameworkRevisionShort, version.frameworkAge, version.frameworkDate)));
-    messages.add(ValidationMessage(userMessages.engineRevision(version.engineRevisionShort)));
-    messages.add(ValidationMessage(userMessages.dartRevision(version.dartSdkVersion)));
     final String genSnapshotPath =
       artifacts.getArtifactPath(Artifact.genSnapshot);
 
@@ -609,7 +618,7 @@ class FlutterValidator extends DoctorValidator {
     }
 
     return ValidationResult(valid, messages,
-      statusInfo: userMessages.flutterStatusInfo(version.channel, version.frameworkVersion, os.name, platform.localeName),
+      statusInfo: userMessages.flutterStatusInfo(versionChannel, frameworkVersion, os.name, platform.localeName),
     );
   }
 }


### PR DESCRIPTION
## Description

Catch and display version check issues instead of crashing.

New text:
```
Doctor summary (to see all details, run flutter doctor -v):
[!] Flutter (Channel unknown, v0.0.0-unknown, Mac OS X 10.14.6 18G87, locale en-US)
    ✗ Command exited with code 69: git -c log.showSignature=false log -n 1 --pretty=format:%ad --date=iso
      Standard error: 
      Agreeing to the Xcode/iOS license requires admin privileges, please run “sudo xcodebuild -license” and then retry this command.
```

## Related Issues

Fixes https://github.com/flutter/flutter/issues/28939

## Tests

Added new doctor_test.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.