### PR TITLE
only run codecov on master

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -135,7 +135,7 @@ task:
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: tool_coverage-linux # linux-only
-      only_if: "$CIRRUS_PR == ''"
+      only_if: "$CIRRUS_PR == '' && $CIRRUS_BRANCH == 'master'"
       environment:
         # As of October 2019, the tool_coverage-linux shard needed at least 12G of RAM to run without
         # getting OOM-killed, and even 8 CPUs took 25 minutes.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -135,7 +135,7 @@ task:
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: tool_coverage-linux # linux-only
-      only_if: "$CIRRUS_PR == '' && $CIRRUS_BRANCH == 'master'"
+      only_if: "$CIRRUS_BRANCH == 'master'"
       environment:
         # As of October 2019, the tool_coverage-linux shard needed at least 12G of RAM to run without
         # getting OOM-killed, and even 8 CPUs took 25 minutes.


### PR DESCRIPTION
Only run tool_coverage test shard on master, which should in turn lead to codecov only evaluating master commits. We only really care about running on master, and we don't want unreliable red checks to mark release builds.

Fixes https://github.com/flutter/flutter/issues/46098.