### PR TITLE
de-null dartDefines in daemon mode

### DIFF
--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -203,10 +203,7 @@ class AttachCommand extends FlutterCommand {
           stdoutCommandResponse,
           notifyingLogger: NotifyingLogger(),
           logToStdout: true,
-          // Since the application was compiled and launched by other means
-          // there's no point in passing Dart defines, we won't be compiling
-          // anything.
-          dartDefines: const <String>[],
+          dartDefines: dartDefines,
         )
       : null;
 

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -198,8 +198,16 @@ class AttachCommand extends FlutterCommand {
     final int devicePort = await getDevicePort();
 
     final Daemon daemon = boolArg('machine')
-      ? Daemon(stdinCommandStream, stdoutCommandResponse,
-            notifyingLogger: NotifyingLogger(), logToStdout: true)
+      ? Daemon(
+          stdinCommandStream,
+          stdoutCommandResponse,
+          notifyingLogger: NotifyingLogger(),
+          logToStdout: true,
+          // Since the application was compiled and launched by other means
+          // there's no point in passing Dart defines, we won't be compiling
+          // anything.
+          dartDefines: const <String>[],
+        )
       : null;
 
     Stream<Uri> observatoryUri;

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -340,8 +340,13 @@ class RunCommand extends RunCommandBase {
       if (devices.length > 1) {
         throwToolExit('--machine does not support -d all.');
       }
-      final Daemon daemon = Daemon(stdinCommandStream, stdoutCommandResponse,
-          notifyingLogger: NotifyingLogger(), logToStdout: true);
+      final Daemon daemon = Daemon(
+        stdinCommandStream,
+        stdoutCommandResponse,
+        notifyingLogger: NotifyingLogger(),
+        logToStdout: true,
+        dartDefines: dartDefines,
+      );
       AppInstance app;
       try {
         final String applicationBinaryPath = stringArg('use-application-binary');

--- a/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
@@ -39,6 +39,7 @@ void main() {
         commands.stream,
         responses.add,
         notifyingLogger: notifyingLogger,
+        dartDefines: const <String>[],
       );
       commands.add(<String, dynamic>{'id': 0, 'method': 'daemon.version'});
       final Map<String, dynamic> response = await responses.stream.firstWhere(_notEvent);
@@ -56,6 +57,7 @@ void main() {
         commands.stream,
         responses.add,
         notifyingLogger: notifyingLogger,
+        dartDefines: const <String>[],
       );
       printError('daemon.logMessage test');
       final Map<String, dynamic> response = await responses.stream.firstWhere((Map<String, dynamic> map) {
@@ -83,6 +85,7 @@ void main() {
           responses.add,
           notifyingLogger: notifyingLogger,
           logToStdout: true,
+          dartDefines: const <String>[],
         );
         printStatus('daemon.logMessage test');
         // Service the event loop.
@@ -103,6 +106,7 @@ void main() {
         commands.stream,
         responses.add,
         notifyingLogger: notifyingLogger,
+        dartDefines: const <String>[],
       );
       commands.add(<String, dynamic>{'id': 0, 'method': 'daemon.shutdown'});
       return daemon.onExit.then<void>((int code) async {
@@ -112,16 +116,13 @@ void main() {
     });
 
     testUsingContext('app.restart without an appId should report an error', () async {
-      final DaemonCommand command = DaemonCommand();
-      applyMocksToCommand(command);
-
       final StreamController<Map<String, dynamic>> commands = StreamController<Map<String, dynamic>>();
       final StreamController<Map<String, dynamic>> responses = StreamController<Map<String, dynamic>>();
       daemon = Daemon(
         commands.stream,
         responses.add,
-        daemonCommand: command,
         notifyingLogger: notifyingLogger,
+        dartDefines: const <String>[],
       );
 
       commands.add(<String, dynamic>{'id': 0, 'method': 'app.restart'});
@@ -133,16 +134,13 @@ void main() {
     });
 
     testUsingContext('ext.flutter.debugPaint via service extension without an appId should report an error', () async {
-      final DaemonCommand command = DaemonCommand();
-      applyMocksToCommand(command);
-
       final StreamController<Map<String, dynamic>> commands = StreamController<Map<String, dynamic>>();
       final StreamController<Map<String, dynamic>> responses = StreamController<Map<String, dynamic>>();
       daemon = Daemon(
         commands.stream,
         responses.add,
-        daemonCommand: command,
         notifyingLogger: notifyingLogger,
+        dartDefines: const <String>[],
       );
 
       commands.add(<String, dynamic>{
@@ -160,16 +158,13 @@ void main() {
     });
 
     testUsingContext('app.stop without appId should report an error', () async {
-      final DaemonCommand command = DaemonCommand();
-      applyMocksToCommand(command);
-
       final StreamController<Map<String, dynamic>> commands = StreamController<Map<String, dynamic>>();
       final StreamController<Map<String, dynamic>> responses = StreamController<Map<String, dynamic>>();
       daemon = Daemon(
         commands.stream,
         responses.add,
-        daemonCommand: command,
         notifyingLogger: notifyingLogger,
+        dartDefines: const <String>[],
       );
 
       commands.add(<String, dynamic>{'id': 0, 'method': 'app.stop'});
@@ -187,6 +182,7 @@ void main() {
         commands.stream,
         responses.add,
         notifyingLogger: notifyingLogger,
+        dartDefines: const <String>[],
       );
       commands.add(<String, dynamic>{'id': 0, 'method': 'device.getDevices'});
       final Map<String, dynamic> response = await responses.stream.firstWhere(_notEvent);
@@ -203,6 +199,7 @@ void main() {
         commands.stream,
         responses.add,
         notifyingLogger: notifyingLogger,
+        dartDefines: const <String>[],
       );
       final MockPollingDeviceDiscovery discoverer = MockPollingDeviceDiscovery();
       daemon.deviceDomain.addDeviceDiscoverer(discoverer);
@@ -221,9 +218,10 @@ void main() {
       final StreamController<Map<String, dynamic>> commands = StreamController<Map<String, dynamic>>();
       final StreamController<Map<String, dynamic>> responses = StreamController<Map<String, dynamic>>();
       daemon = Daemon(
-          commands.stream,
-          responses.add,
-          notifyingLogger: notifyingLogger,
+        commands.stream,
+        responses.add,
+        notifyingLogger: notifyingLogger,
+        dartDefines: const <String>[],
       );
 
       final MockPollingDeviceDiscovery discoverer = MockPollingDeviceDiscovery();
@@ -247,16 +245,13 @@ void main() {
     });
 
     testUsingContext('emulator.launch without an emulatorId should report an error', () async {
-      final DaemonCommand command = DaemonCommand();
-      applyMocksToCommand(command);
-
       final StreamController<Map<String, dynamic>> commands = StreamController<Map<String, dynamic>>();
       final StreamController<Map<String, dynamic>> responses = StreamController<Map<String, dynamic>>();
       daemon = Daemon(
         commands.stream,
         responses.add,
-        daemonCommand: command,
         notifyingLogger: notifyingLogger,
+        dartDefines: const <String>[],
       );
 
       commands.add(<String, dynamic>{'id': 0, 'method': 'emulator.launch'});
@@ -274,6 +269,7 @@ void main() {
         commands.stream,
         responses.add,
         notifyingLogger: notifyingLogger,
+        dartDefines: const <String>[],
       );
       commands.add(<String, dynamic>{'id': 0, 'method': 'emulator.getEmulators'});
       final Map<String, dynamic> response = await responses.stream.firstWhere(_notEvent);


### PR DESCRIPTION
## Description

Do not pass missing `dartDefines` as `null`, but as an empty list instead.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/45048

## Tests

Added `--machine` test in `run_test.dart` that uses the daemon.
