### PR TITLE
Add bitcode and architectures to App.framework build ios framework command

### DIFF
--- a/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
@@ -131,6 +131,10 @@ Future<void> main() async {
           throw TaskResult.failure('$mode App.framework arm64 architecture missing');
         }
 
+        if (aotSymbols.contains('x86_64')) {
+          throw TaskResult.failure('$mode App.framework contains x86_64 architecture');
+        }
+
         if (!aotSymbols.contains('_kDartVmSnapshot')) {
           throw TaskResult.failure('$mode App.framework missing Dart AOT');
         }

--- a/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
@@ -79,7 +79,7 @@ Future<void> main() async {
         'App',
       ));
 
-      String appFrameworkPath = path.join(
+      final String appFrameworkPath = path.join(
         outputPath,
         'Debug',
         'App.framework',

--- a/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
@@ -79,16 +79,31 @@ Future<void> main() async {
         'App',
       ));
 
-      final String aotSymbols = await dylibSymbols(path.join(
+      String appFrameworkPath = path.join(
         outputPath,
         'Debug',
         'App.framework',
         'App',
-      ));
+      );
+      final String aotSymbols = await dylibSymbols(appFrameworkPath);
 
       if (aotSymbols.contains('architecture') ||
           aotSymbols.contains('_kDartVmSnapshot')) {
         throw TaskResult.failure('Debug App.framework contains AOT');
+      }
+
+      final String debugAppArchs = await fileType(appFrameworkPath);
+
+      if (!debugAppArchs.contains('armv7')) {
+        throw TaskResult.failure('Debug App.framework armv7 architecture missing');
+      }
+
+      if (!debugAppArchs.contains('arm64')) {
+        throw TaskResult.failure('Debug App.framework arm64 architecture missing');
+      }
+
+      if (!debugAppArchs.contains('x86_64')) {
+        throw TaskResult.failure('Debug App.framework x86_64 architecture missing');
       }
 
       section('Check profile, release builds has Dart AOT dylib');

--- a/dev/devicelab/lib/framework/ios.dart
+++ b/dev/devicelab/lib/framework/ios.dart
@@ -53,3 +53,7 @@ Future<Map<String, dynamic>> measureIosCpuGpu({
 Future<String> dylibSymbols(String pathToDylib) {
   return eval('nm', <String>['-g', pathToDylib]);
 }
+
+Future<String> fileType(String pathToDylib) {
+  return eval('file', <String>[pathToDylib]);
+}

--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -244,7 +244,7 @@ class AOTSnapshotter {
     final String assemblyO = fs.path.join(outputPath, 'snapshot_assembly.o');
     List<String> isysrootArgs;
     if (isIOS) {
-      final String iPhoneSDKLocation = await xcode.iPhoneSdkLocation();
+      final String iPhoneSDKLocation = await xcode.sdkLocation(SdkType.iPhone);
       if (iPhoneSDKLocation != null) {
         isysrootArgs = <String>['-isysroot', iPhoneSDKLocation];
       }

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -157,17 +157,11 @@ class AotAssemblyProfile extends AotAssemblyBase {
 /// This framework needs to exist for the Xcode project to link/bundle,
 /// but it isn't actually executed. To generate something valid, we compile a trivial
 /// constant.
-Future<RunResult> createStubAppFramework(Directory appFrameworkDirectory) async {
-  File outputFile;
+Future<RunResult> createStubAppFramework(File outputFile, SdkType sdk) async {
   try {
-    if (!appFrameworkDirectory.existsSync()) {
-      appFrameworkDirectory.createSync(recursive: true);
-    }
-
-    outputFile = appFrameworkDirectory.childFile('App');
     outputFile.createSync(recursive: true);
   } catch (e) {
-    throwToolExit('Failed to create App.framework stub at ${appFrameworkDirectory.path}');
+    throwToolExit('Failed to create App.framework stub at ${outputFile.path}');
   }
 
   final Directory tempDir = fs.systemTempDirectory.createTempSync('flutter_tools_stub_source.');
@@ -177,14 +171,32 @@ Future<RunResult> createStubAppFramework(Directory appFrameworkDirectory) async 
   static const int Moo = 88;
   ''');
 
+    List<String> archFlags;
+    if (sdk == SdkType.iPhone) {
+      archFlags = <String>[
+        '-arch',
+        getNameForDarwinArch(DarwinArch.armv7),
+        '-arch',
+        getNameForDarwinArch(DarwinArch.arm64),
+      ];
+    } else {
+      archFlags = <String>[
+        '-arch',
+        getNameForDarwinArch(DarwinArch.x86_64),
+      ];
+    }
+
     return await xcode.clang(<String>[
       '-x',
       'c',
+      ...archFlags,
       stubSource.path,
       '-dynamiclib',
+      '-fembed-bitcode-marker',
       '-Xlinker', '-rpath', '-Xlinker', '@executable_path/Frameworks',
       '-Xlinker', '-rpath', '-Xlinker', '@loader_path/Frameworks',
       '-install_name', '@rpath/App.framework/App',
+      '-isysroot', await xcode.sdkLocation(sdk),
       '-o', outputFile.path,
     ]);
   } finally {
@@ -192,6 +204,8 @@ Future<RunResult> createStubAppFramework(Directory appFrameworkDirectory) async 
       tempDir.deleteSync(recursive: true);
     } on FileSystemException catch (_) {
       // Best effort. Sometimes we can't delete things from system temp.
+    } catch (e) {
+      throwToolExit('Failed to create App.framework stub at ${outputFile.path}');
     }
   }
 }

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -257,6 +257,7 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
   Future<void> _produceAppFramework(BuildMode mode, Directory iPhoneBuildOutput, Directory simulatorBuildOutput, Directory modeDirectory) async {
     const String appFrameworkName = 'App.framework';
     final Directory destinationAppFrameworkDirectory = modeDirectory.childDirectory(appFrameworkName);
+    destinationAppFrameworkDirectory.createSync(recursive: true);
 
     if (mode == BuildMode.debug) {
       final Status status = logger.startProgress(' ├─Add placeholder App.framework for debug...', timeout: timeoutConfiguration.fastOperation);
@@ -298,7 +299,6 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
     final File simulatorAppFrameworkFile = simulatorAppFrameworkDirectory.childFile(binaryName);
     await createStubAppFramework(simulatorAppFrameworkFile, SdkType.iPhoneSimulator);
 
-    copyDirectorySync(iPhoneAppFrameworkDirectory, destinationAppFrameworkDirectory);
     final List<String> lipoCommand = <String>[
       'xcrun',
       'lipo',

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -166,7 +166,7 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
       await _produceFlutterFramework(outputDirectory, mode, iPhoneBuildOutput, simulatorBuildOutput, modeDirectory);
 
       // Build aot, create module.framework and copy.
-      await _produceAppFramework(mode, iPhoneBuildOutput, modeDirectory);
+      await _produceAppFramework(mode, iPhoneBuildOutput, simulatorBuildOutput, modeDirectory);
 
       // Build and copy plugins.
       await processPodsIfNeeded(_project.ios, getIosBuildDirectory(), mode);
@@ -254,13 +254,13 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
     status.stop();
   }
 
-  Future<void> _produceAppFramework(BuildMode mode, Directory iPhoneBuildOutput, Directory modeDirectory) async {
+  Future<void> _produceAppFramework(BuildMode mode, Directory iPhoneBuildOutput, Directory simulatorBuildOutput, Directory modeDirectory) async {
     const String appFrameworkName = 'App.framework';
     final Directory destinationAppFrameworkDirectory = modeDirectory.childDirectory(appFrameworkName);
 
     if (mode == BuildMode.debug) {
       final Status status = logger.startProgress(' ├─Add placeholder App.framework for debug...', timeout: timeoutConfiguration.fastOperation);
-      await createStubAppFramework(destinationAppFrameworkDirectory);
+      await _produceStubAppFrameworkIfNeeded(mode, iPhoneBuildOutput, simulatorBuildOutput, destinationAppFrameworkDirectory);
       status.stop();
     } else {
       await _produceAotAppFrameworkIfNeeded(mode, iPhoneBuildOutput, destinationAppFrameworkDirectory);
@@ -283,6 +283,38 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
     status.stop();
   }
 
+  Future<void> _produceStubAppFrameworkIfNeeded(BuildMode mode, Directory iPhoneBuildOutput, Directory simulatorBuildOutput, Directory destinationAppFrameworkDirectory) async {
+    if (mode != BuildMode.debug) {
+      return;
+    }
+    const String appFrameworkName = 'App.framework';
+    const String binaryName = 'App';
+
+    final Directory iPhoneAppFrameworkDirectory = iPhoneBuildOutput.childDirectory(appFrameworkName);
+    final File iPhoneAppFrameworkFile = iPhoneAppFrameworkDirectory.childFile(binaryName);
+    await createStubAppFramework(iPhoneAppFrameworkFile, SdkType.iPhone);
+
+    final Directory simulatorAppFrameworkDirectory = simulatorBuildOutput.childDirectory(appFrameworkName);
+    final File simulatorAppFrameworkFile = simulatorAppFrameworkDirectory.childFile(binaryName);
+    await createStubAppFramework(simulatorAppFrameworkFile, SdkType.iPhoneSimulator);
+
+    copyDirectorySync(iPhoneAppFrameworkDirectory, destinationAppFrameworkDirectory);
+    final List<String> lipoCommand = <String>[
+      'xcrun',
+      'lipo',
+      '-create',
+      iPhoneAppFrameworkFile.path,
+      simulatorAppFrameworkFile.path,
+      '-output',
+      destinationAppFrameworkDirectory.childFile(binaryName).path
+    ];
+
+    await processUtils.run(
+      lipoCommand,
+      allowReentrantFlutter: false,
+    );
+  }
+
   Future<void> _produceAotAppFrameworkIfNeeded(BuildMode mode, Directory iPhoneBuildOutput, Directory destinationAppFrameworkDirectory) async {
     if (mode == BuildMode.debug) {
       return;
@@ -295,6 +327,7 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
       // Relative paths show noise in the compiler https://github.com/dart-lang/sdk/issues/37978.
       mainDartFile: fs.path.absolute(targetFile),
       quiet: true,
+      bitcode: true,
       reportTimings: false,
       iosBuildArchs: <DarwinArch>[DarwinArch.armv7, DarwinArch.arm64],
       dartDefines: dartDefines,

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -17,6 +17,25 @@ const int kXcodeRequiredVersionMinor = 2;
 
 Xcode get xcode => context.get<Xcode>();
 
+enum SdkType {
+  iPhone,
+  iPhoneSimulator,
+  macOS,
+}
+
+String getNameForSdk(SdkType sdk) {
+  switch (sdk) {
+    case SdkType.iPhone:
+      return 'iphoneos';
+    case SdkType.iPhoneSimulator:
+      return 'iphonesimulator';
+    case SdkType.macOS:
+      return 'macosx';
+  }
+  assert(false);
+  return null;
+}
+
 class Xcode {
   bool get isInstalledAndMeetsVersionCheck => platform.isMacOS && isInstalled && isVersionSatisfactory;
 
@@ -117,9 +136,9 @@ class Xcode {
     );
   }
 
-  Future<String> iPhoneSdkLocation() async {
+  Future<String> sdkLocation(SdkType sdk) async {
     final RunResult runResult = await processUtils.run(
-      <String>['xcrun', '--sdk', 'iphoneos', '--show-sdk-path'],
+      <String>['xcrun', '--sdk', getNameForSdk(sdk), '--show-sdk-path'],
       throwOnError: true,
     );
     if (runResult.exitCode != 0) {

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -23,6 +23,12 @@ enum SdkType {
   macOS,
 }
 
+/// SDK name passed to `xcrun --sdk`. Corresponds to undocumented Xcode
+/// SUPPORTED_PLATFORMS values.
+///
+/// Usage: xcrun [options] <tool name> ... arguments ...
+/// ...
+/// --sdk <sdk name>            find the tool for the given SDK name
 String getNameForSdk(SdkType sdk) {
   switch (sdk) {
     case SdkType.iPhone:
@@ -137,6 +143,7 @@ class Xcode {
   }
 
   Future<String> sdkLocation(SdkType sdk) async {
+    assert(sdk != null);
     final RunResult runResult = await processUtils.run(
       <String>['xcrun', '--sdk', getNameForSdk(sdk), '--show-sdk-path'],
       throwOnError: true,

--- a/packages/flutter_tools/test/general.shard/base/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/build_test.dart
@@ -244,7 +244,7 @@ void main() {
       mockAndroidSdk = MockAndroidSdk();
       mockArtifacts = MockArtifacts();
       mockXcode = MockXcode();
-      when(mockXcode.iPhoneSdkLocation()).thenAnswer((_) => Future<String>.value(kSDKPath));
+      when(mockXcode.sdkLocation(any)).thenAnswer((_) => Future<String>.value(kSDKPath));
 
       bufferLogger = BufferLogger();
       for (BuildMode mode in BuildMode.values) {

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -190,5 +190,11 @@ void main() {
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
     });
+
+    testUsingContext('SDK name', () {
+      expect(getNameForSdk(SdkType.iPhone), 'iphoneos');
+      expect(getNameForSdk(SdkType.iPhoneSimulator), 'iphonesimulator');
+      expect(getNameForSdk(SdkType.macOS), 'macosx');
+    });
   });
 }


### PR DESCRIPTION
##  Description
Make a fat universal binary for the Debug App.framework.
Enable bitcode for all versions of App.framework.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/46125
Fixes https://github.com/flutter/flutter/issues/46129

## Tests

xcode_test
Update build_ios_framework_module_test.dart to check Debug App.framework architectures.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*