### PR TITLE
Reset the global variable before running a test.

### DIFF
--- a/packages/flutter/test/widgets/shadow_test.dart
+++ b/packages/flutter/test/widgets/shadow_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 
 void main() {
   testWidgets('Shadows on BoxDecoration', (WidgetTester tester) async {
+    debugDisableShadows = true;
     await tester.pumpWidget(
       Center(
         child: RepaintBoundary(
@@ -63,6 +64,7 @@ void main() {
   });
 
   testWidgets('Shadows with PhysicalLayer', (WidgetTester tester) async {
+    debugDisableShadows = true;
     await tester.pumpWidget(
       Center(
         child: RepaintBoundary(

--- a/packages/flutter/test/widgets/shadow_test.dart
+++ b/packages/flutter/test/widgets/shadow_test.dart
@@ -6,8 +6,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 
 void main() {
-  testWidgets('Shadows on BoxDecoration', (WidgetTester tester) async {
+  tearDown(() {
     debugDisableShadows = true;
+  });
+
+  testWidgets('Shadows on BoxDecoration', (WidgetTester tester) async {
     await tester.pumpWidget(
       Center(
         child: RepaintBoundary(
@@ -64,7 +67,6 @@ void main() {
   });
 
   testWidgets('Shadows with PhysicalLayer', (WidgetTester tester) async {
-    debugDisableShadows = true;
     await tester.pumpWidget(
       Center(
         child: RepaintBoundary(


### PR DESCRIPTION
The variable debugDisableShadows wasn't reset before each test, so the
output of the test is different depending on whether the previous test
has passed.

Discovered in #45530 