### PR TITLE
Revert "Enable iOS platform views for Flutter Gallery"

### DIFF
--- a/examples/flutter_gallery/ios/Runner/Info.plist
+++ b/examples/flutter_gallery/ios/Runner/Info.plist
@@ -43,7 +43,5 @@
 	<false/>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>io.flutter.embedded_views_preview</key>
-	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Reverts flutter/flutter#45126

Seems to regress: `flutter_gallery_ios__transition_perf 90th_percentile_frame_build_time_millis`
Reverting while investigating.

![Screen Shot 2019-11-18 at 4 40 10 PM](https://user-images.githubusercontent.com/1024117/69106120-40c46500-0a22-11ea-9fcc-233a2be3b566.png)
