### PR TITLE
[Driver] correction of data returned by getWidgetDiagnostics

### DIFF
--- a/packages/flutter_driver/lib/src/driver/driver.dart
+++ b/packages/flutter_driver/lib/src/driver/driver.dart
@@ -621,7 +621,7 @@ class FlutterDriver {
   }) async {
     return _sendCommand(GetDiagnosticsTree(
       finder,
-      DiagnosticsType.renderObject,
+      DiagnosticsType.widget,
       subtreeDepth: subtreeDepth,
       includeProperties: includeProperties,
       timeout: timeout,

--- a/packages/flutter_driver/test/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/flutter_driver_test.dart
@@ -249,6 +249,42 @@ void main() {
       });
     });
 
+    group('getWidgetDiagnostics', () {
+      test('sends the getWidgetDiagnostics command', () async {
+        when(mockIsolate.invokeExtension(any, any)).thenAnswer((Invocation i) {
+          expect(i.positionalArguments[1], <String, dynamic>{
+            'command': 'get_diagnostics_tree',
+            'diagnosticsType': 'widget',
+            'finderType': 'ByTooltipMessage',
+            'text': 'foo',
+            'includeProperties': 'true',
+            'subtreeDepth': '0',
+            'timeout': _kSerializedTestTimeout,
+          });
+          return makeMockResponse(<String, dynamic>{});
+        });
+        await driver.getWidgetDiagnostics(find.byTooltip('foo'), timeout: _kTestTimeout);
+      });
+    });
+
+    group('getRenderObjectDiagnostics', () {
+      test('sends the getRenderObjectDiagnostics command', () async {
+        when(mockIsolate.invokeExtension(any, any)).thenAnswer((Invocation i) {
+          expect(i.positionalArguments[1], <String, dynamic>{
+            'command': 'get_diagnostics_tree',
+            'diagnosticsType': 'renderObject',
+            'finderType': 'ByTooltipMessage',
+            'text': 'foo',
+            'includeProperties': 'true',
+            'subtreeDepth': '0',
+            'timeout': _kSerializedTestTimeout,
+          });
+          return makeMockResponse(<String, dynamic>{});
+        });
+        await driver.getRenderObjectDiagnostics(find.byTooltip('foo'), timeout: _kTestTimeout);
+      });
+    });
+
     group('waitForCondition', () {
       test('sends the wait for NoPendingFrameCondition command', () async {
         when(mockIsolate.invokeExtension(any, any)).thenAnswer((Invocation i) {


### PR DESCRIPTION
## Description

Previously `getWidgetDiagnostics` were returning a render object diagnostics instead of the widget diagnostics.
The method has been returning the same data as `getRenderObjectDiagnostics`.

This is my first contribution to the project, so please forgive me If I do something incorrectly.

## Related Issues

No issues related.
Related change: https://github.com/flutter/flutter/pull/34440

## Tests
The code wasn't covered by tests, so added `sends the getWidgetDiagnostics command` and `sends the getRenderObjectDiagnostics command` tests.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`). **No new features**
- [x] All existing and new tests are passing. **(Hopefully, yes. I've executed `(cd packages/flutter_driver && ../../bin/flutter test)`)**
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

It's hard to say if this is a breaking change. Actually, the method has been returning incorrect results. So the results of using the method in tests are different now.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
