### PR TITLE
cache sdkNameAndVersion logic for web devices

### DIFF
--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -89,7 +89,10 @@ class ChromeDevice extends Device {
   DevicePortForwarder get portForwarder => const NoOpDevicePortForwarder();
 
   @override
-  Future<String> get sdkNameAndVersion async {
+  Future<String> get sdkNameAndVersion async => _sdkNameAndVersion ??= await _computeSdkNameAndVersion();
+
+  String _sdkNameAndVersion;
+  Future<String> _computeSdkNameAndVersion() async {
     if (!isSupported()) {
       return 'unknown';
     }

--- a/packages/flutter_tools/test/general.shard/web/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devices_test.dart
@@ -101,6 +101,10 @@ void main() {
 
     expect(chromeDevice.isSupported(), true);
     expect(await chromeDevice.sdkNameAndVersion, 'ABC');
+
+    // Verify caching works correctly.
+    expect(await chromeDevice.sdkNameAndVersion, 'ABC');
+    verify(mockProcessManager.run(<String>['chrome.foo', '--version'])).called(1);
   }, overrides: <Type, Generator>{
     Platform: () => mockPlatform,
     ProcessManager: () => mockProcessManager,


### PR DESCRIPTION
## Description
Fixes https://github.com/flutter/flutter/issues/45120

Cache the expensive lookup for Chrome's sdkNameAndVersion.