### PR TITLE
Mitigation for current tool test skips on CI

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -262,9 +262,14 @@ Future<void> _runToolTests() async {
       .map<String>((String name) => path.basenameWithoutExtension(name)),
     // The `dynamic` on the next line is because Map.fromIterable isn't generic.
     value: (dynamic subshard) => () async {
+      // Due to https://github.com/flutter/flutter/issues/46180, skip the hermetic directory
+      // on Windows.
+      final String suffix = Platform.isWindows && subshard == 'commands'
+        ? 'permeable'
+        : '';
       await _pubRunTest(
         toolsPath,
-        testPath: path.join(kTest, '$subshard$kDotShard'),
+        testPath: path.join(kTest, '$subshard$kDotShard', suffix),
         useBuildRunner: canUseBuildRunner,
         tableData: bigqueryApi?.tabledata,
         enableFlutterToolAsserts: true,

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -262,30 +262,6 @@ Future<void> _runToolTests() async {
       .map<String>((String name) => path.basenameWithoutExtension(name)),
     // The `dynamic` on the next line is because Map.fromIterable isn't generic.
     value: (dynamic subshard) => () async {
-      if (subshard == 'commands') {
-        // Due to https://github.com/dart-lang/test/issues/1116, pub or test
-        // appears to be skipping all tests from the hermetic shard if not
-        // explicitly specifed.
-        await _pubRunTest(
-          toolsPath,
-          testPath: path.join(kTest, '$subshard$kDotShard', 'hermetic'),
-          useBuildRunner: canUseBuildRunner,
-          tableData: bigqueryApi?.tabledata,
-          enableFlutterToolAsserts: true,
-        );
-        // The permeable shard is currently crashing on windows.
-        // https://github.com/flutter/flutter/issues/46180
-        if (!Platform.isWindows) {
-          await _pubRunTest(
-            toolsPath,
-            testPath: path.join(kTest, '$subshard$kDotShard', 'permeable'),
-            useBuildRunner: canUseBuildRunner,
-            tableData: bigqueryApi?.tabledata,
-            enableFlutterToolAsserts: true,
-          );
-        }
-        return;
-      }
       await _pubRunTest(
         toolsPath,
         testPath: path.join(kTest, '$subshard$kDotShard'),

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -266,24 +266,25 @@ Future<void> _runToolTests() async {
         // Due to https://github.com/dart-lang/test/issues/1116, pub or test
         // appears to be skipping all tests from the hermetic shard if not
         // explicitly specifed.
-        await _pubRunTest(
-          toolsPath,
-          testPath: path.join(kTest, '$subshard$kDotShard', 'hermetic'),
-          useBuildRunner: canUseBuildRunner,
-          tableData: bigqueryApi?.tabledata,
-          enableFlutterToolAsserts: true,
-        );
+
         // The permeable shard is currently crashing on windows.
         // https://github.com/flutter/flutter/issues/46180
         if (!Platform.isWindows) {
           await _pubRunTest(
             toolsPath,
-            testPath: path.join(kTest, '$subshard$kDotShard', 'permeable'),
+            testPath: path.join(kTest, '$subshard$kDotShard', 'hermetic'),
             useBuildRunner: canUseBuildRunner,
             tableData: bigqueryApi?.tabledata,
             enableFlutterToolAsserts: true,
           );
         }
+        await _pubRunTest(
+          toolsPath,
+          testPath: path.join(kTest, '$subshard$kDotShard', 'permeable'),
+          useBuildRunner: canUseBuildRunner,
+          tableData: bigqueryApi?.tabledata,
+          enableFlutterToolAsserts: true,
+        );
         return;
       }
       await _pubRunTest(

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -619,7 +619,7 @@ void main() {
 
     expect(projectDir.childDirectory('macos').childFile('flutter_project.podspec').existsSync(), false);
   }, overrides: <Type, Generator>{
-    FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
+    FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: false),
   });
 
   testUsingContext('has correct content and formatting with module template', () async {

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -15,6 +15,7 @@ import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/create.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/dart/sdk.dart';
+import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/version.dart';
 
@@ -23,6 +24,7 @@ import 'package:process/process.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/testbed.dart';
 
 const String frameworkRevision = '12345678';
 const String frameworkChannel = 'omega';
@@ -404,7 +406,7 @@ void main() {
     );
   }, overrides: <Type, Generator>{
     Pub: () => const Pub(),
-  });
+  }, skip: true); // https://github.com/flutter/flutter/issues/46142
 
   testUsingContext('module project with pub', () async {
     return _createProject(projectDir, <String>[
@@ -439,7 +441,7 @@ void main() {
     ]);
   }, overrides: <Type, Generator>{
     Pub: () => const Pub(),
-  });
+  }, skip: true); // https://github.com/flutter/flutter/issues/46142
 
 
   testUsingContext('androidx is used by default in an app project', () async {
@@ -568,9 +570,11 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
-    await runner.run(<String>['create', '--no-pub', '--macos', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', projectDir.path]);
 
     expect(projectDir.childDirectory('macos').childDirectory('Runner.xcworkspace').existsSync(), true);
+  }, overrides: <Type, Generator>{
+    FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
   });
 
   testUsingContext('app does not include macOS by default', () async {
@@ -584,6 +588,8 @@ void main() {
     await runner.run(<String>['create', '--no-pub', projectDir.path]);
 
     expect(projectDir.childDirectory('macos').childDirectory('Runner.xcworkspace').existsSync(), false);
+  }, overrides: <Type, Generator>{
+    FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: false),
   });
 
   testUsingContext('plugin supports macOS if requested', () async {
@@ -594,9 +600,11 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--macos', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
 
     expect(projectDir.childDirectory('macos').childFile('flutter_project.podspec').existsSync(), true);
+  }, overrides: <Type, Generator>{
+    FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
   });
 
   testUsingContext('plugin does not include macOS by default', () async {
@@ -610,6 +618,8 @@ void main() {
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
 
     expect(projectDir.childDirectory('macos').childFile('flutter_project.podspec').existsSync(), false);
+  }, overrides: <Type, Generator>{
+    FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
   });
 
   testUsingContext('has correct content and formatting with module template', () async {

--- a/packages/flutter_tools/test/commands.shard/permeable/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/test_test.dart
@@ -31,7 +31,9 @@ void main() {
     testUsingContext('report nice errors for exceptions thrown within testWidgets()', () async {
       Cache.flutterRoot = '../..';
       return _testFile('exception_handling', automatedTestsDirectory, flutterTestDirectory);
-    }, skip: io.Platform.isWindows); // TODO(chunhtai): Remove Skip https://github.com/flutter/flutter/issues/35425.
+    }, skip: true); // https://github.com/flutter/flutter/issues/46142
+    // Note: was skip: skip: io.Platform.isWindows
+    // TODO(chunhtai): Remove Skip https://github.com/flutter/flutter/issues/35425.
 
     testUsingContext('report a nice error when a guarded function was called without await', () async {
       Cache.flutterRoot = '../..';
@@ -75,7 +77,8 @@ void main() {
     testUsingContext('can load assets within its own package', () async {
       Cache.flutterRoot = '../..';
       return _testFile('package_assets', automatedTestsDirectory, flutterTestDirectory, exitCode: isZero);
-    }, skip: io.Platform.isWindows);
+    }, skip: true); // https://github.com/flutter/flutter/issues/46142
+    // Note, was skip: io.Platform.isWindows
 
     testUsingContext('run a test when its name matches a regexp', () async {
       Cache.flutterRoot = '../..';

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -6,10 +6,12 @@ import 'package:flutter_tools/runner.dart' as runner;
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/upgrade.dart';
+import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/persistent_tool_state.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'package:flutter_tools/src/version.dart';
@@ -213,12 +215,7 @@ void main() {
     });
 
     group('full command', () {
-      final FakeProcessManager fakeProcessManager = FakeProcessManager.list(<FakeCommand>[
-        const FakeCommand(command: <String>[
-          'git', 'describe', '--match', 'v*.*.*', '--first-parent', '--long', '--tags',
-        ]),
-      ]);
-
+      FakeProcessManager fakeProcessManager;
       Directory tempDir;
       File flutterToolState;
 
@@ -226,6 +223,14 @@ void main() {
 
       setUp(() {
         Cache.disableLocking();
+        fakeProcessManager = FakeProcessManager.list(<FakeCommand>[
+          const FakeCommand(
+            command: <String>[
+              'git', 'describe', '--match', 'v*.*.*', '--first-parent', '--long', '--tags',
+            ],
+            stdout: 'v1.12.16-19-gb45b676af',
+          ),
+        ]);
         tempDir = fs.systemTempDirectory.createTempSync('flutter_upgrade_test.');
         flutterToolState = tempDir.childFile('.flutter_tool_state');
         mockFlutterVersion = MockFlutterVersion(isStable: true);
@@ -238,16 +243,17 @@ void main() {
 
       testUsingContext('upgrade continue prints welcome message', () async {
         final UpgradeCommand upgradeCommand = UpgradeCommand(fakeCommandRunner);
-        await runner.run(
+        applyMocksToCommand(upgradeCommand);
+
+        await createTestCommandRunner(upgradeCommand).run(
           <String>[
             'upgrade',
             '--continue',
           ],
-          <FlutterCommand>[
-            upgradeCommand,
-          ],
         );
-        expect(testLogger.statusText, contains('Welcome to Flutter!'));
+
+        expect(json.decode(flutterToolState.readAsStringSync()),
+          containsPair('redisplay-welcome-message', true));
       }, overrides: <Type, Generator>{
         FlutterVersion: () => mockFlutterVersion,
         ProcessManager: () => fakeProcessManager,

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -2,11 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter_tools/runner.dart' as runner;
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
-import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/cache.dart';

--- a/packages/flutter_tools/test/src/fake_process_manager.dart
+++ b/packages/flutter_tools/test/src/fake_process_manager.dart
@@ -198,9 +198,9 @@ abstract class FakeProcessManager implements ProcessManager {
       fakeCommand.duration,
       fakeCommand.onRun,
       _pid,
-      fakeCommand.stdout,
-      null, // stdin
       fakeCommand.stderr,
+      null, // stdin
+      fakeCommand.stdout,
     );
   }
 


### PR DESCRIPTION
## Description

Mitigation for https://github.com/flutter/flutter/issues/46142, ensures that _most_ tests are being run, but not confirmed yet.

Currently the commands.shard appears to only be running tests for a single subdirectory (due to https://github.com/dart-lang/test/issues/1116), permeable/, while the hermetic/ subdirectory is entirely skipped. To work around this a bit, when selecting the commands.shard I invoke pub twice, once in each sub directory. Unfortunately this has revealed that several of the tests were failing, and further more that shard crashes on windows (https://github.com/flutter/flutter/issues/46180). 

I also attempt to solve this by adjusting the build_runner configuration, but found that the failing tests did not cause a non-zero exit code to be set: https://github.com/dart-lang/build/issues/2562


Due to other bugs in pub/test, we might be skipping tests elsewhere - thus this is only a partial mitigation.

EDIT:

Thanks to @grouma that tracked the issue down. Ultimately the problem was a test calling io.exit which takes down the entire test runner.