### PR TITLE
Feature: `ExpandIcon` should use the `size` parameter

### DIFF
--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -176,6 +176,7 @@ class _ExpandIconState extends State<ExpandIcon> with SingleTickerProviderStateM
       onTapHint: widget.onPressed == null ? null : onTapHint,
       child: IconButton(
         padding: widget.padding,
+        iconSize: widget.size,
         color: _iconColor,
         disabledColor: widget.disabledColor,
         onPressed: widget.onPressed == null ? null : _handlePressed,

--- a/packages/flutter/test/material/expand_icon_test.dart
+++ b/packages/flutter/test/material/expand_icon_test.dart
@@ -134,6 +134,45 @@ void main() {
     expect(rotation.turns.value, 0.5);
   });
 
+  testWidgets('ExpandIcon default size is 24', (WidgetTester tester) async {
+    final ExpandIcon expandIcon =  ExpandIcon(
+      onPressed: (bool isExpanded) {},
+    );
+
+    await tester.pumpWidget(wrap(
+      child: expandIcon
+    ));
+    
+    final ExpandIcon icon = tester.firstWidget(find.byWidget(expandIcon));
+    expect(icon.size, 24);
+  });
+
+  testWidgets('ExpandIcon has the correct given size', (WidgetTester tester) async {
+    ExpandIcon expandIcon =  ExpandIcon(
+      size: 36,
+      onPressed: (bool isExpanded) {},
+    );
+
+    await tester.pumpWidget(wrap(
+      child: expandIcon
+    ));
+    
+    ExpandIcon icon = tester.firstWidget(find.byWidget(expandIcon));
+    expect(icon.size, 36);
+
+    expandIcon =  ExpandIcon(
+      size: 48,
+      onPressed: (bool isExpanded) {},
+    );
+
+    await tester.pumpWidget(wrap(
+      child: expandIcon
+    ));
+
+    icon = tester.firstWidget(find.byWidget(expandIcon));
+    expect(icon.size, 48);
+  });
+
   testWidgets('ExpandIcon has correct semantic hints', (WidgetTester tester) async {
     final SemanticsHandle handle = tester.ensureSemantics();
     const DefaultMaterialLocalizations localizations = DefaultMaterialLocalizations();

--- a/packages/flutter/test/material/expand_icon_test.dart
+++ b/packages/flutter/test/material/expand_icon_test.dart
@@ -142,7 +142,7 @@ void main() {
     await tester.pumpWidget(wrap(
       child: expandIcon
     ));
-    
+
     final ExpandIcon icon = tester.firstWidget(find.byWidget(expandIcon));
     expect(icon.size, 24);
   });
@@ -156,7 +156,7 @@ void main() {
     await tester.pumpWidget(wrap(
       child: expandIcon
     ));
-    
+
     ExpandIcon icon = tester.firstWidget(find.byWidget(expandIcon));
     expect(icon.size, 36);
 


### PR DESCRIPTION
## Related Issues
#45692

## Tests

I added the following tests:
- `ExpandIcon default size is 24`
- `ExpandIcon has the correct given size`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
