### PR TITLE
Revert "Disable tests that fail on non-master branches"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -229,7 +229,6 @@ task:
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: hostonly_devicelab_tests-0-linux
-      only_if: "$CIRRUS_PR != '' || $CIRRUS_BRANCH == 'master'" # https://github.com/flutter/flutter/issues/45453
       environment:
         # Some of the host-only devicelab tests are pretty involved and need a lot of RAM.
         CPU: 2
@@ -238,7 +237,6 @@ task:
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: hostonly_devicelab_tests-1-linux
-      only_if: "$CIRRUS_PR != '' || $CIRRUS_BRANCH == 'master'" # https://github.com/flutter/flutter/issues/45453
       environment:
         # Some of the host-only devicelab tests are pretty involved and need a lot of RAM.
         CPU: 2
@@ -247,7 +245,6 @@ task:
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: hostonly_devicelab_tests-2-linux
-      only_if: "$CIRRUS_PR != '' || $CIRRUS_BRANCH == 'master'" # https://github.com/flutter/flutter/issues/45453
       environment:
         # Some of the host-only devicelab tests are pretty involved and need a lot of RAM.
         CPU: 2
@@ -256,7 +253,6 @@ task:
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: hostonly_devicelab_tests-3_last-linux
-      only_if: "$CIRRUS_PR != '' || $CIRRUS_BRANCH == 'master'" # https://github.com/flutter/flutter/issues/45453
       environment:
         # Some of the host-only devicelab tests are pretty involved and need a lot of RAM.
         CPU: 2
@@ -403,22 +399,22 @@ task:
         - dart --enable-asserts dev\bots\test.dart
 
     - name: hostonly_devicelab_tests-0-windows
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || ($CIRRUS_PR == '' && $CIRRUS_BRANCH == 'master')" # https://github.com/flutter/flutter/issues/41941 https://github.com/flutter/flutter/issues/45453
+      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || $CIRRUS_PR == ''" # https://github.com/flutter/flutter/issues/41941
       script:
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: hostonly_devicelab_tests-1-windows
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || ($CIRRUS_PR == '' && $CIRRUS_BRANCH == 'master')" # https://github.com/flutter/flutter/issues/41941 https://github.com/flutter/flutter/issues/45453
+      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || $CIRRUS_PR == ''" # https://github.com/flutter/flutter/issues/41941
       script:
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: hostonly_devicelab_tests-2-windows
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || ($CIRRUS_PR == '' && $CIRRUS_BRANCH == 'master')" # https://github.com/flutter/flutter/issues/41941 https://github.com/flutter/flutter/issues/45453
+      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || $CIRRUS_PR == ''" # https://github.com/flutter/flutter/issues/41941
       script:
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: hostonly_devicelab_tests-3_last-windows
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || ($CIRRUS_PR == '' && $CIRRUS_BRANCH == 'master')" # https://github.com/flutter/flutter/issues/41941 https://github.com/flutter/flutter/issues/45453
+      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || $CIRRUS_PR == ''" # https://github.com/flutter/flutter/issues/41941
       script:
         - dart --enable-asserts ./dev/bots/test.dart
 
@@ -516,25 +512,25 @@ task:
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: hostonly_devicelab_tests-0-macos
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || ($CIRRUS_PR == '' && $CIRRUS_BRANCH == 'master')" # https://github.com/flutter/flutter/issues/41941 https://github.com/flutter/flutter/issues/45453
+      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || $CIRRUS_PR == ''" # https://github.com/flutter/flutter/issues/41940
       script:
         - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: hostonly_devicelab_tests-1-macos
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || ($CIRRUS_PR == '' && $CIRRUS_BRANCH == 'master')" # https://github.com/flutter/flutter/issues/41941 https://github.com/flutter/flutter/issues/45453
+      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || $CIRRUS_PR == ''" # https://github.com/flutter/flutter/issues/41940
       script:
         - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: hostonly_devicelab_tests-2-macos
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || ($CIRRUS_PR == '' && $CIRRUS_BRANCH == 'master')" # https://github.com/flutter/flutter/issues/41941 https://github.com/flutter/flutter/issues/45453
+      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || $CIRRUS_PR == ''" # https://github.com/flutter/flutter/issues/41940
       script:
         - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: hostonly_devicelab_tests-3_last-macos
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || ($CIRRUS_PR == '' && $CIRRUS_BRANCH == 'master')" # https://github.com/flutter/flutter/issues/41941 https://github.com/flutter/flutter/issues/45453
+      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || $CIRRUS_PR == ''" # https://github.com/flutter/flutter/issues/41940
       script:
         - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
         - dart --enable-asserts ./dev/bots/test.dart

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -291,20 +291,12 @@ Future<void> _runBuildTests() async {
       await _flutterBuildIpa(examplePath);
     }
   }
-
-  final String branch = Platform.environment['CIRRUS_BRANCH'];
-  if (branch != 'beta' && branch != 'stable') {
-    // Web compilation tests.
-    await _flutterBuildDart2js(
-      path.join('dev', 'integration_tests', 'web'),
-      path.join('lib', 'main.dart'),
-    );
-    // Should not fail to compile with dart:io.
-    await _flutterBuildDart2js(
-      path.join('dev', 'integration_tests', 'web_compile_tests'),
-      path.join('lib', 'dart_io_import.dart'),
-    );
-  }
+  // Web compilation tests.
+  await _flutterBuildDart2js(path.join('dev', 'integration_tests', 'web'), path.join('lib', 'main.dart'));
+  // Should not fail to compile with dart:io.
+  await _flutterBuildDart2js(path.join('dev', 'integration_tests', 'web_compile_tests'),
+    path.join('lib', 'dart_io_import.dart'),
+  );
 }
 
 Future<void> _flutterBuildAot(String relativePathToApplication) async {


### PR DESCRIPTION
Reverts flutter/flutter#45455

Per the discussion in https://github.com/flutter/flutter/issues/45453, the failing tests indicated a real problem that we need to fix.