### PR TITLE
Add a note to generated plugins files

### DIFF
--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -317,7 +317,8 @@ List<Plugin> findPlugins(FlutterProject project) {
 /// otherwise returns [false].
 bool _writeFlutterPluginsList(FlutterProject project, List<Plugin> plugins) {
   final List<dynamic> directAppDependencies = <dynamic>[];
-  final StringBuffer flutterPluginsBuffer = StringBuffer();
+  const String info = 'This is a generated file; do not edit or check into version control.';
+  final StringBuffer flutterPluginsBuffer = StringBuffer('# $info\n');
 
   final Set<String> pluginNames = <String>{};
   for (Plugin plugin in plugins) {
@@ -334,7 +335,7 @@ bool _writeFlutterPluginsList(FlutterProject project, List<Plugin> plugins) {
   final File pluginsFile = project.flutterPluginsFile;
   final String oldPluginFileContent = _readFileContent(pluginsFile);
   final String pluginFileContent = flutterPluginsBuffer.toString();
-  if (pluginFileContent.isNotEmpty) {
+  if (pluginNames.isNotEmpty) {
     pluginsFile.writeAsStringSync(pluginFileContent, flush: true);
   } else {
     if (pluginsFile.existsSync()) {
@@ -345,9 +346,10 @@ bool _writeFlutterPluginsList(FlutterProject project, List<Plugin> plugins) {
   final File dependenciesFile = project.flutterPluginsDependenciesFile;
   final String oldDependenciesFileContent = _readFileContent(dependenciesFile);
   final String dependenciesFileContent = json.encode(<String, dynamic>{
+      '_info': '// $info',
       'dependencyGraph': directAppDependencies,
     });
-  if (pluginFileContent.isNotEmpty) {
+  if (pluginNames.isNotEmpty) {
     dependenciesFile.writeAsStringSync(dependenciesFileContent, flush: true);
   } else {
     if (dependenciesFile.existsSync()) {

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -273,6 +273,7 @@ dependencies:
         expect(flutterProject.flutterPluginsFile.existsSync(), true);
         expect(flutterProject.flutterPluginsDependenciesFile.existsSync(), true);
         expect(flutterProject.flutterPluginsFile.readAsStringSync(),
+          '# This is a generated file; do not edit or check into version control.\n'
           'plugin-a=/.tmp_rand0/plugin.rand0/\n'
           'plugin-b=/.tmp_rand0/plugin.rand1/\n'
           'plugin-c=/.tmp_rand0/plugin.rand2/\n'
@@ -280,6 +281,7 @@ dependencies:
         );
         expect(flutterProject.flutterPluginsDependenciesFile.readAsStringSync(),
           '{'
+            '"_info":"// This is a generated file; do not edit or check into version control.",'
             '"dependencyGraph":['
               '{'
                 '"name":"plugin-a",'


### PR DESCRIPTION
## Description

There has been some confusion about whether or not
.flutter-plugins-dependencies should be tracked in version control or
not. Added a comment to both it and .flutter-plugins explaining that
it's generated and shouldn't be.

.flutter-plugins-dependencies is parsed through JSON, and the JSON spec
doesn't support comments. So unfortunately the note is living in an
arbitrary "_info" key instead of an obvious top level comment.

## Related Issues

flutter/flutter#45188

## Tests

I added the following tests:

- Modified `packages/flutter_tools/test/general.shard/plugins_test.dart` to check for the new file content

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
