### PR TITLE
Example of flutter_tool binding experiment

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'runner.dart' as runner;
+import 'src/base/binding.dart';
 import 'src/base/context.dart';
 // The build_runner code generation is provided here to make it easier to
 // avoid introducing the dependency into google3. Not all build* packages
@@ -49,6 +50,13 @@ import 'src/runner/flutter_command.dart';
 import 'src/web/compile.dart';
 import 'src/web/web_runner.dart';
 
+class _FlutterBindings extends Object with BindingBase {
+  _FlutterBindings(this.verbose);
+
+  @override
+  final bool verbose;
+}
+
 /// Main entry point for commands.
 ///
 /// This function is intended to be used from the `flutter` command line tool.
@@ -61,6 +69,8 @@ Future<void> main(List<String> args) async {
       (args.isNotEmpty && args.first == 'help') || (args.length == 1 && verbose);
   final bool muteCommandLogging = help || doctor;
   final bool verboseHelp = help && verbose;
+
+  _FlutterBindings(verbose).initializeBinding();
 
   await runner.run(args, <FlutterCommand>[
     AnalyzeCommand(verboseHelp: verboseHelp),

--- a/packages/flutter_tools/lib/src/base/binding.dart
+++ b/packages/flutter_tools/lib/src/base/binding.dart
@@ -1,0 +1,52 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:meta/meta.dart';
+
+import 'logger.dart';
+import 'platform.dart';
+import 'terminal.dart';
+
+/// The base binding which provides shared dependencies for the rest of the
+/// tool.
+mixin BindingBase {
+  /// Retreive the current [BindingBase] instance.
+  ///
+  /// This will be null if it was never initialized.
+  static BindingBase instance;
+
+  /// Whether the tool is being run in verbose mode.
+  bool get verbose;
+
+  /// The platform the tool is running under.
+  Platform get platform => const LocalPlatform();
+
+  @mustCallSuper
+  void initializeBinding() {
+    instance = this;
+  }
+
+  // Logging APIs
+
+  /// The output preferences for the arg results and logger.
+  OutputPreferences get outputPreferences => OutputPreferences();
+
+  /// The logger instance.
+  Logger get logger => _logger ??= _createLogger();
+  Logger _logger;
+  Logger _createLogger() {
+    Logger logger = platform.isWindows ? WindowsStdoutLogger() : StdoutLogger();
+    if (verbose) {
+      logger = VerboseLogger(logger, createStopwatch());
+    }
+    return logger;
+  }
+
+  // Time APIs
+
+  /// Create a new [Stopwatch] instance.
+  Stopwatch createStopwatch() {
+    return Stopwatch();
+  }
+}

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -356,13 +356,12 @@ class BufferLogger extends Logger {
 }
 
 class VerboseLogger extends Logger {
-  VerboseLogger(this.parent) : assert(terminal != null) {
+  VerboseLogger(this.parent, this._stopwatch) : assert(terminal != null) {
     _stopwatch.start();
   }
 
   final Logger parent;
-
-  final Stopwatch _stopwatch = context.get<Stopwatch>() ?? Stopwatch();
+  final Stopwatch _stopwatch;
 
   @override
   bool get isVerbose => true;

--- a/packages/flutter_tools/lib/src/base/platform.dart
+++ b/packages/flutter_tools/lib/src/base/platform.dart
@@ -4,6 +4,7 @@
 
 import 'package:platform/platform.dart';
 
+import 'binding.dart';
 import 'context.dart';
 import 'file_system.dart';
 
@@ -12,7 +13,8 @@ export 'package:platform/platform.dart';
 const Platform _kLocalPlatform = LocalPlatform();
 const String _kRecordingType = 'platform';
 
-Platform get platform => context.get<Platform>() ?? _kLocalPlatform;
+Platform get platform => BindingBase.instance?.platform ??
+  context.get<Platform>() ?? _kLocalPlatform;
 
 /// Serializes the current [platform] to the specified base recording
 /// [location].

--- a/packages/flutter_tools/lib/src/base/terminal.dart
+++ b/packages/flutter_tools/lib/src/base/terminal.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import '../convert.dart';
 import '../globals.dart';
+import 'binding.dart';
 import 'context.dart';
 import 'io.dart' as io;
 import 'platform.dart';
@@ -37,7 +38,9 @@ String get successMark {
 final AnsiTerminal _defaultAnsiTerminal = AnsiTerminal();
 
 OutputPreferences get outputPreferences {
-  return context?.get<OutputPreferences>() ?? _defaultOutputPreferences;
+  return BindingBase.instance?.outputPreferences ??
+    context?.get<OutputPreferences>() ??
+    _defaultOutputPreferences;
 }
 final OutputPreferences _defaultOutputPreferences = OutputPreferences();
 

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -3,13 +3,14 @@
 // found in the LICENSE file.
 
 import 'artifacts.dart';
+import 'base/binding.dart';
 import 'base/config.dart';
 import 'base/context.dart';
 import 'base/logger.dart';
 import 'base/terminal.dart';
 import 'cache.dart';
 
-Logger get logger => context.get<Logger>();
+Logger get logger => BindingBase.instance?.logger ?? context.get<Logger>();
 Cache get cache => Cache.instance;
 Config get config => Config.instance;
 Artifacts get artifacts => Artifacts.instance;

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -257,7 +257,7 @@ class FlutterCommandRunner extends CommandRunner<void> {
     // Check for verbose.
     if (topLevelResults['verbose'] as bool) {
       // Override the logger.
-      contextOverrides[Logger] = VerboseLogger(logger);
+      contextOverrides[Logger] = VerboseLogger(logger, Stopwatch());
     }
 
     // Don't set wrapColumns unless the user said to: if it's set, then all

--- a/packages/flutter_tools/test/general.shard/base/logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/logger_test.dart
@@ -24,52 +24,6 @@ final String resetBold = RegExp.escape(AnsiTerminal.resetBold);
 final String resetColor = RegExp.escape(AnsiTerminal.resetColor);
 
 void main() {
-  test('AppContext error', () async {
-    final BufferLogger mockLogger = BufferLogger();
-    final VerboseLogger verboseLogger = VerboseLogger(mockLogger, FakeStopwatch());
-    TestBindings(
-      verbose: true,
-      logger: verboseLogger,
-      platform: _noAnsiPlatform,
-      outputPreferences: OutputPreferences(showColor: false),
-    ).initializeBinding();
-
-    verboseLogger.printStatus('Hey Hey Hey Hey');
-    verboseLogger.printTrace('Oooh, I do I do I do');
-    verboseLogger.printError('Helpless!');
-
-    expect(mockLogger.statusText, matches(r'^\[ (?: {0,2}\+[0-9]{1,4} ms|       )\] Hey Hey Hey Hey\n'
-                                            r'\[ (?: {0,2}\+[0-9]{1,4} ms|       )\] Oooh, I do I do I do\n$'));
-    expect(mockLogger.traceText, '');
-    expect(mockLogger.errorText, matches( r'^\[ (?: {0,2}\+[0-9]{1,4} ms|       )\] Helpless!\n$'));
-  });
-
-  test('AppContext ANSI colored errors', () {
-    final BufferLogger mockLogger = BufferLogger();
-    final VerboseLogger verboseLogger = VerboseLogger(mockLogger, FakeStopwatch());
-    TestBindings(
-      verbose: true,
-      logger: verboseLogger,
-      outputPreferences: OutputPreferences(showColor: true),
-      platform: FakePlatform()..stdoutSupportsAnsi = true
-    ).initializeBinding();
-
-    verboseLogger.printStatus('Hey Hey Hey Hey');
-    verboseLogger.printTrace('Oooh, I do I do I do');
-    verboseLogger.printError('Helpless!');
-
-    expect(
-      mockLogger.statusText,
-      matches(r'^\[ (?: {0,2}\+[0-9]{1,4} ms|       )\] '
-        '${bold}Hey Hey Hey Hey$resetBold'
-        r'\n\[ (?: {0,2}\+[0-9]{1,4} ms|       )\] Oooh, I do I do I do\n$'));
-    expect(mockLogger.traceText, '');
-    expect(
-      mockLogger.errorText,
-      matches('^$red' r'\[ (?: {0,2}\+[0-9]{1,4} ms|       )\] '
-        '${bold}Helpless!$resetBold$resetColor' r'\n$'));
-  });
-
   group('Spinners', () {
     MockStdio mockStdio;
     FakeStopwatch mockStopwatch;
@@ -712,6 +666,52 @@ void main() {
       Logger: () => BufferLogger(),
       Platform: _kNoAnsiPlatform,
     });
+  });
+
+  test('AppContext error', () async {
+    final BufferLogger mockLogger = BufferLogger();
+    final VerboseLogger verboseLogger = VerboseLogger(mockLogger, FakeStopwatch());
+    TestBindings(
+      verbose: true,
+      logger: verboseLogger,
+      platform: _noAnsiPlatform,
+      outputPreferences: OutputPreferences(showColor: false),
+    ).initializeBinding();
+
+    verboseLogger.printStatus('Hey Hey Hey Hey');
+    verboseLogger.printTrace('Oooh, I do I do I do');
+    verboseLogger.printError('Helpless!');
+
+    expect(mockLogger.statusText, matches(r'^\[ (?: {0,2}\+[0-9]{1,4} ms|       )\] Hey Hey Hey Hey\n'
+                                            r'\[ (?: {0,2}\+[0-9]{1,4} ms|       )\] Oooh, I do I do I do\n$'));
+    expect(mockLogger.traceText, '');
+    expect(mockLogger.errorText, matches( r'^\[ (?: {0,2}\+[0-9]{1,4} ms|       )\] Helpless!\n$'));
+  });
+
+  test('AppContext ANSI colored errors', () {
+    final BufferLogger mockLogger = BufferLogger();
+    final VerboseLogger verboseLogger = VerboseLogger(mockLogger, FakeStopwatch());
+    TestBindings(
+      verbose: true,
+      logger: verboseLogger,
+      outputPreferences: OutputPreferences(showColor: true),
+      platform: FakePlatform()..stdoutSupportsAnsi = true
+    ).initializeBinding();
+
+    verboseLogger.printStatus('Hey Hey Hey Hey');
+    verboseLogger.printTrace('Oooh, I do I do I do');
+    verboseLogger.printError('Helpless!');
+
+    expect(
+      mockLogger.statusText,
+      matches(r'^\[ (?: {0,2}\+[0-9]{1,4} ms|       )\] '
+        '${bold}Hey Hey Hey Hey$resetBold'
+        r'\n\[ (?: {0,2}\+[0-9]{1,4} ms|       )\] Oooh, I do I do I do\n$'));
+    expect(mockLogger.traceText, '');
+    expect(
+      mockLogger.errorText,
+      matches('^$red' r'\[ (?: {0,2}\+[0-9]{1,4} ms|       )\] '
+        '${bold}Helpless!$resetBold$resetColor' r'\n$'));
   });
 }
 

--- a/packages/flutter_tools/test/src/test_bindings.dart
+++ b/packages/flutter_tools/test/src/test_bindings.dart
@@ -1,0 +1,40 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tools/src/base/binding.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/terminal.dart';
+
+class TestBindings extends Object with BindingBase {
+  TestBindings({
+    this.verbose = false,
+    Platform platform,
+    Logger logger,
+    OutputPreferences outputPreferences,
+    Stopwatch stopwatch,
+  })  : _platform = platform,
+        logger = logger ?? BufferLogger(),
+        outputPreferences = outputPreferences ?? OutputPreferences.test(),
+        _stopwatch = stopwatch;
+
+  @override
+  final OutputPreferences outputPreferences;
+
+  @override
+  final bool verbose;
+
+  @override
+  Platform get platform => _platform ?? super.platform;
+  final Platform _platform;
+
+  @override
+  final Logger logger;
+
+  @override
+  Stopwatch createStopwatch() {
+    return _stopwatch ?? super.createStopwatch();
+  }
+  final Stopwatch _stopwatch;
+}


### PR DESCRIPTION
## Description

The flutter tool currently uses a Zone-based ~dependency injection~ service locator system to provide services, partially to allow the google3 client to override some configuration and partially to allow testing via mocks and fakes. This PR proposes the beginning of a migration to `mixin Binding` based dependency injection system, based on the Flutter framework bindings.

### There are a number of problems with out current usage of the Zone based system.

1. It encourages usage of globals instead of constructor parameters. For example, instead of `wrapText` taking an optional parameter describing the max columns, it reads this value off of `outputPreferences` in the zone. I believe this is generally a worse API design, as it makes dependencies implicit instead of explicit.

2. As a consequence of 1), in order to test this functionality it isn't enough to provide difference values of wrap text, a new Zone handler must be setup. This requires a significant amount of plumbing.

Neither of these issues are unique to a Zone based system, the bindings can have the same issue. However, it is much easier to use globals in the Zone system since there is to typed object that can be accessed.

### The benefits of the Zone based system:

3. Zones can be nested, allowing the system to support multiple scopes of DI. Thus, some child context can override something like the Logger in order to change functionality. In practice, this is only used in a handful of places such as https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/runner.dart#L204. However if we resolved (1), then this could be accomplished by constructing new instances as needed.

### What does the binding do?

The bindings are there to both access to an instance and to construct classes without knowing all of their dependencies. For example, consider the classes below:

```
class A {
  A(this.b);

  final B b;
}

class B {
  B(this.c);
  
  final C c;
}

class C { }
```

Without a DI system, we need to construct A like:

```
A(B(C()));
```

With the binding base, we can create getters that automatically instantiate B and C:

```
class Binding {
  B get b => B(c);
 
  C get c => C();
}

...
A(Binding.instance.b);
```

However, we can still choose to construct B "normally", or to override functionality at the binding level.

### How is this different than the Zone based system?

Essentially it is equivalent, except we've replaced callbacks with methods, and a global Map with one or more classes. As a consequence of it being typed and supporting getters/setters/methods, it should be easier to follow best practices. Also, reducing zones is independently a good thing, as their behavior is generally confusing.

#### Functionality similar:

```
runZoned(..., overrides: <Type, Generator>{
A: () => A(),
B: () => B(),
});

...

class BindingBase {
  A get a => A();

  B get b => ();
}
```

The difference appears when you have dependencies, the latter is much easier to write:

```
runZoned(..., overrides: <Type, Generator>{
A: () => A(context.get<B>()),
B: () => B(),
});
...

class BindingBase {
  A get a => A(b);

  B get b => ();
}
```

### What changed in this PR?

I put together a minimal BindingBase, which contains enough code to support a few of the logger_test instances. Note that these no longer require TestBed or testUsingContext. For backwards compatibility, the global getters like `logger` and `outputConfiguration` redirect to the BindingBase and fall back to the context. We might want to split it up further with a LoggingBinding, and PlatformBinding, et cetera. We should be able to split off a new binding class easily, ensure this can be done with the final API.