### PR TITLE
Add -runFirstLaunch hint text

### DIFF
--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -139,7 +139,8 @@ class UserMessages {
   String get xcodeEula => 'Xcode end user license agreement not signed; open Xcode or run the command \'sudo xcodebuild -license\'.';
   String get xcodeMissingSimct =>
       'Xcode requires additional components to be installed in order to run.\n'
-      'Launch Xcode and install additional required components when prompted.';
+      'Launch Xcode and install additional required components when prompted or run:\n'
+      '  sudo xcodebuild -runFirstLaunch';
   String get xcodeMissing =>
       'Xcode not installed; this is necessary for iOS development.\n'
       'Download at https://developer.apple.com/xcode/download/.';
@@ -148,7 +149,8 @@ class UserMessages {
       'Download at: https://developer.apple.com/xcode/download/\n'
       'Or install Xcode via the App Store.\n'
       'Once installed, run:\n'
-      '  sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer';
+      '  sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer\n'
+      '  sudo xcodebuild -runFirstLaunch';
 
   // Messages used in CocoaPodsValidator
   String cocoaPodsVersion(String version) => 'CocoaPods version $version';


### PR DESCRIPTION
## Description

After installing Xcode, there are additional components to install.  Users can either launch Xcode or run `sudo xcodebuild -runFirstLaunch`.  Give the hint to run that command in more places to match https://flutter.dev/docs/get-started/install/macos#install-xcode.

## Related Issues

Issue where this may have helped:
https://github.com/flutter/flutter/issues/43956

## Tests

None, just changing some constant strings.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.