### PR TITLE
Overridable default platform key bindings

### DIFF
--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -194,10 +194,92 @@ class CupertinoApp extends StatefulWidget {
   /// {@macro flutter.widgets.widgetsApp.debugShowCheckedModeBanner}
   final bool debugShowCheckedModeBanner;
 
-  /// {@macro flutter.widgets.widgetsApp.shortcuts}
+  /// The default map of keyboard shortcuts to intents for the application.
+  ///
+  /// By default, this is set to [WidgetsApp.defaultShortcuts].
+  ///
+  /// {@tool sample}
+  /// This example shows how to add a single shortcut for
+  /// [LogicalKeyboardKey.select] to the default shortcuts without needing to
+  /// add your own [Shortcuts] widget.
+  ///
+  /// Alternatively, you could insert a [Shortcuts] widget with just the mapping
+  /// you want to add between the [WidgetsApp] and its child and get the same
+  /// effect.
+  ///
+  /// ```dart
+  /// Widget build(BuildContext context) {
+  ///   return WidgetsApp(
+  ///     shortcuts: <LogicalKeySet, Intent>{
+  ///       ... WidgetsApp.defaultShortcuts,
+  ///       LogicalKeySet(LogicalKeyboardKey.select): const Intent(ActivateAction.key),
+  ///     },
+  ///     color: const Color(0xFFFF0000),
+  ///     builder: (BuildContext context, Widget child) {
+  ///       return const Placeholder();
+  ///     },
+  ///   );
+  /// }
+  /// ```
+  /// {@end-tool}
+  ///
+  /// See also:
+  ///
+  /// * [LogicalKeySet], a set of [LogicalKeyboardKey]s that make up the keys
+  ///    for this map.
+  /// * The [Shortcuts] widget, which defines a keyboard mapping.
+  /// * The [Actions] widget, which defines the mapping from intent to action.
+  /// * The [Intent] and [Action] classes, which allow definition of new
+  ///    actions.
   final Map<LogicalKeySet, Intent> shortcuts;
 
-  /// {@macro flutter.widgets.widgetsApp.actions}
+  /// The default map of intent keys to actions for the application.
+  ///
+  /// By default, this is the output of [WidgetsApp.defaultActions], called with
+  /// [defaultTargetPlatform]. Specifying [actions] for an app overrides the
+  /// default, so if you wish to modify the default [actions], you can call
+  /// [WidgetsApp.defaultActions] and modify the resulting map, passing it as
+  /// the [actions] for this app. You may also add to the bindings, or override
+  /// specific bindings for a widget subtree, by adding your own [Actions]
+  /// widget.
+  ///
+  /// {@tool sample}
+  /// This example shows how to add a single action handling an
+  /// [ActivateAction] to the default actions without needing to
+  /// add your own [Actions] widget.
+  ///
+  /// Alternatively, you could insert a [Actions] widget with just the mapping
+  /// you want to add between the [WidgetsApp] and its child and get the same
+  /// effect.
+  ///
+  /// ```dart
+  /// Widget build(BuildContext context) {
+  ///   return WidgetsApp(
+  ///     actions: <LocalKey, ActionFactory>{
+  ///       ... WidgetsApp.defaultActions,
+  ///       ActivateAction.key: () => CallbackAction(
+  ///         ActivateAction.key,
+  ///         onInvoke: (FocusNode focusNode, Intent intent) {
+  ///           // Do something here...
+  ///         },
+  ///       ),
+  ///     },
+  ///     color: const Color(0xFFFF0000),
+  ///     builder: (BuildContext context, Widget child) {
+  ///       return const Placeholder();
+  ///     },
+  ///   );
+  /// }
+  /// ```
+  /// {@end-tool}
+  /// See also:
+  ///
+  /// * The [shortcuts] parameter, which defines the default set of shortcuts
+  ///    for the application.
+  /// * The [Shortcuts] widget, which defines a keyboard mapping.
+  /// * The [Actions] widget, which defines the mapping from intent to action.
+  /// * The [Intent] and [Action] classes, which allow definition of new
+  ///    actions.
   final Map<LocalKey, ActionFactory> actions;
 
   @override

--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -194,10 +194,7 @@ class CupertinoApp extends StatefulWidget {
   /// {@macro flutter.widgets.widgetsApp.debugShowCheckedModeBanner}
   final bool debugShowCheckedModeBanner;
 
-  /// The default map of keyboard shortcuts to intents for the application.
-  ///
-  /// By default, this is set to [WidgetsApp.defaultShortcuts].
-  ///
+  /// {@macro flutter.widgets.widgetsApp.shortcuts}
   /// {@tool sample}
   /// This example shows how to add a single shortcut for
   /// [LogicalKeyboardKey.select] to the default shortcuts without needing to
@@ -222,27 +219,10 @@ class CupertinoApp extends StatefulWidget {
   /// }
   /// ```
   /// {@end-tool}
-  ///
-  /// See also:
-  ///
-  /// * [LogicalKeySet], a set of [LogicalKeyboardKey]s that make up the keys
-  ///    for this map.
-  /// * The [Shortcuts] widget, which defines a keyboard mapping.
-  /// * The [Actions] widget, which defines the mapping from intent to action.
-  /// * The [Intent] and [Action] classes, which allow definition of new
-  ///    actions.
+  /// {@macro flutter.widgets.widgetsApp.shortcuts.seeAlso}
   final Map<LogicalKeySet, Intent> shortcuts;
 
-  /// The default map of intent keys to actions for the application.
-  ///
-  /// By default, this is the output of [WidgetsApp.defaultActions], called with
-  /// [defaultTargetPlatform]. Specifying [actions] for an app overrides the
-  /// default, so if you wish to modify the default [actions], you can call
-  /// [WidgetsApp.defaultActions] and modify the resulting map, passing it as
-  /// the [actions] for this app. You may also add to the bindings, or override
-  /// specific bindings for a widget subtree, by adding your own [Actions]
-  /// widget.
-  ///
+  /// {@macro flutter.widgets.widgetsApp.actions}
   /// {@tool sample}
   /// This example shows how to add a single action handling an
   /// [ActivateAction] to the default actions without needing to
@@ -272,14 +252,7 @@ class CupertinoApp extends StatefulWidget {
   /// }
   /// ```
   /// {@end-tool}
-  /// See also:
-  ///
-  /// * The [shortcuts] parameter, which defines the default set of shortcuts
-  ///    for the application.
-  /// * The [Shortcuts] widget, which defines a keyboard mapping.
-  /// * The [Actions] widget, which defines the mapping from intent to action.
-  /// * The [Intent] and [Action] classes, which allow definition of new
-  ///    actions.
+  /// {@macro flutter.widgets.widgetsApp.actions.seeAlso}
   final Map<LocalKey, ActionFactory> actions;
 
   @override

--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -91,6 +91,8 @@ class CupertinoApp extends StatefulWidget {
     this.checkerboardOffscreenLayers = false,
     this.showSemanticsDebugger = false,
     this.debugShowCheckedModeBanner = true,
+    this.shortcuts,
+    this.actions,
   }) : assert(routes != null),
        assert(navigatorObservers != null),
        assert(title != null),
@@ -191,6 +193,12 @@ class CupertinoApp extends StatefulWidget {
 
   /// {@macro flutter.widgets.widgetsApp.debugShowCheckedModeBanner}
   final bool debugShowCheckedModeBanner;
+
+  /// {@macro flutter.widgets.widgetsApp.shortcuts}
+  final Map<LogicalKeySet, Intent> shortcuts;
+
+  /// {@macro flutter.widgets.widgetsApp.actions}
+  final Map<LocalKey, ActionFactory> actions;
 
   @override
   _CupertinoAppState createState() => _CupertinoAppState();
@@ -312,6 +320,8 @@ class _CupertinoAppState extends State<CupertinoApp> {
                     onPressed: onPressed,
                   );
                 },
+                shortcuts: widget.shortcuts,
+                actions: widget.actions,
               );
             },
           ),

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -457,10 +457,92 @@ class MaterialApp extends StatefulWidget {
   /// {@macro flutter.widgets.widgetsApp.debugShowCheckedModeBanner}
   final bool debugShowCheckedModeBanner;
 
-  /// {@macro flutter.widgets.widgetsApp.shortcuts}
+  /// The default map of keyboard shortcuts to intents for the application.
+  ///
+  /// By default, this is set to [WidgetsApp.defaultShortcuts].
+  ///
+  /// {@tool sample}
+  /// This example shows how to add a single shortcut for
+  /// [LogicalKeyboardKey.select] to the default shortcuts without needing to
+  /// add your own [Shortcuts] widget.
+  ///
+  /// Alternatively, you could insert a [Shortcuts] widget with just the mapping
+  /// you want to add between the [WidgetsApp] and its child and get the same
+  /// effect.
+  ///
+  /// ```dart
+  /// Widget build(BuildContext context) {
+  ///   return WidgetsApp(
+  ///     shortcuts: <LogicalKeySet, Intent>{
+  ///       ... WidgetsApp.defaultShortcuts,
+  ///       LogicalKeySet(LogicalKeyboardKey.select): const Intent(ActivateAction.key),
+  ///     },
+  ///     color: const Color(0xFFFF0000),
+  ///     builder: (BuildContext context, Widget child) {
+  ///       return const Placeholder();
+  ///     },
+  ///   );
+  /// }
+  /// ```
+  /// {@end-tool}
+  ///
+  /// See also:
+  ///
+  /// * [LogicalKeySet], a set of [LogicalKeyboardKey]s that make up the keys
+  ///    for this map.
+  /// * The [Shortcuts] widget, which defines a keyboard mapping.
+  /// * The [Actions] widget, which defines the mapping from intent to action.
+  /// * The [Intent] and [Action] classes, which allow definition of new
+  ///    actions.
   final Map<LogicalKeySet, Intent> shortcuts;
 
-  /// {@macro flutter.widgets.widgetsApp.actions}
+  /// The default map of intent keys to actions for the application.
+  ///
+  /// By default, this is the output of [WidgetsApp.defaultActions], called with
+  /// [defaultTargetPlatform]. Specifying [actions] for an app overrides the
+  /// default, so if you wish to modify the default [actions], you can call
+  /// [WidgetsApp.defaultActions] and modify the resulting map, passing it as
+  /// the [actions] for this app. You may also add to the bindings, or override
+  /// specific bindings for a widget subtree, by adding your own [Actions]
+  /// widget.
+  ///
+  /// {@tool sample}
+  /// This example shows how to add a single action handling an
+  /// [ActivateAction] to the default actions without needing to
+  /// add your own [Actions] widget.
+  ///
+  /// Alternatively, you could insert a [Actions] widget with just the mapping
+  /// you want to add between the [WidgetsApp] and its child and get the same
+  /// effect.
+  ///
+  /// ```dart
+  /// Widget build(BuildContext context) {
+  ///   return WidgetsApp(
+  ///     actions: <LocalKey, ActionFactory>{
+  ///       ... WidgetsApp.defaultActions,
+  ///       ActivateAction.key: () => CallbackAction(
+  ///         ActivateAction.key,
+  ///         onInvoke: (FocusNode focusNode, Intent intent) {
+  ///           // Do something here...
+  ///         },
+  ///       ),
+  ///     },
+  ///     color: const Color(0xFFFF0000),
+  ///     builder: (BuildContext context, Widget child) {
+  ///       return const Placeholder();
+  ///     },
+  ///   );
+  /// }
+  /// ```
+  /// {@end-tool}
+  /// See also:
+  ///
+  /// * The [shortcuts] parameter, which defines the default set of shortcuts
+  ///    for the application.
+  /// * The [Shortcuts] widget, which defines a keyboard mapping.
+  /// * The [Actions] widget, which defines the mapping from intent to action.
+  /// * The [Intent] and [Action] classes, which allow definition of new
+  ///    actions.
   final Map<LocalKey, ActionFactory> actions;
 
   /// Turns on a [GridPaper] overlay that paints a baseline grid

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -189,6 +189,8 @@ class MaterialApp extends StatefulWidget {
     this.checkerboardOffscreenLayers = false,
     this.showSemanticsDebugger = false,
     this.debugShowCheckedModeBanner = true,
+    this.shortcuts,
+    this.actions,
   }) : assert(routes != null),
        assert(navigatorObservers != null),
        assert(title != null),
