### PR TITLE
Disable tests that fail on non-master branches

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -229,6 +229,7 @@ task:
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: hostonly_devicelab_tests-0-linux
+      only_if: "$CIRRUS_PR != '' || $CIRRUS_BRANCH == 'master'" # https://github.com/flutter/flutter/issues/45453
       environment:
         # Some of the host-only devicelab tests are pretty involved and need a lot of RAM.
         CPU: 2
@@ -237,6 +238,7 @@ task:
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: hostonly_devicelab_tests-1-linux
+      only_if: "$CIRRUS_PR != '' || $CIRRUS_BRANCH == 'master'" # https://github.com/flutter/flutter/issues/45453
       environment:
         # Some of the host-only devicelab tests are pretty involved and need a lot of RAM.
         CPU: 2
@@ -245,6 +247,7 @@ task:
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: hostonly_devicelab_tests-2-linux
+      only_if: "$CIRRUS_PR != '' || $CIRRUS_BRANCH == 'master'" # https://github.com/flutter/flutter/issues/45453
       environment:
         # Some of the host-only devicelab tests are pretty involved and need a lot of RAM.
         CPU: 2
@@ -253,6 +256,7 @@ task:
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: hostonly_devicelab_tests-3_last-linux
+      only_if: "$CIRRUS_PR != '' || $CIRRUS_BRANCH == 'master'" # https://github.com/flutter/flutter/issues/45453
       environment:
         # Some of the host-only devicelab tests are pretty involved and need a lot of RAM.
         CPU: 2
@@ -399,22 +403,22 @@ task:
         - dart --enable-asserts dev\bots\test.dart
 
     - name: hostonly_devicelab_tests-0-windows
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || $CIRRUS_PR == ''" # https://github.com/flutter/flutter/issues/41941
+      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || ($CIRRUS_PR == '' && $CIRRUS_BRANCH == 'master')" # https://github.com/flutter/flutter/issues/41941 https://github.com/flutter/flutter/issues/45453
       script:
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: hostonly_devicelab_tests-1-windows
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || $CIRRUS_PR == ''" # https://github.com/flutter/flutter/issues/41941
+      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || ($CIRRUS_PR == '' && $CIRRUS_BRANCH == 'master')" # https://github.com/flutter/flutter/issues/41941 https://github.com/flutter/flutter/issues/45453
       script:
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: hostonly_devicelab_tests-2-windows
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || $CIRRUS_PR == ''" # https://github.com/flutter/flutter/issues/41941
+      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || ($CIRRUS_PR == '' && $CIRRUS_BRANCH == 'master')" # https://github.com/flutter/flutter/issues/41941 https://github.com/flutter/flutter/issues/45453
       script:
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: hostonly_devicelab_tests-3_last-windows
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || $CIRRUS_PR == ''" # https://github.com/flutter/flutter/issues/41941
+      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || ($CIRRUS_PR == '' && $CIRRUS_BRANCH == 'master')" # https://github.com/flutter/flutter/issues/41941 https://github.com/flutter/flutter/issues/45453
       script:
         - dart --enable-asserts ./dev/bots/test.dart
 
@@ -512,25 +516,25 @@ task:
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: hostonly_devicelab_tests-0-macos
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || $CIRRUS_PR == ''" # https://github.com/flutter/flutter/issues/41940
+      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || ($CIRRUS_PR == '' && $CIRRUS_BRANCH == 'master')" # https://github.com/flutter/flutter/issues/41941 https://github.com/flutter/flutter/issues/45453
       script:
         - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: hostonly_devicelab_tests-1-macos
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || $CIRRUS_PR == ''" # https://github.com/flutter/flutter/issues/41940
+      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || ($CIRRUS_PR == '' && $CIRRUS_BRANCH == 'master')" # https://github.com/flutter/flutter/issues/41941 https://github.com/flutter/flutter/issues/45453
       script:
         - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: hostonly_devicelab_tests-2-macos
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || $CIRRUS_PR == ''" # https://github.com/flutter/flutter/issues/41940
+      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || ($CIRRUS_PR == '' && $CIRRUS_BRANCH == 'master')" # https://github.com/flutter/flutter/issues/41941 https://github.com/flutter/flutter/issues/45453
       script:
         - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: hostonly_devicelab_tests-3_last-macos
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || $CIRRUS_PR == ''" # https://github.com/flutter/flutter/issues/41940
+      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || ($CIRRUS_PR == '' && $CIRRUS_BRANCH == 'master')" # https://github.com/flutter/flutter/issues/41941 https://github.com/flutter/flutter/issues/45453
       script:
         - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
         - dart --enable-asserts ./dev/bots/test.dart

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -291,12 +291,20 @@ Future<void> _runBuildTests() async {
       await _flutterBuildIpa(examplePath);
     }
   }
-  // Web compilation tests.
-  await _flutterBuildDart2js(path.join('dev', 'integration_tests', 'web'), path.join('lib', 'main.dart'));
-  // Should not fail to compile with dart:io.
-  await _flutterBuildDart2js(path.join('dev', 'integration_tests', 'web_compile_tests'),
-    path.join('lib', 'dart_io_import.dart'),
-  );
+
+  final String branch = Platform.environment['CIRRUS_BRANCH'];
+  if (branch != 'beta' && branch != 'stable') {
+    // Web compilation tests.
+    await _flutterBuildDart2js(
+      path.join('dev', 'integration_tests', 'web'),
+      path.join('lib', 'main.dart'),
+    );
+    // Should not fail to compile with dart:io.
+    await _flutterBuildDart2js(
+      path.join('dev', 'integration_tests', 'web_compile_tests'),
+      path.join('lib', 'dart_io_import.dart'),
+    );
+  }
 }
 
 Future<void> _flutterBuildAot(String relativePathToApplication) async {


### PR DESCRIPTION
## Description

Failing tests in non-master branches make us blind to real failures. This disables the ones that are currently failing (some because we've explicitly turned functionality off in non-master channels - others due to issues).

## Related Issues

https://github.com/flutter/flutter/issues/45453

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.
