### PR TITLE
WIP: Remove extraneous semantic scrolling events in PageView

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -3331,6 +3331,7 @@ class RenderSemanticsGestureHandler extends RenderProxyBox {
     GestureDragUpdateCallback onHorizontalDragUpdate,
     GestureDragUpdateCallback onVerticalDragUpdate,
     this.scrollFactor = 0.8,
+    this.semanticsConfigurationOverride,
   }) : assert(scrollFactor != null),
        _onTap = onTap,
        _onLongPress = onLongPress,
@@ -3415,6 +3416,9 @@ class RenderSemanticsGestureHandler extends RenderProxyBox {
   /// leftwards drag.
   double scrollFactor;
 
+  // TODO(darrenaustin): document
+  final SemanticsConfigurationOverride semanticsConfigurationOverride;
+
   @override
   void describeSemanticsConfiguration(SemanticsConfiguration config) {
     super.describeSemanticsConfiguration(config);
@@ -3435,6 +3439,7 @@ class RenderSemanticsGestureHandler extends RenderProxyBox {
       if (_isValidAction(SemanticsAction.scrollDown))
         config.onScrollDown = _performSemanticScrollDown;
     }
+    semanticsConfigurationOverride?.call(config);
   }
 
   bool _isValidAction(SemanticsAction action) {

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -3947,6 +3947,9 @@ class SemanticsConfiguration {
   }
 }
 
+// TODO(darrenaustin):  document
+typedef void SemanticsConfigurationOverride(SemanticsConfiguration config);
+
 /// Used by [debugDumpSemanticsTree] to specify the order in which child nodes
 /// are printed.
 enum DebugSemanticsDumpOrder {

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -802,6 +802,7 @@ class RawGestureDetector extends StatefulWidget {
     this.behavior,
     this.excludeFromSemantics = false,
     this.semantics,
+    this.semanticsConfigurationOverride,
   }) : assert(gestures != null),
        assert(excludeFromSemantics != null),
        super(key: key);
@@ -898,6 +899,9 @@ class RawGestureDetector extends StatefulWidget {
   /// ```
   /// {@end-tool}
   final SemanticsGestureDelegate semantics;
+
+  // TODO(darrenaustin): document
+  final SemanticsConfigurationOverride semanticsConfigurationOverride;
 
   @override
   RawGestureDetectorState createState() => RawGestureDetectorState();
@@ -1041,6 +1045,7 @@ class RawGestureDetectorState extends State<RawGestureDetector> {
       result = _GestureSemantics(
         child: result,
         assignSemantics: _updateSemanticsForRenderObject,
+        semanticsOverrideCallback: widget.semanticsConfigurationOverride,
       );
     return result;
   }
@@ -1070,14 +1075,18 @@ class _GestureSemantics extends SingleChildRenderObjectWidget {
     Key key,
     Widget child,
     @required this.assignSemantics,
+    this.semanticsOverrideCallback,
   }) : assert(assignSemantics != null),
        super(key: key, child: child);
 
   final _AssignSemantics assignSemantics;
+  final SemanticsConfigurationOverride semanticsOverrideCallback;
 
   @override
   RenderSemanticsGestureHandler createRenderObject(BuildContext context) {
-    final RenderSemanticsGestureHandler renderObject = RenderSemanticsGestureHandler();
+    final RenderSemanticsGestureHandler renderObject = RenderSemanticsGestureHandler(
+      semanticsConfigurationOverride: semanticsOverrideCallback
+    );
     assignSemantics(renderObject);
     return renderObject;
   }

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -728,6 +728,41 @@ class _PageViewState extends State<PageView> {
     return null;
   }
 
+  void _overrideSemanticsConfig(SemanticsConfiguration config) {
+    if (config.onScrollLeft != null) {
+      config.onScrollLeft = _performSemanticsScrollLeft;
+    }
+    if (config.onScrollRight != null) {
+      config.onScrollRight = _performSemanticsScrollRight;
+    }
+    if (config.onScrollUp != null) {
+      config.onScrollUp = _performSemanticsScrollUp;
+    }
+    if (config.onScrollDown != null) {
+      config.onScrollDown = _performSemanticsScrollDown;
+    }
+  }
+
+  void _performSemanticsScrollLeft() {
+    assert(widget.scrollDirection == Axis.horizontal);
+    widget.controller.jumpToPage(widget.controller.page.round() + 1);
+  }
+
+  void _performSemanticsScrollRight() {
+    assert(widget.scrollDirection == Axis.horizontal);
+    widget.controller.jumpToPage(widget.controller.page.round() - 1);
+  }
+
+  void _performSemanticsScrollUp() {
+    assert(widget.scrollDirection == Axis.vertical);
+    widget.controller.jumpToPage(widget.controller.page.round() + 1);
+  }
+
+  void _performSemanticsScrollDown() {
+    assert(widget.scrollDirection == Axis.vertical);
+    widget.controller.jumpToPage(widget.controller.page.round() - 1);
+  }
+
   @override
   Widget build(BuildContext context) {
     final AxisDirection axisDirection = _getDirection(context);
@@ -752,6 +787,7 @@ class _PageViewState extends State<PageView> {
         axisDirection: axisDirection,
         controller: widget.controller,
         physics: physics,
+        semanticsConfigurationOverride: _overrideSemanticsConfig,
         viewportBuilder: (BuildContext context, ViewportOffset position) {
           return Viewport(
             cacheExtent: 0.0,

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -84,6 +84,7 @@ class Scrollable extends StatefulWidget {
     this.excludeFromSemantics = false,
     this.semanticChildCount,
     this.dragStartBehavior = DragStartBehavior.start,
+    this.semanticsConfigurationOverride,
   }) : assert(axisDirection != null),
        assert(dragStartBehavior != null),
        assert(viewportBuilder != null),
@@ -210,6 +211,9 @@ class Scrollable extends StatefulWidget {
   ///
   /// Determined by the [axisDirection].
   Axis get axis => axisDirectionToAxis(axisDirection);
+
+  // TODO(darrenaustin): document
+  final SemanticsConfigurationOverride semanticsConfigurationOverride;
 
   @override
   ScrollableState createState() => ScrollableState();
@@ -588,6 +592,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin
           gestures: _gestureRecognizers,
           behavior: HitTestBehavior.opaque,
           excludeFromSemantics: widget.excludeFromSemantics,
+          semanticsConfigurationOverride: widget.semanticsConfigurationOverride,
           child: Semantics(
             explicitChildNodes: !widget.excludeFromSemantics,
             child: IgnorePointer(


### PR DESCRIPTION
## Description

While trying to come up with a fix for #42590, one of the issues encountered there is when using a `PageScrollPhysics` on a list view (or `PageView`), the iOS accessibility bridge will announce multiple (~10 or so) `UIAccessibilityPageScrolledNotification`s per accessibility scroll action. This is due to the a11y scroll actions being implemented as a simulated drag operation across most of the screen. This causes the scroll physics to snap the page back during the scroll which generates a lot of scroll events that the bridge sees as page scroll changes.

To fix this, I have exposed a new `SemanticsConfigurationOverride` function that can be passed into the `Scrollable` that will allow clients to override any of the handlers for the accessibility actions. This way a `PageView` can replace the scroll actions with just a page jump rather than animating for these operations. Thus it will only generate one scroll page announcement on iOS.

Sadly, this does not fix the original bug. I does reduce the buzzing of multiple scrolling, but for some reason Voice Over moves the focus to the new page item, but does not announce it.

This change is probably still useful, but I am not sure if this is the best way to override the semantic scroll actions.  Before spending more time cleaning this up with docs and tests, can
@goderbauer, @jonahwilliams, or @dnfield take a look at this and let me know what you think?

## Related Issues

Related to #42590 

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behaviour with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
