### PR TITLE
Fix buildCounter returns a widget when set to return null.

### DIFF
--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -661,6 +661,9 @@ class TextField extends StatefulWidget {
   /// }
   /// ```
   /// {@end-tool}
+  ///
+  /// If buildCounter returns null, then no counter and no Semantics widget will
+  /// be created at all.
   final InputCounterWidgetBuilder buildCounter;
 
   /// {@macro flutter.widgets.edtiableText.scrollPhysics}
@@ -759,18 +762,18 @@ class _TextFieldState extends State<TextField> implements TextSelectionGestureDe
         && effectiveDecoration.counterText == null
         && widget.buildCounter != null) {
       final bool isFocused = _effectiveFocusNode.hasFocus;
-      final Widget buildCounter = widget.buildCounter(
+      final Widget builtCounter = widget.buildCounter(
         context,
         currentLength: currentLength,
         maxLength: widget.maxLength,
         isFocused: isFocused,
       );
-      // If buildCounter returns null, the counter widget should return nothing.
-      if (buildCounter != null) {
+      // If buildCounter returns null, don't add a counter widget to the field.
+      if (builtCounter != null) {
         counter = Semantics(
           container: true,
           liveRegion: isFocused,
-          child: buildCounter,
+          child: builtCounter,
         );
       }
       return effectiveDecoration.copyWith(counter: counter);

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -759,16 +759,20 @@ class _TextFieldState extends State<TextField> implements TextSelectionGestureDe
         && effectiveDecoration.counterText == null
         && widget.buildCounter != null) {
       final bool isFocused = _effectiveFocusNode.hasFocus;
-      counter = Semantics(
-        container: true,
-        liveRegion: isFocused,
-        child: widget.buildCounter(
-          context,
-          currentLength: currentLength,
-          maxLength: widget.maxLength,
-          isFocused: isFocused,
-        ),
+      final Widget buildCounter = widget.buildCounter(
+        context,
+        currentLength: currentLength,
+        maxLength: widget.maxLength,
+        isFocused: isFocused,
       );
+      // If buildCounter returns null, the counter widget should return nothing.
+      if (buildCounter != null) {
+        counter = Semantics(
+          container: true,
+          liveRegion: isFocused,
+          child: buildCounter,
+        );
+      }
       return effectiveDecoration.copyWith(counter: counter);
     }
 

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -7399,25 +7399,22 @@ void main() {
     expect(focusNode3.hasPrimaryFocus, isTrue);
   });
 
-  testWidgets('test empty widget when the buildCounter returns null',
-      (WidgetTester tester) async {
+  testWidgets("A buildCounter that returns null doesn't affect the size of the TextField", (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/44909
 
-    final GlobalKey textField1State = GlobalKey();
-    final GlobalKey textField2State = GlobalKey();
+    final GlobalKey textField1Key = GlobalKey();
+    final GlobalKey textField2Key = GlobalKey();
 
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
           body: Column(
             children: <Widget>[
-              TextField(key: textField1State),
+              TextField(key: textField1Key),
               TextField(
-                key: textField2State,
+                key: textField2Key,
                 maxLength: 1,
-                buildCounter: (BuildContext context,
-                        {int currentLength, bool isFocused, int maxLength}) =>
-                    null,
+                buildCounter: (BuildContext context, {int currentLength, bool isFocused, int maxLength}) => null,
               ),
             ],
           ),
@@ -7426,8 +7423,8 @@ void main() {
     );
 
     await tester.pumpAndSettle();
-    final Size textFieldSize1 = tester.getSize(find.byKey(textField1State));
-    final Size textFieldSize2 = tester.getSize(find.byKey(textField2State));
+    final Size textFieldSize1 = tester.getSize(find.byKey(textField1Key));
+    final Size textFieldSize2 = tester.getSize(find.byKey(textField2Key));
 
     expect(textFieldSize1, equals(textFieldSize2));
   });

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -7398,4 +7398,37 @@ void main() {
     await tester.pump();
     expect(focusNode3.hasPrimaryFocus, isTrue);
   });
+
+  testWidgets('test empty widget when the buildCounter returns null',
+      (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/44909
+
+    final GlobalKey textField1State = GlobalKey();
+    final GlobalKey textField2State = GlobalKey();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Column(
+            children: <Widget>[
+              TextField(key: textField1State),
+              TextField(
+                key: textField2State,
+                maxLength: 1,
+                buildCounter: (BuildContext context,
+                        {int currentLength, bool isFocused, int maxLength}) =>
+                    null,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+    final Size textFieldSize1 = tester.getSize(find.byKey(textField1State));
+    final Size textFieldSize2 = tester.getSize(find.byKey(textField2State));
+
+    expect(textFieldSize1, equals(textFieldSize2));
+  });
 }


### PR DESCRIPTION
## Related Issues

#44909 

## Tests

I added the following tests:

Add test to compare if a `TextField`'s size is equal to a `TextField` with `maxLength` and `buildCounter` set to return `null`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.