### PR TITLE
implicit-casts:false in flutter/lib/src/cupertino

### DIFF
--- a/packages/flutter/lib/src/cupertino/action_sheet.dart
+++ b/packages/flutter/lib/src/cupertino/action_sheet.dart
@@ -416,10 +416,10 @@ class _CupertinoAlertRenderElement extends RenderObjectElement {
   Element _actionsElement;
 
   @override
-  _CupertinoAlertRenderWidget get widget => super.widget;
+  _CupertinoAlertRenderWidget get widget => super.widget as _CupertinoAlertRenderWidget;
 
   @override
-  _RenderCupertinoAlert get renderObject => super.renderObject;
+  _RenderCupertinoAlert get renderObject => super.renderObject as _RenderCupertinoAlert;
 
   @override
   void visitChildren(ElementVisitor visitor) {
@@ -483,10 +483,10 @@ class _CupertinoAlertRenderElement extends RenderObjectElement {
     assert(slot != null);
     switch (slot) {
       case _AlertSections.contentSection:
-        renderObject.contentSection = child;
+        renderObject.contentSection = child as RenderBox;
         break;
       case _AlertSections.actionsSection:
-        renderObject.actionsSection = child;
+        renderObject.actionsSection = child as RenderBox;
         break;
     }
   }
@@ -694,13 +694,13 @@ class _RenderCupertinoAlert extends RenderBox {
     // Set the position of the actions box to sit at the bottom of the alert.
     // The content box defaults to the top left, which is where we want it.
     assert(actionsSection.parentData is MultiChildLayoutParentData);
-    final MultiChildLayoutParentData actionParentData = actionsSection.parentData;
+    final MultiChildLayoutParentData actionParentData = actionsSection.parentData as MultiChildLayoutParentData;
     actionParentData.offset = Offset(0.0, contentSize.height + dividerThickness);
   }
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    final MultiChildLayoutParentData contentParentData = contentSection.parentData;
+    final MultiChildLayoutParentData contentParentData = contentSection.parentData as MultiChildLayoutParentData;
     contentSection.paint(context, offset + contentParentData.offset);
 
     final bool hasDivider = contentSection.size.height > 0.0 && actionsSection.size.height > 0.0;
@@ -708,7 +708,7 @@ class _RenderCupertinoAlert extends RenderBox {
       _paintDividerBetweenContentAndActions(context.canvas, offset);
     }
 
-    final MultiChildLayoutParentData actionsParentData = actionsSection.parentData;
+    final MultiChildLayoutParentData actionsParentData = actionsSection.parentData as MultiChildLayoutParentData;
     actionsSection.paint(context, offset + actionsParentData.offset);
   }
 
@@ -726,8 +726,8 @@ class _RenderCupertinoAlert extends RenderBox {
 
   @override
   bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
-    final MultiChildLayoutParentData contentSectionParentData = contentSection.parentData;
-    final MultiChildLayoutParentData actionsSectionParentData = actionsSection.parentData;
+    final MultiChildLayoutParentData contentSectionParentData = contentSection.parentData as MultiChildLayoutParentData;
+    final MultiChildLayoutParentData actionsSectionParentData = actionsSection.parentData as MultiChildLayoutParentData;
     return result.addWithPaintOffset(
              offset: contentSectionParentData.offset,
              position: position,
@@ -965,7 +965,7 @@ class _ActionButtonParentDataWidget extends ParentDataWidget<_CupertinoAlertActi
   @override
   void applyParentData(RenderObject renderObject) {
     assert(renderObject.parentData is _ActionButtonParentData);
-    final _ActionButtonParentData parentData = renderObject.parentData;
+    final _ActionButtonParentData parentData = renderObject.parentData as _ActionButtonParentData;
     if (parentData.isPressed != isPressed) {
       parentData.isPressed = isPressed;
 
@@ -1217,7 +1217,7 @@ class _RenderCupertinoAlertActions extends RenderBox
       );
 
       assert(child.parentData is MultiChildLayoutParentData);
-      final MultiChildLayoutParentData parentData = child.parentData;
+      final MultiChildLayoutParentData parentData = child.parentData as MultiChildLayoutParentData;
       parentData.offset = Offset(0.0, verticalOffset);
 
       verticalOffset += child.size.height;
@@ -1259,14 +1259,13 @@ class _RenderCupertinoAlertActions extends RenderBox
     RenderBox prevChild;
     while (child != null) {
       assert(child.parentData is _ActionButtonParentData);
-      final _ActionButtonParentData currentButtonParentData = child.parentData;
+      final _ActionButtonParentData currentButtonParentData = child.parentData as _ActionButtonParentData;
       final bool isButtonPressed = currentButtonParentData.isPressed;
 
       bool isPrevButtonPressed = false;
       if (prevChild != null) {
         assert(prevChild.parentData is _ActionButtonParentData);
-        final _ActionButtonParentData previousButtonParentData = prevChild
-            .parentData;
+        final _ActionButtonParentData previousButtonParentData = prevChild.parentData as _ActionButtonParentData;
         isPrevButtonPressed = previousButtonParentData.isPressed;
       }
 
@@ -1316,7 +1315,7 @@ class _RenderCupertinoAlertActions extends RenderBox
   void _drawButtons(PaintingContext context, Offset offset) {
     RenderBox child = firstChild;
     while (child != null) {
-      final MultiChildLayoutParentData childParentData = child.parentData;
+      final MultiChildLayoutParentData childParentData = child.parentData as MultiChildLayoutParentData;
       context.paintChild(child, childParentData.offset + offset);
       child = childAfter(child);
     }

--- a/packages/flutter/lib/src/cupertino/bottom_tab_bar.dart
+++ b/packages/flutter/lib/src/cupertino/bottom_tab_bar.dart
@@ -271,7 +271,7 @@ class CupertinoTabBar extends StatelessWidget implements PreferredSizeWidget {
     Color backgroundColor,
     Color activeColor,
     Color inactiveColor,
-    Size iconSize,
+    double iconSize,
     Border border,
     int currentIndex,
     ValueChanged<int> onTap,

--- a/packages/flutter/lib/src/cupertino/colors.dart
+++ b/packages/flutter/lib/src/cupertino/colors.dart
@@ -978,7 +978,7 @@ class CupertinoDynamicColor extends Color with DiagnosticableMixin implements Di
 
     Element _debugContext;
     assert(() {
-      _debugContext = context;
+      _debugContext = context as Element;
       return true;
     }());
     return CupertinoDynamicColor._(

--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -39,7 +39,7 @@ typedef _ContextMenuPreviewBuilderChildless = Widget Function(
 // paintBounds in global coordinates.
 Rect _getRect(GlobalKey globalKey) {
   assert(globalKey.currentContext != null);
-  final RenderBox renderBoxContainer = globalKey.currentContext.findRenderObject();
+  final RenderBox renderBoxContainer = globalKey.currentContext.findRenderObject() as RenderBox;
   final Offset containerOffset = renderBoxContainer.localToGlobal(
     renderBoxContainer.paintBounds.topLeft,
   );
@@ -990,7 +990,7 @@ class _ContextMenuRouteStaticState extends State<_ContextMenuRouteStatic> with T
       _moveAnimation = Tween<Offset>(
         begin: Offset.zero,
         end: Offset(
-          endX.clamp(-_kPadding, _kPadding),
+          endX.clamp(-_kPadding, _kPadding) as double,
           endY,
         ),
       ).animate(

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -408,10 +408,10 @@ class _CupertinoDialogRenderElement extends RenderObjectElement {
   Element _actionsElement;
 
   @override
-  _CupertinoDialogRenderWidget get widget => super.widget;
+  _CupertinoDialogRenderWidget get widget => super.widget as _CupertinoDialogRenderWidget;
 
   @override
-  _RenderCupertinoDialog get renderObject => super.renderObject;
+  _RenderCupertinoDialog get renderObject => super.renderObject as _RenderCupertinoDialog;
 
   @override
   void visitChildren(ElementVisitor visitor) {
@@ -435,10 +435,10 @@ class _CupertinoDialogRenderElement extends RenderObjectElement {
     assert(slot != null);
     switch (slot) {
       case _AlertDialogSections.contentSection:
-        renderObject.contentSection = child;
+        renderObject.contentSection = child as RenderBox;
         break;
       case _AlertDialogSections.actionsSection:
-        renderObject.actionsSection = child;
+        renderObject.actionsSection = child as RenderBox;
         break;
     }
   }
@@ -707,7 +707,7 @@ class _RenderCupertinoDialog extends RenderBox {
     // Set the position of the actions box to sit at the bottom of the dialog.
     // The content box defaults to the top left, which is where we want it.
     assert(actionsSection.parentData is BoxParentData);
-    final BoxParentData actionParentData = actionsSection.parentData;
+    final BoxParentData actionParentData = actionsSection.parentData as BoxParentData;
     actionParentData.offset = Offset(0.0, contentSize.height + dividerThickness);
   }
 
@@ -769,13 +769,13 @@ class _RenderCupertinoDialog extends RenderBox {
     // Set the position of the actions box to sit at the bottom of the dialog.
     // The content box defaults to the top left, which is where we want it.
     assert(actionsSection.parentData is BoxParentData);
-    final BoxParentData actionParentData = actionsSection.parentData;
+    final BoxParentData actionParentData = actionsSection.parentData as BoxParentData;
     actionParentData.offset = Offset(0.0, contentSize.height + dividerThickness);
   }
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    final BoxParentData contentParentData = contentSection.parentData;
+    final BoxParentData contentParentData = contentSection.parentData as BoxParentData;
     contentSection.paint(context, offset + contentParentData.offset);
 
     final bool hasDivider = contentSection.size.height > 0.0 && actionsSection.size.height > 0.0;
@@ -783,7 +783,7 @@ class _RenderCupertinoDialog extends RenderBox {
       _paintDividerBetweenContentAndActions(context.canvas, offset);
     }
 
-    final BoxParentData actionsParentData = actionsSection.parentData;
+    final BoxParentData actionsParentData = actionsSection.parentData as BoxParentData;
     actionsSection.paint(context, offset + actionsParentData.offset);
   }
 
@@ -801,8 +801,8 @@ class _RenderCupertinoDialog extends RenderBox {
 
   @override
   bool hitTestChildren(BoxHitTestResult result, { Offset position }) {
-    final BoxParentData contentSectionParentData = contentSection.parentData;
-    final BoxParentData actionsSectionParentData = actionsSection.parentData;
+    final BoxParentData contentSectionParentData = contentSection.parentData as BoxParentData;
+    final BoxParentData actionsSectionParentData = actionsSection.parentData as BoxParentData;
     return result.addWithPaintOffset(
              offset: contentSectionParentData.offset,
              position: position,
@@ -1032,7 +1032,7 @@ class _ActionButtonParentDataWidget extends ParentDataWidget<_CupertinoDialogAct
   @override
   void applyParentData(RenderObject renderObject) {
     assert(renderObject.parentData is _ActionButtonParentData);
-    final _ActionButtonParentData parentData = renderObject.parentData;
+    final _ActionButtonParentData parentData = renderObject.parentData as _ActionButtonParentData;
     if (parentData.isPressed != isPressed) {
       parentData.isPressed = isPressed;
 
@@ -1384,7 +1384,7 @@ class _RenderCupertinoDialogActions extends RenderBox
     RenderBox currentChild = firstChild;
     while (currentChild != null) {
       assert(currentChild.parentData is _ActionButtonParentData);
-      final _ActionButtonParentData parentData = currentChild.parentData;
+      final _ActionButtonParentData parentData = currentChild.parentData as _ActionButtonParentData;
       if (parentData.isPressed) {
         yield currentChild;
       }
@@ -1396,7 +1396,7 @@ class _RenderCupertinoDialogActions extends RenderBox
     RenderBox currentChild = firstChild;
     while (currentChild != null) {
       assert(currentChild.parentData is _ActionButtonParentData);
-      final _ActionButtonParentData parentData = currentChild.parentData;
+      final _ActionButtonParentData parentData = currentChild.parentData as _ActionButtonParentData;
       if (parentData.isPressed) {
         return true;
       }
@@ -1569,7 +1569,7 @@ class _RenderCupertinoDialogActions extends RenderBox
 
         // The 2nd button needs to be offset to the right.
         assert(lastChild.parentData is MultiChildLayoutParentData);
-        final MultiChildLayoutParentData secondButtonParentData = lastChild.parentData;
+        final MultiChildLayoutParentData secondButtonParentData = lastChild.parentData as MultiChildLayoutParentData;
         secondButtonParentData.offset = Offset(firstChild.size.width + dividerThickness, 0.0);
 
         // Calculate our size based on the button sizes.
@@ -1600,7 +1600,7 @@ class _RenderCupertinoDialogActions extends RenderBox
         );
 
         assert(child.parentData is MultiChildLayoutParentData);
-        final MultiChildLayoutParentData parentData = child.parentData;
+        final MultiChildLayoutParentData parentData = child.parentData as MultiChildLayoutParentData;
         parentData.offset = Offset(0.0, verticalOffset);
 
         verticalOffset += child.size.height;
@@ -1650,7 +1650,7 @@ class _RenderCupertinoDialogActions extends RenderBox
       : Rect.zero;
 
     final List<Rect> pressedButtonRects = _pressedButtons.map<Rect>((RenderBox pressedButton) {
-      final MultiChildLayoutParentData buttonParentData = pressedButton.parentData;
+      final MultiChildLayoutParentData buttonParentData = pressedButton.parentData as MultiChildLayoutParentData;
 
       return Rect.fromLTWH(
         offset.dx + buttonParentData.offset.dx,
@@ -1713,14 +1713,13 @@ class _RenderCupertinoDialogActions extends RenderBox
     RenderBox prevChild;
     while (child != null) {
       assert(child.parentData is _ActionButtonParentData);
-      final _ActionButtonParentData currentButtonParentData = child.parentData;
+      final _ActionButtonParentData currentButtonParentData = child.parentData as _ActionButtonParentData;
       final bool isButtonPressed = currentButtonParentData.isPressed;
 
       bool isPrevButtonPressed = false;
       if (prevChild != null) {
         assert(prevChild.parentData is _ActionButtonParentData);
-        final _ActionButtonParentData previousButtonParentData = prevChild
-            .parentData;
+        final _ActionButtonParentData previousButtonParentData = prevChild.parentData as _ActionButtonParentData;
         isPrevButtonPressed = previousButtonParentData.isPressed;
       }
 
@@ -1770,7 +1769,7 @@ class _RenderCupertinoDialogActions extends RenderBox
   void _drawButtons(PaintingContext context, Offset offset) {
     RenderBox child = firstChild;
     while (child != null) {
-      final MultiChildLayoutParentData childParentData = child.parentData;
+      final MultiChildLayoutParentData childParentData = child.parentData as MultiChildLayoutParentData;
       context.paintChild(child, childParentData.offset + offset);
       child = childAfter(child);
     }

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -69,8 +69,8 @@ class _HeroTag {
     if (other.runtimeType != runtimeType) {
       return false;
     }
-    final _HeroTag otherTag = other;
-    return navigator == otherTag.navigator;
+    return other is _HeroTag
+        && other.navigator == navigator;
   }
 
   @override
@@ -1416,7 +1416,7 @@ class _BackLabel extends StatelessWidget {
     if (specifiedPreviousTitle != null) {
       return _buildPreviousTitleWidget(context, specifiedPreviousTitle, null);
     } else if (route is CupertinoPageRoute<dynamic> && !route.isFirst) {
-      final CupertinoPageRoute<dynamic> cupertinoRoute = route;
+      final CupertinoPageRoute<dynamic> cupertinoRoute = route as CupertinoPageRoute<dynamic>;
       // There is no timing issue because the previousTitle Listenable changes
       // happen during route modifications before the ValueListenableBuilder
       // is built.
@@ -1465,7 +1465,7 @@ class _TransitionableNavigationBar extends StatelessWidget {
   final Widget child;
 
   RenderBox get renderBox {
-    final RenderBox box = componentsKeys.navBarBoxKey.currentContext.findRenderObject();
+    final RenderBox box = componentsKeys.navBarBoxKey.currentContext.findRenderObject() as RenderBox;
     assert(
       box.attached,
       '_TransitionableNavigationBar.renderBox should be called when building '
@@ -1697,7 +1697,7 @@ class _NavigationBarComponentsTransition {
     GlobalKey key, {
     @required RenderBox from,
   }) {
-    final RenderBox componentBox = key.currentContext.findRenderObject();
+    final RenderBox componentBox = key.currentContext.findRenderObject() as RenderBox;
     assert(componentBox.attached);
 
     return RelativeRect.fromRect(
@@ -1724,8 +1724,8 @@ class _NavigationBarComponentsTransition {
   }) {
     final RelativeRect fromRect = positionInTransitionBox(fromKey, from: fromNavBarBox);
 
-    final RenderBox fromBox = fromKey.currentContext.findRenderObject();
-    final RenderBox toBox = toKey.currentContext.findRenderObject();
+    final RenderBox fromBox = fromKey.currentContext.findRenderObject() as RenderBox;
+    final RenderBox toBox = toKey.currentContext.findRenderObject() as RenderBox;
 
     // We move a box with the size of the 'from' render object such that its
     // upper left corner is at the upper left corner of the 'to' render object.
@@ -1764,7 +1764,7 @@ class _NavigationBarComponentsTransition {
   }
 
   Widget get bottomLeading {
-    final KeyedSubtree bottomLeading = bottomComponents.leadingKey.currentWidget;
+    final KeyedSubtree bottomLeading = bottomComponents.leadingKey.currentWidget as KeyedSubtree;
 
     if (bottomLeading == null) {
       return null;
@@ -1780,7 +1780,7 @@ class _NavigationBarComponentsTransition {
   }
 
   Widget get bottomBackChevron {
-    final KeyedSubtree bottomBackChevron = bottomComponents.backChevronKey.currentWidget;
+    final KeyedSubtree bottomBackChevron = bottomComponents.backChevronKey.currentWidget as KeyedSubtree;
 
     if (bottomBackChevron == null) {
       return null;
@@ -1799,7 +1799,7 @@ class _NavigationBarComponentsTransition {
   }
 
   Widget get bottomBackLabel {
-    final KeyedSubtree bottomBackLabel = bottomComponents.backLabelKey.currentWidget;
+    final KeyedSubtree bottomBackLabel = bottomComponents.backLabelKey.currentWidget as KeyedSubtree;
 
     if (bottomBackLabel == null) {
       return null;
@@ -1831,9 +1831,9 @@ class _NavigationBarComponentsTransition {
   }
 
   Widget get bottomMiddle {
-    final KeyedSubtree bottomMiddle = bottomComponents.middleKey.currentWidget;
-    final KeyedSubtree topBackLabel = topComponents.backLabelKey.currentWidget;
-    final KeyedSubtree topLeading = topComponents.leadingKey.currentWidget;
+    final KeyedSubtree bottomMiddle = bottomComponents.middleKey.currentWidget as KeyedSubtree;
+    final KeyedSubtree topBackLabel = topComponents.backLabelKey.currentWidget as KeyedSubtree;
+    final KeyedSubtree topLeading = topComponents.leadingKey.currentWidget as KeyedSubtree;
 
     // The middle component is non-null when the nav bar is a large title
     // nav bar but would be invisible when expanded, therefore don't show it here.
@@ -1890,9 +1890,9 @@ class _NavigationBarComponentsTransition {
   }
 
   Widget get bottomLargeTitle {
-    final KeyedSubtree bottomLargeTitle = bottomComponents.largeTitleKey.currentWidget;
-    final KeyedSubtree topBackLabel = topComponents.backLabelKey.currentWidget;
-    final KeyedSubtree topLeading = topComponents.leadingKey.currentWidget;
+    final KeyedSubtree bottomLargeTitle = bottomComponents.largeTitleKey.currentWidget as KeyedSubtree;
+    final KeyedSubtree topBackLabel = topComponents.backLabelKey.currentWidget as KeyedSubtree;
+    final KeyedSubtree topLeading = topComponents.leadingKey.currentWidget as KeyedSubtree;
 
     if (bottomLargeTitle == null || !bottomLargeExpanded) {
       return null;
@@ -1961,7 +1961,7 @@ class _NavigationBarComponentsTransition {
   }
 
   Widget get bottomTrailing {
-    final KeyedSubtree bottomTrailing = bottomComponents.trailingKey.currentWidget;
+    final KeyedSubtree bottomTrailing = bottomComponents.trailingKey.currentWidget as KeyedSubtree;
 
     if (bottomTrailing == null) {
       return null;
@@ -1977,7 +1977,7 @@ class _NavigationBarComponentsTransition {
   }
 
   Widget get topLeading {
-    final KeyedSubtree topLeading = topComponents.leadingKey.currentWidget;
+    final KeyedSubtree topLeading = topComponents.leadingKey.currentWidget as KeyedSubtree;
 
     if (topLeading == null) {
       return null;
@@ -1993,8 +1993,8 @@ class _NavigationBarComponentsTransition {
   }
 
   Widget get topBackChevron {
-    final KeyedSubtree topBackChevron = topComponents.backChevronKey.currentWidget;
-    final KeyedSubtree bottomBackChevron = bottomComponents.backChevronKey.currentWidget;
+    final KeyedSubtree topBackChevron = topComponents.backChevronKey.currentWidget as KeyedSubtree;
+    final KeyedSubtree bottomBackChevron = bottomComponents.backChevronKey.currentWidget as KeyedSubtree;
 
     if (topBackChevron == null) {
       return null;
@@ -2006,7 +2006,7 @@ class _NavigationBarComponentsTransition {
     // If it's the first page with a back chevron, shift in slightly from the
     // right.
     if (bottomBackChevron == null) {
-      final RenderBox topBackChevronBox = topComponents.backChevronKey.currentContext.findRenderObject();
+      final RenderBox topBackChevronBox = topComponents.backChevronKey.currentContext.findRenderObject() as RenderBox;
       from = to.shift(
         Offset(
           forwardDirection * topBackChevronBox.size.width * 2.0,
@@ -2033,9 +2033,9 @@ class _NavigationBarComponentsTransition {
   }
 
   Widget get topBackLabel {
-    final KeyedSubtree bottomMiddle = bottomComponents.middleKey.currentWidget;
-    final KeyedSubtree bottomLargeTitle = bottomComponents.largeTitleKey.currentWidget;
-    final KeyedSubtree topBackLabel = topComponents.backLabelKey.currentWidget;
+    final KeyedSubtree bottomMiddle = bottomComponents.middleKey.currentWidget as KeyedSubtree;
+    final KeyedSubtree bottomLargeTitle = bottomComponents.largeTitleKey.currentWidget as KeyedSubtree;
+    final KeyedSubtree topBackLabel = topComponents.backLabelKey.currentWidget as KeyedSubtree;
 
     if (topBackLabel == null) {
       return null;
@@ -2109,7 +2109,7 @@ class _NavigationBarComponentsTransition {
   }
 
   Widget get topMiddle {
-    final KeyedSubtree topMiddle = topComponents.middleKey.currentWidget;
+    final KeyedSubtree topMiddle = topComponents.middleKey.currentWidget as KeyedSubtree;
 
     if (topMiddle == null) {
       return null;
@@ -2147,7 +2147,7 @@ class _NavigationBarComponentsTransition {
   }
 
   Widget get topTrailing {
-    final KeyedSubtree topTrailing = topComponents.trailingKey.currentWidget;
+    final KeyedSubtree topTrailing = topComponents.trailingKey.currentWidget as KeyedSubtree;
 
     if (topTrailing == null) {
       return null;
@@ -2163,7 +2163,7 @@ class _NavigationBarComponentsTransition {
   }
 
   Widget get topLargeTitle {
-    final KeyedSubtree topLargeTitle = topComponents.largeTitleKey.currentWidget;
+    final KeyedSubtree topLargeTitle = topComponents.largeTitleKey.currentWidget as KeyedSubtree;
 
     if (topLargeTitle == null || !topLargeExpanded) {
       return null;
@@ -2251,14 +2251,14 @@ final HeroFlightShuttleBuilder _navBarHeroFlightShuttleBuilder = (
   assert(fromHeroContext.widget is Hero);
   assert(toHeroContext.widget is Hero);
 
-  final Hero fromHeroWidget = fromHeroContext.widget;
-  final Hero toHeroWidget = toHeroContext.widget;
+  final Hero fromHeroWidget = fromHeroContext.widget as Hero;
+  final Hero toHeroWidget = toHeroContext.widget as Hero;
 
   assert(fromHeroWidget.child is _TransitionableNavigationBar);
   assert(toHeroWidget.child is _TransitionableNavigationBar);
 
-  final _TransitionableNavigationBar fromNavBar = fromHeroWidget.child;
-  final _TransitionableNavigationBar toNavBar = toHeroWidget.child;
+  final _TransitionableNavigationBar fromNavBar = fromHeroWidget.child as _TransitionableNavigationBar;
+  final _TransitionableNavigationBar toNavBar = toHeroWidget.child as _TransitionableNavigationBar;
 
   assert(fromNavBar.componentsKeys != null);
   assert(toNavBar.componentsKeys != null);

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -721,16 +721,16 @@ class _CupertinoEdgeShadowDecoration extends Decoration {
 
   @override
   _CupertinoEdgeShadowDecoration lerpFrom(Decoration a, double t) {
-    if (a is! _CupertinoEdgeShadowDecoration)
-      return _CupertinoEdgeShadowDecoration.lerp(null, this, t);
-    return _CupertinoEdgeShadowDecoration.lerp(a, this, t);
+    if (a is _CupertinoEdgeShadowDecoration)
+      return _CupertinoEdgeShadowDecoration.lerp(a, this, t);
+    return _CupertinoEdgeShadowDecoration.lerp(null, this, t);
   }
 
   @override
   _CupertinoEdgeShadowDecoration lerpTo(Decoration b, double t) {
-    if (b is! _CupertinoEdgeShadowDecoration)
-      return _CupertinoEdgeShadowDecoration.lerp(this, null, t);
-    return _CupertinoEdgeShadowDecoration.lerp(this, b, t);
+    if (b is _CupertinoEdgeShadowDecoration)
+      return _CupertinoEdgeShadowDecoration.lerp(this, b, t);
+    return _CupertinoEdgeShadowDecoration.lerp(this, null, t);
   }
 
   @override
@@ -742,8 +742,8 @@ class _CupertinoEdgeShadowDecoration extends Decoration {
   bool operator ==(dynamic other) {
     if (runtimeType != other.runtimeType)
       return false;
-    final _CupertinoEdgeShadowDecoration typedOther = other;
-    return edgeGradient == typedOther.edgeGradient;
+    return other is _CupertinoEdgeShadowDecoration
+        && other.edgeGradient == edgeGradient;
   }
 
   @override

--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -416,9 +416,9 @@ bool _hitTestInteractive(GlobalKey customPaintKey, Offset offset) {
   if (customPaintKey.currentContext == null) {
     return false;
   }
-  final CustomPaint customPaint = customPaintKey.currentContext.widget;
-  final ScrollbarPainter painter = customPaint.foregroundPainter;
-  final RenderBox renderBox = customPaintKey.currentContext.findRenderObject();
+  final CustomPaint customPaint = customPaintKey.currentContext.widget as CustomPaint;
+  final ScrollbarPainter painter = customPaint.foregroundPainter as ScrollbarPainter;
+  final RenderBox renderBox = customPaintKey.currentContext.findRenderObject() as RenderBox;
   final Offset localOffset = renderBox.globalToLocal(offset);
   return painter.hitTestInteractive(localOffset);
 }

--- a/packages/flutter/lib/src/cupertino/segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/segmented_control.dart
@@ -541,8 +541,7 @@ class _RenderSegmentedControl<T> extends RenderBox
     RenderBox child = firstChild;
     double minWidth = 0.0;
     while (child != null) {
-      final _SegmentedControlContainerBoxParentData childParentData =
-        child.parentData as _SegmentedControlContainerBoxParentData;
+      final _SegmentedControlContainerBoxParentData childParentData = child.parentData as _SegmentedControlContainerBoxParentData;
       final double childWidth = child.getMinIntrinsicWidth(height);
       minWidth = math.max(minWidth, childWidth);
       child = childParentData.nextSibling;
@@ -555,8 +554,7 @@ class _RenderSegmentedControl<T> extends RenderBox
     RenderBox child = firstChild;
     double maxWidth = 0.0;
     while (child != null) {
-      final _SegmentedControlContainerBoxParentData childParentData =
-        child.parentData as _SegmentedControlContainerBoxParentData;
+      final _SegmentedControlContainerBoxParentData childParentData = child.parentData as _SegmentedControlContainerBoxParentData;
       final double childWidth = child.getMaxIntrinsicWidth(height);
       maxWidth = math.max(maxWidth, childWidth);
       child = childParentData.nextSibling;
@@ -569,8 +567,7 @@ class _RenderSegmentedControl<T> extends RenderBox
     RenderBox child = firstChild;
     double minHeight = 0.0;
     while (child != null) {
-      final _SegmentedControlContainerBoxParentData childParentData =
-        child.parentData as _SegmentedControlContainerBoxParentData;
+      final _SegmentedControlContainerBoxParentData childParentData = child.parentData as _SegmentedControlContainerBoxParentData;
       final double childHeight = child.getMinIntrinsicHeight(width);
       minHeight = math.max(minHeight, childHeight);
       child = childParentData.nextSibling;
@@ -583,8 +580,7 @@ class _RenderSegmentedControl<T> extends RenderBox
     RenderBox child = firstChild;
     double maxHeight = 0.0;
     while (child != null) {
-      final _SegmentedControlContainerBoxParentData childParentData =
-        child.parentData as _SegmentedControlContainerBoxParentData;
+      final _SegmentedControlContainerBoxParentData childParentData = child.parentData as _SegmentedControlContainerBoxParentData;
       final double childHeight = child.getMaxIntrinsicHeight(width);
       maxHeight = math.max(maxHeight, childHeight);
       child = childParentData.nextSibling;
@@ -608,8 +604,7 @@ class _RenderSegmentedControl<T> extends RenderBox
     RenderBox child = leftChild;
     double start = 0.0;
     while (child != null) {
-      final _SegmentedControlContainerBoxParentData childParentData =
-        child.parentData as _SegmentedControlContainerBoxParentData;
+      final _SegmentedControlContainerBoxParentData childParentData = child.parentData as _SegmentedControlContainerBoxParentData;
       final Offset childOffset = Offset(start, 0.0);
       childParentData.offset = childOffset;
       final Rect childRect = Rect.fromLTWH(start, 0.0, child.size.width, child.size.height);
@@ -693,8 +688,7 @@ class _RenderSegmentedControl<T> extends RenderBox
   void _paintChild(PaintingContext context, Offset offset, RenderBox child, int childIndex) {
     assert(child != null);
 
-    final _SegmentedControlContainerBoxParentData childParentData =
-      child.parentData as _SegmentedControlContainerBoxParentData;
+    final _SegmentedControlContainerBoxParentData childParentData = child.parentData as _SegmentedControlContainerBoxParentData;
 
     context.canvas.drawRRect(
       childParentData.surroundingRect.shift(offset),
@@ -718,8 +712,7 @@ class _RenderSegmentedControl<T> extends RenderBox
     assert(position != null);
     RenderBox child = lastChild;
     while (child != null) {
-      final _SegmentedControlContainerBoxParentData childParentData =
-        child.parentData as _SegmentedControlContainerBoxParentData;
+      final _SegmentedControlContainerBoxParentData childParentData = child.parentData as _SegmentedControlContainerBoxParentData;
       if (childParentData.surroundingRect.contains(position)) {
         final Offset center = (Offset.zero & child.size).center;
         return result.addWithRawTransform(

--- a/packages/flutter/lib/src/cupertino/segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/segmented_control.dart
@@ -541,7 +541,8 @@ class _RenderSegmentedControl<T> extends RenderBox
     RenderBox child = firstChild;
     double minWidth = 0.0;
     while (child != null) {
-      final _SegmentedControlContainerBoxParentData childParentData = child.parentData;
+      final _SegmentedControlContainerBoxParentData childParentData =
+        child.parentData as _SegmentedControlContainerBoxParentData;
       final double childWidth = child.getMinIntrinsicWidth(height);
       minWidth = math.max(minWidth, childWidth);
       child = childParentData.nextSibling;
@@ -554,7 +555,8 @@ class _RenderSegmentedControl<T> extends RenderBox
     RenderBox child = firstChild;
     double maxWidth = 0.0;
     while (child != null) {
-      final _SegmentedControlContainerBoxParentData childParentData = child.parentData;
+      final _SegmentedControlContainerBoxParentData childParentData =
+        child.parentData as _SegmentedControlContainerBoxParentData;
       final double childWidth = child.getMaxIntrinsicWidth(height);
       maxWidth = math.max(maxWidth, childWidth);
       child = childParentData.nextSibling;
@@ -567,7 +569,8 @@ class _RenderSegmentedControl<T> extends RenderBox
     RenderBox child = firstChild;
     double minHeight = 0.0;
     while (child != null) {
-      final _SegmentedControlContainerBoxParentData childParentData = child.parentData;
+      final _SegmentedControlContainerBoxParentData childParentData =
+        child.parentData as _SegmentedControlContainerBoxParentData;
       final double childHeight = child.getMinIntrinsicHeight(width);
       minHeight = math.max(minHeight, childHeight);
       child = childParentData.nextSibling;
@@ -580,7 +583,8 @@ class _RenderSegmentedControl<T> extends RenderBox
     RenderBox child = firstChild;
     double maxHeight = 0.0;
     while (child != null) {
-      final _SegmentedControlContainerBoxParentData childParentData = child.parentData;
+      final _SegmentedControlContainerBoxParentData childParentData =
+        child.parentData as _SegmentedControlContainerBoxParentData;
       final double childHeight = child.getMaxIntrinsicHeight(width);
       maxHeight = math.max(maxHeight, childHeight);
       child = childParentData.nextSibling;
@@ -604,7 +608,8 @@ class _RenderSegmentedControl<T> extends RenderBox
     RenderBox child = leftChild;
     double start = 0.0;
     while (child != null) {
-      final _SegmentedControlContainerBoxParentData childParentData = child.parentData;
+      final _SegmentedControlContainerBoxParentData childParentData =
+        child.parentData as _SegmentedControlContainerBoxParentData;
       final Offset childOffset = Offset(start, 0.0);
       childParentData.offset = childOffset;
       final Rect childRect = Rect.fromLTWH(start, 0.0, child.size.width, child.size.height);
@@ -688,7 +693,8 @@ class _RenderSegmentedControl<T> extends RenderBox
   void _paintChild(PaintingContext context, Offset offset, RenderBox child, int childIndex) {
     assert(child != null);
 
-    final _SegmentedControlContainerBoxParentData childParentData = child.parentData;
+    final _SegmentedControlContainerBoxParentData childParentData =
+      child.parentData as _SegmentedControlContainerBoxParentData;
 
     context.canvas.drawRRect(
       childParentData.surroundingRect.shift(offset),
@@ -712,7 +718,8 @@ class _RenderSegmentedControl<T> extends RenderBox
     assert(position != null);
     RenderBox child = lastChild;
     while (child != null) {
-      final _SegmentedControlContainerBoxParentData childParentData = child.parentData;
+      final _SegmentedControlContainerBoxParentData childParentData =
+        child.parentData as _SegmentedControlContainerBoxParentData;
       if (childParentData.surroundingRect.contains(position)) {
         final Offset center = (Offset.zero & child.size).center;
         return result.addWithRawTransform(

--- a/packages/flutter/lib/src/cupertino/slider.dart
+++ b/packages/flutter/lib/src/cupertino/slider.dart
@@ -426,7 +426,7 @@ class _RenderCupertinoSlider extends RenderConstrainedBox {
   double _currentDragValue = 0.0;
 
   double get _discretizedCurrentDragValue {
-    double dragValue = _currentDragValue.clamp(0.0, 1.0);
+    double dragValue = _currentDragValue.clamp(0.0, 1.0) as double;
     if (divisions != null)
       dragValue = (dragValue * divisions).round() / divisions;
     return dragValue;
@@ -558,11 +558,11 @@ class _RenderCupertinoSlider extends RenderConstrainedBox {
 
   void _increaseAction() {
     if (isInteractive)
-      onChanged((value + _semanticActionUnit).clamp(0.0, 1.0));
+      onChanged((value + _semanticActionUnit).clamp(0.0, 1.0) as double);
   }
 
   void _decreaseAction() {
     if (isInteractive)
-      onChanged((value - _semanticActionUnit).clamp(0.0, 1.0));
+      onChanged((value - _semanticActionUnit).clamp(0.0, 1.0) as double);
   }
 }

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -686,9 +686,9 @@ class _RenderSegmentedControl<T> extends RenderBox
     return childCount == 0
       ? null
       // This assumes all children have the same width.
-      : (location.dx / (size.width / childCount))
+      : ((location.dx / (size.width / childCount))
         .floor()
-        .clamp(0, childCount - 1);
+        .clamp(0, childCount - 1) as int);
   }
 
   void _onTapUp(TapUpDetails details) {
@@ -761,7 +761,8 @@ class _RenderSegmentedControl<T> extends RenderBox
     RenderBox child = firstChild;
     double maxMinChildWidth = 0;
     while (child != null) {
-      final _SegmentedControlContainerBoxParentData childParentData = child.parentData;
+      final _SegmentedControlContainerBoxParentData childParentData =
+        child.parentData as _SegmentedControlContainerBoxParentData;
       final double childWidth = child.getMinIntrinsicWidth(height);
       maxMinChildWidth = math.max(maxMinChildWidth, childWidth);
       child = childParentData.nextSibling;
@@ -774,7 +775,8 @@ class _RenderSegmentedControl<T> extends RenderBox
     RenderBox child = firstChild;
     double maxMaxChildWidth = 0;
     while (child != null) {
-      final _SegmentedControlContainerBoxParentData childParentData = child.parentData;
+      final _SegmentedControlContainerBoxParentData childParentData =
+        child.parentData as _SegmentedControlContainerBoxParentData;
       final double childWidth = child.getMaxIntrinsicWidth(height);
       maxMaxChildWidth = math.max(maxMaxChildWidth, childWidth);
       child = childParentData.nextSibling;
@@ -787,7 +789,8 @@ class _RenderSegmentedControl<T> extends RenderBox
     RenderBox child = firstChild;
     double maxMinChildHeight = 0;
     while (child != null) {
-      final _SegmentedControlContainerBoxParentData childParentData = child.parentData;
+      final _SegmentedControlContainerBoxParentData childParentData =
+        child.parentData as _SegmentedControlContainerBoxParentData;
       final double childHeight = child.getMinIntrinsicHeight(width);
       maxMinChildHeight = math.max(maxMinChildHeight, childHeight);
       child = childParentData.nextSibling;
@@ -800,7 +803,8 @@ class _RenderSegmentedControl<T> extends RenderBox
     RenderBox child = firstChild;
     double maxMaxChildHeight = 0;
     while (child != null) {
-      final _SegmentedControlContainerBoxParentData childParentData = child.parentData;
+      final _SegmentedControlContainerBoxParentData childParentData =
+        child.parentData as _SegmentedControlContainerBoxParentData;
       final double childHeight = child.getMaxIntrinsicHeight(width);
       maxMaxChildHeight = math.max(maxMaxChildHeight, childHeight);
       child = childParentData.nextSibling;
@@ -859,7 +863,8 @@ class _RenderSegmentedControl<T> extends RenderBox
     child = firstChild;
 
     while (child != null) {
-      final _SegmentedControlContainerBoxParentData childParentData = child.parentData;
+      final _SegmentedControlContainerBoxParentData childParentData =
+        child.parentData as _SegmentedControlContainerBoxParentData;
       final Offset childOffset = Offset(start, 0);
       childParentData.offset = childOffset;
       start += child.size.width + _kSeparatorWidth + _kSeparatorInset.horizontal;
@@ -888,7 +893,8 @@ class _RenderSegmentedControl<T> extends RenderBox
 
       final RenderBox selectedChild = children[highlightedIndex];
 
-      final _SegmentedControlContainerBoxParentData childParentData = selectedChild.parentData;
+      final _SegmentedControlContainerBoxParentData childParentData =
+        selectedChild.parentData as _SegmentedControlContainerBoxParentData;
       final Rect unscaledThumbTargetRect = _kThumbInsets.inflateRect(childParentData.offset & selectedChild.size);
 
       // Update related Tweens before animation update phase.
@@ -948,7 +954,8 @@ class _RenderSegmentedControl<T> extends RenderBox
   // Paint the separator to the right of the given child.
   void _paintSeparator(PaintingContext context, Offset offset, RenderBox child) {
     assert(child != null);
-    final _SegmentedControlContainerBoxParentData childParentData = child.parentData;
+    final _SegmentedControlContainerBoxParentData childParentData =
+      child.parentData as _SegmentedControlContainerBoxParentData;
 
     final Paint paint = Paint();
 
@@ -970,7 +977,8 @@ class _RenderSegmentedControl<T> extends RenderBox
 
   void _paintChild(PaintingContext context, Offset offset, RenderBox child, int childIndex) {
     assert(child != null);
-    final _SegmentedControlContainerBoxParentData childParentData = child.parentData;
+    final _SegmentedControlContainerBoxParentData childParentData =
+      child.parentData as _SegmentedControlContainerBoxParentData;
     context.paintChild(child, childParentData.offset + offset);
   }
 
@@ -1011,7 +1019,8 @@ class _RenderSegmentedControl<T> extends RenderBox
     assert(position != null);
     RenderBox child = lastChild;
     while (child != null) {
-      final _SegmentedControlContainerBoxParentData childParentData = child.parentData;
+      final _SegmentedControlContainerBoxParentData childParentData =
+        child.parentData as _SegmentedControlContainerBoxParentData;
       if ((childParentData.offset & child.size).contains(position)) {
         final Offset center = (Offset.zero & child.size).center;
         return result.addWithRawTransform(

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -97,7 +97,7 @@ class _CupertinoTextFieldSelectionGestureDetectorBuilder extends TextSelectionGe
     // this handler. If the clear button widget recognizes the up event,
     // then do not handle it.
     if (_state._clearGlobalKey.currentContext != null) {
-      final RenderBox renderBox = _state._clearGlobalKey.currentContext.findRenderObject();
+      final RenderBox renderBox = _state._clearGlobalKey.currentContext.findRenderObject() as RenderBox;
       final Offset localOffset = renderBox.globalToLocal(details.globalPosition);
       if (renderBox.hitTest(BoxHitTestResult(), position: localOffset)) {
         return;
@@ -841,7 +841,7 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with AutomaticK
     final Color decorationColor = CupertinoDynamicColor.resolve(widget.decoration?.color, context);
 
     final BoxBorder border = widget.decoration?.border;
-    Border resolvedBorder = border;
+    Border resolvedBorder = border as Border;
     if (border is Border) {
       BorderSide resolveBorderSide(BorderSide side) {
         return side == BorderSide.none

--- a/packages/flutter/lib/src/cupertino/text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection.dart
@@ -169,12 +169,12 @@ class _ToolbarRenderBox extends RenderShiftedBox {
       .loosen();
 
     child.layout(heightConstraint.enforce(enforcedConstraint), parentUsesSize: true,);
-    final _ToolbarParentData childParentData = child.parentData;
+    final _ToolbarParentData childParentData = child.parentData as _ToolbarParentData;
 
     // The local x-coordinate of the center of the toolbar.
     final double lowerBound = child.size.width/2 + _kToolbarScreenPadding;
     final double upperBound = size.width - child.size.width/2 - _kToolbarScreenPadding;
-    final double adjustedCenterX = _arrowTipX.clamp(lowerBound, upperBound);
+    final double adjustedCenterX = _arrowTipX.clamp(lowerBound, upperBound) as double;
 
     childParentData.offset = Offset(adjustedCenterX - child.size.width / 2, _barTopY);
     childParentData.arrowXOffsetFromCenter = _arrowTipX - adjustedCenterX;
@@ -182,7 +182,7 @@ class _ToolbarRenderBox extends RenderShiftedBox {
 
   // The path is described in the toolbar's coordinate system.
   Path _clipPath() {
-    final _ToolbarParentData childParentData = child.parentData;
+    final _ToolbarParentData childParentData = child.parentData as _ToolbarParentData;
     final Path rrect = Path()
       ..addRRect(
         RRect.fromRectAndRadius(
@@ -215,7 +215,7 @@ class _ToolbarRenderBox extends RenderShiftedBox {
       return;
     }
 
-    final _ToolbarParentData childParentData = child.parentData;
+    final _ToolbarParentData childParentData = child.parentData as _ToolbarParentData;
     context.pushClipPath(
       needsCompositing,
       offset + childParentData.offset,
@@ -245,7 +245,7 @@ class _ToolbarRenderBox extends RenderShiftedBox {
       ..strokeWidth = 2.0
       ..style = PaintingStyle.stroke;
 
-      final _ToolbarParentData childParentData = child.parentData;
+      final _ToolbarParentData childParentData = child.parentData as _ToolbarParentData;
       context.canvas.drawPath(_clipPath().shift(offset + childParentData.offset), _debugPaint);
       return true;
     }());
@@ -322,7 +322,7 @@ class _CupertinoTextSelectionControls extends TextSelectionControls {
     final double arrowTipX = (position.dx + globalEditableRegion.left).clamp(
       _kArrowScreenPadding + mediaQuery.padding.left,
       mediaQuery.size.width - mediaQuery.padding.right - _kArrowScreenPadding,
-    );
+    ) as double;
 
     // The y-coordinate has to be calculated instead of directly quoting postion.dy,
     // since the caller (TextSelectionOverlay._buildToolbar) does not know whether


### PR DESCRIPTION
## Description

Enable `implicit-casts:false` in `flutter/lib/src/cupertino`

## Related Issues

None

## Tests

None because it's a refactoring.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
