### PR TITLE
Default doctor command to verbose

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -73,7 +73,7 @@ Future<void> main(List<String> args) async {
     CreateCommand(),
     DaemonCommand(hidden: !verboseHelp),
     DevicesCommand(),
-    DoctorCommand(verbose: verbose),
+    DoctorCommand(verboseHelp: verboseHelp),
     DriveCommand(),
     EmulatorsCommand(),
     FormatCommand(),

--- a/packages/flutter_tools/lib/src/commands/doctor.dart
+++ b/packages/flutter_tools/lib/src/commands/doctor.dart
@@ -9,20 +9,23 @@ import '../doctor.dart';
 import '../runner/flutter_command.dart';
 
 class DoctorCommand extends FlutterCommand {
-  DoctorCommand({this.verbose = false}) {
+  DoctorCommand({ bool verboseHelp = false }) {
+    argParser.addFlag('summary',
+      defaultsTo: false,
+      negatable: false,
+      help: 'Summarize doctor diagnosis.',
+    );
     argParser.addFlag('android-licenses',
       defaultsTo: false,
       negatable: false,
       help: 'Run the Android SDK manager tool to accept the SDK\'s licenses.',
     );
     argParser.addOption('check-for-remote-artifacts',
-      hide: !verbose,
+      hide: !verboseHelp,
       help: 'Used to determine if Flutter engine artifacts for all platforms '
             'are available for download.',
       valueHelp: 'engine revision git hash',);
   }
-
-  final bool verbose;
 
   @override
   final String name = 'doctor';
@@ -56,6 +59,7 @@ class DoctorCommand extends FlutterCommand {
             'git hash.');
       }
     }
+    final bool verbose = !argResults['summary'];
     final bool success = await doctor.diagnose(androidLicenses: argResults['android-licenses'], verbose: verbose);
     return FlutterCommandResult(success ? ExitStatus.success : ExitStatus.warning);
   }

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -244,7 +244,7 @@ class Doctor {
     }
 
     if (!verbose) {
-      printStatus('Doctor summary (to see all details, run flutter doctor -v):');
+      printStatus('Doctor summary:');
     }
     bool doctorResult = true;
     int issues = 0;

