### PR TITLE
fix child rebuild under layoutbuild cause duplicate globalkey error

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -190,7 +190,7 @@ abstract class GlobalKey<T extends State<StatefulWidget>> extends Key {
       // of dirty node rebuild will be overwritten by the LayoutBuilder rebuild.
       // It should be safe to remove all the other reservations of GlobalKeys.
       // See https://github.com/flutter/flutter/issues/43780
-      _debugReservations.removeWhere((_, Element e) => e == parent);
+      _debugReservations.removeWhere((GlobalKey key, Element element) => element == parent);
       _debugReservations[this] = parent;
       return true;
     }());

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -184,11 +184,11 @@ abstract class GlobalKey<T extends State<StatefulWidget>> extends Key {
           ),
         ]);
       }
-      // The parent might have multiple global key reservation. This can happens
+      // The parent might have multiple global key reservations. This can happen
       // when a dirty node under LayoutBuilder is rebuilt before the LayoutBuilder
-      // updates its widget subtree. At the end, the result of dirty node rebuild will
-      // be overwritten by the LayoutBuilder rebuild. It should be safe to remove
-      // all the other reservations of GlobalKeys.
+      // updates its widget subtree in rendering layer. At the end, the result
+      // of dirty node rebuild will be overwritten by the LayoutBuilder rebuild.
+      // It should be safe to remove all the other reservations of GlobalKeys.
       // See https://github.com/flutter/flutter/issues/43780
       _debugReservations.removeWhere((_, Element e) => e == parent);
       _debugReservations[this] = parent;

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -184,6 +184,13 @@ abstract class GlobalKey<T extends State<StatefulWidget>> extends Key {
           ),
         ]);
       }
+      // The parent might have multiple global key reservation. This can happens
+      // when a dirty node under LayoutBuilder is rebuilt before the LayoutBuilder
+      // updates its widget subtree. At the end, the result of dirty node rebuild will
+      // be overwritten by the LayoutBuilder rebuild. It should be safe to remove
+      // all the other reservations of GlobalKeys.
+      // See https://github.com/flutter/flutter/issues/43780
+      _debugReservations.removeWhere((_, Element e) => e == parent);
       _debugReservations[this] = parent;
       return true;
     }());


### PR DESCRIPTION
## Description

The layoutbuilder delays its rebuild to rendering time. If a child under it is marked dirty, it will rebuild with outdated widget that will eventually updated and rebuild during layout.
This is generally ok except this will pose a problem for global key reservation.
This pr attempts to remove global key reservation that cause by dirty node rebuild prior to layoutbuilder rebuild

## Related Issues

https://github.com/flutter/flutter/issues/43780

## Tests

I added the following tests:

"GlobalKey - can reorder under LayoutBuilder while dirtying children"

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
