### PR TITLE
Android log reader reads any recent logs

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -688,7 +688,7 @@ class AndroidDevice extends Device {
     String output;
     try {
       output = runAdbCheckedSync(<String>[
-        'shell', '-x', 'logcat', '-v', 'time', '-t', '1',
+        'shell', '-x', 'logcat', '-v', 'time', '-t', '1'
       ]);
     } catch (error) {
       printError('Failed to extract the most recent timestamp from the Android log: $error.');
@@ -1007,8 +1007,9 @@ class _AdbLogReader extends DeviceLogReader {
   String get name => device.name;
 
   void _start() {
-    // Start the adb logcat process and filter logs by the "flutter" tag.
-    final List<String> args = <String>['shell', '-x', 'logcat', '-v', 'time', '-s', 'flutter'];
+    final String lastTimestamp = device.lastLogcatTimestamp;
+    // Start the adb logcat process and filter the most recent logs since `lastTimestamp`.
+    final List<String> args = <String>['logcat', '-v', 'time', '-T', lastTimestamp];
     processUtils.start(device.adbCommandForDevice(args)).then<void>((Process process) {
       _process = process;
       // We expect logcat streams to occasionally contain invalid utf-8,


### PR DESCRIPTION
## Description

After https://github.com/flutter/flutter/pull/45307, the Android log reader doesn't filter older logs. Instead, it filters by tag and the protocol discovery class throttles the logs to discover the most recent observatory URI. The intention with this change was to allow `flutter attach` to attach to an app already running on the device. However, this implementation detail is used by the microbenchmarks test to extract the benchmark data.  

This PR reverts to the old behavior. Going forward, we can have two factories for the Android log reader such the one that filters by tags is explicitly injected in the `flutter attach` flow and the other one is injected in `flutter run/logs` flows. cc @xster 

## Related Issues

Fixes https://github.com/flutter/flutter/issues/45732

## Tests

I added the following tests: Unit test

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
