### PR TITLE
Re-land "Add option to delay rendering the first frame (#45135)"

### DIFF
--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -283,6 +283,53 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
     drawFrame();
   }
 
+  int _firstFrameDeferredCount = 0;
+  bool _firstFrameSent = false;
+
+  /// Whether frames produced by [drawFrame] are sent to the engine.
+  ///
+  /// If false the framework will do all the work to produce a frame,
+  /// but the frame is never send to the engine to actually appear on screen.
+  ///
+  /// See also:
+  ///
+  ///  * [deferFirstFrame], which defers when the first frame is send to the
+  ///    engine.
+  bool get sendFramesToEngine => _firstFrameSent || _firstFrameDeferredCount == 0;
+
+  /// Tell the framework to not send the first frames to the engine until there
+  /// is a corresponding call to [allowFirstFrame].
+  ///
+  /// Call this to perform asynchronous initialisation work before the first
+  /// frame is rendered (which takes down the splash screen). The framework
+  /// will still do all the work to produce frames, but those frames are never
+  /// send to the engine and will not appear on screen.
+  ///
+  /// Calling this has no effect after the first frame has been send to the
+  /// engine.
+  void deferFirstFrame() {
+    assert(_firstFrameDeferredCount >= 0);
+    _firstFrameDeferredCount += 1;
+  }
+
+  /// Called after [deferFirstFrame] to tell the framework that it is ok to
+  /// send the first frame to the engine now.
+  ///
+  /// For best performance, this method should only be called while the
+  /// [schedulerPhase] is [SchedulerPhase.idle].
+  ///
+  /// This method may only be called once for each corresponding call
+  /// to [deferFirstFrame].
+  void allowFirstFrame() {
+    assert(_firstFrameDeferredCount > 0);
+    _firstFrameDeferredCount -= 1;
+    // Always schedule a warm up frame even if the deferral count is not down to
+    // zero yet since the removal of a deferral may uncover new deferrals that
+    // are lower in the widget tree.
+    if (!_firstFrameSent)
+      scheduleWarmUpFrame();
+  }
+
   /// Pump the rendering pipeline to generate a frame.
   ///
   /// This method is called by [handleDrawFrame], which itself is called
@@ -344,8 +391,11 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
     pipelineOwner.flushLayout();
     pipelineOwner.flushCompositingBits();
     pipelineOwner.flushPaint();
-    renderView.compositeFrame(); // this sends the bits to the GPU
-    pipelineOwner.flushSemantics(); // this also sends the semantics to the OS.
+    if (sendFramesToEngine) {
+      renderView.compositeFrame(); // this sends the bits to the GPU
+      pipelineOwner.flushSemantics(); // this also sends the semantics to the OS.
+      _firstFrameSent = true;
+    }
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -330,6 +330,15 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
       scheduleWarmUpFrame();
   }
 
+  /// Call this to pretend that no frames have been sent to the engine yet.
+  ///
+  /// This is useful for tests that want to call [deferFirstFrame] and
+  /// [allowFirstFrame] since those methods only have an effect if no frames
+  /// have been sent to the engine yet.
+  void resetFirstFrameSent() {
+    _firstFrameSent = false;
+  }
+
   /// Pump the rendering pipeline to generate a frame.
   ///
   /// This method is called by [handleDrawFrame], which itself is called

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:ui' show Locale;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
 
 import 'basic.dart';
 import 'binding.dart';
