### PR TITLE
Don't log stack traces to console on build failures

### DIFF
--- a/packages/flutter_tools/lib/src/aot.dart
+++ b/packages/flutter_tools/lib/src/aot.dart
@@ -226,8 +226,11 @@ class AotBuilder {
     status?.stop();
     if (!result.success) {
       for (ExceptionMeasurement measurement in result.exceptions.values) {
-        printError(measurement.exception.toString());
-        printError(measurement.stackTrace.toString());
+        printError('Target ${measurement.target} failed: ${measurement.exception}',
+          stackTrace: measurement.fatal
+            ? measurement.stackTrace
+            : null,
+        );
       }
       throwToolExit('Failed to build aot.');
     }

--- a/packages/flutter_tools/lib/src/build_system/build_system.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_system.dart
@@ -556,6 +556,8 @@ class _BuildInstance {
         }
       }
     } catch (exception, stackTrace) {
+      // TODO(jonahwilliams): throw specific exception for expected errors to mark
+      // as non-fatal. All others should be fatal.
       node.target.clearStamp(environment);
       passed = false;
       skipped = false;
@@ -573,11 +575,14 @@ class _BuildInstance {
 
 /// Helper class to collect exceptions.
 class ExceptionMeasurement {
-  ExceptionMeasurement(this.target, this.exception, this.stackTrace);
+  ExceptionMeasurement(this.target, this.exception, this.stackTrace, {this.fatal = false});
 
   final String target;
   final dynamic exception;
   final StackTrace stackTrace;
+
+  /// Whether this exception was a fatal build system error.
+  final bool fatal;
 
   @override
   String toString() => 'target: $target\nexception:$exception\n$stackTrace';

--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -126,8 +126,11 @@ Future<void> buildWithAssemble({
 
   if (!result.success) {
     for (ExceptionMeasurement measurement in result.exceptions.values) {
-      printError(measurement.exception.toString());
-      printError(measurement.stackTrace.toString());
+        printError('Target ${measurement.target} failed: ${measurement.exception}',
+          stackTrace: measurement.fatal
+            ? measurement.stackTrace
+            : null,
+        );
     }
     throwToolExit('Failed to build bundle.');
   }

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -156,7 +156,7 @@ class AssembleCommand extends FlutterCommand {
     ));
     if (!result.success) {
       for (MapEntry<String, ExceptionMeasurement> data in result.exceptions.entries) {
-        printError('Target ${data.key} failed: ${data.value.exception}', stackTrace: data.value.stackTrace);
+        printError('Target ${data.key} failed: ${data.value.exception}');
       }
       throwToolExit('build failed.');
     }

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -155,8 +155,12 @@ class AssembleCommand extends FlutterCommand {
       resourcePoolSize: argResults['resource-pool-size'],
     ));
     if (!result.success) {
-      for (MapEntry<String, ExceptionMeasurement> data in result.exceptions.entries) {
-        printError('Target ${data.key} failed: ${data.value.exception}');
+      for (ExceptionMeasurement measurement in result.exceptions.values) {
+        printError('Target ${measurement.target} failed: ${measurement.exception}',
+          stackTrace: measurement.fatal
+            ? measurement.stackTrace
+            : null,
+        );
       }
       throwToolExit('build failed.');
     }

--- a/packages/flutter_tools/lib/src/web/compile.dart
+++ b/packages/flutter_tools/lib/src/web/compile.dart
@@ -54,8 +54,11 @@ Future<void> buildWeb(
     ));
     if (!result.success) {
       for (ExceptionMeasurement measurement in result.exceptions.values) {
-        printError(measurement.stackTrace.toString());
-        printError(measurement.exception.toString());
+        printError('Target ${measurement.target} failed: ${measurement.exception}',
+          stackTrace: measurement.fatal
+            ? measurement.stackTrace
+            : null,
+        );
       }
       throwToolExit('Failed to compile application for the Web.');
     }

--- a/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
@@ -41,7 +41,8 @@ void main() {
       });
     final CommandRunner<void> commandRunner = createTestCommandRunner(AssembleCommand());
 
-    expect(commandRunner.run(<String>['assemble', 'debug_macos_bundle_flutter_assets']), throwsA(isInstanceOf<ToolExit>()));
+    expect(commandRunner.run(<String>['assemble', 'debug_macos_bundle_flutter_assets']),
+      throwsA(isInstanceOf<ToolExit>()));
   });
 
   testbed.test('Throws ToolExit if called with non-existent rule', () async {
@@ -51,7 +52,8 @@ void main() {
       });
     final CommandRunner<void> commandRunner = createTestCommandRunner(AssembleCommand());
 
-    expect(commandRunner.run(<String>['assemble', '-o Output', 'undefined']), throwsA(isInstanceOf<ToolExit>()));
+    expect(commandRunner.run(<String>['assemble', '-o Output', 'undefined']),
+      throwsA(isInstanceOf<ToolExit>()));
   });
 
   testbed.test('Does not log stack traces during build failure', () async {
@@ -65,7 +67,8 @@ void main() {
       });
     final CommandRunner<void> commandRunner = createTestCommandRunner(AssembleCommand());
 
-    await expectLater(commandRunner.run(<String>['assemble', '-o Output', 'debug_macos_bundle_flutter_assets']), throwsA(isInstanceOf<ToolExit>()));
+    await expectLater(commandRunner.run(<String>['assemble', '-o Output', 'debug_macos_bundle_flutter_assets']),
+      throwsA(isInstanceOf<ToolExit>()));
     expect(bufferLogger.errorText, contains('bar'));
     expect(bufferLogger.errorText, isNot(contains(testStackTrace.toString())));
   });
