### PR TITLE
Memory test on scrolling large images quickly

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/common.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/common.dart
@@ -7,3 +7,4 @@ const String kCubicBezierRouteName = '/cubic_bezier';
 const String kBackdropFilterRouteName = '/backdrop_filter';
 const String kSimpleAnimationRouteName = '/simple_animation';
 const String kPictureCacheRouteName = '/picture_cache';
+const String kLargeImagesRouteName = '/large_images';

--- a/dev/benchmarks/macrobenchmarks/lib/main.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/main.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:macrobenchmarks/src/large_images.dart';
 import 'package:macrobenchmarks/src/picture_cache.dart';
 
 import 'common.dart';
@@ -13,24 +14,29 @@ import 'src/simple_animation.dart';
 
 const String kMacrobenchmarks ='Macrobenchmarks';
 
-void main() => runApp(MacrobenchmarksApp());
+void main() => runApp(const MacrobenchmarksApp());
 
 class MacrobenchmarksApp extends StatelessWidget {
+  const MacrobenchmarksApp({this.initialRoute = '/'});
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: kMacrobenchmarks,
-      initialRoute: '/',
+      initialRoute: initialRoute,
       routes: <String, WidgetBuilder>{
         '/': (BuildContext context) => HomePage(),
         kCullOpacityRouteName: (BuildContext context) => CullOpacityPage(),
         kCubicBezierRouteName: (BuildContext context) => CubicBezierPage(),
         kBackdropFilterRouteName: (BuildContext context) => BackdropFilterPage(),
         kSimpleAnimationRouteName: (BuildContext conttext) => SimpleAnimationPage(),
-        kPictureCacheRouteName: (BuildContext conttext) => PictureCachePage(),
+        kPictureCacheRouteName: (BuildContext context) => PictureCachePage(),
+        kLargeImagesRouteName: (BuildContext context) => LargeImagesPage(),
       },
     );
   }
+
+  final String initialRoute;
 }
 
 class HomePage extends StatelessWidget {
@@ -73,6 +79,13 @@ class HomePage extends StatelessWidget {
             child: const Text('Picture Cache'),
             onPressed: () {
               Navigator.pushNamed(context, kPictureCacheRouteName);
+            },
+          ),
+          RaisedButton(
+            key: const Key(kLargeImagesRouteName),
+            child: const Text('Large Images'),
+            onPressed: () {
+              Navigator.pushNamed(context, kLargeImagesRouteName);
             },
           ),
         ],

--- a/dev/benchmarks/macrobenchmarks/lib/src/large_images.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/large_images.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/dev/benchmarks/macrobenchmarks/lib/src/large_images.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/large_images.dart
@@ -1,0 +1,25 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+class LargeImagesPage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final ImageCache imageCache = PaintingBinding.instance.imageCache;
+    imageCache.maximumSize = 30;
+    imageCache.maximumSizeBytes = 50 << 20;
+    return GridView.builder(
+      itemCount: 1000,
+      gridDelegate:
+      const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 3),
+      itemBuilder: (BuildContext context, int index) {
+        return Image.network(
+            'http://via.placeholder.com/'
+                '${500 + index}x1000',
+            key: ValueKey<int>(index));
+      },
+    ).build(context);
+  }
+}

--- a/dev/benchmarks/macrobenchmarks/test_memory/large_images.dart
+++ b/dev/benchmarks/macrobenchmarks/test_memory/large_images.dart
@@ -1,0 +1,37 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// See //dev/devicelab/bin/tasks/flutter_gallery__memory_nav.dart
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:macrobenchmarks/common.dart';
+import 'package:macrobenchmarks/main.dart';
+
+Future<void> endOfAnimation() async {
+  do {
+    await SchedulerBinding.instance.endOfFrame;
+  } while (SchedulerBinding.instance.hasScheduledFrame);
+}
+
+int iteration = 0;
+
+class LifecycleObserver extends WidgetsBindingObserver {
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    debugPrint('==== MEMORY BENCHMARK ==== $state ====');
+    debugPrint('This was lifecycle event number $iteration in this instance');
+  }
+}
+
+Future<void> main() async {
+  runApp(MacrobenchmarksApp(initialRoute: kLargeImagesRouteName));
+  await endOfAnimation();
+  await Future<void>.delayed(const Duration(milliseconds: 50));
+  debugPrint('==== MEMORY BENCHMARK ==== READY ====');
+  WidgetsBinding.instance.addObserver(LifecycleObserver());
+}

