### PR TITLE
Set modal bottom sheet barrier color

### DIFF
--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -343,6 +343,7 @@ class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
     this.elevation,
     this.shape,
     this.clipBehavior,
+    this.modalBarrierColor,
     this.isDismissible = true,
     @required this.isScrollControlled,
     RouteSettings settings,
@@ -357,6 +358,7 @@ class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
   final double elevation;
   final ShapeBorder shape;
   final Clip clipBehavior;
+  final Color modalBarrierColor;
   final bool isDismissible;
 
   @override
@@ -369,7 +371,7 @@ class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
   final String barrierLabel;
 
   @override
-  Color get barrierColor => Colors.black54;
+  Color get barrierColor => modalBarrierColor ?? Colors.black54;
 
   AnimationController _animationController;
 
@@ -457,6 +459,7 @@ Future<T> showModalBottomSheet<T>({
   double elevation,
   ShapeBorder shape,
   Clip clipBehavior,
+  Color barrierColor,
   bool isScrollControlled = false,
   bool useRootNavigator = false,
   bool isDismissible = true,
@@ -479,6 +482,7 @@ Future<T> showModalBottomSheet<T>({
     shape: shape,
     clipBehavior: clipBehavior,
     isDismissible: isDismissible,
+    modalBarrierColor: barrierColor
   ));
 }
 

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -342,6 +342,7 @@ void main() {
     const double elevation = 9.0;
     final ShapeBorder shape = BeveledRectangleBorder(borderRadius: BorderRadius.circular(12));
     const Clip clipBehavior = Clip.antiAlias;
+    const Color barrierColor = Colors.red;
 
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
@@ -353,6 +354,7 @@ void main() {
     showModalBottomSheet<void>(
       context: scaffoldKey.currentContext,
       backgroundColor: color,
+      barrierColor: barrierColor,
       elevation: elevation,
       shape: shape,
       clipBehavior: clipBehavior,
@@ -371,6 +373,9 @@ void main() {
     expect(bottomSheet.elevation, elevation);
     expect(bottomSheet.shape, shape);
     expect(bottomSheet.clipBehavior, clipBehavior);
+
+    final ModalBarrier modalBarrier = tester.widget(find.byType(ModalBarrier).last);
+    expect(modalBarrier.color, barrierColor);
   });
 
   testWidgets('modal BottomSheet with scrollController has semantics', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

When presenting a Modal Bottom Sheet this PR allows to pass down a value for the color of the modal barrier. This is a non-breaking change, because the default behavior is being kept.

## Tests

I added the following tests:

* A test which confirms that the presented modal barrier color reflects the passed in value for the color.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
