### PR TITLE
fix issues with incremental compiler support

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -48,7 +48,7 @@ class DwdsWebRunnerFactory extends WebRunnerFactory {
     @required DebuggingOptions debuggingOptions,
     @required List<String> dartDefines,
   }) {
-    if (featureFlags.isWebIncrementalCompilerEnabled) {
+    if (featureFlags.isWebIncrementalCompilerEnabled && debuggingOptions.buildInfo.isDebug) {
       return _ExperimentalResidentWebRunner(
         device,
         target: target,
@@ -448,10 +448,10 @@ class _ExperimentalResidentWebRunner extends ResidentWebRunner {
 
     try {
       if (fullRestart) {
-        await _wipConnection.sendCommand('Page.reload');
+        await _wipConnection?.sendCommand('Page.reload');
       } else {
-        await _wipConnection.debugger
-            .sendCommand('Runtime.evaluate', params: <String, Object>{
+        await _wipConnection?.debugger
+            ?.sendCommand('Runtime.evaluate', params: <String, Object>{
           'expression': 'window.\$hotReloadHook([$modules])',
           'awaitPromise': true,
           'returnByValue': true,
@@ -523,12 +523,14 @@ class _ExperimentalResidentWebRunner extends ResidentWebRunner {
     Completer<DebugConnectionInfo> connectionInfoCompleter,
     Completer<void> appStartedCompleter,
   }) async {
-    final Chrome chrome = await ChromeLauncher.connectedInstance;
-    final ChromeTab chromeTab =
-        await chrome.chromeConnection.getTab((ChromeTab chromeTab) {
-      return chromeTab.url.contains(debuggingOptions.hostname);
-    });
-    _wipConnection = await chromeTab.connect();
+    if (device.device is ChromeDevice) {
+      final Chrome chrome = await ChromeLauncher.connectedInstance;
+      final ChromeTab chromeTab =
+          await chrome.chromeConnection.getTab((ChromeTab chromeTab) {
+        return chromeTab.url.contains(debuggingOptions.hostname);
+      });
+      _wipConnection = await chromeTab.connect();
+    }
     appStartedCompleter?.complete();
     connectionInfoCompleter?.complete();
     if (stayResident) {

--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -525,8 +525,7 @@ class _ExperimentalResidentWebRunner extends ResidentWebRunner {
   }) async {
     if (device.device is ChromeDevice) {
       final Chrome chrome = await ChromeLauncher.connectedInstance;
-      final ChromeTab chromeTab =
-          await chrome.chromeConnection.getTab((ChromeTab chromeTab) {
+      final ChromeTab chromeTab = await chrome.chromeConnection.getTab((ChromeTab chromeTab) {
         return chromeTab.url.contains(debuggingOptions.hostname);
       });
       _wipConnection = await chromeTab.connect();

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -461,7 +461,7 @@ void main() {
     expect(testLogger.statusText, contains('Restarted application in'));
     expect(result.code, 0);
     verify(mockResidentCompiler.accept()).called(2);
-	  // ensure that analytics are sent.
+    // ensure that analytics are sent.
     verify(Usage.instance.sendEvent('hot', 'restart', parameters: <String, String>{
       'cd27': 'web-javascript',
       'cd28': null,

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -49,6 +49,7 @@ void main() {
   MockChromeTab mockChromeTab;
   MockWipConnection mockWipConnection;
   MockWipDebugger mockWipDebugger;
+  MockWebServerDevice mockWebServerDevice;
   bool didSkipDwds;
 
   setUp(() {
@@ -66,6 +67,7 @@ void main() {
     mockChromeTab = MockChromeTab();
     mockWipConnection = MockWipConnection();
     mockWipDebugger = MockWipDebugger();
+    mockWebServerDevice = MockWebServerDevice();
     when(mockFlutterDevice.device).thenReturn(mockChromeDevice);
     testbed = Testbed(
       setup: () {
@@ -429,6 +431,49 @@ void main() {
     FeatureFlags: () => TestFeatureFlags(isWebIncrementalCompilerEnabled: true),
   }));
 
+  test('Can hot restart after attaching - experimental with web-server device', () => testbed.run(() async {
+    _setupMocks();
+    when(mockFlutterDevice.device).thenReturn(mockWebServerDevice);
+    when(mockWebDevFS.update(
+      mainPath: anyNamed('mainPath'),
+      target: anyNamed('target'),
+      bundle: anyNamed('bundle'),
+      firstBuildTime: anyNamed('firstBuildTime'),
+      bundleFirstUpload: anyNamed('bundleFirstUpload'),
+      generator: anyNamed('generator'),
+      fullRestart: anyNamed('fullRestart'),
+      dillOutputPath: anyNamed('dillOutputPath'),
+      trackWidgetCreation: anyNamed('trackWidgetCreation'),
+      projectRootPath: anyNamed('projectRootPath'),
+      pathToReload: anyNamed('pathToReload'),
+      invalidatedFiles: anyNamed('invalidatedFiles'),
+    )).thenAnswer((Invocation invocation) async {
+      return UpdateFSReport(success: true)
+        ..invalidatedModules = <String>['example'];
+    });
+    final Completer<DebugConnectionInfo> connectionInfoCompleter = Completer<DebugConnectionInfo>();
+    unawaited(residentWebRunner.run(
+      connectionInfoCompleter: connectionInfoCompleter,
+    ));
+    await connectionInfoCompleter.future;
+    final OperationResult result = await residentWebRunner.restart(fullRestart: true);
+
+    expect(testLogger.statusText, contains('Restarted application in'));
+    expect(result.code, 0);
+    verify(mockResidentCompiler.accept()).called(2);
+	  // ensure that analytics are sent.
+    verify(Usage.instance.sendEvent('hot', 'restart', parameters: <String, String>{
+      'cd27': 'web-javascript',
+      'cd28': null,
+      'cd29': 'false',
+      'cd30': 'true',
+    })).called(1);
+    verifyNever(Usage.instance.sendTiming('hot', 'web-incremental-restart', any));
+  }, overrides: <Type, Generator>{
+    Usage: () => MockFlutterUsage(),
+    FeatureFlags: () => TestFeatureFlags(isWebIncrementalCompilerEnabled: true),
+  }));
+
   test('Can hot restart after attaching', () => testbed.run(() async {
     _setupMocks();
     final Completer<DebugConnectionInfo> connectionInfoCompleter = Completer<DebugConnectionInfo>();
@@ -458,6 +503,21 @@ void main() {
     verify(Usage.instance.sendTiming('hot', 'web-recompile', any)).called(1);
   }, overrides: <Type, Generator>{
     Usage: () => MockFlutterUsage(),
+  }));
+
+  test('Selects Dwds runner in profile mode with incremental compiler enabled', () => testbed.run(() async {
+    final ResidentWebRunner residentWebRunner = DwdsWebRunnerFactory().createWebRunner(
+      mockFlutterDevice,
+      flutterProject: FlutterProject.current(),
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.profile),
+      ipv6: true,
+      stayResident: true,
+      dartDefines: const <String>[],
+    ) as ResidentWebRunner;
+
+    expect(residentWebRunner.runtimeType.toString(), '_DwdsResidentWebRunner');
+  }, overrides: <Type, Generator>{
+    FeatureFlags: () => TestFeatureFlags(isWebIncrementalCompilerEnabled: true),
   }));
 
   test('Fails on compilation errors in hot restart', () => testbed.run(() async {
@@ -1022,3 +1082,4 @@ class MockChromeTab extends Mock implements ChromeTab {}
 class MockWipConnection extends Mock implements WipConnection {}
 class MockWipDebugger extends Mock implements WipDebugger {}
 class MockLogger extends Mock implements Logger {}
+class MockWebServerDevice extends Mock implements WebServerDevice {}


### PR DESCRIPTION
## Description

Currently the incremental compiler support does not handle release/profile mode. Fall back to the dwds runner, since we don't use the incremental compiler in that mode anyway.

Ensure we can handle the lack of a connected chrome instance for web-server device.

Fixes https://github.com/flutter/flutter/issues/45302