### PR TITLE
Add a VisualDensity manual test

### DIFF
--- a/dev/manual_tests/lib/density.dart
+++ b/dev/manual_tests/lib/density.dart
@@ -1,0 +1,504 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart' show timeDilation;
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+
+final Map<int, Color> m2SwatchColors = <int, Color>{
+  50: const Color(0xfff2e7fe),
+  100: const Color(0xffd7b7fd),
+  200: const Color(0xffbb86fc),
+  300: const Color(0xff9e55fc),
+  400: const Color(0xff7f22fd),
+  500: const Color(0xff6200ee),
+  600: const Color(0xff4b00d1),
+  700: const Color(0xff3700b3),
+  800: const Color(0xff270096),
+  900: const Color(0xff270096),
+};
+final MaterialColor m2Swatch = MaterialColor(m2SwatchColors[500].value, m2SwatchColors);
+
+// Sets a platform override for desktop to avoid exceptions. See
+// https://flutter.dev/desktop#target-platform-override for more info.
+// TODO(gspencergoog): Remove once TargetPlatform includes all desktop platforms.
+void _enablePlatformOverrideForDesktop() {
+  if (!kIsWeb && (Platform.isWindows || Platform.isLinux)) {
+    debugDefaultTargetPlatformOverride = TargetPlatform.fuchsia;
+  }
+}
+
+void main() {
+  _enablePlatformOverrideForDesktop();
+  runApp(MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  static const String _title = 'Density Test';
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      title: _title,
+      home: MyHomePage(title: _title),
+    );
+  }
+}
+
+class MyHomePage extends StatefulWidget {
+  const MyHomePage({Key key, this.title}) : super(key: key);
+
+  final String title;
+
+  @override
+  _MyHomePageState createState() => _MyHomePageState();
+}
+
+class OptionModel extends ChangeNotifier {
+  double get size => _size;
+  double _size = 1.0;
+  set size(double size) {
+    if (size != _size) {
+      _size = size;
+      notifyListeners();
+    }
+  }
+
+  VisualDensity get density => _density;
+  VisualDensity _density = const VisualDensity();
+  set density(VisualDensity density) {
+    if (density != _density) {
+      _density = density;
+      notifyListeners();
+    }
+  }
+
+  bool get enable => _enable;
+  bool _enable = true;
+  set enable(bool enable) {
+    if (enable != _enable) {
+      _enable = enable;
+      notifyListeners();
+    }
+  }
+
+  bool get slowAnimations => _slowAnimations;
+  bool _slowAnimations = false;
+  set slowAnimations(bool slowAnimations) {
+    if (slowAnimations != _slowAnimations) {
+      _slowAnimations = slowAnimations;
+      notifyListeners();
+    }
+  }
+
+  bool get rtl => _rtl;
+  bool _rtl = false;
+  set rtl(bool rtl) {
+    if (rtl != _rtl) {
+      _rtl = rtl;
+      notifyListeners();
+    }
+  }
+
+  bool get longText => _longText;
+  bool _longText = false;
+  set longText(bool longText) {
+    if (longText != _longText) {
+      _longText = longText;
+      notifyListeners();
+    }
+  }
+
+  void reset() {
+    final OptionModel defaultModel = OptionModel();
+    _size = defaultModel._size;
+    _enable = defaultModel._enable;
+    _slowAnimations = defaultModel._slowAnimations;
+    _longText = defaultModel._longText;
+    _density = defaultModel._density;
+    _rtl = defaultModel._rtl;
+    notifyListeners();
+  }
+}
+
+class LabeledCheckbox extends StatelessWidget {
+  const LabeledCheckbox({Key key, this.label, this.onChanged, this.value}) : super(key: key);
+
+  final String label;
+  final ValueChanged<bool> onChanged;
+  final bool value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        Checkbox(
+          onChanged: onChanged,
+          value: value,
+        ),
+        Text(label),
+      ],
+    );
+  }
+}
+
+class Options extends StatefulWidget {
+  const Options(this.model);
+
+  final OptionModel model;
+
+  @override
+  _OptionsState createState() => _OptionsState();
+}
+
+class _OptionsState extends State<Options> {
+  static final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
+
+  @override
+  void initState() {
+    super.initState();
+    widget.model.addListener(_modelChanged);
+  }
+
+  @override
+  void didUpdateWidget(Options oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.model != oldWidget.model) {
+      oldWidget.model.removeListener(_modelChanged);
+      widget.model.addListener(_modelChanged);
+    }
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    widget.model.removeListener(_modelChanged);
+  }
+
+  void _modelChanged() {
+    setState(() {});
+  }
+
+  double sliderValue = 0.0;
+
+  String _densityToProfile(VisualDensity density) {
+    if (density == VisualDensity.standard) {
+      return 'standard';
+    }
+    if (density == VisualDensity.compact) {
+      return 'compact';
+    }
+    if (density == VisualDensity.comfortable) {
+      return 'comfortable';
+    }
+    return 'custom';
+  }
+
+  VisualDensity _profileToDensity(String profile) {
+    switch (profile) {
+      case 'standard':
+        return VisualDensity.standard;
+      case 'comfortable':
+        return VisualDensity.comfortable;
+      case 'compact':
+        return VisualDensity.compact;
+      case 'custom':
+      default:
+        return widget.model.density;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final SliderThemeData controlTheme = SliderTheme.of(context).copyWith(
+      thumbColor: Colors.grey[50],
+      activeTickMarkColor: Colors.deepPurple[200],
+      activeTrackColor: Colors.deepPurple[300],
+      inactiveTrackColor: Colors.grey[50],
+    );
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(5.0, 0.0, 5.0, 10.0),
+      child: Builder(builder: (BuildContext context) {
+        return DefaultTextStyle(
+          style: TextStyle(color: Colors.grey[50]),
+          child: Column(
+            children: <Widget>[
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Row(
+                  children: <Widget>[
+                    const Text('Text Scale'),
+                    Expanded(
+                      child: SliderTheme(
+                        data: controlTheme,
+                        child: Slider(
+                            label: '${widget.model.size}',
+                            min: 0.5,
+                            max: 3.0,
+                            onChanged: (double value) {
+                              widget.model.size = value;
+                            },
+                            value: widget.model.size),
+                      ),
+                    ),
+                    Text(
+                      '${widget.model.size.toStringAsFixed(3)}',
+                      style: TextStyle(color: Colors.grey[50]),
+                    ),
+                  ],
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Row(
+                  children: <Widget>[
+                    const Text('X Density'),
+                    Expanded(
+                      child: SliderTheme(
+                        data: controlTheme,
+                        child: Slider(
+                            label: '${widget.model.density.horizontal.toStringAsFixed(1)}',
+                            min: VisualDensity.minimumDensity,
+                            max: VisualDensity.maximumDensity,
+                            onChanged: (double value) {
+                              widget.model.density = widget.model.density.copyWith(horizontal: value, vertical: widget.model.density.vertical);
+                            },
+                            value: widget.model.density.horizontal),
+                      ),
+                    ),
+                    Text(
+                      '${widget.model.density.horizontal.toStringAsFixed(3)}',
+                      style: TextStyle(color: Colors.grey[50]),
+                    ),
+                  ],
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Row(
+                  children: <Widget>[
+                    const Text('Y Density'),
+                    Expanded(
+                      child: SliderTheme(
+                        data: controlTheme,
+                        child: Slider(
+                            label: '${widget.model.density.vertical.toStringAsFixed(1)}',
+                            min: VisualDensity.minimumDensity,
+                            max: VisualDensity.maximumDensity,
+                            onChanged: (double value) {
+                              widget.model.density = widget.model.density.copyWith(horizontal: widget.model.density.horizontal, vertical: value);
+                            },
+                            value: widget.model.density.vertical),
+                      ),
+                    ),
+                    Text(
+                      '${widget.model.density.vertical.toStringAsFixed(3)}',
+                      style: TextStyle(color: Colors.grey[50]),
+                    ),
+                  ],
+                ),
+              ),
+              Wrap(
+                alignment: WrapAlignment.center,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: <Widget>[
+                  Theme(
+                    data: Theme.of(context).copyWith(canvasColor: Colors.grey[600]),
+                    child: DropdownButton<String>(
+                      style: TextStyle(color: Colors.grey[50]),
+                      isDense: true,
+                      onChanged: (String value) {
+                        widget.model.density = _profileToDensity(value);
+                      },
+                      items: const <DropdownMenuItem<String>>[
+                        DropdownMenuItem<String>(child: Text('Standard'), value: 'standard',),
+                        DropdownMenuItem<String>(child: Text('Comfortable'), value: 'comfortable'),
+                        DropdownMenuItem<String>(child: Text('Compact'), value: 'compact'),
+                        DropdownMenuItem<String>(child: Text('Custom'), value: 'custom'),
+                      ],
+                      value: _densityToProfile(widget.model.density),
+                    ),
+                  ),
+                  LabeledCheckbox(
+                    label: 'Enabled',
+                    onChanged: (bool checked) {
+                      widget.model.enable = checked;
+                    },
+                    value: widget.model.enable,
+                  ),
+                  LabeledCheckbox(
+                    label: 'Slow',
+                    onChanged: (bool checked) {
+                      widget.model.slowAnimations = checked;
+                      Future<void>.delayed(const Duration(milliseconds: 150)).then((_) {
+                        if (widget.model.slowAnimations) {
+                          timeDilation = 20.0;
+                        } else {
+                          timeDilation = 1.0;
+                        }
+                      });
+                    },
+                    value: widget.model.slowAnimations,
+                  ),
+                  LabeledCheckbox(
+                    label: 'RTL',
+                    onChanged: (bool checked) {
+                      widget.model.rtl = checked;
+                    },
+                    value: widget.model.rtl,
+                  ),
+                  MaterialButton(
+                    onPressed: () {
+                      widget.model.reset();
+                      sliderValue = 0.0;
+                    },
+                    child: Text('Reset', style: TextStyle(color: Colors.grey[50])),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        );
+      }),
+    );
+  }
+}
+
+class _ControlTile extends StatelessWidget {
+  const _ControlTile({Key key, @required this.label, @required this.child})
+      : assert(label != null),
+        assert(child != null),
+        super(key: key);
+
+  final String label;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          children: <Widget>[
+            Align(alignment: AlignmentDirectional.topStart, child: Text(label, textAlign: TextAlign.start)),
+            child,
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  static final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
+  final OptionModel _model = OptionModel();
+
+  @override
+  void initState() {
+    super.initState();
+    _model.addListener(_modelChanged);
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _model.removeListener(_modelChanged);
+  }
+
+  void _modelChanged() {
+    setState(() {});
+  }
+
+  double sliderValue = 0.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = ThemeData(
+      primarySwatch: m2Swatch,
+    );
+    final Widget label = Text(_model.rtl ? 'اضغط علي' : 'Press Me');
+
+    final List<Widget> tiles = <Widget>[
+      _ControlTile(
+        label: _model.rtl ? 'زر المواد' : 'Material Button',
+        child: MaterialButton(
+          color: m2Swatch[200],
+          onPressed: _model.enable ? () {} : null,
+          child: label,
+        ),
+      ),
+      _ControlTile(
+        label: _model.rtl ? 'زر مسطح' : 'Flat Button',
+        child: FlatButton(
+          color: m2Swatch[200],
+          onPressed: _model.enable ? () {} : null,
+          child: label,
+        ),
+      ),
+      _ControlTile(
+        label: _model.rtl ? 'أثارت زر' : 'Raised Button',
+        child: RaisedButton(
+          color: m2Swatch[200],
+          onPressed: _model.enable ? () {} : null,
+          child: label,
+        ),
+      ),
+      _ControlTile(
+        label: _model.rtl ? 'زر المخطط التفصيلي' : 'Outline Button',
+        child: OutlineButton(
+          color: m2Swatch[500],
+          onPressed: _model.enable ? () {} : null,
+          child: label,
+        ),
+      ),
+    ];
+
+    return SafeArea(
+      child: Theme(
+        data: theme,
+        child: Scaffold(
+          key: scaffoldKey,
+          appBar: AppBar(
+            title: const Text('Density'),
+            bottom: PreferredSize(
+              preferredSize: const Size.fromHeight(220.0),
+              child: Options(_model),
+            ),
+            backgroundColor: const Color(0xff323232),
+          ),
+          body: DefaultTextStyle(
+            style: const TextStyle(
+              color: Colors.black,
+              fontSize: 14.0,
+              fontFamily: 'Roboto',
+              fontStyle: FontStyle.normal,
+            ),
+            child: Theme(
+              data: Theme.of(context).copyWith(visualDensity: _model.density),
+              child: Directionality(
+                textDirection: _model.rtl ? TextDirection.rtl : TextDirection.ltr,
+                child: Scrollbar(
+                  child: MediaQuery(
+                    data: MediaQuery.of(context).copyWith(textScaleFactor: _model.size),
+                    child: SizedBox.expand(
+                      child: ListView(
+                        children: tiles,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/flutter/test/material/flat_button_test.dart
+++ b/packages/flutter/test/material/flat_button_test.dart
@@ -693,6 +693,7 @@ void main() {
 
   testWidgets('FlatButton responds to density changes.', (WidgetTester tester) async {
     const Key key = Key('test');
+    const Key childKey = Key('test child');
 
     Future<void> buildTest(VisualDensity visualDensity, {bool useText = false}) async {
       return await tester.pumpWidget(
@@ -704,7 +705,7 @@ void main() {
                 visualDensity: visualDensity,
                 key: key,
                 onPressed: () {},
-                child: useText ? const Text('Text') : Container(width: 100, height: 100, color: const Color(0xffff0000)),
+                child: useText ? const Text('Text', key: childKey) : Container(key: childKey, width: 100, height: 100, color: const Color(0xffff0000)),
               ),
             ),
           ),
@@ -714,28 +715,40 @@ void main() {
 
     await buildTest(const VisualDensity());
     final RenderBox box = tester.renderObject(find.byKey(key));
+    Rect childRect = tester.getRect(find.byKey(childKey));
     await tester.pumpAndSettle();
     expect(box.size, equals(const Size(132, 100)));
+    expect(childRect, equals(const Rect.fromLTRB(350, 250, 450, 350)));
 
     await buildTest(const VisualDensity(horizontal: 3.0, vertical: 3.0));
     await tester.pumpAndSettle();
+    childRect = tester.getRect(find.byKey(childKey));
     expect(box.size, equals(const Size(156, 124)));
+    expect(childRect, equals(const Rect.fromLTRB(350, 250, 450, 350)));
 
     await buildTest(const VisualDensity(horizontal: -3.0, vertical: -3.0));
     await tester.pumpAndSettle();
+    childRect = tester.getRect(find.byKey(childKey));
     expect(box.size, equals(const Size(108, 100)));
+    expect(childRect, equals(const Rect.fromLTRB(350, 250, 450, 350)));
 
     await buildTest(const VisualDensity(), useText: true);
     await tester.pumpAndSettle();
+    childRect = tester.getRect(find.byKey(childKey));
     expect(box.size, equals(const Size(88, 48)));
+    expect(childRect, equals(const Rect.fromLTRB(372.0, 293.0, 428.0, 307.0)));
 
     await buildTest(const VisualDensity(horizontal: 3.0, vertical: 3.0), useText: true);
     await tester.pumpAndSettle();
+    childRect = tester.getRect(find.byKey(childKey));
     expect(box.size, equals(const Size(112, 60)));
+    expect(childRect, equals(const Rect.fromLTRB(372.0, 293.0, 428.0, 307.0)));
 
     await buildTest(const VisualDensity(horizontal: -3.0, vertical: -3.0), useText: true);
     await tester.pumpAndSettle();
+    childRect = tester.getRect(find.byKey(childKey));
     expect(box.size, equals(const Size(76, 36)));
+    expect(childRect, equals(const Rect.fromLTRB(372.0, 293.0, 428.0, 307.0)));
   });
 }
 

--- a/packages/flutter/test/material/material_button_test.dart
+++ b/packages/flutter/test/material/material_button_test.dart
@@ -731,6 +731,7 @@ void main() {
 
   testWidgets('MaterialButton responds to density changes.', (WidgetTester tester) async {
     const Key key = Key('test');
+    const Key childKey = Key('test child');
 
     Future<void> buildTest(VisualDensity visualDensity, {bool useText = false}) async {
       return await tester.pumpWidget(
@@ -742,7 +743,7 @@ void main() {
                 visualDensity: visualDensity,
                 key: key,
                 onPressed: () {},
-                child: useText ? const Text('Text') : Container(width: 100, height: 100, color: const Color(0xffff0000)),
+                child: useText ? const Text('Text', key: childKey) : Container(key: childKey, width: 100, height: 100, color: const Color(0xffff0000)),
               ),
             ),
           ),
@@ -752,27 +753,39 @@ void main() {
 
     await buildTest(const VisualDensity());
     final RenderBox box = tester.renderObject(find.byKey(key));
+    Rect childRect = tester.getRect(find.byKey(childKey));
     await tester.pumpAndSettle();
     expect(box.size, equals(const Size(132, 100)));
+    expect(childRect, equals(const Rect.fromLTRB(350, 250, 450, 350)));
 
     await buildTest(const VisualDensity(horizontal: 3.0, vertical: 3.0));
     await tester.pumpAndSettle();
+    childRect = tester.getRect(find.byKey(childKey));
     expect(box.size, equals(const Size(156, 124)));
+    expect(childRect, equals(const Rect.fromLTRB(350, 250, 450, 350)));
 
     await buildTest(const VisualDensity(horizontal: -3.0, vertical: -3.0));
     await tester.pumpAndSettle();
+    childRect = tester.getRect(find.byKey(childKey));
     expect(box.size, equals(const Size(108, 100)));
+    expect(childRect, equals(const Rect.fromLTRB(350, 250, 450, 350)));
 
     await buildTest(const VisualDensity(), useText: true);
     await tester.pumpAndSettle();
+    childRect = tester.getRect(find.byKey(childKey));
     expect(box.size, equals(const Size(88, 48)));
+    expect(childRect, equals(const Rect.fromLTRB(372.0, 293.0, 428.0, 307.0)));
 
     await buildTest(const VisualDensity(horizontal: 3.0, vertical: 3.0), useText: true);
     await tester.pumpAndSettle();
+    childRect = tester.getRect(find.byKey(childKey));
     expect(box.size, equals(const Size(112, 60)));
+    expect(childRect, equals(const Rect.fromLTRB(372.0, 293.0, 428.0, 307.0)));
 
     await buildTest(const VisualDensity(horizontal: -3.0, vertical: -3.0), useText: true);
     await tester.pumpAndSettle();
+    childRect = tester.getRect(find.byKey(childKey));
     expect(box.size, equals(const Size(76, 36)));
+    expect(childRect, equals(const Rect.fromLTRB(372.0, 293.0, 428.0, 307.0)));
   });
 }

--- a/packages/flutter/test/material/outline_button_test.dart
+++ b/packages/flutter/test/material/outline_button_test.dart
@@ -981,6 +981,7 @@ void main() {
 
   testWidgets('OutlineButton responds to density changes.', (WidgetTester tester) async {
     const Key key = Key('test');
+    const Key childKey = Key('test child');
 
     Future<void> buildTest(VisualDensity visualDensity, {bool useText = false}) async {
       return await tester.pumpWidget(
@@ -992,7 +993,7 @@ void main() {
                 visualDensity: visualDensity,
                 key: key,
                 onPressed: () {},
-                child: useText ? const Text('Text') : Container(width: 100, height: 100, color: const Color(0xffff0000)),
+                child: useText ? const Text('Text', key: childKey) : Container(key: childKey, width: 100, height: 100, color: const Color(0xffff0000)),
               ),
             ),
           ),
@@ -1002,28 +1003,40 @@ void main() {
 
     await buildTest(const VisualDensity());
     final RenderBox box = tester.renderObject(find.byKey(key));
+    Rect childRect = tester.getRect(find.byKey(childKey));
     await tester.pumpAndSettle();
     expect(box.size, equals(const Size(132, 100)));
+    expect(childRect, equals(const Rect.fromLTRB(350, 250, 450, 350)));
 
     await buildTest(const VisualDensity(horizontal: 3.0, vertical: 3.0));
     await tester.pumpAndSettle();
+    childRect = tester.getRect(find.byKey(childKey));
     expect(box.size, equals(const Size(156, 124)));
+    expect(childRect, equals(const Rect.fromLTRB(350, 250, 450, 350)));
 
     await buildTest(const VisualDensity(horizontal: -3.0, vertical: -3.0));
     await tester.pumpAndSettle();
+    childRect = tester.getRect(find.byKey(childKey));
     expect(box.size, equals(const Size(108, 100)));
+    expect(childRect, equals(const Rect.fromLTRB(350, 250, 450, 350)));
 
     await buildTest(const VisualDensity(), useText: true);
     await tester.pumpAndSettle();
+    childRect = tester.getRect(find.byKey(childKey));
     expect(box.size, equals(const Size(88, 48)));
+    expect(childRect, equals(const Rect.fromLTRB(372.0, 293.0, 428.0, 307.0)));
 
     await buildTest(const VisualDensity(horizontal: 3.0, vertical: 3.0), useText: true);
     await tester.pumpAndSettle();
+    childRect = tester.getRect(find.byKey(childKey));
     expect(box.size, equals(const Size(112, 60)));
+    expect(childRect, equals(const Rect.fromLTRB(372.0, 293.0, 428.0, 307.0)));
 
     await buildTest(const VisualDensity(horizontal: -3.0, vertical: -3.0), useText: true);
     await tester.pumpAndSettle();
+    childRect = tester.getRect(find.byKey(childKey));
     expect(box.size, equals(const Size(76, 36)));
+    expect(childRect, equals(const Rect.fromLTRB(372.0, 293.0, 428.0, 307.0)));
   });
 }
 

--- a/packages/flutter/test/material/raised_button_test.dart
+++ b/packages/flutter/test/material/raised_button_test.dart
@@ -560,6 +560,7 @@ void main() {
 
   testWidgets('RaisedButton responds to density changes.', (WidgetTester tester) async {
     const Key key = Key('test');
+    const Key childKey = Key('test child');
 
     Future<void> buildTest(VisualDensity visualDensity, {bool useText = false}) async {
       return await tester.pumpWidget(
@@ -571,7 +572,7 @@ void main() {
                 visualDensity: visualDensity,
                 key: key,
                 onPressed: () {},
-                child: useText ? const Text('Text') : Container(width: 100, height: 100, color: const Color(0xffff0000)),
+                child: useText ? const Text('Text', key: childKey) : Container(key: childKey, width: 100, height: 100, color: const Color(0xffff0000)),
               ),
             ),
           ),
@@ -581,28 +582,40 @@ void main() {
 
     await buildTest(const VisualDensity());
     final RenderBox box = tester.renderObject(find.byKey(key));
+    Rect childRect = tester.getRect(find.byKey(childKey));
     await tester.pumpAndSettle();
     expect(box.size, equals(const Size(132, 100)));
+    expect(childRect, equals(const Rect.fromLTRB(350, 250, 450, 350)));
 
     await buildTest(const VisualDensity(horizontal: 3.0, vertical: 3.0));
     await tester.pumpAndSettle();
+    childRect = tester.getRect(find.byKey(childKey));
     expect(box.size, equals(const Size(156, 124)));
+    expect(childRect, equals(const Rect.fromLTRB(350, 250, 450, 350)));
 
     await buildTest(const VisualDensity(horizontal: -3.0, vertical: -3.0));
     await tester.pumpAndSettle();
+    childRect = tester.getRect(find.byKey(childKey));
     expect(box.size, equals(const Size(108, 100)));
+    expect(childRect, equals(const Rect.fromLTRB(350, 250, 450, 350)));
 
     await buildTest(const VisualDensity(), useText: true);
     await tester.pumpAndSettle();
+    childRect = tester.getRect(find.byKey(childKey));
     expect(box.size, equals(const Size(88, 48)));
+    expect(childRect, equals(const Rect.fromLTRB(372.0, 293.0, 428.0, 307.0)));
 
     await buildTest(const VisualDensity(horizontal: 3.0, vertical: 3.0), useText: true);
     await tester.pumpAndSettle();
+    childRect = tester.getRect(find.byKey(childKey));
     expect(box.size, equals(const Size(112, 60)));
+    expect(childRect, equals(const Rect.fromLTRB(372.0, 293.0, 428.0, 307.0)));
 
     await buildTest(const VisualDensity(horizontal: -3.0, vertical: -3.0), useText: true);
     await tester.pumpAndSettle();
+    childRect = tester.getRect(find.byKey(childKey));
     expect(box.size, equals(const Size(76, 36)));
+    expect(childRect, equals(const Rect.fromLTRB(372.0, 293.0, 428.0, 307.0)));
   });
 }
 

--- a/packages/flutter/test/material/raw_material_button_test.dart
+++ b/packages/flutter/test/material/raw_material_button_test.dart
@@ -513,6 +513,7 @@ void main() {
 
   testWidgets('RawMaterialButton responds to density changes.', (WidgetTester tester) async {
     const Key key = Key('test');
+    const Key childKey = Key('test child');
 
     Future<void> buildTest(VisualDensity visualDensity, {bool useText = false}) async {
       return await tester.pumpWidget(
@@ -524,7 +525,7 @@ void main() {
                 visualDensity: visualDensity,
                 key: key,
                 onPressed: () {},
-                child: useText ? const Text('Text') : Container(width: 100, height: 100, color: const Color(0xffff0000)),
+                child: useText ? const Text('Text', key: childKey) : Container(key: childKey, width: 100, height: 100, color: const Color(0xffff0000)),
               ),
             ),
           ),
@@ -534,27 +535,39 @@ void main() {
 
     await buildTest(const VisualDensity());
     final RenderBox box = tester.renderObject(find.byKey(key));
+    Rect childRect = tester.getRect(find.byKey(childKey));
     await tester.pumpAndSettle();
     expect(box.size, equals(const Size(100, 100)));
+    expect(childRect, equals(const Rect.fromLTRB(350, 250, 450, 350)));
 
     await buildTest(const VisualDensity(horizontal: 3.0, vertical: 3.0));
     await tester.pumpAndSettle();
+    childRect = tester.getRect(find.byKey(childKey));
     expect(box.size, equals(const Size(124, 124)));
+    expect(childRect, equals(const Rect.fromLTRB(350, 250, 450, 350)));
 
     await buildTest(const VisualDensity(horizontal: -3.0, vertical: -3.0));
     await tester.pumpAndSettle();
+    childRect = tester.getRect(find.byKey(childKey));
     expect(box.size, equals(const Size(100, 100)));
+    expect(childRect, equals(const Rect.fromLTRB(350, 250, 450, 350)));
 
     await buildTest(const VisualDensity(), useText: true);
     await tester.pumpAndSettle();
+    childRect = tester.getRect(find.byKey(childKey));
     expect(box.size, equals(const Size(88, 48)));
+    expect(childRect, equals(const Rect.fromLTRB(372.0, 293.0, 428.0, 307.0)));
 
     await buildTest(const VisualDensity(horizontal: 3.0, vertical: 3.0), useText: true);
     await tester.pumpAndSettle();
+    childRect = tester.getRect(find.byKey(childKey));
     expect(box.size, equals(const Size(100, 60)));
+    expect(childRect, equals(const Rect.fromLTRB(372.0, 293.0, 428.0, 307.0)));
 
     await buildTest(const VisualDensity(horizontal: -3.0, vertical: -3.0), useText: true);
     await tester.pumpAndSettle();
+    childRect = tester.getRect(find.byKey(childKey));
     expect(box.size, equals(const Size(76, 36)));
+    expect(childRect, equals(const Rect.fromLTRB(372.0, 293.0, 428.0, 307.0)));
   });
 }

--- a/packages/flutter_tools/ide_templates/intellij/.idea/runConfigurations/manual_tests___density.xml.copy.tmpl
+++ b/packages/flutter_tools/ide_templates/intellij/.idea/runConfigurations/manual_tests___density.xml.copy.tmpl
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="manual_tests - density" type="FlutterRunConfigurationType" factoryName="Flutter" singleton="false">
+    <option name="filePath" value="$PROJECT_DIR$/dev/manual_tests/lib/density.dart" />
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
## Description
Adds a manual test that allows testing of density for buttons.  Also updates some of the button tests to be somewhat simpler and to test the child positions in the test to make sure they are consistent.

## Tests

- This *is* a test.

## Breaking Change

- [X] No, this is *not* a breaking change.