### PR TITLE
Ensure that docker tag is legal

### DIFF
--- a/dev/ci/docker_linux/docker_build.sh
+++ b/dev/ci/docker_linux/docker_build.sh
@@ -5,6 +5,10 @@
 
 TAG="${CIRRUS_TAG:-latest}"
 
+# Convert "+" to "-" to make hotfix tags legal Docker tag names.
+# See https://docs.docker.com/engine/reference/commandline/tag/
+TAG=${TAG/+/-}
+
 # pull to make sure we are not rebuilding for nothing
 sudo docker pull "gcr.io/flutter-cirrus/build-flutter-image:$TAG"
 


### PR DESCRIPTION
## Description

Our docker image build is failing with hotfix releases because the tag name is illegal
(cannot contain `+`).  This fixes the tag name to be valid before attempting to build
the image.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.
