### PR TITLE
Migrate TextTheme to 2018 APIs.

### DIFF
--- a/packages/flutter/lib/src/material/text_theme.dart
+++ b/packages/flutter/lib/src/material/text_theme.dart
@@ -7,6 +7,10 @@ import 'package:flutter/painting.dart';
 
 import 'typography.dart';
 
+// Eventually we'll get rid of the deprecated members, but for now, we have to use them
+// in order to implement them.
+// ignore_for_file: deprecated_member_use_from_same_package
+
 /// Material design text theme.
 ///
 /// Definitions for the various typographical styles found in material design
@@ -15,6 +19,10 @@ import 'typography.dart';
 ///
 /// To obtain the current text theme, call [Theme.of] with the current
 /// [BuildContext] and read the [ThemeData.textTheme] property.
+///
+/// ![](https://storage.googleapis.com/spec-host-backup/mio-design%2Fassets%2F1W8kyGVruuG_O8psvyiOaCf1lLFIMzB-N%2Ftypesystem-typescale.png)
+///
+/// ## Migrating from the 2014 names
 ///
 /// The Material Design typography scheme was significantly changed in the
 /// current (2018) version of the specification
@@ -31,26 +39,27 @@ import 'typography.dart';
 /// headline6    20.0  medium   0.15
 /// subtitle1    16.0  normal   0.15
 /// subtitle2    14.0  medium   0.1
-/// body1        16.0  normal   0.5
-/// body2        14.0  normal   0.25
+/// body1        16.0  normal   0.5   (bodyText1)
+/// body2        14.0  normal   0.25  (bodyText2)
 /// button       14.0  medium   0.75
 /// caption      12.0  normal   0.4
 /// overline     10.0  normal   1.5
-///
 /// ```
-/// Where "light" is `FontWeight.w300`, "normal" is `FontWeight.w400` and
+///
+/// ...where "light" is `FontWeight.w300`, "normal" is `FontWeight.w400` and
 /// "medium" is `FontWeight.w500`.
 ///
-/// The [TextTheme] API is based on the original material (2014)
+/// The [TextTheme] API was originally based on the original material (2014)
 /// design spec, which used different text style names. For backwards
-/// compatibility's sake, this API continues to use the original
-/// names. The table below should help with understanding the API in
-/// terms of the 2018 material spec.
+/// compatibility's sake, this API continues to expose the old names. The table
+/// below should help with understanding the mapping of the API's old names and
+/// the new names (those in terms of the 2018 material specification).
 ///
 /// Each of the [TextTheme] text styles corresponds to one of the
 /// styles from 2018 spec. By default, the font sizes, font weights
 /// and letter spacings have not changed from their original,
 /// 2014, values.
+///
 /// ```
 /// NAME       SIZE   WEIGHT   SPACING  2018 NAME
 /// display4   112.0  thin     0.0      headline1
@@ -60,8 +69,8 @@ import 'typography.dart';
 /// headline   24.0   normal   0.0      headline5
 /// title      20.0   medium   0.0      headline6
 /// subhead    16.0   normal   0.0      subtitle1
-/// body2      14.0   medium   0.0      body1
-/// body1      14.0   normal   0.0      body2
+/// body2      14.0   medium   0.0      body1 (bodyText2)
+/// body1      14.0   normal   0.0      body2 (bodyText1)
 /// caption    12.0   normal   0.0      caption
 /// button     14.0   medium   0.0      button
 /// subtitle   14.0   medium   0.0      subtitle2
@@ -72,21 +81,14 @@ import 'typography.dart';
 /// "medium" is `FontWeight.w500`. Letter spacing for all of the original
 /// text styles was 0.0.
 ///
+/// The old names are deprecated in this API.
+///
+/// Since the names `body1` and `body2` are used in both specifications but with
+/// different meanings, the API uses the terms `bodyText1` and `bodyText2` for
+/// the new API.
+///
 /// To configure a [Theme] for the new sizes, weights, and letter spacings,
-/// initialize its [ThemeData.typography] value with a [Typography] that
-/// object that specifies the 2018 versions of the geometry themes:
-/// [Typography.englishLike2018], [Typography.dense2018],
-/// and [Typography.tall2018].
-///
-/// The following image [from the material design
-/// specification](https://material.io/go/design-typography#typography-styles)
-/// shows the recommended styles for each of the properties of a [TextTheme].
-/// This image uses the `Roboto` font, which is the font used on Android. On
-/// iOS, the [San Francisco
-/// font](https://developer.apple.com/ios/human-interface-guidelines/visual-design/typography/)
-/// is automatically used instead.
-///
-/// ![To see the image, visit the typography site referenced below.](https://storage.googleapis.com/material-design/publish/material_v_11/assets/0Bzhp5Z4wHba3alhXZ2pPWGk3Zjg/style_typography_styles_scale.png)
+/// initialize its [ThemeData.typography] value using [Typography.material2018].
 ///
 /// See also:
 ///
