### PR TITLE
Fix analytics regression

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -284,6 +284,10 @@ class RunCommand extends RunCommandBase {
     if (!runningWithPrebuiltApplication) {
       await super.validateCommand();
     }
+    devices = await findAllTargetDevices();
+    if (devices == null) {
+      throwToolExit(null);
+    }
     if (deviceManager.hasSpecifiedAllDevices && runningWithPrebuiltApplication) {
       throwToolExit('Using -d all with --use-application-binary is not supported');
     }
@@ -331,11 +335,6 @@ class RunCommand extends RunCommandBase {
     final bool hotMode = shouldUseHotMode();
 
     writePidFile(stringArg('pid-file'));
-
-    devices = await findAllTargetDevices();
-    if (devices == null) {
-      throwToolExit(null);
-    }
 
     if (boolArg('machine')) {
       if (devices.length > 1) {

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -588,8 +588,6 @@ abstract class FlutterCommand extends Command<void> {
   /// rather than calling [runCommand] directly.
   @mustCallSuper
   Future<FlutterCommandResult> verifyThenRunCommand(String commandPath) async {
-    await validateCommand();
-
     // Populate the cache. We call this before pub get below so that the
     // sky_engine package is available in the flutter cache for pub to find.
     if (shouldUpdateCache) {
@@ -599,6 +597,8 @@ abstract class FlutterCommand extends Command<void> {
 
       await cache.updateAll(await requiredArtifacts);
     }
+
+    await validateCommand();
 
     if (shouldRunPub) {
       await pub.get(context: PubContext.getVerifyContext(name));

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -132,10 +132,10 @@ void main() {
         ProcessManager: () => mockProcessManager,
       });
 
-      testUsingContext('passes device to usage', () async {
+      testUsingContext('passes device target platform to usage', () async {
         final RunCommand command = RunCommand();
         applyMocksToCommand(command);
-        final MockDevice mockDevice = MockDevice(TargetPlatform.android_arm);
+        final MockDevice mockDevice = MockDevice(TargetPlatform.ios);
         when(mockDevice.isLocalEmulator).thenAnswer((Invocation invocation) => Future<bool>.value(false));
         when(mockDevice.getLogReader(app: anyNamed('app'))).thenReturn(MockDeviceLogReader());
         // App fails to start because we're only interested in usage
@@ -162,20 +162,6 @@ void main() {
         when(mockDeviceManager.findTargetDevices(any)).thenAnswer(
           (Invocation invocation) => Future<List<Device>>.value(<Device>[mockDevice])
         );
-        //int findTargetDevicesCount = 0;
-        //when(mockDeviceManager.findTargetDevices(any)).thenAnswer(
-        //  (Invocation invocation) {
-        //    List<Device> devices;
-        //    // The first invocation should return nothing, because cache isn't synced
-        //    if (findTargetDevicesCount == 0) {
-        //      devices = <Device>[];
-        //    } else {
-        //      devices = <Device>[mockDevice];
-        //    }
-        //    findTargetDevicesCount += 1;
-        //    return Future<List<Device>>.value(devices);
-        //  }
-        //);
 
         try {
           await createTestCommandRunner(command).run(<String>[
@@ -188,8 +174,7 @@ void main() {
           // We expect a ToolExit because app does not start
           expect(e.message, null);
         } catch (e) {
-          rethrow;
-          //fail('ToolExit expected');
+          fail('ToolExit expected');
         }
         final List<dynamic> captures = verify(mockUsage.sendCommand(
           captureAny,
@@ -197,7 +182,7 @@ void main() {
         )).captured;
         expect(captures[0], 'run');
         final Map<String, String> parameters = captures[1] as Map<String, String>;
-        expect(parameters['cd4'], 'android-arm');
+        expect(parameters['cd4'], 'ios');
       }, overrides: <Type, Generator>{
         ApplicationPackageFactory: () => mockApplicationPackageFactory,
         Artifacts: () => mockArtifacts,


### PR DESCRIPTION
## Description

In https://github.com/flutter/flutter/pull/45267, the tool stopped sending target device information on run command analytics events. This happened because the setting of `List<Device> devices` was moved from the run `validateCommand()` method to the `runCommand()` method. However, the order of events in the `verifyThenRunCommand()` method is to:

1. call `validateCommand()`
2. update the cache
3. send usage event
4. call `runCommand()`

This PR fixes the regression by moving the setting of `devices` back to `validateCommand()`, but changing the order of events in `verifyThenRunCommand()` to:

1. update the cache
2. call `validateCommand()`
3. send the usage event
4. call `runCommand()`

## Related Issues

Fixes https://github.com/flutter/flutter/issues/46165.

## Tests

I fixed the "updates before checking devices" test, and added a new test verifying that we send the command event with the proper device data.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*