### PR TITLE
Add option to delay rendering the first frame

### DIFF
--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -283,6 +283,54 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
     drawFrame();
   }
 
+  int _firstFrameDeferredCount = 0;
+  bool _firstFrameSend = false;
+
+  /// Whether frames produced by [drawFrame] should be send to the engine.
+  ///
+  /// If set to false the framework will do all the work to produce a frame,
+  /// but the frame is never send to the engine to actually appear on screen.
+  @protected
+  bool get sendFramesToEngine => _firstFrameDeferredCount == 0;
+
+  /// Tell the framework to not render the first frames until there is a
+  /// corresponding call to [allowFirstFrame].
+  ///
+  /// Calling this allows a [Widget] to perform asynchronous initialisation work
+  /// before the first frame is rendered (which will take down the splash
+  /// screen).
+  ///
+  /// Calling this has no effect after the first frame has already been
+  /// rendered.
+  void deferFirstFrame() {
+    assert(_firstFrameDeferredCount >= 0);
+    _firstFrameDeferredCount += 1;
+    if (_firstFrameSend) {
+      return;
+    }
+  }
+
+  /// Called after [deferFirstFrame] to tell the framework that it is ok to
+  /// render the first frame now.
+  ///
+  /// For best performance, this method should only be called while the
+  /// [schedulerPhase] is [SchedulerPhase.idle].
+  ///
+  /// This method may only be called once for each corresponding call
+  /// to [deferFirstFrame].
+  void allowFirstFrame() {
+    assert(_firstFrameDeferredCount > 0);
+    _firstFrameDeferredCount -= 1;
+    if (_firstFrameSend) {
+      return;
+    }
+    // Always schedule a warm up frame even if the deferral count is not down to
+    // zero yet since the removal of a deferral may uncover new deferrals that
+    // are lower in the widget tree.
+    if (!_firstFrameSend)
+      scheduleWarmUpFrame();
+  }
+
   /// Pump the rendering pipeline to generate a frame.
   ///
   /// This method is called by [handleDrawFrame], which itself is called
@@ -344,8 +392,11 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
     pipelineOwner.flushLayout();
     pipelineOwner.flushCompositingBits();
     pipelineOwner.flushPaint();
-    renderView.compositeFrame(); // this sends the bits to the GPU
-    pipelineOwner.flushSemantics(); // this also sends the semantics to the OS.
+    if (sendFramesToEngine) {
+      renderView.compositeFrame(); // this sends the bits to the GPU
+      pipelineOwner.flushSemantics(); // this also sends the semantics to the OS.
+      _firstFrameSend = true;
+    }
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -298,22 +298,23 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
   @protected
   bool get sendFramesToEngine => _firstFrameSent || _firstFrameDeferredCount == 0;
 
-  /// Tell the framework to not render the first frames until there is a
-  /// corresponding call to [allowFirstFrame].
+  /// Tell the framework to not send the first frames to the engine until there
+  /// is a corresponding call to [allowFirstFrame].
   ///
-  /// Calling this allows a [Widget] to perform asynchronous initialisation work
-  /// before the first frame is rendered (which will take down the splash
-  /// screen).
+  /// Call this to perform asynchronous initialisation work before the first
+  /// frame is rendered (which takes down the splash screen). The framework
+  /// will still do all the work to produce frames, but those frames are never
+  /// send to the engine and will not appear on screen.
   ///
-  /// Calling this has no effect after the first frame has already been
-  /// rendered.
+  /// Calling this has no effect after the first frame has been send to the
+  /// engine.
   void deferFirstFrame() {
     assert(_firstFrameDeferredCount >= 0);
     _firstFrameDeferredCount += 1;
   }
 
   /// Called after [deferFirstFrame] to tell the framework that it is ok to
-  /// render the first frame now.
+  /// send the first frame to the engine now.
   ///
   /// For best performance, this method should only be called while the
   /// [schedulerPhase] is [SchedulerPhase.idle].

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -290,6 +290,11 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
   ///
   /// If false the framework will do all the work to produce a frame,
   /// but the frame is never send to the engine to actually appear on screen.
