### PR TITLE
Only schedule mouse tracking callback when there is a mouse

### DIFF
--- a/packages/flutter/lib/src/gestures/mouse_tracking.dart
+++ b/packages/flutter/lib/src/gestures/mouse_tracking.dart
@@ -502,6 +502,8 @@ class MouseTracker extends ChangeNotifier {
   void schedulePostFrameCheck() {
     assert(_duringBuildPhase);
     assert(!_duringDeviceUpdate);
+    if (!mouseIsConnected)
+      return;
     if (!_hasScheduledPostFrameCheck) {
       _hasScheduledPostFrameCheck = true;
       SchedulerBinding.instance.addPostFrameCallback((Duration duration) {

--- a/packages/flutter/test/gestures/mouse_tracking_test.dart
+++ b/packages/flutter/test/gestures/mouse_tracking_test.dart
@@ -591,6 +591,27 @@ void main() {
     ]));
   });
 
+  test('should not schedule postframe callbacks when no mouse is connected', () {
+    const MouseTrackerAnnotation annotation = MouseTrackerAnnotation();
+    _setUpMouseAnnotationFinder((Offset position) sync* {
+    });
+
+    // This device only supports touching
+    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+      _pointerData(PointerChange.add, const Offset(0.0, 100.0), kind: PointerDeviceKind.touch),
+    ]));
+    expect(_mouseTracker.mouseIsConnected, isFalse);
+
+    // Attaching an annotation just in case
+    _mouseTracker.attachAnnotation(annotation);
+    expect(_binding.postFrameCallbacks, hasLength(0));
+
+    _binding.scheduleMouseTrackerPostFrameCheck();
+    expect(_binding.postFrameCallbacks, hasLength(0));
+
+    _mouseTracker.detachAnnotation(annotation);
+  });
+
   test('should not flip out if not all mouse events are listened to', () {
     bool isInHitRegionOne = true;
     bool isInHitRegionTwo = false;
@@ -782,12 +803,13 @@ ui.PointerData _pointerData(
   PointerChange change,
   Offset logicalPosition, {
   int device = 0,
+  PointerDeviceKind kind = PointerDeviceKind.mouse,
 }) {
   return ui.PointerData(
     change: change,
     physicalX: logicalPosition.dx * ui.window.devicePixelRatio,
     physicalY: logicalPosition.dy * ui.window.devicePixelRatio,
-    kind: PointerDeviceKind.mouse,
+    kind: kind,
     device: device,
   );
 }


### PR DESCRIPTION
## Description

PR https://github.com/flutter/flutter/pull/44631 introduces a post-frame check that is scheduled after every frame, which affected some benchmarks (namely stock_layout_iteration).

After this PR, the post-frame check is only scheduled when there is a mouse connected, which hopefully improves the performance. (Through my local testing there is ~1% improvement)

## Related Issues

- https://github.com/flutter/flutter/pull/44631#issuecomment-561394779

## Tests

I added the following tests:

- should not schedule postframe callbacks when no mouse is connected

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
