### PR TITLE
[flutter_tool] Various fixes for 'run' for Fuchsia.

### DIFF
--- a/examples/flutter_gallery/fuchsia/meta/flutter_gallery.cmx
+++ b/examples/flutter_gallery/fuchsia/meta/flutter_gallery.cmx
@@ -1,0 +1,18 @@
+{
+    "program": {
+        "data": "data/flutter_gallery"
+    },
+    "sandbox": {
+        "services": [
+            "fuchsia.cobalt.LoggerFactory",
+            "fuchsia.fonts.Provider",
+            "fuchsia.logger.LogSink",
+            "fuchsia.modular.Clipboard",
+            "fuchsia.sys.Environment",
+            "fuchsia.sys.Launcher",
+            "fuchsia.ui.input.ImeService",
+            "fuchsia.ui.policy.Presenter",
+            "fuchsia.ui.scenic.Scenic"
+        ]
+    }
+}

--- a/examples/hello_world/fuchsia/meta/hello_world.cmx
+++ b/examples/hello_world/fuchsia/meta/hello_world.cmx
@@ -1,0 +1,18 @@
+{
+    "program": {
+        "data": "data/hello_world"
+    },
+    "sandbox": {
+        "services": [
+            "fuchsia.cobalt.LoggerFactory",
+            "fuchsia.fonts.Provider",
+            "fuchsia.logger.LogSink",
+            "fuchsia.modular.Clipboard",
+            "fuchsia.sys.Environment",
+            "fuchsia.sys.Launcher",
+            "fuchsia.ui.input.ImeService",
+            "fuchsia.ui.policy.Presenter",
+            "fuchsia.ui.scenic.Scenic"
+        ]
+    }
+}

--- a/packages/flutter_tools/lib/src/fuchsia/amber_ctl.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/amber_ctl.dart
@@ -102,7 +102,7 @@ class FuchsiaAmberCtl {
   /// the Fuchsia package server that it was accessing via [serverUrl].
   Future<bool> pkgCtlRepoRemove(FuchsiaDevice device, FuchsiaPackageServer server) async {
     final String repoUrl = 'fuchsia-pkg://${server.name}';
-    final RunResult result = await device.shell('pkgctl repo remove --repo-url $repoUrl');
+    final RunResult result = await device.shell('pkgctl repo rm $repoUrl');
     return result.exitCode == 0;
   }
 }

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_kernel_compiler.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_kernel_compiler.dart
@@ -58,7 +58,9 @@ class FuchsiaKernelCompiler {
       '--filesystem-root', fsRoot,
       '--packages', '$multiRootScheme:///$relativePackagesFile',
       '--output', fs.path.join(outDir, '$appName.dil'),
-      '--no-link-platform',
+      // TODO(zra): Add back when this is supported again.
+      // See: https://github.com/flutter/flutter/issues/44925
+      // '--no-link-platform',
       '--split-output-by-packages',
       '--manifest', manifestPath,
       '--component-name', appName,


### PR DESCRIPTION
## Description

A few things:
- Fixes the pkgctl command to remove the tool's package repo
- Makes the code that creates and deletes the package repo a little more resilient
- Adds cmx files for hello_world and flutter_gallery examples
- Stops passing the --no-link-platform flag to the Fuchsia kernel compiler. This was needed to avoid crashes with the flutter_runner most recently rolled into flutter/flutter. I suspect a similar change may be needed in dart_kernel.gni in the engine repo.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.