--- a/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
@@ -206,7 +206,7 @@ void main() {
     testUsingContext('validate non-verbose output format for run without issues', () async {
       expect(await doctor.diagnose(verbose: false), isTrue);
       expect(testLogger.statusText, equals(
-              'Doctor summary (to see all details, run flutter doctor -v):\n'
+              'Doctor summary:\n'
               '[✓] Passing Validator (with statusInfo)\n'
               '[✓] Another Passing Validator (with statusInfo)\n'
               '[✓] Providing validators is fun (with statusInfo)\n'
@@ -353,7 +353,7 @@ void main() {
     testUsingContext('validate non-verbose output format for run without issues', () async {
       expect(await FakeQuietDoctor().diagnose(verbose: false), isTrue);
       expect(testLogger.statusText, equals(
-              'Doctor summary (to see all details, run flutter doctor -v):\n'
+              'Doctor summary:\n'
               '[✓] Passing Validator (with statusInfo)\n'
               '[✓] Another Passing Validator (with statusInfo)\n'
               '[✓] Validators are fun (with statusInfo)\n'
@@ -366,7 +366,7 @@ void main() {
     testUsingContext('validate non-verbose output format for run with crash', () async {
       expect(await FakeCrashingDoctor().diagnose(verbose: false), isFalse);
       expect(testLogger.statusText, equals(
-              'Doctor summary (to see all details, run flutter doctor -v):\n'
+              'Doctor summary:\n'
               '[✓] Passing Validator (with statusInfo)\n'
               '[✓] Another Passing Validator (with statusInfo)\n'
               '[☠] Crashing validator (the doctor check crashed)\n'
@@ -398,7 +398,7 @@ void main() {
         return completer.future;
       });
       expect(testLogger.statusText, equals(
-              'Doctor summary (to see all details, run flutter doctor -v):\n'
+              'Doctor summary:\n'
               '[✓] Passing Validator (with statusInfo)\n'
               '[✓] Another Passing Validator (with statusInfo)\n'
               '[☠] Async crashing validator (the doctor check crashed)\n'
@@ -416,7 +416,7 @@ void main() {
     testUsingContext('validate non-verbose output format when only one category fails', () async {
       expect(await FakeSinglePassingDoctor().diagnose(verbose: false), isTrue);
       expect(testLogger.statusText, equals(
-              'Doctor summary (to see all details, run flutter doctor -v):\n'
+              'Doctor summary:\n'
               '[!] Partial Validator with only a Hint\n'
               '    ! There is a hint here\n'
               '\n'
@@ -427,7 +427,7 @@ void main() {
     testUsingContext('validate non-verbose output format for a passing run', () async {
       expect(await FakePassingDoctor().diagnose(verbose: false), isTrue);
       expect(testLogger.statusText, equals(
-              'Doctor summary (to see all details, run flutter doctor -v):\n'
+              'Doctor summary:\n'
               '[✓] Passing Validator (with statusInfo)\n'
               '[!] Partial Validator with only a Hint\n'
               '    ! There is a hint here\n'
@@ -443,7 +443,7 @@ void main() {
     testUsingContext('validate non-verbose output format', () async {
       expect(await FakeDoctor().diagnose(verbose: false), isFalse);
       expect(testLogger.statusText, equals(
-              'Doctor summary (to see all details, run flutter doctor -v):\n'
+              'Doctor summary:\n'
               '[✓] Passing Validator (with statusInfo)\n'
               '[✗] Missing Validator\n'
               '    ✗ A useful error message\n'
@@ -530,7 +530,7 @@ void main() {
       expect(await FlutterValidatorDoctor().diagnose(verbose: false), isTrue);
 
       expect(testLogger.statusText, equals(
-        'Doctor summary (to see all details, run flutter doctor -v):\n'
+        'Doctor summary:\n'
           '[!] Flutter (Channel unknown, v0.0.0, on fake OS name and version, locale en_US.UTF-8)\n'
           '    ✗ version error\n\n'
           '! Doctor found issues in 1 category.\n'

--- a/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
@@ -546,9 +546,7 @@ void main() {
   testUsingContext('validate non-verbose output wrapping', () async {
     expect(await FakeDoctor().diagnose(verbose: false), isFalse);
     expect(testLogger.statusText, equals(
-        'Doctor summary (to see all\n'
-        'details, run flutter doctor\n'
-        '-v):\n'
+        'Doctor summary:\n'
         '[✓] Passing Validator (with\n'
         '    statusInfo)\n'
         '[✗] Missing Validator\n'

--- a/packages/flutter_tools/test/general.shard/analytics_test.dart
+++ b/packages/flutter_tools/test/general.shard/analytics_test.dart
@@ -156,7 +156,7 @@ void main() {
 
     testUsingContext('flutter commands send timing events', () async {
       mockTimes = <int>[1000, 2000];
-      when(mockDoctor.diagnose(androidLicenses: false, verbose: false)).thenAnswer((_) async => true);
+      when(mockDoctor.diagnose(androidLicenses: false, verbose: true)).thenAnswer((_) async => true);
       final DoctorCommand command = DoctorCommand();
       final CommandRunner<void> runner = createTestCommandRunner(command);
       await runner.run(<String>['doctor']);
@@ -175,7 +175,7 @@ void main() {
 
     testUsingContext('doctor fail sends warning', () async {
       mockTimes = <int>[1000, 2000];
-      when(mockDoctor.diagnose(androidLicenses: false, verbose: false)).thenAnswer((_) async => false);
+      when(mockDoctor.diagnose(androidLicenses: false, verbose: true)).thenAnswer((_) async => false);
       final DoctorCommand command = DoctorCommand();
       final CommandRunner<void> runner = createTestCommandRunner(command);
       await runner.run(<String>['doctor']);


### PR DESCRIPTION
## Description

Default `flutter doctor` to verbose.  Add a `--summary` flag for previous behavior.

```
$ flutter doctor -h
Show information about the installed tooling.

Usage: flutter doctor [arguments]
-h, --help                Print this usage information.
    --summary             Summarize doctor diagnosis.
    --android-licenses    Run the Android SDK manager tool to accept the SDK's
                          licenses.

Run "flutter help" to see global options.
```
`--check-for-remote-artifacts` help is still hidden behind `-v`:
```
$ flutter doctor -h -v
Show information about the installed tooling.

Usage: flutter doctor [arguments]
-h, --help                                                     Print this usage
                                                               information.

    --summary                                                  Summarize doctor
                                                               diagnosis.

    --android-licenses                                         Run the Android
                                                               SDK manager tool
                                                               to accept the
                                                               SDK's licenses.

    --check-for-remote-artifacts=<engine revision git hash>    Used to determine
                                                               if Flutter engine
                                                               artifacts for all
                                                               platforms are
                                                               available for
                                                               download.

Run "flutter help" to see global options.
```
```
$ flutter doctor
[✓] Flutter (Channel dr-verbose, v1.12.1-pre.62, on Mac OS X 10.14.6 18G87,
    locale en-US)
    • Flutter version 1.12.1-pre.62 at /Users/magder/Projects/flutter
    • Framework revision c557613d08 (19 minutes ago), 2019-11-14 17:01:54 -0800
    • Engine revision 77c3512ec8
    • Dart version 2.7.0

[✓] Android toolchain - develop for Android devices (Android SDK version 28.0.3)
    • Android SDK at /Users/magder/Library/Android/sdk
    • Android NDK location not configured (optional; useful for native profiling
      support)
    • Platform android-28, build-tools 28.0.3
    • Java binary at: /Applications/Android
      Studio.app/Contents/jre/jdk/Contents/Home/bin/java
    • Java version OpenJDK Runtime Environment (build
      1.8.0_202-release-1483-b49-5587405)
    • All Android licenses accepted.

[✓] Xcode - develop for iOS and macOS (Xcode 11.2)
    • Xcode at /Users/magder/Applications/Xcode-11_2.app/Contents/Developer
    • Xcode 11.2, Build version 11B41
    • CocoaPods version 1.8.4

[✓] Android Studio (version 3.5)
    • Android Studio at /Applications/Android Studio.app/Contents
    • Flutter plugin version 40.2.2
    • Dart plugin version 191.8593
    • Java version OpenJDK Runtime Environment (build
      1.8.0_202-release-1483-b49-5587405)

[✓] IntelliJ IDEA Community Edition (version 2019.2.3)
    • IntelliJ at /Applications/IntelliJ IDEA CE.app
    • Flutter plugin version 41.1.3
    • Dart plugin version 192.7402

[✓] VS Code (version 1.39.2)
    • VS Code at /Applications/Visual Studio Code.app/Contents
    • Flutter extension version 3.6.0

[✓] Connected device (3 available)
    • iPhone            • d83d5bc53967baa0ee18626ba87b6254b2ab5418 • ios • iOS
      13.1.3
    • iPod touch        • 9fbe53ba4d06927398644c5bd520d2aa18053017 • ios • iOS
      11.3.1
    • iPhone 11 Pro Max • 389148FB-E436-4F8B-B37A-8564AF1627C0     • ios •
      com.apple.CoreSimulator.SimRuntime.iOS-13-2 (simulator)

• No issues found!
```
```
$ flutter doctor --summary
Doctor summary:
[✓] Flutter (Channel dr-verbose, v1.12.1-pre.62, on Mac OS X 10.14.6 18G87,
    locale en-US)
[✓] Android toolchain - develop for Android devices (Android SDK version 28.0.3)
[✓] Xcode - develop for iOS and macOS (Xcode 11.2)
[✓] Android Studio (version 3.5)
[✓] IntelliJ IDEA Community Edition (version 2019.2.3)
[✓] VS Code (version 1.39.2)
[✓] Connected device (3 available)

• No issues found!
```
And `flutter doctor -v` does the same thing as `flutter doctor`, so no harm if people are following older instructions.

### Pros
- Reduce the number of back-and-forth to get actionable information in GitHub issues (no more "can you paste the output of `flutter doctor -v`")
- Give users more diagnosable context for installation issues

### Cons
Will break anyone relying on the format of this command for automated workflows?  Not sure if this is a real issue.  We can try it and see if anyone complains.  If they do, I would suggest adding a `--machine` flag instead of reverting this.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/44124

## Tests

Updated doctor tests summary text.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.