### PR TITLE
Semantics Debugger message fixes and updates.

### DIFF
--- a/packages/flutter/lib/src/widgets/semantics_debugger.dart
+++ b/packages/flutter/lib/src/widgets/semantics_debugger.dart
@@ -256,18 +256,17 @@ class _SemanticsDebuggerPainter extends CustomPainter {
 
     if (data.hasFlag(SemanticsFlag.hasCheckedState)) {
       annotations.add(data.hasFlag(SemanticsFlag.isChecked) ? 'checked' : 'unchecked');
-      if (!data.hasAction(SemanticsAction.tap)) {
-        annotations.add('disabled');
-      }
     } else if (data.hasFlag(SemanticsFlag.isButton)) {
       annotations.add('button');
-      if (!data.hasAction(SemanticsAction.tap)) {
-        annotations.add('disabled');
-      }
     } else if (data.hasFlag(SemanticsFlag.isTextField)) {
       annotations.add('textfield');
     } else if (data.hasAction(SemanticsAction.tap)) {
       annotations.add('tappable');
+    }
+
+    if (data.hasFlag(SemanticsFlag.hasEnabledState) &&
+        !data.hasFlag(SemanticsFlag.isEnabled)) {
+      annotations.add('disabled');
     }
 
     if (data.hasAction(SemanticsAction.longPress))

--- a/packages/flutter/lib/src/widgets/semantics_debugger.dart
+++ b/packages/flutter/lib/src/widgets/semantics_debugger.dart
@@ -250,22 +250,24 @@ class _SemanticsDebuggerPainter extends CustomPainter {
     final SemanticsData data = node.getSemanticsData();
     final List<String> annotations = <String>[];
 
-    bool wantsTap = false;
-    if (data.hasFlag(SemanticsFlag.hasCheckedState)) {
-      annotations.add(data.hasFlag(SemanticsFlag.isChecked) ? 'checked' : 'unchecked');
-      wantsTap = true;
-    }
-    if (data.hasFlag(SemanticsFlag.isTextField)) {
-      annotations.add('textfield');
-      wantsTap = true;
+    if (data.hasFlag(SemanticsFlag.isHeader)) {
+      annotations.add('header');
     }
 
-    if (data.hasAction(SemanticsAction.tap)) {
-      if (!wantsTap)
-        annotations.add('button');
-    } else {
-      if (wantsTap)
+    if (data.hasFlag(SemanticsFlag.hasCheckedState)) {
+      annotations.add(data.hasFlag(SemanticsFlag.isChecked) ? 'checked' : 'unchecked');
+      if (!data.hasAction(SemanticsAction.tap)) {
         annotations.add('disabled');
+      }
+    } else if (data.hasFlag(SemanticsFlag.isButton)) {
+      annotations.add('button');
+      if (!data.hasAction(SemanticsAction.tap)) {
+        annotations.add('disabled');
+      }
+    } else if (data.hasFlag(SemanticsFlag.isTextField)) {
+      annotations.add('textfield');
+    } else if (data.hasAction(SemanticsAction.tap)) {
+      annotations.add('tappable');
     }
 
     if (data.hasAction(SemanticsAction.longPress))

--- a/packages/flutter/test/widgets/semantics_debugger_test.dart
+++ b/packages/flutter/test/widgets/semantics_debugger_test.dart
@@ -435,7 +435,48 @@ void main() {
     );
   });
 
-  testWidgets('SemanticsDebugger textfield', (WidgetTester tester) async {
+  testWidgets('SemanticsDebugger button message', (WidgetTester tester) async {
+    final UniqueKey button = UniqueKey();
+    final UniqueKey disabledButton = UniqueKey();
+    final UniqueKey debugger = UniqueKey();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SemanticsDebugger(
+          key: debugger,
+          child: Material(
+            child: Column(
+              children: <Widget>[
+                RaisedButton(
+                  key: button,
+                  onPressed: () {},
+                ),
+                RaisedButton(
+                  key: disabledButton,
+                  onPressed: null,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final dynamic semanticsDebuggerPainter = _getSemanticsDebuggerPainter(debuggerKey: debugger, tester: tester);
+    final RenderObject renderButton = tester.renderObject(find.descendant(of: find.byKey(button), matching: find.byType(Semantics)).first);
+    final RenderObject renderDisabledButton = tester.renderObject(find.descendant(of: find.byKey(disabledButton), matching: find.byType(Semantics)).first);
+
+    expect(
+      semanticsDebuggerPainter.getMessage(renderButton.debugSemantics),
+      'button',
+    );
+    expect(
+      semanticsDebuggerPainter.getMessage(renderDisabledButton.debugSemantics),
+      'button; disabled',
+    );
+  });
+
+  testWidgets('SemanticsDebugger textfield message', (WidgetTester tester) async {
     final UniqueKey textField = UniqueKey();
     final UniqueKey debugger = UniqueKey();
 
@@ -458,6 +499,61 @@ void main() {
     expect(
       semanticsDebuggerPainter.getMessage(renderTextfield.debugSemantics),
       'textfield',
+    );
+  });
+
+  testWidgets('SemanticsDebugger tappable message', (WidgetTester tester) async {
+    final UniqueKey tappable = UniqueKey();
+    final UniqueKey debugger = UniqueKey();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SemanticsDebugger(
+          key: debugger,
+          child: Material(
+            child: InkWell(
+              key: tappable,
+              onTap: () {},
+              child: const Text('Label'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final dynamic semanticsDebuggerPainter = _getSemanticsDebuggerPainter(debuggerKey: debugger, tester: tester);
+    final RenderObject renderTappable = tester.renderObject(find.descendant(of: find.byKey(tappable), matching: find.byType(Semantics)).first);
+
+    expect(
+      semanticsDebuggerPainter.getMessage(renderTappable.debugSemantics),
+      'Label (tappable)',
+    );
+  });
+
+  testWidgets('SemanticsDebugger header message', (WidgetTester tester) async {
+    final UniqueKey header = UniqueKey();
+    final UniqueKey debugger = UniqueKey();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SemanticsDebugger(
+          key: debugger,
+          child: Material(
+            child: Semantics(
+              key: header,
+              header: true,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final dynamic semanticsDebuggerPainter = _getSemanticsDebuggerPainter(debuggerKey: debugger, tester: tester);
+    final RenderObject renderHeader = tester.renderObject(find.byType(Semantics).last);
+
+    expect(
+      semanticsDebuggerPainter.getMessage(renderHeader.debugSemantics),
+      'header',
     );
   });
 


### PR DESCRIPTION
## Description

This PR updates several SemanticsDebugger label messages:

- Only display 'button' for Semantics with 'button' flag.
- For non-buttons with tap handlers display 'tappable'.
- For elements with 'header' flag, display 'header'.

## Related Issues

Fixes #46039

## Tests

I updated the tests for the SemanticDebugger to test these new cases.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.

This shouldn't be a breaking change, but it is possible people have tests against the specific labels used by the SemanticDebugger (or screenshots of them). I will attempt to run these against internal tests and update this if needed.
