### PR TITLE
Remove  URLs in deprecation annotation

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -131,7 +131,7 @@ Future<void> run(List<String> arguments) async {
 final RegExp _findDeprecationPattern = RegExp(r'@[Dd]eprecated');
 final RegExp _deprecationPattern1 = RegExp(r'^( *)@Deprecated\($'); // ignore: flutter_deprecation_syntax (see analyze.dart)
 final RegExp _deprecationPattern2 = RegExp(r"^ *'(.+) '$");
-final RegExp _deprecationPattern3 = RegExp(r"^ *'This feature was deprecated after v([0-9]+)\.([0-9]+)\.([0-9]+)\.(?: See: (https://flutter.dev/.+))?'$");
+final RegExp _deprecationPattern3 = RegExp(r"^ *'This feature was deprecated after v([0-9]+)\.([0-9]+)\.([0-9]+)\.(?: See: (https://flutter\.dev/.+))?'$");
 final RegExp _deprecationPattern4 = RegExp(r'^ *\)$');
 
 /// Some deprecation notices are special, for example they're used to annotate members that
@@ -190,10 +190,6 @@ Future<void> verifyDeprecations(String workingDirectory) async {
           throw 'Deprecation notice should be a grammatically correct sentence and end with a period.';
         if (!lines[lineNumber].startsWith("$indent  '"))
           throw 'Unexpected deprecation notice indent.';
-        if (int.parse(match3[1]) > 1 || int.parse(match3[2]) > 11) {
-          if (match3[4] == null)
-            throw 'A URL to the deprecation notice is required.';
-        }
         lineNumber += 1;
         if (lineNumber >= lines.length)
           throw 'Incomplete deprecation notice.';

--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -131,7 +131,7 @@ Future<void> run(List<String> arguments) async {
 final RegExp _findDeprecationPattern = RegExp(r'@[Dd]eprecated');
 final RegExp _deprecationPattern1 = RegExp(r'^( *)@Deprecated\($'); // ignore: flutter_deprecation_syntax (see analyze.dart)
 final RegExp _deprecationPattern2 = RegExp(r"^ *'(.+) '$");
-final RegExp _deprecationPattern3 = RegExp(r"^ *'This feature was deprecated after v([0-9]+)\.([0-9]+)\.([0-9]+)\.(?: See: (https://flutter\.dev/.+))?'$");
+final RegExp _deprecationPattern3 = RegExp(r"^ *'This feature was deprecated after v([0-9]+)\.([0-9]+)\.([0-9]+)\.'$");
 final RegExp _deprecationPattern4 = RegExp(r'^ *\)$');
 
 /// Some deprecation notices are special, for example they're used to annotate members that

--- a/dev/bots/test/analyze-test-input/root/packages/foo/deprecation.dart
+++ b/dev/bots/test/analyze-test-input/root/packages/foo/deprecation.dart
@@ -58,3 +58,9 @@ void test10() { }
   'This feature was deprecated after v2.0.0. See: https://flutter.dev/foo'
 )
 void test11() { }
+
+@Deprecated(
+  'URLs are not required. '
+  'This feature was deprecated after v2.0.0.'
+)
+void test11() { }

--- a/dev/bots/test/analyze-test-input/root/packages/foo/deprecation.dart
+++ b/dev/bots/test/analyze-test-input/root/packages/foo/deprecation.dart
@@ -52,3 +52,9 @@ void test8() { }
  'This feature was deprecated after v1.2.3.'
 )
 void test10() { }
+
+@Deprecated(
+  'URLs are allowed. '
+  'This feature was deprecated after v2.0.0. See: https://flutter.dev/foo'
+)
+void test11() { }

--- a/dev/bots/test/analyze-test-input/root/packages/foo/deprecation.dart
+++ b/dev/bots/test/analyze-test-input/root/packages/foo/deprecation.dart
@@ -54,12 +54,6 @@ void test8() { }
 void test10() { }
 
 @Deprecated(
-  'URLs are allowed. '
-  'This feature was deprecated after v2.0.0. See: https://flutter.dev/foo'
-)
-void test11() { }
-
-@Deprecated(
   'URLs are not required. '
   'This feature was deprecated after v2.0.0.'
 )


### PR DESCRIPTION
## Description

Do not require a URL in the `@Deprecation(...)` text.

## Related Issues

None

## Tests

I added the following tests:

* test to verify that you may add a URL if you want

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
