### PR TITLE
Add macOS hot reload test

### DIFF
--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_macos_target__benchmark.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_macos_target__benchmark.dart
@@ -1,4 +1,4 @@
-// Copyright 2016 The Chromium Authors. All rights reserved.
+// Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_macos_target__benchmark.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_macos_target__benchmark.dart
@@ -1,0 +1,14 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/tasks/hot_mode_tests.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+
+Future<void> main() async {
+  await task(createHotModeTest(deviceIdOverride: 'macos', environment: <String, String>{
+    'FLUTTER_MACOS': 'true',
+  }));
+}

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -121,7 +121,7 @@ void recursiveCopy(Directory source, Directory target) {
 
   for (FileSystemEntity entity in source.listSync(followLinks: false)) {
     final String name = path.basename(entity.path);
-    if (entity is Directory)
+    if (entity is Directory && !entity.path.contains('.dart_tool'))
       recursiveCopy(entity, Directory(path.join(target.path, name)));
     else if (entity is File) {
       final File dest = File(path.join(target.path, name));

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -567,7 +567,7 @@ tasks:
     required_agent_capabilities: ["mac-catalina/android"]
 
   # macOS target platform tests
-  smoke_catalina_hot_mode_dev_cycle_macos_target_benchmark:
+  hot_mode_dev_cycle_macos_target_benchmark:
     description: >
       Checks the functionality and performance of hot reload on a macOS target platform
     stage: devicelab

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -566,6 +566,14 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["mac-catalina/android"]
 
+  # macOS target platform tests
+  smoke_catalina_hot_mode_dev_cycle_macos_target_benchmark:
+    description: >
+      Checks the functionality and performance of hot reload on a macOS target platform
+    stage: devicelab
+    required_agent_capabilities: ["mac/ios"]
+    flaky: true
+
   # Tests running on Windows host
 
   flavors_test_win:

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -567,7 +567,7 @@ tasks:
     required_agent_capabilities: ["mac-catalina/android"]
 
   # macOS target platform tests
-  hot_mode_dev_cycle_macos_target_benchmark:
+  hot_mode_dev_cycle_macos_target__benchmark:
     description: >
       Checks the functionality and performance of hot reload on a macOS target platform
     stage: devicelab


### PR DESCRIPTION
## Description

Runs the same hot reload test/benchmark that we do on iOS/Android on macOS. Adds a flutter clean step before running to clear any copied xcode caches.

https://github.com/flutter/flutter/issues/42281

FYI @godofredoc @digiter 