### PR TITLE
Allow unknown fields in pubspec plugin section

### DIFF
--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -163,7 +163,8 @@ class Plugin {
     if (usesOldPluginFormat && usesNewPluginFormat) {
       const String errorMessage =
           'The flutter.plugin.platforms key cannot be used in combination with the old'
-          'flutter.plugin.{androidPackage,iosPrefix,pluginClass} keys.';
+          'flutter.plugin.{androidPackage,iosPrefix,pluginClass} keys.'
+          'See: https://flutter.dev/docs/development/packages-and-plugins/developing-packages#plugin';
       return <String>[errorMessage];
     }
 

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -151,15 +151,24 @@ class Plugin {
   }
 
   static List<String> validatePluginYaml(YamlMap yaml) {
-    if (yaml.containsKey('platforms')) {
-      final int numKeys = yaml.keys.toSet().length;
-      if (numKeys != 1) {
-        return <String>[
-          'Invalid plugin specification. There must be only one key: "platforms", found multiple: ${yaml.keys.join(',')}',
-        ];
-      } else {
-        return _validateMultiPlatformYaml(yaml['platforms'] as YamlMap);
-      }
+
+    final bool usesOldPluginFormat = const <String>{
+      'androidPackage',
+      'iosPrefix',
+      'pluginClass',
+    }.any(yaml.containsKey);
+
+    final bool usesNewPluginFormat = yaml.containsKey('platforms');
+
+    if (usesOldPluginFormat && usesNewPluginFormat) {
+      const String errorMessage =
+          'The flutter.plugin.platforms key cannot be used in combination with the old'
+          'flutter.plugin.{androidPackage,iosPrefix,pluginClass} keys.';
+      return <String>[errorMessage];
+    }
+
+    if (usesNewPluginFormat) {
+      return _validateMultiPlatformYaml(yaml['platforms'] as YamlMap);
     } else {
       return _validateLegacyYaml(yaml);
     }

--- a/packages/flutter_tools/test/general.shard/plugin_parsing_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugin_parsing_test.dart
@@ -78,5 +78,52 @@ void main() {
       expect(webPlugin.fileName, 'web_plugin.dart');
       expect(windowsPlugin.pluginClass, 'WinSamplePlugin');
     });
+
+    test('Unknown fields are allowed (allows some future compatibility)', () {
+      const String pluginYamlRaw = 'implements: same_plugin\n' // this should be ignored by the tool
+          'platforms:\n'
+          ' android:\n'
+          '  package: com.flutter.dev\n'
+          '  pluginClass: ASamplePlugin\n'
+          '  anUnknownField: ASamplePlugin\n' // this should be ignored by the tool
+          ' ios:\n'
+          '  pluginClass: ISamplePlugin\n'
+          ' linux:\n'
+          '  pluginClass: LSamplePlugin\n'
+          ' macos:\n'
+          '  pluginClass: MSamplePlugin\n'
+          ' web:\n'
+          '  pluginClass: WebSamplePlugin\n'
+          '  fileName: web_plugin.dart\n'
+          ' windows:\n'
+          '  pluginClass: WinSamplePlugin\n';
+
+      final dynamic pluginYaml = loadYaml(pluginYamlRaw);
+      final Plugin plugin =
+      Plugin.fromYaml(_kTestPluginName, _kTestPluginPath, pluginYaml);
+
+      final AndroidPlugin androidPlugin =
+      plugin.platforms[AndroidPlugin.kConfigKey];
+      final IOSPlugin iosPlugin = plugin.platforms[IOSPlugin.kConfigKey];
+      final LinuxPlugin linuxPlugin =
+      plugin.platforms[LinuxPlugin.kConfigKey];
+      final MacOSPlugin macOSPlugin =
+      plugin.platforms[MacOSPlugin.kConfigKey];
+      final WebPlugin webPlugin = plugin.platforms[WebPlugin.kConfigKey];
+      final WindowsPlugin windowsPlugin =
+      plugin.platforms[WindowsPlugin.kConfigKey];
+      final String androidPluginClass = androidPlugin.pluginClass;
+      final String iosPluginClass = iosPlugin.pluginClass;
+
+      expect(iosPluginClass, 'ISamplePlugin');
+      expect(androidPluginClass, 'ASamplePlugin');
+      expect(iosPlugin.classPrefix, '');
+      expect(androidPlugin.package, 'com.flutter.dev');
+      expect(linuxPlugin.pluginClass, 'LSamplePlugin');
+      expect(macOSPlugin.pluginClass, 'MSamplePlugin');
+      expect(webPlugin.pluginClass, 'WebSamplePlugin');
+      expect(webPlugin.fileName, 'web_plugin.dart');
+      expect(windowsPlugin.pluginClass, 'WinSamplePlugin');
+    });
   });
 }


### PR DESCRIPTION
## Description

We allow (and ignore) unknown fields in the `plugin` section in pubspec to allow some forward compatibility (e.g if we add a new field in a future tool version we want older tool versions to ignore it).

## Related Issues
https://github.com/flutter/flutter/issues/44288

## Tests

I added the following tests:

  - Unit test that checks that unknown fields are ignored.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
