### PR TITLE
Fix docker tag during upload as well

### DIFF
--- a/dev/ci/docker_linux/docker_push.sh
+++ b/dev/ci/docker_linux/docker_push.sh
@@ -5,5 +5,8 @@
 
 TAG="${CIRRUS_TAG:-latest}"
 
-sudo docker push "gcr.io/flutter-cirrus/build-flutter-image:$TAG"
+# Convert "+" to "-" to make hotfix tags legal Docker tag names.
+# See https://docs.docker.com/engine/reference/commandline/tag/
+TAG=${TAG/+/-}
 
+sudo docker push "gcr.io/flutter-cirrus/build-flutter-image:$TAG"


### PR DESCRIPTION
## Description

In https://github.com/flutter/flutter/pull/46035, we fixed the docker
tag to be a legal tag during build.  This PR makes the corresponding
change to the tag during upload.  Without this, we build the right tag,
but then we try to upload the wrong tag.
## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.
