### PR TITLE
Adds floatLabelBehavior to InputDecoration

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1886,6 +1886,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     _floatingLabelController = AnimationController(
       duration: _kTransitionDuration,
       vsync: this,
+      // ignore: deprecated_member_use_from_same_package
       value: widget.decoration.floatLabelBehavior == FloatLabelBehavior.always || (widget.decoration.hasFloatingPlaceholder && widget._labelShouldWithdraw) ? 1.0 : 0.0,
     );
     _floatingLabelController.addListener(_handleChange);
@@ -1927,7 +1928,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
   bool get isFocused => widget.isFocused && decoration.enabled;
   bool get isHovering => widget.isHovering && decoration.enabled;
   bool get isEmpty => widget.isEmpty;
-  bool get _floatLabelEnabled => decoration.hasFloatingPlaceholder && decoration.floatLabelBehavior != FloatLabelBehavior.never;
+  bool get _floatLabelEnabled => decoration.hasFloatingPlaceholder && decoration.floatLabelBehavior != FloatLabelBehavior.never;  // ignore: deprecated_member_use_from_same_package
 
   @override
   void didUpdateWidget(InputDecorator old) {
@@ -1935,6 +1936,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     if (widget.decoration != old.decoration)
       _effectiveDecoration = null;
 
+    // ignore: deprecated_member_use_from_same_package
     final bool floatBehaviourChanged = widget.decoration.floatLabelBehavior != old.decoration.floatLabelBehavior || widget.decoration.hasFloatingPlaceholder != old.decoration.hasFloatingPlaceholder;
 
     if (widget._labelShouldWithdraw != old._labelShouldWithdraw || floatBehaviourChanged) {
@@ -2447,7 +2449,7 @@ class InputDecoration {
       'Use floatLabelBehaviour instead. '
       'This feature was deprecated after v1.13.2.'
     )
-    this.hasFloatingPlaceholder = true,
+    this.hasFloatingPlaceholder = true, // ignore: deprecated_member_use_from_same_package
     this.floatLabelBehavior = FloatLabelBehavior.auto,
     this.isDense,
     this.contentPadding,
@@ -2478,6 +2480,7 @@ class InputDecoration {
   }) : assert(enabled != null),
        assert(!(prefix != null && prefixText != null), 'Declaring both prefix and prefixText is not supported.'),
        assert(!(suffix != null && suffixText != null), 'Declaring both suffix and suffixText is not supported.'),
+       // ignore: deprecated_member_use_from_same_package
        assert(!(!hasFloatingPlaceholder && identical(floatLabelBehavior, FloatLabelBehavior.always)),
             'hasFloatingPlaceholder=false conflicts with FloatLabelBehavior.always'),
        isCollapsed = false;
@@ -2493,6 +2496,7 @@ class InputDecoration {
       'Use floatLabelBehaviour instead. '
       'This feature was deprecated after v1.13.2.'
     )
+    // ignore: deprecated_member_use_from_same_package
     this.hasFloatingPlaceholder = true,
     this.floatLabelBehavior = FloatLabelBehavior.auto,
     this.hintStyle,
@@ -2503,6 +2507,7 @@ class InputDecoration {
     this.border = InputBorder.none,
     this.enabled = true,
   }) : assert(enabled != null),
+       // ignore: deprecated_member_use_from_same_package
        assert(!(!hasFloatingPlaceholder && identical(floatLabelBehavior, FloatLabelBehavior.always)),
         'hasFloatingPlaceholder=false conflicts with FloatLabelBehavior.always'),
        icon = null,
