### PR TITLE
Fix parameter name: handlePointerEvent

### DIFF
--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -787,7 +787,7 @@ mixin _PlatformViewGestureMixin on RenderBox {
   ///
   /// Any active gesture arena the `PlatformView` participates in is rejected when the
   /// set of gesture recognizers is changed.
-  void _updateGestureRecognizersWithCallBack(Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers, _HandlePointerEvent _handlePointerEvent) {
+  void _updateGestureRecognizersWithCallBack(Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers, _HandlePointerEvent handlePointerEvent) {
     assert(gestureRecognizers != null);
     assert(
     _factoriesTypeSet(gestureRecognizers).length == gestureRecognizers.length,
@@ -797,7 +797,7 @@ mixin _PlatformViewGestureMixin on RenderBox {
       return;
     }
     _gestureRecognizer?.dispose();
-    _gestureRecognizer = _PlatformViewGestureRecognizer(_handlePointerEvent, gestureRecognizers);
+    _gestureRecognizer = _PlatformViewGestureRecognizer(handlePointerEvent, gestureRecognizers);
   }
 
   _PlatformViewGestureRecognizer _gestureRecognizer;


### PR DESCRIPTION
Removes an unnecessary leading underscore from a parameter name. The
parameter type is library private, but parameters cannot be 'private'.