### PR TITLE
Add variant testing to testWidgets

### DIFF
--- a/packages/flutter/test/services/system_chrome_test.dart
+++ b/packages/flutter/test/services/system_chrome_test.dart
@@ -9,8 +9,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('SystemChrome overlay style test', (WidgetTester tester) async {
-    await tester.idle(); // Flush any outstanding microtasks.
-
     // The first call is a cache miss and will queue a microtask
     SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle.light);
     expect(tester.binding.microtaskCount, equals(1));

--- a/packages/flutter/test/services/system_chrome_test.dart
+++ b/packages/flutter/test/services/system_chrome_test.dart
@@ -9,6 +9,8 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('SystemChrome overlay style test', (WidgetTester tester) async {
+    await tester.idle(); // Flush any outstanding microtasks.
+
     // The first call is a cache miss and will queue a microtask
     SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle.light);
     expect(tester.binding.microtaskCount, equals(1));

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -85,8 +85,8 @@ typedef WidgetTesterCallback = Future<void> Function(WidgetTester widgetTester);
 /// provides convenient widget [Finder]s for use with the
 /// [WidgetTester].
 ///
-/// When the [variants] argument is set, [testWidgets] will run one test for
-/// each value of each variant in [variants]. If [variants] is empty, the test
+/// When the [variant] argument is set, [testWidgets] will run the test once for
+/// each value of the [TestVariant.values]. If [variant] is not set, the test
 /// will be run once using the base test environment.
 ///
 /// See also:

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -84,6 +85,10 @@ typedef WidgetTesterCallback = Future<void> Function(WidgetTester widgetTester);
 /// provides convenient widget [Finder]s for use with the
 /// [WidgetTester].
 ///
+/// Will define one [testWidgets] test for each platform in [matrix]. If
+/// [matrix] is empty, the test will be run once in the default test
+/// environment.
+///
 /// See also:
 ///
 ///  * [AutomatedTestWidgetsFlutterBinding.addTime] to learn more about
@@ -100,39 +105,142 @@ typedef WidgetTesterCallback = Future<void> Function(WidgetTester widgetTester);
 /// ```
 @isTest
 void testWidgets(
-  String description,
-  WidgetTesterCallback callback, {
-  bool skip = false,
-  test_package.Timeout timeout,
-  Duration initialTimeout,
-  bool semanticsEnabled = true,
-}) {
+    String description,
+    WidgetTesterCallback callback, {
+      bool skip = false,
+      test_package.Timeout timeout,
+      Duration initialTimeout,
+      bool semanticsEnabled = true,
+      Iterable<TestDimension<dynamic>> matrix = const <TestDimension<dynamic>>[],
+    }) {
   final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized() as TestWidgetsFlutterBinding;
   final WidgetTester tester = WidgetTester._(binding);
-  test(
-    description,
-    () {
-      SemanticsHandle semanticsHandle;
-      if (semanticsEnabled == true) {
-        semanticsHandle = tester.ensureSemantics();
-      }
-      tester._recordNumberOfSemanticsHandles();
-      test_package.addTearDown(binding.postTest);
-      return binding.runTest(
-        () async {
-          debugResetSemanticsIdCounter();
-          tester.resetTestTextInput();
-          await callback(tester);
-          semanticsHandle?.dispose();
-        },
-        tester._endOfTestVerifications,
-        description: description ?? '',
-        timeout: initialTimeout,
+  if (matrix == null || matrix.isEmpty) {
+    matrix = <DefaultDimension>[DefaultDimension()];
+  }
+  for (TestDimension<dynamic> dimension in matrix) {
+    for (dynamic variation in dimension.variations) {
+      final String variationDescription = dimension.describeVariation(variation);
+      final String combinedDescription = variationDescription.isNotEmpty ? '$description ($variationDescription)' : description;
+      test(combinedDescription, () {
+        SemanticsHandle semanticsHandle;
+        if (semanticsEnabled == true) {
+          semanticsHandle = tester.ensureSemantics();
+        }
+        tester._recordNumberOfSemanticsHandles();
+        test_package.addTearDown(binding.postTest);
+        return binding.runTest(
+              () async {
+            debugResetSemanticsIdCounter();
+            tester.resetTestTextInput();
+            try {
+              dimension.setUp(variation);
+              await callback(tester);
+            } catch (e) {
+              debugPrint('══╡ EXCEPTION with $variationDescription ╞════════════════════════════════════════════════════');
+              rethrow;
+            } finally {
+              dimension.tearDown(variation);
+            }
+            semanticsHandle?.dispose();
+          },
+          tester._endOfTestVerifications,
+          description: description ?? '',
+          timeout: initialTimeout,
+        );
+      },
+        skip: skip,
+        timeout: timeout ?? binding.defaultTestTimeout,
       );
-    },
-    skip: skip,
-    timeout: timeout ?? binding.defaultTestTimeout,
-  );
+    }
+  }
+}
+
+/// An abstract base class for describing test environment variations.
+///
+/// These serve as elements of the `matrix` argument to [testWidgets].
+///
+/// Use care when adding dimensions to the testing matrix: it multiplies the
+/// number of tests run, which can drastically increase the time it takes to run
+/// all the tests.
+abstract class TestDimension<T> {
+  /// A const constructor so that subclasses can be const.
+  const TestDimension();
+
+  /// Returns an iterable of the variations that this test dimension represents.
+  ///
+  /// The variations returned should be unique so that the same variation isn't
+  /// needlessly run twice.
+  Iterable<T> get variations;
+
+  /// Returns the string that will be used to both add to the test description, and
+  /// be printed when a test fails for this variation.
+  String describeVariation(T variation);
+
+  /// A function that will be called before each variation is tested, with the
+  /// variation that will be tested.
+  ///
+  /// This function should preserve any state needed to restore the testing
+  /// environment back to its base state when [tearDown] is called.
+  Future<void> setUp(T variation);
+
+  /// A function that is guaranteed to be called after this variation is tested,
+  /// even if it throws an exception.
+  ///
+  /// Calling this function must return the testing environment back to the base
+  /// state it was in before [setUp] was called.
+  Future<void> tearDown(T variation);
+}
+
+/// The [TestDimension] that represents the "default" test that is run if no
+/// `matrix` is specified for [testWidgets].
+///
+/// This dimension can be added into a list of other test dimensions to provide
+/// a "control" test where nothing is changed from the base test environment.
+class DefaultDimension extends TestDimension<dynamic> {
+  @override
+  final Iterable<dynamic> variations = <String>['default'];
+
+  @override
+  String describeVariation(dynamic variation) => '';
+
+  @override
+  Future<void> setUp(dynamic variation) async {}
+
+  @override
+  Future<void> tearDown(dynamic variation) async {}
+}
+
+/// A [TestDimension] that runs tests with [debugDefaultTargetPlatformOverride]
+/// set to different values of [TargetPlatform].
+class TargetPlatformDimension extends TestDimension<TargetPlatform> {
+  /// Creates a [TargetPlatformDimension] that tests the given [variations].
+  TargetPlatformDimension(this.variations)
+    : assert(variations.toSet().length == variations.length,
+             'There were ${variations.length - variations.toSet().length} platforms '
+             'that were specified more than once. Each platform may only be tested once.');
+
+  // Stores the target platform that was set when setUp was called.
+  TargetPlatform _previousTargetPlatform;
+
+  @override
+  final Iterable<TargetPlatform> variations;
+
+  @override
+  String describeVariation(TargetPlatform variation) => 'TargetPlatform ${describeEnum(variation)}';
+
+  @override
+  Future<void> setUp(TargetPlatform variation) async {
+    assert(_previousTargetPlatform == null);
+    _previousTargetPlatform = debugDefaultTargetPlatformOverride;
+    debugDefaultTargetPlatformOverride = variation;
+  }
+
+  @override
+  Future<void> tearDown(TargetPlatform variation) async {
+    debugDefaultTargetPlatformOverride = _previousTargetPlatform;
+    _previousTargetPlatform = null;
+  }
 }
 
 /// Runs the [callback] inside the Flutter benchmark environment.

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -218,19 +218,18 @@ class DefaultTestVariant extends TestVariant<void> {
 /// set to different values of [TargetPlatform].
 class TargetPlatformVariant extends TestVariant<TargetPlatform> {
   /// Creates a [TargetPlatformVariant] that tests the given [values].
-  TargetPlatformVariant(this.values)
-    : assert(values.toSet().length == values.length, 'Each platform may only be tested once.');
+  const TargetPlatformVariant(this.values);
 
   /// Creates a [TargetPlatformVariant] that tests all values from
   /// the [TargetPlatform] enum.
-  TargetPlatformVariant.all() : values = TargetPlatform.values;
+  TargetPlatformVariant.all() : values = TargetPlatform.values.toSet();
 
   /// Creates a [TargetPlatformVariant] that tests only the given value of
   /// [TargetPlatform].
-  TargetPlatformVariant.only(TargetPlatform platform) : values = <TargetPlatform>[platform];
+  TargetPlatformVariant.only(TargetPlatform platform) : values = <TargetPlatform>{platform};
 
   @override
-  final Iterable<TargetPlatform> values;
+  final Set<TargetPlatform> values;
 
   @override
   String describeValue(TargetPlatform value) => value.toString();

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -111,17 +111,18 @@ void testWidgets(
   test_package.Timeout timeout,
   Duration initialTimeout,
   bool semanticsEnabled = true,
-  Iterable<TestVariant<Object>> variants = const <DefaultTestVariant>[ DefaultTestVariant() ],
+  TestVariant<Object> variant = const DefaultTestVariant(),
 }) {
-  assert(variants != null);
-  assert(variants.isNotEmpty, 'There must be at least on variant in the testing variants');
+  assert(variant != null);
+  assert(variant.values.isNotEmpty, 'There must be at least on value to test in the testing variant');
   final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized() as TestWidgetsFlutterBinding;
   final WidgetTester tester = WidgetTester._(binding);
-  for (TestVariant<Object> variant in variants) {
-    for (dynamic value in variant.values) {
-      final String variationDescription = variant.describeValue(value);
-      final String combinedDescription = variationDescription.isNotEmpty ? '$description ($variationDescription)' : description;
-      test(combinedDescription, () {
+  for (dynamic value in variant.values) {
+    final String variationDescription = variant.describeValue(value);
+    final String combinedDescription = variationDescription.isNotEmpty ? '$description ($variationDescription)' : description;
+    test(
+      combinedDescription,
+      () {
         tester._testDescription = combinedDescription;
         SemanticsHandle semanticsHandle;
         if (semanticsEnabled == true) {
@@ -146,10 +147,10 @@ void testWidgets(
           description: combinedDescription ?? '',
           timeout: initialTimeout,
         );
-      }, skip: skip,
-         timeout: timeout ?? binding.defaultTestTimeout,
-      );
-    }
+      },
+      skip: skip,
+      timeout: timeout ?? binding.defaultTestTimeout,
+    );
   }
 }
 

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -668,49 +668,88 @@ void main() {
   });
 
   testWidgets('verifyTickersWereDisposed control test', (WidgetTester tester) async {
-      FlutterError error;
-      final Ticker ticker = tester.createTicker((Duration duration) {});
-      ticker.start();
-      try {
-        tester.verifyTickersWereDisposed('');
-      } on FlutterError catch (e) {
-        error = e;
-      } finally {
-        expect(error, isNotNull);
-        expect(error.diagnostics.length, 4);
-        expect(error.diagnostics[2].level, DiagnosticLevel.hint);
-        expect(
-          error.diagnostics[2].toStringDeep(),
-          'Tickers used by AnimationControllers should be disposed by\n'
-          'calling dispose() on the AnimationController itself. Otherwise,\n'
-          'the ticker will leak.\n',
-        );
-        expect(error.diagnostics.last, isInstanceOf<DiagnosticsProperty<Ticker>>());
-        expect(error.diagnostics.last.value, ticker);
-        expect(error.toStringDeep(), startsWith(
-          'FlutterError\n'
-          '   A Ticker was active .\n'
-          '   All Tickers must be disposed.\n'
-          '   Tickers used by AnimationControllers should be disposed by\n'
-          '   calling dispose() on the AnimationController itself. Otherwise,\n'
-          '   the ticker will leak.\n'
-          '   The offending ticker was:\n'
-          '     _TestTicker()\n',
-        ));
-      }
-      ticker.stop();
+    FlutterError error;
+    final Ticker ticker = tester.createTicker((Duration duration) {});
+    ticker.start();
+    try {
+      tester.verifyTickersWereDisposed('');
+    } on FlutterError catch (e) {
+      error = e;
+    } finally {
+      expect(error, isNotNull);
+      expect(error.diagnostics.length, 4);
+      expect(error.diagnostics[2].level, DiagnosticLevel.hint);
+      expect(
+        error.diagnostics[2].toStringDeep(),
+        'Tickers used by AnimationControllers should be disposed by\n'
+        'calling dispose() on the AnimationController itself. Otherwise,\n'
+        'the ticker will leak.\n',
+      );
+      expect(error.diagnostics.last, isInstanceOf<DiagnosticsProperty<Ticker>>());
+      expect(error.diagnostics.last.value, ticker);
+      expect(error.toStringDeep(), startsWith(
+        'FlutterError\n'
+        '   A Ticker was active .\n'
+        '   All Tickers must be disposed.\n'
+        '   Tickers used by AnimationControllers should be disposed by\n'
+        '   calling dispose() on the AnimationController itself. Otherwise,\n'
+        '   the ticker will leak.\n'
+        '   The offending ticker was:\n'
+        '     _TestTicker()\n',
+      ));
+    }
+    ticker.stop();
   });
 
-  group('testWidgets matrix works', () {
+  group('testWidgets variants work', () {
     int numberOfVariationsRun = 0;
 
-    testWidgets('matrix tests run all variations', (WidgetTester tester) async {
+    testWidgets('variant tests run all values', (WidgetTester tester) async {
       if (debugDefaultTargetPlatformOverride == null) {
         expect(numberOfVariationsRun, equals(TargetPlatform.values.length));
       } else {
         numberOfVariationsRun += 1;
       }
-    }, matrix: <TestDimension<dynamic>>[ TargetPlatformDimension(TargetPlatform.values), DefaultDimension() ]);
+    }, variants: <TestVariant<dynamic>>[ TargetPlatformVariant(TargetPlatform.values), const DefaultTestVariant() ]);
+
+    testWidgets('variant tests have descriptions with details', (WidgetTester tester) async {
+      if (debugDefaultTargetPlatformOverride == null) {
+        expect(tester.testDescription, equals('variant tests have descriptions with details'));
+      } else {
+        expect(tester.testDescription, equals('variant tests have descriptions with details ($debugDefaultTargetPlatformOverride)'));
+      }
+    }, variants: <TestVariant<dynamic>>[ TargetPlatformVariant(TargetPlatform.values), const DefaultTestVariant() ]);
+  });
+
+  group('TargetPlatformVariant', () {
+    int numberOfVariationsRun = 0;
+    TargetPlatform origTargetPlatform;
+
+    setUpAll((){
+      origTargetPlatform = debugDefaultTargetPlatformOverride;
+    });
+
+    tearDownAll((){
+      expect(debugDefaultTargetPlatformOverride, equals(origTargetPlatform));
+    });
+
+    testWidgets('TargetPlatformVariant tests return debugDefaultTargetPlatformOverride to original value', (WidgetTester tester) async {
+      expect(debugDefaultTargetPlatformOverride, equals(TargetPlatform.iOS));
+      expect(defaultTargetPlatform, equals(TargetPlatform.iOS));
+    }, variants: <TestVariant<dynamic>>[ TargetPlatformVariant(<TargetPlatform> [ TargetPlatform.iOS ]) ]);
+
+    testWidgets('TargetPlatformVariant.only tests given value', (WidgetTester tester) async {
+      expect(debugDefaultTargetPlatformOverride, equals(TargetPlatform.iOS));
+      expect(defaultTargetPlatform, equals(TargetPlatform.iOS));
+    }, variants: <TestVariant<dynamic>>[ TargetPlatformVariant.only(TargetPlatform.iOS) ]);
+
+    testWidgets('TargetPlatformVariant.all tests run all variants', (WidgetTester tester) async {
+      if (debugDefaultTargetPlatformOverride == null) {
+        expect(numberOfVariationsRun, equals(TargetPlatform.values.length));
+      } else {
+        numberOfVariationsRun += 1;
+      }
+    }, variants: <TestVariant<dynamic>>[ TargetPlatformVariant.all(), const DefaultTestVariant() ]);
   });
 
 }

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -710,7 +710,7 @@ void main() {
       } else {
         numberOfVariationsRun += 1;
       }
-    }, variants: <TestVariant<dynamic>>[ TargetPlatformVariant.all(), const DefaultTestVariant() ]);
+    }, variant: TargetPlatformVariant(TargetPlatform.values.toSet()));
 
     testWidgets('variant tests have descriptions with details', (WidgetTester tester) async {
       if (debugDefaultTargetPlatformOverride == null) {
@@ -718,7 +718,7 @@ void main() {
       } else {
         expect(tester.testDescription, equals('variant tests have descriptions with details ($debugDefaultTargetPlatformOverride)'));
       }
-    }, variants: <TestVariant<dynamic>>[ TargetPlatformVariant.all(), const DefaultTestVariant() ]);
+    }, variant: TargetPlatformVariant(TargetPlatform.values.toSet()));
   });
 
   group('TargetPlatformVariant', () {
@@ -736,7 +736,7 @@ void main() {
     testWidgets('TargetPlatformVariant.only tests given value', (WidgetTester tester) async {
       expect(debugDefaultTargetPlatformOverride, equals(TargetPlatform.iOS));
       expect(defaultTargetPlatform, equals(TargetPlatform.iOS));
-    }, variants: <TestVariant<dynamic>>[ TargetPlatformVariant.only(TargetPlatform.iOS) ]);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
     testWidgets('TargetPlatformVariant.all tests run all variants', (WidgetTester tester) async {
       if (debugDefaultTargetPlatformOverride == null) {
@@ -744,7 +744,7 @@ void main() {
       } else {
         numberOfVariationsRun += 1;
       }
-    }, variants: <TestVariant<dynamic>>[ TargetPlatformVariant.all(), const DefaultTestVariant() ]);
+    }, variant: TargetPlatformVariant.all());
   });
 
 }

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:ui';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -665,6 +666,7 @@ void main() {
     await tester.showKeyboard(find.byType(TextField));
     await tester.pump();
   });