@@ -455,6 +457,12 @@ class MaterialApp extends StatefulWidget {
   /// {@macro flutter.widgets.widgetsApp.debugShowCheckedModeBanner}
   final bool debugShowCheckedModeBanner;
 
+  /// {@macro flutter.widgets.widgetsApp.shortcuts}
+  final Map<LogicalKeySet, Intent> shortcuts;
+
+  /// {@macro flutter.widgets.widgetsApp.actions}
+  final Map<LocalKey, ActionFactory> actions;
+
   /// Turns on a [GridPaper] overlay that paints a baseline grid
   /// Material apps.
   ///
@@ -626,6 +634,8 @@ class _MaterialAppState extends State<MaterialApp> {
           mini: true,
         );
       },
+      shortcuts: widget.shortcuts,
+      actions: widget.actions,
     );
 
     assert(() {

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -457,10 +457,7 @@ class MaterialApp extends StatefulWidget {
   /// {@macro flutter.widgets.widgetsApp.debugShowCheckedModeBanner}
   final bool debugShowCheckedModeBanner;
 
-  /// The default map of keyboard shortcuts to intents for the application.
-  ///
-  /// By default, this is set to [WidgetsApp.defaultShortcuts].
-  ///
+  /// {@macro flutter.widgets.widgetsApp.shortcuts}
   /// {@tool sample}
   /// This example shows how to add a single shortcut for
   /// [LogicalKeyboardKey.select] to the default shortcuts without needing to
@@ -485,27 +482,10 @@ class MaterialApp extends StatefulWidget {
   /// }
   /// ```
   /// {@end-tool}
-  ///
-  /// See also:
-  ///
-  /// * [LogicalKeySet], a set of [LogicalKeyboardKey]s that make up the keys
-  ///    for this map.
-  /// * The [Shortcuts] widget, which defines a keyboard mapping.
-  /// * The [Actions] widget, which defines the mapping from intent to action.
-  /// * The [Intent] and [Action] classes, which allow definition of new
-  ///    actions.
+  /// {@macro flutter.widgets.widgetsApp.shortcuts.seeAlso}
   final Map<LogicalKeySet, Intent> shortcuts;
 
-  /// The default map of intent keys to actions for the application.
-  ///
-  /// By default, this is the output of [WidgetsApp.defaultActions], called with
-  /// [defaultTargetPlatform]. Specifying [actions] for an app overrides the
-  /// default, so if you wish to modify the default [actions], you can call
-  /// [WidgetsApp.defaultActions] and modify the resulting map, passing it as
-  /// the [actions] for this app. You may also add to the bindings, or override
-  /// specific bindings for a widget subtree, by adding your own [Actions]
-  /// widget.
-  ///
+  /// {@macro flutter.widgets.widgetsApp.actions}
   /// {@tool sample}
   /// This example shows how to add a single action handling an
   /// [ActivateAction] to the default actions without needing to
@@ -535,14 +515,7 @@ class MaterialApp extends StatefulWidget {
   /// }
   /// ```
   /// {@end-tool}
-  /// See also:
-  ///
-  /// * The [shortcuts] parameter, which defines the default set of shortcuts
-  ///    for the application.
-  /// * The [Shortcuts] widget, which defines a keyboard mapping.
-  /// * The [Actions] widget, which defines the mapping from intent to action.
-  /// * The [Intent] and [Action] classes, which allow definition of new
-  ///    actions.
+  /// {@macro flutter.widgets.widgetsApp.actions.seeAlso}
   final Map<LocalKey, ActionFactory> actions;
 
   /// Turns on a [GridPaper] overlay that paints a baseline grid

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -164,8 +164,7 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin {
   void initState() {
     super.initState();
     _actionMap = <LocalKey, ActionFactory>{
-      SelectAction.key: _createAction,
-      if (!kIsWeb) ActivateAction.key: _createAction,
+      ActivateAction.key: _createAction,
     };
   }
 
@@ -189,7 +188,7 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin {
 
   Action _createAction() {
     return CallbackAction(
-      SelectAction.key,
+      ActivateAction.key,
       onInvoke: _actionHandler,
     );
   }

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1059,7 +1059,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
       _internalNode ??= _createFocusNode();
     }
     _actionMap = <LocalKey, ActionFactory>{
-      ActivateAction.key: _createActivateAction,
+      ActivateAction.key: _createAction,
     };
     focusNode.addListener(_handleFocusChanged);
     final FocusManager focusManager = WidgetsBinding.instance.focusManager;
@@ -1172,7 +1172,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     });
   }
 
-  Action _createActivateAction() {
+  Action _createAction() {
     return CallbackAction(
       ActivateAction.key,
       onInvoke: (FocusNode node, Intent intent) {

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -152,7 +152,7 @@ class _DropdownMenuItemButtonState<T> extends State<_DropdownMenuItemButton<T>> 
   }
 
   static final Map<LogicalKeySet, Intent> _webShortcuts =<LogicalKeySet, Intent>{
-    LogicalKeySet(LogicalKeyboardKey.enter): const Intent(SelectAction.key),
+    LogicalKeySet(LogicalKeyboardKey.enter): const Intent(ActivateAction.key),
   };
 
   @override
@@ -1059,8 +1059,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
       _internalNode ??= _createFocusNode();
     }
     _actionMap = <LocalKey, ActionFactory>{
-      SelectAction.key: _createAction,
-      if (!kIsWeb) ActivateAction.key: _createAction,
+      ActivateAction.key: _createActivateAction,
     };
     focusNode.addListener(_handleFocusChanged);
     final FocusManager focusManager = WidgetsBinding.instance.focusManager;
@@ -1173,7 +1172,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     });
   }
 
-  Action _createAction() {
+  Action _createActivateAction() {
     return CallbackAction(
       ActivateAction.key,
       onInvoke: (FocusNode node, Intent intent) {

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -505,8 +505,7 @@ class _InkResponseState<T extends InkResponse> extends State<T> with AutomaticKe
   void initState() {
     super.initState();
     _actionMap = <LocalKey, ActionFactory>{
-      SelectAction.key: _createAction,
-      if (!kIsWeb) ActivateAction.key: _createAction,
+      ActivateAction.key: _createAction,
     };
     FocusManager.instance.addHighlightModeListener(_handleFocusHighlightModeChange);
   }

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -192,8 +192,7 @@ class _RadioState<T> extends State<Radio<T>> with TickerProviderStateMixin {
   void initState() {
     super.initState();
     _actionMap = <LocalKey, ActionFactory>{
-      SelectAction.key: _createAction,
-      if (!kIsWeb) ActivateAction.key: _createAction,
+      ActivateAction.key: _createAction,
     };
   }
 
@@ -207,7 +206,7 @@ class _RadioState<T> extends State<Radio<T>> with TickerProviderStateMixin {
 
   Action _createAction() {
     return CallbackAction(
-      SelectAction.key,
+      ActivateAction.key,
       onInvoke: _actionHandler,
     );
   }

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -219,8 +219,7 @@ class _SwitchState extends State<Switch> with TickerProviderStateMixin {
   void initState() {
     super.initState();
     _actionMap = <LocalKey, ActionFactory>{
-      SelectAction.key: _createAction,
-      if (!kIsWeb) ActivateAction.key: _createAction,
+      ActivateAction.key: _createAction,
     };
   }
 
@@ -234,7 +233,7 @@ class _SwitchState extends State<Switch> with TickerProviderStateMixin {
 
   Action _createAction() {
     return CallbackAction(
-      SelectAction.key,
+      ActivateAction.key,
       onInvoke: _actionHandler,
     );
   }

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -9,7 +9,6 @@ import 'package:flutter/gestures.dart';
 import 'basic.dart';
 import 'focus_manager.dart';
 import 'focus_scope.dart';
-import 'focus_traversal.dart';
 import 'framework.dart';
 import 'shortcuts.dart';
 
@@ -706,19 +705,6 @@ class _FocusableActionDetectorState extends State<FocusableActionDetector> {
   }
 }
 
-/// Creates the default map of actions used by [WidgetsApp] to define the set
-/// of available actions for an application.
-Map<LocalKey, ActionFactory> defaultActions(TargetPlatform targetPlatform) {
-  // At the moment, all platforms have the same set of available actions.
-  return <LocalKey, ActionFactory>{
-    DoNothingAction.key: () => const DoNothingAction(),
-    RequestFocusAction.key: () => RequestFocusAction(),
-    NextFocusAction.key: () => NextFocusAction(),
-    PreviousFocusAction.key: () => PreviousFocusAction(),
-    DirectionalFocusAction.key: () => DirectionalFocusAction(),
-  };
-}
-
 /// An [Action], that, as the name implies, does nothing.
 ///
 /// This action is bound to the [Intent.doNothing] intent inside of
@@ -752,8 +738,7 @@ abstract class ActivateAction extends Action {
 /// An action that selects the currently focused control.
 ///
 /// This is an abstract class that serves as a base class for actions that
-/// select something, like a checkbox or a radio button. By default, it is bound
-/// to [LogicalKeyboardKey.space] in the default keyboard map in [WidgetsApp].
+/// select something. It is not bound to any key by default.
 abstract class SelectAction extends Action {
   /// Creates a [SelectAction] with a fixed [key];
   const SelectAction() : super(key);

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -9,6 +9,7 @@ import 'package:flutter/gestures.dart';
 import 'basic.dart';
 import 'focus_manager.dart';
 import 'focus_scope.dart';
+import 'focus_traversal.dart';
 import 'framework.dart';
 import 'shortcuts.dart';
 
@@ -705,6 +706,18 @@ class _FocusableActionDetectorState extends State<FocusableActionDetector> {
   }
 }
 
+/// Creates the default map of actions used by [WidgetsApp] to define the set
+/// of available actions for an application.
+Map<LocalKey, ActionFactory> defaultActions(TargetPlatform targetPlatform) {
+  return <LocalKey, ActionFactory>{
+    DoNothingAction.key: () => const DoNothingAction(),
+    RequestFocusAction.key: () => RequestFocusAction(),
+    NextFocusAction.key: () => NextFocusAction(),
+    PreviousFocusAction.key: () => PreviousFocusAction(),
+    DirectionalFocusAction.key: () => DirectionalFocusAction(),
+  };
+}
+
 /// An [Action], that, as the name implies, does nothing.
 ///
 /// This action is bound to the [Intent.doNothing] intent inside of
@@ -733,17 +746,4 @@ abstract class ActivateAction extends Action {
 
   /// The [LocalKey] that uniquely identifies this action.
   static const LocalKey key = ValueKey<Type>(ActivateAction);
-}
-
-/// An action that selects the currently focused control.
-///
-/// This is an abstract class that serves as a base class for actions that
-/// select something, like a checkbox or a radio button. By default, it is bound
-/// to [LogicalKeyboardKey.space] in the default keyboard map in [WidgetsApp].
-abstract class SelectAction extends Action {
-  /// Creates a [SelectAction] with a fixed [key];
-  const SelectAction() : super(key);
-
-  /// The [LocalKey] that uniquely identifies this action.
-  static const LocalKey key = ValueKey<Type>(SelectAction);
 }

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -709,6 +709,7 @@ class _FocusableActionDetectorState extends State<FocusableActionDetector> {
 /// Creates the default map of actions used by [WidgetsApp] to define the set
 /// of available actions for an application.
 Map<LocalKey, ActionFactory> defaultActions(TargetPlatform targetPlatform) {
+  // At the moment, all platforms have the same set of available actions.
   return <LocalKey, ActionFactory>{
     DoNothingAction.key: () => const DoNothingAction(),
     RequestFocusAction.key: () => RequestFocusAction(),
@@ -746,4 +747,17 @@ abstract class ActivateAction extends Action {
 
   /// The [LocalKey] that uniquely identifies this action.
   static const LocalKey key = ValueKey<Type>(ActivateAction);
+}
+
+/// An action that selects the currently focused control.
+///
+/// This is an abstract class that serves as a base class for actions that
+/// select something, like a checkbox or a radio button. By default, it is bound
+/// to [LogicalKeyboardKey.space] in the default keyboard map in [WidgetsApp].
+abstract class SelectAction extends Action {
+  /// Creates a [SelectAction] with a fixed [key];
+  const SelectAction() : super(key);
+
+  /// The [LocalKey] that uniquely identifies this action.
+  static const LocalKey key = ValueKey<Type>(SelectAction);
 }

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -684,7 +684,6 @@ class WidgetsApp extends StatefulWidget {
   /// {@endtemplate}
   final bool debugShowCheckedModeBanner;
 
-  /// {@template flutter.widgets.widgetsApp.shortcuts}
   /// The default map of keyboard shortcuts to intents for the application.
   ///
   /// By default, this is set to [WidgetsApp.defaultShortcuts].
@@ -722,10 +721,8 @@ class WidgetsApp extends StatefulWidget {
   /// * The [Actions] widget, which defines the mapping from intent to action.
   /// * The [Intent] and [Action] classes, which allow definition of new
   ///    actions.
-  /// {@endtemplate}
   final Map<LogicalKeySet, Intent> shortcuts;
 
-  /// {@template flutter.widgets.widgetsApp.actions}
   /// The default map of intent keys to actions for the application.
   ///
   /// By default, this is the output of [WidgetsApp.defaultActions], called with
@@ -773,7 +770,6 @@ class WidgetsApp extends StatefulWidget {
   /// * The [Actions] widget, which defines the mapping from intent to action.
   /// * The [Intent] and [Action] classes, which allow definition of new
   ///    actions.
-  /// {@endtemplate}
   final Map<LocalKey, ActionFactory> actions;
 
   /// If true, forces the performance overlay to be visible in all instances.

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:collection' show HashMap;
-import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
@@ -684,9 +683,11 @@ class WidgetsApp extends StatefulWidget {
   /// {@endtemplate}
   final bool debugShowCheckedModeBanner;
 
+  /// {@template flutter.widgets.widgetsApp.shortcuts}
   /// The default map of keyboard shortcuts to intents for the application.
   ///
   /// By default, this is set to [WidgetsApp.defaultShortcuts].
+  /// {@endtemplate}
   ///
   /// {@tool sample}
   /// This example shows how to add a single shortcut for
@@ -713,16 +714,19 @@ class WidgetsApp extends StatefulWidget {
   /// ```
   /// {@end-tool}
   ///
+  /// {@template flutter.widgets.widgetsApp.shortcuts.seeAlso}
   /// See also:
   ///
-  /// * [LogicalKeySet], a set of [LogicalKeyboardKey]s that make up the keys
+  ///  * [LogicalKeySet], a set of [LogicalKeyboardKey]s that make up the keys
   ///    for this map.
-  /// * The [Shortcuts] widget, which defines a keyboard mapping.
-  /// * The [Actions] widget, which defines the mapping from intent to action.
-  /// * The [Intent] and [Action] classes, which allow definition of new
+  ///  * The [Shortcuts] widget, which defines a keyboard mapping.
+  ///  * The [Actions] widget, which defines the mapping from intent to action.
+  ///  * The [Intent] and [Action] classes, which allow definition of new
   ///    actions.
+  /// {@endtemplate}
   final Map<LogicalKeySet, Intent> shortcuts;
 
+  /// {@template flutter.widgets.widgetsApp.actions}
   /// The default map of intent keys to actions for the application.
   ///
   /// By default, this is the output of [WidgetsApp.defaultActions], called with
@@ -732,6 +736,7 @@ class WidgetsApp extends StatefulWidget {
   /// the [actions] for this app. You may also add to the bindings, or override
   /// specific bindings for a widget subtree, by adding your own [Actions]
   /// widget.
+  /// {@endtemplate}
   ///
   /// {@tool sample}
   /// This example shows how to add a single action handling an
@@ -762,14 +767,17 @@ class WidgetsApp extends StatefulWidget {
   /// }
   /// ```
   /// {@end-tool}
+  ///
+  /// {@template flutter.widgets.widgetsApp.actions.seeAlso}
   /// See also:
   ///
-  /// * The [shortcuts] parameter, which defines the default set of shortcuts
+  ///  * The [shortcuts] parameter, which defines the default set of shortcuts
   ///    for the application.
-  /// * The [Shortcuts] widget, which defines a keyboard mapping.
-  /// * The [Actions] widget, which defines the mapping from intent to action.
-  /// * The [Intent] and [Action] classes, which allow definition of new
+  ///  * The [Shortcuts] widget, which defines a keyboard mapping.
+  ///  * The [Actions] widget, which defines the mapping from intent to action.
+  ///  * The [Intent] and [Action] classes, which allow definition of new
   ///    actions.
+  /// {@endtemplate}
   final Map<LocalKey, ActionFactory> actions;
 
   /// If true, forces the performance overlay to be visible in all instances.

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -687,12 +687,10 @@ class WidgetsApp extends StatefulWidget {
   /// The default map of keyboard shortcuts to intents for the application.
   ///
   /// By default, this is the output of [defaultShortcuts], called with
-  /// [defaultTargetPlatform]. Specifying [shortcuts] for an app overrides the
-  /// default, so if you wish to modify the default [shortcuts], you can call
-  /// [defaultShortcuts] and modify the resulting map, passing it as the
-  /// [shortcuts] for this app. You may also add to the bindings, or override
-  /// specific bindings for a widget subtree, by adding your own [Shortcuts]
-  /// widget.
+  /// [defaultTargetPlatform]. If you wish to modify the default [shortcuts],
+  /// call [defaultShortcuts] and modify the resulting map, passing it as the
+  /// [shortcuts] for this app. Add to the bindings, or override specific
+  /// bindings for a widget subtree, by adding your own [Shortcuts] widget.
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -169,6 +169,8 @@ class WidgetsApp extends StatefulWidget {
     this.debugShowWidgetInspector = false,
     this.debugShowCheckedModeBanner = true,
     this.inspectorSelectButtonBuilder,
+    this.shortcuts,
+    this.actions,
   }) : assert(navigatorObservers != null),
        assert(routes != null),
        assert(
@@ -681,6 +683,50 @@ class WidgetsApp extends StatefulWidget {
   /// {@endtemplate}
   final bool debugShowCheckedModeBanner;
 
+  /// {@template flutter.widgets.widgetsApp.shortcuts}
+  /// The default map of keyboard keys to intents for the application.
+  ///
+  /// By default, this is the output of [defaultShortcuts], called with
+  /// [defaultTargetPlatform]. Specifying [shortcuts] for an app overrides the
+  /// default, so if you wish to modify the default [shortcuts], you can call
+  /// [defaultShortcuts] and modify the resulting map, passing it as the
+  /// [shortcuts] for this app. You may also add to the bindings, or override
+  /// specific bindings for a widget subtree, by adding your own [Shortcuts]
+  /// widget.
+  ///
+  /// See also:
+  ///
+  ///  - [LogicalKeySet], a set of [LogicalKeyboardKey]s that make up the keys
+  ///    for this map.
+  ///  - The [Shortcuts] widget, which defines a keyboard mapping.
+  ///  - The [Actions] widget, which defines the mapping from intent to action.
+  ///  - The [Intent] and [Action] classes, which allow definition of new
+  ///    actions.
+  /// {@endtemplate}
+  final Map<LogicalKeySet, Intent> shortcuts;
+
+  /// {@template flutter.widgets.widgetsApp.actions}
+  /// The default map of intent keys to actions for the application.
+  ///
+  /// By default, this is the output of [defaultActions], called with
+  /// [defaultTargetPlatform]. Specifying [actions] for an app overrides the
+  /// default, so if you wish to modify the default [actions], you can call
+  /// [defaultActions] and modify the resulting map, passing it as the
+  /// [actions] for this app. You may also add to the bindings, or override
+  /// specific bindings for a widget subtree, by adding your own [Actions]
+  /// widget.
+  ///
+  /// See also:
+  ///
+  ///  - The [shortcuts] parameter, which defines the default set of shortcuts
+  ///    for the application.
+  ///  - The [Shortcuts] widget, which defines a keyboard mapping.
+  ///  - The [Actions] widget, which defines the mapping from intent to action.
+  ///  - The [Intent] and [Action] classes, which allow definition of new
+  ///    actions.
+  /// {@endtemplate}
+  final Map<LocalKey, ActionFactory> actions;
+
   /// If true, forces the performance overlay to be visible in all instances.
   ///
   /// Used by the `showPerformanceOverlay` observatory extension.
@@ -712,6 +758,7 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
   // STATE LIFECYCLE
 
   Map<LogicalKeySet, Intent> _keyMap;
+  Map<LocalKey, ActionFactory> _actionMap;
 
   @override
   void initState() {
@@ -719,7 +766,8 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
     _updateNavigator();
     _locale = _resolveLocales(WidgetsBinding.instance.window.locales, widget.supportedLocales);
     WidgetsBinding.instance.addObserver(this);
-    _keyMap = defaultKeyBindings(defaultTargetPlatform);
+    _keyMap = widget.shortcuts ?? defaultShortcuts(defaultTargetPlatform);
+    _actionMap = widget.actions ?? defaultActions(defaultTargetPlatform);
   }
 
   @override
@@ -819,7 +867,6 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
     navigator.pushNamed(route);
     return true;
   }
-
 
   // LOCALIZATION
 

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -684,7 +684,7 @@ class WidgetsApp extends StatefulWidget {
   final bool debugShowCheckedModeBanner;
 
   /// {@template flutter.widgets.widgetsApp.shortcuts}
-  /// The default map of keyboard keys to intents for the application.
+  /// The default map of keyboard shortcuts to intents for the application.
   ///
   /// By default, this is the output of [defaultShortcuts], called with
   /// [defaultTargetPlatform]. Specifying [shortcuts] for an app overrides the
@@ -757,17 +757,12 @@ class WidgetsApp extends StatefulWidget {
 class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
   // STATE LIFECYCLE
 
-  Map<LogicalKeySet, Intent> _keyMap;
-  Map<LocalKey, ActionFactory> _actionMap;
-
   @override
   void initState() {
     super.initState();
     _updateNavigator();
     _locale = _resolveLocales(WidgetsBinding.instance.window.locales, widget.supportedLocales);
     WidgetsBinding.instance.addObserver(this);
-    _keyMap = widget.shortcuts ?? defaultShortcuts(defaultTargetPlatform);
-    _actionMap = widget.actions ?? defaultActions(defaultTargetPlatform);
   }
 
   @override
@@ -1256,9 +1251,9 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
 
     assert(_debugCheckLocalizations(appLocale));
     return Shortcuts(
-      shortcuts: _keyMap,
+      shortcuts: widget.shortcuts ?? defaultShortcuts(defaultTargetPlatform),
       child: Actions(
-        actions: _actionMap,
+        actions: widget.actions ?? defaultActions(defaultTargetPlatform),
         child: DefaultFocusTraversal(
           policy: ReadingOrderTraversalPolicy(),
           child: _MediaQueryFromWindow(

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -871,17 +871,12 @@ class WidgetsApp extends StatefulWidget {
       return _defaultWebShortcuts;
     }
 
-    // TODO(gspencergoog): Move this into the switch below once TargetPlatform.macOS exists.
-    // https://github.com/flutter/flutter/issues/31366
-    if (Platform.isMacOS) {
-      return _defaultMacOsShortcuts;
-    }
-
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
         return _defaultShortcuts;
-        break;
+      case TargetPlatform.macOS:
+        return _defaultMacOsShortcuts;
       case TargetPlatform.iOS:
         // No keyboard support on iOS yet.
         break;

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -799,35 +799,67 @@ class WidgetsApp extends StatefulWidget {
   /// with "s".
   static bool debugAllowBannerOverride = true;
 
-  // Default shortcuts for the web platform.
-  static final Map<LogicalKeySet, Intent> _defaultWebShortcuts = <LogicalKeySet, Intent>{
+  static final Map<LogicalKeySet, Intent> _defaultShortcuts = <LogicalKeySet, Intent>{
+    // Activation
+    LogicalKeySet(LogicalKeyboardKey.enter): const Intent(ActivateAction.key),
+    LogicalKeySet(LogicalKeyboardKey.space): const Intent(ActivateAction.key),
+
+    // Keyboard traversal.
     LogicalKeySet(LogicalKeyboardKey.tab): const Intent(NextFocusAction.key),
     LogicalKeySet(LogicalKeyboardKey.shift, LogicalKeyboardKey.tab): const Intent(PreviousFocusAction.key),
+    LogicalKeySet(LogicalKeyboardKey.arrowLeft): const DirectionalFocusIntent(TraversalDirection.left),
+    LogicalKeySet(LogicalKeyboardKey.arrowRight): const DirectionalFocusIntent(TraversalDirection.right),
+    LogicalKeySet(LogicalKeyboardKey.arrowDown): const DirectionalFocusIntent(TraversalDirection.down),
+    LogicalKeySet(LogicalKeyboardKey.arrowUp): const DirectionalFocusIntent(TraversalDirection.up),
+
+    // Scrolling
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.arrowUp): const ScrollIntent(direction: AxisDirection.up),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.arrowDown): const ScrollIntent(direction: AxisDirection.down),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.arrowLeft): const ScrollIntent(direction: AxisDirection.left),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.arrowRight): const ScrollIntent(direction: AxisDirection.right),
+    LogicalKeySet(LogicalKeyboardKey.pageUp): const ScrollIntent(direction: AxisDirection.up, type: ScrollIncrementType.page),
+    LogicalKeySet(LogicalKeyboardKey.pageDown): const ScrollIntent(direction: AxisDirection.down, type: ScrollIncrementType.page),
+  };
+
+  // Default shortcuts for the web platform.
+  static final Map<LogicalKeySet, Intent> _defaultWebShortcuts = <LogicalKeySet, Intent>{
+    // Activation
     LogicalKeySet(LogicalKeyboardKey.space): const Intent(ActivateAction.key),
+
+    // Keyboard traversal.
+    LogicalKeySet(LogicalKeyboardKey.tab): const Intent(NextFocusAction.key),
+    LogicalKeySet(LogicalKeyboardKey.shift, LogicalKeyboardKey.tab): const Intent(PreviousFocusAction.key),
+
+    // Scrolling
+    LogicalKeySet(LogicalKeyboardKey.arrowUp): const ScrollIntent(direction: AxisDirection.up),
+    LogicalKeySet(LogicalKeyboardKey.arrowDown): const ScrollIntent(direction: AxisDirection.down),
+    LogicalKeySet(LogicalKeyboardKey.arrowLeft): const ScrollIntent(direction: AxisDirection.left),
+    LogicalKeySet(LogicalKeyboardKey.arrowRight): const ScrollIntent(direction: AxisDirection.right),
+    LogicalKeySet(LogicalKeyboardKey.pageUp): const ScrollIntent(direction: AxisDirection.up, type: ScrollIncrementType.page),
+    LogicalKeySet(LogicalKeyboardKey.pageDown): const ScrollIntent(direction: AxisDirection.down, type: ScrollIncrementType.page),
   };
 
   // Default shortcuts for the macOS platform.
   static final Map<LogicalKeySet, Intent> _defaultMacOsShortcuts = <LogicalKeySet, Intent>{
-    LogicalKeySet(LogicalKeyboardKey.tab): const Intent(NextFocusAction.key),
-    LogicalKeySet(LogicalKeyboardKey.shift, LogicalKeyboardKey.tab): const Intent(PreviousFocusAction.key),
-    LogicalKeySet(LogicalKeyboardKey.arrowLeft): const DirectionalFocusIntent(TraversalDirection.left),
-    LogicalKeySet(LogicalKeyboardKey.arrowRight): const DirectionalFocusIntent(TraversalDirection.right),
-    LogicalKeySet(LogicalKeyboardKey.arrowDown): const DirectionalFocusIntent(TraversalDirection.down),
-    LogicalKeySet(LogicalKeyboardKey.arrowUp): const DirectionalFocusIntent(TraversalDirection.up),
+    // Activation
     LogicalKeySet(LogicalKeyboardKey.enter): const Intent(ActivateAction.key),
     LogicalKeySet(LogicalKeyboardKey.space): const Intent(ActivateAction.key),
-  };
 
-  // Default shortcuts for most platforms.
-  static final Map<LogicalKeySet, Intent> _defaultShortcuts = <LogicalKeySet, Intent>{
+    // Keyboard traversal
     LogicalKeySet(LogicalKeyboardKey.tab): const Intent(NextFocusAction.key),
     LogicalKeySet(LogicalKeyboardKey.shift, LogicalKeyboardKey.tab): const Intent(PreviousFocusAction.key),
     LogicalKeySet(LogicalKeyboardKey.arrowLeft): const DirectionalFocusIntent(TraversalDirection.left),
     LogicalKeySet(LogicalKeyboardKey.arrowRight): const DirectionalFocusIntent(TraversalDirection.right),
     LogicalKeySet(LogicalKeyboardKey.arrowDown): const DirectionalFocusIntent(TraversalDirection.down),
     LogicalKeySet(LogicalKeyboardKey.arrowUp): const DirectionalFocusIntent(TraversalDirection.up),
-    LogicalKeySet(LogicalKeyboardKey.enter): const Intent(ActivateAction.key),
-    LogicalKeySet(LogicalKeyboardKey.space): const Intent(ActivateAction.key),
+
+    // Scrolling
+    LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.arrowUp): const ScrollIntent(direction: AxisDirection.up),
+    LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.arrowDown): const ScrollIntent(direction: AxisDirection.down),
+    LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.arrowLeft): const ScrollIntent(direction: AxisDirection.left),
+    LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.arrowRight): const ScrollIntent(direction: AxisDirection.right),
+    LogicalKeySet(LogicalKeyboardKey.pageUp): const ScrollIntent(direction: AxisDirection.up, type: ScrollIncrementType.page),
+    LogicalKeySet(LogicalKeyboardKey.pageDown): const ScrollIntent(direction: AxisDirection.down, type: ScrollIncrementType.page),
   };
 
   /// Generates the default shortcut key bindings based on the
@@ -864,6 +896,7 @@ class WidgetsApp extends StatefulWidget {
     NextFocusAction.key: () => NextFocusAction(),
     PreviousFocusAction.key: () => PreviousFocusAction(),
     DirectionalFocusAction.key: () => DirectionalFocusAction(),
+    ScrollAction.key: () => ScrollAction(),
   };
 
   @override
@@ -1201,60 +1234,6 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
     }());
     return true;
   }
-
-  final Map<LogicalKeySet, Intent> _keyMap = <LogicalKeySet, Intent>{
-    // Next/previous keyboard traversal.
-    LogicalKeySet(LogicalKeyboardKey.tab): const Intent(NextFocusAction.key),
-    LogicalKeySet(LogicalKeyboardKey.shift, LogicalKeyboardKey.tab): const Intent(PreviousFocusAction.key),
-
-    // Directional keyboard traversal. Not available on web.
-    if (!kIsWeb) ...<LogicalKeySet, Intent>{
-      LogicalKeySet(LogicalKeyboardKey.arrowLeft): const DirectionalFocusIntent(TraversalDirection.left),
-      LogicalKeySet(LogicalKeyboardKey.arrowRight): const DirectionalFocusIntent(TraversalDirection.right),
-      LogicalKeySet(LogicalKeyboardKey.arrowDown): const DirectionalFocusIntent(TraversalDirection.down),
-      LogicalKeySet(LogicalKeyboardKey.arrowUp): const DirectionalFocusIntent(TraversalDirection.up)
-    },
-
-    // Keyboard scrolling.
-    // TODO(gspencergoog): Convert all of the Platform.isMacOS checks to be
-    // defaultTargetPlatform == TargetPlatform.macOS, once that exists.
-    // https://github.com/flutter/flutter/issues/31366
-    if (!kIsWeb && !Platform.isMacOS) ...<LogicalKeySet, Intent>{
-      LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.arrowUp): const ScrollIntent(direction: AxisDirection.up),
-      LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.arrowDown): const ScrollIntent(direction: AxisDirection.down),
-      LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.arrowLeft): const ScrollIntent(direction: AxisDirection.left),
-      LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.arrowRight): const ScrollIntent(direction: AxisDirection.right),
-    },
-    if (!kIsWeb && Platform.isMacOS) ...<LogicalKeySet, Intent>{
-      LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.arrowUp): const ScrollIntent(direction: AxisDirection.up),
-      LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.arrowDown): const ScrollIntent(direction: AxisDirection.down),
-      LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.arrowLeft): const ScrollIntent(direction: AxisDirection.left),
-      LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.arrowRight): const ScrollIntent(direction: AxisDirection.right),
-    },
-
-    // Web scrolling.
-    if (kIsWeb) ...<LogicalKeySet, Intent>{
-      LogicalKeySet(LogicalKeyboardKey.arrowUp): const ScrollIntent(direction: AxisDirection.up),
-      LogicalKeySet(LogicalKeyboardKey.arrowDown): const ScrollIntent(direction: AxisDirection.down),
-      LogicalKeySet(LogicalKeyboardKey.arrowLeft): const ScrollIntent(direction: AxisDirection.left),
-      LogicalKeySet(LogicalKeyboardKey.arrowRight): const ScrollIntent(direction: AxisDirection.right),
-    },
-
-    LogicalKeySet(LogicalKeyboardKey.pageUp): const ScrollIntent(direction: AxisDirection.up, type: ScrollIncrementType.page),
-    LogicalKeySet(LogicalKeyboardKey.pageDown): const ScrollIntent(direction: AxisDirection.down, type: ScrollIncrementType.page),
-
-    LogicalKeySet(LogicalKeyboardKey.enter): const Intent(ActivateAction.key),
-    LogicalKeySet(LogicalKeyboardKey.space): const Intent(SelectAction.key),
-  };
-
-  final Map<LocalKey, ActionFactory> _actionMap = <LocalKey, ActionFactory>{
-    DoNothingAction.key: () => const DoNothingAction(),
-    RequestFocusAction.key: () => RequestFocusAction(),
-    NextFocusAction.key: () => NextFocusAction(),
-    PreviousFocusAction.key: () => PreviousFocusAction(),
-    DirectionalFocusAction.key: () => DirectionalFocusAction(),
-    ScrollAction.key: () => ScrollAction(),
-  };
 
   @override
   Widget build(BuildContext context) {

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -687,12 +687,32 @@ class WidgetsApp extends StatefulWidget {
   /// {@template flutter.widgets.widgetsApp.shortcuts}
   /// The default map of keyboard shortcuts to intents for the application.
   ///
-  /// By default, this is the output of [WidgetsApp.defaultShortcuts], called
-  /// with [defaultTargetPlatform]. If you wish to modify the default
-  /// [shortcuts], call [WidgetsApp.defaultShortcuts] and modify the resulting
-  /// map, passing it as the [shortcuts] for this app. Add to the bindings, or
-  /// override specific bindings for a widget subtree, by adding your own
-  /// [Shortcuts] widget.
+  /// By default, this is set to [WidgetsApp.defaultShortcuts].
+  ///
+  /// {@tool sample}
+  /// This example shows how to add a single shortcut for
+  /// [LogicalKeyboardKey.select] to the default shortcuts without needing to
+  /// add your own [Shortcuts] widget.
+  ///
+  /// Alternatively, you could insert a [Shortcuts] widget with just the mapping
+  /// you want to add between the [WidgetsApp] and its child and get the same
+  /// effect.
+  ///
+  /// ```dart
+  /// Widget build(BuildContext context) {
+  ///   return WidgetsApp(
+  ///     shortcuts: <LogicalKeySet, Intent>{
+  ///       ... WidgetsApp.defaultShortcuts,
+  ///       LogicalKeySet(LogicalKeyboardKey.select): const Intent(ActivateAction.key),
+  ///     },
+  ///     color: const Color(0xFFFF0000),
+  ///     builder: (BuildContext context, Widget child) {
+  ///       return const Placeholder();
+  ///     },
+  ///   );
+  /// }
+  /// ```
+  /// {@end-tool}
   ///
   /// See also:
   ///
@@ -716,6 +736,35 @@ class WidgetsApp extends StatefulWidget {
   /// specific bindings for a widget subtree, by adding your own [Actions]
   /// widget.
   ///
+  /// {@tool sample}
+  /// This example shows how to add a single action handling an
+  /// [ActivateAction] to the default actions without needing to
+  /// add your own [Actions] widget.
+  ///
+  /// Alternatively, you could insert a [Actions] widget with just the mapping
+  /// you want to add between the [WidgetsApp] and its child and get the same
+  /// effect.
+  ///
+  /// ```dart
+  /// Widget build(BuildContext context) {
+  ///   return WidgetsApp(
+  ///     actions: <LocalKey, ActionFactory>{
+  ///       ... WidgetsApp.defaultActions,
+  ///       ActivateAction.key: () => CallbackAction(
+  ///         ActivateAction.key,
+  ///         onInvoke: (FocusNode focusNode, Intent intent) {
+  ///           // Do something here...
+  ///         },
+  ///       ),
+  ///     },
+  ///     color: const Color(0xFFFF0000),
+  ///     builder: (BuildContext context, Widget child) {
+  ///       return const Placeholder();
+  ///     },
+  ///   );
+  /// }
+  /// ```
+  /// {@end-tool}
   /// See also:
   ///
   /// * The [shortcuts] parameter, which defines the default set of shortcuts
@@ -781,10 +830,11 @@ class WidgetsApp extends StatefulWidget {
     LogicalKeySet(LogicalKeyboardKey.space): const Intent(ActivateAction.key),
   };
 
-  /// Generates the default shortcut key bindings for the given `platform`.
+  /// Generates the default shortcut key bindings based on the
+  /// [defaultTargetPlatform].
   ///
-  /// Used by [WidgetsApp] to assign the default key bindings.
-  static Map<LogicalKeySet, Intent> defaultShortcuts(TargetPlatform platform) {
+  /// Used by [WidgetsApp] to assign a default value to [WidgetsApp.shortcuts].
+  static Map<LogicalKeySet, Intent> get defaultShortcuts {
     if (kIsWeb) {
       return _defaultWebShortcuts;
     }
@@ -795,7 +845,7 @@ class WidgetsApp extends StatefulWidget {
       return _defaultMacOsShortcuts;
     }
 
-    switch (platform) {
+    switch (defaultTargetPlatform) {
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
         return _defaultShortcuts;
@@ -804,24 +854,17 @@ class WidgetsApp extends StatefulWidget {
         // No keyboard support on iOS yet.
         break;
     }
-    return const <LogicalKeySet, Intent>{};
+    return <LogicalKeySet, Intent>{};
   }
 
-  // Default actions for all platforms.
-  static final Map<LocalKey, ActionFactory> _defaultActions = <LocalKey, ActionFactory>{
+  /// The default value of [WidgetsApp.actions].
+  static final Map<LocalKey, ActionFactory> defaultActions = <LocalKey, ActionFactory>{
     DoNothingAction.key: () => const DoNothingAction(),
     RequestFocusAction.key: () => RequestFocusAction(),
     NextFocusAction.key: () => NextFocusAction(),
     PreviousFocusAction.key: () => PreviousFocusAction(),
     DirectionalFocusAction.key: () => DirectionalFocusAction(),
   };
-
-  /// Returns the default map of actions used by [WidgetsApp] as the set of
-  /// available actions for an application.
-  static Map<LocalKey, ActionFactory> defaultActions(TargetPlatform targetPlatform) {
-    // At the moment, all platforms have the same set of available actions.
-    return _defaultActions;
-  }
 
   @override
   _WidgetsAppState createState() => _WidgetsAppState();
@@ -1324,9 +1367,9 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
 
     assert(_debugCheckLocalizations(appLocale));
     return Shortcuts(
-      shortcuts: widget.shortcuts ?? WidgetsApp.defaultShortcuts(defaultTargetPlatform),
+      shortcuts: widget.shortcuts ?? WidgetsApp.defaultShortcuts,
       child: Actions(
-        actions: widget.actions ?? WidgetsApp.defaultActions(defaultTargetPlatform),
+        actions: widget.actions ?? WidgetsApp.defaultActions,
         child: DefaultFocusTraversal(
           policy: ReadingOrderTraversalPolicy(),
           child: _MediaQueryFromWindow(

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -8,7 +8,6 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
-import 'package:flutter/services.dart';
 
 import 'actions.dart';
 import 'banner.dart';
@@ -712,12 +711,15 @@ class WidgetsApp extends StatefulWidget {
 class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
   // STATE LIFECYCLE
 
+  Map<LogicalKeySet, Intent> _keyMap;
+
   @override
   void initState() {
     super.initState();
     _updateNavigator();
     _locale = _resolveLocales(WidgetsBinding.instance.window.locales, widget.supportedLocales);
     WidgetsBinding.instance.addObserver(this);
+    _keyMap = defaultKeyBindings(defaultTargetPlatform);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:collection';
+import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
@@ -11,6 +12,7 @@ import 'package:flutter/services.dart';
 import 'actions.dart';
 import 'focus_manager.dart';
 import 'focus_scope.dart';
+import 'focus_traversal.dart';
 import 'framework.dart';
 import 'inherited_notifier.dart';
 
@@ -365,4 +367,52 @@ class _ShortcutsMarker extends InheritedNotifier<ShortcutManager> {
   })  : assert(manager != null),
         assert(child != null),
         super(notifier: manager, child: child);
+}
+
+/// Generates the default key bindings for the given `platform`.
+///
+/// Used by [WidgetsApp] to assign the default key bindings if none are
+/// supplied.
+Map<LogicalKeySet, Intent> defaultKeyBindings(TargetPlatform platform) {
+  if (kIsWeb) {
+    return <LogicalKeySet, Intent>{
+      LogicalKeySet(LogicalKeyboardKey.tab): const Intent(NextFocusAction.key),
+      LogicalKeySet(LogicalKeyboardKey.shift, LogicalKeyboardKey.tab): const Intent(PreviousFocusAction.key),
+      LogicalKeySet(LogicalKeyboardKey.space): const Intent(ActivateAction.key),
+    };
+  }
+
+  // TODO(gspencergoog): Move this into the switch below once TargetPlatform.macOS exists.
+  if (Platform.isMacOS) {
+    return  <LogicalKeySet, Intent>{
+      LogicalKeySet(LogicalKeyboardKey.tab): const Intent(NextFocusAction.key),
+      LogicalKeySet(LogicalKeyboardKey.shift, LogicalKeyboardKey.tab): const Intent(PreviousFocusAction.key),
+      LogicalKeySet(LogicalKeyboardKey.arrowLeft): const DirectionalFocusIntent(TraversalDirection.left),
+      LogicalKeySet(LogicalKeyboardKey.arrowRight): const DirectionalFocusIntent(TraversalDirection.right),
+      LogicalKeySet(LogicalKeyboardKey.arrowDown): const DirectionalFocusIntent(TraversalDirection.down),
+      LogicalKeySet(LogicalKeyboardKey.arrowUp): const DirectionalFocusIntent(TraversalDirection.up),
+      LogicalKeySet(LogicalKeyboardKey.enter): const Intent(ActivateAction.key),
+      LogicalKeySet(LogicalKeyboardKey.space): const Intent(ActivateAction.key),
+    };
+  }
+
+  switch (platform) {
+    case TargetPlatform.android:
+    case TargetPlatform.fuchsia:
+      return <LogicalKeySet, Intent>{
+        LogicalKeySet(LogicalKeyboardKey.tab): const Intent(NextFocusAction.key),
+        LogicalKeySet(LogicalKeyboardKey.shift, LogicalKeyboardKey.tab): const Intent(PreviousFocusAction.key),
+        LogicalKeySet(LogicalKeyboardKey.arrowLeft): const DirectionalFocusIntent(TraversalDirection.left),
+        LogicalKeySet(LogicalKeyboardKey.arrowRight): const DirectionalFocusIntent(TraversalDirection.right),
+        LogicalKeySet(LogicalKeyboardKey.arrowDown): const DirectionalFocusIntent(TraversalDirection.down),
+        LogicalKeySet(LogicalKeyboardKey.arrowUp): const DirectionalFocusIntent(TraversalDirection.up),
+        LogicalKeySet(LogicalKeyboardKey.enter): const Intent(ActivateAction.key),
+        LogicalKeySet(LogicalKeyboardKey.space): const Intent(ActivateAction.key),
+      };
+      break;
+    case TargetPlatform.iOS:
+      // No keyboard support on iOS yet.
+      break;
+  }
+  return const <LogicalKeySet, Intent>{};
 }

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -373,7 +373,7 @@ class _ShortcutsMarker extends InheritedNotifier<ShortcutManager> {
 ///
 /// Used by [WidgetsApp] to assign the default key bindings if none are
 /// supplied.
-Map<LogicalKeySet, Intent> defaultKeyBindings(TargetPlatform platform) {
+Map<LogicalKeySet, Intent> defaultShortcuts(TargetPlatform platform) {
   if (kIsWeb) {
     return <LogicalKeySet, Intent>{
       LogicalKeySet(LogicalKeyboardKey.tab): const Intent(NextFocusAction.key),

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -369,46 +369,55 @@ class _ShortcutsMarker extends InheritedNotifier<ShortcutManager> {
         super(notifier: manager, child: child);
 }
 
+// Default shortcuts for the web platform.
+final Map<LogicalKeySet, Intent> _defaultWebShortcuts = <LogicalKeySet, Intent>{
+  LogicalKeySet(LogicalKeyboardKey.tab): const Intent(NextFocusAction.key),
+  LogicalKeySet(LogicalKeyboardKey.shift, LogicalKeyboardKey.tab): const Intent(PreviousFocusAction.key),
+  LogicalKeySet(LogicalKeyboardKey.space): const Intent(ActivateAction.key),
+};
+
+// Default shortcuts for the macOS platform.
+final Map<LogicalKeySet, Intent> _defaultMacOsShortcuts = <LogicalKeySet, Intent>{
+  LogicalKeySet(LogicalKeyboardKey.tab): const Intent(NextFocusAction.key),
+  LogicalKeySet(LogicalKeyboardKey.shift, LogicalKeyboardKey.tab): const Intent(PreviousFocusAction.key),
+  LogicalKeySet(LogicalKeyboardKey.arrowLeft): const DirectionalFocusIntent(TraversalDirection.left),
+  LogicalKeySet(LogicalKeyboardKey.arrowRight): const DirectionalFocusIntent(TraversalDirection.right),
+  LogicalKeySet(LogicalKeyboardKey.arrowDown): const DirectionalFocusIntent(TraversalDirection.down),
+  LogicalKeySet(LogicalKeyboardKey.arrowUp): const DirectionalFocusIntent(TraversalDirection.up),
+  LogicalKeySet(LogicalKeyboardKey.enter): const Intent(ActivateAction.key),
+  LogicalKeySet(LogicalKeyboardKey.space): const Intent(ActivateAction.key),
+};
+
+// Default shortcuts for most platforms.
+final Map<LogicalKeySet, Intent> _defaultShortcuts = <LogicalKeySet, Intent>{
+  LogicalKeySet(LogicalKeyboardKey.tab): const Intent(NextFocusAction.key),
+  LogicalKeySet(LogicalKeyboardKey.shift, LogicalKeyboardKey.tab): const Intent(PreviousFocusAction.key),
+  LogicalKeySet(LogicalKeyboardKey.arrowLeft): const DirectionalFocusIntent(TraversalDirection.left),
+  LogicalKeySet(LogicalKeyboardKey.arrowRight): const DirectionalFocusIntent(TraversalDirection.right),
+  LogicalKeySet(LogicalKeyboardKey.arrowDown): const DirectionalFocusIntent(TraversalDirection.down),
+  LogicalKeySet(LogicalKeyboardKey.arrowUp): const DirectionalFocusIntent(TraversalDirection.up),
+  LogicalKeySet(LogicalKeyboardKey.enter): const Intent(ActivateAction.key),
+  LogicalKeySet(LogicalKeyboardKey.space): const Intent(ActivateAction.key),
+};
+
 /// Generates the default key bindings for the given `platform`.
 ///
 /// Used by [WidgetsApp] to assign the default key bindings if none are
 /// supplied.
 Map<LogicalKeySet, Intent> defaultShortcuts(TargetPlatform platform) {
   if (kIsWeb) {
-    return <LogicalKeySet, Intent>{
-      LogicalKeySet(LogicalKeyboardKey.tab): const Intent(NextFocusAction.key),
-      LogicalKeySet(LogicalKeyboardKey.shift, LogicalKeyboardKey.tab): const Intent(PreviousFocusAction.key),
-      LogicalKeySet(LogicalKeyboardKey.space): const Intent(ActivateAction.key),
-    };
+    return _defaultWebShortcuts;
   }
 
   // TODO(gspencergoog): Move this into the switch below once TargetPlatform.macOS exists.
   if (Platform.isMacOS) {
-    return  <LogicalKeySet, Intent>{
-      LogicalKeySet(LogicalKeyboardKey.tab): const Intent(NextFocusAction.key),
-      LogicalKeySet(LogicalKeyboardKey.shift, LogicalKeyboardKey.tab): const Intent(PreviousFocusAction.key),
-      LogicalKeySet(LogicalKeyboardKey.arrowLeft): const DirectionalFocusIntent(TraversalDirection.left),
-      LogicalKeySet(LogicalKeyboardKey.arrowRight): const DirectionalFocusIntent(TraversalDirection.right),
-      LogicalKeySet(LogicalKeyboardKey.arrowDown): const DirectionalFocusIntent(TraversalDirection.down),
-      LogicalKeySet(LogicalKeyboardKey.arrowUp): const DirectionalFocusIntent(TraversalDirection.up),
-      LogicalKeySet(LogicalKeyboardKey.enter): const Intent(ActivateAction.key),
-      LogicalKeySet(LogicalKeyboardKey.space): const Intent(ActivateAction.key),
-    };
+    return _defaultMacOsShortcuts;
   }
 
   switch (platform) {
     case TargetPlatform.android:
     case TargetPlatform.fuchsia:
-      return <LogicalKeySet, Intent>{
-        LogicalKeySet(LogicalKeyboardKey.tab): const Intent(NextFocusAction.key),
-        LogicalKeySet(LogicalKeyboardKey.shift, LogicalKeyboardKey.tab): const Intent(PreviousFocusAction.key),
-        LogicalKeySet(LogicalKeyboardKey.arrowLeft): const DirectionalFocusIntent(TraversalDirection.left),
-        LogicalKeySet(LogicalKeyboardKey.arrowRight): const DirectionalFocusIntent(TraversalDirection.right),
-        LogicalKeySet(LogicalKeyboardKey.arrowDown): const DirectionalFocusIntent(TraversalDirection.down),
-        LogicalKeySet(LogicalKeyboardKey.arrowUp): const DirectionalFocusIntent(TraversalDirection.up),
-        LogicalKeySet(LogicalKeyboardKey.enter): const Intent(ActivateAction.key),
-        LogicalKeySet(LogicalKeyboardKey.space): const Intent(ActivateAction.key),
-      };
+      return _defaultShortcuts;
       break;
     case TargetPlatform.iOS:
       // No keyboard support on iOS yet.

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:collection';
-import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
@@ -12,7 +11,6 @@ import 'package:flutter/services.dart';
 import 'actions.dart';
 import 'focus_manager.dart';
 import 'focus_scope.dart';
-import 'focus_traversal.dart';
 import 'framework.dart';
 import 'inherited_notifier.dart';
 
@@ -367,61 +365,4 @@ class _ShortcutsMarker extends InheritedNotifier<ShortcutManager> {
   })  : assert(manager != null),
         assert(child != null),
         super(notifier: manager, child: child);
-}
-
-// Default shortcuts for the web platform.
-final Map<LogicalKeySet, Intent> _defaultWebShortcuts = <LogicalKeySet, Intent>{
-  LogicalKeySet(LogicalKeyboardKey.tab): const Intent(NextFocusAction.key),
-  LogicalKeySet(LogicalKeyboardKey.shift, LogicalKeyboardKey.tab): const Intent(PreviousFocusAction.key),
-  LogicalKeySet(LogicalKeyboardKey.space): const Intent(ActivateAction.key),
-};
-
-// Default shortcuts for the macOS platform.
-final Map<LogicalKeySet, Intent> _defaultMacOsShortcuts = <LogicalKeySet, Intent>{
-  LogicalKeySet(LogicalKeyboardKey.tab): const Intent(NextFocusAction.key),
-  LogicalKeySet(LogicalKeyboardKey.shift, LogicalKeyboardKey.tab): const Intent(PreviousFocusAction.key),
-  LogicalKeySet(LogicalKeyboardKey.arrowLeft): const DirectionalFocusIntent(TraversalDirection.left),
-  LogicalKeySet(LogicalKeyboardKey.arrowRight): const DirectionalFocusIntent(TraversalDirection.right),
-  LogicalKeySet(LogicalKeyboardKey.arrowDown): const DirectionalFocusIntent(TraversalDirection.down),
-  LogicalKeySet(LogicalKeyboardKey.arrowUp): const DirectionalFocusIntent(TraversalDirection.up),
-  LogicalKeySet(LogicalKeyboardKey.enter): const Intent(ActivateAction.key),
-  LogicalKeySet(LogicalKeyboardKey.space): const Intent(ActivateAction.key),
-};
-
-// Default shortcuts for most platforms.
-final Map<LogicalKeySet, Intent> _defaultShortcuts = <LogicalKeySet, Intent>{
-  LogicalKeySet(LogicalKeyboardKey.tab): const Intent(NextFocusAction.key),
-  LogicalKeySet(LogicalKeyboardKey.shift, LogicalKeyboardKey.tab): const Intent(PreviousFocusAction.key),
-  LogicalKeySet(LogicalKeyboardKey.arrowLeft): const DirectionalFocusIntent(TraversalDirection.left),
-  LogicalKeySet(LogicalKeyboardKey.arrowRight): const DirectionalFocusIntent(TraversalDirection.right),
-  LogicalKeySet(LogicalKeyboardKey.arrowDown): const DirectionalFocusIntent(TraversalDirection.down),
-  LogicalKeySet(LogicalKeyboardKey.arrowUp): const DirectionalFocusIntent(TraversalDirection.up),
-  LogicalKeySet(LogicalKeyboardKey.enter): const Intent(ActivateAction.key),
-  LogicalKeySet(LogicalKeyboardKey.space): const Intent(ActivateAction.key),
-};
-
-/// Generates the default key bindings for the given `platform`.
-///
-/// Used by [WidgetsApp] to assign the default key bindings if none are
-/// supplied.
-Map<LogicalKeySet, Intent> defaultShortcuts(TargetPlatform platform) {
-  if (kIsWeb) {
-    return _defaultWebShortcuts;
-  }
-
-  // TODO(gspencergoog): Move this into the switch below once TargetPlatform.macOS exists.
-  if (Platform.isMacOS) {
-    return _defaultMacOsShortcuts;
-  }
-
-  switch (platform) {
-    case TargetPlatform.android:
-    case TargetPlatform.fuchsia:
-      return _defaultShortcuts;
-      break;
-    case TargetPlatform.iOS:
-      // No keyboard support on iOS yet.
-      break;
-  }
-  return const <LogicalKeySet, Intent>{};
 }

--- a/packages/flutter/test/material/ink_paint_test.dart
+++ b/packages/flutter/test/material/ink_paint_test.dart
@@ -356,7 +356,7 @@ void main() {
     }
 
     // Now try it with a select action instead.
-    await buildTest(SelectAction.key);
+    await buildTest(ActivateAction.key);
     await tester.pumpAndSettle();
     await tester.sendKeyEvent(LogicalKeyboardKey.space);
     await tester.pump();

--- a/packages/flutter/test/material/ink_paint_test.dart
+++ b/packages/flutter/test/material/ink_paint_test.dart
@@ -322,46 +322,12 @@ void main() {
         );
     }
 
-    // Now activate it with a keypress.
-    await tester.sendKeyEvent(LogicalKeyboardKey.space);
-    await tester.pump();
-
-    RenderBox box = Material.of(tester.element(find.byType(InkWell))) as dynamic;
-
-    if (kIsWeb) {
-      expect(box, isNot(ripplePattern(30.0, 0)));
-    } else {
-      // ripplePattern always add a translation of topLeft.
-      expect(box, ripplePattern(30.0, 0));
-
-      // The ripple fades in for 75ms. During that time its alpha is eased from
-      // 0 to the splashColor's alpha value.
-      await tester.pump(const Duration(milliseconds: 50));
-      expect(box, ripplePattern(56.0, 120));
-
-      // At 75ms the ripple has faded in: it's alpha matches the splashColor's
-      // alpha.
-      await tester.pump(const Duration(milliseconds: 25));
-      expect(box, ripplePattern(73.0, 180));
-
-      // At this point the splash radius has expanded to its limit: 5 past the
-      // ink well's radius parameter. The fade-out is about to start.
-      // The fade-out begins at 225ms = 50ms + 25ms + 150ms.
-      await tester.pump(const Duration(milliseconds: 150));
-      expect(box, ripplePattern(105.0, 180));
-
-      // After another 150ms the fade-out is complete.
-      await tester.pump(const Duration(milliseconds: 150));
-      expect(box, ripplePattern(105.0, 0));
-    }
-
-    // Now try it with a select action instead.
     await buildTest(ActivateAction.key);
     await tester.pumpAndSettle();
     await tester.sendKeyEvent(LogicalKeyboardKey.space);
     await tester.pump();
 
-    box = Material.of(tester.element(find.byType(InkWell))) as dynamic;
+    final RenderBox box = Material.of(tester.element(find.byType(InkWell))) as dynamic;
 
     // ripplePattern always add a translation of topLeft.
     expect(box, ripplePattern(30.0, 0));

--- a/packages/flutter/test/material/raw_material_button_test.dart
+++ b/packages/flutter/test/material/raw_material_button_test.dart
@@ -78,7 +78,7 @@ void main() {
 
     await tester.pumpAndSettle();
 
-    expect(pressed, kIsWeb ? isFalse : isTrue);
+    expect(pressed, isTrue);
 
     pressed = false;
     await tester.sendKeyEvent(LogicalKeyboardKey.space);

--- a/packages/flutter/test/material/raw_material_button_test.dart
+++ b/packages/flutter/test/material/raw_material_button_test.dart
@@ -48,7 +48,7 @@ void main() {
       Shortcuts(
         shortcuts: <LogicalKeySet, Intent>{
           LogicalKeySet(LogicalKeyboardKey.enter): const Intent(ActivateAction.key),
-          LogicalKeySet(LogicalKeyboardKey.space): const Intent(SelectAction.key),
+          LogicalKeySet(LogicalKeyboardKey.space): const Intent(ActivateAction.key),
         },
         child: Directionality(
           textDirection: TextDirection.ltr,

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -16,7 +16,7 @@ class TestAction extends Action {
 
   @override
   void invoke(FocusNode node, Intent intent) {
-    calls++;
+    calls += 1;
   }
 }
 

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -36,7 +36,6 @@ void main() {
   });
 
   testWidgets('WidgetsApp can override default key bindings', (WidgetTester tester) async {
-    final TestAction action = TestAction();
     bool checked = false;
     final GlobalKey key = GlobalKey();
     await tester.pumpWidget(
@@ -63,6 +62,7 @@ void main() {
     expect(checked, isTrue);
     checked = false;
 
+    final TestAction action = TestAction();
     await tester.pumpWidget(
       WidgetsApp(
         key: key,

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -3,8 +3,22 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+class TestAction extends Action {
+  TestAction() : super(key);
+
+  static const LocalKey key = ValueKey<Type>(TestAction);
+
+  int calls = 0;
+
+  @override
+  void invoke(FocusNode node, Intent intent) {
+    calls++;
+  }
+}
 
 void main() {
   testWidgets('WidgetsApp with builder only', (WidgetTester tester) async {
@@ -19,6 +33,67 @@ void main() {
       ),
     );
     expect(find.byKey(key), findsOneWidget);
+  });
+
+  testWidgets('WidgetsApp can override default key bindings', (WidgetTester tester) async {
+    final TestAction action = TestAction();
+    bool checked = false;
+    final GlobalKey key = GlobalKey();
+    await tester.pumpWidget(
+      WidgetsApp(
+        key: key,
+        builder: (BuildContext context, Widget child) {
+          return Material(
+            child: Checkbox(
+              value: checked,
+              autofocus: true,
+              onChanged: (bool value) {
+                checked = value;
+              },
+            ),
+          );
+        },
+        color: const Color(0xFF123456),
+      ),
+    );
+    await tester.pump(); // Wait for focus to take effect.
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.pumpAndSettle();
+    // Default key mapping worked.
+    expect(checked, isTrue);
+    checked = false;
+
+    await tester.pumpWidget(
+      WidgetsApp(
+        key: key,
+        actions: <LocalKey, ActionFactory>{
+          TestAction.key: () => action,
+        },
+        shortcuts: <LogicalKeySet, Intent> {
+          LogicalKeySet(LogicalKeyboardKey.space): const Intent(TestAction.key),
+        },
+        builder: (BuildContext context, Widget child) {
+          return Material(
+            child: Checkbox(
+              value: checked,
+              autofocus: true,
+              onChanged: (bool value) {
+                checked = value;
+              },
+            ),
+          );
+        },
+        color: const Color(0xFF123456),
+      ),
+    );
+    await tester.pump();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.pumpAndSettle();
+    // Default key mapping was not invoked.
+    expect(checked, isFalse);
+    // Overridden mapping was invoked.
+    expect(action.calls, equals(1));
   });
 
   group('error control test', () {

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -35,7 +35,7 @@ Future<void> pumpTest(
 
 const double dragOffset = 200.0;
 
-final LogicalKeyboardKey modifierKey = (!kIsWeb && defaultTargetPlatform == TargetPlatform.macOS)
+final LogicalKeyboardKey modifierKey = defaultTargetPlatform == TargetPlatform.macOS
     ? LogicalKeyboardKey.metaLeft
     : LogicalKeyboardKey.controlLeft;
 

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
@@ -36,11 +35,7 @@ Future<void> pumpTest(
 
 const double dragOffset = 200.0;
 
-// TODO(gspencergoog): Change this to use TargetPlatform.macOS once that is available.
-// https://github.com/flutter/flutter/issues/31366
-// Can't be const, since Platform.macOS asserts if called in const context.
-// ignore: prefer_const_declarations
-final LogicalKeyboardKey modifierKey = (!kIsWeb && Platform.isMacOS)
+final LogicalKeyboardKey modifierKey = (!kIsWeb && defaultTargetPlatform == TargetPlatform.macOS)
     ? LogicalKeyboardKey.metaLeft
     : LogicalKeyboardKey.controlLeft;
 


### PR DESCRIPTION
## Description

This adds `actions` and `shortcuts` arguments to `WidgetsApp` (and `MaterialApp` and `CupertinoApp`) to allow developers to override the default mappings on an application, and to allow for a more complex definition of the default mappings.

I've stopped using `SelectAction` here, in favor of using `ActivateAction` for all activations, but haven't removed it, to avoid a breaking change, and to allow a common base class for these types of actions. This is because some platforms use the same mapping (web) for both kinds of activations (both select and activate).

## Tests

- Added a test for `WidgetsApp` to see that default mappings are working, and that they can be overridden.

## Breaking Change

- [X] No, this is not a breaking change.