### PR TITLE
Handle bare modifier flags on macOS

### DIFF
--- a/packages/flutter/lib/src/services/raw_keyboard_macos.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_macos.dart
@@ -143,17 +143,23 @@ class RawKeyEventDataMacOs extends RawKeyEventData {
   @override
   bool isModifierPressed(ModifierKey key, {KeyboardSide side = KeyboardSide.any}) {
     final int independentModifier = modifiers & deviceIndependentMask;
+    bool result;
     switch (key) {
       case ModifierKey.controlModifier:
-        return _isLeftRightModifierPressed(side, independentModifier & modifierControl, modifierLeftControl, modifierRightControl);
+        result = _isLeftRightModifierPressed(side, independentModifier & modifierControl, modifierLeftControl, modifierRightControl);
+        break;
       case ModifierKey.shiftModifier:
-        return _isLeftRightModifierPressed(side, independentModifier & modifierShift, modifierLeftShift, modifierRightShift);
+        result = _isLeftRightModifierPressed(side, independentModifier & modifierShift, modifierLeftShift, modifierRightShift);
+        break;
       case ModifierKey.altModifier:
-        return _isLeftRightModifierPressed(side, independentModifier & modifierOption, modifierLeftOption, modifierRightOption);
+        result = _isLeftRightModifierPressed(side, independentModifier & modifierOption, modifierLeftOption, modifierRightOption);
+        break;
       case ModifierKey.metaModifier:
-        return _isLeftRightModifierPressed(side, independentModifier & modifierCommand, modifierLeftCommand, modifierRightCommand);
+        result = _isLeftRightModifierPressed(side, independentModifier & modifierCommand, modifierLeftCommand, modifierRightCommand);
+        break;
       case ModifierKey.capsLockModifier:
-        return independentModifier & modifierCapsLock != 0;
+        result = independentModifier & modifierCapsLock != 0;
+        break;
     // On macOS, the function modifier bit is set for any function key, like F1,
     // F2, etc., but the meaning of ModifierKey.modifierFunction in Flutter is
     // that of the Fn modifier key, so there's no good way to emulate that on
@@ -163,16 +169,19 @@ class RawKeyEventDataMacOs extends RawKeyEventData {
       case ModifierKey.symbolModifier:
       case ModifierKey.scrollLockModifier:
         // These modifier masks are not used in macOS keyboards.
-        return false;
+        result = false;
+        break;
     }
-    return false;
+    assert(!result || getModifierSide(key) != null, "$runtimeType thinks that a modifier is pressed, but can't figure out what side it's on.");
+    return result;
   }
 
   @override
   KeyboardSide getModifierSide(ModifierKey key) {
+    final int independentModifier = modifiers & deviceIndependentMask;
     KeyboardSide findSide(int leftMask, int rightMask) {
       final int combinedMask = leftMask | rightMask;
-      final int combined = modifiers & combinedMask;
+      final int combined = independentModifier & combinedMask;
       if (combined == leftMask) {
         return KeyboardSide.left;
       } else if (combined == rightMask) {

--- a/packages/flutter/test/services/raw_keyboard_test.dart
+++ b/packages/flutter/test/services/raw_keyboard_test.dart
@@ -563,6 +563,10 @@ void main() {
       RawKeyEventDataMacOs.modifierControl | RawKeyEventDataMacOs.modifierRightControl: _ModifierCheck(ModifierKey.controlModifier, KeyboardSide.right),
       RawKeyEventDataMacOs.modifierCommand | RawKeyEventDataMacOs.modifierLeftCommand: _ModifierCheck(ModifierKey.metaModifier, KeyboardSide.left),
       RawKeyEventDataMacOs.modifierCommand | RawKeyEventDataMacOs.modifierRightCommand: _ModifierCheck(ModifierKey.metaModifier, KeyboardSide.right),
+      RawKeyEventDataMacOs.modifierOption: _ModifierCheck(ModifierKey.altModifier, KeyboardSide.all),
+      RawKeyEventDataMacOs.modifierShift: _ModifierCheck(ModifierKey.shiftModifier, KeyboardSide.all),
+      RawKeyEventDataMacOs.modifierControl: _ModifierCheck(ModifierKey.controlModifier, KeyboardSide.all),
+      RawKeyEventDataMacOs.modifierCommand: _ModifierCheck(ModifierKey.metaModifier, KeyboardSide.all),
       RawKeyEventDataMacOs.modifierCapsLock: _ModifierCheck(ModifierKey.capsLockModifier, KeyboardSide.all),
     };
 


### PR DESCRIPTION
## Description

This fixes an unreported bug in the macOS key handling where for some remote access situations, the modifier mask is set to the "any modifier" mask without any side specified (e.g. modifierShift bit is specified and not modifierLeftShift bit).

## Tests

- Added tests for bare modifier flags.

## Breaking Change

- [X] No, this is *not* a breaking change.