### PR TITLE
implicit-casts:false in fuchsia_remote_debug_protocol

### DIFF
--- a/packages/fuchsia_remote_debug_protocol/analysis_options.yaml
+++ b/packages/fuchsia_remote_debug_protocol/analysis_options.yaml
@@ -1,0 +1,12 @@
+# Override the parent analysis_options until all the repo has implicit-casts: false
+
+include: ../analysis_options.yaml
+
+analyzer:
+  strong-mode:
+    implicit-casts: false
+    implicit-dynamic: false
+
+linter:
+  rules:
+    avoid_as: false

--- a/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
@@ -171,7 +171,7 @@ class DartVm {
         await invokeRpc('getVM', timeout: timeout);
     final List<IsolateRef> result = <IsolateRef>[];
     for (Map<String, dynamic> jsonIsolate in jsonVmRef['isolates']) {
-      final String name = jsonIsolate['name'];
+      final String name = jsonIsolate['name'] as String;
       if (pattern.matchAsPrefix(name) != null) {
         _log.fine('Found Isolate matching "$pattern": "$name"');
         result.add(IsolateRef._fromJson(jsonIsolate, this));
@@ -197,7 +197,7 @@ class DartVm {
           'Peer connection timed out during RPC call',
           timeout,
         );
-      });
+      }) as Map<String, dynamic>;
     return result;
   }
 
@@ -243,11 +243,11 @@ class FlutterView {
   /// All other cases return a [FlutterView] instance. The name of the
   /// view may be null, but the id will always be set.
   factory FlutterView._fromJson(Map<String, dynamic> json) {
-    final Map<String, dynamic> isolate = json['isolate'];
-    final String id = json['id'];
+    final Map<String, dynamic> isolate = json['isolate'] as Map<String, dynamic>;
+    final String id = json['id'] as String;
     String name;
     if (isolate != null) {
-      name = isolate['name'];
+      name = isolate['name'] as String;
       if (name == null) {
         throw RpcFormatError('Unable to find name for isolate "$isolate"');
       }
@@ -286,9 +286,9 @@ class IsolateRef {
   IsolateRef._(this.name, this.number, this.dartVm);
 
   factory IsolateRef._fromJson(Map<String, dynamic> json, DartVm dartVm) {
-    final String number = json['number'];
-    final String name = json['name'];
-    final String type = json['type'];
+    final String number = json['number'] as String;
+    final String name = json['name'] as String;
+    final String type = json['type'] as String;
     if (type == null) {
       throw RpcFormatError('Unable to find type within JSON "$json"');
     }

--- a/packages/fuchsia_remote_debug_protocol/lib/src/runners/ssh_command_runner.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/runners/ssh_command_runner.dart
@@ -99,6 +99,6 @@ class SshCommandRunner {
           'Command failed: $command\nstdout: ${result.stdout}\nstderr: ${result.stderr}');
     }
     _log.fine('SSH command stdout in brackets:[${result.stdout}]');
-    return result.stdout.split('\n');
+    return (result.stdout as String).split('\n');
   }
 }

--- a/packages/fuchsia_remote_debug_protocol/test/src/runners/ssh_command_runner_test.dart
+++ b/packages/fuchsia_remote_debug_protocol/test/src/runners/ssh_command_runner_test.dart
@@ -53,11 +53,11 @@ void main() {
         interface: interface,
         sshConfigPath: '/whatever',
       );
-      when<String>(mockProcessResult.stdout).thenReturn('somestuff');
+      when<dynamic>(mockProcessResult.stdout).thenReturn('somestuff');
       when(mockProcessResult.exitCode).thenReturn(0);
       await runner.run('ls /whatever');
       final List<String> passedCommand =
-          verify(mockProcessManager.run(captureAny)).captured.single;
+          verify(mockProcessManager.run(captureAny)).captured.single as List<String>;
       expect(passedCommand, contains('$ipV6Addr%$interface'));
     });
 
@@ -67,11 +67,11 @@ void main() {
         mockProcessManager,
         address: ipV6Addr,
       );
-      when<String>(mockProcessResult.stdout).thenReturn('somestuff');
+      when<dynamic>(mockProcessResult.stdout).thenReturn('somestuff');
       when(mockProcessResult.exitCode).thenReturn(0);
       await runner.run('ls /whatever');
       final List<String> passedCommand =
-          verify(mockProcessManager.run(captureAny)).captured.single;
+          verify(mockProcessManager.run(captureAny)).captured.single as List<String>;
       expect(passedCommand, contains(ipV6Addr));
     });
 
@@ -79,7 +79,7 @@ void main() {
       const String addr = '192.168.1.1';
       runner = SshCommandRunner.withProcessManager(mockProcessManager,
           address: addr);
-      when<String>(mockProcessResult.stdout).thenReturn('''this
+      when<dynamic>(mockProcessResult.stdout).thenReturn('''this
           has
           four
           lines''');
@@ -92,7 +92,7 @@ void main() {
       const String addr = '192.168.1.1';
       runner = SshCommandRunner.withProcessManager(mockProcessManager,
           address: addr);
-      when<String>(mockProcessResult.stdout).thenReturn('whatever');
+      when<dynamic>(mockProcessResult.stdout).thenReturn('whatever');
       when(mockProcessResult.exitCode).thenReturn(1);
       Future<void> failingFunction() async {
         await runner.run('oihaw');
@@ -109,11 +109,11 @@ void main() {
         address: addr,
         sshConfigPath: config,
       );
-      when<String>(mockProcessResult.stdout).thenReturn('somestuff');
+      when<dynamic>(mockProcessResult.stdout).thenReturn('somestuff');
       when(mockProcessResult.exitCode).thenReturn(0);
       await runner.run('ls /whatever');
       final List<String> passedCommand =
-          verify(mockProcessManager.run(captureAny)).captured.single;
+          verify(mockProcessManager.run(captureAny)).captured.single as List<String>;
       expect(passedCommand, contains('-F'));
       final int indexOfFlag = passedCommand.indexOf('-F');
       final String passedConfig = passedCommand[indexOfFlag + 1];
@@ -126,11 +126,11 @@ void main() {
         mockProcessManager,
         address: addr,
       );
-      when<String>(mockProcessResult.stdout).thenReturn('somestuff');
+      when<dynamic>(mockProcessResult.stdout).thenReturn('somestuff');
       when(mockProcessResult.exitCode).thenReturn(0);
       await runner.run('ls /whatever');
       final List<String> passedCommand =
-          verify(mockProcessManager.run(captureAny)).captured.single;
+          verify(mockProcessManager.run(captureAny)).captured.single as List<String>;
       final int indexOfFlag = passedCommand.indexOf('-F');
       expect(indexOfFlag, equals(-1));
     });


### PR DESCRIPTION
## Description

Enable `implicit-casts:false` on `fuchsia_remote_debug_protocol`

## Related Issues

None

## Tests

None because it's a refactoring.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
