### PR TITLE
Add integration test for transitive plugin dependencies

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -763,6 +763,7 @@ Future<void> _runHostOnlyDeviceLabTests() async {
 
     () => _runDevicelabTest('module_host_with_custom_build_test', environment: gradleEnvironment, testEmbeddingV2: true),
     () => _runDevicelabTest('module_test', environment: gradleEnvironment, testEmbeddingV2: true),
+    () => _runDevicelabTest('plugin_dependencies_test', environment: gradleEnvironment),
 
     // TODO(jmagman): Re-enable once flakiness is resolved, https://github.com/flutter/flutter/issues/37525
     // if (Platform.isMacOS) () => _runDevicelabTest('module_test_ios'),

--- a/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
+++ b/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
@@ -135,6 +135,7 @@ public class DummyPluginAClass {
       final String flutterPluginsDependenciesFileContent = flutterPluginsDependenciesFile.readAsStringSync();
       const String kExpectedPluginsDependenciesContent =
         '{'
+          '\"_info\":\"// This is a generated file; do not edit or check into version control.\",'
           '\"dependencyGraph\":['
             '{'
               '\"name\":\"plugin_a\",'

--- a/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
+++ b/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
@@ -1,0 +1,190 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/framework/utils.dart';
+import 'package:path/path.dart' as path;
+
+/// Tests that a plugin A can depend on platform code from a plugin B
+/// as long as plugin B is defined as a pub dependency of plugin A.
+Future<void> main() async {
+  await task(() async {
+
+    section('Find Java');
+
+    final String javaHome = await findJavaHome();
+    if (javaHome == null) {
+      return TaskResult.failure('Could not find Java');
+    }
+
+    print('\nUsing JAVA_HOME=$javaHome');
+
+    final Directory tempDir = Directory.systemTemp.createTempSync('flutter_plugin_dependencies.');
+    try {
+
+      section('Create plugin A');
+
+      final Directory pluginADirectory = Directory(path.join(tempDir.path, 'plugin_a'));
+      await inDirectory(tempDir, () async {
+        await flutter(
+          'create',
+          options: <String>[
+            '--org',
+            'io.flutter.devicelab.plugin_a',
+            '--template=plugin',
+            pluginADirectory.path,
+          ],
+        );
+      });
+
+      section('Create plugin B');
+
+      final Directory pluginBDirectory = Directory(path.join(tempDir.path, 'plugin_b'));
+      await inDirectory(tempDir, () async {
+        await flutter(
+          'create',
+          options: <String>[
+            '--org',
+            'io.flutter.devicelab.plugin_b',
+            '--template=plugin',
+            pluginBDirectory.path,
+          ],
+        );
+      });
+
+      section('Write dummy Kotlin code in plugin B');
+
+      final File pluginBKotlinClass = File(path.join(
+        pluginBDirectory.path,
+        'android',
+        'src',
+        'main',
+        'kotlin',
+        'DummyPluginBClass.kt',
+      ));
+
+      await pluginBKotlinClass.writeAsString('''
+package io.flutter.devicelab.plugin_b
+
+public class DummyPluginBClass {
+  companion object {
+    fun dummyStaticMethod() {
+    }
+  }
+}
+''', flush: true);
+
+      section('Make plugin A depend on plugin B');
+
+      final File pubspec = File(path.join(pluginADirectory.path, 'pubspec.yaml'));
+      String content = await pubspec.readAsString();
+      content = content.replaceFirst(
+        '\ndependencies:\n',
+        '\ndependencies:\n'
+        '  plugin_b:\n'
+        '    path: ${pluginBDirectory.path}\n',
+      );
+      await pubspec.writeAsString(content, flush: true);
+
+      section('Write Kotlin code in plugin A that references Kotlin code from plugin B');
+
+      final File pluginAKotlinClass = File(path.join(
+        pluginADirectory.path,
+        'android',
+        'src',
+        'main',
+        'kotlin',
+        'DummyPluginAClass.kt',
+      ));
+
+      await pluginAKotlinClass.writeAsString('''
+package io.flutter.devicelab.plugin_a
+
+import io.flutter.devicelab.plugin_b.DummyPluginBClass
+
+public class DummyPluginAClass {
+  constructor() {
+    // Call a method from plugin b.
+    DummyPluginBClass.dummyStaticMethod();
+  }
+}
+''', flush: true);
+
+      section('Verify .flutter-plugins-dependencies');
+
+      final Directory exampleApp = Directory(path.join(pluginADirectory.path, 'example'));
+
+      await inDirectory(exampleApp, () async {
+        await flutter(
+          'packages',
+          options: <String>['get'],
+        );
+      });
+
+      final File flutterPluginsDependenciesFile =
+          File(path.join(exampleApp.path, '.flutter-plugins-dependencies'));
+
+      if (!flutterPluginsDependenciesFile.existsSync()) {
+        return TaskResult.failure('${flutterPluginsDependenciesFile.path} doesn\'t exist');
+      }
+
+      final String flutterPluginsDependenciesFileContent = flutterPluginsDependenciesFile.readAsStringSync();
+      const String kExpectedPluginsDependenciesContent =
+        '{'
+          '\"dependencyGraph\":['
+            '{'
+              '\"name\":\"plugin_a\",'
+              '\"dependencies\":[\"plugin_b\"]'
+            '},'
+            '{'
+              '\"name\":\"plugin_b\",'
+              '\"dependencies\":[]'
+            '}'
+          ']'
+        '}';
+      if (flutterPluginsDependenciesFileContent != kExpectedPluginsDependenciesContent) {
+        return TaskResult.failure(
+          'Unexpected file content in ${flutterPluginsDependenciesFile.path}: '
+          'Found "$flutterPluginsDependenciesFileContent" instead of '
+          '"$kExpectedPluginsDependenciesContent"'
+        );
+      }
+
+      section('Build plugin A example app');
+
+      await inDirectory(exampleApp, () async {
+        await flutter(
+          'build',
+          options: <String>['apk', '--target-platform', 'android-arm'],
+        );
+      });
+
+      final bool pluginAExampleApk = exists(File(path.join(
+        pluginADirectory.path,
+        'example',
+        'build',
+        'app',
+        'outputs',
+        'apk',
+        'release',
+        'app-release.apk',
+      )));
+
+      if (!pluginAExampleApk) {
+        return TaskResult.failure('Failed to build plugin A example APK');
+      }
+
+      return TaskResult.success(null);
+    } on TaskResult catch (taskResult) {
+      return taskResult;
+    } catch (e) {
+      return TaskResult.failure(e.toString());
+    } finally {
+      rmTree(tempDir);
+    }
+  });
+}

--- a/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
+++ b/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
@@ -146,6 +146,7 @@ public class DummyPluginAClass {
             '}'
           ']'
         '}';
+
       if (flutterPluginsDependenciesFileContent != kExpectedPluginsDependenciesContent) {
         return TaskResult.failure(
           'Unexpected file content in ${flutterPluginsDependenciesFile.path}: '


### PR DESCRIPTION
## Description

Integration test for https://github.com/flutter/flutter/pull/45379

## Related Issues

Fixes https://github.com/flutter/flutter/issues/45561

## Tests

This is a test.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
