### PR TITLE
Allow a no-op default_package key for a plugin platform

### DIFF
--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -81,7 +81,7 @@ class Plugin {
 
     final Map<String, PluginPlatform> platforms = <String, PluginPlatform>{};
 
-    if (platformsYaml[AndroidPlugin.kConfigKey] != null) {
+      if (_providesImplementationForPlatform(platformsYaml, AndroidPlugin.kConfigKey)) {
       platforms[AndroidPlugin.kConfigKey] = AndroidPlugin.fromYaml(
         name,
         platformsYaml[AndroidPlugin.kConfigKey] as YamlMap,
@@ -89,27 +89,27 @@ class Plugin {
       );
     }
 
-    if (platformsYaml[IOSPlugin.kConfigKey] != null) {
+    if (_providesImplementationForPlatform(platformsYaml, IOSPlugin.kConfigKey)) {
       platforms[IOSPlugin.kConfigKey] =
           IOSPlugin.fromYaml(name, platformsYaml[IOSPlugin.kConfigKey] as YamlMap);
     }
 
-    if (platformsYaml[LinuxPlugin.kConfigKey] != null) {
+    if (_providesImplementationForPlatform(platformsYaml, LinuxPlugin.kConfigKey)) {
       platforms[LinuxPlugin.kConfigKey] =
           LinuxPlugin.fromYaml(name, platformsYaml[LinuxPlugin.kConfigKey] as YamlMap);
     }
 
-    if (platformsYaml[MacOSPlugin.kConfigKey] != null) {
+    if (_providesImplementationForPlatform(platformsYaml, MacOSPlugin.kConfigKey)) {
       platforms[MacOSPlugin.kConfigKey] =
           MacOSPlugin.fromYaml(name, platformsYaml[MacOSPlugin.kConfigKey] as YamlMap);
     }
 
-    if (platformsYaml[WebPlugin.kConfigKey] != null) {
+    if (_providesImplementationForPlatform(platformsYaml, WebPlugin.kConfigKey)) {
       platforms[WebPlugin.kConfigKey] =
           WebPlugin.fromYaml(name, platformsYaml[WebPlugin.kConfigKey] as YamlMap);
     }
 
-    if (platformsYaml[WindowsPlugin.kConfigKey] != null) {
+    if (_providesImplementationForPlatform(platformsYaml, WindowsPlugin.kConfigKey)) {
       platforms[WindowsPlugin.kConfigKey] =
           WindowsPlugin.fromYaml(name, platformsYaml[WindowsPlugin.kConfigKey] as YamlMap);
     }
@@ -178,7 +178,13 @@ class Plugin {
   static List<String> _validateMultiPlatformYaml(YamlMap yaml) {
     bool isInvalid(String key, bool Function(YamlMap) validate) {
       final dynamic value = yaml[key];
-      return value is YamlMap && !validate(value);
+      if (!(value is YamlMap)) {
+        return false;
+      }
+      if (value.containsKey('default_package')) {
+        return false;
+      }
+      return !validate(value);
     }
     final List<String> errors = <String>[];
     if (isInvalid(AndroidPlugin.kConfigKey, AndroidPlugin.validate)) {
@@ -211,6 +217,16 @@ class Plugin {
       errors.add('The "pluginClass" must either be null or a string..');
     }
     return errors;
+  }
+
+  static bool _providesImplementationForPlatform(YamlMap platformsYaml, String platformKey) {
+    if (!platformsYaml.containsKey(platformKey)) {
+      return false;
+    }
+    if (platformsYaml[platformKey].containsKey('default_package')) {
+      return false;
+    }
+    return true;
   }
 
   final String name;

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -81,7 +81,7 @@ class Plugin {
 
     final Map<String, PluginPlatform> platforms = <String, PluginPlatform>{};
 
-      if (_providesImplementationForPlatform(platformsYaml, AndroidPlugin.kConfigKey)) {
+    if (_providesImplementationForPlatform(platformsYaml, AndroidPlugin.kConfigKey)) {
       platforms[AndroidPlugin.kConfigKey] = AndroidPlugin.fromYaml(
         name,
         platformsYaml[AndroidPlugin.kConfigKey] as YamlMap,

--- a/packages/flutter_tools/test/general.shard/plugin_parsing_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugin_parsing_test.dart
@@ -125,5 +125,28 @@ void main() {
       expect(webPlugin.fileName, 'web_plugin.dart');
       expect(windowsPlugin.pluginClass, 'WinSamplePlugin');
     });
+
+    test('A default_package field is allowed', () {
+      const String pluginYamlRaw =
+          'platforms:\n'
+          ' android:\n'
+          '  default_package: sample_package_android\n'
+          ' ios:\n'
+          '  default_package: sample_package_ios\n'
+          ' linux:\n'
+          '  default_package: sample_package_linux\n'
+          ' macos:\n'
+          '  default_package: sample_package_macos\n'
+          ' web:\n'
+          '  default_package: sample_package_web\n'
+          ' windows:\n'
+          '  default_package: sample_package_windows\n';
+
+      final dynamic pluginYaml = loadYaml(pluginYamlRaw);
+      final Plugin plugin =
+      Plugin.fromYaml(_kTestPluginName, _kTestPluginPath, pluginYaml);
+
+      expect(plugin.platforms, <String, PluginPlatform> {});
+    });
   });
 }


### PR DESCRIPTION
## Description

Don't fail when running into plugins that specify a default platform implementation, for example with the following plugin section in the pubspec:

```yaml
plugin:
  platforms:
    android:
      default_package: sample_plugin_android
```

The tool currently fails when validating  the `android:` map.

With this change the tool just ignores the `android:` map (and treats the plugin as a non-Android plugin). This will be future compatible with the federated plugins support when it lands.

## Related Issues

https://github.com/flutter/flutter/issues/44288

## Tests

I added the following tests:

Unit test that verifies the platform is ignored when there's a `default_package`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