@@ -107,53 +109,120 @@ class TextTheme extends Diagnosticable {
   /// If you do decide to create your own text theme, consider using one of
   /// those predefined themes as a starting point for [copyWith] or [apply].
   const TextTheme({
-    this.display4,
-    this.display3,
-    this.display2,
-    this.display1,
-    this.headline,
-    this.title,
-    this.subhead,
-    this.body2,
-    this.body1,
+    TextStyle headline1,
+    TextStyle headline2,
+    TextStyle headline3,
+    TextStyle headline4,
+    TextStyle headline5,
+    TextStyle headline6,
+    TextStyle subtitle1,
+    TextStyle subtitle2,
+    TextStyle bodyText1,
+    TextStyle bodyText2,
     this.caption,
     this.button,
-    this.subtitle,
     this.overline,
-  });
+    @Deprecated(
+      'This is the term used in the 2014 version of material design. The modern term is headline1. '
+      'This feature was deprecated after v1.12.15.'
+    )
+    TextStyle display4,
+    @Deprecated(
+      'This is the term used in the 2014 version of material design. The modern term is headline2. '
+      'This feature was deprecated after v1.12.15.'
+    )
+    TextStyle display3,
+    @Deprecated(
+      'This is the term used in the 2014 version of material design. The modern term is headline3. '
+      'This feature was deprecated after v1.12.15.'
+    )
+    TextStyle display2,
+    @Deprecated(
+      'This is the term used in the 2014 version of material design. The modern term is headline4. '
+      'This feature was deprecated after v1.12.15.'
+    )
+    TextStyle display1,
+    @Deprecated(
+      'This is the term used in the 2014 version of material design. The modern term is headline5. '
+      'This feature was deprecated after v1.12.15.'
+    )
+    TextStyle headline,
+    @Deprecated(
+      'This is the term used in the 2014 version of material design. The modern term is headline6. '
+      'This feature was deprecated after v1.12.15.'
+    )
+    TextStyle title,
+    @Deprecated(
+      'This is the term used in the 2014 version of material design. The modern term is subtitle1. '
+      'This feature was deprecated after v1.12.15.'
+    )
+    TextStyle subhead,
+    @Deprecated(
+      'This is the term used in the 2014 version of material design. The modern term is subtitle2. '
+      'This feature was deprecated after v1.12.15.'
+    )
+    TextStyle subtitle,
+    @Deprecated(
+      'This is the term used in the 2014 version of material design. The modern term is bodyText1. '
+      'This feature was deprecated after v1.12.15.'
+    )
+    TextStyle body2,
+    @Deprecated(
+      'This is the term used in the 2014 version of material design. The modern term is bodyText2. '
+      'This feature was deprecated after v1.12.15.'
+    )
+    TextStyle body1,
+  }) : assert(
+         (headline1 == null && headline2 == null && headline3 == null && headline4 == null && headline5 == null && headline6 == null &&
+          subtitle1 == null && subtitle2 == null &&
+          bodyText1 == null && bodyText2 == null) ||
+         (display4 == null && display3 == null && display2 == null && display1 == null && headline == null && title == null &&
+          subhead == null && subtitle == null &&
+          body2 == null && body1 == null), 'Cannot mix 2014 and 2018 terms in call to TextTheme() constructor.'),
+       headline1 = headline1 ?? display4,
+       headline2 = headline2 ?? display3,
+       headline3 = headline3 ?? display2,
+       headline4 = headline4 ?? display1,
+       headline5 = headline5 ?? headline,
+       headline6 = headline6 ?? title,
+       subtitle1 = subtitle1 ?? subhead,
+       subtitle2 = subtitle2 ?? subtitle,
+       bodyText1 = bodyText1 ?? body2,
+       bodyText2 = bodyText2 ?? body1;
 
   /// Extremely large text.
-  ///
-  /// The font size is 112 pixels.
-  final TextStyle display4;
+  final TextStyle headline1;
 
   /// Very, very large text.
   ///
   /// Used for the date in the dialog shown by [showDatePicker].
-  final TextStyle display3;
+  final TextStyle headline2;
 
   /// Very large text.
-  final TextStyle display2;
+  final TextStyle headline3;
 
   /// Large text.
-  final TextStyle display1;
+  final TextStyle headline4;
 
   /// Used for large text in dialogs (e.g., the month and year in the dialog
   /// shown by [showDatePicker]).
-  final TextStyle headline;
+  final TextStyle headline5;
 
   /// Used for the primary text in app bars and dialogs (e.g., [AppBar.title]
   /// and [AlertDialog.title]).
-  final TextStyle title;
+  final TextStyle headline6;
 
   /// Used for the primary text in lists (e.g., [ListTile.title]).
-  final TextStyle subhead;
+  final TextStyle subtitle1;
 
