### PR TITLE
implicit-casts:false in flutter/lib/src/gestures

### DIFF
--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -632,7 +632,7 @@ class PointerAddedEvent extends PointerEvent {
       orientation: orientation,
       tilt: tilt,
       transform: transform,
-      original: original ?? this,
+      original: original as PointerAddedEvent ?? this,
     );
   }
 }
@@ -694,7 +694,7 @@ class PointerRemovedEvent extends PointerEvent {
       radiusMin: radiusMin,
       radiusMax: radiusMax,
       transform: transform,
-      original: original ?? this,
+      original: original as PointerRemovedEvent ?? this,
     );
   }
 }
@@ -799,7 +799,7 @@ class PointerHoverEvent extends PointerEvent {
       tilt: tilt,
       synthesized: synthesized,
       transform: transform,
-      original: original ?? this,
+      original: original as PointerHoverEvent ?? this,
     );
   }
 }
@@ -907,7 +907,7 @@ class PointerEnterEvent extends PointerEvent {
     down: event?.down,
     synthesized: event?.synthesized,
     transform: event?.transform,
-    original: event?.original,
+    original: event?.original as PointerEnterEvent,
   );
 
   @override
@@ -945,7 +945,7 @@ class PointerEnterEvent extends PointerEvent {
       down: down,
       synthesized: synthesized,
       transform: transform,
-      original: original ?? this,
+      original: original as PointerEnterEvent ?? this,
     );
   }
 }
@@ -1053,7 +1053,7 @@ class PointerExitEvent extends PointerEvent {
     down: event?.down,
     synthesized: event?.synthesized,
     transform: event?.transform,
-    original: event?.original,
+    original: event?.original as PointerExitEvent,
   );
 
   @override
@@ -1091,7 +1091,7 @@ class PointerExitEvent extends PointerEvent {
       down: down,
       synthesized: synthesized,
       transform: transform,
-      original: original ?? this,
+      original: original as PointerExitEvent ?? this,
     );
   }
 }
@@ -1175,7 +1175,7 @@ class PointerDownEvent extends PointerEvent {
       orientation: orientation,
       tilt: tilt,
       transform: transform,
-      original: original ?? this,
+      original: original as PointerDownEvent ?? this,
     );
   }
 }
@@ -1284,7 +1284,7 @@ class PointerMoveEvent extends PointerEvent {
       platformData: platformData,
       synthesized: synthesized,
       transform: transform,
-      original: original ?? this,
+      original: original as PointerMoveEvent ?? this,
     );
   }
 }
@@ -1372,7 +1372,7 @@ class PointerUpEvent extends PointerEvent {
       orientation: orientation,
       tilt: tilt,
       transform: transform,
-      original: original ?? this,
+      original: original as PointerUpEvent ?? this,
     );
   }
 }
@@ -1454,7 +1454,7 @@ class PointerScrollEvent extends PointerSignalEvent {
       localPosition: PointerEvent.transformPosition(transform, position),
       scrollDelta: scrollDelta,
       transform: transform,
-      original: original ?? this,
+      original: original as PointerScrollEvent ?? this,
     );
   }
 
@@ -1544,7 +1544,7 @@ class PointerCancelEvent extends PointerEvent {
       orientation: orientation,
       tilt: tilt,
       transform: transform,
-      original: original ?? this,
+      original: original as PointerCancelEvent ?? this,
     );
   }
 }

--- a/packages/flutter/lib/src/gestures/force_press.dart
+++ b/packages/flutter/lib/src/gestures/force_press.dart
@@ -341,7 +341,7 @@ class ForcePressGestureRecognizer extends OneSequenceGestureRecognizer {
     // If the device incorrectly reports a pressure outside of pressureMin
     // and pressureMax, we still want this recognizer to respond normally.
     if (!value.isNaN)
-      value = value.clamp(0.0, 1.0);
+      value = value.clamp(0.0, 1.0) as double;
     return value;
   }
 

--- a/packages/flutter/lib/src/gestures/hit_test.dart
+++ b/packages/flutter/lib/src/gestures/hit_test.dart
@@ -142,7 +142,7 @@ class HitTestResult {
       'matrix through PointerEvent.removePerspectiveTransform?'
       'The provided matrix is:\n$transform'
     );
