### PR TITLE
Update Android CPU device detection

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -45,3 +45,5 @@ Sarbagya Dhaubanjar <mail@sarbagyastha.com.np>
 Rody Davis Jr <rody.davis.jr@gmail.com>
 Robin Jespersen <info@unitedpartners.de>
 Jefferson Quesado <jeff.quesado@gmail.com>
+Mark Diener <rpzrpzrpz@gmail.com>
+

--- a/AUTHORS
+++ b/AUTHORS
@@ -46,4 +46,3 @@ Rody Davis Jr <rody.davis.jr@gmail.com>
 Robin Jespersen <info@unitedpartners.de>
 Jefferson Quesado <jeff.quesado@gmail.com>
 Mark Diener <rpzrpzrpz@gmail.com>
-

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -192,7 +192,16 @@ class AndroidDevice extends Device {
       // http://developer.android.com/ndk/guides/abis.html (x86, armeabi-v7a, ...)
       switch (await _getProperty('ro.product.cpu.abi')) {
         case 'arm64-v8a':
-          _platform = TargetPlatform.android_arm64;
+          // Perform additional verification for 64 bit ABI. Some devices,
+          // like the Kindle Fire 8, misreport the abilist. We might not
+          // be able to retrieve this property, in which case we fall back
+          // to assuming 64 bit.
+          final String gabilist = await _getProperty('ro.product.cpu.abilist');
+          if (gabilist == null || gabilist.contains('arm64-v8a')) {
+            _platform = TargetPlatform.android_arm64;
+          } else {
+            _platform = TargetPlatform.android_arm;
+          }
           break;
         case 'x86_64':
           _platform = TargetPlatform.android_x64;

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -196,8 +196,8 @@ class AndroidDevice extends Device {
           // like the Kindle Fire 8, misreport the abilist. We might not
           // be able to retrieve this property, in which case we fall back
           // to assuming 64 bit.
-          final String gabilist = await _getProperty('ro.product.cpu.abilist');
-          if (gabilist == null || gabilist.contains('arm64-v8a')) {
+          final String abilist = await _getProperty('ro.product.cpu.abilist');
+          if (abilist == null || abilist.contains('arm64-v8a')) {
             _platform = TargetPlatform.android_arm64;
           } else {
             _platform = TargetPlatform.android_arm;

--- a/packages/flutter_tools/test/general.shard/android/android_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_test.dart
@@ -343,22 +343,34 @@ Use the 'android' tool to install them:
       });
     });
 
-    testUsingContext('detects normal ABIs', () async {
+    testUsingContext('detects x64', () async {
       cpu = 'x86_64';
       final AndroidDevice device = AndroidDevice('test');
 
       expect(await device.targetPlatform, TargetPlatform.android_x64);
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager
+    });
 
+    testUsingContext('detects x86', () async {
       cpu = 'x86';
-      expect(await device.targetPlatform, TargetPlatform.android_x86);
+      final AndroidDevice device = AndroidDevice('test');
 
+      expect(await device.targetPlatform, TargetPlatform.android_x86);
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager
+    });
+
+    testUsingContext('unknown device defaults to 32bit arm', () async {
       cpu = '???';
+      final AndroidDevice device = AndroidDevice('test');
+
       expect(await device.targetPlatform, TargetPlatform.android_arm);
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager
     });
 
-    testUsingContext('detects kindle fire ABI', () async {
+    testUsingContext('detects 64 bit arm', () async {
       cpu = 'arm64-v8a';
       abilist = 'arm64-v8a,';
 
@@ -366,16 +378,17 @@ Use the 'android' tool to install them:
 
       // If both abi properties agree, we are 64 bit.
       expect(await device.targetPlatform, TargetPlatform.android_arm64);
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager
+    });
 
-      abilist = 'arm6';
+    testUsingContext('detects kind fire ABI', () async {
+      final AndroidDevice device = AndroidDevice('test');
+      cpu = 'arm64-v8a';
+      abilist = 'arm';
 
       // If one does not contain arm64, assume 32 bit.
-      expect(await device.targetPlatform, TargetPlatform.android_arm);
-
-      includeAbilist = false;
-
-      // If the property cannot be retrieved assume 64 bit.
-      expect(await device.targetPlatform, TargetPlatform.android_arm64);
+      expect(await device.targetPlatform, TargetPlatform.android_arm)
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager
     });

--- a/packages/flutter_tools/test/general.shard/android/android_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_test.dart
@@ -322,7 +322,6 @@ Use the 'android' tool to install them:
     ProcessManager mockProcessManager;
     String cpu;
     String abilist;
-    bool includeAbilist = true;
 
     setUp(() {
       mockProcessManager = MockProcessManager();
@@ -334,10 +333,8 @@ Use the 'android' tool to install them:
         stdoutEncoding: anyNamed('stdoutEncoding'),
       )).thenAnswer((_) {
         final StringBuffer buf = StringBuffer()
-          ..writeln('[ro.product.cpu.abi]: [$cpu]');
-        if (includeAbilist) {
-          buf.writeln('[ro.product.cpu.abilist]: [$abilist]');
-        }
+          ..writeln('[ro.product.cpu.abi]: [$cpu]')
+          ..writeln('[ro.product.cpu.abilist]: [$abilist]');
         final ProcessResult result = ProcessResult(1, 0, buf.toString(), '');
         return Future<ProcessResult>.value(result);
       });
@@ -373,7 +370,6 @@ Use the 'android' tool to install them:
     testUsingContext('detects 64 bit arm', () async {
       cpu = 'arm64-v8a';
       abilist = 'arm64-v8a,';
-
       final AndroidDevice device = AndroidDevice('test');
 
       // If both abi properties agree, we are 64 bit.
@@ -383,12 +379,12 @@ Use the 'android' tool to install them:
     });
 
     testUsingContext('detects kind fire ABI', () async {
-      final AndroidDevice device = AndroidDevice('test');
       cpu = 'arm64-v8a';
       abilist = 'arm';
+      final AndroidDevice device = AndroidDevice('test');
 
       // If one does not contain arm64, assume 32 bit.
-      expect(await device.targetPlatform, TargetPlatform.android_arm)
+      expect(await device.targetPlatform, TargetPlatform.android_arm);
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager
     });


### PR DESCRIPTION
## Description

Certain devices are running 64 bit, but oddly enough only support running 32 bit applications

Fixes https://github.com/flutter/flutter/issues/44999

~TODO: is there a non-null sentinel that would be returned if we cannot access `ro.product.cpu.abilist` ?~
