### PR TITLE
Refactor RenderSliverFillRemaining

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_fill.dart
+++ b/packages/flutter/lib/src/rendering/sliver_fill.dart
@@ -178,10 +178,10 @@ class RenderSliverFillRemaining extends RenderSliverSingleBoxAdapter {
     }
 
     assert(childExtent.isFinite,
-    'The calculated extent for the child of SliverFillRemaining is not finite.'
-        'This can happen if the child is a scrollable, in which case, the'
-        'hasScrollBody property of SliverFillRemaining should not be set to'
-        'false.',
+      'The calculated extent for the child of SliverFillRemaining is not finite.'
+      'This can happen if the child is a scrollable, in which case, the'
+      'hasScrollBody property of SliverFillRemaining should not be set to'
+      'false.',
     );
     final double paintedChildSize = calculatePaintOffset(constraints, from: 0.0, to: childExtent);
     assert(paintedChildSize.isFinite);


### PR DESCRIPTION
## Description

Ian noticed that we can implement RenderSliverFillRemaining without double layout and without using intrinsic sizes. 

## Related Issues

https://github.com/flutter/flutter/pull/44471

## Tests

I added the following tests:

None, just internal refactoring.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
