### PR TITLE
Remove canTransitionFrom override from Material/CupertinoPageRoute

### DIFF
--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -177,11 +177,6 @@ class CupertinoPageRoute<T> extends PageRoute<T> {
   String get barrierLabel => null;
 
   @override
-  bool canTransitionFrom(TransitionRoute<dynamic> previousRoute) {
-    return previousRoute is CupertinoPageRoute;
-  }
-
-  @override
   bool canTransitionTo(TransitionRoute<dynamic> nextRoute) {
     // Don't perform outgoing animation if the next route is a fullscreen dialog.
     return nextRoute is CupertinoPageRoute && !nextRoute.fullscreenDialog;

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -67,11 +67,6 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   String get barrierLabel => null;
 
   @override
-  bool canTransitionFrom(TransitionRoute<dynamic> previousRoute) {
-    return previousRoute is MaterialPageRoute || previousRoute is CupertinoPageRoute;
-  }
-
-  @override
   bool canTransitionTo(TransitionRoute<dynamic> nextRoute) {
     // Don't perform outgoing animation if the next route is a fullscreen dialog.
     return (nextRoute is MaterialPageRoute && !nextRoute.fullscreenDialog)

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -787,10 +787,7 @@ void main() {
     expect(pageTapCount, 1);
   });
 
-  testWidgets(
-    'On iOS, a MaterialPageRoute should slide out with CupertinoPageTransition'
-      'when a compatible PageRoute is pushed on top of it',
-      (WidgetTester tester) async {
+  testWidgets('On iOS, a MaterialPageRoute should slide out with CupertinoPageTransition when a compatible PageRoute is pushed on top of it', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/44864.
     
     await tester.pumpWidget(

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart' show CupertinoPageRoute;
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -785,4 +786,34 @@ void main() {
     expect(homeTapCount, 2);
     expect(pageTapCount, 1);
   });
+
+  testWidgets(
+      'On iOS, a MaterialPageRoute should slide out with CupertinoPageTransition'
+          'when a compatible PageRoute is pushed on top of it',
+          (WidgetTester tester) async {
+        // Regression test for https://github.com/flutter/flutter/issues/44864.
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(platform: TargetPlatform.iOS),
+            home: Scaffold(
+              appBar: AppBar(title: const Text('Title')),
+            ),
+          ),
+        );
+
+        final Offset titleInitialTopLeft = tester.getTopLeft(find.text('Title'));
+
+        tester.state<NavigatorState>(find.byType(Navigator)).push<void>(
+          CupertinoPageRoute<void>(builder: (BuildContext context) => const Placeholder()),
+        );
+
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 150));
+
+        final Offset titleTransientTopLeft = tester.getTopLeft(find.text('Title'));
+
+        // Title of the first route slides to the left.
+        expect(titleInitialTopLeft.dy, equals(titleTransientTopLeft.dy));
+        expect(titleInitialTopLeft.dx, greaterThan(titleTransientTopLeft.dx));
+      });
 }

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -788,32 +788,33 @@ void main() {
   });
 
   testWidgets(
-      'On iOS, a MaterialPageRoute should slide out with CupertinoPageTransition'
-          'when a compatible PageRoute is pushed on top of it',
-          (WidgetTester tester) async {
-        // Regression test for https://github.com/flutter/flutter/issues/44864.
-        await tester.pumpWidget(
-          MaterialApp(
-            theme: ThemeData(platform: TargetPlatform.iOS),
-            home: Scaffold(
-              appBar: AppBar(title: const Text('Title')),
-            ),
-          ),
-        );
+    'On iOS, a MaterialPageRoute should slide out with CupertinoPageTransition'
+      'when a compatible PageRoute is pushed on top of it',
+      (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/44864.
+    
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(platform: TargetPlatform.iOS),
+        home: Scaffold(
+          appBar: AppBar(title: const Text('Title')),
+        ),
+      ),
+    );
 
-        final Offset titleInitialTopLeft = tester.getTopLeft(find.text('Title'));
+    final Offset titleInitialTopLeft = tester.getTopLeft(find.text('Title'));
 
-        tester.state<NavigatorState>(find.byType(Navigator)).push<void>(
-          CupertinoPageRoute<void>(builder: (BuildContext context) => const Placeholder()),
-        );
+    tester.state<NavigatorState>(find.byType(Navigator)).push<void>(
+      CupertinoPageRoute<void>(builder: (BuildContext context) => const Placeholder()),
+    );
 
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 150));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 150));
 
-        final Offset titleTransientTopLeft = tester.getTopLeft(find.text('Title'));
+    final Offset titleTransientTopLeft = tester.getTopLeft(find.text('Title'));
 
-        // Title of the first route slides to the left.
-        expect(titleInitialTopLeft.dy, equals(titleTransientTopLeft.dy));
-        expect(titleInitialTopLeft.dx, greaterThan(titleTransientTopLeft.dx));
-      });
+    // Title of the first route slides to the left.
+    expect(titleInitialTopLeft.dy, equals(titleTransientTopLeft.dy));
+    expect(titleInitialTopLeft.dx, greaterThan(titleTransientTopLeft.dx));
+  });
 }

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -789,7 +789,7 @@ void main() {
 
   testWidgets('On iOS, a MaterialPageRoute should slide out with CupertinoPageTransition when a compatible PageRoute is pushed on top of it', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/44864.
-    
+
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(platform: TargetPlatform.iOS),


### PR DESCRIPTION
Overriding this method will cause the route transition animation to be lost, so remove this method

## Description
On iOS, a MaterialPageRoute should slide out with CupertinoPageTransition when a compatible PageRoute is pushed on top of it.  Overriding `canTransitionFrom` method will cause the route transition animation to be lost when a `CupertinoPageRoute` push on another route. So I remove this method from material/pages.dart and cupertino/pages.dart.

## Related Issues

Fixes #44864

## Tests

I added the following tests:

/packages/flutter/test/material/page_test.dart

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.
