### PR TITLE
fix global key error

### DIFF
--- a/packages/flutter/lib/src/cupertino/action_sheet.dart
+++ b/packages/flutter/lib/src/cupertino/action_sheet.dart
@@ -469,6 +469,7 @@ class _CupertinoAlertRenderElement extends RenderObjectElement {
     } else if (_actionsElement == child) {
       _actionsElement = null;
     }
+    super.forgetChild(child);
   }
 
   @override

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -464,6 +464,7 @@ class _CupertinoDialogRenderElement extends RenderObjectElement {
       assert(_actionsElement == child);
       _actionsElement = null;
     }
+    super.forgetChild(child);
   }
 
   @override

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -2072,6 +2072,7 @@ class _RenderChipElement extends RenderObjectElement {
     final _ChipSlot slot = childToSlot[child];
     childToSlot.remove(child);
     slotToChild.remove(slot);
+    super.forgetChild(child);
   }
 
   void _mountChild(Widget widget, _ChipSlot slot) {

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1511,6 +1511,7 @@ class _RenderDecorationElement extends RenderObjectElement {
     final _DecorationSlot slot = childToSlot[child];
     childToSlot.remove(child);
     slotToChild.remove(slot);
+    super.forgetChild(child);
   }
 
   void _mountChild(Widget widget, _DecorationSlot slot) {

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -992,6 +992,7 @@ class _ListTileElement extends RenderObjectElement {
     final _ListTileSlot slot = childToSlot[child];
     childToSlot.remove(child);
     slotToChild.remove(slot);
+    super.forgetChild(child);
   }
 
   void _mountChild(Widget widget, _ListTileSlot slot) {

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -1016,6 +1016,7 @@ class RenderObjectToWidgetElement<T extends RenderObject> extends RootRenderObje
   void forgetChild(Element child) {
     assert(child == _child);
     _child = null;
+    super.forgetChild(child);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -60,6 +60,7 @@ class _LayoutBuilderElement<ConstraintType extends Constraints> extends RenderOb
   void forgetChild(Element child) {
     assert(child == _child);
     _child = null;
+    super.forgetChild(child);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
@@ -924,6 +924,7 @@ class ListWheelElement extends RenderObjectElement implements ListWheelChildMana
   @override
   void forgetChild(Element child) {
     _childElements.remove(child.slot);
+    super.forgetChild(child);
   }
 
 }

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1160,6 +1160,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
     assert(child.slot != null);
     assert(_childElements.containsKey(child.slot));
     _childElements.remove(child.slot);
+    super.forgetChild(child);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
@@ -230,6 +230,7 @@ class _SliverPersistentHeaderElement extends RenderObjectElement {
   void forgetChild(Element child) {
     assert(child == this.child);
     this.child = null;
+    super.forgetChild(child);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/table.dart
+++ b/packages/flutter/lib/src/widgets/table.dart
@@ -344,6 +344,7 @@ class _TableElement extends RenderObjectElement {
   @override
   bool forgetChild(Element child) {
     _forgottenChildren.add(child);
+    super.forgetChild(child);
     return true;
   }
 }

--- a/packages/flutter/test/foundation/diagnostics_json_test.dart
+++ b/packages/flutter/test/foundation/diagnostics_json_test.dart
@@ -222,11 +222,6 @@ class _TestElement extends Element {
   _TestElement() : super(const Placeholder());
 
   @override
-  void forgetChild(Element child) {
-    // Intentionally left empty.
-  }
-
-  @override
   void performRebuild() {
     // Intentionally left empty.
   }

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -6,6 +6,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
+typedef ElementRebuildCallback = void Function(StatefulElement element);
+
 class TestState extends State<StatefulWidget> {
   @override
   Widget build(BuildContext context) => null;
@@ -59,6 +61,358 @@ void main() {
     expect(keyA, equals(keyA2));
     expect(keyA.hashCode, equals(keyA2.hashCode));
     expect(keyA, isNot(equals(keyB)));
+  });
+
+  testWidgets('GlobalKey correct case 1 - can move global key from container widget to layoutbuilder', (WidgetTester tester) async {
+    final Key key = GlobalKey(debugLabel: 'correct');
+    await tester.pumpWidget(Stack(
+      textDirection: TextDirection.ltr,
+      children: <Widget>[
+        Container(
+          key: const ValueKey<int>(1),
+          child: SizedBox(key: key),
+        ),
+        LayoutBuilder(
+          key: const ValueKey<int>(2),
+          builder: (BuildContext context, BoxConstraints constraints) {
+            return const Placeholder();
+          },
+        ),
+      ],
+    ));
+
+    await tester.pumpWidget(Stack(
+      textDirection: TextDirection.ltr,
+      children: <Widget>[
+        Container(
+          key: const ValueKey<int>(1),
+          child: const Placeholder(),
+        ),
+        LayoutBuilder(
+          key: const ValueKey<int>(2),
+          builder: (BuildContext context, BoxConstraints constraints) {
+            return SizedBox(key: key);
+          },
+        ),
+      ],
+    ));
+  });
+
+  testWidgets('GlobalKey correct case 2 - can move global key from layoutbuilder to container widget', (WidgetTester tester) async {
+    final Key key = GlobalKey(debugLabel: 'correct');
+    await tester.pumpWidget(Stack(
+      textDirection: TextDirection.ltr,
+      children: <Widget>[
+        Container(
+          key: const ValueKey<int>(1),
+          child: const Placeholder(),
+        ),
+        LayoutBuilder(
+          key: const ValueKey<int>(2),
+          builder: (BuildContext context, BoxConstraints constraints) {
+            return SizedBox(key: key);
+          },
+        ),
+      ],
+    ));
+    await tester.pumpWidget(Stack(
+      textDirection: TextDirection.ltr,
+      children: <Widget>[
+        Container(
+          key: const ValueKey<int>(1),
+          child: SizedBox(key: key),
+        ),
+        LayoutBuilder(
+          key: const ValueKey<int>(2),
+          builder: (BuildContext context, BoxConstraints constraints) {
+            return const Placeholder();
+          },
+        ),
+      ],
+    ));
+  });
+
+  testWidgets('GlobalKey correct case 3 - can deal with early rebuild in layoutbuilder - move backward', (WidgetTester tester) async {
+    const Key key1 = GlobalObjectKey('Text1');
+    const Key key2 = GlobalObjectKey('Text2');
+    Key rebuiltKeyOfSecondChildBeforeLayout;
+    Key rebuiltKeyOfFirstChildAfterLayout;
+    Key rebuiltKeyOfSecondChildAfterLayout;
+    await tester.pumpWidget(
+      LayoutBuilder(
+        builder: (BuildContext context, BoxConstraints constraints) {
+          return Column(
+            children: <Widget>[
+              const _Stateful(
+                child: Text(
+                  'Text1',
+                  textDirection: TextDirection.ltr,
+                  key: key1,
+                ),
+              ),
+              _Stateful(
+                child: const Text(
+                  'Text2',
+                  textDirection: TextDirection.ltr,
+                  key: key2,
+                ),
+                onElementRebuild: (StatefulElement element) {
+                  // We don't want noise to override the result;
+                  expect(rebuiltKeyOfSecondChildBeforeLayout, isNull);
+                  final _Stateful statefulWidget = element.widget as _Stateful;
+                  rebuiltKeyOfSecondChildBeforeLayout =
+                    statefulWidget.child.key;
+                },
+              ),
+            ],
+          );
+        },
+      )
+    );
+    // Result will be written during first build and need to clear it to remove
+    // noise.
+    rebuiltKeyOfSecondChildBeforeLayout = null;
+
+    final _StatefulState state = tester.firstState(find.byType(_Stateful).at(1));
+    state.rebuild();
+    // Reorders the items
+    await tester.pumpWidget(
+      LayoutBuilder(
+        builder: (BuildContext context, BoxConstraints constraints) {
+          return Column(
+            children: <Widget>[
+              _Stateful(
+                child: const Text(
+                  'Text2',
+                  textDirection: TextDirection.ltr,
+                  key: key2,
+                ),
+                onElementRebuild: (StatefulElement element) {
+                  // Verifies the early rebuild happens before layout.
+                  expect(rebuiltKeyOfSecondChildBeforeLayout, key2);
+                  // We don't want noise to override the result;
+                  expect(rebuiltKeyOfFirstChildAfterLayout, isNull);
+                  final _Stateful statefulWidget = element.widget as _Stateful;
+                  rebuiltKeyOfFirstChildAfterLayout = statefulWidget.child.key;
+                },
+              ),
+              _Stateful(
+                child: const Text(
+                  'Text1',
+                  textDirection: TextDirection.ltr,
+                  key: key1,
+                ),
+                onElementRebuild: (StatefulElement element) {
+                  // Verifies the early rebuild happens before layout.
+                  expect(rebuiltKeyOfSecondChildBeforeLayout, key2);
+                  // We don't want noise to override the result;
+                  expect(rebuiltKeyOfSecondChildAfterLayout, isNull);
+                  final _Stateful statefulWidget = element.widget as _Stateful;
+                  rebuiltKeyOfSecondChildAfterLayout = statefulWidget.child.key;
+                },
+              ),
+            ],
+          );
+        },
+      )
+    );
+    expect(rebuiltKeyOfSecondChildBeforeLayout, key2);
+    expect(rebuiltKeyOfFirstChildAfterLayout, key2);
+    expect(rebuiltKeyOfSecondChildAfterLayout, key1);
+  });
+
+  testWidgets('GlobalKey correct case 4 - can deal with early rebuild in layoutbuilder - move forward', (WidgetTester tester) async {
+    const Key key1 = GlobalObjectKey('Text1');
+    const Key key2 = GlobalObjectKey('Text2');
+    const Key key3 = GlobalObjectKey('Text3');
+    Key rebuiltKeyOfSecondChildBeforeLayout;
+    Key rebuiltKeyOfSecondChildAfterLayout;
+    Key rebuiltKeyOfThirdChildAfterLayout;
+    await tester.pumpWidget(
+      LayoutBuilder(
+        builder: (BuildContext context, BoxConstraints constraints) {
+          return Column(
+            children: <Widget>[
+              const _Stateful(
+                child: Text(
+                  'Text1',
+                  textDirection: TextDirection.ltr,
+                  key: key1,
+                ),
+              ),
+              _Stateful(
+                child: const Text(
+                  'Text2',
+                  textDirection: TextDirection.ltr,
+                  key: key2,
+                ),
+                onElementRebuild: (StatefulElement element) {
+                  // We don't want noise to override the result;
+                  expect(rebuiltKeyOfSecondChildBeforeLayout, isNull);
+                  final _Stateful statefulWidget = element.widget as _Stateful;
+                  rebuiltKeyOfSecondChildBeforeLayout = statefulWidget.child.key;
+                },
+              ),
+              const _Stateful(
+                child: Text(
+                  'Text3',
+                  textDirection: TextDirection.ltr,
+                  key: key3,
+                ),
+              ),
+            ],
+          );
+        },
+      )
+    );
+    // Result will be written during first build and need to clear it to remove
+    // noise.
+    rebuiltKeyOfSecondChildBeforeLayout = null;
+
+    final _StatefulState state = tester.firstState(find.byType(_Stateful).at(1));
+    state.rebuild();
+    // Reorders the items
+    await tester.pumpWidget(
+      LayoutBuilder(
+        builder: (BuildContext context, BoxConstraints constraints) {
+          return Column(
+            children: <Widget>[
+              const _Stateful(
+                child: Text(
+                  'Text1',
+                  textDirection: TextDirection.ltr,
+                  key: key1,
+                ),
+              ),
+              _Stateful(
+                child: const Text(
+                  'Text3',
+                  textDirection: TextDirection.ltr,
+                  key: key3,
+                ),
+                onElementRebuild: (StatefulElement element) {
+                  // Verifies the early rebuild happens before layout.
+                  expect(rebuiltKeyOfSecondChildBeforeLayout, key2);
+                  // We don't want noise to override the result;
+                  expect(rebuiltKeyOfSecondChildAfterLayout, isNull);
+                  final _Stateful statefulWidget = element.widget as _Stateful;
+                  rebuiltKeyOfSecondChildAfterLayout = statefulWidget.child.key;
+                },
+              ),
+              _Stateful(
+                child: const Text(
+                  'Text2',
+                  textDirection: TextDirection.ltr,
+                  key: key2,
+                ),
+                onElementRebuild: (StatefulElement element) {
+                  // Verifies the early rebuild happens before layout.
+                  expect(rebuiltKeyOfSecondChildBeforeLayout, key2);
+                  // We don't want noise to override the result;
+                  expect(rebuiltKeyOfThirdChildAfterLayout, isNull);
+                  final _Stateful statefulWidget = element.widget as _Stateful;
+                  rebuiltKeyOfThirdChildAfterLayout = statefulWidget.child.key;
+                },
+              ),
+            ],
+          );
+        },
+      )
+    );
+    expect(rebuiltKeyOfSecondChildBeforeLayout, key2);
+    expect(rebuiltKeyOfSecondChildAfterLayout, key3);
+    expect(rebuiltKeyOfThirdChildAfterLayout, key2);
+  });
+
+  testWidgets('GlobalKey correct case 5 - can deal with early rebuild in layoutbuilder - only one global key', (WidgetTester tester) async {
+    const Key key1 = GlobalObjectKey('Text1');
+    Key rebuiltKeyOfSecondChildBeforeLayout;
+    Key rebuiltKeyOfThirdChildAfterLayout;
+    await tester.pumpWidget(
+      LayoutBuilder(
+        builder: (BuildContext context, BoxConstraints constraints) {
+          return Column(
+            children: <Widget>[
+              const _Stateful(
+                child: Text(
+                  'Text1',
+                  textDirection: TextDirection.ltr,
+                ),
+              ),
+              _Stateful(
+                child: const Text(
+                  'Text2',
+                  textDirection: TextDirection.ltr,
+                  key: key1,
+                ),
+                onElementRebuild: (StatefulElement element) {
+                  // We don't want noise to override the result;
+                  expect(rebuiltKeyOfSecondChildBeforeLayout, isNull);
+                  final _Stateful statefulWidget = element.widget as _Stateful;
+                  rebuiltKeyOfSecondChildBeforeLayout = statefulWidget.child.key;
+                },
+              ),
+              const _Stateful(
+                child: Text(
+                  'Text3',
+                  textDirection: TextDirection.ltr,
+                ),
+              ),
+            ],
+          );
+        },
+      )
+    );
+    // Result will be written during first build and need to clear it to remove
+    // noise.
+    rebuiltKeyOfSecondChildBeforeLayout = null;
+
+    final _StatefulState state = tester.firstState(find.byType(_Stateful).at(1));
+    state.rebuild();
+    // Reorders the items
+    await tester.pumpWidget(
+      LayoutBuilder(
+        builder: (BuildContext context, BoxConstraints constraints) {
+          return Column(
+            children: <Widget>[
+              const _Stateful(
+                child: Text(
+                  'Text1',
+                  textDirection: TextDirection.ltr,
+                ),
+              ),
+              _Stateful(
+                child: const Text(
+                  'Text3',
+                  textDirection: TextDirection.ltr,
+                ),
+                onElementRebuild: (StatefulElement element) {
+                  // Verifies the early rebuild happens before layout.
+                  expect(rebuiltKeyOfSecondChildBeforeLayout, key1);
+                },
+              ),
+              _Stateful(
+                child: const Text(
+                  'Text2',
+                  textDirection: TextDirection.ltr,
+                  key: key1,
+                ),
+                onElementRebuild: (StatefulElement element) {
+                  // Verifies the early rebuild happens before layout.
+                  expect(rebuiltKeyOfSecondChildBeforeLayout, key1);
+                  // We don't want noise to override the result;
+                  expect(rebuiltKeyOfThirdChildAfterLayout, isNull);
+                  final _Stateful statefulWidget = element.widget as _Stateful;
+                  rebuiltKeyOfThirdChildAfterLayout = statefulWidget.child.key;
+                },
+              ),
+            ],
+          );
+        },
+      )
+    );
+    expect(rebuiltKeyOfSecondChildBeforeLayout, key1);
+    expect(rebuiltKeyOfThirdChildAfterLayout, key1);
   });
 
   testWidgets('GlobalKey duplication 1 - double appearance', (WidgetTester tester) async {
@@ -501,7 +855,173 @@ void main() {
       ],
     ));
     FlutterError.onError = oldHandler;
-    expect(count, 2);
+    expect(count, 1);
+  });
+
+  testWidgets('GlobalKey duplication 18 - subtree build duplicate key with same type', (WidgetTester tester) async {
+    final Key key = GlobalKey(debugLabel: 'problematic');
+    final Stack stack = Stack(
+      textDirection: TextDirection.ltr,
+      children: <Widget>[
+        const SwapKeyWidget(childKey: ValueKey<int>(0)),
+        Container(key: const ValueKey<int>(1)),
+        Container(key: key),
+      ],
+    );
+    await tester.pumpWidget(stack);
+    final SwapKeyWidgetState state = tester.state(find.byType(SwapKeyWidget));
+    state.swapKey(key);
+    await tester.pump();
+    final dynamic exception = tester.takeException();
+    expect(exception, isFlutterError);
+    expect(
+      exception.toString(),
+      equalsIgnoringHashCodes(
+        'Duplicate GlobalKey detected in widget tree.\n'
+        'The following GlobalKey was specified multiple times in the widget tree. This will lead '
+        'to parts of the widget tree being truncated unexpectedly, because the second time a key is seen, the '
+        'previous instance is moved to the new location. The key was:\n'
+        '- [GlobalKey#00000 problematic]\n'
+        'This was determined by noticing that after the widget with the above global key was '
+        'moved out of its previous parent, that previous parent never updated during this frame, meaning that '
+        'it either did not update at all or updated before the widget was moved, in either case implying that '
+        'it still thinks that it should have a child with that global key.\n'
+        'The specific parent that did not update after having one or more children forcibly '
+        'removed due to GlobalKey reparenting is:\n'
+        '- Stack(alignment: AlignmentDirectional.topStart, textDirection: ltr, fit: loose, '
+        'overflow: clip, renderObject: RenderStack#00000)\n'
+        'A GlobalKey can only be specified on one widget at a time in the widget tree.'
+      ),
+    );
+  });
+
+  testWidgets('GlobalKey duplication 19 - subtree build duplicate key with different types', (WidgetTester tester) async {
+    final Key key = GlobalKey(debugLabel: 'problematic');
+    final Stack stack = Stack(
+      textDirection: TextDirection.ltr,
+      children: <Widget>[
+        const SwapKeyWidget(childKey: ValueKey<int>(0)),
+        Container(key: const ValueKey<int>(1)),
+        Container(child: SizedBox(key: key)),
+      ],
+    );
+    await tester.pumpWidget(stack);
+    final SwapKeyWidgetState state = tester.state(find.byType(SwapKeyWidget));
+    state.swapKey(key);
+    await tester.pump();
+    final dynamic exception = tester.takeException();
+    expect(exception, isFlutterError);
+    expect(
+      exception.toString(),
+      equalsIgnoringHashCodes(
+        'Multiple widgets used the same GlobalKey.\n'
+        'The key [GlobalKey#95367 problematic] was used by 2 widgets:\n'
+        '  SizedBox-[GlobalKey#00000 problematic]\n'
+        '  Container-[GlobalKey#00000 problematic]\n'
+        'A GlobalKey can only be specified on one widget at a time in the widget tree.'
+      ),
+    );
+  });
+
+  testWidgets('GlobalKey duplication 20 - real duplication with early rebuild in layoutbuilder will throw', (WidgetTester tester) async {
+    const Key key1 = GlobalObjectKey('Text1');
+    const Key key2 = GlobalObjectKey('Text2');
+    Key rebuiltKeyOfSecondChildBeforeLayout;
+    Key rebuiltKeyOfFirstChildAfterLayout;
+    Key rebuiltKeyOfSecondChildAfterLayout;
+    await tester.pumpWidget(
+      LayoutBuilder(
+        builder: (BuildContext context, BoxConstraints constraints) {
+          return Column(
+            children: <Widget>[
+              const _Stateful(
+                child: Text(
+                  'Text1',
+                  textDirection: TextDirection.ltr,
+                  key: key1,
+                ),
+              ),
+              _Stateful(
+                child: const Text(
+                  'Text2',
+                  textDirection: TextDirection.ltr,
+                  key: key2,
+                ),
+                onElementRebuild: (StatefulElement element) {
+                  // We don't want noise to override the result;
+                  expect(rebuiltKeyOfSecondChildBeforeLayout, isNull);
+                  final _Stateful statefulWidget = element.widget as _Stateful;
+                  rebuiltKeyOfSecondChildBeforeLayout = statefulWidget.child.key;
+                },
+              ),
+            ],
+          );
+        },
+      )
+    );
+    // Result will be written during first build and need to clear it to remove
+    // noise.
+    rebuiltKeyOfSecondChildBeforeLayout = null;
+
+    final _StatefulState state = tester.firstState(find.byType(_Stateful).at(1));
+    state.rebuild();
+
+    await tester.pumpWidget(
+      LayoutBuilder(
+        builder: (BuildContext context, BoxConstraints constraints) {
+          return Column(
+            children: <Widget>[
+              _Stateful(
+                child: const Text(
+                  'Text2',
+                  textDirection: TextDirection.ltr,
+                  key: key2,
+                ),
+                onElementRebuild: (StatefulElement element) {
+                  // Verifies the early rebuild happens before layout.
+                  expect(rebuiltKeyOfSecondChildBeforeLayout, key2);
+                  // We don't want noise to override the result;
+                  expect(rebuiltKeyOfFirstChildAfterLayout, isNull);
+                  final _Stateful statefulWidget = element.widget as _Stateful;
+                  rebuiltKeyOfFirstChildAfterLayout = statefulWidget.child.key;
+                },
+              ),
+              _Stateful(
+                child: const Text(
+                  'Text1',
+                  textDirection: TextDirection.ltr,
+                  key: key2,
+                ),
+                onElementRebuild: (StatefulElement element) {
+                  // Verifies the early rebuild happens before layout.
+                  expect(rebuiltKeyOfSecondChildBeforeLayout, key2);
+                  // We don't want noise to override the result;
+                  expect(rebuiltKeyOfSecondChildAfterLayout, isNull);
+                  final _Stateful statefulWidget = element.widget as _Stateful;
+                  rebuiltKeyOfSecondChildAfterLayout = statefulWidget.child.key;
+                },
+              ),
+            ],
+          );
+        },
+      )
+    );
+    expect(rebuiltKeyOfSecondChildBeforeLayout, key2);
+    expect(rebuiltKeyOfFirstChildAfterLayout, key2);
+    expect(rebuiltKeyOfSecondChildAfterLayout, key2);
+    final dynamic exception = tester.takeException();
+    expect(exception, isFlutterError);
+    expect(
+      exception.toString(),
+      equalsIgnoringHashCodes(
+        'Multiple widgets used the same GlobalKey.\n'
+        'The key [GlobalObjectKey String#00000] was used by multiple widgets. The '
+        'parents of those widgets were:\n'
+        '- _Stateful(state: _StatefulState#00000)\n'
+        '- _Stateful(state: _StatefulState#00000)\n'
+        'A GlobalKey can only be specified on one widget at a time in the widget tree.'
+      ),
+    );
   });
 
   testWidgets('GlobalKey - dettach and re-attach child to different parents', (WidgetTester tester) async {
@@ -759,9 +1279,6 @@ class NullChildElement extends Element {
   }
 
   @override
-  void forgetChild(Element child) { }
-
-  @override
   void performRebuild() { }
 }
 
@@ -771,9 +1288,6 @@ class DirtyElementWithCustomBuildOwner extends Element {
     : _owner = buildOwner, super(widget);
 
   final BuildOwner _owner;
-
-  @override
-  void forgetChild(Element child) {}
 
   @override
   void performRebuild() {}
@@ -821,5 +1335,68 @@ class DependentState extends State<DependentStatefulWidget> {
   void deactivate() {
     super.deactivate();
     deactivatedCount += 1;
+  }
+}
+
+class SwapKeyWidget extends StatefulWidget {
+  const SwapKeyWidget({this.childKey}): super();
+
+  final Key childKey;
+  @override
+  SwapKeyWidgetState createState() => SwapKeyWidgetState();
+}
+
+class SwapKeyWidgetState extends State<SwapKeyWidget> {
+  Key key;
+
+  @override
+  void initState() {
+    super.initState();
+    key = widget.childKey;
+  }
+
+  void swapKey(Key newKey) {
+    setState(() {
+      key = newKey;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(key: key);
+  }
+}
+
+class _Stateful extends StatefulWidget {
+  const _Stateful({Key key, this.child, this.onElementRebuild}) : super(key: key);
+  final Text child;
+  final ElementRebuildCallback onElementRebuild;
+  @override
+  State<StatefulWidget> createState() => _StatefulState();
+
+  @override
+  StatefulElement createElement() => StatefulElementSpy(this);
+}
+
+class _StatefulState extends State<_Stateful> {
+  void rebuild() => setState(() {});
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}
+
+class StatefulElementSpy extends StatefulElement {
+  StatefulElementSpy(StatefulWidget widget) : super(widget);
+
+  _Stateful get _statefulWidget => widget as _Stateful;
+
+  @override
+  void rebuild() {
+    if (_statefulWidget.onElementRebuild != null) {
+      _statefulWidget.onElementRebuild(this);
+    }
+    super.rebuild();
   }
 }


### PR DESCRIPTION
## Description

This is a draft to fix global key error. 

Previously we reserve global key and instantly through error if we detect the global key has been reserved before. However, there is cases where the previous reserve global key is not valid and will eventually be removed.

This pr change the way we throw global key error that we allow every global key reservations and record them. We only verify the global key reservations at the end of build stage when every thing is finalized.

breaking change announcement: https://groups.google.com/g/flutter-dev/c/Evjv6r5JYp8 

design doc: flutter.dev/go/globalkey-duplication-refactoring
## Related Issues

https://github.com/flutter/flutter/issues/43780

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behaviour with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
