### PR TITLE
Make all of the driver interface public.

### DIFF
--- a/packages/flutter_driver/lib/driver_extension.dart
+++ b/packages/flutter_driver/lib/driver_extension.dart
@@ -24,4 +24,4 @@
 ///     }
 library flutter_driver_extension;
 
-export 'src/extension/extension.dart' show enableFlutterDriverExtension, DataHandler;
+export 'src/extension/extension.dart';

--- a/packages/flutter_driver/lib/flutter_driver.dart
+++ b/packages/flutter_driver/lib/flutter_driver.dart
@@ -11,39 +11,22 @@
 /// Protractor (Angular), Espresso (Android) or Earl Gray (iOS).
 library flutter_driver;
 
-export 'src/common/error.dart' show
-  DriverError,
-  LogLevel,
-  LogRecord,
-  flutterDriverLog;
-export 'src/common/find.dart' show
-  SerializableFinder;
-export 'src/common/health.dart' show
-  Health,
-  HealthStatus;
-export 'src/common/message.dart' show
-  Command,
-  Result;
-export 'src/common/render_tree.dart' show
-  RenderTree;
-export 'src/common/wait.dart' show
-  CombinedCondition,
-  FirstFrameRasterized,
-  NoPendingFrame,
-  NoPendingPlatformMessages,
-  NoTransientCallbacks,
-  SerializableWaitCondition;
-export 'src/driver/common.dart' show
-  testOutputsDirectory;
-export 'src/driver/driver.dart' show
-  find,
-  CommonFinders,
-  EvaluatorFunction,
-  FlutterDriver,
-  TimelineStream;
-export 'src/driver/timeline.dart' show
-  Timeline,
-  TimelineEvent;
-export 'src/driver/timeline_summary.dart' show
-  TimelineSummary,
-  kBuildBudget;
+export 'src/common/diagnostics_tree.dart';
+export 'src/common/enum_util.dart';
+export 'src/common/error.dart';
+export 'src/common/find.dart';
+export 'src/common/frame_sync.dart';
+export 'src/common/fuchsia_compat.dart';
+export 'src/common/geometry.dart';
+export 'src/common/gesture.dart';
+export 'src/common/health.dart';
+export 'src/common/message.dart';
+export 'src/common/render_tree.dart';
+export 'src/common/request_data.dart';
+export 'src/common/semantics.dart';
+export 'src/common/text.dart';
+export 'src/common/wait.dart';
+export 'src/driver/common.dart';
+export 'src/driver/driver.dart';
+export 'src/driver/timeline.dart';
+export 'src/driver/timeline_summary.dart';

--- a/packages/flutter_driver/lib/src/driver/driver.dart
+++ b/packages/flutter_driver/lib/src/driver/driver.dart
@@ -1248,5 +1248,5 @@ class DriverOffset {
   }
 
   @override
-  int get hashCode => dx.hashCode + dy.hashCode;
+  int get hashCode => dx.hashCode ^ dy.hashCode;
 }

--- a/packages/fuchsia_remote_debug_protocol/examples/drive_todo_list_scroll.dart
+++ b/packages/fuchsia_remote_debug_protocol/examples/drive_todo_list_scroll.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:core';
 
-import 'package:flutter_driver/flutter_driver.dart';
+import 'package:flutter_driver/flutter_driver.dart' hide Logger;
 import 'package:fuchsia_remote_debug_protocol/fuchsia_remote_debug_protocol.dart';
 import 'package:fuchsia_remote_debug_protocol/logging.dart';
 


### PR DESCRIPTION
We keep finding things that we've accidentally not made public. The
pattern we use elsewhere in the platform is to just export everything,
to avoid encouraging people from importing `src/` files directly.
