### PR TITLE
Allow flutter run to run release x64

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -491,10 +491,9 @@ class AndroidDevice extends Device {
     }
 
     final TargetPlatform devicePlatform = await targetPlatform;
-    if (!(devicePlatform == TargetPlatform.android_arm ||
-          devicePlatform == TargetPlatform.android_arm64) &&
-        !debuggingOptions.buildInfo.isDebug) {
-      printError('Profile and release builds are only supported on ARM targets.');
+    if (devicePlatform == TargetPlatform.android_x86 &&
+       !debuggingOptions.buildInfo.isDebug) {
+      printError('Profile and release builds are only supported on ARM/x64 targets.');
       return LaunchResult.failed();
     }
 


### PR DESCRIPTION
## Description

Now that flutter supports x86_64 release builds on android, there is no reason to prevent flutter run from working on them. While this technically allows release/profile to run on emulators, it also allows running on chromebooks and other x64 devices.

Since emulator detection is a best guess, attempting further restrictions would likely lead to false positives.