### PR TITLE
catch IOSDeviceNotFoundError in IOSDevice.startApp()

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -286,7 +286,8 @@ class IOSDevice extends Device {
 
       try {
         cpuArchitecture = await iMobileDevice.getInfoForDevice(id, 'CPUArchitecture');
-      } on IOSDeviceNotFoundError {
+      } on IOSDeviceNotFoundError catch (e) {
+        printError(e.message);
         return LaunchResult.failed();
       }
 

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -282,7 +282,14 @@ class IOSDevice extends Device {
       // TODO(chinmaygarde): Use mainPath, route.
       printTrace('Building ${package.name} for $id');
 
-      final String cpuArchitecture = await iMobileDevice.getInfoForDevice(id, 'CPUArchitecture');
+      String cpuArchitecture;
+
+      try {
+        cpuArchitecture = await iMobileDevice.getInfoForDevice(id, 'CPUArchitecture');
+      } on IOSDeviceNotFoundError {
+        return LaunchResult.failed();
+      }
+
       final DarwinArch iosArch = getIOSArchForName(cpuArchitecture);
 
       // Step 1: Build the precompiled/DBC application if necessary.

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -249,6 +249,20 @@ void main() {
         Cache.enableLocking();
       });
 
+      testUsingContext('returns failed if the IOSDevice is not found', () async {
+        final IOSDevice device = IOSDevice('123');
+        when(mockIMobileDevice.getInfoForDevice(any, 'CPUArchitecture')).thenThrow(
+          const IOSDeviceNotFoundError(
+            'ideviceinfo could not find device:\n'
+            'No device found with udid 123, is it plugged in?\n'
+            'Try unlocking attached devices.'
+          )
+        );
+        await device.startApp(mockApp);
+      }, overrides: <Type, Generator>{
+        IMobileDevice: () => mockIMobileDevice,
+      });
+
       testUsingContext(' succeeds in debug mode via mDNS', () async {
         final IOSDevice device = IOSDevice('123');
         device.portForwarder = mockPortForwarder;

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -262,6 +262,7 @@ void main() {
         expect(result.started, false);
       }, overrides: <Type, Generator>{
         IMobileDevice: () => mockIMobileDevice,
+        Platform: () => macPlatform,
       });
 
       testUsingContext(' succeeds in debug mode via mDNS', () async {

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -258,7 +258,8 @@ void main() {
             'Try unlocking attached devices.'
           )
         );
-        await device.startApp(mockApp);
+        final LaunchResult result = await device.startApp(mockApp);
+        expect(result.started, false);
       }, overrides: <Type, Generator>{
         IMobileDevice: () => mockIMobileDevice,
       });


### PR DESCRIPTION
## Description

We have been seeing crash reports where an uncaught `IOSDeviceNotFoundError` bubbles up during `flutter run`, probably because the screen for the device is locked. I actually couldn't reproduce this, either with a CLI tool or an IDE, but I wrote a unit test for it and fixed it by catching the error in the `device.startApp()` method and returning a `LaunchResult.failed()`.

## Related Issues

Fixes 45010

## Tests

I added a new test to verify there are no uncaught exceptions in `device.startApp()` when `IMobileDevice.getAttachedDevices()` throws `IOSDeviceNotFoundError` and that it returns a failed result.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.