### PR TITLE
Update SliverPersistentHeader docs

### DIFF
--- a/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
@@ -91,8 +91,11 @@ abstract class SliverPersistentHeaderDelegate {
   bool shouldRebuild(covariant SliverPersistentHeaderDelegate oldDelegate);
 }
 
-/// A sliver whose size varies when the sliver is scrolled to the leading edge
-/// of the viewport.
+/// A sliver whose size varies when the sliver is scrolled to the edge
+/// of the viewport opposite its [GrowthDirection].
+///
+/// In the normal case of a [CustomScrollView] with no centered sliver, this
+/// sliver will vary its size when scrolled to the leading edge of the viewport.
 ///
 /// This is the layout primitive that [SliverAppBar] uses for its
 /// shrinking/growing effect.

--- a/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
@@ -92,7 +92,7 @@ abstract class SliverPersistentHeaderDelegate {
 }
 
 /// A sliver whose size varies when the sliver is scrolled to the edge
-/// of the viewport opposite its [GrowthDirection].
+/// of the viewport opposite the sliver's [GrowthDirection].
 ///
 /// In the normal case of a [CustomScrollView] with no centered sliver, this
 /// sliver will vary its size when scrolled to the leading edge of the viewport.


### PR DESCRIPTION
## Description
Update SliverPersistentHeader docs to match the class' behaviour.
Fixes #35019.

## Related Issues

Fixes #35019.

## Tests

Doc update only

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x] I signed the [CLA].
- [x ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x ] I updated/added relevant documentation (doc comments with `///`).
- [x ] All existing and new tests are passing.
- [x ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x ] No, no existing tests failed, so this is *not* a breaking change.


<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
