### PR TITLE
fix release web builds where the target file is not under lib

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -68,11 +68,10 @@ class WebEntrypointTarget extends Target {
     );
 
     // By construction, this will only be null if the .packages file does not
-    // have an entry for the user's application.
-    final Uri mainImport = packageUriMapper.map(importPath);
-    if (mainImport == null) {
-      throw Exception('Missing package definition for $mainImport');
-    }
+    // have an entry for the user's application or if the main file is
+    // outisde of the lib/ directory.
+    final String mainImport = packageUriMapper.map(importPath)?.toString()
+      ?? fs.file(importPath).absolute.uri.toString();
 
     String contents;
     if (hasPlugins) {

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -69,7 +69,7 @@ class WebEntrypointTarget extends Target {
 
     // By construction, this will only be null if the .packages file does not
     // have an entry for the user's application or if the main file is
-    // outisde of the lib/ directory.
+    // outside of the lib/ directory.
     final String mainImport = packageUriMapper.map(importPath)?.toString()
       ?? fs.file(importPath).absolute.uri.toString();
 

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -76,6 +76,17 @@ void main() {
     expect(generated, contains("import 'package:foo/main.dart' as entrypoint;"));
   }));
 
+  test('WebEntrypointTarget generates an entrypoint for a file outside of main', () => testbed.run(() async {
+    environment.defines[kTargetFile] = fs.path.join('other', 'lib', 'main.dart');
+    await const WebEntrypointTarget().build(environment);
+
+    final String generated = environment.buildDir.childFile('main.dart').readAsStringSync();
+
+    // Import.
+    expect(generated, contains("import 'file:///other/lib/main.dart' as entrypoint;"));
+  }));
+
+
   test('WebEntrypointTarget generates an entrypoint with plugins and init platform on windows', () => testbed.run(() async {
     environment.defines[kHasWebPlugins] = 'true';
     environment.defines[kInitializePlatform] = 'true';


### PR DESCRIPTION
## Description

If the target file is not under lib, we will currently fail to build an app as we can't find a package uri. Fall back to a file uri in this case, which is okay since that library will probably have a package import.