-  /// Used for emphasizing text that would otherwise be [body1].
-  final TextStyle body2;
+  /// For medium emphasis text that's a little smaller than [subtitle1].
+  final TextStyle subtitle2;
+
+  /// Used for emphasizing text that would otherwise be [bodyText2].
+  final TextStyle bodyText1;
 
   /// Used for the default text style for [Material].
-  final TextStyle body1;
+  final TextStyle bodyText2;
 
   /// Used for auxiliary text associated with images.
   final TextStyle caption;
@@ -161,13 +230,114 @@ class TextTheme extends Diagnosticable {
   /// Used for text on [RaisedButton] and [FlatButton].
   final TextStyle button;
 
-  /// For medium emphasis text that's a little smaller than [subhead].
-  final TextStyle subtitle;
-
-  /// The smallest style,
+  /// The smallest style.
   ///
   /// Typically used for captions or to introduce a (larger) headline.
   final TextStyle overline;
+
+
+  /// Extremely large text.
+  ///
+  /// This was the name used in the material design 2014 specification. The new
+  /// specification calls this [headline1].
+  @Deprecated(
+    'This is the term used in the 2014 version of material design. The modern term is headline1. '
+    'This feature was deprecated after v1.12.15.'
+  )
+  TextStyle get display4 => headline1;
+
+  /// Very, very large text.
+  ///
+  /// This was the name used in the material design 2014 specification. The new
+  /// specification calls this [headline2].
+  @Deprecated(
+    'This is the term used in the 2014 version of material design. The modern term is headline2. '
+    'This feature was deprecated after v1.12.15.'
+  )
+  TextStyle get display3 => headline2;
+
+  /// Very large text.
+  ///
+  /// This was the name used in the material design 2014 specification. The new
+  /// specification calls this [headline3].
+  @Deprecated(
+    'This is the term used in the 2014 version of material design. The modern term is headline3. '
+    'This feature was deprecated after v1.12.15.'
+  )
+  TextStyle get display2 => headline3;
+
+  /// Large text.
+  ///
+  /// This was the name used in the material design 2014 specification. The new
+  /// specification calls this [headline4].
+  @Deprecated(
+    'This is the term used in the 2014 version of material design. The modern term is headline4. '
+    'This feature was deprecated after v1.12.15.'
+  )
+  TextStyle get display1 => headline4;
+
+  /// Used for large text in dialogs.
+  ///
+  /// This was the name used in the material design 2014 specification. The new
+  /// specification calls this [headline5].
+  @Deprecated(
+    'This is the term used in the 2014 version of material design. The modern term is headline5. '
+    'This feature was deprecated after v1.12.15.'
+  )
+  TextStyle get headline => headline5;
+
+  /// Used for the primary text in app bars and dialogs.
+  ///
+  /// This was the name used in the material design 2014 specification. The new
+  /// specification calls this [headline6].
+  @Deprecated(
+    'This is the term used in the 2014 version of material design. The modern term is headline6. '
+    'This feature was deprecated after v1.12.15.'
+  )
+  TextStyle get title => headline6;
+
+  /// Used for the primary text in lists (e.g., [ListTile.title]).
+  ///
+  /// This was the name used in the material design 2014 specification. The new
+  /// specification calls this [subtitle1].
+  @Deprecated(
+    'This is the term used in the 2014 version of material design. The modern term is subtitle1. '
+    'This feature was deprecated after v1.12.15.'
+  )
+  TextStyle get subhead => subtitle1;
+
+  /// For medium emphasis text that's a little smaller than [subhead].
+  ///
+  /// This was the name used in the material design 2014 specification. The new
+  /// specification calls this [subtitle2].
+  @Deprecated(
+    'This is the term used in the 2014 version of material design. The modern term is subtitle2. '
+    'This feature was deprecated after v1.12.15.'
+  )
+  TextStyle get subtitle => subtitle2;
+
+  /// Used for emphasizing text that would otherwise be [body1].
+  ///
+  /// This was the name used in the material design 2014 specification. The new
+  /// specification calls this `body1`, and it is exposed in this API as
+  /// [textBody1].
+  @Deprecated(
+    'This is the term used in the 2014 version of material design. The modern term is bodyText1. '
+    'This feature was deprecated after v1.12.15.'
+  )
+  TextStyle get body2 => bodyText1;
+
+  /// Used for the default text style for [Material].
+  ///
+  /// This was the name used in the material design 2014 specification. The new
+  /// specification calls this `body2`, and it is exposed in this API as
+  /// [textBody2].
+  @Deprecated(
+    'This is the term used in the 2014 version of material design. The modern term is bodyText1. '
+    'This feature was deprecated after v1.12.15.'
+  )
+  TextStyle get body1 => bodyText2;
+
 
   /// Creates a copy of this text theme but with the given fields replaced with
   /// the new values.
@@ -210,33 +380,90 @@ class TextTheme extends Diagnosticable {
   ///  * [merge] is used instead of [copyWith] when you want to merge all
   ///    of the fields of a TextTheme instead of individual fields.
   TextTheme copyWith({
-    TextStyle display4,
-    TextStyle display3,
-    TextStyle display2,
-    TextStyle display1,
-    TextStyle headline,
-    TextStyle title,
-    TextStyle subhead,
-    TextStyle body2,
-    TextStyle body1,
+    TextStyle headline1,
+    TextStyle headline2,
+    TextStyle headline3,
+    TextStyle headline4,
+    TextStyle headline5,
+    TextStyle headline6,
+    TextStyle subtitle1,
+    TextStyle subtitle2,
+    TextStyle bodyText1,
+    TextStyle bodyText2,
     TextStyle caption,
     TextStyle button,
-    TextStyle subtitle,
     TextStyle overline,
+    @Deprecated(
+      'This is the term used in the 2014 version of material design. The modern term is headline1. '
+      'This feature was deprecated after v1.12.15.'
+    )
+    TextStyle display4,
+    @Deprecated(
+      'This is the term used in the 2014 version of material design. The modern term is headline2. '
+      'This feature was deprecated after v1.12.15.'
+    )
+    TextStyle display3,
+    @Deprecated(
+      'This is the term used in the 2014 version of material design. The modern term is headline3. '
+      'This feature was deprecated after v1.12.15.'
+    )
+    TextStyle display2,
+    @Deprecated(
+      'This is the term used in the 2014 version of material design. The modern term is headline4. '
+      'This feature was deprecated after v1.12.15.'
+    )
+    TextStyle display1,
+    @Deprecated(
+      'This is the term used in the 2014 version of material design. The modern term is headline5. '
+      'This feature was deprecated after v1.12.15.'
+    )
+    TextStyle headline,
+    @Deprecated(
+      'This is the term used in the 2014 version of material design. The modern term is headline6. '
+      'This feature was deprecated after v1.12.15.'
+    )
+    TextStyle title,
+    @Deprecated(
+      'This is the term used in the 2014 version of material design. The modern term is subtitle1. '
+      'This feature was deprecated after v1.12.15.'
+    )
+    TextStyle subhead,
+    @Deprecated(
+      'This is the term used in the 2014 version of material design. The modern term is subtitle2. '
+      'This feature was deprecated after v1.12.15.'
+    )
+    TextStyle subtitle,
+    @Deprecated(
+      'This is the term used in the 2014 version of material design. The modern term is bodyText1. '
+      'This feature was deprecated after v1.12.15.'
+    )
+    TextStyle body2,
+    @Deprecated(
+      'This is the term used in the 2014 version of material design. The modern term is bodyText2. '
+      'This feature was deprecated after v1.12.15.'
+    )
+    TextStyle body1,
   }) {
+    assert(
+      (headline1 == null && headline2 == null && headline3 == null && headline4 == null && headline5 == null && headline6 == null &&
+       subtitle1 == null && subtitle2 == null &&
+       bodyText1 == null && bodyText2 == null) ||
+      (display4 == null && display3 == null && display2 == null && display1 == null && headline == null && title == null &&
+       subhead == null && subtitle == null &&
+       body2 == null && body1 == null), 'Cannot mix 2014 and 2018 terms in call to TextTheme.copyWith().');
     return TextTheme(
-      display4: display4 ?? this.display4,
-      display3: display3 ?? this.display3,
-      display2: display2 ?? this.display2,
-      display1: display1 ?? this.display1,
-      headline: headline ?? this.headline,
-      title: title ?? this.title,
-      subhead: subhead ?? this.subhead,
-      body2: body2 ?? this.body2,
-      body1: body1 ?? this.body1,
+      headline1: headline1 ?? display4 ?? this.headline1,
+      headline2: headline2 ?? display3 ?? this.headline2,
+      headline3: headline3 ?? display2 ?? this.headline3,
+      headline4: headline4 ?? display1 ?? this.headline4,
+      headline5: headline5 ?? headline ?? this.headline5,
+      headline6: headline6 ?? title ?? this.headline6,
+      subtitle1: subtitle1 ?? subhead ?? this.subtitle1,
+      subtitle2: subtitle2 ?? subtitle ?? this.subtitle2,
+      bodyText1: bodyText1 ?? body2 ?? this.bodyText1,
+      bodyText2: bodyText2 ?? body1 ?? this.bodyText2,
       caption: caption ?? this.caption,
       button: button ?? this.button,
-      subtitle: subtitle ?? this.subtitle,
       overline: overline ?? this.overline,
     );
   }
@@ -296,18 +523,18 @@ class TextTheme extends Diagnosticable {
     if (other == null)
       return this;
     return copyWith(
-      display4: display4?.merge(other.display4) ?? other.display4,
-      display3: display3?.merge(other.display3) ?? other.display3,
-      display2: display2?.merge(other.display2) ?? other.display2,
-      display1: display1?.merge(other.display1) ?? other.display1,
-      headline: headline?.merge(other.headline) ?? other.headline,
-      title: title?.merge(other.title) ?? other.title,
-      subhead: subhead?.merge(other.subhead) ?? other.subhead,
-      body2: body2?.merge(other.body2) ?? other.body2,
-      body1: body1?.merge(other.body1) ?? other.body1,
+      headline1: headline1?.merge(other.headline1) ?? other.headline1,
+      headline2: headline2?.merge(other.headline2) ?? other.headline2,
+      headline3: headline3?.merge(other.headline3) ?? other.headline3,
+      headline4: headline4?.merge(other.headline4) ?? other.headline4,
+      headline5: headline5?.merge(other.headline5) ?? other.headline5,
+      headline6: headline6?.merge(other.headline6) ?? other.headline6,
+      subtitle1: subtitle1?.merge(other.subtitle1) ?? other.subtitle1,
+      subtitle2: subtitle2?.merge(other.subtitle2) ?? other.subtitle2,
+      bodyText1: bodyText1?.merge(other.bodyText1) ?? other.bodyText1,
+      bodyText2: bodyText2?.merge(other.bodyText2) ?? other.bodyText2,
       caption: caption?.merge(other.caption) ?? other.caption,
       button: button?.merge(other.button) ?? other.button,
-      subtitle: subtitle?.merge(other.subtitle) ?? other.subtitle,
       overline: overline?.merge(other.overline) ?? other.overline,
     );
   }
@@ -333,7 +560,7 @@ class TextTheme extends Diagnosticable {
     TextDecorationStyle decorationStyle,
   }) {
     return TextTheme(
-      display4: display4?.apply(
+      headline1: headline1?.apply(
         color: displayColor,
         decoration: decoration,
         decorationColor: decorationColor,
@@ -342,7 +569,7 @@ class TextTheme extends Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      display3: display3?.apply(
+      headline2: headline2?.apply(
         color: displayColor,
         decoration: decoration,
         decorationColor: decorationColor,
@@ -351,7 +578,7 @@ class TextTheme extends Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      display2: display2?.apply(
+      headline3: headline3?.apply(
         color: displayColor,
         decoration: decoration,
         decorationColor: decorationColor,
@@ -360,7 +587,7 @@ class TextTheme extends Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      display1: display1?.apply(
+      headline4: headline4?.apply(
         color: displayColor,
         decoration: decoration,
         decorationColor: decorationColor,
@@ -369,8 +596,8 @@ class TextTheme extends Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      headline: headline?.apply(
-        color: bodyColor,
+      headline5: headline5?.apply(
+        color: displayColor,
         decoration: decoration,
         decorationColor: decorationColor,
         decorationStyle: decorationStyle,
@@ -378,8 +605,8 @@ class TextTheme extends Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      title: title?.apply(
-        color: bodyColor,
+      headline6: headline6?.apply(
+        color: displayColor,
         decoration: decoration,
         decorationColor: decorationColor,
         decorationStyle: decorationStyle,
@@ -387,8 +614,8 @@ class TextTheme extends Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      subhead: subhead?.apply(
-        color: bodyColor,
+      subtitle1: subtitle1?.apply(
+        color: displayColor,
         decoration: decoration,
         decorationColor: decorationColor,
         decorationStyle: decorationStyle,
@@ -396,8 +623,8 @@ class TextTheme extends Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      body2: body2?.apply(
-        color: bodyColor,
+      subtitle2: subtitle2?.apply(
+        color: displayColor,
         decoration: decoration,
         decorationColor: decorationColor,
         decorationStyle: decorationStyle,
@@ -405,8 +632,17 @@ class TextTheme extends Diagnosticable {
         fontSizeFactor: fontSizeFactor,
         fontSizeDelta: fontSizeDelta,
       ),
-      body1: body1?.apply(
-        color: bodyColor,
+      bodyText1: bodyText1?.apply(
+        color: displayColor,
+        decoration: decoration,
+        decorationColor: decorationColor,
+        decorationStyle: decorationStyle,
+        fontFamily: fontFamily,
+        fontSizeFactor: fontSizeFactor,
+        fontSizeDelta: fontSizeDelta,
+      ),
+      bodyText2: bodyText2?.apply(
+        color: displayColor,
         decoration: decoration,
         decorationColor: decorationColor,
         decorationStyle: decorationStyle,
@@ -424,15 +660,6 @@ class TextTheme extends Diagnosticable {
         fontSizeDelta: fontSizeDelta,
       ),
       button: button?.apply(
-        color: bodyColor,
-        decoration: decoration,
-        decorationColor: decorationColor,
-        decorationStyle: decorationStyle,
-        fontFamily: fontFamily,
-        fontSizeFactor: fontSizeFactor,
-        fontSizeDelta: fontSizeDelta,
-      ),
-      subtitle: subtitle?.apply(
         color: bodyColor,
         decoration: decoration,
         decorationColor: decorationColor,
@@ -459,18 +686,18 @@ class TextTheme extends Diagnosticable {
   static TextTheme lerp(TextTheme a, TextTheme b, double t) {
     assert(t != null);
     return TextTheme(
-      display4: TextStyle.lerp(a?.display4, b?.display4, t),
-      display3: TextStyle.lerp(a?.display3, b?.display3, t),
-      display2: TextStyle.lerp(a?.display2, b?.display2, t),
-      display1: TextStyle.lerp(a?.display1, b?.display1, t),
-      headline: TextStyle.lerp(a?.headline, b?.headline, t),
-      title: TextStyle.lerp(a?.title, b?.title, t),
-      subhead: TextStyle.lerp(a?.subhead, b?.subhead, t),
-      body2: TextStyle.lerp(a?.body2, b?.body2, t),
-      body1: TextStyle.lerp(a?.body1, b?.body1, t),
+      headline1: TextStyle.lerp(a?.headline1, b?.headline1, t),
+      headline2: TextStyle.lerp(a?.headline2, b?.headline2, t),
+      headline3: TextStyle.lerp(a?.headline3, b?.headline3, t),
+      headline4: TextStyle.lerp(a?.headline4, b?.headline4, t),
+      headline5: TextStyle.lerp(a?.headline5, b?.headline5, t),
+      headline6: TextStyle.lerp(a?.headline6, b?.headline6, t),
+      subtitle1: TextStyle.lerp(a?.subtitle1, b?.subtitle1, t),
+      subtitle2: TextStyle.lerp(a?.subtitle2, b?.subtitle2, t),
+      bodyText1: TextStyle.lerp(a?.bodyText1, b?.bodyText1, t),
+      bodyText2: TextStyle.lerp(a?.bodyText2, b?.bodyText2, t),
       caption: TextStyle.lerp(a?.caption, b?.caption, t),
       button: TextStyle.lerp(a?.button, b?.button, t),
-      subtitle: TextStyle.lerp(a?.subtitle, b?.subtitle, t),
       overline: TextStyle.lerp(a?.overline, b?.overline, t),
     );
   }
@@ -482,18 +709,18 @@ class TextTheme extends Diagnosticable {
     if (other.runtimeType != runtimeType)
       return false;
     final TextTheme typedOther = other;
-    return display4 == typedOther.display4
-        && display3 == typedOther.display3
-        && display2 == typedOther.display2
-        && display1 == typedOther.display1
-        && headline == typedOther.headline
-        && title == typedOther.title
-        && subhead == typedOther.subhead
-        && body2 == typedOther.body2
-        && body1 == typedOther.body1
+    return headline1 == typedOther.headline1
+        && headline2 == typedOther.headline2
+        && headline3 == typedOther.headline3
+        && headline4 == typedOther.headline4
+        && headline5 == typedOther.headline5
+        && headline6 == typedOther.headline6
+        && subtitle1 == typedOther.subtitle1
+        && subtitle2 == typedOther.subtitle2
+        && bodyText1 == typedOther.bodyText1
+        && bodyText2 == typedOther.bodyText2
         && caption == typedOther.caption
         && button == typedOther.button
-        && subtitle == typedOther.subtitle
         && overline == typedOther.overline;
   }
 
@@ -501,18 +728,18 @@ class TextTheme extends Diagnosticable {
   int get hashCode {
     // The hashValues() function supports up to 20 arguments.
     return hashValues(
-      display4,
-      display3,
-      display2,
-      display1,
-      headline,
-      title,
-      subhead,
-      body2,
+      headline1,
+      headline2,
+      headline3,
+      headline4,
+      headline5,
+      headline6,
+      subtitle1,
+      subtitle2,
       body1,
-      caption,
+      body2,
       button,
-      subtitle,
+      caption,
       overline,
     );
   }
@@ -520,19 +747,19 @@ class TextTheme extends Diagnosticable {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    final TextTheme defaultTheme = Typography(platform: defaultTargetPlatform).black;
-    properties.add(DiagnosticsProperty<TextStyle>('display4', display4, defaultValue: defaultTheme.display4));
-    properties.add(DiagnosticsProperty<TextStyle>('display3', display3, defaultValue: defaultTheme.display3));
-    properties.add(DiagnosticsProperty<TextStyle>('display2', display2, defaultValue: defaultTheme.display2));
-    properties.add(DiagnosticsProperty<TextStyle>('display1', display1, defaultValue: defaultTheme.display1));
-    properties.add(DiagnosticsProperty<TextStyle>('headline', headline, defaultValue: defaultTheme.headline));
-    properties.add(DiagnosticsProperty<TextStyle>('title', title, defaultValue: defaultTheme.title));
-    properties.add(DiagnosticsProperty<TextStyle>('subhead', subhead, defaultValue: defaultTheme.subhead));
-    properties.add(DiagnosticsProperty<TextStyle>('body2', body2, defaultValue: defaultTheme.body2));
+    final TextTheme defaultTheme = Typography.material2018(platform: defaultTargetPlatform).black;
+    properties.add(DiagnosticsProperty<TextStyle>('headline1', headline1, defaultValue: defaultTheme.headline1));
+    properties.add(DiagnosticsProperty<TextStyle>('headline2', headline2, defaultValue: defaultTheme.headline2));
+    properties.add(DiagnosticsProperty<TextStyle>('headline3', headline3, defaultValue: defaultTheme.headline3));
+    properties.add(DiagnosticsProperty<TextStyle>('headline4', headline4, defaultValue: defaultTheme.headline4));
+    properties.add(DiagnosticsProperty<TextStyle>('headline5', headline5, defaultValue: defaultTheme.headline5));
+    properties.add(DiagnosticsProperty<TextStyle>('headline6', headline6, defaultValue: defaultTheme.headline6));
+    properties.add(DiagnosticsProperty<TextStyle>('subtitle1', subtitle1, defaultValue: defaultTheme.subtitle1));
+    properties.add(DiagnosticsProperty<TextStyle>('subtitle2', subtitle2, defaultValue: defaultTheme.subtitle2));
     properties.add(DiagnosticsProperty<TextStyle>('body1', body1, defaultValue: defaultTheme.body1));
-    properties.add(DiagnosticsProperty<TextStyle>('caption', caption, defaultValue: defaultTheme.caption));
+    properties.add(DiagnosticsProperty<TextStyle>('body2', body2, defaultValue: defaultTheme.body2));
     properties.add(DiagnosticsProperty<TextStyle>('button', button, defaultValue: defaultTheme.button));
-    properties.add(DiagnosticsProperty<TextStyle>('subtitle)', subtitle, defaultValue: defaultTheme.subtitle));
+    properties.add(DiagnosticsProperty<TextStyle>('caption', caption, defaultValue: defaultTheme.caption));
     properties.add(DiagnosticsProperty<TextStyle>('overline', overline, defaultValue: defaultTheme.overline));
   }
 }

--- a/packages/flutter/lib/src/material/typography.dart
+++ b/packages/flutter/lib/src/material/typography.dart
@@ -53,10 +53,12 @@ enum ScriptCategory {
 /// `Theme.of(context).primaryTextTheme` or
 /// `Theme.of(context).accentTextTheme`.
 ///
-/// The color text themes are [blackMountainView],
-/// [whiteMountainView], and [blackCupertino] and [whiteCupertino]. The
-/// Mountain View theme [TextStyles] are based on the Roboto fonts and the
-/// Cupertino themes are based on the San Francisco fonts.
+/// The color text themes are [blackMountainView], [whiteMountainView], and
+/// [blackCupertino] and [whiteCupertino]. The Mountain View theme [TextStyles]
+/// are based on the Roboto fonts as used on Android. The Cupertino themes are
+/// based on the [San Francisco
+/// font](https://developer.apple.com/ios/human-interface-guidelines/visual-design/typography/)
+/// fonts as used by Apple on iOS.
 ///
 /// Two sets of geometry themes are provided: 2014 and 2018. The 2014 themes
 /// correspond to the original version of the Material Design spec and are
@@ -64,18 +66,13 @@ enum ScriptCategory {
 /// specification and feature different font sizes, font weights, and
 /// letter spacing values.
 ///
-/// By default, [ThemeData.typography] is
-/// `Typography(platform: platform)` which uses [englishLike2014],
-/// [dense2014] and [tall2014]. To use the 2018 text theme
-/// geometries, specify a typography value:
+/// By default, [ThemeData.typography] is `Typography.material2014(platform:
+/// platform)` which uses [englishLike2014], [dense2014] and [tall2014]. To use
+/// the 2018 text theme geometries, specify a value using the [material2018]
+/// constructor:
 ///
 /// ```dart
-/// Typography(
-///   platorm: platform,
-///   englishLike: Typography.englishLike2018,
-///   dense: Typography.dense2018,
-///   tall: Typography.tall2018,
-/// )
+/// typography: Typography.material2018(platform: platform)
 /// ```
 ///
 /// See also:
@@ -88,6 +85,27 @@ enum ScriptCategory {
 class Typography extends Diagnosticable {
   /// Creates a typography instance.
   ///
+  /// This constructor is identical to [Typography.material2014]. It is
+  /// deprecated because the 2014 material design defaults used by that
+  /// constructor are obsolete. The current material design specification
+  /// recommendations are those reflected by [Typography.material2018].
+  @Deprecated(
+    'The default Typography constructor defaults to the 2014 material design defaults. '
+    'Applications are urged to migrate to Typography.material2018(), or, if the 2014 defaults '
+    'are desired, to explicitly request them using Typography.material2014(). '
+    'This feature was deprecated after v1.12.15.'
+  )
+  factory Typography({
+    TargetPlatform platform,
+    TextTheme black,
+    TextTheme white,
+    TextTheme englishLike,
+    TextTheme dense,
+    TextTheme tall,
+  }) = Typography.material2014;
+
+  /// Creates a typography instance using material design's 2014 defaults.
+  ///
   /// If [platform] is [TargetPlatform.iOS] or [TargetPlatform.macOS], the
   /// default values for [black] and [white] are [blackCupertino] and
   /// [whiteCupertino] respectively. Otherwise they are [blackMountainView] and
@@ -96,7 +114,7 @@ class Typography extends Diagnosticable {
   ///
   /// The default values for [englishLike], [dense], and [tall] are
   /// [englishLike2014], [dense2014], and [tall2014].
-  factory Typography({
+  factory Typography.material2014({
     TargetPlatform platform = TargetPlatform.android,
     TextTheme black,
     TextTheme white,
@@ -105,6 +123,55 @@ class Typography extends Diagnosticable {
     TextTheme tall,
   }) {
     assert(platform != null || (black != null && white != null));
+    return Typography._withPlatform(
+      platform,
+      black, white,
+      englishLike ?? englishLike2014,
+      dense ?? dense2014,
+      tall ?? tall2014,
+    );
+  }
+
+  /// Creates a typography instance using material design's 2018 defaults.
+  ///
+  /// If [platform] is [TargetPlatform.iOS] or [TargetPlatform.macOS], the
+  /// default values for [black] and [white] are [blackCupertino] and
+  /// [whiteCupertino] respectively. Otherwise they are [blackMountainView] and
+  /// [whiteMoutainView]. If [platform] is null then both [black] and [white]
+  /// must be specified.
+  ///
+  /// The default values for [englishLike], [dense], and [tall] are
+  /// [englishLike2018], [dense2018], and [tall2018].
+  factory Typography.material2018({
+    TargetPlatform platform = TargetPlatform.android,
+    TextTheme black,
+    TextTheme white,
+    TextTheme englishLike,
+    TextTheme dense,
+    TextTheme tall,
+  }) {
+    assert(platform != null || (black != null && white != null));
+    return Typography._withPlatform(
+      platform,
+      black, white,
+      englishLike ?? englishLike2018,
+      dense ?? dense2018,
+      tall ?? tall2018,
+    );
+  }
+
+  factory Typography._withPlatform(
+    TargetPlatform platform,
+    TextTheme black,
+    TextTheme white,
+    TextTheme englishLike,
+    TextTheme dense,
+    TextTheme tall,
+  ) {
+    assert(platform != null || (black != null && white != null));
+    assert(englishLike != null);
+    assert(dense != null);
+    assert(tall != null);
     switch (platform) {
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
@@ -116,9 +183,6 @@ class Typography extends Diagnosticable {
         black ??= blackMountainView;
         white ??= whiteMountainView;
     }
-    englishLike ??= englishLike2014;
-    dense ??= dense2014;
-    tall ??= tall2014;
     return Typography._(black, white, englishLike, dense, tall);
   }
 
@@ -206,12 +270,12 @@ class Typography extends Diagnosticable {
     TextTheme dense,
     TextTheme tall,
   }) {
-    return Typography(
-      black: black ?? this.black,
-      white: white ?? this.white,
-      englishLike: englishLike ?? this.englishLike,
-      dense: dense ?? this.dense,
-      tall: tall ?? this.tall,
+    return Typography._(
+      black ?? this.black,
+      white ?? this.white,
+      englishLike ?? this.englishLike,
+      dense ?? this.dense,
+      tall ?? this.tall,
     );
   }
 
@@ -219,12 +283,12 @@ class Typography extends Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static Typography lerp(Typography a, Typography b, double t) {
-    return Typography(
-      black: TextTheme.lerp(a.black, b.black, t),
-      white: TextTheme.lerp(a.white, b.white, t),
-      englishLike: TextTheme.lerp(a.englishLike, b.englishLike, t),
-      dense: TextTheme.lerp(a.dense, b.dense, t),
-      tall: TextTheme.lerp(a.tall, b.tall, t),
+    return Typography._(
+      TextTheme.lerp(a.black, b.black, t),
+      TextTheme.lerp(a.white, b.white, t),
+      TextTheme.lerp(a.englishLike, b.englishLike, t),
+      TextTheme.lerp(a.dense, b.dense, t),
+      TextTheme.lerp(a.tall, b.tall, t),
     );
   }
 
@@ -256,7 +320,7 @@ class Typography extends Diagnosticable {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    final Typography defaultTypography = Typography();
+    final Typography defaultTypography = Typography.material2018();
     properties.add(DiagnosticsProperty<TextTheme>('black', black, defaultValue: defaultTypography.black));
     properties.add(DiagnosticsProperty<TextTheme>('white', white, defaultValue: defaultTypography.white));
     properties.add(DiagnosticsProperty<TextTheme>('englishLike', englishLike, defaultValue: defaultTypography.englishLike));


### PR DESCRIPTION
This isn't complete, we also have to migrate the 586 usages of these APIs to the new terms, and write tests that verify the old and new terms work together peacefully.

We also should check with the material team about the use of `bodyText1` vs `body1`.