@@ -519,9 +520,9 @@ class _LocalizationsState extends State<Localizations> {
       // have finished loading. Until then the old locale will continue to be used.
       // - If we're running at app startup time then defer reporting the first
       // "useful" frame until after the async load has completed.
-      WidgetsBinding.instance.deferFirstFrameReport();
+      RendererBinding.instance.deferFirstFrame();
       typeToResourcesFuture.then<void>((Map<Type, dynamic> value) {
-        WidgetsBinding.instance.allowFirstFrameReport();
+        RendererBinding.instance.allowFirstFrame();
         if (!mounted)
           return;
         setState(() {

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -522,13 +522,13 @@ class _LocalizationsState extends State<Localizations> {
       // "useful" frame until after the async load has completed.
       RendererBinding.instance.deferFirstFrame();
       typeToResourcesFuture.then<void>((Map<Type, dynamic> value) {
+        if (mounted) {
+          setState(() {
+            _typeToResources = value;
+            _locale = locale;
+          });
+        }
         RendererBinding.instance.allowFirstFrame();
-        if (!mounted)
-          return;
-        setState(() {
-          _typeToResources = value;
-          _locale = locale;
-        });
       });
     }
   }

--- a/packages/flutter/test/widgets/binding_deferred_first_frame_test.dart
+++ b/packages/flutter/test/widgets/binding_deferred_first_frame_test.dart
@@ -1,0 +1,84 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+const String _actualContent = 'Actual Content';
+const String _loading = 'Loading...';
+
+void main() {
+  testWidgets('deferFirstFrame/allowFirstFrame stops sending frames to engine', (WidgetTester tester) async {
+    expect(RendererBinding.instance.sendFramesToEngine, isTrue);
+
+    final Completer<void> completer = Completer<void>();
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: _DeferringWidget(
+          key: UniqueKey(),
+          loader: completer.future,
+        ),
+      ),
+    );
+    final _DeferringWidgetState state = tester.state<_DeferringWidgetState>(find.byType(_DeferringWidget));
+
+    expect(find.text(_loading), findsOneWidget);
+    expect(find.text(_actualContent), findsNothing);
+    expect(RendererBinding.instance.sendFramesToEngine, isFalse);
+
+    await tester.pump();
+    expect(find.text(_loading), findsOneWidget);
+    expect(find.text(_actualContent), findsNothing);
+    expect(RendererBinding.instance.sendFramesToEngine, isFalse);
+    expect(state.doneLoading, isFalse);
+
+    // Complete the future to start sending frames.
+    completer.complete();
+    await tester.idle();
+    expect(state.doneLoading, isTrue);
+    expect(RendererBinding.instance.sendFramesToEngine, isTrue);
+
+    await tester.pump();
+    expect(find.text(_loading), findsNothing);
+    expect(find.text(_actualContent), findsOneWidget);
+    expect(RendererBinding.instance.sendFramesToEngine, isTrue);
+  });
+}
+
+class _DeferringWidget extends StatefulWidget {
+  const _DeferringWidget({Key key, this.loader}) : super(key: key);
+
+  final Future<void> loader;
+
+  @override
+  State<_DeferringWidget> createState() => _DeferringWidgetState();
+}
+
+class _DeferringWidgetState extends State<_DeferringWidget> {
+  bool doneLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    RendererBinding.instance.deferFirstFrame();
+    widget.loader.then((_) {
+      setState(() {
+        doneLoading = true;
+        RendererBinding.instance.allowFirstFrame();
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return doneLoading
+        ? const Text(_actualContent)
+        : const Text(_loading);
+  }
+}

--- a/packages/flutter/test/widgets/localizations_test.dart
+++ b/packages/flutter/test/widgets/localizations_test.dart
@@ -1,0 +1,73 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+
+void main() {
+  final TestAutomatedTestWidgetsFlutterBinding binding = TestAutomatedTestWidgetsFlutterBinding();
+
+  testWidgets('Locale is available when Localizations widget stops defering frames', (WidgetTester tester) async {
+    final FakeLocalizationsDelegate delegate = FakeLocalizationsDelegate();
+    await tester.pumpWidget(Localizations(
+      locale: const Locale('fo'),
+      delegates: <LocalizationsDelegate<dynamic>>[
+        WidgetsLocalizationsDelegate(),
+        delegate,
+      ],
+      child: const Text('loaded')
+    ));
+    final dynamic state = tester.state(find.byType(Localizations));
+    expect(state.locale, isNull);
+    expect(find.text('loaded'), findsNothing);
+
+    Locale locale;
+    binding.onAllowFrame = () {
+      locale = state.locale;
+    };
+    delegate.completer.complete('foo');
+    await tester.idle();
+    expect(locale, const Locale('fo'));
+    await tester.pump();
+    expect(find.text('loaded'), findsOneWidget);
+  });
+}
+
+class FakeLocalizationsDelegate extends LocalizationsDelegate<String> {
+  final Completer<String> completer = Completer<String>();
+
+  @override
+  bool isSupported(Locale locale) => true;
+
+  @override
+  Future<String> load(Locale locale) => completer.future;
+
+  @override
+  bool shouldReload(LocalizationsDelegate<String> old) => false;
+}
+
+class TestAutomatedTestWidgetsFlutterBinding extends AutomatedTestWidgetsFlutterBinding {
+
+  VoidCallback onAllowFrame;
+
+  @override
+  void allowFirstFrame() {
+    if (onAllowFrame != null)
+      onAllowFrame();
+    super.allowFirstFrame();
+  }
+}
+
+class WidgetsLocalizationsDelegate extends LocalizationsDelegate<WidgetsLocalizations> {
+  @override
+  bool isSupported(Locale locale) => true;
+
+  @override
+  Future<WidgetsLocalizations> load(Locale locale) => DefaultWidgetsLocalizations.load(locale);
+
+  @override
+  bool shouldReload(WidgetsLocalizationsDelegate old) => false;
+}

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -687,6 +687,9 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
 
     runApp(Container(key: UniqueKey(), child: _preTestMessage)); // Reset the tree to a known state.
     await pump();
+    // Pretend that the first frame produced in the test body is the first frame
+    // sent to the engine.
+    resetFirstFrameSent();
 
     final bool autoUpdateGoldensBeforeTest = autoUpdateGoldenFiles && !isBrowser;
     final TestExceptionReporter reportTestExceptionBeforeTest = reportTestException;
@@ -963,6 +966,31 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
     return result;
   }
 
+  int _firstFrameDeferredCount = 0;
+  bool _firstFrameSent = false;
+
+  @override
+  bool get sendFramesToEngine => _firstFrameSent || _firstFrameDeferredCount == 0;
+
+  @override
+  void deferFirstFrame() {
+    assert(_firstFrameDeferredCount >= 0);
+    _firstFrameDeferredCount += 1;
+  }
+
+  @override
+  void allowFirstFrame() {
+    assert(_firstFrameDeferredCount > 0);
+    _firstFrameDeferredCount -= 1;
+    // Unlike in RendererBinding.allowFirstFrame we do not force a frame her
+    // to give the test full control over frame scheduling.
+  }
+
+  @override
+  void resetFirstFrameSent() {
+    _firstFrameSent = false;
+  }
+
   EnginePhase _phase = EnginePhase.sendSemanticsUpdate;
 
   // Cloned from RendererBinding.drawFrame() but with early-exit semantics.
@@ -979,7 +1007,8 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
           pipelineOwner.flushCompositingBits();
           if (_phase != EnginePhase.compositingBits) {
             pipelineOwner.flushPaint();
-            if (_phase != EnginePhase.paint) {
+            if (_phase != EnginePhase.paint && sendFramesToEngine) {
+              _firstFrameSent = true;
               renderView.compositeFrame(); // this sends the bits to the GPU
               if (_phase != EnginePhase.composite) {
                 pipelineOwner.flushSemantics();


### PR DESCRIPTION
## Description

See #45135 for detailed description. In addition to that PR, this PR contains the following fixes:

* allowFirstFrame does not schedule a warmup frame in tests.
* The localizations widget stops deferring frames only after it has processed the data it was waiting for.

## Related Issues

None

## Tests

I added the following tests:

Tests from #45135 plus new 2 tests for the new fixes.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (Please read [Handling breaking changes]): https://groups.google.com/forum/#!topic/flutter-announce/kBf4cXjD2y4
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