+  /// 
+  /// See also:
+  /// 
+  ///  * [deferFirstFrame], which defers when the first frame is send to the
+  ///    engine.
   @protected
   bool get sendFramesToEngine => _firstFrameSent || _firstFrameDeferredCount == 0;
 

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -290,9 +290,9 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
   ///
   /// If false the framework will do all the work to produce a frame,
   /// but the frame is never send to the engine to actually appear on screen.
-  /// 
+  ///
   /// See also:
-  /// 
+  ///
   ///  * [deferFirstFrame], which defers when the first frame is send to the
   ///    engine.
   bool get sendFramesToEngine => _firstFrameSent || _firstFrameDeferredCount == 0;

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -295,7 +295,6 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
   /// 
   ///  * [deferFirstFrame], which defers when the first frame is send to the
   ///    engine.
-  @protected
   bool get sendFramesToEngine => _firstFrameSent || _firstFrameDeferredCount == 0;
 
   /// Tell the framework to not send the first frames to the engine until there

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -284,14 +284,14 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
   }
 
   int _firstFrameDeferredCount = 0;
-  bool _firstFrameSend = false;
+  bool _firstFrameSent = false;
 
-  /// Whether frames produced by [drawFrame] should be send to the engine.
+  /// Whether frames produced by [drawFrame] are sent to the engine.
   ///
-  /// If set to false the framework will do all the work to produce a frame,
+  /// If false the framework will do all the work to produce a frame,
   /// but the frame is never send to the engine to actually appear on screen.
   @protected
-  bool get sendFramesToEngine => _firstFrameDeferredCount == 0;
+  bool get sendFramesToEngine => _firstFrameSent || _firstFrameDeferredCount == 0;
 
   /// Tell the framework to not render the first frames until there is a
   /// corresponding call to [allowFirstFrame].
@@ -305,9 +305,6 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
   void deferFirstFrame() {
     assert(_firstFrameDeferredCount >= 0);
     _firstFrameDeferredCount += 1;
-    if (_firstFrameSend) {
-      return;
-    }
   }
 
   /// Called after [deferFirstFrame] to tell the framework that it is ok to
@@ -321,13 +318,10 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
   void allowFirstFrame() {
     assert(_firstFrameDeferredCount > 0);
     _firstFrameDeferredCount -= 1;
-    if (_firstFrameSend) {
-      return;
-    }
     // Always schedule a warm up frame even if the deferral count is not down to
     // zero yet since the removal of a deferral may uncover new deferrals that
     // are lower in the widget tree.
-    if (!_firstFrameSend)
+    if (!_firstFrameSent)
       scheduleWarmUpFrame();
   }
 
@@ -395,7 +389,7 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
     if (sendFramesToEngine) {
       renderView.compositeFrame(); // this sends the bits to the GPU
       pipelineOwner.flushSemantics(); // this also sends the semantics to the OS.
-      _firstFrameSend = true;
+      _firstFrameSent = true;
     }
   }
 

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -608,8 +608,8 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
   /// Tell the framework not to report the frame it is building as a "useful"
   /// first frame until there is a corresponding call to [allowFirstFrameReport].
   ///
