### PR TITLE
prevent VsCode from crashing on malformed packages.json file

### DIFF
--- a/packages/flutter_tools/lib/src/vscode/vscode.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode.dart
@@ -224,8 +224,12 @@ class VsCode {
       return null;
     }
     final String jsonString = fs.file(packageJsonPath).readAsStringSync();
-    final Map<String, dynamic> jsonObject = castStringKeyedMap(json.decode(jsonString));
-    return jsonObject['version'] as String;
+    try {
+      final Map<String, dynamic> jsonObject = castStringKeyedMap(json.decode(jsonString));
+      return jsonObject['version'] as String;
+    } on FormatException {
+      return null;
+    }
   }
 }
 

--- a/packages/flutter_tools/test/general.shard/vscode_test.dart
+++ b/packages/flutter_tools/test/general.shard/vscode_test.dart
@@ -1,0 +1,28 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/version.dart';
+import 'package:flutter_tools/src/vscode/vscode.dart';
+
+import '../src/common.dart';
+import '../src/context.dart';
+
+void main() {
+  testUsingContext('VsCode.fromDirectory does not crash when packages.json is malformed', () {
+    // Create invalid JSON file.
+    fs.file(fs.path.join('', 'resources', 'app', 'package.json'))
+      ..createSync(recursive: true)
+      ..writeAsStringSync('{');
+
+    final VsCode vsCode = VsCode.fromDirectory('', '');
+
+    expect(vsCode.version, Version.unknown);
+  }, overrides: <Type, Generator>{
+    FileSystem: () => MemoryFileSystem(),
+    ProcessManager: () => FakeProcessManager.any(),
+  });
+}


### PR DESCRIPTION
## Description

If packages.json was malformed, flutter doctor could crash due to an uncaught FormatException. Catch the error and fallback to an unknown version

Fixes https://github.com/flutter/flutter/issues/45753