@@ -81,7 +84,13 @@ void main() {
       });
 
     final CommandRunner<void> commandRunner = createTestCommandRunner(AssembleCommand());
-    await commandRunner.run(<String>['assemble', '-o Output', '--build-outputs=outputs', '--build-inputs=inputs', 'debug_macos_bundle_flutter_assets']);
+    await commandRunner.run(<String>[
+      'assemble',
+      '-o Output',
+      '--build-outputs=outputs',
+      '--build-inputs=inputs',
+      'debug_macos_bundle_flutter_assets',
+    ]);
 
     final File inputs = fs.file('inputs');
     final File outputs = fs.file('outputs');
@@ -91,7 +100,13 @@ void main() {
     final DateTime theDistantPast = DateTime(1991, 8, 23);
     inputs.setLastModifiedSync(theDistantPast);
     outputs.setLastModifiedSync(theDistantPast);
-    await commandRunner.run(<String>['assemble', '-o Output', '--build-outputs=outputs', '--build-inputs=inputs', 'debug_macos_bundle_flutter_assets']);
+    await commandRunner.run(<String>[
+      'assemble',
+      '-o Output',
+      '--build-outputs=outputs',
+      '--build-inputs=inputs',
+      'debug_macos_bundle_flutter_assets',
+    ]);
 
     expect(inputs.lastModifiedSync(), theDistantPast);
     expect(outputs.lastModifiedSync(), theDistantPast);
@@ -103,7 +118,13 @@ void main() {
           inputFiles: <File>[fs.file('foo'), fs.file('fizz')..createSync()],
           outputFiles: <File>[fs.file('bar'), fs.file(fs.path.join('.dart_tool', 'fizz2'))..createSync(recursive: true)]);
       });
-    await commandRunner.run(<String>['assemble', '-o Output', '--build-outputs=outputs', '--build-inputs=inputs', 'debug_macos_bundle_flutter_assets']);
+    await commandRunner.run(<String>[
+      'assemble',
+      '-o Output',
+      '--build-outputs=outputs',
+      '--build-inputs=inputs',
+      'debug_macos_bundle_flutter_assets',
+    ]);
 
     expect(inputs.readAsStringSync(), contains('foo'));
     expect(inputs.readAsStringSync(), contains('fizz'));


### PR DESCRIPTION
## Description

These are confusing when there is a compilation error, as it seems like the tool has failed.

Fixes https://github.com/flutter/flutter/issues/44963