-  /// Deprecated. Use deferFirstFrame/allowFirstFrame to delay rendering the first
-  /// frame.
+  /// Deprecated. Use [deferFirstFrame]/[allowFirstFrame] to delay rendering the
+  /// first frame.
   @Deprecated('Use deferFirstFrame/allowFirstFrame to delay rendering the first frame.')
   void deferFirstFrameReport() {
     if (!kReleaseMode) {
@@ -620,8 +620,8 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
   /// When called after [deferFirstFrameReport]: tell the framework to report
   /// the frame it is building as a "useful" first frame.
   ///
-  /// Deprecated. Use deferFirstFrame/allowFirstFrame to delay rendering the first
-  /// frame.
+  /// Deprecated. Use [deferFirstFrame]/[allowFirstFrame] to delay rendering the
+  /// first frame.
   @Deprecated('Use deferFirstFrame/allowFirstFrame to delay rendering the first frame.')
   void allowFirstFrameReport() {
     if (!kReleaseMode) {
@@ -747,13 +747,14 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
       assert(!_firstFrameCompleter.isCompleted);
 
       firstFrameCallback = (List<FrameTiming> timings) {
+        assert(sendFramesToEngine);
         if (!kReleaseMode) {
           developer.Timeline.instantSync('Rasterized first useful frame');
           developer.postEvent('Flutter.FirstFrame', <String, dynamic>{});
         }
-        _firstFrameCompleter.complete();
         SchedulerBinding.instance.removeTimingsCallback(firstFrameCallback);
         firstFrameCallback = null;
+        _firstFrameCompleter.complete();
       };
       // Callback is only invoked when [Window.render] is called. When
       // [sendFramesToEngine] is set to false during the frame, it will not

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -610,7 +610,10 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
   ///
   /// Deprecated. Use [deferFirstFrame]/[allowFirstFrame] to delay rendering the
   /// first frame.
-  @Deprecated('Use deferFirstFrame/allowFirstFrame to delay rendering the first frame.')
+  @Deprecated(
+    'Use deferFirstFrame/allowFirstFrame to delay rendering the first frame. '
+    'This feature was deprecated after v1.12.4.'
+  )
   void deferFirstFrameReport() {
     if (!kReleaseMode) {
       deferFirstFrame();
@@ -622,7 +625,10 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
   ///
   /// Deprecated. Use [deferFirstFrame]/[allowFirstFrame] to delay rendering the
   /// first frame.
-  @Deprecated('Use deferFirstFrame/allowFirstFrame to delay rendering the first frame.')
+  @Deprecated(
+    'Use deferFirstFrame/allowFirstFrame to delay rendering the first frame. '
+    'This feature was deprecated after v1.12.4.'
+  )
   void allowFirstFrameReport() {
     if (!kReleaseMode) {
       allowFirstFrame();

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -773,12 +773,12 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
         return true;
       }());
     }
-    if (_needToReportFirstFrame && sendFramesToEngine) {
-      _needToReportFirstFrame = false;
-      if (!kReleaseMode) {
+    if (!kReleaseMode) {
+      if (_needToReportFirstFrame && sendFramesToEngine) {
         developer.Timeline.instantSync('Widgets built first useful frame');
       }
     }
+    _needToReportFirstFrame = false;
     if (firstFrameCallback != null && !sendFramesToEngine) {
       SchedulerBinding.instance.removeTimingsCallback(firstFrameCallback);
     }

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -637,7 +637,7 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
   int _firstFrameDeferredCount = 0;
   bool get _firstFrameDeferred => _firstFrameDeferredCount > 0;
   bool _firstFrameRequested = false;
-  bool _firstFrameHappened = false;
+  bool _firstFrameRendered = false;
 
   /// Tell the framework to not render the first frames until there is a
   /// corresponding call to [allowFirstFrame].
@@ -661,7 +661,7 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
   void allowFirstFrame() {
     assert(_firstFrameDeferredCount > 0);
     _firstFrameDeferredCount -= 1;
-    if (_firstFrameRequested && !_firstFrameHappened && !_firstFrameDeferred) {
+    if (_firstFrameRequested && !_firstFrameRendered && !_firstFrameDeferred) {
       drawFrame();
     }
   }
@@ -773,11 +773,11 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
   // When editing the above, also update rendering/binding.dart's copy.
   @override
   void drawFrame() {
-    if (!_firstFrameHappened && _firstFrameDeferred) {
+    if (!_firstFrameRendered && _firstFrameDeferred) {
       _firstFrameRequested = true;
       return;
     }
-    _firstFrameHappened = true;
+    _firstFrameRendered = true;
 
     assert(!debugBuildingDirtyElements);
     assert(() {

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:ui' show Locale;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
 
 import 'basic.dart';
 import 'binding.dart';
@@ -519,9 +520,9 @@ class _LocalizationsState extends State<Localizations> {
       // have finished loading. Until then the old locale will continue to be used.
       // - If we're running at app startup time then defer reporting the first
       // "useful" frame until after the async load has completed.
-      WidgetsBinding.instance.deferFirstFrame();
+      RendererBinding.instance.deferFirstFrame();
       typeToResourcesFuture.then<void>((Map<Type, dynamic> value) {
-        WidgetsBinding.instance.allowFirstFrame();
+        RendererBinding.instance.allowFirstFrame();
         if (!mounted)
           return;
         setState(() {

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -519,9 +519,9 @@ class _LocalizationsState extends State<Localizations> {
       // have finished loading. Until then the old locale will continue to be used.
       // - If we're running at app startup time then defer reporting the first
       // "useful" frame until after the async load has completed.
-      WidgetsBinding.instance.deferFirstFrameReport();
+      WidgetsBinding.instance.deferFirstFrame();
       typeToResourcesFuture.then<void>((Map<Type, dynamic> value) {
-        WidgetsBinding.instance.allowFirstFrameReport();
+        WidgetsBinding.instance.allowFirstFrame();
         if (!mounted)
           return;
         setState(() {

--- a/packages/flutter/test/widgets/binding_deferred_first_frame_test.dart
+++ b/packages/flutter/test/widgets/binding_deferred_first_frame_test.dart
@@ -1,0 +1,86 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+const String _actualContent = 'Actual Content';
+const String _loading = 'Loading...';
+
+
+void main() {
+  testWidgets('deferFirstFrame/allowFirstFrame stops sending frames to engine', (WidgetTester tester) async {
+    expect(RendererBinding.instance.sendFramesToEngine, isTrue);
+
+    final Completer<void> completer = Completer<void>();
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: _DeferringWidget(
+          key: UniqueKey(),
+          loader: completer.future,
+        ),
+      ),
+    );
+    final _DeferringWidgetState state = tester.state<_DeferringWidgetState>(find.byType(_DeferringWidget));
+
+    expect(find.text(_loading), findsOneWidget);
+    expect(find.text(_actualContent), findsNothing);
+    expect(RendererBinding.instance.sendFramesToEngine, isFalse);
+
+    await tester.pump();
+    expect(find.text(_loading), findsOneWidget);
+    expect(find.text(_actualContent), findsNothing);
+    expect(RendererBinding.instance.sendFramesToEngine, isFalse);
+    expect(state.doneLoading, isFalse);
+
+    // Complete the future to start sending frames.
+    completer.complete();
+    await tester.idle();
+    expect(state.doneLoading, isTrue);
+    expect(RendererBinding.instance.sendFramesToEngine, isTrue);
+
+    await tester.pump();
+    expect(find.text(_loading), findsNothing);
+    expect(find.text(_actualContent), findsOneWidget);
+    expect(RendererBinding.instance.sendFramesToEngine, isTrue);
+  });
+}
+
+
+class _DeferringWidget extends StatefulWidget {
+  const _DeferringWidget({Key key, this.loader}) : super(key: key);
+
+  final Future<void> loader;
+
+  @override
+  State<_DeferringWidget> createState() => _DeferringWidgetState();
+}
+
+class _DeferringWidgetState extends State<_DeferringWidget> {
+  bool doneLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    RendererBinding.instance.deferFirstFrame();
+    widget.loader.then((_) {
+      setState(() {
+        doneLoading = true;
+        RendererBinding.instance.allowFirstFrame();
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return doneLoading
+        ? const Text(_actualContent)
+        : const Text(_loading);
+  }
+}

--- a/packages/flutter/test/widgets/binding_deferred_first_frame_test.dart
+++ b/packages/flutter/test/widgets/binding_deferred_first_frame_test.dart
@@ -12,7 +12,6 @@ import 'package:flutter/widgets.dart';
 const String _actualContent = 'Actual Content';
 const String _loading = 'Loading...';
 
-
 void main() {
   testWidgets('deferFirstFrame/allowFirstFrame stops sending frames to engine', (WidgetTester tester) async {
     expect(RendererBinding.instance.sendFramesToEngine, isTrue);
@@ -51,7 +50,6 @@ void main() {
     expect(RendererBinding.instance.sendFramesToEngine, isTrue);
   });
 }
-
 
 class _DeferringWidget extends StatefulWidget {
   const _DeferringWidget({Key key, this.loader}) : super(key: key);


### PR DESCRIPTION
## Description

Adds API to RendererBinding to delay rendering the first frame. This is useful for widgets that need to obtain initialization information asynchronously and while they are waiting for that information no frame should render as that would take down the splash screen pre-maturely. 

## Related Issues

None

## Tests

I added the following tests:

* deferFirstFrame/allowFirstFrame stops sending frames to engine

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (Please read [Handling breaking changes]). https://groups.google.com/forum/#!topic/flutter-announce/kBf4cXjD2y4
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
