### PR TITLE
Fake locale in doctor_test

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
@@ -29,7 +29,10 @@ import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/testbed.dart';
 
-final Generator _kNoColorOutputPlatform = () => FakePlatform.fromPlatform(const LocalPlatform())..stdoutSupportsAnsi = false;
+final Generator _kNoColorOutputPlatform = () => FakePlatform.fromPlatform(const LocalPlatform())
+  ..localeName = 'en_US.UTF-8'
+  ..stdoutSupportsAnsi = false;
+
 final Map<Type, Generator> noColorTerminalOverride = <Type, Generator>{
   Platform: _kNoColorOutputPlatform,
 };
@@ -528,7 +531,7 @@ void main() {
 
       expect(testLogger.statusText, equals(
         'Doctor summary (to see all details, run flutter doctor -v):\n'
-          '[!] Flutter (Channel unknown, v0.0.0, on fake OS name and version, locale en-US)\n'
+          '[!] Flutter (Channel unknown, v0.0.0, on fake OS name and version, locale en_US.UTF-8)\n'
           '    ✗ version error\n\n'
           '! Doctor found issues in 1 category.\n'
       ));


### PR DESCRIPTION
## Description

Fake out the doctor_test locale to account for locale variances between CI hosts.

```
12:32 +1590 ~5 -1: test/commands.shard/hermetic/doctor_test.dart: doctor with fake validators version checking does not work                                                                           
12:32 +1590 ~5 -1: test/commands.shard/hermetic/doctor_test.dart: doctor with fake validators version checking does not work [E]                                                                       
  Expected: 'Doctor summary (to see all details, run flutter doctor -v):\n'
              '[!] Flutter (Channel unknown, v0.0.0, on fake OS name and version, locale en-US)\n'
              '    ✗ version error\n'
              '\n'
              '! Doctor found issues in 1 category.\n'
              ''
    Actual: 'Doctor summary (to see all details, run flutter doctor -v):\n'
              '[!] Flutter (Channel unknown, v0.0.0, on fake OS name and version, locale en_US.UTF-8)\n'
              '    ✗ version error\n'
              '\n'
              '! Doctor found issues in 1 category.\n'
              ''
     Which: is different.
            Expected: ...  locale en-US)\n     ...
              Actual: ...  locale en_US.UTF-8) ...
                                    ^
             Differ at offset 137
  package:test_api                                                         expect
  org-dartlang-app:///test/commands.shard/hermetic/doctor_test.dart 529:7  main.<fn>.<fn>
  ===== asynchronous gap ===========================
  dart:async                                                               _asyncErrorWrapperHelper
  package:flutter_tools/src/base/context.dart                              AppContext.run
  org-dartlang-app:///test/src/context.dart 120:30                         testUsingContext.<fn>.<fn>.<fn>.<fn>
  dart:async                                                               runZoned
  org-dartlang-app:///test/src/context.dart 118:18                         testUsingContext.<fn>.<fn>.<fn>
  package:flutter_tools/src/base/context.dart 146:29                       AppContext.run.<fn>
```

## Related Issues

Introduced with https://github.com/flutter/flutter/pull/44868.