### PR TITLE
Always compile with -isysroot flag on iOS to point to SDK root

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -242,8 +242,16 @@ class AOTSnapshotter {
 
     const String embedBitcodeArg = '-fembed-bitcode';
     final String assemblyO = fs.path.join(outputPath, 'snapshot_assembly.o');
+    List<String> isysrootArgs;
+    if (isIOS) {
+      final String iPhoneSDKLocation = await xcode.iPhoneSdkLocation();
+      if (iPhoneSDKLocation != null) {
+        isysrootArgs = <String>['-isysroot', iPhoneSDKLocation];
+      }
+    }
     final RunResult compileResult = await xcode.cc(<String>[
       '-arch', targetArch,
+      if (isysrootArgs != null) ...isysrootArgs,
       if (bitcode) embedBitcodeArg,
       '-c',
       assemblyPath,
@@ -265,7 +273,7 @@ class AOTSnapshotter {
       '-Xlinker', '-rpath', '-Xlinker', '@loader_path/Frameworks',
       '-install_name', '@rpath/App.framework/App',
       if (bitcode) embedBitcodeArg,
-      if (bitcode && isIOS) ...<String>[embedBitcodeArg, '-isysroot', await xcode.iPhoneSdkLocation()],
+      if (isysrootArgs != null) ...isysrootArgs,
       '-o', appLib,
       assemblyO,
     ];

--- a/packages/flutter_tools/test/general.shard/base/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/build_test.dart
@@ -214,6 +214,7 @@ void main() {
 
   group('Snapshotter - AOT', () {
     const String kSnapshotDart = 'snapshot.dart';
+    const String kSDKPath = '/path/to/sdk';
     String skyEnginePath;
 
     _FakeGenSnapshot genSnapshot;
@@ -243,6 +244,8 @@ void main() {
       mockAndroidSdk = MockAndroidSdk();
       mockArtifacts = MockArtifacts();
       mockXcode = MockXcode();
+      when(mockXcode.iPhoneSdkLocation()).thenAnswer((_) => Future<String>.value(kSDKPath));
+
       bufferLogger = BufferLogger();
       for (BuildMode mode in BuildMode.values) {
         when(mockArtifacts.getArtifactPath(Artifact.snapshotDart,
@@ -334,8 +337,19 @@ void main() {
         'main.dill',
       ]);
 
-      verify(xcode.cc(argThat(contains('-fembed-bitcode')))).called(1);
-      verify(xcode.clang(argThat(contains('-fembed-bitcode')))).called(1);
+      final VerificationResult toVerifyCC = verify(xcode.cc(captureAny));
+      expect(toVerifyCC.callCount, 1);
+      final List<String> ccArgs = toVerifyCC.captured.first;
+      expect(ccArgs, contains('-fembed-bitcode'));
+      expect(ccArgs, contains('-isysroot'));
+      expect(ccArgs, contains(kSDKPath));
+
+      final VerificationResult toVerifyClang = verify(xcode.clang(captureAny));
+      expect(toVerifyClang.callCount, 1);
+      final List<String> clangArgs = toVerifyClang.captured.first;
+      expect(clangArgs, contains('-fembed-bitcode'));
+      expect(clangArgs, contains('-isysroot'));
+      expect(clangArgs, contains(kSDKPath));
 
       final File assemblyFile = fs.file(assembly);
       expect(assemblyFile.existsSync(), true);
@@ -380,8 +394,19 @@ void main() {
         'main.dill',
       ]);
 
-      verify(xcode.cc(argThat(contains('-fembed-bitcode')))).called(1);
-      verify(xcode.clang(argThat(contains('-fembed-bitcode')))).called(1);
+      final VerificationResult toVerifyCC = verify(xcode.cc(captureAny));
+      expect(toVerifyCC.callCount, 1);
+      final List<String> ccArgs = toVerifyCC.captured.first;
+      expect(ccArgs, contains('-fembed-bitcode'));
+      expect(ccArgs, contains('-isysroot'));
+      expect(ccArgs, contains(kSDKPath));
+
+      final VerificationResult toVerifyClang = verify(xcode.clang(captureAny));
+      expect(toVerifyClang.callCount, 1);
+      final List<String> clangArgs = toVerifyClang.captured.first;
+      expect(clangArgs, contains('-fembed-bitcode'));
+      expect(clangArgs, contains('-isysroot'));
+      expect(clangArgs, contains(kSDKPath));
 
       final File assemblyFile = fs.file(assembly);
       final File assemblyBitcodeFile = fs.file('$assembly.stripped.S');
@@ -430,6 +455,9 @@ void main() {
       ]);
       verifyNever(xcode.cc(argThat(contains('-fembed-bitcode'))));
       verifyNever(xcode.clang(argThat(contains('-fembed-bitcode'))));
+
+      verify(xcode.cc(argThat(contains('-isysroot')))).called(1);
+      verify(xcode.clang(argThat(contains('-isysroot')))).called(1);
 
       final File assemblyFile = fs.file(assembly);
       expect(assemblyFile.existsSync(), true);


### PR DESCRIPTION
## Description

Prevent warning when `flutter build aot` is called directly from the command line:
"clang: warning: using sysroot for 'MacOSX' but targeting 'iPhone' [-Wincompatible-sysroot]"

## Related Issues

Reported at https://github.com/flutter/flutter/issues/39916#issuecomment-554838473.

## Tests
Updated tests in build_test.dart.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.