+
   testWidgets('verifyTickersWereDisposed control test', (WidgetTester tester) async {
       FlutterError error;
       final Ticker ticker = tester.createTicker((Duration duration) {});
@@ -697,6 +699,18 @@ void main() {
         ));
       }
       ticker.stop();
+  });
+
+  group('testWidgets matrix works', () {
+    int numberOfVariationsRun = 0;
+
+    testWidgets('matrix tests run all variations', (WidgetTester tester) async {
+      if (debugDefaultTargetPlatformOverride == null) {
+        expect(numberOfVariationsRun, equals(TargetPlatform.values.length));
+      } else {
+        numberOfVariationsRun += 1;
+      }
+    }, matrix: <TestDimension<dynamic>>[ TargetPlatformDimension(TargetPlatform.values), DefaultDimension() ]);
   });
 
 }

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -704,13 +704,13 @@ void main() {
   group('testWidgets variants work', () {
     int numberOfVariationsRun = 0;
 
-    testWidgets('variant tests run all values', (WidgetTester tester) async {
+    testWidgets('variant tests run all values provided', (WidgetTester tester) async {
       if (debugDefaultTargetPlatformOverride == null) {
         expect(numberOfVariationsRun, equals(TargetPlatform.values.length));
       } else {
         numberOfVariationsRun += 1;
       }
-    }, variants: <TestVariant<dynamic>>[ TargetPlatformVariant(TargetPlatform.values), const DefaultTestVariant() ]);
+    }, variants: <TestVariant<dynamic>>[ TargetPlatformVariant.all(), const DefaultTestVariant() ]);
 
     testWidgets('variant tests have descriptions with details', (WidgetTester tester) async {
       if (debugDefaultTargetPlatformOverride == null) {
@@ -718,7 +718,7 @@ void main() {
       } else {
         expect(tester.testDescription, equals('variant tests have descriptions with details ($debugDefaultTargetPlatformOverride)'));
       }
-    }, variants: <TestVariant<dynamic>>[ TargetPlatformVariant(TargetPlatform.values), const DefaultTestVariant() ]);
+    }, variants: <TestVariant<dynamic>>[ TargetPlatformVariant.all(), const DefaultTestVariant() ]);
   });
 
   group('TargetPlatformVariant', () {
@@ -732,11 +732,6 @@ void main() {
     tearDownAll((){
       expect(debugDefaultTargetPlatformOverride, equals(origTargetPlatform));
     });
-
-    testWidgets('TargetPlatformVariant tests return debugDefaultTargetPlatformOverride to original value', (WidgetTester tester) async {
-      expect(debugDefaultTargetPlatformOverride, equals(TargetPlatform.iOS));
-      expect(defaultTargetPlatform, equals(TargetPlatform.iOS));
-    }, variants: <TestVariant<dynamic>>[ TargetPlatformVariant(<TargetPlatform> [ TargetPlatform.iOS ]) ]);
 
     testWidgets('TargetPlatformVariant.only tests given value', (WidgetTester tester) async {
       expect(debugDefaultTargetPlatformOverride, equals(TargetPlatform.iOS));


### PR DESCRIPTION
## Description
This adds the ability to define variants of tests with different environmental values for a particular `testWidgets` test.

This allows you to run the same test multiple times with a different test environment.  One test variant has been implemented that allows running a test with different settings of the `TargetPlatform`.

For example, instead of doing this:
```dart
    testWidgets('test stuff on iOS', (WidgetTester tester) async {
      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
      // test stuff...
      debugDefaultTargetPlatformOverride = null;
    });

    testWidgets('test stuff on Android', (WidgetTester tester) async {
      debugDefaultTargetPlatformOverride = TargetPlatform.android;
      // test stuff...
      debugDefaultTargetPlatformOverride = null;
    });
```

You can now do this:
```dart
    testWidgets('test stuff on iOS', (WidgetTester tester) async {
      // test stuff...
    }, variant: TargetPlatformVariant(
      <TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.android },
    ));
```

and not have to duplicate the "// test stuff..." code.

You can also extend this mechanism by creating your own `TestVariant` subclass that iterates through values on a variant.

## Tests

- Adds a test to make sure we actually do run the test variants.

## Breaking Change

- [X] No, this is *not* a breaking change.