### PR TITLE
add printTrace when vscode package.json parsing fails

### DIFF
--- a/packages/flutter_tools/lib/src/vscode/vscode.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode.dart
@@ -9,6 +9,7 @@ import '../base/utils.dart';
 import '../base/version.dart';
 import '../convert.dart';
 import '../doctor.dart';
+import '../globals.dart';
 
 // Include VS Code insiders (useful for debugging).
 const bool _includeInsiders = false;
@@ -227,7 +228,8 @@ class VsCode {
     try {
       final Map<String, dynamic> jsonObject = castStringKeyedMap(json.decode(jsonString));
       return jsonObject['version'] as String;
-    } on FormatException {
+    } on FormatException catch (err) {
+      printTrace('Error parsing VSCode $packageJsonPath:\n$err');
       return null;
     }
   }

--- a/packages/flutter_tools/test/general.shard/vscode_test.dart
+++ b/packages/flutter_tools/test/general.shard/vscode_test.dart
@@ -5,7 +5,9 @@
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/version.dart';
+import 'package:flutter_tools/src/globals.dart';
 import 'package:flutter_tools/src/vscode/vscode.dart';
 
 import '../src/common.dart';
@@ -13,6 +15,7 @@ import '../src/context.dart';
 
 void main() {
   testUsingContext('VsCode.fromDirectory does not crash when packages.json is malformed', () {
+    final BufferLogger bufferLogger = logger as BufferLogger;
     // Create invalid JSON file.
     fs.file(fs.path.join('', 'resources', 'app', 'package.json'))
       ..createSync(recursive: true)
@@ -21,6 +24,7 @@ void main() {
     final VsCode vsCode = VsCode.fromDirectory('', '');
 
     expect(vsCode.version, Version.unknown);
+    expect(bufferLogger.traceText, contains('Error parsing VSCode'));
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(),
     ProcessManager: () => FakeProcessManager.any(),


### PR DESCRIPTION
## Description

From suggested review comment in https://github.com/flutter/flutter/pull/45786/files/148c682502c23fadb4e637b3f0b3b9332ce24429#r353288719