### PR TITLE
implicit-casts:false in flutter/lib/src/physics

### DIFF
--- a/packages/flutter/lib/src/physics/clamped_simulation.dart
+++ b/packages/flutter/lib/src/physics/clamped_simulation.dart
@@ -48,10 +48,10 @@ class ClampedSimulation extends Simulation {
   final double dxMax;
 
   @override
-  double x(double time) => simulation.x(time).clamp(xMin, xMax);
+  double x(double time) => simulation.x(time).clamp(xMin, xMax) as double;
 
   @override
-  double dx(double time) => simulation.dx(time).clamp(dxMin, dxMax);
+  double dx(double time) => simulation.dx(time).clamp(dxMin, dxMax) as double;
 
   @override
   bool isDone(double time) => simulation.isDone(time);

--- a/packages/flutter/lib/src/physics/friction_simulation.dart
+++ b/packages/flutter/lib/src/physics/friction_simulation.dart
@@ -65,7 +65,7 @@ class FrictionSimulation extends Simulation {
   // Solving for D given x(time) is trickier. Algebra courtesy of Wolfram Alpha:
   // x1 = x0 + (v0 * D^((log(v1) - log(v0)) / log(D))) / log(D) - v0 / log(D), find D
   static double _dragFor(double startPosition, double endPosition, double startVelocity, double endVelocity) {
-    return math.pow(math.e, (startVelocity - endVelocity) / (startPosition - endPosition));
+    return math.pow(math.e, (startVelocity - endVelocity) / (startPosition - endPosition)) as double;
   }
 
   @override
@@ -116,7 +116,7 @@ class BoundedFrictionSimulation extends FrictionSimulation {
 
   @override
   double x(double time) {
-    return super.x(time).clamp(_minX, _maxX);
+    return super.x(time).clamp(_minX, _maxX) as double;
   }
 
   @override

--- a/packages/flutter/lib/src/physics/spring_simulation.dart
+++ b/packages/flutter/lib/src/physics/spring_simulation.dart
@@ -196,7 +196,7 @@ class _CriticalSolution implements _SpringSolution {
 
   @override
   double dx(double time) {
-    final double power = math.pow(math.e, _r * time);
+    final double power = math.pow(math.e, _r * time) as double;
     return _r * (_c1 + _c2 * time) * power + _c2 * power;
   }
 
@@ -266,13 +266,13 @@ class _UnderdampedSolution implements _SpringSolution {
 
   @override
   double x(double time) {
-    return math.pow(math.e, _r * time) *
+    return (math.pow(math.e, _r * time) as double) *
            (_c1 * math.cos(_w * time) + _c2 * math.sin(_w * time));
   }
 
   @override
   double dx(double time) {
-    final double power = math.pow(math.e, _r * time);
+    final double power = math.pow(math.e, _r * time) as double;
     final double cosine = math.cos(_w * time);
     final double sine = math.sin(_w * time);
     return      power * (_c2 * _w * cosine - _c1 * _w * sine) +


### PR DESCRIPTION
## Description

Enable `implicit-casts:false` in `flutter/lib/src/physics`

## Related Issues

None

## Tests

None because it's a refactoring.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
