### PR TITLE
Stopped adjusting the ImageCache max bytes size when loading very large images.

### DIFF
--- a/packages/flutter/lib/src/painting/image_cache.dart
+++ b/packages/flutter/lib/src/painting/image_cache.dart
@@ -170,11 +170,8 @@ class ImageCache {
       // Images that fail to load don't contribute to cache size.
       final int imageSize = info?.image == null ? 0 : info.image.height * info.image.width * 4;
       final _CachedImage image = _CachedImage(result, imageSize);
-      // If the image is bigger than the maximum cache size, and the cache size
-      // is not zero, then increase the cache size to the size of the image plus
-      // some change.
       if (maximumSizeBytes > 0 && imageSize > maximumSizeBytes) {
-        _maximumSizeBytes = imageSize + 1000;
+        throw 'Attempting to cache an image whose size exceeds ImageCache.maximumSizeBytes: $maximumSizeBytes';
       }
       _currentSizeBytes += imageSize;
       final _PendingImage pendingImage = _pendingImages.remove(key);

--- a/packages/flutter/test/painting/image_cache_test.dart
+++ b/packages/flutter/test/painting/image_cache_test.dart
@@ -121,14 +121,14 @@ void main() {
       expect(imageCache.currentSizeBytes, 256);
     });
 
-    test('Increases cache size if an image is loaded that is larger then the maximum size', () async {
+    test('Image larger than maximumSizeBytes', () async {
       const TestImage testImage = TestImage(width: 8, height: 8);
 
       imageCache.maximumSizeBytes = 1;
       await extractOneFrame(const TestImageProvider(1, 1, image: testImage).resolve(ImageConfiguration.empty));
-      expect(imageCache.currentSize, 1);
-      expect(imageCache.currentSizeBytes, 256);
-      expect(imageCache.maximumSizeBytes, 256 + 1000);
+      expect(imageCache.currentSize, 0);
+      expect(imageCache.currentSizeBytes, 0);
+      expect(imageCache.maximumSizeBytes, 1);
     });
 
     test('Returns null if an error is caught resolving an image', () {


### PR DESCRIPTION
## Description

Previously we were adjusting the image_cache max byte size without the developers explicit direction.  This can lead the image cache to behave in ways the developer didn't intend.

The [issue that originally lead to this change]( https://github.com/flutter/flutter/issues/19345 ) no longer has any problem on master since we've increased our default image cache size.  The default is now 100MB and we are beyond the limits of many GPU's max texture size.

I opted to throw an exception to give developers a chance to address the problem.  The exception just aborts caching and loading of the image continues fine for that frame.  There is no way the developer can literally catch the exception with AssetImage, it serves as a log.

I also opted not to eject the contents of the ImageCache when this exception happens.  We might want to consider that.  Or giving developers the ability to do that.

## Related Issues

- https://github.com/flutter/flutter/issues/45643

## Tests

Tweaked existing tests, manually tested against repro in [this issue](https://github.com/flutter/flutter/issues/19345)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
