### PR TITLE
[flutter_tools] Fix for Unsupported Android Plugin version.

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle_utils.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_utils.dart
@@ -200,7 +200,10 @@ String getGradleVersionFor(String androidPluginVersion) {
   if (_isWithinVersionRange(androidPluginVersion, min: '3.4.0', max: '3.5.0')) {
     return '5.6.2';
   }
-  throwToolExit('Unsuported Android Plugin version: $androidPluginVersion.');
+  if (Version.parse(androidPluginVersion) > Version.parse('3.5.0')) {
+    return '5.6.4';
+  }
+  throwToolExit('Unsupported Android Plugin version: $androidPluginVersion.');
   return '';
 }
 


### PR DESCRIPTION
Build getting a weird error since upgrade:
`Unsuported Android Plugin version: 3.5.2`

Tracked it down to this line:
https://github.com/flutter/flutter/blob/4f54e46f56c2ffc92eb440dbdab1a7f8e722e593/packages/flutter_tools/lib/src/android/gradle_utils.dart#L203

According to the comments above the function the details for this compatibility was from https://developer.android.com/studio/releases/gradle-plugin#updating-gradle which clearly states **3.5.0+** requires gradle version **5.6.4**. This is not what is in the dart code for the flutter tool and so the latest android plugin/studio builds **3.5.1 to 3.5.3 are not compatible with the latest hotfix branch** of the tool.