### PR TITLE
SliverOffstage Fix

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -2124,7 +2124,14 @@ class RenderSliverOffstage extends RenderSliver with RenderObjectWithChildMixin<
   void performLayout() {
     assert(child != null);
     child.layout(constraints, parentUsesSize: true);
-    geometry = child.geometry;
+    if (!offstage)
+      geometry = child.geometry;
+    else
+      geometry = const SliverGeometry(
+        scrollExtent: 0.0,
+        visible: false,
+        maxPaintExtent: 0.0,
+      );
   }
 
   @override
@@ -2159,7 +2166,7 @@ class RenderSliverOffstage extends RenderSliver with RenderObjectWithChildMixin<
   void paint(PaintingContext context, Offset offset) {
     if (offstage)
       return;
-    super.paint(context, offset);
+    context.paintChild(child, offset);
   }
 
   @override

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -454,6 +454,10 @@ void main() {
 
       expect(semantics.nodesWith(label: 'a'), hasLength(0));
       expect(find.byType(Text), findsNothing);
+      final RenderViewport renderViewport = tester.renderObject(find.byType(Viewport));
+      final RenderSliver renderSliver = renderViewport.lastChild;
+      expect(renderSliver.geometry.scrollExtent, 0.0);
+      expect(find.byType(SliverOffstage), findsNothing);
     });
 
     testWidgets('offstage false', (WidgetTester tester) async {
@@ -469,6 +473,10 @@ void main() {
 
       expect(semantics.nodesWith(label: 'a'), hasLength(1));
       expect(find.byType(Text), findsOneWidget);
+      final RenderViewport renderViewport = tester.renderObject(find.byType(Viewport));
+      final RenderSliver renderSliver = renderViewport.lastChild;
+      expect(renderSliver.geometry.scrollExtent, 14.0);
+      expect(find.byType(SliverOffstage), paints..paragraph());
     });
   });
 


### PR DESCRIPTION
## Description

Fixes bug in the new SliverOffstage that results in painting errors.

## Tests

Made more robust. :)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
