### PR TITLE
[flutter_tool] Make Device.dispose() abstract

### DIFF
--- a/packages/flutter_tools/lib/src/desktop_device.dart
+++ b/packages/flutter_tools/lib/src/desktop_device.dart
@@ -137,6 +137,11 @@ abstract class DesktopDevice extends Device {
     return succeeded;
   }
 
+  @override
+  Future<void> dispose() async {
+    await portForwarder?.dispose();
+  }
+
   /// Builds the current project for this device, with the given options.
   Future<void> buildForDevice(
     ApplicationPackage package, {
@@ -173,4 +178,9 @@ class DesktopLogReader extends DeviceLogReader {
 
   @override
   String get name => 'desktop';
+
+  @override
+  void dispose() {
+    // Nothing to dispose.
+  }
 }

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -492,7 +492,7 @@ abstract class Device {
   /// Clean up resources allocated by device
   ///
   /// For example log readers or port forwarders.
-  void dispose() {}
+  Future<void> dispose();
 }
 
 /// Information about an application's memory usage.
@@ -633,7 +633,7 @@ abstract class DevicePortForwarder {
   Future<void> unforward(ForwardedPort forwardedPort);
 
   /// Cleanup allocated resources, like forwardedPorts
-  Future<void> dispose() async { }
+  Future<void> dispose();
 }
 
 /// Read the log for a particular device.
@@ -654,7 +654,7 @@ abstract class DeviceLogReader {
   int appPid;
 
   // Clean up resources allocated by log reader e.g. subprocesses
-  void dispose() { }
+  void dispose();
 }
 
 /// Describes an app running on the device.

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -472,11 +472,11 @@ class IOSDevice extends Device {
   }
 
   @override
-  void dispose() {
+  Future<void> dispose() async {
     _logReaders.forEach((IOSApp application, DeviceLogReader logReader) {
       logReader.dispose();
     });
-    _portForwarder?.dispose();
+    await _portForwarder?.dispose();
   }
 }
 

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -171,7 +171,7 @@ class ColdRunner extends ResidentRunner {
   @override
   Future<void> cleanupAtFinish() async {
     for (FlutterDevice flutterDevice in flutterDevices) {
-      flutterDevice.device.dispose();
+      await flutterDevice.device.dispose();
     }
 
     await stopEchoingDeviceLog();

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -1031,7 +1031,7 @@ class HotRunner extends ResidentRunner {
   @override
   Future<void> cleanupAtFinish() async {
     for (FlutterDevice flutterDevice in flutterDevices) {
-      flutterDevice.device.dispose();
+      await flutterDevice.device.dispose();
     }
     await _cleanupDevFS();
     await stopEchoingDeviceLog();

--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -212,6 +212,12 @@ class FlutterTesterDevice extends Device {
 
   @override
   bool isSupportedForProject(FlutterProject flutterProject) => true;
+
+  @override
+  Future<void> dispose() async {
+    _logReader?.dispose();
+    await _portForwarder?.dispose();
+  }
 }
 
 class FlutterTesterDevices extends PollingDeviceDiscovery {
@@ -250,6 +256,9 @@ class _FlutterTesterDeviceLogReader extends DeviceLogReader {
   String get name => 'flutter tester log reader';
 
   void addLine(String line) => _logLinesController.add(line);
+
+  @override
+  void dispose() {}
 }
 
 /// A fake port forwarder that doesn't do anything. Used by flutter tester
@@ -268,4 +277,7 @@ class _NoopPortForwarder extends DevicePortForwarder {
 
   @override
   Future<void> unforward(ForwardedPort forwardedPort) async { }
+
+  @override
+  Future<void> dispose() async { }
 }

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -59,9 +59,11 @@ class ChromeDevice extends Device {
   @override
   void clearLogs() { }
 
+  DeviceLogReader _logReader;
+
   @override
   DeviceLogReader getLogReader({ApplicationPackage app}) {
-    return NoOpDeviceLogReader(app?.name);
+    return _logReader ??= NoOpDeviceLogReader(app?.name);
   }
 
   @override
@@ -160,6 +162,12 @@ class ChromeDevice extends Device {
   bool isSupportedForProject(FlutterProject flutterProject) {
     return flutterProject.web.existsSync();
   }
+
+  @override
+  Future<void> dispose() async {
+    _logReader?.dispose();
+    await portForwarder?.dispose();
+  }
 }
 
 class WebDevices extends PollingDeviceDiscovery {
@@ -206,9 +214,11 @@ class WebServerDevice extends Device {
   @override
   Future<String> get emulatorId => null;
 
+  DeviceLogReader _logReader;
+
   @override
   DeviceLogReader getLogReader({ApplicationPackage app}) {
-    return NoOpDeviceLogReader(app.name);
+    return _logReader ??= NoOpDeviceLogReader(app.name);
   }
 
   @override
@@ -270,5 +280,11 @@ class WebServerDevice extends Device {
   @override
   Future<bool> uninstallApp(ApplicationPackage app) async {
     return true;
+  }
+
+  @override
+  Future<void> dispose() async {
+    _logReader?.dispose();
+    await portForwarder?.dispose();
   }
 }

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
@@ -71,6 +71,14 @@ void main() {
       expect(names.length, 0);
     });
 
+    testUsingContext('disposing device disposes the portForwarder', () async {
+      final MockPortForwarder mockPortForwarder = MockPortForwarder();
+      final FuchsiaDevice device = FuchsiaDevice('123');
+      device.portForwarder = mockPortForwarder;
+      await device.dispose();
+      verify(mockPortForwarder.dispose()).called(1);
+    });
+
     testUsingContext('default capabilities', () async {
       final FuchsiaDevice device = FuchsiaDevice('123');
       fs.directory('fuchsia').createSync(recursive: true);

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -138,7 +138,7 @@ void main() {
         device.setLogReader(appPackage2, logReader2);
         device.portForwarder = portForwarder;
 
-        device.dispose();
+        await device.dispose();
 
         verify(mockProcess1.kill());
         verify(mockProcess2.kill());
@@ -247,6 +247,16 @@ void main() {
         tryToDelete(tempDir);
 
         Cache.enableLocking();
+      });
+
+      testUsingContext('disposing device disposes the portForwarder', () async {
+        final IOSDevice device = IOSDevice('123');
+        device.portForwarder = mockPortForwarder;
+        device.setLogReader(mockApp, mockLogReader);
+        await device.dispose();
+        verify(mockPortForwarder.dispose()).called(1);
+      }, overrides: <Type, Generator>{
+        Platform: () => macPlatform,
       });
 
       testUsingContext('returns failed if the IOSDevice is not found', () async {

--- a/packages/flutter_tools/test/general.shard/protocol_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/protocol_discovery_test.dart
@@ -381,4 +381,7 @@ class MockPortForwarder extends DevicePortForwarder {
   Future<void> unforward(ForwardedPort forwardedPort) {
     throw 'not implemented';
   }
+
+  @override
+  Future<void> dispose() async {}
 }

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -550,6 +550,33 @@ void main() {
     expect(await fs.file('foo').readAsString(), testUri.toString());
   }));
 
+  test('HotRunner unforwards device ports', () => testbed.run(() async {
+    final MockDevicePortForwarder mockPortForwarder = MockDevicePortForwarder();
+    when(mockDevice.portForwarder).thenReturn(mockPortForwarder);
+    fs.file(fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        mockFlutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+    );
+    when(mockFlutterDevice.runHot(
+      hotRunner: anyNamed('hotRunner'),
+      route: anyNamed('route'),
+    )).thenAnswer((Invocation invocation) async {
+      return 0;
+    });
+
+    when(mockDevice.dispose()).thenAnswer((Invocation invocation) async {
+      await mockDevice.portForwarder.dispose();
+    });
+
+    await residentRunner.run();
+
+    verify(mockPortForwarder.dispose()).called(1);
+  }));
+
   test('HotRunner handles failure to write vmservice file', () => testbed.run(() async {
     fs.file(fs.path.join('lib', 'main.dart')).createSync(recursive: true);
     residentRunner = HotRunner(
@@ -650,6 +677,7 @@ class MockDevFS extends Mock implements DevFS {}
 class MockIsolate extends Mock implements Isolate {}
 class MockDevice extends Mock implements Device {}
 class MockDeviceLogReader extends Mock implements DeviceLogReader {}
+class MockDevicePortForwarder extends Mock implements DevicePortForwarder {}
 class MockUsage extends Mock implements Usage {}
 class MockProcessManager extends Mock implements ProcessManager {}
 class MockServiceEvent extends Mock implements ServiceEvent {}


### PR DESCRIPTION
## Description

We were failing to unforward ports for Android. The resident runner is calling `Device.dispose()` in the correct places, but `AndroidDevice` was inheriting a no-op `dispose()` method from the `Device` base class. This PR removes the no-op `dispose` from the `Device` base class (and a couple others). This requires implementers of `Device` to provide an implementation that makes sense. On Android, `dispose()` now unforwards ports.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/45948

## Tests

I added the following tests:

Added a test to resident_runner_test.dart that ensures that the resident runner is calling dispose() on devices. Added tests to platform specific device tests that calling dispose() on the device results in a call to dispose() on the devices' port forwarders, where appropriate.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.
