### PR TITLE
Revert "Add the rally_assets package to Gallery's BUILD.gn (#45180)"

### DIFF
--- a/examples/flutter_gallery/BUILD.gn
+++ b/examples/flutter_gallery/BUILD.gn
@@ -31,7 +31,6 @@ flutter_app("flutter_gallery") {
     "//third_party/dart-pkg/pub/flutter_gallery_assets",
     "//third_party/dart-pkg/pub/meta",
     "//third_party/dart-pkg/pub/path",
-    "//third_party/dart-pkg/pub/rally_assets",
     "//third_party/dart-pkg/pub/scoped_model",
     "//third_party/dart-pkg/pub/shrine_images",
     "//third_party/dart-pkg/pub/source_span",


### PR DESCRIPTION
Reverting since https://github.com/flutter/flutter/commit/2c7af1e24e45a79f4eb73d67d98fcecea8bf6146
reverted the original commit that required this in the first place.

This reverts commit 68d1fe58da759c22a8c3ce6f2735c914f7844316.
