### PR TITLE
Resume isolate before terminating tests to prevent flutter_tester leaks in integration tests

### DIFF
--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -168,7 +168,7 @@ abstract class FlutterTestDriver {
     // it forcefully and it won't terminate child processes, so we need to ensure
     // it's running before terminating.
     try {
-    await resume().timeout(defaultTimeout);
+      await resume().timeout(defaultTimeout);
     } catch (e) {
       _debugPrint('Ignoring failure to resume during shutdown');
     }
@@ -353,7 +353,7 @@ abstract class FlutterTestDriver {
         return;
       }
       if ((event != null && json['event'] == event) ||
-          (id    != null && json['id']    == id)) {
+          (id != null && json['id'] == id)) {
         await subscription.cancel();
         _debugPrint('OK ($interestingOccurrence)');
         response.complete(json);
@@ -533,7 +533,7 @@ class FlutterRunTestDriver extends FlutterTestDriver {
         // have already completed.
         _currentRunningAppId = (await started)['params']['appId'] as String;
         prematureExitGuard.complete();
-      } catch(error, stackTrace) {
+      } catch (error, stackTrace) {
         prematureExitGuard.completeError(error, stackTrace);
       }
     }());
@@ -554,7 +554,7 @@ class FlutterRunTestDriver extends FlutterTestDriver {
       'app.restart',
       <String, dynamic>{'appId': _currentRunningAppId, 'fullRestart': fullRestart, 'pause': pause},
     );
-    _debugPrint('${ fullRestart ? "Hot restart" : "Hot reload" } complete.');
+    _debugPrint('${fullRestart ? "Hot restart" : "Hot reload"} complete.');
 
     if (hotReloadResponse == null || hotReloadResponse['code'] != 0) {
       _throwErrorResponse('Hot ${fullRestart ? 'restart' : 'reload'} request failed');

--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -167,7 +167,7 @@ abstract class FlutterTestDriver {
     // If we try to kill the process while it's paused, we'll end up terminating
     // it forcefully and it won't terminate child processes, so we need to ensure
     // it's running before terminating.
-    await resume().timeout(defaultTimeout).catchError((_) => _debugPrint('Ignoring failure to resume during shutdown'));
+    await resume().timeout(defaultTimeout).catchError(() => _debugPrint('Ignoring failure to resume during shutdown'));
     _debugPrint('Sending SIGTERM to $_processPid..');
     ProcessSignal.SIGTERM.send(_processPid);
     return _process.exitCode.timeout(quitTimeout, onTimeout: _killForcefully);

--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -167,7 +167,11 @@ abstract class FlutterTestDriver {
     // If we try to kill the process while it's paused, we'll end up terminating
     // it forcefully and it won't terminate child processes, so we need to ensure
     // it's running before terminating.
-    await resume().timeout(defaultTimeout).catchError(() => _debugPrint('Ignoring failure to resume during shutdown'));
+    try {
+    await resume().timeout(defaultTimeout);
+    } catch (e) {
+      _debugPrint('Ignoring failure to resume during shutdown');
+    }
     _debugPrint('Sending SIGTERM to $_processPid..');
     ProcessSignal.SIGTERM.send(_processPid);
     return _process.exitCode.timeout(quitTimeout, onTimeout: _killForcefully);

--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -164,6 +164,10 @@ abstract class FlutterTestDriver {
     if (_processPid == null) {
       return -1;
     }
+    // If we try to kill the process while it's paused, we'll end up terminating
+    // it forcefully and it won't terminate child processes, so we need to ensure
+    // it's running before terminating.
+    await resume().timeout(defaultTimeout).catchError((_) => _debugPrint('Ignoring failure to resume during shutdown'));
     _debugPrint('Sending SIGTERM to $_processPid..');
     ProcessSignal.SIGTERM.send(_processPid);
     return _process.exitCode.timeout(quitTimeout, onTimeout: _killForcefully);

--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -167,10 +167,12 @@ abstract class FlutterTestDriver {
     // If we try to kill the process while it's paused, we'll end up terminating
     // it forcefully and it won't terminate child processes, so we need to ensure
     // it's running before terminating.
-    try {
-      await resume().timeout(defaultTimeout);
-    } catch (e) {
-      _debugPrint('Ignoring failure to resume during shutdown');
+    if (_vmService != null) {
+      try {
+        await resume().timeout(defaultTimeout);
+      } catch (e) {
+        _debugPrint('Ignoring failure to resume during shutdown');
+      }
     }
     _debugPrint('Sending SIGTERM to $_processPid..');
     ProcessSignal.SIGTERM.send(_processPid);


### PR DESCRIPTION
When running integration tests locally I noticed that `flutter_tester` processes were being leaked. This is because during some of the tests the Flutter isolate is left paused and when we try to tear down (by  sending `SIGTERM`) the output of the process says

> Waiting for current test to finish
> Press Ctrl+C again to terminate

Since the process doesn't quit within 10s, we then send `SIGTERM` which terminates the process and no cleanup is performed (so the child flutter_tester process is left). Sending a second `SIGTERM` did not resolve the issue in my testing because it also resulted in an unclean shutdown.

This probably fixes #26350, though I don't think it's a perfect fix since other code that terminates while paused (for example the user clicking Stop in the IDE while at a breakpoint) could still leak these processes - I don't think that's really a Flutter issue though (it's likely a `package:test` issue, or limitation that the IDEs should consider).