### PR TITLE
Analyze dartpad

### DIFF
--- a/dev/bots/analyze-sample-code.dart
+++ b/dev/bots/analyze-sample-code.dart
@@ -64,6 +64,12 @@ void main(List<String> arguments) {
         'automatically removed at the end of execution.',
   );
   argParser.addFlag(
+    'verbose',
+    defaultsTo: false,
+    negatable: false,
+    help: 'Print verbose output for the analysis process.',
+  );
+  argParser.addFlag(
     'help',
     defaultsTo: false,
     negatable: false,
@@ -100,7 +106,7 @@ void main(List<String> arguments) {
     tempDirectory.createSync();
   }
   try {
-    exitCode = SampleChecker(flutterPackage, tempDirectory: tempDirectory).checkSamples();
+    exitCode = SampleChecker(flutterPackage, tempDirectory: tempDirectory, verbose: parsedArguments['verbose']).checkSamples();
   } on SampleCheckerException catch (e) {
     stderr.write(e);
     exit(1);
@@ -140,7 +146,7 @@ class SampleCheckerException implements Exception {
 /// don't necessarily match. It does, however, print the source of the
 /// problematic line.
 class SampleChecker {
-  SampleChecker(this._flutterPackage, {Directory tempDirectory})
+  SampleChecker(this._flutterPackage, {Directory tempDirectory, this.verbose = false})
       : _tempDirectory = tempDirectory,
         _keepTmp = tempDirectory != null {
     _tempDirectory ??= Directory.systemTemp.createTempSync('flutter_analyze_sample_code.');
@@ -166,6 +172,9 @@ class SampleChecker {
 
   /// A RegExp that matches a Dart constructor.
   static final RegExp _constructorRegExp = RegExp(r'(const\s+)?_*[A-Z][a-zA-Z0-9<>._]*\(');
+
+  /// Whether or not to print verbose output.
+  final bool verbose;
 
   /// Whether or not to keep the temp directory around after running.
   ///
@@ -313,6 +322,9 @@ class SampleChecker {
     ];
     print('Generating snippet for ${snippet.start?.filename}:${snippet.start?.line}');
     final ProcessResult process = _runSnippetsScript(args);
+    if (verbose) {
+      stderr.write('${process.stderr}');
+    }
     if (process.exitCode != 0) {
       throw SampleCheckerException(
         'Unable to create snippet for ${snippet.start.filename}:${snippet.start.line} '
@@ -427,7 +439,7 @@ class SampleChecker {
             startLine = Line('', filename: relativeFilePath, line: lineNumber + 1, indent: 3);
             inPreamble = true;
           } else if (sampleMatch != null) {
-            inSnippet = sampleMatch != null && sampleMatch[1] == 'snippet';
+            inSnippet = sampleMatch != null && (sampleMatch[1] == 'snippet' || sampleMatch[1] == 'dartpad');
             if (inSnippet) {
               startLine = Line(
                 '',

--- a/dev/bots/analyze-sample-code.dart
+++ b/dev/bots/analyze-sample-code.dart
@@ -153,7 +153,7 @@ class SampleChecker {
   static const String _dartDocPrefixWithSpace = '$_dartDocPrefix ';
 
   /// A RegExp that matches the beginning of a dartdoc snippet or sample.
-  static final RegExp _dartDocSampleBeginRegex = RegExp(r'{@tool (sample|snippet)(?:| ([^}]*))}');
+  static final RegExp _dartDocSampleBeginRegex = RegExp(r'{@tool (sample|snippet|dartpad)(?:| ([^}]*))}');
 
   /// A RegExp that matches the end of a dartdoc snippet or sample.
   static final RegExp _dartDocSampleEndRegex = RegExp(r'{@end-tool}');

--- a/dev/bots/test/analyze-sample-code-test-input/known_broken_documentation.dart
+++ b/dev/bots/test/analyze-sample-code-test-input/known_broken_documentation.dart
@@ -34,6 +34,26 @@
 /// ```
 /// {@end-tool}
 ///
+/// {@tool dartpad --template=stateless_widget_material}
+/// Bla blabla blabla some [Text] when the `_blabla` blabla blabla is true, and
+/// blabla it when it is blabla:
+///
+/// ```dart preamble
+/// bool _visible = true;
+/// final GlobalKey globalKey = GlobalKey();
+/// ```
+///
+/// ```dart
+/// Widget build(BuildContext context) {
+///   return Opacity(
+///     key: globalKey,
+///     opacity: _visible ? 1.0 : 0.0,
+///     child: const Text('Poor wandering ones!'),
+///   );
+/// }
+/// ```
+/// {@end-tool}
+///
 /// {@tool sample}
 /// Bla blabla blabla some [Text] when the `_blabla` blabla blabla is true, and
 /// blabla finale blabla:

--- a/dev/bots/test/analyze-sample-code_test.dart
+++ b/dev/bots/test/analyze-sample-code_test.dart
@@ -19,12 +19,17 @@ void main() {
     expect(stderrLines, <String>[
       'known_broken_documentation.dart:30:9: new Opacity(',
       '>>> Unnecessary new keyword (unnecessary_new)',
-      'known_broken_documentation.dart:42:9: new Opacity(',
+      'known_broken_documentation.dart:62:9: new Opacity(',
       '>>> Unnecessary new keyword (unnecessary_new)',
       '',
       'Found 1 sample code errors.',
       '',
     ]);
-    expect(stdoutLines, <String>['Found 7 sample code sections.', 'Starting analysis of samples.', '']);
+    expect(stdoutLines, <String>[
+      'Found 7 sample code sections.',
+      'Generating snippet for known_broken_documentation.dart:38',
+      'Starting analysis of samples.',
+      '',
+    ]);
   }, skip: Platform.isWindows);
 }

--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -79,10 +79,13 @@ enum _ContextMenuLocation {
 /// This sample shows a very simple CupertinoContextMenu for an empty red
 /// 100x100 Container. Simply long press on it to open.
 ///
+/// ```dart imports
+/// import 'package:flutter/cupertino.dart';
+/// ```
+///
 /// ```dart
 /// Widget build(BuildContext context) {
 ///   return Scaffold(
-///     key: scaffoldKey,
 ///     body: Center(
 ///       child: Container(
 ///         width: 100,


### PR DESCRIPTION
## Description

This fixes the sample code analysis to treat `dartpad` snippets in the same way as `snippet` snippets, which it wasn't until now (the snippet generator was treating them as "samples"), and some errors crept in. This PR also fixes those errors.

Also, added a `--verbose` option to the sample analyzer.

## Tests

- Added a test for dartpad snippets in the test for the sample analyzer tool.

## Breaking Change

- [X] No, this is *not* a breaking change.