### PR TITLE
SliverIgnorePointer

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -3016,8 +3016,8 @@ class RenderRepaintBoundary extends RenderProxyBox {
 class RenderIgnorePointer extends RenderProxyBox {
   /// Creates a render object that is invisible to hit testing.
   ///
-  /// The [ignoring] argument must not be null. If [ignoringSemantics], this
-  /// render object will be ignored for semantics if [ignoring] is true.
+  /// The [ignoring] argument must not be null. If [ignoringSemantics] is null,
+  /// this render object will be ignored for semantics if [ignoring] is true.
   RenderIgnorePointer({
     RenderBox child,
     bool ignoring = true,
@@ -3039,7 +3039,7 @@ class RenderIgnorePointer extends RenderProxyBox {
     if (value == _ignoring)
       return;
     _ignoring = value;
-    if (ignoringSemantics == null)
+    if (_ignoringSemantics == null || !_ignoringSemantics)
       markNeedsSemanticsUpdate();
   }
 

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -1817,3 +1817,125 @@ class RenderSliverToBoxAdapter extends RenderSliverSingleBoxAdapter {
     setChildParentData(child, constraints, geometry);
   }
 }
+
+/// A render object that is invisible during hit testing.
+///
+/// When [ignoring] is true, this render object (and its subtree) is invisible
+/// to hit testing. It still consumes space during layout and paints its sliver
+/// child as usual. It just cannot be the target of located events, because its
+/// render object returns false from [hitTest].
+///
+/// When [ignoringSemantics] is true, the subtree will be invisible to the
+/// semantics layer (and thus e.g. accessibility tools). If [ignoringSemantics]
+/// is null, it uses the value of [ignoring].
+class RenderSliverIgnorePointer extends RenderSliver with RenderObjectWithChildMixin<RenderSliver> {
+  /// Creates a render object that is invisible to hit testing.
+  ///
+  /// The [ignoring] argument must not be null. If [ignoringSemantics], this
+  /// render object will be ignored for semantics if [ignoring] is true.
+  RenderSliverIgnorePointer({
+    RenderSliver sliver,
+    bool ignoring = true,
+    bool ignoringSemantics,
+  }) : assert(ignoring != null),
+      _ignoring = ignoring,
+      _ignoringSemantics = ignoringSemantics {
+    child = sliver;
+  }
+
+  /// Whether this render object is ignored during hit testing.
+  ///
+  /// Regardless of whether this render object is ignored during hit testing, it
+  /// will still consume space during layout and be visible during painting.
+  bool get ignoring => _ignoring;
+  bool _ignoring;
+  set ignoring(bool value) {
+    assert(value != null);
+    if (value == _ignoring)
+      return;
+    _ignoring = value;
+    if (ignoringSemantics == null)
+      markNeedsSemanticsUpdate();
+  }
+
+  /// Whether the semantics of this render object is ignored when compiling the
+  /// semantics tree.
+  ///
+  /// If null, defaults to value of [ignoring].
+  ///
+  /// See [SemanticsNode] for additional information about the semantics tree.
+  bool get ignoringSemantics => _ignoringSemantics;
+  bool _ignoringSemantics;
+  set ignoringSemantics(bool value) {
+    if (value == _ignoringSemantics)
+      return;
+    final bool oldEffectiveValue = _effectiveIgnoringSemantics;
+    _ignoringSemantics = value;
+    if (oldEffectiveValue != _effectiveIgnoringSemantics)
+      markNeedsSemanticsUpdate();
+  }
+
+  bool get _effectiveIgnoringSemantics => ignoringSemantics ?? ignoring;
+
+  @override
+  void setupParentData(RenderObject child) {
+    if (child.parentData is! SliverPhysicalParentData)
+      child.parentData = SliverPhysicalParentData();
+  }
+
+  @override
+  void performLayout() {
+    assert(child != null);
+    child.layout(constraints, parentUsesSize: true);
+    geometry = child.geometry;
+  }
+
+  @override
+  bool hitTest(SliverHitTestResult result, {double mainAxisPosition, double crossAxisPosition}) {
+    return !ignoring
+      && super.hitTest(
+        result,
+        mainAxisPosition: mainAxisPosition,
+        crossAxisPosition: crossAxisPosition,
+      );
+  }
+
+  @override
+  bool hitTestChildren(SliverHitTestResult result, {double mainAxisPosition, double crossAxisPosition}) {
+    return child != null
+      && child.geometry.hitTestExtent > 0
+      && child.hitTest(
+        result,
+        mainAxisPosition: mainAxisPosition,
+        crossAxisPosition: crossAxisPosition,
+      );
+  }
+
+  @override
+  void applyPaintTransform(RenderObject child, Matrix4 transform) {
+    assert(child != null);
+    final SliverPhysicalParentData childParentData = child.parentData;
+    childParentData.applyPaintTransform(transform);
+  }
+
+  @override
+  void visitChildrenForSemantics(RenderObjectVisitor visitor) {
+    if (child != null && !_effectiveIgnoringSemantics)
+      visitor(child);
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<bool>('ignoring', ignoring));
+    properties.add(
+      DiagnosticsProperty<bool>(
+        'ignoringSemantics',
+        _effectiveIgnoringSemantics,
+        description: ignoringSemantics == null ?
+          'implicitly $_effectiveIgnoringSemantics' :
+          null,
+      ),
+    );
+  }
+}

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -1831,15 +1831,15 @@ class RenderSliverToBoxAdapter extends RenderSliverSingleBoxAdapter {
 class RenderSliverIgnorePointer extends RenderSliver with RenderObjectWithChildMixin<RenderSliver> {
   /// Creates a render object that is invisible to hit testing.
   ///
-  /// The [ignoring] argument must not be null. If [ignoringSemantics], this
-  /// render object will be ignored for semantics if [ignoring] is true.
+  /// The [ignoring] argument must not be null. If [ignoringSemantics] is null,
+  /// this render object will be ignored for semantics if [ignoring] is true.
   RenderSliverIgnorePointer({
     RenderSliver sliver,
     bool ignoring = true,
     bool ignoringSemantics,
   }) : assert(ignoring != null),
-      _ignoring = ignoring,
-      _ignoringSemantics = ignoringSemantics {
+       _ignoring = ignoring,
+       _ignoringSemantics = ignoringSemantics {
     child = sliver;
   }
 
@@ -1854,7 +1854,7 @@ class RenderSliverIgnorePointer extends RenderSliver with RenderObjectWithChildM
     if (value == _ignoring)
       return;
     _ignoring = value;
-    if (ignoringSemantics == null)
+    if (_ignoringSemantics == null || !_ignoringSemantics)
       markNeedsSemanticsUpdate();
   }
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -6014,8 +6014,8 @@ class RepaintBoundary extends SingleChildRenderObjectWidget {
 class IgnorePointer extends SingleChildRenderObjectWidget {
   /// Creates a widget that is invisible to hit testing.
   ///
-  /// The [ignoring] argument must not be null. If [ignoringSemantics], this
-  /// render object will be ignored for semantics if [ignoring] is true.
+  /// The [ignoring] argument must not be null. If [ignoringSemantics] is null,
+  /// this render object will be ignored for semantics if [ignoring] is true.
   const IgnorePointer({
     Key key,
     this.ignoring = true,

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1638,15 +1638,15 @@ class SliverFillRemaining extends SingleChildRenderObjectWidget {
 class SliverIgnorePointer extends SingleChildRenderObjectWidget {
   /// Creates a sliver widget that is invisible to hit testing.
   ///
-  /// The [ignoring] argument must not be null. If [ignoringSemantics], this
-  /// render object will be ignored for semantics if [ignoring] is true.
+  /// The [ignoring] argument must not be null. If [ignoringSemantics] is null,
+  /// this render object will be ignored for semantics if [ignoring] is true.
   const SliverIgnorePointer({
     Key key,
     this.ignoring = true,
     this.ignoringSemantics,
     Widget sliver,
   }) : assert(ignoring != null),
-      super(key: key, child: sliver);
+       super(key: key, child: sliver);
 
   /// Whether this sliver is ignored during hit testing.
   ///

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1625,6 +1625,66 @@ class SliverFillRemaining extends SingleChildRenderObjectWidget {
   }
 }
 
+/// A sliver widget that is invisible during hit testing.
+///
+/// When [ignoring] is true, this widget (and its subtree) is invisible
+/// to hit testing. It still consumes space during layout and paints its sliver
+/// child as usual. It just cannot be the target of located events, because it
+/// returns false from [RenderSliver.hitTest].
+///
+/// When [ignoringSemantics] is true, the subtree will be invisible to
+/// the semantics layer (and thus e.g. accessibility tools). If
+/// [ignoringSemantics] is null, it uses the value of [ignoring].
+class SliverIgnorePointer extends SingleChildRenderObjectWidget {
+  /// Creates a sliver widget that is invisible to hit testing.
+  ///
+  /// The [ignoring] argument must not be null. If [ignoringSemantics], this
+  /// render object will be ignored for semantics if [ignoring] is true.
+  const SliverIgnorePointer({
+    Key key,
+    this.ignoring = true,
+    this.ignoringSemantics,
+    Widget sliver,
+  }) : assert(ignoring != null),
+      super(key: key, child: sliver);
+
+  /// Whether this sliver is ignored during hit testing.
+  ///
+  /// Regardless of whether this sliver is ignored during hit testing, it will
+  /// still consume space during layout and be visible during painting.
+  final bool ignoring;
+
+  /// Whether the semantics of this sliver is ignored when compiling the
+  /// semantics tree.
+  ///
+  /// If null, defaults to value of [ignoring].
+  ///
+  /// See [SemanticsNode] for additional information about the semantics tree.
+  final bool ignoringSemantics;
+
+  @override
+  RenderSliverIgnorePointer createRenderObject(BuildContext context) {
+    return RenderSliverIgnorePointer(
+      ignoring: ignoring,
+      ignoringSemantics: ignoringSemantics,
+    );
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, RenderSliverIgnorePointer renderObject) {
+    renderObject
+      ..ignoring = ignoring
+      ..ignoringSemantics = ignoringSemantics;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<bool>('ignoring', ignoring));
+    properties.add(DiagnosticsProperty<bool>('ignoringSemantics', ignoringSemantics, defaultValue: null));
+  }
+}
+
 /// Mark a child as needing to stay alive even when it's in a lazy list that
 /// would otherwise remove it.
 ///

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -3,8 +3,12 @@
 // found in the LICENSE file.
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/rendering.dart';
+
+import '../rendering/mock_canvas.dart';
+import 'semantics_tester.dart';
 
 Future<void> test(WidgetTester tester, double offset, { double anchor = 0.0 }) {
   return tester.pumpWidget(
@@ -417,6 +421,113 @@ void main() {
     await tester.pumpAndSettle();
     // It will be corrected after a auto scroll animation.
     expect(controller.offset, 800.0);
+  });
+
+  group('SliverIgnorePointer - ', () {
+    Widget _boilerPlate(Widget sliver) {
+      return Localizations(
+        locale: const Locale('en', 'us'),
+        delegates: const <LocalizationsDelegate<dynamic>>[
+          DefaultWidgetsLocalizations.delegate,
+          DefaultMaterialLocalizations.delegate,
+        ],
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: CustomScrollView(slivers: <Widget>[sliver])
+          )
+        )
+      );
+    }
+
+    testWidgets('ignores pointer events', (WidgetTester tester) async {
+      final SemanticsTester semantics = SemanticsTester(tester);
+      final List<String> events = <String>[];
+      await tester.pumpWidget(_boilerPlate(
+        SliverIgnorePointer(
+          ignoring: true,
+          ignoringSemantics: false,
+          sliver: SliverToBoxAdapter(
+            child: GestureDetector(
+              child: const Text('a'),
+              onTap: () {
+                events.add('tap');
+              },
+            )
+          )
+        )
+      ));
+      expect(semantics.nodesWith(label: 'a'), hasLength(1));
+      await tester.tap(find.byType(GestureDetector));
+      expect(events, equals(<String>[]));
+    });
+
+    testWidgets('ignores semantics', (WidgetTester tester) async {
+      final SemanticsTester semantics = SemanticsTester(tester);
+      final List<String> events = <String>[];
+      await tester.pumpWidget(_boilerPlate(
+        SliverIgnorePointer(
+          ignoring: false,
+          ignoringSemantics: true,
+          sliver: SliverToBoxAdapter(
+            child: GestureDetector(
+              child: const Text('a'),
+              onTap: () {
+                events.add('tap');
+              },
+            )
+          )
+        )
+      ));
+      expect(semantics.nodesWith(label: 'a'), hasLength(0));
+      await tester.tap(find.byType(GestureDetector));
+      expect(events, equals(<String>['tap']));
+    });
+
+    testWidgets('ignores pointer events & semantics', (WidgetTester tester) async {
+      final SemanticsTester semantics = SemanticsTester(tester);
+      final List<String> events = <String>[];
+      await tester.pumpWidget(_boilerPlate(
+        SliverIgnorePointer(
+          ignoring: true,
+          ignoringSemantics: true,
+          sliver: SliverToBoxAdapter(
+            child: GestureDetector(
+              child: const Text('a'),
+              onTap: () {
+                events.add('tap');
+              },
+            )
+          )
+        )
+      ));
+      expect(semantics.nodesWith(label: 'a'), hasLength(0));
+      await tester.tap(find.byType(GestureDetector));
+      expect(events, equals(<String>[]));
+    });
+
+    testWidgets('ignores nothing', (WidgetTester tester) async {
+      final SemanticsTester semantics = SemanticsTester(tester);
+      final List<String> events = <String>[];
+      await tester.pumpWidget(_boilerPlate(
+        SliverIgnorePointer(
+          ignoring: false,
+          ignoringSemantics: false,
+          sliver: SliverToBoxAdapter(
+            child: GestureDetector(
+              child: const Text('a'),
+              onTap: () {
+                events.add('tap');
+              },
+            )
+          )
+        )
+      ));
+      expect(semantics.nodesWith(label: 'a'), hasLength(1));
+      await tester.tap(find.byType(GestureDetector));
+      expect(events, equals(<String>['tap']));
+    });
   });
 }
 

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -7,7 +7,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/rendering.dart';
 
-import '../rendering/mock_canvas.dart';
 import 'semantics_tester.dart';
 
 Future<void> test(WidgetTester tester, double offset, { double anchor = 0.0 }) {


### PR DESCRIPTION
## Description

Part of #44289, SliverVisibility, SliverFadeTransition, and SliverAnimatedOpacity work.
This adds a sliver equivalent of the IgnorePointer class.

## Related Issues
Part of #45182

## Tests

- SliverIgnorePointer
  - ignores pointer events
  - ignores semantics
  - ignores both
  - ignores nothing

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