@@ -3175,6 +3180,7 @@ class InputDecoration {
       errorText: errorText ?? this.errorText,
       errorStyle: errorStyle ?? this.errorStyle,
       errorMaxLines: errorMaxLines ?? this.errorMaxLines,
+      // ignore: deprecated_member_use_from_same_package
       hasFloatingPlaceholder: hasFloatingPlaceholder ?? this.hasFloatingPlaceholder,
       floatLabelBehavior: floatLabelBehavior ?? this.floatLabelBehavior,
       isDense: isDense ?? this.isDense,
@@ -3219,6 +3225,7 @@ class InputDecoration {
       hintStyle: hintStyle ?? theme.hintStyle,
       errorStyle: errorStyle ?? theme.errorStyle,
       errorMaxLines: errorMaxLines ?? theme.errorMaxLines,
+      // ignore: deprecated_member_use_from_same_package
       hasFloatingPlaceholder: hasFloatingPlaceholder ?? theme.hasFloatingPlaceholder,
       floatLabelBehavior: floatLabelBehavior ?? theme.floatLabelBehavior,
       isDense: isDense ?? theme.isDense,
@@ -3259,6 +3266,7 @@ class InputDecoration {
         && other.errorText == errorText
         && other.errorStyle == errorStyle
         && other.errorMaxLines == errorMaxLines
+        // ignore: deprecated_member_use_from_same_package
         && other.hasFloatingPlaceholder == hasFloatingPlaceholder
         && other.floatLabelBehavior == floatLabelBehavior
         && other.isDense == isDense
@@ -3305,7 +3313,7 @@ class InputDecoration {
       errorText,
       errorStyle,
       errorMaxLines,
-      hasFloatingPlaceholder,
+      hasFloatingPlaceholder,// ignore: deprecated_member_use_from_same_package
       floatLabelBehavior,
       isDense,
       contentPadding,
@@ -3352,6 +3360,7 @@ class InputDecoration {
       if (errorText != null) 'errorText: "$errorText"',
       if (errorStyle != null) 'errorStyle: "$errorStyle"',
       if (errorMaxLines != null) 'errorMaxLines: "$errorMaxLines"',
+      // ignore: deprecated_member_use_from_same_package
       if (hasFloatingPlaceholder == false) 'hasFloatingPlaceholder: false',
       if (floatLabelBehavior != null) 'floatLabelBehavior: $floatLabelBehavior',
       if (isDense ?? false) 'isDense: $isDense',
@@ -3413,6 +3422,7 @@ class InputDecorationTheme extends Diagnosticable {
       'Use floatLabelBehaviour instead. '
       'This feature was deprecated after v1.13.2.'
     )
+    // ignore: deprecated_member_use_from_same_package
     this.hasFloatingPlaceholder = true,
     this.floatLabelBehavior = FloatLabelBehavior.auto,
     this.isDense = false,
@@ -3436,6 +3446,7 @@ class InputDecorationTheme extends Diagnosticable {
        assert(isCollapsed != null),
        assert(filled != null),
        assert(alignLabelWithHint != null),
+       // ignore: deprecated_member_use_from_same_package
        assert(!(!hasFloatingPlaceholder && identical(floatLabelBehavior, FloatLabelBehavior.always)),
         'hasFloatingPlaceholder=false conflicts with FloatLabelBehavior.always');
 
@@ -3788,6 +3799,7 @@ class InputDecorationTheme extends Diagnosticable {
       hintStyle: hintStyle ?? this.hintStyle,
       errorStyle: errorStyle ?? this.errorStyle,
       errorMaxLines: errorMaxLines ?? this.errorMaxLines,
+      // ignore: deprecated_member_use_from_same_package
       hasFloatingPlaceholder: hasFloatingPlaceholder ?? this.hasFloatingPlaceholder,
       floatLabelBehavior: floatLabelBehavior ?? this.floatLabelBehavior,
       isDense: isDense ?? this.isDense,
@@ -3819,6 +3831,7 @@ class InputDecorationTheme extends Diagnosticable {
       hintStyle,
       errorStyle,
       errorMaxLines,
+      // ignore: deprecated_member_use_from_same_package
       hasFloatingPlaceholder,
       floatLabelBehavior,
       isDense,
@@ -3885,6 +3898,7 @@ class InputDecorationTheme extends Diagnosticable {
     properties.add(DiagnosticsProperty<TextStyle>('hintStyle', hintStyle, defaultValue: defaultTheme.hintStyle));
     properties.add(DiagnosticsProperty<TextStyle>('errorStyle', errorStyle, defaultValue: defaultTheme.errorStyle));
     properties.add(IntProperty('errorMaxLines', errorMaxLines, defaultValue: defaultTheme.errorMaxLines));
+    // ignore: deprecated_member_use_from_same_package
     properties.add(DiagnosticsProperty<bool>('hasFloatingPlaceholder', hasFloatingPlaceholder, defaultValue: defaultTheme.hasFloatingPlaceholder));
     properties.add(DiagnosticsProperty<FloatLabelBehavior>('floatLabelBehavior', floatLabelBehavior, defaultValue: defaultTheme.floatLabelBehavior));
     properties.add(DiagnosticsProperty<bool>('isDense', isDense, defaultValue: defaultTheme.isDense));

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -464,7 +464,7 @@ class _HelperErrorState extends State<_HelperError> with SingleTickerProviderSta
 }
 
 /// Defines the behaviour of the floating label
-enum FloatLabelBehavior {
+enum FloatingLabelBehavior {
   /// The label will always be positioned within the content, or hidden.
   never,
   /// The label will float when the input is focused, or has content.
@@ -1887,7 +1887,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
       duration: _kTransitionDuration,
       vsync: this,
       // ignore: deprecated_member_use_from_same_package
-      value: widget.decoration.floatLabelBehavior == FloatLabelBehavior.always || (widget.decoration.hasFloatingPlaceholder && widget._labelShouldWithdraw) ? 1.0 : 0.0,
+      value: widget.decoration.floatingLabelBehavior == FloatingLabelBehavior.always || (widget.decoration.hasFloatingPlaceholder && widget._labelShouldWithdraw) ? 1.0 : 0.0,
     );
     _floatingLabelController.addListener(_handleChange);
 
@@ -1928,7 +1928,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
   bool get isFocused => widget.isFocused && decoration.enabled;
   bool get isHovering => widget.isHovering && decoration.enabled;
   bool get isEmpty => widget.isEmpty;
-  bool get _floatLabelEnabled => decoration.hasFloatingPlaceholder && decoration.floatLabelBehavior != FloatLabelBehavior.never;  // ignore: deprecated_member_use_from_same_package
+  bool get _floatingLabelEnabled => decoration.hasFloatingPlaceholder && decoration.floatingLabelBehavior != FloatingLabelBehavior.never;  // ignore: deprecated_member_use_from_same_package
 
   @override
   void didUpdateWidget(InputDecorator old) {
@@ -1937,10 +1937,10 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
       _effectiveDecoration = null;
 
     // ignore: deprecated_member_use_from_same_package
-    final bool floatBehaviourChanged = widget.decoration.floatLabelBehavior != old.decoration.floatLabelBehavior || widget.decoration.hasFloatingPlaceholder != old.decoration.hasFloatingPlaceholder;
+    final bool floatBehaviourChanged = widget.decoration.floatingLabelBehavior != old.decoration.floatingLabelBehavior || widget.decoration.hasFloatingPlaceholder != old.decoration.hasFloatingPlaceholder;
 
     if (widget._labelShouldWithdraw != old._labelShouldWithdraw || floatBehaviourChanged) {
-      if ((widget._labelShouldWithdraw || widget.decoration.floatLabelBehavior == FloatLabelBehavior.always) && _floatLabelEnabled)
+      if ((widget._labelShouldWithdraw || widget.decoration.floatingLabelBehavior == FloatingLabelBehavior.always) && _floatingLabelEnabled)
         _floatingLabelController.forward();
       else
         _floatingLabelController.reverse();
@@ -2036,7 +2036,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
   bool get _hasInlineLabel => !widget._labelShouldWithdraw && decoration.labelText != null;
 
   // If the label is a floating placeholder, it's always shown.
-  bool get _shouldShowLabel => _hasInlineLabel || _floatLabelEnabled;
+  bool get _shouldShowLabel => _hasInlineLabel || _floatingLabelEnabled;
 
   // The base style for the inline label or hint when they're displayed "inline",
   // i.e. when they appear in place of the empty text field.
@@ -2446,11 +2446,11 @@ class InputDecoration {
     this.errorStyle,
     this.errorMaxLines,
     @Deprecated(
-      'Use floatLabelBehaviour instead. '
+      'Use floatingLabelBehaviour instead. '
       'This feature was deprecated after v1.13.2.'
     )
     this.hasFloatingPlaceholder = true, // ignore: deprecated_member_use_from_same_package
-    this.floatLabelBehavior = FloatLabelBehavior.auto,
+    this.floatingLabelBehavior = FloatingLabelBehavior.auto,
     this.isDense,
     this.contentPadding,
     this.prefixIcon,
@@ -2481,8 +2481,8 @@ class InputDecoration {
        assert(!(prefix != null && prefixText != null), 'Declaring both prefix and prefixText is not supported.'),
        assert(!(suffix != null && suffixText != null), 'Declaring both suffix and suffixText is not supported.'),
        // ignore: deprecated_member_use_from_same_package
-       assert(!(!hasFloatingPlaceholder && identical(floatLabelBehavior, FloatLabelBehavior.always)),
-            'hasFloatingPlaceholder=false conflicts with FloatLabelBehavior.always'),
+       assert(!(!hasFloatingPlaceholder && identical(floatingLabelBehavior, FloatingLabelBehavior.always)),
+            'hasFloatingPlaceholder=false conflicts with FloatingLabelBehavior.always'),
        isCollapsed = false;
 
   /// Defines an [InputDecorator] that is the same size as the input field.
@@ -2493,12 +2493,12 @@ class InputDecoration {
   const InputDecoration.collapsed({
     @required this.hintText,
     @Deprecated(
-      'Use floatLabelBehaviour instead. '
+      'Use floatingLabelBehaviour instead. '
       'This feature was deprecated after v1.13.2.'
     )
     // ignore: deprecated_member_use_from_same_package
     this.hasFloatingPlaceholder = true,
-    this.floatLabelBehavior = FloatLabelBehavior.auto,
+    this.floatingLabelBehavior = FloatingLabelBehavior.auto,
     this.hintStyle,
     this.filled = false,
     this.fillColor,
@@ -2508,8 +2508,8 @@ class InputDecoration {
     this.enabled = true,
   }) : assert(enabled != null),
        // ignore: deprecated_member_use_from_same_package
-       assert(!(!hasFloatingPlaceholder && identical(floatLabelBehavior, FloatLabelBehavior.always)),
-        'hasFloatingPlaceholder=false conflicts with FloatLabelBehavior.always'),
+       assert(!(!hasFloatingPlaceholder && identical(floatingLabelBehavior, FloatingLabelBehavior.always)),
+        'hasFloatingPlaceholder=false conflicts with FloatingLabelBehavior.always'),
        icon = null,
        labelText = null,
        labelStyle = null,
@@ -2667,27 +2667,27 @@ class InputDecoration {
   /// Defaults to true.
   ///
   @Deprecated(
-    'Use floatLabelBehaviour instead. '
+    'Use floatingLabelBehaviour instead. '
     'This feature was deprecated after v1.13.2.'
   )
   final bool hasFloatingPlaceholder;
 
-  /// {@template flutter.material.inputDecoration.floatLabelBehavior}
+  /// {@template flutter.material.inputDecoration.floatingLabelBehavior}
   /// Defines how the floating label should be displayed.
   ///
-  /// When [FloatLabelBehavior.auto] the label will float to the top only when
+  /// When [FloatingLabelBehavior.auto] the label will float to the top only when
   /// the field is focused or has some text content, otherwise it will appear
   /// in the field in place of the content.
   ///
-  /// When [FloatLabelBehavior.always] the label will always float at the top
+  /// When [FloatingLabelBehavior.always] the label will always float at the top
   /// of the field above the content.
   ///
-  /// When [FloatLabelBehavior.never] the label will always appear in an empty
+  /// When [FloatingLabelBehavior.never] the label will always appear in an empty
   /// field in place of the content.
   ///
-  /// Defaults to [FloatLabelBehavior.auto].
+  /// Defaults to [FloatingLabelBehavior.auto].
   /// {@endtemplate}
-  final FloatLabelBehavior floatLabelBehavior;
+  final FloatingLabelBehavior floatingLabelBehavior;
 
   /// Whether the input [child] is part of a dense form (i.e., uses less vertical
   /// space).
@@ -3139,7 +3139,7 @@ class InputDecoration {
     TextStyle errorStyle,
     int errorMaxLines,
     bool hasFloatingPlaceholder,
-    FloatLabelBehavior floatLabelBehavior,
+    FloatingLabelBehavior floatingLabelBehavior,
     bool isDense,
     EdgeInsetsGeometry contentPadding,
     Widget prefixIcon,
@@ -3182,7 +3182,7 @@ class InputDecoration {
       errorMaxLines: errorMaxLines ?? this.errorMaxLines,
       // ignore: deprecated_member_use_from_same_package
       hasFloatingPlaceholder: hasFloatingPlaceholder ?? this.hasFloatingPlaceholder,
-      floatLabelBehavior: floatLabelBehavior ?? this.floatLabelBehavior,
+      floatingLabelBehavior: floatingLabelBehavior ?? this.floatingLabelBehavior,
       isDense: isDense ?? this.isDense,
       contentPadding: contentPadding ?? this.contentPadding,
       prefixIcon: prefixIcon ?? this.prefixIcon,
@@ -3227,7 +3227,7 @@ class InputDecoration {
       errorMaxLines: errorMaxLines ?? theme.errorMaxLines,
       // ignore: deprecated_member_use_from_same_package
       hasFloatingPlaceholder: hasFloatingPlaceholder ?? theme.hasFloatingPlaceholder,
-      floatLabelBehavior: floatLabelBehavior ?? theme.floatLabelBehavior,
+      floatingLabelBehavior: floatingLabelBehavior ?? theme.floatingLabelBehavior,
       isDense: isDense ?? theme.isDense,
       contentPadding: contentPadding ?? theme.contentPadding,
       prefixStyle: prefixStyle ?? theme.prefixStyle,
@@ -3268,7 +3268,7 @@ class InputDecoration {
         && other.errorMaxLines == errorMaxLines
         // ignore: deprecated_member_use_from_same_package
         && other.hasFloatingPlaceholder == hasFloatingPlaceholder
-        && other.floatLabelBehavior == floatLabelBehavior
+        && other.floatingLabelBehavior == floatingLabelBehavior
         && other.isDense == isDense
         && other.contentPadding == contentPadding
         && other.isCollapsed == isCollapsed
@@ -3314,7 +3314,7 @@ class InputDecoration {
       errorStyle,
       errorMaxLines,
       hasFloatingPlaceholder,// ignore: deprecated_member_use_from_same_package
-      floatLabelBehavior,
+      floatingLabelBehavior,
       isDense,
       contentPadding,
       isCollapsed,
@@ -3362,7 +3362,7 @@ class InputDecoration {
       if (errorMaxLines != null) 'errorMaxLines: "$errorMaxLines"',
       // ignore: deprecated_member_use_from_same_package
       if (hasFloatingPlaceholder == false) 'hasFloatingPlaceholder: false',
-      if (floatLabelBehavior != null) 'floatLabelBehavior: $floatLabelBehavior',
+      if (floatingLabelBehavior != null) 'floatingLabelBehavior: $floatingLabelBehavior',
       if (isDense ?? false) 'isDense: $isDense',
       if (contentPadding != null) 'contentPadding: $contentPadding',
       if (isCollapsed) 'isCollapsed: $isCollapsed',
@@ -3419,12 +3419,12 @@ class InputDecorationTheme extends Diagnosticable {
     this.errorStyle,
     this.errorMaxLines,
     @Deprecated(
-      'Use floatLabelBehaviour instead. '
+      'Use floatingLabelBehaviour instead. '
       'This feature was deprecated after v1.13.2.'
     )
     // ignore: deprecated_member_use_from_same_package
     this.hasFloatingPlaceholder = true,
-    this.floatLabelBehavior = FloatLabelBehavior.auto,
+    this.floatingLabelBehavior = FloatingLabelBehavior.auto,
     this.isDense = false,
     this.contentPadding,
     this.isCollapsed = false,
@@ -3447,8 +3447,8 @@ class InputDecorationTheme extends Diagnosticable {
        assert(filled != null),
        assert(alignLabelWithHint != null),
        // ignore: deprecated_member_use_from_same_package
-       assert(!(!hasFloatingPlaceholder && identical(floatLabelBehavior, FloatLabelBehavior.always)),
-        'hasFloatingPlaceholder=false conflicts with FloatLabelBehavior.always');
+       assert(!(!hasFloatingPlaceholder && identical(floatingLabelBehavior, FloatingLabelBehavior.always)),
+        'hasFloatingPlaceholder=false conflicts with FloatingLabelBehavior.always');
 
   /// The style to use for [InputDecoration.labelText] when the label is
   /// above (i.e., vertically adjacent to) the input field.
@@ -3514,13 +3514,13 @@ class InputDecorationTheme extends Diagnosticable {
   ///
   /// Defaults to true.
   @Deprecated(
-    'Use floatLabelBehaviour instead. '
+    'Use floatingLabelBehaviour instead. '
     'This feature was deprecated after v1.13.2.'
   )
   final bool hasFloatingPlaceholder;
 
-  /// {@macro flutter.material.inputDecoration.floatLabelBehavior}
-  final FloatLabelBehavior floatLabelBehavior;
+  /// {@macro flutter.material.inputDecoration.floatingLabelBehavior}
+  final FloatingLabelBehavior floatingLabelBehavior;
 
   /// Whether the input decorator's child is part of a dense form (i.e., uses
   /// less vertical space).
@@ -3769,11 +3769,11 @@ class InputDecorationTheme extends Diagnosticable {
     TextStyle errorStyle,
     int errorMaxLines,
     @Deprecated(
-      'Use floatLabelBehaviour instead. '
+      'Use floatingLabelBehaviour instead. '
       'This feature was deprecated after v1.13.2.'
     )
     bool hasFloatingPlaceholder,
-    FloatLabelBehavior floatLabelBehavior,
+    FloatingLabelBehavior floatingLabelBehavior,
     bool isDense,
     EdgeInsetsGeometry contentPadding,
     bool isCollapsed,
@@ -3801,7 +3801,7 @@ class InputDecorationTheme extends Diagnosticable {
       errorMaxLines: errorMaxLines ?? this.errorMaxLines,
       // ignore: deprecated_member_use_from_same_package
       hasFloatingPlaceholder: hasFloatingPlaceholder ?? this.hasFloatingPlaceholder,
-      floatLabelBehavior: floatLabelBehavior ?? this.floatLabelBehavior,
+      floatingLabelBehavior: floatingLabelBehavior ?? this.floatingLabelBehavior,
       isDense: isDense ?? this.isDense,
       contentPadding: contentPadding ?? this.contentPadding,
       isCollapsed: isCollapsed ?? this.isCollapsed,
@@ -3833,7 +3833,7 @@ class InputDecorationTheme extends Diagnosticable {
       errorMaxLines,
       // ignore: deprecated_member_use_from_same_package
       hasFloatingPlaceholder,
-      floatLabelBehavior,
+      floatingLabelBehavior,
       isDense,
       contentPadding,
       isCollapsed,
@@ -3873,7 +3873,7 @@ class InputDecorationTheme extends Diagnosticable {
         && other.prefixStyle == prefixStyle
         && other.suffixStyle == suffixStyle
         && other.counterStyle == counterStyle
-        && other.floatLabelBehavior == floatLabelBehavior
+        && other.floatingLabelBehavior == floatingLabelBehavior
         && other.filled == filled
         && other.fillColor == fillColor
         && other.focusColor == focusColor
@@ -3900,7 +3900,7 @@ class InputDecorationTheme extends Diagnosticable {
     properties.add(IntProperty('errorMaxLines', errorMaxLines, defaultValue: defaultTheme.errorMaxLines));
     // ignore: deprecated_member_use_from_same_package
     properties.add(DiagnosticsProperty<bool>('hasFloatingPlaceholder', hasFloatingPlaceholder, defaultValue: defaultTheme.hasFloatingPlaceholder));
-    properties.add(DiagnosticsProperty<FloatLabelBehavior>('floatLabelBehavior', floatLabelBehavior, defaultValue: defaultTheme.floatLabelBehavior));
+    properties.add(DiagnosticsProperty<FloatingLabelBehavior>('floatingLabelBehavior', floatingLabelBehavior, defaultValue: defaultTheme.floatingLabelBehavior));
     properties.add(DiagnosticsProperty<bool>('isDense', isDense, defaultValue: defaultTheme.isDense));
     properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('contentPadding', contentPadding, defaultValue: defaultTheme.contentPadding));
     properties.add(DiagnosticsProperty<bool>('isCollapsed', isCollapsed, defaultValue: defaultTheme.isCollapsed));

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -464,6 +464,8 @@ class _HelperErrorState extends State<_HelperError> with SingleTickerProviderSta
 
 /// Defines the behaviour of the floating label
 enum FloatLabelBehavior {
+  /// the label will always be positioned within the content, or hidden
+  never,
   /// the label will float when the input is focused, or has content
   auto,
   /// the label will always float above the content
@@ -1925,19 +1927,20 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
   bool get isHovering => widget.isHovering && decoration.enabled;
   bool get isEmpty => widget.isEmpty;
 
+  bool get floatLabelEnabled => decoration.hasFloatingPlaceholder && decoration.floatLabelBehavior != FloatLabelBehavior.never;
+
   @override
   void didUpdateWidget(InputDecorator old) {
     super.didUpdateWidget(old);
     if (widget.decoration != old.decoration)
       _effectiveDecoration = null;
 
-    final bool floatBehaviourChanged = widget.decoration.floatLabelBehavior != old.decoration.floatLabelBehavior;
-    final bool hasFloatingPlaceholderChanged = widget.decoration.hasFloatingPlaceholder != old.decoration.hasFloatingPlaceholder;
+    final bool floatBehaviourChanged = widget.decoration.floatLabelBehavior != old.decoration.floatLabelBehavior || widget.decoration.hasFloatingPlaceholder != old.decoration.hasFloatingPlaceholder;
 
-    if (widget._labelShouldWithdraw != old._labelShouldWithdraw || floatBehaviourChanged || hasFloatingPlaceholderChanged) {
-      if (widget._labelShouldWithdraw || (widget.decoration.floatLabelBehavior == FloatLabelBehavior.always && widget.decoration.hasFloatingPlaceholder))
+    if (widget._labelShouldWithdraw != old._labelShouldWithdraw || floatBehaviourChanged) {
+      if ((widget._labelShouldWithdraw || widget.decoration.floatLabelBehavior == FloatLabelBehavior.always) && floatLabelEnabled)
         _floatingLabelController.forward();
-      else if (widget.decoration.floatLabelBehavior != FloatLabelBehavior.always || !widget.decoration.hasFloatingPlaceholder)
+      else
         _floatingLabelController.reverse();
     }
 
@@ -2031,7 +2034,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
   bool get _hasInlineLabel => !widget._labelShouldWithdraw && decoration.labelText != null;
 
   // If the label is a floating placeholder, it's always shown.
-  bool get _shouldShowLabel => _hasInlineLabel || decoration.hasFloatingPlaceholder;
+  bool get _shouldShowLabel => _hasInlineLabel || floatLabelEnabled;
 
   // The base style for the inline label or hint when they're displayed "inline",
   // i.e. when they appear in place of the empty text field.
@@ -2440,6 +2443,7 @@ class InputDecoration {
     this.errorText,
     this.errorStyle,
     this.errorMaxLines,
+    @Deprecated('Use floatLabelBehaviour instead.')
     this.hasFloatingPlaceholder = true,
     this.floatLabelBehavior = FloatLabelBehavior.auto,
     this.isDense,
@@ -2480,6 +2484,7 @@ class InputDecoration {
   /// Sets the [isCollapsed] property to true.
   const InputDecoration.collapsed({
     @required this.hintText,
+    @Deprecated('Use floatLabelBehaviour instead.')
     this.hasFloatingPlaceholder = true,
     this.floatLabelBehavior = FloatLabelBehavior.auto,
     this.hintStyle,
@@ -2645,6 +2650,8 @@ class InputDecoration {
   /// the input has focus or text has been entered.
   ///
   /// Defaults to true.
+  ///
+  @Deprecated('Use floatLabelBehaviour instead.')
   final bool hasFloatingPlaceholder;
 
   /// Defines how the floating label should be displayed.
@@ -2655,6 +2662,9 @@ class InputDecoration {
   ///
   /// When [FloatLabelBehavior.always] the label will always float at the top
   /// of the field above the content.
+  ///
+  /// When [FloatLabelBehavior.never] the label will always will appear
+  /// in the field in place of the content.
   ///
   /// Defaults to [FloatLabelBehavior.auto].
   ///
@@ -3385,6 +3395,7 @@ class InputDecorationTheme extends Diagnosticable {
     this.hintStyle,
     this.errorStyle,
     this.errorMaxLines,
+    @Deprecated('Use floatLabelBehaviour instead.')
     this.hasFloatingPlaceholder = true,
     this.floatLabelBehavior = FloatLabelBehavior.auto,
     this.isDense = false,
@@ -3472,12 +3483,10 @@ class InputDecorationTheme extends Diagnosticable {
   /// the input has focus or text has been entered.
   ///
   /// Defaults to true.
+  @Deprecated('Use floatLabelBehaviour instead.')
   final bool hasFloatingPlaceholder;
 
   /// Defines how the floating label should be displayed.
-  ///
-  /// When [FloatLabelBehavior.never] the label will always appear
-  /// in the field in place of the content, or disappear when there is text content.
   ///
   /// When [FloatLabelBehavior.auto] the label will float to the top only when
   /// the field is focused or has some text content, otherwise it will appear
@@ -3485,6 +3494,9 @@ class InputDecorationTheme extends Diagnosticable {
   ///
   /// When [FloatLabelBehavior.always] the label will always float at the top
   /// of the field above the content.
+  ///
+  /// When [FloatLabelBehavior.never] the label will always will appear
+  /// in the field in place of the content.
   ///
   /// Defaults to [FloatLabelBehavior.auto].
   ///
@@ -3736,6 +3748,7 @@ class InputDecorationTheme extends Diagnosticable {
     TextStyle hintStyle,
     TextStyle errorStyle,
     int errorMaxLines,
+    @Deprecated('Use floatLabelBehaviour instead.')
     bool hasFloatingPlaceholder,
     FloatLabelBehavior floatLabelBehavior,
     bool isDense,

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1875,7 +1875,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     _floatingLabelController = AnimationController(
       duration: _kTransitionDuration,
       vsync: this,
-      value: (widget.decoration.hasFloatingPlaceholder && widget._labelShouldWithdraw) ? 1.0 : 0.0,
+      value: widget.decoration.alwaysFloatLabel || (widget.decoration.hasFloatingPlaceholder && widget._labelShouldWithdraw) ? 1.0 : 0.0,
     );
     _floatingLabelController.addListener(_handleChange);
 
@@ -1923,7 +1923,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     if (widget.decoration != old.decoration)
       _effectiveDecoration = null;
 
-    if (widget._labelShouldWithdraw != old._labelShouldWithdraw && widget.decoration.hasFloatingPlaceholder) {
+    if (widget._labelShouldWithdraw != old._labelShouldWithdraw && widget.decoration.hasFloatingPlaceholder && !widget.decoration.alwaysFloatLabel) {
       if (widget._labelShouldWithdraw)
         _floatingLabelController.forward();
       else
@@ -2020,7 +2020,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
   bool get _hasInlineLabel => !widget._labelShouldWithdraw && decoration.labelText != null;
 
   // If the label is a floating placeholder, it's always shown.
-  bool get _shouldShowLabel => _hasInlineLabel || decoration.hasFloatingPlaceholder;
+  bool get _shouldShowLabel => decoration.alwaysFloatLabel || _hasInlineLabel || decoration.hasFloatingPlaceholder;
 
 
   // The base style for the inline label or hint when they're displayed "inline",
@@ -2431,6 +2431,7 @@ class InputDecoration {
     this.errorStyle,
     this.errorMaxLines,
     this.hasFloatingPlaceholder = true,
+    this.alwaysFloatLabel = false,
     this.isDense,
     this.contentPadding,
     this.prefixIcon,
@@ -2470,6 +2471,7 @@ class InputDecoration {
   const InputDecoration.collapsed({
     @required this.hintText,
     this.hasFloatingPlaceholder = true,
+    this.alwaysFloatLabel = false,
     this.hintStyle,
     this.filled = false,
     this.fillColor,
@@ -2634,6 +2636,14 @@ class InputDecoration {
   ///
   /// Defaults to true.
   final bool hasFloatingPlaceholder;
+
+  /// Whether the label is always floated.
+  ///
+  /// If this is false, the placeholder label floats when the input has focus or text has been entered.
+  /// If this is true, the placeholder label will always float at the top of the input.
+  ///
+  /// Defaults to false.
+  final bool alwaysFloatLabel;
 
   /// Whether the input [child] is part of a dense form (i.e., uses less vertical
   /// space).
@@ -3085,6 +3095,7 @@ class InputDecoration {
     TextStyle errorStyle,
     int errorMaxLines,
     bool hasFloatingPlaceholder,
+    bool alwaysFloatLabel,
     bool isDense,
     EdgeInsetsGeometry contentPadding,
     Widget prefixIcon,
@@ -3126,6 +3137,7 @@ class InputDecoration {
       errorStyle: errorStyle ?? this.errorStyle,
       errorMaxLines: errorMaxLines ?? this.errorMaxLines,
       hasFloatingPlaceholder: hasFloatingPlaceholder ?? this.hasFloatingPlaceholder,
+      alwaysFloatLabel: alwaysFloatLabel ?? this.alwaysFloatLabel,
       isDense: isDense ?? this.isDense,
       contentPadding: contentPadding ?? this.contentPadding,
       prefixIcon: prefixIcon ?? this.prefixIcon,
@@ -3169,6 +3181,7 @@ class InputDecoration {
       errorStyle: errorStyle ?? theme.errorStyle,
       errorMaxLines: errorMaxLines ?? theme.errorMaxLines,
       hasFloatingPlaceholder: hasFloatingPlaceholder ?? theme.hasFloatingPlaceholder,
+      alwaysFloatLabel: alwaysFloatLabel ?? theme.alwaysFloatLabel,
       isDense: isDense ?? theme.isDense,
       contentPadding: contentPadding ?? theme.contentPadding,
       prefixStyle: prefixStyle ?? theme.prefixStyle,
@@ -3208,6 +3221,7 @@ class InputDecoration {
         && other.errorStyle == errorStyle
         && other.errorMaxLines == errorMaxLines
         && other.hasFloatingPlaceholder == hasFloatingPlaceholder
+        && typedOther.alwaysFloatLabel == alwaysFloatLabel
         && other.isDense == isDense
         && other.contentPadding == contentPadding
         && other.isCollapsed == isCollapsed
@@ -3253,6 +3267,7 @@ class InputDecoration {
       errorStyle,
       errorMaxLines,
       hasFloatingPlaceholder,
+      alwaysFloatLabel,
       isDense,
       contentPadding,
       isCollapsed,
@@ -3299,6 +3314,7 @@ class InputDecoration {
       if (errorStyle != null) 'errorStyle: "$errorStyle"',
       if (errorMaxLines != null) 'errorMaxLines: "$errorMaxLines"',
       if (hasFloatingPlaceholder == false) 'hasFloatingPlaceholder: false',
+      if (alwaysFloatLabel) 'alwaysFloatLabel: true',
       if (isDense ?? false) 'isDense: $isDense',
       if (contentPadding != null) 'contentPadding: $contentPadding',
       if (isCollapsed) 'isCollapsed: $isCollapsed',
@@ -3355,6 +3371,7 @@ class InputDecorationTheme extends Diagnosticable {
     this.errorStyle,
     this.errorMaxLines,
     this.hasFloatingPlaceholder = true,
+    this.alwaysFloatLabel = false,
     this.isDense = false,
     this.contentPadding,
     this.isCollapsed = false,
@@ -3441,6 +3458,14 @@ class InputDecorationTheme extends Diagnosticable {
   ///
   /// Defaults to true.
   final bool hasFloatingPlaceholder;
+
+  /// Whether the label is always floated.
+  ///
+  /// If this is false, the placeholder label floats when the input has focus or text has been entered.
+  /// If this is true, the placeholder label will always float at the top of the input.
+  ///
+  /// Defaults to false.
+  final bool alwaysFloatLabel;
 
   /// Whether the input decorator's child is part of a dense form (i.e., uses
   /// less vertical space).
@@ -3745,6 +3770,7 @@ class InputDecorationTheme extends Diagnosticable {
       errorStyle,
       errorMaxLines,
       hasFloatingPlaceholder,
+      alwaysFloatLabel,
       isDense,
       contentPadding,
       isCollapsed,
@@ -3809,6 +3835,7 @@ class InputDecorationTheme extends Diagnosticable {
     properties.add(DiagnosticsProperty<TextStyle>('errorStyle', errorStyle, defaultValue: defaultTheme.errorStyle));
     properties.add(IntProperty('errorMaxLines', errorMaxLines, defaultValue: defaultTheme.errorMaxLines));
     properties.add(DiagnosticsProperty<bool>('hasFloatingPlaceholder', hasFloatingPlaceholder, defaultValue: defaultTheme.hasFloatingPlaceholder));
+    properties.add(DiagnosticsProperty<bool>('alwaysFloatLabel', alwaysFloatLabel, defaultValue: defaultTheme.alwaysFloatLabel));
     properties.add(DiagnosticsProperty<bool>('isDense', isDense, defaultValue: defaultTheme.isDense));
     properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('contentPadding', contentPadding, defaultValue: defaultTheme.contentPadding));
     properties.add(DiagnosticsProperty<bool>('isCollapsed', isCollapsed, defaultValue: defaultTheme.isCollapsed));

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2443,7 +2443,10 @@ class InputDecoration {
     this.errorText,
     this.errorStyle,
     this.errorMaxLines,
-    @Deprecated('Use floatLabelBehaviour instead.')
+    @Deprecated(
+      'Use floatLabelBehaviour instead. '
+      'This feature was deprecated after v1.13.2.'
+    )
     this.hasFloatingPlaceholder = true,
     this.floatLabelBehavior = FloatLabelBehavior.auto,
     this.isDense,
@@ -2484,7 +2487,10 @@ class InputDecoration {
   /// Sets the [isCollapsed] property to true.
   const InputDecoration.collapsed({
     @required this.hintText,
-    @Deprecated('Use floatLabelBehaviour instead.')
+    @Deprecated(
+      'Use floatLabelBehaviour instead. '
+      'This feature was deprecated after v1.13.2.'
+    )
     this.hasFloatingPlaceholder = true,
     this.floatLabelBehavior = FloatLabelBehavior.auto,
     this.hintStyle,
@@ -2651,7 +2657,10 @@ class InputDecoration {
   ///
   /// Defaults to true.
   ///
-  @Deprecated('Use floatLabelBehaviour instead.')
+  @Deprecated(
+    'Use floatLabelBehaviour instead. '
+    'This feature was deprecated after v1.13.2.'
+  )
   final bool hasFloatingPlaceholder;
 
   /// Defines how the floating label should be displayed.
@@ -3395,7 +3404,10 @@ class InputDecorationTheme extends Diagnosticable {
     this.hintStyle,
     this.errorStyle,
     this.errorMaxLines,
-    @Deprecated('Use floatLabelBehaviour instead.')
+    @Deprecated(
+      'Use floatLabelBehaviour instead. '
+      'This feature was deprecated after v1.13.2.'
+    )
     this.hasFloatingPlaceholder = true,
     this.floatLabelBehavior = FloatLabelBehavior.auto,
     this.isDense = false,
@@ -3483,7 +3495,10 @@ class InputDecorationTheme extends Diagnosticable {
   /// the input has focus or text has been entered.
   ///
   /// Defaults to true.
-  @Deprecated('Use floatLabelBehaviour instead.')
+  @Deprecated(
+    'Use floatLabelBehaviour instead. '
+    'This feature was deprecated after v1.13.2.'
+  )
   final bool hasFloatingPlaceholder;
 
   /// Defines how the floating label should be displayed.
@@ -3748,7 +3763,10 @@ class InputDecorationTheme extends Diagnosticable {
     TextStyle hintStyle,
     TextStyle errorStyle,
     int errorMaxLines,
-    @Deprecated('Use floatLabelBehaviour instead.')
+    @Deprecated(
+      'Use floatLabelBehaviour instead. '
+      'This feature was deprecated after v1.13.2.'
+    )
     bool hasFloatingPlaceholder,
     FloatLabelBehavior floatLabelBehavior,
     bool isDense,

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -6,7 +6,6 @@ import 'dart:math' as math;
 import 'dart:ui' show lerpDouble;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1883,11 +1883,15 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
   @override
   void initState() {
     super.initState();
+
+    final bool labelIsInitiallyFloating = widget.decoration.floatingLabelBehavior == FloatingLabelBehavior.always
+        // ignore: deprecated_member_use_from_same_package
+        || (widget.decoration.hasFloatingPlaceholder && widget._labelShouldWithdraw);
+
     _floatingLabelController = AnimationController(
       duration: _kTransitionDuration,
       vsync: this,
-      // ignore: deprecated_member_use_from_same_package
-      value: widget.decoration.floatingLabelBehavior == FloatingLabelBehavior.always || (widget.decoration.hasFloatingPlaceholder && widget._labelShouldWithdraw) ? 1.0 : 0.0,
+      value: labelIsInitiallyFloating ? 1.0 : 0.0
     );
     _floatingLabelController.addListener(_handleChange);
 
@@ -1928,7 +1932,10 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
   bool get isFocused => widget.isFocused && decoration.enabled;
   bool get isHovering => widget.isHovering && decoration.enabled;
   bool get isEmpty => widget.isEmpty;
-  bool get _floatingLabelEnabled => decoration.hasFloatingPlaceholder && decoration.floatingLabelBehavior != FloatingLabelBehavior.never;  // ignore: deprecated_member_use_from_same_package
+  bool get _floatingLabelEnabled {
+    // ignore: deprecated_member_use_from_same_package
+    return decoration.hasFloatingPlaceholder && decoration.floatingLabelBehavior != FloatingLabelBehavior.never;
+  }
 
   @override
   void didUpdateWidget(InputDecorator old) {
@@ -1936,11 +1943,13 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     if (widget.decoration != old.decoration)
       _effectiveDecoration = null;
 
-    // ignore: deprecated_member_use_from_same_package
-    final bool floatBehaviourChanged = widget.decoration.floatingLabelBehavior != old.decoration.floatingLabelBehavior || widget.decoration.hasFloatingPlaceholder != old.decoration.hasFloatingPlaceholder;
+    final bool floatBehaviourChanged = widget.decoration.floatingLabelBehavior != old.decoration.floatingLabelBehavior
+        // ignore: deprecated_member_use_from_same_package
+        || widget.decoration.hasFloatingPlaceholder != old.decoration.hasFloatingPlaceholder;
 
     if (widget._labelShouldWithdraw != old._labelShouldWithdraw || floatBehaviourChanged) {
-      if ((widget._labelShouldWithdraw || widget.decoration.floatingLabelBehavior == FloatingLabelBehavior.always) && _floatingLabelEnabled)
+      if (_floatingLabelEnabled
+          && (widget._labelShouldWithdraw || widget.decoration.floatingLabelBehavior == FloatingLabelBehavior.always))
         _floatingLabelController.forward();
       else
         _floatingLabelController.reverse();
@@ -2481,7 +2490,7 @@ class InputDecoration {
        assert(!(prefix != null && prefixText != null), 'Declaring both prefix and prefixText is not supported.'),
        assert(!(suffix != null && suffixText != null), 'Declaring both suffix and suffixText is not supported.'),
        // ignore: deprecated_member_use_from_same_package
-       assert(!(!hasFloatingPlaceholder && identical(floatingLabelBehavior, FloatingLabelBehavior.always)),
+       assert(!(!hasFloatingPlaceholder && floatingLabelBehavior == FloatingLabelBehavior.always),
             'hasFloatingPlaceholder=false conflicts with FloatingLabelBehavior.always'),
        isCollapsed = false;
 

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -6,6 +6,7 @@ import 'dart:math' as math;
 import 'dart:ui' show lerpDouble;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
@@ -464,12 +465,12 @@ class _HelperErrorState extends State<_HelperError> with SingleTickerProviderSta
 
 /// Defines the behaviour of the floating label
 enum FloatLabelBehavior {
-  /// the label will always be positioned within the content, or hidden
+  /// The label will always be positioned within the content, or hidden.
   never,
-  /// the label will float when the input is focused, or has content
+  /// The label will float when the input is focused, or has content.
   auto,
-  /// the label will always float above the content
-  always
+  /// The label will always float above the content.
+  always,
 }
 
 // Identifies the children of a _RenderDecorationElement.
@@ -1926,8 +1927,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
   bool get isFocused => widget.isFocused && decoration.enabled;
   bool get isHovering => widget.isHovering && decoration.enabled;
   bool get isEmpty => widget.isEmpty;
-
-  bool get floatLabelEnabled => decoration.hasFloatingPlaceholder && decoration.floatLabelBehavior != FloatLabelBehavior.never;
+  bool get _floatLabelEnabled => decoration.hasFloatingPlaceholder && decoration.floatLabelBehavior != FloatLabelBehavior.never;
 
   @override
   void didUpdateWidget(InputDecorator old) {
@@ -1938,7 +1938,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     final bool floatBehaviourChanged = widget.decoration.floatLabelBehavior != old.decoration.floatLabelBehavior || widget.decoration.hasFloatingPlaceholder != old.decoration.hasFloatingPlaceholder;
 
     if (widget._labelShouldWithdraw != old._labelShouldWithdraw || floatBehaviourChanged) {
-      if ((widget._labelShouldWithdraw || widget.decoration.floatLabelBehavior == FloatLabelBehavior.always) && floatLabelEnabled)
+      if ((widget._labelShouldWithdraw || widget.decoration.floatLabelBehavior == FloatLabelBehavior.always) && _floatLabelEnabled)
         _floatingLabelController.forward();
       else
         _floatingLabelController.reverse();
@@ -2034,7 +2034,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
   bool get _hasInlineLabel => !widget._labelShouldWithdraw && decoration.labelText != null;
 
   // If the label is a floating placeholder, it's always shown.
-  bool get _shouldShowLabel => _hasInlineLabel || floatLabelEnabled;
+  bool get _shouldShowLabel => _hasInlineLabel || _floatLabelEnabled;
 
   // The base style for the inline label or hint when they're displayed "inline",
   // i.e. when they appear in place of the empty text field.
@@ -2478,6 +2478,8 @@ class InputDecoration {
   }) : assert(enabled != null),
        assert(!(prefix != null && prefixText != null), 'Declaring both prefix and prefixText is not supported.'),
        assert(!(suffix != null && suffixText != null), 'Declaring both suffix and suffixText is not supported.'),
+       assert(!(!hasFloatingPlaceholder && identical(floatLabelBehavior, FloatLabelBehavior.always)),
+            'hasFloatingPlaceholder=false conflicts with FloatLabelBehavior.always'),
        isCollapsed = false;
 
   /// Defines an [InputDecorator] that is the same size as the input field.
@@ -2501,6 +2503,8 @@ class InputDecoration {
     this.border = InputBorder.none,
     this.enabled = true,
   }) : assert(enabled != null),
+       assert(!(!hasFloatingPlaceholder && identical(floatLabelBehavior, FloatLabelBehavior.always)),
+        'hasFloatingPlaceholder=false conflicts with FloatLabelBehavior.always'),
        icon = null,
        labelText = null,
        labelStyle = null,
@@ -2663,6 +2667,7 @@ class InputDecoration {
   )
   final bool hasFloatingPlaceholder;
 
+  /// {@template flutter.material.inputDecoration.floatLabelBehavior}
   /// Defines how the floating label should be displayed.
   ///
   /// When [FloatLabelBehavior.auto] the label will float to the top only when
@@ -2672,11 +2677,11 @@ class InputDecoration {
   /// When [FloatLabelBehavior.always] the label will always float at the top
   /// of the field above the content.
   ///
-  /// When [FloatLabelBehavior.never] the label will always will appear
-  /// in the field in place of the content.
+  /// When [FloatLabelBehavior.never] the label will always appear in an empty
+  /// field in place of the content.
   ///
   /// Defaults to [FloatLabelBehavior.auto].
-  ///
+  /// {@endtemplate}
   final FloatLabelBehavior floatLabelBehavior;
 
   /// Whether the input [child] is part of a dense form (i.e., uses less vertical
@@ -3430,7 +3435,9 @@ class InputDecorationTheme extends Diagnosticable {
   }) : assert(isDense != null),
        assert(isCollapsed != null),
        assert(filled != null),
-       assert(alignLabelWithHint != null);
+       assert(alignLabelWithHint != null),
+       assert(!(!hasFloatingPlaceholder && identical(floatLabelBehavior, FloatLabelBehavior.always)),
+        'hasFloatingPlaceholder=false conflicts with FloatLabelBehavior.always');
 
   /// The style to use for [InputDecoration.labelText] when the label is
   /// above (i.e., vertically adjacent to) the input field.
@@ -3501,20 +3508,7 @@ class InputDecorationTheme extends Diagnosticable {
   )
   final bool hasFloatingPlaceholder;
 
-  /// Defines how the floating label should be displayed.
-  ///
-  /// When [FloatLabelBehavior.auto] the label will float to the top only when
-  /// the field is focused or has some text content, otherwise it will appear
-  /// in the field in place of the content.
-  ///
-  /// When [FloatLabelBehavior.always] the label will always float at the top
-  /// of the field above the content.
-  ///
-  /// When [FloatLabelBehavior.never] the label will always will appear
-  /// in the field in place of the content.
-  ///
-  /// Defaults to [FloatLabelBehavior.auto].
-  ///
+  /// {@macro flutter.material.inputDecoration.floatLabelBehavior}
   final FloatLabelBehavior floatLabelBehavior;
 
   /// Whether the input decorator's child is part of a dense form (i.e., uses

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2488,9 +2488,6 @@ class InputDecoration {
   }) : assert(enabled != null),
        assert(!(prefix != null && prefixText != null), 'Declaring both prefix and prefixText is not supported.'),
        assert(!(suffix != null && suffixText != null), 'Declaring both suffix and suffixText is not supported.'),
-       // ignore: deprecated_member_use_from_same_package
-       assert(!(!hasFloatingPlaceholder && floatingLabelBehavior == FloatingLabelBehavior.always),
-            'hasFloatingPlaceholder=false conflicts with FloatingLabelBehavior.always'),
        isCollapsed = false;
 
   /// Defines an [InputDecorator] that is the same size as the input field.

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -141,14 +141,29 @@ void main() {
     expect(getBorderBottom(tester), 56.0);
     expect(getBorderWeight(tester), 1.0);
 
-    // The label appears above the input text when empty and alwaysFloatLabel
+    // The label appears within the input when there is no text content
     await tester.pumpWidget(
       buildInputDecorator(
         isEmpty: true,
         // isFocused: false (default)
         decoration: const InputDecoration(
           labelText: 'label',
-          alwaysFloatLabel: true
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final double labelYPosition = tester.getTopLeft(find.text('label')).dy;
+    expect(labelYPosition, 20.0);
+
+    // The label appears above the input text when there is not content and floatLabelBehavior is always
+    await tester.pumpWidget(
+      buildInputDecorator(
+        isEmpty: true,
+        // isFocused: false (default)
+        decoration: const InputDecoration(
+          labelText: 'label',
+          floatLabelBehavior: FloatLabelBehavior.always
         ),
       ),
     );
@@ -168,6 +183,29 @@ void main() {
     expect(tester.getBottomLeft(find.text('label')).dy, 24.0);
     expect(getBorderBottom(tester), 56.0);
     expect(getBorderWeight(tester), 1.0);
+
+    // The label appears within the input when hasFloatingPlaceholder is false
+    await tester.pumpWidget(
+      buildInputDecorator(
+        isEmpty: true,
+        // isFocused: false (default)
+        decoration: const InputDecoration(
+          labelText: 'label',
+          hasFloatingPlaceholder: false,
+          floatLabelBehavior: FloatLabelBehavior.always
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Overall height for this InputDecorator is 56dps:
+    //   12 - top padding
+    //   12 - floating label (ahem font size 16dps * 0.75 = 12)
+    //    4 - floating label / input text gap
+    //   16 - input text (ahem font size 16dps)
+    //   12 - bottom padding
+
+    expect(tester.getTopLeft(find.text('label')).dy, 20.0);
 
     // isFocused: true increases the border's weight from 1.0 to 2.0
     // but does not change the overall height.
@@ -2708,7 +2746,7 @@ void main() {
     );
     expect(
       child.toString(),
-      "InputDecorator-[<'key'>](decoration: InputDecoration(), baseStyle: TextStyle(<all styles inherited>), isFocused: false, isEmpty: false)",
+      "InputDecorator-[<'key'>](decoration: InputDecoration(floatLabelBehavior: FloatLabelBehavior.auto), baseStyle: TextStyle(<all styles inherited>), isFocused: false, isEmpty: false)",
     );
   });
 
@@ -3539,7 +3577,7 @@ void main() {
       hintStyle: TextStyle(),
       errorMaxLines: 5,
       hasFloatingPlaceholder: false,
-      alwaysFloatLabel: true,
+      floatLabelBehavior: FloatLabelBehavior.always,
       contentPadding: EdgeInsetsDirectional.only(start: 40.0, top: 12.0, bottom: 12.0),
       prefixStyle: TextStyle(),
       suffixStyle: TextStyle(),
@@ -3565,7 +3603,7 @@ void main() {
       'hintStyle: TextStyle(<all styles inherited>)',
       'errorMaxLines: 5',
       'hasFloatingPlaceholder: false',
-      'alwaysFloatLabel: true',
+      'floatLabelBehavior: FloatLabelBehavior.always',
       'contentPadding: EdgeInsetsDirectional(40.0, 12.0, 0.0, 12.0)',
       'prefixStyle: TextStyle(<all styles inherited>)',
       'suffixStyle: TextStyle(<all styles inherited>)',

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -185,20 +185,6 @@ void main() {
 
     expect(tester.getTopLeft(find.text('label')).dy, 20.0);
 
-    // The label appears within the input when hasFloatingPlaceholder is false and floatLabelBehavior is always
-    await tester.pumpWidget(
-      buildInputDecorator(
-        isEmpty: true,
-        // isFocused: false (default)
-        decoration: const InputDecoration(
-          labelText: 'label',
-          hasFloatingPlaceholder: false,
-          floatLabelBehavior: FloatLabelBehavior.always
-        ),
-      ),
-    );
-    await tester.pumpAndSettle();
-
     // Overall height for this InputDecorator is 56dps:
     //   12 - top padding
     //   12 - floating label (ahem font size 16dps * 0.75 = 12)
@@ -3578,7 +3564,7 @@ void main() {
       hintStyle: TextStyle(),
       errorMaxLines: 5,
       hasFloatingPlaceholder: false,
-      floatLabelBehavior: FloatLabelBehavior.always,
+      floatLabelBehavior: FloatLabelBehavior.never,
       contentPadding: EdgeInsetsDirectional.only(start: 40.0, top: 12.0, bottom: 12.0),
       prefixStyle: TextStyle(),
       suffixStyle: TextStyle(),
@@ -3604,7 +3590,7 @@ void main() {
       'hintStyle: TextStyle(<all styles inherited>)',
       'errorMaxLines: 5',
       'hasFloatingPlaceholder: false',
-      'floatLabelBehavior: FloatLabelBehavior.always',
+      'floatLabelBehavior: FloatLabelBehavior.never',
       'contentPadding: EdgeInsetsDirectional(40.0, 12.0, 0.0, 12.0)',
       'prefixStyle: TextStyle(<all styles inherited>)',
       'suffixStyle: TextStyle(<all styles inherited>)',

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -2530,6 +2530,7 @@ void main() {
         isEmpty: true,
         decoration: const InputDecoration(
           border: OutlineInputBorder(borderSide: BorderSide.none),
+          // ignore: deprecated_member_use_from_same_package
           hasFloatingPlaceholder: false,
           labelText: 'label',
         ),
@@ -2554,6 +2555,7 @@ void main() {
         // isFocused: false (default)
         decoration: const InputDecoration(
           border: OutlineInputBorder(borderSide: BorderSide.none),
+          // ignore: deprecated_member_use_from_same_package
           hasFloatingPlaceholder: false,
           labelText: 'label',
         ),
@@ -3563,6 +3565,7 @@ void main() {
       helperMaxLines: 6,
       hintStyle: TextStyle(),
       errorMaxLines: 5,
+      // ignore: deprecated_member_use_from_same_package
       hasFloatingPlaceholder: false,
       floatLabelBehavior: FloatLabelBehavior.never,
       contentPadding: EdgeInsetsDirectional.only(start: 40.0, top: 12.0, bottom: 12.0),

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -153,10 +153,9 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    final double labelYPosition = tester.getTopLeft(find.text('label')).dy;
-    expect(labelYPosition, 20.0);
+    expect(tester.getTopLeft(find.text('label')).dy, 20.0);
 
-    // The label appears above the input text when there is not content and floatLabelBehavior is always
+    // The label appears above the input text when there is no content and floatLabelBehavior is always
     await tester.pumpWidget(
       buildInputDecorator(
         isEmpty: true,
@@ -169,22 +168,24 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    // Overall height for this InputDecorator is 56dps:
-    //   12 - top padding
-    //   12 - floating label (ahem font size 16dps * 0.75 = 12)
-    //    4 - floating label / input text gap
-    //   16 - input text (ahem font size 16dps)
-    //   12 - bottom padding
-
-    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 56.0));
-    expect(tester.getTopLeft(find.text('text')).dy, 28.0);
-    expect(tester.getBottomLeft(find.text('text')).dy, 44.0);
     expect(tester.getTopLeft(find.text('label')).dy, 12.0);
-    expect(tester.getBottomLeft(find.text('label')).dy, 24.0);
-    expect(getBorderBottom(tester), 56.0);
-    expect(getBorderWeight(tester), 1.0);
 
-    // The label appears within the input when hasFloatingPlaceholder is false
+    // The label appears within the input text when there is content and floatLabelBehavior is never
+    await tester.pumpWidget(
+      buildInputDecorator(
+        isEmpty: false,
+        // isFocused: false (default)
+        decoration: const InputDecoration(
+          labelText: 'label',
+          floatLabelBehavior: FloatLabelBehavior.never
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.getTopLeft(find.text('label')).dy, 20.0);
+
+    // The label appears within the input when hasFloatingPlaceholder is false and floatLabelBehavior is always
     await tester.pumpWidget(
       buildInputDecorator(
         isEmpty: true,

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -155,14 +155,14 @@ void main() {
 
     expect(tester.getTopLeft(find.text('label')).dy, 20.0);
 
-    // The label appears above the input text when there is no content and floatLabelBehavior is always
+    // The label appears above the input text when there is no content and floatingLabelBehavior is always
     await tester.pumpWidget(
       buildInputDecorator(
         isEmpty: true,
         // isFocused: false (default)
         decoration: const InputDecoration(
           labelText: 'label',
-          floatLabelBehavior: FloatLabelBehavior.always
+          floatingLabelBehavior: FloatingLabelBehavior.always
         ),
       ),
     );
@@ -170,14 +170,14 @@ void main() {
 
     expect(tester.getTopLeft(find.text('label')).dy, 12.0);
 
-    // The label appears within the input text when there is content and floatLabelBehavior is never
+    // The label appears within the input text when there is content and floatingLabelBehavior is never
     await tester.pumpWidget(
       buildInputDecorator(
         isEmpty: false,
         // isFocused: false (default)
         decoration: const InputDecoration(
           labelText: 'label',
-          floatLabelBehavior: FloatLabelBehavior.never
+          floatingLabelBehavior: FloatingLabelBehavior.never
         ),
       ),
     );
@@ -2735,7 +2735,7 @@ void main() {
     );
     expect(
       child.toString(),
-      "InputDecorator-[<'key'>](decoration: InputDecoration(floatLabelBehavior: FloatLabelBehavior.auto), baseStyle: TextStyle(<all styles inherited>), isFocused: false, isEmpty: false)",
+      "InputDecorator-[<'key'>](decoration: InputDecoration(floatingLabelBehavior: FloatingLabelBehavior.auto), baseStyle: TextStyle(<all styles inherited>), isFocused: false, isEmpty: false)",
     );
   });
 
@@ -3567,7 +3567,7 @@ void main() {
       errorMaxLines: 5,
       // ignore: deprecated_member_use_from_same_package
       hasFloatingPlaceholder: false,
-      floatLabelBehavior: FloatLabelBehavior.never,
+      floatingLabelBehavior: FloatingLabelBehavior.never,
       contentPadding: EdgeInsetsDirectional.only(start: 40.0, top: 12.0, bottom: 12.0),
       prefixStyle: TextStyle(),
       suffixStyle: TextStyle(),
@@ -3593,7 +3593,7 @@ void main() {
       'hintStyle: TextStyle(<all styles inherited>)',
       'errorMaxLines: 5',
       'hasFloatingPlaceholder: false',
-      'floatLabelBehavior: FloatLabelBehavior.never',
+      'floatingLabelBehavior: FloatingLabelBehavior.never',
       'contentPadding: EdgeInsetsDirectional(40.0, 12.0, 0.0, 12.0)',
       'prefixStyle: TextStyle(<all styles inherited>)',
       'suffixStyle: TextStyle(<all styles inherited>)',

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -124,6 +124,35 @@ void main() {
         ),
       ),
     );
+    await tester.pumpAndSettle();
+
+    // Overall height for this InputDecorator is 56dps:
+    //   12 - top padding
+    //   12 - floating label (ahem font size 16dps * 0.75 = 12)
+    //    4 - floating label / input text gap
+    //   16 - input text (ahem font size 16dps)
+    //   12 - bottom padding
+
+    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 56.0));
+    expect(tester.getTopLeft(find.text('text')).dy, 28.0);
+    expect(tester.getBottomLeft(find.text('text')).dy, 44.0);
+    expect(tester.getTopLeft(find.text('label')).dy, 12.0);
+    expect(tester.getBottomLeft(find.text('label')).dy, 24.0);
+    expect(getBorderBottom(tester), 56.0);
+    expect(getBorderWeight(tester), 1.0);
+
+    // The label appears above the input text when empty and alwaysFloatLabel
+    await tester.pumpWidget(
+      buildInputDecorator(
+        isEmpty: true,
+        // isFocused: false (default)
+        decoration: const InputDecoration(
+          labelText: 'label',
+          alwaysFloatLabel: true
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
 
     // Overall height for this InputDecorator is 56dps:
     //   12 - top padding
@@ -3510,6 +3539,7 @@ void main() {
       hintStyle: TextStyle(),
       errorMaxLines: 5,
       hasFloatingPlaceholder: false,
+      alwaysFloatLabel: true,
       contentPadding: EdgeInsetsDirectional.only(start: 40.0, top: 12.0, bottom: 12.0),
       prefixStyle: TextStyle(),
       suffixStyle: TextStyle(),
@@ -3535,6 +3565,7 @@ void main() {
       'hintStyle: TextStyle(<all styles inherited>)',
       'errorMaxLines: 5',
       'hasFloatingPlaceholder: false',
+      'alwaysFloatLabel: true',
       'contentPadding: EdgeInsetsDirectional(40.0, 12.0, 0.0, 12.0)',
       'prefixStyle: TextStyle(<all styles inherited>)',
       'suffixStyle: TextStyle(<all styles inherited>)',

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -6565,7 +6565,7 @@ void main() {
 
     expect(description, <String>[
       'enabled: false',
-      'decoration: InputDecoration(labelText: "foo")',
+      'decoration: InputDecoration(labelText: "foo", floatingLabelBehavior: FloatingLabelBehavior.auto)',
       'style: TextStyle(inherit: true, color: Color(0xff00ff00))',
       'autofocus: true',
       'autocorrect: false',


### PR DESCRIPTION
## Description

Adds floatLabelBehavior to InputDecoration, which allows control of the floating label.

FloatLabelBehavior has the following values:
- never: the label is never floated. Replaces `hasFloatingPlaceholder` (now deprecated)
- auto: standard behavior, label floats when there is content or input is focused
- always: label is always floated above input


## Related Issues

https://github.com/flutter/flutter/issues/30664#issuecomment-561783017

## Tests

I added the following tests:

input_decorator_test.dart line 144 - tests that the label is shown even when the input is empty, if alwaysFloatLabel is true

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*