--- a/dev/benchmarks/macrobenchmarks/test_memory/large_images.dart
+++ b/dev/benchmarks/macrobenchmarks/test_memory/large_images.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -29,7 +29,7 @@ class LifecycleObserver extends WidgetsBindingObserver {
 }
 
 Future<void> main() async {
-  runApp(MacrobenchmarksApp(initialRoute: kLargeImagesRouteName));
+  runApp(const MacrobenchmarksApp(initialRoute: kLargeImagesRouteName));
   await endOfAnimation();
   await Future<void>.delayed(const Duration(milliseconds: 50));
   debugPrint('==== MEMORY BENCHMARK ==== READY ====');

--- a/dev/devicelab/bin/tasks/fast_scroll_large_images__memory.dart
+++ b/dev/devicelab/bin/tasks/fast_scroll_large_images__memory.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/dev/devicelab/bin/tasks/fast_scroll_large_images__memory.dart
+++ b/dev/devicelab/bin/tasks/fast_scroll_large_images__memory.dart
@@ -33,9 +33,9 @@ class FastScrollLargeImagesMemoryTest extends MemoryTest {
   Future<void> useMemory() async {
     await launchApp();
     await recordStart();
-    for (int iteration = 0; iteration < 4; iteration += 1) {
-      await device.shellExec('input', <String>['swipe', '0 1000 0 0 100']);
-      await Future<void>.delayed(const Duration(milliseconds: 2000));
+    for (int i = 0; i < 3; i += 1) {
+      await device.shellExec('input', <String>['swipe', '0 1500 0 0 50']);
+      await Future<void>.delayed(const Duration(milliseconds: 3000));
     }
     await recordEnd();
   }

--- a/dev/devicelab/bin/tasks/fast_scroll_large_images__memory.dart
+++ b/dev/devicelab/bin/tasks/fast_scroll_large_images__memory.dart
@@ -1,0 +1,47 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// Measure application memory usage after pausing and resuming the app
+/// with the Android back button.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/framework/adb.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/framework/utils.dart';
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+
+const String kPackageName = 'com.example.macrobenchmarks';
+const String kActivityName = 'com.example.macrobenchmarks.MainActivity';
+
+class FastScrollLargeImagesMemoryTest extends MemoryTest {
+  FastScrollLargeImagesMemoryTest()
+      : super(
+          '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
+          'test_memory/large_images.dart', kPackageName,
+        );
+
+  @override
+  AndroidDevice get device => super.device;
+
+  @override
+  int get iterationCount => 5;
+
+  /// Perform a series of back button suspend and resume cycles.
+  @override
+  Future<void> useMemory() async {
+    await launchApp();
+    await recordStart();
+    for (int iteration = 0; iteration < 4; iteration += 1) {
+      await device.shellExec('input', <String>['swipe', '0 1000 0 0 100']);
+      await Future<void>.delayed(const Duration(milliseconds: 2000));
+    }
+    await recordEnd();
+  }
+}
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.android;
+  await task(FastScrollLargeImagesMemoryTest().run);
+}

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -670,6 +670,12 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
 
+  fast_scroll_large_images__memory:
+    description: >
+      Measures memory usage for scrolling through a list of large images.
+    stage: devicelab
+    required_agent_capabilities: ["mac/android"]
+
   analyzer_benchmark:
     description: >
       Measures the speed of Dart analyzer.


### PR DESCRIPTION
For https://github.com/flutter/flutter/issues/19558

This test reveals the issue that Flutter currently retains as much as
200MB memory after scrolling. (200MB can further grow if we scroll more
times). There should be plenty of time for the GC to clean such memory.
