### PR TITLE
Revert "update macOS configuration settings"

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -146,6 +146,22 @@ class CreateCommand extends FlutterCommand {
       defaultsTo: true,
       help: 'Generate a project using the AndroidX support libraries',
     );
+    // Deprecated
+    argParser.addFlag(
+      'macos',
+      negatable: true,
+      defaultsTo: false,
+      hide: true,
+      help: 'Include support for building a macOS application',
+    );
+    // Deprecated
+    argParser.addFlag(
+      'web',
+      negatable: true,
+      defaultsTo: false,
+      hide: true,
+      help: 'Deprecated',
+    );
   }
 
   @override
@@ -390,7 +406,7 @@ class CreateCommand extends FlutterCommand {
       androidLanguage: stringArg('android-language'),
       iosLanguage: stringArg('ios-language'),
       web: featureFlags.isWebEnabled,
-      macos: featureFlags.isMacOSEnabled,
+      macos: boolArg('macos'),
     );
 
     final String relativeDirPath = fs.path.relative(projectDirPath);

--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -106,10 +106,6 @@ const Feature flutterMacOSDesktopFeature = Feature(
     available: true,
     enabledByDefault: false,
   ),
-  dev: FeatureChannelSetting(
-    available: true,
-    enabledByDefault: false,
-  ),
 );
 
 /// The [Feature] for Linux desktop.

--- a/packages/flutter_tools/test/general.shard/features_test.dart
+++ b/packages/flutter_tools/test/general.shard/features_test.dart
@@ -78,27 +78,19 @@ void main() {
     }));
 
     test('flutter web help string', () {
-      expect(flutterWebFeature.generateHelpMessage(),
-      'Enable or disable Flutter for web. '
-      'This setting will take effect on the master, dev, and beta channels.');
+      expect(flutterWebFeature.generateHelpMessage(), 'Enable or disable Flutter for web. This setting will take effect on the master, dev, and beta channels.');
     });
 
     test('flutter macOS desktop help string', () {
-      expect(flutterMacOSDesktopFeature.generateHelpMessage(),
-      'Enable or disable Flutter for desktop on macOS. '
-      'This setting will take effect on the master and dev channels.');
+      expect(flutterMacOSDesktopFeature.generateHelpMessage(), 'Enable or disable Flutter for desktop on macOS. This setting will take effect on the master channel.');
     });
 
     test('flutter Linux desktop help string', () {
-      expect(flutterLinuxDesktopFeature.generateHelpMessage(),
-      'Enable or disable Flutter for desktop on Linux. '
-      'This setting will take effect on the master channel.');
+      expect(flutterLinuxDesktopFeature.generateHelpMessage(), 'Enable or disable Flutter for desktop on Linux. This setting will take effect on the master channel.');
     });
 
     test('flutter Windows desktop help string', () {
-      expect(flutterWindowsDesktopFeature.generateHelpMessage(),
-      'Enable or disable Flutter for desktop on Windows. '
-      'This setting will take effect on the master channel.');
+      expect(flutterWindowsDesktopFeature.generateHelpMessage(), 'Enable or disable Flutter for desktop on Windows. This setting will take effect on the master channel.');
     });
 
     test('help string on multiple channels', () {
@@ -225,18 +217,18 @@ void main() {
       expect(featureFlags.isMacOSEnabled, false);
     }));
 
-    test('flutter macos desktop enabled with config on dev', () => testbed.run(() {
+    test('flutter macos desktop not enabled with config on dev', () => testbed.run(() {
       when(mockFlutterVerion.channel).thenReturn('dev');
-      when<bool>(mockFlutterConfig.getValue('enable-macos-desktop') as bool).thenReturn(true);
+      when<bool>(mockFlutterConfig.getValue('flutter-desktop-macos') as bool).thenReturn(true);
 
-      expect(featureFlags.isMacOSEnabled, true);
+      expect(featureFlags.isMacOSEnabled, false);
     }));
 
-    test('flutter macos desktop enabled with environment variable on dev', () => testbed.run(() {
+    test('flutter macos desktop not enabled with environment variable on dev', () => testbed.run(() {
       when(mockFlutterVerion.channel).thenReturn('dev');
       when(mockPlatform.environment).thenReturn(<String, String>{'FLUTTER_MACOS': 'true'});
 
-      expect(featureFlags.isMacOSEnabled, true);
+      expect(featureFlags.isMacOSEnabled, false);
     }));
 
     test('flutter macos desktop off by default on beta', () => testbed.run(() {


### PR DESCRIPTION
Reverts flutter/flutter#45920


Breaks web-size-compile-test

```
2019-12-02T21:32:05.899424: stdout: [  +37 ms] web_release_bundle: Starting due to {InvalidatedReason.inputChanged, InvalidatedReason.outputMissing}
2019-12-02T21:32:06.102281: stdout: [ +202 ms] web_release_bundle: Complete
2019-12-02T21:32:06.153537: stdout: [  +51 ms] Persisting file store
2019-12-02T21:32:06.158978: stdout: [   +5 ms] Done persisting file store
2019-12-02T21:32:06.168686: stdout: [   +9 ms] Compiling lib/main.dart for the Web... (completed in 26.1s)
2019-12-02T21:32:06.169779: stdout: [   +1 ms] "flutter web" took 26,405ms.
2019-12-02T21:32:06.177830: "/home/flutter/.cocoon/flutter/bin/flutter" exit code: 0
2019-12-02T21:32:06.271035: 
Executing: /home/flutter/.cocoon/flutter/bin/flutter create --template=app --web sample_flutter_app in /tmp with environment {FLUTTER_WEB: true}
2019-12-02T21:32:06.495145: stderr: Could not find an option named "web".
2019-12-02T21:32:06.496050: stderr: 
2019-12-02T21:32:06.496110: stderr: Run 'flutter -h' (or 'flutter <command> -h') for available flutter commands and options.
2019-12-02T21:32:06.534229: "/home/flutter/.cocoon/flutter/bin/flutter" exit code: 64
2019-12-02T21:32:06.539598: Task failed: Executable "/home/flutter/.cocoon/flutter/bin/flutter" failed with exit code 64.2019-12-02T21:32:06.539779: 
```