### PR TITLE
Drops detached message until we can handle it properly

### DIFF
--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -338,6 +338,11 @@ mixin SchedulerBinding on BindingBase, ServicesBinding {
   }
 
   Future<String> _handleLifecycleMessage(String message) async {
+    // TODO(chunhtai): remove the workaround once the issue is fixed
+    // https://github.com/flutter/flutter/issues/39832
+    if (message == 'AppLifecycleState.detached')
+      return null;
+
     handleAppLifecycleStateChanged(_parseAppLifecycleMessage(message));
     return null;
   }

--- a/packages/flutter/test/widgets/binding_test.dart
+++ b/packages/flutter/test/widgets/binding_test.dart
@@ -67,6 +67,14 @@ void main() {
     message = const StringCodec().encodeMessage('AppLifecycleState.inactive');
     await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
     expect(observer.lifecycleState, AppLifecycleState.inactive);
+
+
+    message = const StringCodec().encodeMessage('AppLifecycleState.detached');
+    await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
+    // TODO(chunhtai): this should be detached once the issue is fixed
+    // https://github.com/flutter/flutter/issues/39832
+    // The binding drops detached message for now.
+    expect(observer.lifecycleState, AppLifecycleState.inactive);
   });
 
   testWidgets('didPushRoute callback', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

Engine add to app starts sending detached message to framework. However, framework side change is pending on desktop embedding.
This pr drops the detached message as a workaround to unblock stable release.

## Related Issues

https://github.com/flutter/flutter/issues/45575

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behaviour with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
