### PR TITLE
Mark unused but desired private constructors as such

### DIFF
--- a/examples/flutter_gallery/lib/gallery/icons.dart
+++ b/examples/flutter_gallery/lib/gallery/icons.dart
@@ -5,8 +5,8 @@
 import 'package:flutter/material.dart';
 
 class GalleryIcons {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
+  // This class is not meant to be instatiated or extended; this constructor
+  // prevents instantiation and extension.
   // ignore: unused_element
   GalleryIcons._();
 

--- a/examples/flutter_gallery/lib/gallery/icons.dart
+++ b/examples/flutter_gallery/lib/gallery/icons.dart
@@ -5,6 +5,9 @@
 import 'package:flutter/material.dart';
 
 class GalleryIcons {
+  // This class is intended to be used as an interface, and should not be
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   GalleryIcons._();
 
   static const IconData tooltip = IconData(0xe900, fontFamily: 'GalleryIcons');

--- a/packages/flutter/lib/src/animation/curves.dart
+++ b/packages/flutter/lib/src/animation/curves.dart
@@ -517,8 +517,8 @@ class ElasticInOutCurve extends Curve {
 ///  * [Curve], the interface implemented by the constants available from the
 ///    [Curves] class.
 class Curves {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
+  // This class is not meant to be instatiated or extended; this constructor
+  // prevents instantiation and extension.
   // ignore: unused_element
   Curves._();
 

--- a/packages/flutter/lib/src/animation/curves.dart
+++ b/packages/flutter/lib/src/animation/curves.dart
@@ -517,6 +517,9 @@ class ElasticInOutCurve extends Curve {
 ///  * [Curve], the interface implemented by the constants available from the
 ///    [Curves] class.
 class Curves {
+  // This class is intended to be used as an interface, and should not be
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   Curves._();
 
   /// A linear animation curve.

--- a/packages/flutter/lib/src/cupertino/colors.dart
+++ b/packages/flutter/lib/src/cupertino/colors.dart
@@ -18,8 +18,8 @@ import 'theme.dart';
 /// A palette of [Color] constants that describe colors commonly used when
 /// matching the iOS platform aesthetics.
 class CupertinoColors {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
+  // This class is not meant to be instatiated or extended; this constructor
+  // prevents instantiation and extension.
   // ignore: unused_element
   CupertinoColors._();
 

--- a/packages/flutter/lib/src/cupertino/colors.dart
+++ b/packages/flutter/lib/src/cupertino/colors.dart
@@ -18,6 +18,9 @@ import 'theme.dart';
 /// A palette of [Color] constants that describe colors commonly used when
 /// matching the iOS platform aesthetics.
 class CupertinoColors {
+  // This class is intended to be used as an interface, and should not be
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   CupertinoColors._();
 
   /// iOS 13's default blue color. Used to indicate active elements such as

--- a/packages/flutter/lib/src/cupertino/icons.dart
+++ b/packages/flutter/lib/src/cupertino/icons.dart
@@ -26,8 +26,8 @@ import 'package:flutter/widgets.dart';
 ///  * [Icon], used to show these icons.
 ///  * <https://github.com/flutter/cupertino_icons/blob/master/map.png>, a map of the icons in this icons font.
 class CupertinoIcons {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
+  // This class is not meant to be instatiated or extended; this constructor
+  // prevents instantiation and extension.
   // ignore: unused_element
   CupertinoIcons._();
 

--- a/packages/flutter/lib/src/cupertino/icons.dart
+++ b/packages/flutter/lib/src/cupertino/icons.dart
@@ -26,6 +26,9 @@ import 'package:flutter/widgets.dart';
 ///  * [Icon], used to show these icons.
 ///  * <https://github.com/flutter/cupertino_icons/blob/master/map.png>, a map of the icons in this icons font.
 class CupertinoIcons {
+  // This class is intended to be used as an interface, and should not be
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   CupertinoIcons._();
 
   /// The icon font used for Cupertino icons.

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -112,6 +112,7 @@ class ErrorDescription extends _ErrorDiagnostic {
 
   /// Calls to the default constructor may be rewritten to use this constructor
   /// in debug mode using a kernel transformer.
+  // ignore: unused_element
   ErrorDescription._fromParts(List<Object> messageParts) : super._fromParts(messageParts, level: DiagnosticLevel.info);
 }
 
@@ -146,6 +147,7 @@ class ErrorSummary extends _ErrorDiagnostic {
 
   /// Calls to the default constructor may be rewritten to use this constructor
   /// in debug mode using a kernel transformer.
+  // ignore: unused_element
   ErrorSummary._fromParts(List<Object> messageParts) : super._fromParts(messageParts, level: DiagnosticLevel.summary);
 }
 
@@ -176,6 +178,7 @@ class ErrorHint extends _ErrorDiagnostic {
 
   /// Calls to the default constructor may be rewritten to use this constructor
   /// in debug mode using a kernel transformer.
+  // ignore: unused_element
   ErrorHint._fromParts(List<Object> messageParts) : super._fromParts(messageParts, level:DiagnosticLevel.hint);
 }
 

--- a/packages/flutter/lib/src/foundation/licenses.dart
+++ b/packages/flutter/lib/src/foundation/licenses.dart
@@ -288,8 +288,8 @@ class LicenseEntryWithLineBreaks extends LicenseEntry {
 ///  * [AboutListTile], which is a widget that can be added to a [Drawer]. When
 ///    tapped it calls [showAboutDialog].
 class LicenseRegistry {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
+  // This class is not meant to be instatiated or extended; this constructor
+  // prevents instantiation and extension.
   // ignore: unused_element
   LicenseRegistry._();
 

--- a/packages/flutter/lib/src/foundation/licenses.dart
+++ b/packages/flutter/lib/src/foundation/licenses.dart
@@ -288,6 +288,9 @@ class LicenseEntryWithLineBreaks extends LicenseEntry {
 ///  * [AboutListTile], which is a widget that can be added to a [Drawer]. When
 ///    tapped it calls [showAboutDialog].
 class LicenseRegistry {
+  // This class is intended to be used as an interface, and should not be
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   LicenseRegistry._();
 
   static List<LicenseEntryCollector> _collectors;

--- a/packages/flutter/lib/src/foundation/unicode.dart
+++ b/packages/flutter/lib/src/foundation/unicode.dart
@@ -11,8 +11,8 @@
 ///  * <http://unicode.org/reports/tr9/>, which describes the Unicode
 ///    bidirectional text algorithm.
 class Unicode {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
+  // This class is not meant to be instatiated or extended; this constructor
+  // prevents instantiation and extension.
   // ignore: unused_element
   Unicode._();
   /// U+202A LEFT-TO-RIGHT EMBEDDING

--- a/packages/flutter/lib/src/foundation/unicode.dart
+++ b/packages/flutter/lib/src/foundation/unicode.dart
@@ -11,6 +11,9 @@
 ///  * <http://unicode.org/reports/tr9/>, which describes the Unicode
 ///    bidirectional text algorithm.
 class Unicode {
+  // This class is intended to be used as an interface, and should not be
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   Unicode._();
   /// U+202A LEFT-TO-RIGHT EMBEDDING
   ///

--- a/packages/flutter/lib/src/gestures/converter.dart
+++ b/packages/flutter/lib/src/gestures/converter.dart
@@ -32,8 +32,8 @@ int _synthesiseDownButtons(int buttons, PointerDeviceKind kind) {
 /// [dart:ui.Window.onPointerDataPacket], and converts them to [PointerEvent]
 /// objects.
 class PointerEventConverter {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
+  // This class is not meant to be instatiated or extended; this constructor
+  // prevents instantiation and extension.
   // ignore: unused_element
   PointerEventConverter._();
 

--- a/packages/flutter/lib/src/gestures/converter.dart
+++ b/packages/flutter/lib/src/gestures/converter.dart
@@ -32,6 +32,9 @@ int _synthesiseDownButtons(int buttons, PointerDeviceKind kind) {
 /// [dart:ui.Window.onPointerDataPacket], and converts them to [PointerEvent]
 /// objects.
 class PointerEventConverter {
+  // This class is intended to be used as an interface, and should not be
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   PointerEventConverter._();
 
   /// Expand the given packet of pointer data into a sequence of framework

--- a/packages/flutter/lib/src/gestures/hit_test.dart
+++ b/packages/flutter/lib/src/gestures/hit_test.dart
@@ -11,8 +11,9 @@ import 'events.dart';
 
 /// An object that can hit-test pointers.
 abstract class HitTestable {
-  // This class is intended to be used as an interface with the implements
-  // keyword, and should not be extended directly.
+  // This class is intended to be used as an interface, and should not be
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   factory HitTestable._() => null;
 
   /// Check whether the given position hits this object.
@@ -24,8 +25,9 @@ abstract class HitTestable {
 
 /// An object that can dispatch events.
 abstract class HitTestDispatcher {
-  // This class is intended to be used as an interface with the implements
-  // keyword, and should not be extended directly.
+  // This class is intended to be used as an interface, and should not be
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   factory HitTestDispatcher._() => null;
 
   /// Override this method to dispatch events.
@@ -34,8 +36,9 @@ abstract class HitTestDispatcher {
 
 /// An object that can handle events.
 abstract class HitTestTarget {
-  // This class is intended to be used as an interface with the implements
-  // keyword, and should not be extended directly.
+  // This class is intended to be used as an interface, and should not be
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   factory HitTestTarget._() => null;
 
   /// Override this method to receive events.

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -63,7 +63,8 @@ const Icon _kDefaultDeleteIcon = Icon(Icons.cancel, size: _kDeleteIconSize);
 ///  * <https://material.io/design/components/chips.html>
 abstract class ChipAttributes {
   // This class is intended to be used as an interface, and should not be
-  // extended directly.
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   factory ChipAttributes._() => null;
 
   /// The primary content of the chip.
@@ -174,7 +175,8 @@ abstract class ChipAttributes {
 ///  * <https://material.io/design/components/chips.html>
 abstract class DeletableChipAttributes {
   // This class is intended to be used as an interface, and should not be
-  // extended directly.
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   factory DeletableChipAttributes._() => null;
 
   /// The icon displayed when [onDeleted] is set.
@@ -275,7 +277,8 @@ abstract class DeletableChipAttributes {
 ///  * <https://material.io/design/components/chips.html>
 abstract class CheckmarkableChipAttributes {
   // This class is intended to be used as an interface, and should not be
-  // extended directly.
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   factory CheckmarkableChipAttributes._() => null;
 
   /// Whether or not to show a check mark when [selected] is true.
@@ -309,7 +312,8 @@ abstract class CheckmarkableChipAttributes {
 ///  * <https://material.io/design/components/chips.html>
 abstract class SelectableChipAttributes {
   // This class is intended to be used as an interface, and should not be
-  // extended directly.
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   factory SelectableChipAttributes._() => null;
 
   /// Whether or not this chip is selected.
@@ -417,7 +421,8 @@ abstract class SelectableChipAttributes {
 ///  * <https://material.io/design/components/chips.html>
 abstract class DisabledChipAttributes {
   // This class is intended to be used as an interface, and should not be
-  // extended directly.
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   factory DisabledChipAttributes._() => null;
 
   /// Whether or not this chip is enabled for input.
@@ -464,7 +469,8 @@ abstract class DisabledChipAttributes {
 ///  * <https://material.io/design/components/chips.html>
 abstract class TappableChipAttributes {
   // This class is intended to be used as an interface, and should not be
-  // extended directly.
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   factory TappableChipAttributes._() => null;
 
   /// Called when the user taps the chip.

--- a/packages/flutter/lib/src/material/colors.dart
+++ b/packages/flutter/lib/src/material/colors.dart
@@ -192,8 +192,8 @@ class MaterialAccentColor extends ColorSwatch<int> {
 /// The [Colors.transparent] color isn't shown here because it is entirely
 /// invisible!
 class Colors {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
+  // This class is not meant to be instatiated or extended; this constructor
+  // prevents instantiation and extension.
   // ignore: unused_element
   Colors._();
 

--- a/packages/flutter/lib/src/material/colors.dart
+++ b/packages/flutter/lib/src/material/colors.dart
@@ -192,6 +192,9 @@ class MaterialAccentColor extends ColorSwatch<int> {
 /// The [Colors.transparent] color isn't shown here because it is entirely
 /// invisible!
 class Colors {
+  // This class is intended to be used as an interface, and should not be
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   Colors._();
 
   /// Completely invisible.

--- a/packages/flutter/lib/src/material/elevation_overlay.dart
+++ b/packages/flutter/lib/src/material/elevation_overlay.dart
@@ -14,8 +14,8 @@ import 'theme.dart';
 /// This is an internal implementation class and should not be exported by
 /// the material package.
 class ElevationOverlay {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
+  // This class is not meant to be instatiated or extended; this constructor
+  // prevents instantiation and extension.
   // ignore: unused_element
   ElevationOverlay._();
 

--- a/packages/flutter/lib/src/material/elevation_overlay.dart
+++ b/packages/flutter/lib/src/material/elevation_overlay.dart
@@ -14,7 +14,9 @@ import 'theme.dart';
 /// This is an internal implementation class and should not be exported by
 /// the material package.
 class ElevationOverlay {
-
+  // This class is intended to be used as an interface, and should not be
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   ElevationOverlay._();
 
   /// Applies an elevation overlay color to a surface color to indicate

--- a/packages/flutter/lib/src/material/feedback.dart
+++ b/packages/flutter/lib/src/material/feedback.dart
@@ -80,6 +80,9 @@ import 'theme.dart';
 /// ```
 /// {@end-tool}
 class Feedback {
+  // This class is intended to be used as an interface, and should not be
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   Feedback._();
 
   /// Provides platform-specific feedback for a tap.

--- a/packages/flutter/lib/src/material/feedback.dart
+++ b/packages/flutter/lib/src/material/feedback.dart
@@ -80,8 +80,8 @@ import 'theme.dart';
 /// ```
 /// {@end-tool}
 class Feedback {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
+  // This class is not meant to be instatiated or extended; this constructor
+  // prevents instantiation and extension.
   // ignore: unused_element
   Feedback._();
 

--- a/packages/flutter/lib/src/material/icons.dart
+++ b/packages/flutter/lib/src/material/icons.dart
@@ -59,8 +59,8 @@ import 'package:flutter/widgets.dart';
 ///  * [IconButton]
 ///  * <https://design.google.com/icons/>
 class Icons {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
+  // This class is not meant to be instatiated or extended; this constructor
+  // prevents instantiation and extension.
   // ignore: unused_element
   Icons._();
 

--- a/packages/flutter/lib/src/material/icons.dart
+++ b/packages/flutter/lib/src/material/icons.dart
@@ -59,6 +59,9 @@ import 'package:flutter/widgets.dart';
 ///  * [IconButton]
 ///  * <https://design.google.com/icons/>
 class Icons {
+  // This class is intended to be used as an interface, and should not be
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   Icons._();
 
   // Generated code: do not hand-edit.

--- a/packages/flutter/lib/src/painting/matrix_utils.dart
+++ b/packages/flutter/lib/src/painting/matrix_utils.dart
@@ -11,8 +11,8 @@ import 'basic_types.dart';
 
 /// Utility functions for working with matrices.
 class MatrixUtils {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
+  // This class is not meant to be instatiated or extended; this constructor
+  // prevents instantiation and extension.
   // ignore: unused_element
   MatrixUtils._();
 

--- a/packages/flutter/lib/src/painting/matrix_utils.dart
+++ b/packages/flutter/lib/src/painting/matrix_utils.dart
@@ -11,6 +11,9 @@ import 'basic_types.dart';
 
 /// Utility functions for working with matrices.
 class MatrixUtils {
+  // This class is intended to be used as an interface, and should not be
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   MatrixUtils._();
 
   /// Returns the given [transform] matrix as an [Offset], if the matrix is

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -30,8 +30,9 @@ enum CacheExtentStyle {
 /// the framework recognize such render objects and interact with them without
 /// having specific knowledge of all the various types of viewports.
 abstract class RenderAbstractViewport extends RenderObject {
-  // This class is intended to be used as an interface with the implements
-  // keyword, and should not be extended directly.
+  // This class is intended to be used as an interface, and should not be
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   factory RenderAbstractViewport._() => null;
 
   /// Returns the [RenderAbstractViewport] that most tightly encloses the given

--- a/packages/flutter/lib/src/semantics/semantics_service.dart
+++ b/packages/flutter/lib/src/semantics/semantics_service.dart
@@ -18,6 +18,9 @@ import 'semantics_event.dart' show AnnounceSemanticsEvent, TooltipSemanticsEvent
 /// When possible, prefer using mechanisms like [Semantics] to implicitly
 /// trigger announcements over using this event.
 class SemanticsService {
+  // This class is intended to be used as an interface, and should not be
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   SemanticsService._();
 
   /// Sends a semantic announcement.

--- a/packages/flutter/lib/src/semantics/semantics_service.dart
+++ b/packages/flutter/lib/src/semantics/semantics_service.dart
@@ -18,8 +18,8 @@ import 'semantics_event.dart' show AnnounceSemanticsEvent, TooltipSemanticsEvent
 /// When possible, prefer using mechanisms like [Semantics] to implicitly
 /// trigger announcements over using this event.
 class SemanticsService {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
+  // This class is not meant to be instatiated or extended; this constructor
+  // prevents instantiation and extension.
   // ignore: unused_element
   SemanticsService._();
 

--- a/packages/flutter/lib/src/services/clipboard.dart
+++ b/packages/flutter/lib/src/services/clipboard.dart
@@ -23,6 +23,9 @@ class ClipboardData {
 
 /// Utility methods for interacting with the system's clipboard.
 class Clipboard {
+  // This class is intended to be used as an interface, and should not be
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   Clipboard._();
 
   // Constants for common [getData] [format] types.

--- a/packages/flutter/lib/src/services/clipboard.dart
+++ b/packages/flutter/lib/src/services/clipboard.dart
@@ -23,8 +23,8 @@ class ClipboardData {
 
 /// Utility methods for interacting with the system's clipboard.
 class Clipboard {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
+  // This class is not meant to be instatiated or extended; this constructor
+  // prevents instantiation and extension.
   // ignore: unused_element
   Clipboard._();
 

--- a/packages/flutter/lib/src/services/haptic_feedback.dart
+++ b/packages/flutter/lib/src/services/haptic_feedback.dart
@@ -11,8 +11,8 @@ import 'system_channels.dart';
 /// This API is intentionally terse since it calls default platform behavior. It
 /// is not suitable for precise control of the system's haptic feedback module.
 class HapticFeedback {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
+  // This class is not meant to be instatiated or extended; this constructor
+  // prevents instantiation and extension.
   // ignore: unused_element
   HapticFeedback._();
 

--- a/packages/flutter/lib/src/services/haptic_feedback.dart
+++ b/packages/flutter/lib/src/services/haptic_feedback.dart
@@ -11,6 +11,9 @@ import 'system_channels.dart';
 /// This API is intentionally terse since it calls default platform behavior. It
 /// is not suitable for precise control of the system's haptic feedback module.
 class HapticFeedback {
+  // This class is intended to be used as an interface, and should not be
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   HapticFeedback._();
 
   /// Provides vibration haptic feedback to the user for a short duration.

--- a/packages/flutter/lib/src/services/platform_messages.dart
+++ b/packages/flutter/lib/src/services/platform_messages.dart
@@ -31,8 +31,8 @@ import 'platform_channel.dart';
   'This feature was deprecated after v1.6.5.'
 )
 class BinaryMessages {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
+  // This class is not meant to be instatiated or extended; this constructor
+  // prevents instantiation and extension.
   // ignore: unused_element
   BinaryMessages._();
 

--- a/packages/flutter/lib/src/services/platform_messages.dart
+++ b/packages/flutter/lib/src/services/platform_messages.dart
@@ -31,6 +31,9 @@ import 'platform_channel.dart';
   'This feature was deprecated after v1.6.5.'
 )
 class BinaryMessages {
+  // This class is intended to be used as an interface, and should not be
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   BinaryMessages._();
 
   /// The messenger which sends the platform messages, not null.

--- a/packages/flutter/lib/src/services/system_channels.dart
+++ b/packages/flutter/lib/src/services/system_channels.dart
@@ -9,6 +9,9 @@ import 'platform_channel.dart';
 
 /// Platform channels used by the Flutter system.
 class SystemChannels {
+  // This class is intended to be used as an interface, and should not be
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   SystemChannels._();
 
   /// A JSON [MethodChannel] for navigation.

--- a/packages/flutter/lib/src/services/system_channels.dart
+++ b/packages/flutter/lib/src/services/system_channels.dart
@@ -9,8 +9,8 @@ import 'platform_channel.dart';
 
 /// Platform channels used by the Flutter system.
 class SystemChannels {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
+  // This class is not meant to be instatiated or extended; this constructor
+  // prevents instantiation and extension.
   // ignore: unused_element
   SystemChannels._();
 

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -213,8 +213,8 @@ List<String> _stringify(List<dynamic> list) => <String>[
 /// Controls specific aspects of the operating system's graphical interface and
 /// how it interacts with the application.
 class SystemChrome {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
+  // This class is not meant to be instatiated or extended; this constructor
+  // prevents instantiation and extension.
   // ignore: unused_element
   SystemChrome._();
 

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -213,6 +213,9 @@ List<String> _stringify(List<dynamic> list) => <String>[
 /// Controls specific aspects of the operating system's graphical interface and
 /// how it interacts with the application.
 class SystemChrome {
+  // This class is intended to be used as an interface, and should not be
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   SystemChrome._();
 
   /// Specifies the set of orientations the application interface can

--- a/packages/flutter/lib/src/services/system_navigator.dart
+++ b/packages/flutter/lib/src/services/system_navigator.dart
@@ -8,6 +8,9 @@ import 'system_channels.dart';
 
 /// Controls specific aspects of the system navigation stack.
 class SystemNavigator {
+  // This class is intended to be used as an interface, and should not be
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   SystemNavigator._();
 
   /// Removes the topmost Flutter instance, presenting what was before

--- a/packages/flutter/lib/src/services/system_navigator.dart
+++ b/packages/flutter/lib/src/services/system_navigator.dart
@@ -8,8 +8,8 @@ import 'system_channels.dart';
 
 /// Controls specific aspects of the system navigation stack.
 class SystemNavigator {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
+  // This class is not meant to be instatiated or extended; this constructor
+  // prevents instantiation and extension.
   // ignore: unused_element
   SystemNavigator._();
 

--- a/packages/flutter/lib/src/services/system_sound.dart
+++ b/packages/flutter/lib/src/services/system_sound.dart
@@ -15,8 +15,8 @@ enum SystemSoundType {
 /// Provides access to the library of short system specific sounds for common
 /// tasks.
 class SystemSound {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
+  // This class is not meant to be instatiated or extended; this constructor
+  // prevents instantiation and extension.
   // ignore: unused_element
   SystemSound._();
 

--- a/packages/flutter/lib/src/services/system_sound.dart
+++ b/packages/flutter/lib/src/services/system_sound.dart
@@ -15,6 +15,9 @@ enum SystemSoundType {
 /// Provides access to the library of short system specific sounds for common
 /// tasks.
 class SystemSound {
+  // This class is intended to be used as an interface, and should not be
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   SystemSound._();
 
   /// Play the specified system sound. If that sound is not present on the

--- a/packages/flutter/lib/src/widgets/route_notification_messages.dart
+++ b/packages/flutter/lib/src/widgets/route_notification_messages.dart
@@ -9,6 +9,9 @@ import 'navigator.dart';
 
 /// Messages for route change notifications.
 class RouteNotificationMessages {
+  // This class is intended to be used as an interface, and should not be
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   RouteNotificationMessages._();
 
   /// When the engine is Web notify the platform for a route change.

--- a/packages/flutter/lib/src/widgets/route_notification_messages.dart
+++ b/packages/flutter/lib/src/widgets/route_notification_messages.dart
@@ -9,8 +9,8 @@ import 'navigator.dart';
 
 /// Messages for route change notifications.
 class RouteNotificationMessages {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
+  // This class is not meant to be instatiated or extended; this constructor
+  // prevents instantiation and extension.
   // ignore: unused_element
   RouteNotificationMessages._();
 

--- a/packages/flutter_test/lib/src/test_async_utils.dart
+++ b/packages/flutter_test/lib/src/test_async_utils.dart
@@ -7,9 +7,6 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 
 class _AsyncScope {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
-  // ignore: unused_element
   _AsyncScope(this.creationStack, this.zone);
   final StackTrace creationStack;
   final Zone zone;
@@ -48,6 +45,9 @@ class _AsyncScope {
 /// });
 /// ```
 class TestAsyncUtils {
+  // This class is not meant to be instatiated or extended; this constructor
+  // prevents instantiation and extension.
+  // ignore: unused_element
   TestAsyncUtils._();
   static const String _className = 'TestAsyncUtils';
 

--- a/packages/flutter_test/lib/src/test_async_utils.dart
+++ b/packages/flutter_test/lib/src/test_async_utils.dart
@@ -7,6 +7,9 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 
 class _AsyncScope {
+  // This class is intended to be used as an interface, and should not be
+  // extended directly; this constructor prevents instantiation and extension.
+  // ignore: unused_element
   _AsyncScope(this.creationStack, this.zone);
   final StackTrace creationStack;
   final Zone zone;


### PR DESCRIPTION
## Description

The flutter codebase has "unused" but intentional private constructors, in place to prevent instantiation and extension. The analyzer will begin to report unused private constructors. These constructors need to be marked with `// ignore: unused_element`.

## Related Issues

https://github.com/dart-lang/sdk/issues/35108

## Tests

I added no tests.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
