### PR TITLE
Fix device daemon test when desktop or web are enabled

### DIFF
--- a/packages/flutter_tools/test/integration.shard/daemon_mode_test.dart
+++ b/packages/flutter_tools/test/integration.shard/daemon_mode_test.dart
@@ -60,7 +60,8 @@ void main() {
       'id': 2,
       'method': 'device.getDevices',
     })}]');
-    response = await stream.first;
+    // Skip other device.added events that may fire (desktop/web devices).
+    response = await stream.firstWhere((Map<String, dynamic> response) => response['event'] != 'device.added');
     expect(response['id'], 2);
     expect(response['error'], isNull);
 


### PR DESCRIPTION
This test fails when desktop or web are enabled, because there are multiple `device.added` events and the test expects only one (`flutter-tester`) and that the second item in the stream is the response to its request.

The change filters out any additional `device.added` events. We could also just filter out any `event`, or even anything without an `id`, but I wasn't sure if we'd prefer the test to fail on unknown changes or ignore them.