-    _transforms.add(_transforms.isEmpty ? transform :  transform * _transforms.last);
+    _transforms.add(_transforms.isEmpty ? transform : (transform * _transforms.last as Matrix4));
   }
 
   /// Removes the last transform added via [pushTransform].

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -218,7 +218,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
         return false;
       }
     }
-    return super.isPointerAllowed(event);
+    return super.isPointerAllowed(event as PointerDownEvent);
   }
 
   @override
@@ -412,7 +412,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
     assert(tracker != null);
 
     DragEndDetails details;
-    void Function() debugReport;
+    String Function() debugReport;
 
     final VelocityEstimate estimate = tracker.getVelocityEstimate();
     if (estimate != null && isFlingGesture(estimate)) {

--- a/packages/flutter/lib/src/gestures/mouse_tracking.dart
+++ b/packages/flutter/lib/src/gestures/mouse_tracking.dart
@@ -264,7 +264,7 @@ class MouseTracker extends ChangeNotifier {
         ? LinkedHashSet<MouseTrackerAnnotation>.from(
             annotationFinder(mouseState.mostRecentEvent.position)
           )
-        : <MouseTrackerAnnotation>{};
+        : <MouseTrackerAnnotation>{} as LinkedHashSet<MouseTrackerAnnotation>;
 
     _dispatchDeviceCallbacks(
       currentState: mouseState,

--- a/packages/flutter/lib/src/gestures/multitap.dart
+++ b/packages/flutter/lib/src/gestures/multitap.dart
@@ -168,7 +168,7 @@ class DoubleTapGestureRecognizer extends GestureRecognizer {
           return false;
       }
     }
-    return super.isPointerAllowed(event);
+    return super.isPointerAllowed(event as PointerDownEvent);
   }
 
   @override
@@ -177,7 +177,7 @@ class DoubleTapGestureRecognizer extends GestureRecognizer {
       if (!_firstTap.isWithinGlobalTolerance(event, kDoubleTapSlop)) {
         // Ignore out-of-bounds second taps.
         return;
-      } else if (!_firstTap.hasElapsedMinTime() || !_firstTap.hasSameButton(event)) {
+      } else if (!_firstTap.hasElapsedMinTime() || !_firstTap.hasSameButton(event as PointerDownEvent)) {
         // Restart when the second tap is too close to the first, or when buttons
         // mismatch.
         _reset();
@@ -190,7 +190,7 @@ class DoubleTapGestureRecognizer extends GestureRecognizer {
   void _trackFirstTap(PointerEvent event) {
     _stopDoubleTapTimer();
     final _TapTracker tracker = _TapTracker(
-      event: event,
+      event: event as PointerDownEvent,
       entry: GestureBinding.instance.gestureArena.add(event.pointer, this),
       doubleTapMinTime: kDoubleTapMinTime,
     );
@@ -322,7 +322,7 @@ class _TapGesture extends _TapTracker {
     Duration longTapDelay,
   }) : _lastPosition = OffsetPair.fromEventPosition(event),
        super(
-    event: event,
+    event: event as PointerDownEvent,
     entry: GestureBinding.instance.gestureArena.add(event.pointer, gestureRecognizer),
     doubleTapMinTime: kDoubleTapMinTime,
   ) {

--- a/packages/flutter/lib/src/gestures/velocity_tracker.dart
+++ b/packages/flutter/lib/src/gestures/velocity_tracker.dart
@@ -65,8 +65,8 @@ class Velocity {
   bool operator ==(dynamic other) {
     if (other is! Velocity)
       return false;
-    final Velocity typedOther = other;
-    return pixelsPerSecond == typedOther.pixelsPerSecond;
+    return other is Velocity
+        && other.pixelsPerSecond == pixelsPerSecond;
   }
 
   @override

--- a/packages/flutter/lib/src/gestures/velocity_tracker.dart
+++ b/packages/flutter/lib/src/gestures/velocity_tracker.dart
@@ -63,8 +63,6 @@ class Velocity {
 
   @override
   bool operator ==(dynamic other) {
-    if (other is! Velocity)
-      return false;
     return other is Velocity
         && other.pixelsPerSecond == pixelsPerSecond;
   }


### PR DESCRIPTION
## Description

Enable `implicit-casts:false` in `flutter/lib/src/gestures`

## Related Issues

None

## Tests

None because it's a refactoring.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
