### PR TITLE
Ignore vscode Java plugin auto-generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,10 @@
 .idea/
 
 # Visual Studio Code related
-.vscode/
+.classpath
 .project
+.settings/
+.vscode/
 
 # Flutter repo-specific
 /bin/cache/


### PR DESCRIPTION
I'm seeing `classpath` and `.settings` files being auto-generated for me in VSCode because of the Java plugin. 

Related to https://github.com/flutter/flutter/pull/44019
