### PR TITLE
Deprecate `flutter logs` command

### DIFF
--- a/packages/flutter_tools/lib/src/commands/logs.dart
+++ b/packages/flutter_tools/lib/src/commands/logs.dart
@@ -24,6 +24,9 @@ class LogsCommand extends FlutterCommand {
   final String name = 'logs';
 
   @override
+  final bool deprecated = true;
+
+  @override
   final String description = 'Show log output for running Flutter apps.';
 
   @override

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -130,6 +130,8 @@ abstract class FlutterCommand extends Command<void> {
 
   bool get shouldUpdateCache => true;
 
+  bool get deprecated => false;
+
   bool _excludeDebug = false;
 
   BuildMode _defaultBuildMode;
@@ -500,6 +502,7 @@ abstract class FlutterCommand extends Command<void> {
       body: () async {
         // Prints the welcome message if needed.
         flutterUsage.printWelcome();
+        _printDeprecationWarning();
         final String commandPath = await usagePath;
         _registerSignalHandlers(commandPath, startTime);
         FlutterCommandResult commandResult;
@@ -515,6 +518,13 @@ abstract class FlutterCommand extends Command<void> {
         }
       },
     );
+  }
+
+  void _printDeprecationWarning() {
+    if (deprecated) {
+      printStatus('$warningMark The "$name" command will be deprecated in a future version of Flutter.');
+      printStatus('');
+    }
   }
 
   void _registerSignalHandlers(String commandPath, DateTime startTime) {

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -522,7 +522,7 @@ abstract class FlutterCommand extends Command<void> {
 
   void _printDeprecationWarning() {
     if (deprecated) {
-      printStatus('$warningMark The "$name" command will be deprecated in a future version of Flutter.');
+      printStatus('$warningMark The "$name" command is deprecated and will be removed in a future version of Flutter.');
       printStatus('');
     }
   }

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -63,7 +63,6 @@ void main() {
       await flutterCommand.run();
 
       expect(testLogger.statusText, contains('is deprecated and will be removed'));
-      verify(cache.updateAll(any)).called(1);
     },
     overrides: <Type, Generator>{
       Cache: () => cache,

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -58,6 +58,17 @@ void main() {
       Cache: () => cache,
     });
 
+    testUsingContext('deprecated command should warn', () async {
+      final FakeDeprecatedCommand flutterCommand = FakeDeprecatedCommand();
+      await flutterCommand.run();
+
+      expect(testLogger.statusText, contains('is deprecated and will be removed'));
+      verify(cache.updateAll(any)).called(1);
+    },
+    overrides: <Type, Generator>{
+      Cache: () => cache,
+    });
+
     void testUsingCommandContext(String testName, Function testBody) {
       testUsingContext(testName, testBody, overrides: <Type, Generator>{
         ProcessInfo: () => mockProcessInfo,
@@ -359,13 +370,15 @@ void main() {
   });
 }
 
-
-class FakeCommand extends FlutterCommand {
+class FakeDeprecatedCommand extends FlutterCommand {
   @override
   String get description => null;
 
   @override
-  String get name => 'fake';
+  String get name => 'deprecated';
+
+  @override
+  bool get deprecated => true;
 
   @override
   Future<FlutterCommandResult> runCommand() async {


### PR DESCRIPTION
## Description

Add deprecation warning to `flutter logs`
To be completely deleted someday with https://github.com/flutter/flutter/issues/44875.

```
$ flutter logs
[!] The "logs" command is deprecated and will be removed in a future version of Flutter.

Showing Flutter iOS Device logs:

```

![Screen Shot 2019-11-14 at 11 20 38 AM](https://user-images.githubusercontent.com/682784/68888977-d1244200-06d0-11ea-89e1-40085d922dc7.png)


## Related Issues

Fixes https://github.com/flutter/flutter/issues/44199
(doesn't really fix the iOS 13 issue, obviously)

## Tests

Added flutter_command_test.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.