### PR TITLE
Don't crash if the tool cannot delete asset directory

### DIFF
--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -10,6 +10,7 @@ import 'package:pool/pool.dart';
 import 'asset.dart';
 import 'base/common.dart';
 import 'base/file_system.dart';
+import 'base/logger.dart';
 import 'build_info.dart';
 import 'build_system/build_system.dart';
 import 'build_system/depfile.dart';
@@ -173,9 +174,18 @@ Future<AssetBundle> buildAssets({
 Future<void> writeBundle(
   Directory bundleDir,
   Map<String, DevFSContent> assetEntries,
+  { Logger loggerOverride }
 ) async {
+  loggerOverride ??= logger;
   if (bundleDir.existsSync()) {
-    bundleDir.deleteSync(recursive: true);
+    try {
+      bundleDir.deleteSync(recursive: true);
+    } on FileSystemException catch (err) {
+      loggerOverride.printError(
+        'Failed to clean up asset directory ${bundleDir.path}: $err\n'
+        'To clean build artifacts, use the command "flutter clean".'
+      );
+    }
   }
   bundleDir.createSync(recursive: true);
 

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -9,8 +9,12 @@ import 'package:file/memory.dart';
 
 import 'package:flutter_tools/src/asset.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/bundle.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/devfs.dart';
+import 'package:mockito/mockito.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
@@ -179,4 +183,18 @@ flutter:
     });
   });
 
+  test('Failed directory delete shows message', () async {
+    final MockDirectory mockDirectory = MockDirectory();
+    final BufferLogger bufferLogger = BufferLogger();
+    when(mockDirectory.existsSync()).thenReturn(true);
+    when(mockDirectory.deleteSync(recursive: true)).thenThrow(const FileSystemException('ABCD'));
+
+    await writeBundle(mockDirectory, <String, DevFSContent>{}, loggerOverride: bufferLogger);
+
+    verify(mockDirectory.createSync(recursive: true)).called(1);
+    expect(bufferLogger.errorText, contains('ABCD'));
+  });
 }
+
+class MockDirectory extends Mock implements Directory {}
+


### PR DESCRIPTION
## Description

For an unknown reason, deleteSync is throwing an odd error for some clients when it fails. Since this delete is not required, we can instead catch the error and log a warning.

Fixes https://github.com/flutter/flutter/issues/45399