### PR TITLE
Detect and dump flaky LineMetrics test data

### DIFF
--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -844,11 +844,6 @@ class TextPainter {
   /// should be invalidated upon the next successful [layout].
   List<ui.LineMetrics> computeLineMetrics() {
     assert(!_needsLayout);
-    final List<ui.LineMetrics> metrics = _paragraph.computeLineMetrics();
-    print('LineMetrics called: ${metrics.length}');
-    for (ui.LineMetrics line in metrics) {
-      print('${line.lineNumber}: ${line.hardBreak}');
-    }
     return _paragraph.computeLineMetrics();
   }
 }

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -844,6 +844,11 @@ class TextPainter {
   /// should be invalidated upon the next successful [layout].
   List<ui.LineMetrics> computeLineMetrics() {
     assert(!_needsLayout);
+    List<ui.LineMetrics> metrics = _paragraph.computeLineMetrics();
+    print('LineMetrics called: ${metrics.length}');
+    for (ui.LineMetrics line in metrics) {
+      print('${line.lineNumber}: ${line.hardBreak}')
+    }
     return _paragraph.computeLineMetrics();
   }
 }

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -844,10 +844,10 @@ class TextPainter {
   /// should be invalidated upon the next successful [layout].
   List<ui.LineMetrics> computeLineMetrics() {
     assert(!_needsLayout);
-    List<ui.LineMetrics> metrics = _paragraph.computeLineMetrics();
+    final List<ui.LineMetrics> metrics = _paragraph.computeLineMetrics();
     print('LineMetrics called: ${metrics.length}');
     for (ui.LineMetrics line in metrics) {
-      print('${line.lineNumber}: ${line.hardBreak}')
+      print('${line.lineNumber}: ${line.hardBreak}');
     }
     return _paragraph.computeLineMetrics();
   }

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -745,6 +745,13 @@ void main() {
 
     expect(lines.length, 4);
 
+    if (lines[1].hardBreak == true) {
+      print('LineMetrics called: ${lines.length}');
+      for (ui.LineMetrics line in lines) {
+        print('${line.lineNumber}: ${line.hardBreak}');
+      }
+    }
+
     expect(lines[0].hardBreak, true);
     expect(lines[1].hardBreak, false);
     expect(lines[2].hardBreak, true);

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -745,6 +745,8 @@ void main() {
 
     expect(lines.length, 4);
 
+    // TODO(garyq): This data dump is for debugging a test flake. This should
+    // be removed when it is no longer useful.
     if (lines[1].hardBreak == true) {
       print('LineMetrics called: ${lines.length}');
       for (ui.LineMetrics line in lines) {


### PR DESCRIPTION
PR meant to add additional logging to provide info on https://github.com/flutter/flutter/issues/43763 where a `LineMetrics` test is flaking on Cirrus.