### PR TITLE
[flutter_tool] Print version info on a no-op upgrade.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -63,7 +63,6 @@ class UpgradeCommand extends FlutterCommand {
   }
 }
 
-
 @visibleForTesting
 class UpgradeCommandRunner {
   Future<FlutterCommandResult> runCommand(
@@ -120,7 +119,8 @@ class UpgradeCommandRunner {
     final bool alreadyUpToDate = await attemptFastForward(flutterVersion);
     if (alreadyUpToDate) {
       // If the upgrade was a no op, then do not continue with the second half.
-      printTrace('Flutter is already up to date on channel ${flutterVersion.channel}');
+      printStatus('Flutter is already up to date on channel ${flutterVersion.channel}');
+      printStatus('$flutterVersion');
     } else {
       await flutterUpgradeContinue();
     }

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -140,6 +140,7 @@ void main() {
         environment: anyNamed('environment'),
         workingDirectory: anyNamed('workingDirectory'),
       ));
+      expect(testLogger.statusText, contains('Flutter is already up to date'));
     }, overrides: <Type, Generator>{
       ProcessManager: () => processManager,
       Platform: () => fakePlatform,


### PR DESCRIPTION
## Description

Previous PR removed too much info.

## Issues

https://github.com/flutter/flutter/issues/46004

## Tests

I added the following tests:

Updated test in upgrade_test.dart.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
