### PR TITLE
Do not delete output directory during flutter build ios-framework

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -155,6 +155,10 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
       printStatus('Building framework for $iosProject in ${getNameForBuildMode(mode)} mode...');
       final String xcodeBuildConfiguration = toTitleCase(getNameForBuildMode(mode));
       final Directory modeDirectory = outputDirectory.childDirectory(xcodeBuildConfiguration);
+
+      if (modeDirectory.existsSync()) {
+        modeDirectory.deleteSync(recursive: true);
+      }
       final Directory iPhoneBuildOutput = modeDirectory.childDirectory('iphoneos');
       final Directory simulatorBuildOutput = modeDirectory.childDirectory('iphonesimulator');
 

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -146,13 +146,7 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
       throwToolExit("Module's iOS folder missing");
     }
 
-    // Append a known directory so if they pass in /Users/user/Desktop/ the command doesn't delete their Desktop...
-    final Directory outputDirectory = fs.directory(fs.path.normalize(outputArgument))
-      .childDirectory('FlutterFrameworks');
-
-    if (outputDirectory.existsSync()) {
-      outputDirectory.deleteSync(recursive: true);
-    }
+    final Directory outputDirectory = fs.directory(fs.path.normalize(outputArgument));
 
     aotBuilder ??= AotBuilder();
     bundleBuilder ??= BundleBuilder();

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -146,7 +146,9 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
       throwToolExit("Module's iOS folder missing");
     }
 
-    final Directory outputDirectory = fs.directory(fs.path.normalize(outputArgument));
+    // Append a known directory so if they pass in /Users/user/Desktop/ the command doesn't delete their Desktop...
+    final Directory outputDirectory = fs.directory(fs.path.normalize(outputArgument))
+      .childDirectory('FlutterFrameworks');
 
     if (outputDirectory.existsSync()) {
       outputDirectory.deleteSync(recursive: true);


### PR DESCRIPTION
## Description

Don't delete the output directory since they might pass in something they don't want to delete... like their existing app directory or their Desktop or something else.

Delete the build mode directory to clean removed plugins.