### PR TITLE
Revert "Improve MouseTracker lifecycle: Move checks to post-frame"

### DIFF
--- a/packages/flutter/lib/src/gestures/mouse_tracking.dart
+++ b/packages/flutter/lib/src/gestures/mouse_tracking.dart
@@ -13,109 +13,38 @@ import 'pointer_router.dart';
 
 /// Signature for listening to [PointerEnterEvent] events.
 ///
-/// Used by [MouseTrackerAnnotation], [MouseRegion] and [RenderMouseRegion].
+/// Used by [MouseTrackerAnnotation], [Listener] and [RenderPointerListener].
 typedef PointerEnterEventListener = void Function(PointerEnterEvent event);
 
 /// Signature for listening to [PointerExitEvent] events.
 ///
-/// Used by [MouseTrackerAnnotation], [MouseRegion] and [RenderMouseRegion].
+/// Used by [MouseTrackerAnnotation], [Listener] and [RenderPointerListener].
 typedef PointerExitEventListener = void Function(PointerExitEvent event);
 
 /// Signature for listening to [PointerHoverEvent] events.
 ///
-/// Used by [MouseTrackerAnnotation], [MouseRegion] and [RenderMouseRegion].
+/// Used by [MouseTrackerAnnotation], [Listener] and [RenderPointerListener].
 typedef PointerHoverEventListener = void Function(PointerHoverEvent event);
 
 /// The annotation object used to annotate layers that are interested in mouse
 /// movements.
 ///
-/// This is added to a layer and managed by the [MouseRegion] widget.
+/// This is added to a layer and managed by the [Listener] widget.
 class MouseTrackerAnnotation {
   /// Creates an annotation that can be used to find layers interested in mouse
   /// movements.
   const MouseTrackerAnnotation({this.onEnter, this.onHover, this.onExit});
 
-  /// Triggered when a mouse pointer, with or without buttons pressed, has
-  /// entered the annotated region.
-  ///
-  /// This callback is triggered when the pointer has started to be contained
-  /// by the annotationed region for any reason.
-  ///
-  /// More specifically, the callback is triggered by the following cases:
-  ///
-  ///  * A new annotated region has appeared under a pointer.
-  ///  * An existing annotated region has moved to under a pointer.
-  ///  * A new pointer has been added to somewhere within an annotated region.
-  ///  * An existing pointer has moved into an annotated region.
-  ///
-  /// This callback is not always matched by an [onExit]. If the render object
-  /// that owns the annotation is disposed while being hovered by a pointer,
-  /// the [onExit] callback of that annotation will never called, despite
-  /// the earlier call of [onEnter]. For more details, see [onExit].
-  ///
-  /// See also:
-  ///
-  ///  * [MouseRegion.onEnter], which uses this callback.
-  ///  * [onExit], which is triggered when a mouse pointer exits the region.
+  /// Triggered when a pointer has entered the bounding box of the annotated
+  /// layer.
   final PointerEnterEventListener onEnter;
 
-  /// Triggered when a pointer has moved within the annotated region without
-  /// buttons pressed.
-  ///
-  /// This callback is triggered when:
-  ///
-  ///  * An annotation that did not contain the pointer has moved to under a
-  ///    pointer that has no buttons pressed.
-  ///  * A pointer has moved onto, or moved within an annotation without buttons
-  ///    pressed.
-  ///
-  /// This callback is not triggered when
-  ///
-  ///  * An annotation that is containing the pointer has moved, and still
-  ///    contains the pointer.
+  /// Triggered when a pointer has moved within the bounding box of the
+  /// annotated layer.
   final PointerHoverEventListener onHover;
 
-  /// Triggered when a mouse pointer, with or without buttons pressed, has
-  /// exited the annotated region when the annotated region still exists.
-  ///
-  /// This callback is triggered when the pointer has stopped to be contained
-  /// by the region, except when it's caused by the removal of the render object
-  /// that owns the annotation. More specifically, the callback is triggered by
-  /// the following cases:
-  ///
-  ///  * An annotated region that used to contain a pointer has moved away.
-  ///  * A pointer that used to be within an annotated region has been removed.
-  ///  * A pointer that used to be within an annotated region has moved away.
-  ///
-  /// And is __not__ triggered by the following case,
-  ///
-  ///  * An annotated region that used to contain a pointer has disappeared.
-  ///
-  /// The last case is the only case when [onExit] does not match an earlier
-  /// [onEnter].
-  /// {@template flutter.mouseTracker.onExit}
-  /// This design is because the last case is very likely to be
-  /// handled improperly and cause exceptions (such as calling `setState` of the
-  /// disposed widget). There are a few ways to mitigate this limit:
-  ///
-  ///  * If the state of hovering is contained within a widget that
-  ///    unconditionally attaches the annotation (as long as a mouse is
-  ///    connected), then this will not be a concern, since when the annotation
-  ///    is disposed the state is no longer used.
-  ///  * If you're accessible to the condition that controls whether the
-  ///    annotation is attached, then you can call the callback when that
-  ///    condition goes from true to false.
-  ///  * In the cases where the solutions above won't work, you can always
-  ///    override [State.dispose] or [RenderObject.detach].
-  /// {@endtemplate}
-  ///
-  /// Technically, whether [onExit] will be called is controlled by
-  /// [MouseTracker.attachAnnotation] and [MouseTracker.detachAnnotation].
-  ///
-  /// See also:
-  ///
-  ///  * [MouseRegion.onExit], which uses this callback.
-  ///  * [onEnter], which is triggered when a mouse pointer enters the region.
+  /// Triggered when a pointer has exited the bounding box of the annotated
+  /// layer.
   final PointerExitEventListener onExit;
 
   @override
@@ -140,45 +69,39 @@ class MouseTrackerAnnotation {
 /// position.
 typedef MouseDetectorAnnotationFinder = Iterable<MouseTrackerAnnotation> Function(Offset offset);
 
-typedef _UpdatedDeviceHandler = void Function(_MouseState mouseState, LinkedHashSet<MouseTrackerAnnotation> previousAnnotations);
-
-// Various states of a connected mouse device used by [MouseTracker].
+// Various states of each connected mouse device.
+//
+// It is used by [MouseTracker] to compute which callbacks should be triggered
+// by each event.
 class _MouseState {
   _MouseState({
-    @required PointerAddedEvent initialEvent,
-  }) : assert(initialEvent != null),
-       _latestEvent = initialEvent;
+    @required PointerEvent mostRecentEvent,
+  }) : assert(mostRecentEvent != null),
+       _mostRecentEvent = mostRecentEvent;
 
-  // The list of annotations that contains this device.
+  // The list of annotations that contains this device during the last frame.
   //
   // It uses [LinkedHashSet] to keep the insertion order.
-  LinkedHashSet<MouseTrackerAnnotation> get annotations => _annotations;
-  LinkedHashSet<MouseTrackerAnnotation> _annotations = LinkedHashSet<MouseTrackerAnnotation>();
+  LinkedHashSet<MouseTrackerAnnotation> lastAnnotations = LinkedHashSet<MouseTrackerAnnotation>();
 
-  LinkedHashSet<MouseTrackerAnnotation> replaceAnnotations(LinkedHashSet<MouseTrackerAnnotation> value) {
-    final LinkedHashSet<MouseTrackerAnnotation> previous = _annotations;
-    _annotations = value;
-    return previous;
-  }
-
-  // The most recently processed mouse event observed from this device.
-  PointerEvent get latestEvent => _latestEvent;
-  PointerEvent _latestEvent;
-  set latestEvent(PointerEvent value) {
+  // The most recent mouse event observed from this device.
+  //
+  // The [mostRecentEvent] is never null.
+  PointerEvent get mostRecentEvent => _mostRecentEvent;
+  PointerEvent _mostRecentEvent;
+  set mostRecentEvent(PointerEvent value) {
     assert(value != null);
-    _latestEvent = value;
+    assert(value.device == _mostRecentEvent.device);
+    _mostRecentEvent = value;
   }
 
-  int get device => latestEvent.device;
+  int get device => _mostRecentEvent.device;
 
   @override
   String toString() {
-    String describeEvent(PointerEvent event) {
-      return event == null ? 'null' : '${describeIdentity(event)}';
-    }
-    final String describeLatestEvent = 'latestEvent: ${describeEvent(latestEvent)}';
-    final String describeAnnotations = 'annotations: [list of ${annotations.length}]';
-    return '${describeIdentity(this)}($describeLatestEvent, $describeAnnotations)';
+    final String describeEvent = '${_mostRecentEvent.runtimeType}(device: ${_mostRecentEvent.device})';
+    final String describeAnnotations = '[list of ${lastAnnotations.length}]';
+    return '${describeIdentity(this)}(event: $describeEvent, annotations: $describeAnnotations)';
   }
 }
 
@@ -191,24 +114,6 @@ class _MouseState {
 ///
 /// An instance of [MouseTracker] is owned by the global singleton of
 /// [RendererBinding].
-///
-/// ### Details
-///
-/// The state of [MouseTracker] consists of 3 parts:
-///
-///  * The mouse devices that are connected.
-///  * The annotations that are attached, i.e. whose owner render object is
-///    painted on the screen.
-///  * In which annotations each device is contained.
-///
-/// The states remain stable most of the time, and are only changed at the
-/// following moments:
-///
-///  * An eligible [PointerEvent] has been observed, e.g. a device is added,
-///    removed, or moved. In this case, the state related to this device will
-///    be immediately updated.
-///  * A frame has been painted. In this case, a callback will be scheduled for
-///    the upcoming post-frame phase to update all devices.
 class MouseTracker extends ChangeNotifier {
   /// Creates a mouse tracker to keep track of mouse locations.
   ///
@@ -247,212 +152,168 @@ class MouseTracker extends ChangeNotifier {
   // mouse events from.
   final PointerRouter _router;
 
-  // The collection of annotations that are currently being tracked. It is
-  // operated on by [attachAnnotation] and [detachAnnotation].
-  final Set<MouseTrackerAnnotation> _trackedAnnotations = <MouseTrackerAnnotation>{};
-
   // Tracks the state of connected mouse devices.
   //
   // It is the source of truth for the list of connected mouse devices.
   final Map<int, _MouseState> _mouseStates = <int, _MouseState>{};
 
-  // Whether an observed event might update a device.
-  static bool _shouldMarkStateDirty(_MouseState state, PointerEvent value) {
-    if (state == null)
-      return true;
-    assert(value != null);
-    final PointerEvent lastEvent = state.latestEvent;
-    assert(value.device == lastEvent.device);
-    // An Added can only follow a Removed, and a Removed can only be followed
-    // by an Added.
-    assert((value is PointerAddedEvent) == (lastEvent is PointerRemovedEvent));
+  // Returns the mouse state of a device. If it doesn't exist, create one using
+  // `mostRecentEvent`.
+  //
+  // The returned value is never null.
+  _MouseState _guaranteeMouseState(int device, PointerEvent mostRecentEvent) {
+    final _MouseState currentState = _mouseStates[device];
+    if (currentState == null) {
+      _addMouseDevice(device, mostRecentEvent);
+    }
+    final _MouseState result = currentState ?? _mouseStates[device];
+    assert(result != null);
+    return result;
+  }
 
-    // Ignore events that are unrelated to mouse tracking.
-    if (value is PointerSignalEvent)
-      return false;
-    return lastEvent is PointerAddedEvent
-      || value is PointerRemovedEvent
-      || lastEvent.position != value.position;
+  // The collection of annotations that are currently being tracked.
+  // It is operated on by [attachAnnotation] and [detachAnnotation].
+  final Set<MouseTrackerAnnotation> _trackedAnnotations = <MouseTrackerAnnotation>{};
+  bool get _hasAttachedAnnotations => _trackedAnnotations.isNotEmpty;
+
+  void _addMouseDevice(int device, PointerEvent event) {
+    final bool wasConnected = mouseIsConnected;
+    assert(!_mouseStates.containsKey(device));
+    _mouseStates[device] = _MouseState(mostRecentEvent: event);
+    // Schedule a check to enter annotations that might contain this pointer.
+    _checkDeviceUpdates(device: device);
+    if (mouseIsConnected != wasConnected) {
+      notifyListeners();
+    }
+  }
+
+  void _removeMouseDevice(int device, PointerEvent event) {
+    final bool wasConnected = mouseIsConnected;
+    assert(_mouseStates.containsKey(device));
+    final _MouseState disconnectedMouseState = _mouseStates.remove(device);
+    disconnectedMouseState.mostRecentEvent = event;
+    // Schedule a check to exit annotations that used to contain this pointer.
+    _checkDeviceUpdates(
+      device: device,
+      disconnectedMouseState: disconnectedMouseState,
+    );
+    if (mouseIsConnected != wasConnected) {
+      notifyListeners();
+    }
   }
 
   // Handler for events coming from the PointerRouter.
-  //
-  // If the event marks the device dirty, update the device immediately.
   void _handleEvent(PointerEvent event) {
-    if (event.kind != PointerDeviceKind.mouse)
+    if (event.kind != PointerDeviceKind.mouse) {
       return;
-    if (event is PointerSignalEvent)
-      return;
+    }
     final int device = event.device;
-    final _MouseState existingState = _mouseStates[device];
-    if (!_shouldMarkStateDirty(existingState, event))
-      return;
-
-    final PointerEvent previousEvent = existingState?.latestEvent;
-    _updateDevices(
-      targetEvent: event,
-      handleUpdatedDevice: (_MouseState mouseState, LinkedHashSet<MouseTrackerAnnotation> previousAnnotations) {
-        assert(mouseState.device == event.device);
-        _dispatchDeviceCallbacks(
-          lastAnnotations: previousAnnotations,
-          nextAnnotations: mouseState.annotations,
-          handledEvent: previousEvent,
-          unhandledEvent: event,
-          trackedAnnotations: _trackedAnnotations,
-        );
-      },
-    );
-  }
-
-  // Find the annotations that is hovered by the device of the `state`.
-  //
-  // If the device is not connected or there are no annotations attached, empty
-  // is returned without calling `annotationFinder`.
-  LinkedHashSet<MouseTrackerAnnotation> _findAnnotations(_MouseState state) {
-    final Offset globalPosition = state.latestEvent.position;
-    final int device = state.device;
-    return (_mouseStates.containsKey(device) && _trackedAnnotations.isNotEmpty)
-      ? LinkedHashSet<MouseTrackerAnnotation>.from(annotationFinder(globalPosition))
-      : <MouseTrackerAnnotation>{};
-  }
-
-  static bool get _duringBuildPhase {
-    return SchedulerBinding.instance.schedulerPhase == SchedulerPhase.persistentCallbacks;
-  }
-
-  // Update all devices, despite observing no new events.
-  //
-  // This is called after a new frame, since annotations can be moved after
-  // every frame.
-  void _updateAllDevices() {
-    _updateDevices(
-      handleUpdatedDevice: (_MouseState mouseState, LinkedHashSet<MouseTrackerAnnotation> previousAnnotations) {
-        _dispatchDeviceCallbacks(
-          lastAnnotations: previousAnnotations,
-          nextAnnotations: mouseState.annotations,
-          handledEvent: mouseState.latestEvent,
-          unhandledEvent: mouseState.latestEvent,
-          trackedAnnotations: _trackedAnnotations,
-        );
+    if (event is PointerAddedEvent) {
+      _addMouseDevice(device, event);
+    } else if (event is PointerRemovedEvent) {
+      _removeMouseDevice(device, event);
+    } else if (event is PointerHoverEvent) {
+      final _MouseState mouseState = _guaranteeMouseState(device, event);
+      final PointerEvent previousEvent = mouseState.mostRecentEvent;
+      mouseState.mostRecentEvent = event;
+      if (previousEvent is PointerAddedEvent || previousEvent.position != event.position) {
+        // Only send notifications if we have our first event, or if the
+        // location of the mouse has changed
+        _checkDeviceUpdates(device: device);
       }
-    );
+    }
   }
 
-  bool _duringDeviceUpdate = false;
-  // Update device states with the change of a new event or a new frame, and
-  // trigger `handleUpdateDevice` for each dirty device.
+  bool _scheduledPostFramePositionCheck = false;
+  // Schedules a position check at the end of this frame.
+  // It is only called during a frame during which annotations have been added.
+  void _scheduleMousePositionCheck() {
+    // If we're not tracking anything, then there is no point in registering a
+    // frame callback or scheduling a frame. By definition there are no active
+    // annotations that need exiting, either.
+    if (!_scheduledPostFramePositionCheck) {
+      _scheduledPostFramePositionCheck = true;
+      SchedulerBinding.instance.addPostFrameCallback((Duration duration) {
+        _checkAllDevicesUpdates();
+        _scheduledPostFramePositionCheck = false;
+      });
+    }
+  }
+
+  // Collect the latest states of the given mouse device `device`, and call
+  // interested callbacks.
   //
-  // This method is called either when a new event is observed (`targetEvent`
-  // being non-null), or when no new event is observed but all devices are
-  // marked dirty due to a new frame. It means that it will not happen that all
-  // devices are marked dirty when a new event is unprocessed.
+  // The enter or exit events are called for annotations that the pointer
+  // enters or leaves, while hover events are always called for each
+  // annotations that the pointer stays in, even if the pointer has not moved
+  // since the last call. Therefore it's caller's responsibility to check if
+  // the pointer has moved.
   //
-  // This method is the moment where `_mouseState` is updated. Before
-  // this method, `_mouseState` is in sync with the state before the event or
-  // before the frame. During `handleUpdateDevice` and after this method,
-  // `_mouseState` is in sync with the state after the event or after the frame.
-  //
-  // The dirty devices are decided as follows: if `targetEvent` is not null, the
-  // dirty devices are the device that observed the event; otherwise all devices
-  // are dirty.
-  //
-  // This method first keeps `_mouseStates` up to date. More specifically,
-  //
-  //  * If an event is observed, update `_mouseStates` by inserting or removing
-  //    the state that corresponds to the event if needed, then update the
-  //    `latestEvent` property of this mouse state.
-  //  * For each mouse state that will correspond to a dirty device, update the
-  //    `annotations` property with the annotations the device is contained.
-  //
-  // Then, for each dirty device, `handleUpdatedDevice` is called with the
-  // updated state and the annotations before the update.
-  //
-  // Last, the method checks if `mouseIsConnected` has been changed, and notify
-  // listeners if needed.
-  void _updateDevices({
-    PointerEvent targetEvent,
-    @required _UpdatedDeviceHandler handleUpdatedDevice,
+  // If `disconnectedMouseState` is provided, this state will be used instead,
+  // but this mouse will be hovering no annotations.
+  void _checkDeviceUpdates({
+    int device,
+    _MouseState disconnectedMouseState,
   }) {
-    assert(handleUpdatedDevice != null);
-    assert(!_duringBuildPhase);
-    assert(!_duringDeviceUpdate);
-    final bool mouseWasConnected = mouseIsConnected;
+    final _MouseState mouseState = disconnectedMouseState ?? _mouseStates[device];
+    final bool thisDeviceIsConnected = mouseState != disconnectedMouseState;
+    assert(mouseState != null);
 
-    // If new event is not null, only the device that observed this event is
-    // dirty. The target device's state is inserted into or removed from
-    // `_mouseStates` if needed, stored as `targetState`, and its
-    // `mostRecentDevice` is updated.
-    _MouseState targetState;
-    if (targetEvent != null) {
-      targetState = _mouseStates[targetEvent.device];
-      assert((targetState == null) == (targetEvent is PointerAddedEvent));
-      if (targetEvent is PointerAddedEvent) {
-        targetState = _MouseState(initialEvent: targetEvent);
-        _mouseStates[targetState.device] = targetState;
-      } else {
-        targetState.latestEvent = targetEvent;
-        // Update mouseState to the latest devices that have not been removed,
-        // so that [mouseIsConnected], which is decided by `_mouseStates`, is
-        // correct during the callbacks.
-        if (targetEvent is PointerRemovedEvent)
-          _mouseStates.remove(targetEvent.device);
-      }
+    final LinkedHashSet<MouseTrackerAnnotation> nextAnnotations =
+      (_hasAttachedAnnotations && thisDeviceIsConnected)
+        ? LinkedHashSet<MouseTrackerAnnotation>.from(
+            annotationFinder(mouseState.mostRecentEvent.position)
+          )
+        : <MouseTrackerAnnotation>{} as LinkedHashSet<MouseTrackerAnnotation>;
+
+    _dispatchDeviceCallbacks(
+      currentState: mouseState,
+      nextAnnotations: nextAnnotations,
+    );
+
+    mouseState.lastAnnotations = nextAnnotations;
+  }
+
+  // Collect the latest states of all mouse devices, and call interested
+  // callbacks.
+  //
+  // For detailed behaviors, see [_checkDeviceUpdates].
+  void _checkAllDevicesUpdates() {
+    for (final int device in _mouseStates.keys) {
+      _checkDeviceUpdates(device: device);
     }
-    assert((targetState == null) == (targetEvent == null));
-
-    assert(() {
-      _duringDeviceUpdate = true;
-      return true;
-    }());
-    // We can safely use `_mouseStates` here without worrying about the removed
-    // state, because `targetEvent` should be null when `_mouseStates` is used.
-    final Iterable<_MouseState> dirtyStates = targetEvent == null ? _mouseStates.values : <_MouseState>[targetState];
-    for (_MouseState dirtyState in dirtyStates) {
-      final LinkedHashSet<MouseTrackerAnnotation> nextAnnotations = _findAnnotations(dirtyState);
-      final LinkedHashSet<MouseTrackerAnnotation> lastAnnotations = dirtyState.replaceAnnotations(nextAnnotations);
-      handleUpdatedDevice(dirtyState, lastAnnotations);
-    }
-    assert(() {
-      _duringDeviceUpdate = false;
-      return true;
-    }());
-
-    if (mouseWasConnected != mouseIsConnected)
-      notifyListeners();
   }
 
   // Dispatch callbacks related to a device after all necessary information
   // has been collected.
   //
-  // The `unhandledEvent` can be null. Other arguments must not be null.
+  // This function should not change the provided states, and should not access
+  // information that is not provided in parameters (hence being static).
   static void _dispatchDeviceCallbacks({
-    @required LinkedHashSet<MouseTrackerAnnotation> lastAnnotations,
     @required LinkedHashSet<MouseTrackerAnnotation> nextAnnotations,
-    @required PointerEvent handledEvent,
-    @required PointerEvent unhandledEvent,
-    @required Set<MouseTrackerAnnotation> trackedAnnotations,
+    @required _MouseState currentState,
   }) {
-    assert(lastAnnotations != null);
-    assert(nextAnnotations != null);
-    // handledEvent can be null
-    assert(unhandledEvent != null);
-    assert(trackedAnnotations != null);
     // Order is important for mouse event callbacks. The `findAnnotations`
     // returns annotations in the visual order from front to back. We call
     // it the "visual order", and the opposite one "reverse visual order".
     // The algorithm here is explained in
     // https://github.com/flutter/flutter/issues/41420
 
+    // The `nextAnnotations` is annotations that contains this device in the
+    // coming frame in visual order.
+    // Order is preserved with the help of [LinkedHashSet].
+
+    final PointerEvent mostRecentEvent = currentState.mostRecentEvent;
+    // The `lastAnnotations` is annotations that contains this device in the
+    // previous frame in visual order.
+    final LinkedHashSet<MouseTrackerAnnotation> lastAnnotations = currentState.lastAnnotations;
+
     // Send exit events in visual order.
     final Iterable<MouseTrackerAnnotation> exitingAnnotations =
       lastAnnotations.difference(nextAnnotations);
     for (final MouseTrackerAnnotation annotation in exitingAnnotations) {
-      final bool attached = trackedAnnotations.contains(annotation);
-      // Exit is not sent if annotation is no longer attached, because this
-      // trigger may cause exceptions and has safer alternatives. See
-      // [MouseRegion.onExit] for details.
-      if (annotation.onExit != null && attached) {
-        annotation.onExit(PointerExitEvent.fromMouseEvent(unhandledEvent));
+      if (annotation.onExit != null) {
+        annotation.onExit(PointerExitEvent.fromMouseEvent(mostRecentEvent));
       }
     }
 
@@ -460,62 +321,24 @@ class MouseTracker extends ChangeNotifier {
     final Iterable<MouseTrackerAnnotation> enteringAnnotations =
       nextAnnotations.difference(lastAnnotations).toList().reversed;
     for (final MouseTrackerAnnotation annotation in enteringAnnotations) {
-      assert(trackedAnnotations.contains(annotation));
       if (annotation.onEnter != null) {
-        annotation.onEnter(PointerEnterEvent.fromMouseEvent(unhandledEvent));
+        annotation.onEnter(PointerEnterEvent.fromMouseEvent(mostRecentEvent));
       }
     }
 
     // Send hover events in reverse visual order.
     // For now the order between the hover events is designed this way for no
     // solid reasons but to keep it aligned with enter events for simplicity.
-    if (unhandledEvent is PointerHoverEvent) {
+    if (mostRecentEvent is PointerHoverEvent) {
       final Iterable<MouseTrackerAnnotation> hoveringAnnotations =
         nextAnnotations.toList().reversed;
       for (final MouseTrackerAnnotation annotation in hoveringAnnotations) {
-        // Deduplicate: Trigger hover if it's a newly hovered annotation
-        // or the position has changed
-        assert(trackedAnnotations.contains(annotation));
-        if (!lastAnnotations.contains(annotation)
-            || handledEvent is! PointerHoverEvent
-            || handledEvent.position != unhandledEvent.position) {
-          if (annotation.onHover != null) {
-            annotation.onHover(unhandledEvent);
-          }
+        if (annotation.onHover != null) {
+          annotation.onHover(mostRecentEvent);
         }
       }
     }
   }
-
-  bool _hasScheduledPostFrameCheck = false;
-  /// Mark all devices as dirty, and schedule a callback that is executed in the
-  /// upcoming post-frame phase to check their updates.
-  ///
-  /// Checking a device means to collect the annotations that the pointer
-  /// hovers, and triggers necessary callbacks accordingly.
-  ///
-  /// Although the actual callback belongs to the scheduler's post-frame phase,
-  /// this method must be called in persistent callback phase to ensure that
-  /// the callback is scheduled after every frame, since every frame can change
-  /// the position of annotations. Typically the method is called by
-  /// [RendererBinding]'s drawing method.
-  void schedulePostFrameCheck() {
-    assert(_duringBuildPhase);
-    assert(!_duringDeviceUpdate);
-    if (!mouseIsConnected)
-      return;
-    if (!_hasScheduledPostFrameCheck) {
-      _hasScheduledPostFrameCheck = true;
-      SchedulerBinding.instance.addPostFrameCallback((Duration duration) {
-        assert(_hasScheduledPostFrameCheck);
-        _hasScheduledPostFrameCheck = false;
-        _updateAllDevices();
-      });
-    }
-  }
-
-  /// Whether or not a mouse is connected and has produced events.
-  bool get mouseIsConnected => _mouseStates.isNotEmpty;
 
   /// Checks if the given [MouseTrackerAnnotation] is attached to this
   /// [MouseTracker].
@@ -527,52 +350,56 @@ class MouseTracker extends ChangeNotifier {
     return _trackedAnnotations.contains(annotation);
   }
 
-  /// Notify [MouseTracker] that a new [MouseTrackerAnnotation] has started to
+  /// Whether or not a mouse is connected and has produced events.
+  bool get mouseIsConnected => _mouseStates.isNotEmpty;
+
+  /// Notify [MouseTracker] that a new mouse tracker annotation has started to
   /// take effect.
   ///
-  /// This method is typically called by the [RenderObject] that owns an
-  /// annotation, as soon as the render object is added to the render tree.
+  /// This should be called as soon as the layer that owns this annotation is
+  /// added to the layer tree.
   ///
-  /// {@template flutter.mouseTracker.attachAnnotation}
-  /// Render objects that call this method might want to schedule a frame as
-  /// well, typically by calling [RenderObject.markNeedsPaint], because this
-  /// method does not cause any immediate effect, since the state it changes is
-  /// used during a post-frame callback or when handling certain pointer events.
+  /// This triggers [MouseTracker] to schedule a mouse position check during the
+  /// post frame to see if this new annotation might trigger enter events.
   ///
-  /// ### About annotation attachment
-  ///
-  /// It is the responsibility of the render object that owns the annotation to
-  /// maintain the attachment of the annotation. Whether an annotation is
-  /// attached should be kept in sync with whether its owner object is mounted,
-  /// which is used in the following ways:
-  ///
-  ///  * If a pointer enters an annotation, it is asserted that the annotation
-  ///    is attached.
-  ///  * If a pointer stops being contained by an annotation,
-  ///    the exit event is triggered only if the annotation is still attached.
-  ///    This is to prevent exceptions caused calling setState of a disposed
-  ///    widget. See [MouseTrackerAnnotation.onExit] for more details.
-  ///  * The [MouseTracker] also uses the attachment to track the number of
-  ///    attached annotations, and will skip mouse position checks if there is no
-  ///    annotations attached.
-  /// {@endtemplate}
-  ///  * Attaching an annotation that has been attached will assert.
+  /// The [MouseTracker] also uses this to track the number of attached
+  /// annotations, and will skip mouse position checks if there is no
+  /// annotations attached.
   void attachAnnotation(MouseTrackerAnnotation annotation) {
-    assert(!_duringDeviceUpdate);
-    assert(!_trackedAnnotations.contains(annotation));
+    // Schedule a check so that we test this new annotation to see if any mouse
+    // is currently inside its region. It has to happen after the frame is
+    // complete so that the annotation layer has been added before the check.
     _trackedAnnotations.add(annotation);
+    if (mouseIsConnected) {
+      _scheduleMousePositionCheck();
+    }
   }
+
 
   /// Notify [MouseTracker] that a mouse tracker annotation that was previously
   /// attached has stopped taking effect.
   ///
-  /// This method is typically called by the [RenderObject] that owns an
-  /// annotation, as soon as the render object is removed from the render tree.
-  /// {@macro flutter.mouseTracker.attachAnnotation}
-  ///  * Detaching an annotation that has not been attached will assert.
+  /// This should be called as soon as the layer that owns this annotation is
+  /// removed from the layer tree. An assertion error will be thrown if the
+  /// associated layer is not removed and receives another mouse hit.
+  ///
+  /// This triggers [MouseTracker] to perform a mouse position check immediately
+  /// to see if this annotation removal triggers any exit events.
+  ///
+  /// The [MouseTracker] also uses this to track the number of attached
+  /// annotations, and will skip mouse position checks if there is no
+  /// annotations attached.
   void detachAnnotation(MouseTrackerAnnotation annotation) {
-    assert(!_duringDeviceUpdate);
-    assert(_trackedAnnotations.contains(annotation));
+    _mouseStates.forEach((int device, _MouseState mouseState) {
+      if (mouseState.lastAnnotations.contains(annotation)) {
+        if (annotation.onExit != null) {
+          final PointerEvent event = mouseState.mostRecentEvent;
+          assert(event != null);
+          annotation.onExit(PointerExitEvent.fromMouseEvent(event));
+        }
+        mouseState.lastAnnotations.remove(annotation);
+      }
+    });
     _trackedAnnotations.remove(annotation);
   }
 }

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -281,7 +281,6 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
 
   void _handlePersistentFrameCallback(Duration timeStamp) {
     drawFrame();
-    _mouseTracker.schedulePostFrameCheck();
   }
 
   int _firstFrameDeferredCount = 0;

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2720,8 +2720,7 @@ class RenderMouseRegion extends RenderProxyBox {
       _onHover(event);
   }
 
-  /// Called when a pointer leaves the region (with or without buttons pressed)
-  /// and the annotation is still attached.
+  /// Called when a pointer leaves the region (with or without buttons pressed).
   PointerExitEventListener get onExit => _onExit;
   set onExit(PointerExitEventListener value) {
     if (_onExit != value) {

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -5857,71 +5857,18 @@ class MouseRegion extends SingleChildRenderObjectWidget {
   }) : assert(opaque != null),
        super(key: key, child: child);
 
-  /// Called when a mouse pointer, with or without buttons pressed, has
-  /// entered this widget.
-  ///
-  /// This callback is triggered when the pointer has started to be contained
-  /// by the region of this widget. More specifically, the callback is triggered
-  /// by the following cases:
-  ///
-  ///  * This widget has appeared under a pointer.
-  ///  * This widget has moved to under a pointer.
-  ///  * A new pointer has been added to somewhere within this widget.
-  ///  * An existing pointer has moved into this widget.
-  ///
-  /// This callback is not always matched by an [onExit]. If the [MouseRegion]
-  /// is unmounted while being hovered by a pointer, the [onExit] of the widget
-  /// callback will never called, despite the earlier call of [onEnter]. For
-  /// more details, see [onExit].
-  ///
-  /// See also:
-  ///
-  ///  * [onExit], which is triggered when a mouse pointer exits the region.
-  ///  * [MouseTrackerAnnotation.onEnter], which is how this callback is
-  ///    internally implemented.
+  /// Called when a mouse pointer (with or without buttons pressed) enters the
+  /// region defined by this widget, or when the widget appears under the
+  /// pointer.
   final PointerEnterEventListener onEnter;
 
-  /// Called when a mouse pointer changes position without buttons pressed, and
-  /// the new position is within the region defined by this widget.
-  ///
-  /// This callback is triggered when:
-  ///
-  ///  * An annotation that did not contain the pointer has moved to under a
-  ///    pointer that has no buttons pressed.
-  ///  * A pointer has moved onto, or moved within an annotation without buttons
-  ///    pressed.
-  ///
-  /// This callback is not triggered when
-  ///
-  ///  * An annotation that is containing the pointer has moved, and still
-  ///    contains the pointer.
+  /// Called when a mouse pointer (with or without buttons pressed) changes
+  /// position, and the new position is within the region defined by this widget.
   final PointerHoverEventListener onHover;
 
-  /// Called when a mouse pointer, with or without buttons pressed, has exited
-  /// this widget when the widget is still mounted.
-  ///
-  /// This callback is triggered when the pointer has stopped to be contained
-  /// by the region of this widget, except when it's caused by the removal of
-  /// this widget. More specifically, the callback is triggered by
-  /// the following cases:
-  ///
-  ///  * This widget, which used to contain a pointer, has moved away.
-  ///  * A pointer that used to be within this widget has been removed.
-  ///  * A pointer that used to be within this widget has moved away.
-  ///
-  /// And is __not__ triggered by the following case,
-  ///
-  ///  * This widget, which used to contain a pointer, has disappeared.
-  ///
-  /// The last case is the only case when [onExit] does not match an earlier
-  /// [onEnter].
-  /// {@macro flutter.mouseTracker.onExit}
-  ///
-  /// See also:
-  ///
-  ///  * [onEnter], which is triggered when a mouse pointer enters the region.
-  ///  * [MouseTrackerAnnotation.onExit], which is how this callback is
-  ///    internally implemented.
+  /// Called when a mouse pointer (with or without buttons pressed) leaves the
+  /// region defined by this widget, or when the widget disappears from under
+  /// the pointer.
   final PointerExitEventListener onExit;
 
   /// Whether this widget should prevent other [MouseRegion]s visually behind it

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -2596,11 +2596,10 @@ void main() {
 
       // Double tap at the end of text.
       final Offset textEndPos = textOffsetToPosition(tester, 11); // Position at the end of text.
-      final TestGesture gesture = await tester.startGesture(
+      TestGesture gesture = await tester.startGesture(
         textEndPos,
         kind: PointerDeviceKind.mouse,
       );
-      addTearDown(gesture.removePointer);
       await tester.pump(const Duration(milliseconds: 50));
       await gesture.up();
       await tester.pump();
@@ -2615,7 +2614,11 @@ void main() {
       final Offset hPos = textOffsetToPosition(tester, 9); // Position of 'h'.
 
       // Double tap on 'h' to select 'ghi'.
-      await gesture.down(hPos);
+      gesture = await tester.startGesture(
+        hPos,
+        kind: PointerDeviceKind.mouse,
+      );
+      addTearDown(gesture.removePointer);
       await tester.pump(const Duration(milliseconds: 50));
       await gesture.up();
       await tester.pump();

--- a/packages/flutter/test/gestures/mouse_tracking_test.dart
+++ b/packages/flutter/test/gestures/mouse_tracking_test.dart
@@ -401,27 +401,6 @@ void main() {
     ]));
   });
 
-  test('should not schedule postframe callbacks when no mouse is connected', () {
-    const MouseTrackerAnnotation annotation = MouseTrackerAnnotation();
-    _setUpMouseAnnotationFinder((Offset position) sync* {
-    });
-
-    // This device only supports touching
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
-      _pointerData(PointerChange.add, const Offset(0.0, 100.0), kind: PointerDeviceKind.touch),
-    ]));
-    expect(_mouseTracker.mouseIsConnected, isFalse);
-
-    // Attaching an annotation just in case
-    _mouseTracker.attachAnnotation(annotation);
-    expect(_binding.postFrameCallbacks, hasLength(0));
-
-    _binding.scheduleMouseTrackerPostFrameCheck();
-    expect(_binding.postFrameCallbacks, hasLength(0));
-
-    _mouseTracker.detachAnnotation(annotation);
-  });
-
   test('should not flip out if not all mouse events are listened to', () {
     bool isInHitRegionOne = true;
     bool isInHitRegionTwo = false;

--- a/packages/flutter/test/gestures/mouse_tracking_test.dart
+++ b/packages/flutter/test/gestures/mouse_tracking_test.dart
@@ -24,24 +24,9 @@ class _TestGestureFlutterBinding extends BindingBase
     postFrameCallbacks = <void Function(Duration)>[];
   }
 
-  SchedulerPhase _overridePhase;
-  @override
-  SchedulerPhase get schedulerPhase => _overridePhase ?? super.schedulerPhase;
-
-  // Mannually schedule a postframe check.
-  //
-  // In real apps this is done by the renderer binding, but in tests we have to
-  // bypass the phase assertion of [MouseTracker.schedulePostFrameCheck].
-  void scheduleMouseTrackerPostFrameCheck() {
-    final SchedulerPhase lastPhase = _overridePhase;
-    _overridePhase = SchedulerPhase.persistentCallbacks;
-    mouseTracker.schedulePostFrameCheck();
-    _overridePhase = lastPhase;
-  }
-
   List<void Function(Duration)> postFrameCallbacks;
 
-  // Proxy post-frame callbacks.
+  // Proxy post-frame callbacks
   @override
   void addPostFrameCallback(void Function(Duration) callback) {
     postFrameCallbacks.add(callback);
@@ -123,18 +108,19 @@ void main() {
 
     expect(_mouseTracker.mouseIsConnected, isFalse);
 
-    // Pointer enters the annotation.
+    // Enter
     ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
-      _pointerData(PointerChange.add, const Offset(0.0, 0.0)),
+      _pointerData(PointerChange.hover, const Offset(1.0, 0.0)),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<PointerEvent>[
-      const PointerEnterEvent(position: Offset(0.0, 0.0)),
+      const PointerEnterEvent(position: Offset(1.0, 0.0)),
+      const PointerHoverEvent(position: Offset(1.0, 0.0)),
     ]));
     expect(listenerLogs, <bool>[true]);
     events.clear();
     listenerLogs.clear();
 
-    // Pointer hovers the annotation.
+    // Hover
     ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(1.0, 101.0)),
     ]));
@@ -145,7 +131,7 @@ void main() {
     expect(listenerLogs, <bool>[]);
     events.clear();
 
-    // Pointer is removed while on the annotation.
+    // Remove
     ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, const Offset(1.0, 101.0)),
     ]));
@@ -156,12 +142,13 @@ void main() {
     events.clear();
     listenerLogs.clear();
 
-    // Pointer is added on the annotation.
+    // Add again
     ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
-      _pointerData(PointerChange.add, const Offset(0.0, 301.0)),
+      _pointerData(PointerChange.hover, const Offset(1.0, 301.0)),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<PointerEvent>[
-      const PointerEnterEvent(position: Offset(0.0, 301.0)),
+      const PointerEnterEvent(position: Offset(1.0, 301.0)),
+      const PointerHoverEvent(position: Offset(1.0, 301.0)),
     ]));
     expect(listenerLogs, <bool>[true]);
     events.clear();
@@ -174,31 +161,29 @@ void main() {
 
     expect(_mouseTracker.mouseIsConnected, isFalse);
 
-    // The first mouse is added on the annotation.
+    // First mouse
     ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
-      _pointerData(PointerChange.add, const Offset(0.0, 0.0)),
       _pointerData(PointerChange.hover, const Offset(0.0, 1.0)),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<PointerEvent>[
-      const PointerEnterEvent(position: Offset(0.0, 0.0)),
+      const PointerEnterEvent(position: Offset(0.0, 1.0)),
       const PointerHoverEvent(position: Offset(0.0, 1.0)),
     ]));
     expect(_mouseTracker.mouseIsConnected, isTrue);
     events.clear();
 
-    // The second mouse is added on the annotation.
+    // Second mouse
     ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
-      _pointerData(PointerChange.add, const Offset(0.0, 401.0), device: 1),
       _pointerData(PointerChange.hover, const Offset(1.0, 401.0), device: 1),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<PointerEvent>[
-      const PointerEnterEvent(position: Offset(0.0, 401.0), device: 1),
+      const PointerEnterEvent(position: Offset(1.0, 401.0), device: 1),
       const PointerHoverEvent(position: Offset(1.0, 401.0), device: 1),
     ]));
     expect(_mouseTracker.mouseIsConnected, isTrue);
     events.clear();
 
-    // The first mouse moves on the annotation.
+    // First mouse hover
     ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(0.0, 101.0)),
     ]));
@@ -208,7 +193,7 @@ void main() {
     expect(_mouseTracker.mouseIsConnected, isTrue);
     events.clear();
 
-    // The second mouse moves on the annotation.
+    // Second mouse hover
     ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(1.0, 501.0), device: 1),
     ]));
@@ -218,7 +203,7 @@ void main() {
     expect(_mouseTracker.mouseIsConnected, isTrue);
     events.clear();
 
-    // The first mouse is removed while on the annotation.
+    // First mouse remove
     ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, const Offset(0.0, 101.0)),
     ]));
@@ -228,7 +213,7 @@ void main() {
     expect(_mouseTracker.mouseIsConnected, isTrue);
     events.clear();
 
-    // The second mouse still moves on the annotation.
+    // Second mouse hover
     ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(1.0, 601.0), device: 1),
     ]));
@@ -238,7 +223,7 @@ void main() {
     expect(_mouseTracker.mouseIsConnected, isTrue);
     events.clear();
 
-    // The second mouse is removed while on the annotation.
+    // Second mouse remove
     ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, const Offset(1.0, 601.0), device: 1),
     ]));
@@ -249,12 +234,8 @@ void main() {
     events.clear();
   });
 
-  test('should not flip out when attaching and detaching during callbacks', () {
-    // It is a common pattern that a callback that listens to the changes of
-    // [MouseTracker.mouseIsConnected] triggers annotation attaching and
-    // detaching. This test ensures that no exceptions are thrown for this
-    // pattern.
-    bool isInHitRegion = false;
+  test('should handle detaching during the callback of exiting', () {
+    bool isInHitRegion;
     final List<PointerEvent> events = <PointerEvent>[];
     final MouseTrackerAnnotation annotation = MouseTrackerAnnotation(
       onEnter: (PointerEnterEvent event) => events.add(event),
@@ -267,39 +248,21 @@ void main() {
       }
     });
 
-    void mockMarkNeedsPaint() {
-      _binding.scheduleMouseTrackerPostFrameCheck();
-    }
+    isInHitRegion = true;
+    _mouseTracker.attachAnnotation(annotation);
 
-    final VoidCallback firstListener = () {
-      if (!_mouseTracker.mouseIsConnected) {
-        _mouseTracker.detachAnnotation(annotation);
-        isInHitRegion = false;
-      } else {
-        _mouseTracker.attachAnnotation(annotation);
-        isInHitRegion = true;
-      }
-      mockMarkNeedsPaint();
-    };
-    _mouseTracker.addListener(firstListener);
-
-    // The pointer is added onto the annotation, triggering attaching callback.
+    // Enter
     ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
-      _pointerData(PointerChange.add, const Offset(1.0, 0.0)),
+      _pointerData(PointerChange.hover, const Offset(1.0, 0.0)),
     ]));
-    expect(events, _equalToEventsOnCriticalFields(<PointerEvent>[
-    ]));
-    expect(_mouseTracker.mouseIsConnected, isTrue);
-
-    _binding.flushPostFrameCallbacks(Duration.zero);
     expect(events, _equalToEventsOnCriticalFields(<PointerEvent>[
       const PointerEnterEvent(position: Offset(1.0, 0.0)),
+      const PointerHoverEvent(position: Offset(1.0, 0.0)),
     ]));
     expect(_mouseTracker.mouseIsConnected, isTrue);
     events.clear();
 
-    // The pointer is removed while on the annotation, triggering dettaching callback.
-    _mouseTracker.removeListener(firstListener);
+    // Remove
     _mouseTracker.addListener(() {
       if (!_mouseTracker.mouseIsConnected) {
         _mouseTracker.detachAnnotation(annotation);
@@ -346,202 +309,8 @@ void main() {
     events.clear();
   });
 
-  test('should correctly handle when the annotation is attached or detached on the pointer', () {
+  test('should detect enter or exit when annotations are attached or detached on the pointer', () {
     bool isInHitRegion;
-    final List<Object> events = <PointerEvent>[];
-    final MouseTrackerAnnotation annotation = MouseTrackerAnnotation(
-      onEnter: (PointerEnterEvent event) => events.add(event),
-      onHover: (PointerHoverEvent event) => events.add(event),
-      onExit: (PointerExitEvent event) => events.add(event),
-    );
-    _setUpMouseAnnotationFinder((Offset position) sync* {
-      if (isInHitRegion) {
-        yield annotation;
-      }
-    });
-
-    isInHitRegion = false;
-
-    // Connect a mouse when there is no annotation.
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
-      _pointerData(PointerChange.add, const Offset(0.0, 100.0)),
-    ]));
-    expect(events, _equalToEventsOnCriticalFields(<PointerEvent>[
-    ]));
-    expect(_mouseTracker.mouseIsConnected, isTrue);
-    events.clear();
-
-    // Attaching an annotation should trigger Enter event.
-    isInHitRegion = true;
-    _mouseTracker.attachAnnotation(annotation);
-    expect(events, _equalToEventsOnCriticalFields(<PointerEvent>[
-    ]));
-    expect(_binding.postFrameCallbacks, hasLength(0));
-
-    _binding.scheduleMouseTrackerPostFrameCheck();
-    expect(_binding.postFrameCallbacks, hasLength(1));
-
-    _binding.flushPostFrameCallbacks(Duration.zero);
-    expect(events, _equalToEventsOnCriticalFields(<PointerEvent>[
-      const PointerEnterEvent(position: Offset(0.0, 100.0)),
-    ]));
-    events.clear();
-
-    // Detaching an annotation should not trigger events.
-    isInHitRegion = false;
-    _mouseTracker.detachAnnotation(annotation);
-    expect(events, _equalToEventsOnCriticalFields(<PointerEvent>[
-    ]));
-    expect(_binding.postFrameCallbacks, hasLength(0));
-
-    _binding.scheduleMouseTrackerPostFrameCheck();
-    expect(_binding.postFrameCallbacks, hasLength(1));
-
-    _binding.flushPostFrameCallbacks(Duration.zero);
-    expect(events, _equalToEventsOnCriticalFields(<PointerEvent>[
-    ]));
-    expect(_binding.postFrameCallbacks, hasLength(0));
-  });
-
-  test('should correctly handle when the annotation moves in or out of the pointer', () {
-    bool isInHitRegion;
-    final List<Object> events = <PointerEvent>[];
-    final MouseTrackerAnnotation annotation = MouseTrackerAnnotation(
-      onEnter: (PointerEnterEvent event) => events.add(event),
-      onHover: (PointerHoverEvent event) => events.add(event),
-      onExit: (PointerExitEvent event) => events.add(event),
-    );
-    _setUpMouseAnnotationFinder((Offset position) sync* {
-      if (isInHitRegion) {
-        yield annotation;
-      }
-    });
-
-    // Start with an annotation attached.
-    _mouseTracker.attachAnnotation(annotation);
-    isInHitRegion = false;
-
-    // Connect a mouse.
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
-      _pointerData(PointerChange.add, const Offset(0.0, 100.0)),
-    ]));
-    events.clear();
-
-    // During a frame, the annotation moves into the pointer.
-    isInHitRegion = true;
-    expect(_binding.postFrameCallbacks, hasLength(0));
-    _binding.scheduleMouseTrackerPostFrameCheck();
-    expect(_binding.postFrameCallbacks, hasLength(1));
-
-    _binding.flushPostFrameCallbacks(Duration.zero);
-    expect(events, _equalToEventsOnCriticalFields(<PointerEvent>[
-      const PointerEnterEvent(position: Offset(0.0, 100.0)),
-    ]));
-    events.clear();
-
-    expect(_binding.postFrameCallbacks, hasLength(0));
-
-    // During a frame, the annotation moves out of the pointer.
-    isInHitRegion = false;
-    expect(_binding.postFrameCallbacks, hasLength(0));
-    _binding.scheduleMouseTrackerPostFrameCheck();
-    expect(_binding.postFrameCallbacks, hasLength(1));
-
-    _binding.flushPostFrameCallbacks(Duration.zero);
-    expect(events, _equalToEventsOnCriticalFields(<PointerEvent>[
-      const PointerExitEvent(position: Offset(0.0, 100.0)),
-    ]));
-    expect(_binding.postFrameCallbacks, hasLength(0));
-  });
-
-  test('should correctly handle when the pointer is added or removed on the annotation', () {
-    bool isInHitRegion;
-    final List<Object> events = <PointerEvent>[];
-    final MouseTrackerAnnotation annotation = MouseTrackerAnnotation(
-      onEnter: (PointerEnterEvent event) => events.add(event),
-      onHover: (PointerHoverEvent event) => events.add(event),
-      onExit: (PointerExitEvent event) => events.add(event),
-    );
-    _setUpMouseAnnotationFinder((Offset position) sync* {
-      if (isInHitRegion) {
-        yield annotation;
-      }
-    });
-
-    // Start with an annotation attached.
-    _mouseTracker.attachAnnotation(annotation);
-    isInHitRegion = false;
-
-    // Connect a mouse in the region. Should trigger Enter.
-    isInHitRegion = true;
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
-      _pointerData(PointerChange.add, const Offset(0.0, 100.0)),
-    ]));
-
-    expect(_binding.postFrameCallbacks, hasLength(0));
-    expect(events, _equalToEventsOnCriticalFields(<PointerEvent>[
-      const PointerEnterEvent(position: Offset(0.0, 100.0)),
-    ]));
-    events.clear();
-
-    // Disconnect the mouse from the region. Should trigger Exit.
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
-      _pointerData(PointerChange.remove, const Offset(0.0, 100.0)),
-    ]));
-    expect(_binding.postFrameCallbacks, hasLength(0));
-    expect(events, _equalToEventsOnCriticalFields(<PointerEvent>[
-      const PointerExitEvent(position: Offset(0.0, 100.0)),
-    ]));
-  });
-
-  test('should correctly handle when the pointer moves in or out of the annotation', () {
-    bool isInHitRegion;
-    final List<Object> events = <PointerEvent>[];
-    final MouseTrackerAnnotation annotation = MouseTrackerAnnotation(
-      onEnter: (PointerEnterEvent event) => events.add(event),
-      onHover: (PointerHoverEvent event) => events.add(event),
-      onExit: (PointerExitEvent event) => events.add(event),
-    );
-    _setUpMouseAnnotationFinder((Offset position) sync* {
-      if (isInHitRegion) {
-        yield annotation;
-      }
-    });
-
-    // Start with annotation and mouse attached.
-    _mouseTracker.attachAnnotation(annotation);
-    isInHitRegion = false;
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
-      _pointerData(PointerChange.add, const Offset(200.0, 100.0)),
-    ]));
-
-    expect(_binding.postFrameCallbacks, hasLength(0));
-    events.clear();
-
-    // Moves the mouse into the region. Should trigger Enter.
-    isInHitRegion = true;
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
-      _pointerData(PointerChange.hover, const Offset(0.0, 100.0)),
-    ]));
-    expect(_binding.postFrameCallbacks, hasLength(0));
-    expect(events, _equalToEventsOnCriticalFields(<PointerEvent>[
-      const PointerEnterEvent(position: Offset(0.0, 100.0)),
-      const PointerHoverEvent(position: Offset(0.0, 100.0)),
-    ]));
-    events.clear();
-
-    // Moves the mouse out of the region. Should trigger Exit.
-    isInHitRegion = false;
-    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
-      _pointerData(PointerChange.hover, const Offset(200.0, 100.0)),
-    ]));
-    expect(_binding.postFrameCallbacks, hasLength(0));
-    expect(events, _equalToEventsOnCriticalFields(<PointerEvent>[
-      const PointerExitEvent(position: Offset(200.0, 100.0)),
-    ]));
-  });
-
-  test('should correctly handle when annotation is attached or detached while not containing the pointer', () {
     final List<PointerEvent> events = <PointerEvent>[];
     final MouseTrackerAnnotation annotation = MouseTrackerAnnotation(
       onEnter: (PointerEnterEvent event) => events.add(event),
@@ -549,10 +318,14 @@ void main() {
       onExit: (PointerExitEvent event) => events.add(event),
     );
     _setUpMouseAnnotationFinder((Offset position) sync* {
-      // This annotation is never in the region.
+      if (isInHitRegion) {
+        yield annotation;
+      }
     });
 
-    // Connect a mouse when there is no annotation.
+    isInHitRegion = false;
+
+    // Connect a mouse when there is no annotation
     ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 100.0)),
     ]));
@@ -561,13 +334,53 @@ void main() {
     expect(_mouseTracker.mouseIsConnected, isTrue);
     events.clear();
 
-    // Attaching an annotation should not trigger events.
+    // Attach an annotation
+    isInHitRegion = true;
+    _mouseTracker.attachAnnotation(annotation);
+    // No callbacks are triggered immediately
+    expect(events, _equalToEventsOnCriticalFields(<PointerEvent>[
+    ]));
+    expect(_binding.postFrameCallbacks, hasLength(1));
+
+    _binding.flushPostFrameCallbacks(Duration.zero);
+    expect(events, _equalToEventsOnCriticalFields(<PointerEvent>[
+      const PointerEnterEvent(position: Offset(0.0, 100.0)),
+    ]));
+    events.clear();
+
+    // Detach the annotation
+    isInHitRegion = false;
+    _mouseTracker.detachAnnotation(annotation);
+    expect(events, _equalToEventsOnCriticalFields(<PointerEvent>[
+      const PointerExitEvent(position: Offset(0.0, 100.0)),
+    ]));
+    expect(_binding.postFrameCallbacks, hasLength(0));
+  });
+
+  test('should correctly stay quiet when annotations are attached or detached not on the pointer', () {
+    final List<PointerEvent> events = <PointerEvent>[];
+    final MouseTrackerAnnotation annotation = MouseTrackerAnnotation(
+      onEnter: (PointerEnterEvent event) => events.add(event),
+      onHover: (PointerHoverEvent event) => events.add(event),
+      onExit: (PointerExitEvent event) => events.add(event),
+    );
+    _setUpMouseAnnotationFinder((Offset position) sync* {
+      // This annotation is never in the region
+    });
+
+    // Connect a mouse when there is no annotation
+    ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
+      _pointerData(PointerChange.add, const Offset(0.0, 100.0)),
+    ]));
+    expect(events, _equalToEventsOnCriticalFields(<PointerEvent>[
+    ]));
+    expect(_mouseTracker.mouseIsConnected, isTrue);
+    events.clear();
+
+    // Attach an annotation out of region
     _mouseTracker.attachAnnotation(annotation);
     expect(events, _equalToEventsOnCriticalFields(<PointerEvent>[
     ]));
-    expect(_binding.postFrameCallbacks, hasLength(0));
-
-    _binding.scheduleMouseTrackerPostFrameCheck();
     expect(_binding.postFrameCallbacks, hasLength(1));
 
     _binding.flushPostFrameCallbacks(Duration.zero);
@@ -575,14 +388,11 @@ void main() {
     ]));
     events.clear();
 
-    // Detaching an annotation should not trigger events.
+    // Detach the annotation
     _mouseTracker.detachAnnotation(annotation);
     expect(events, _equalToEventsOnCriticalFields(<PointerEvent>[
     ]));
     expect(_binding.postFrameCallbacks, hasLength(0));
-
-    _binding.scheduleMouseTrackerPostFrameCheck();
-    expect(_binding.postFrameCallbacks, hasLength(1));
 
     ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, const Offset(0.0, 100.0)),
@@ -629,7 +439,6 @@ void main() {
     });
 
     final ui.PointerDataPacket packet = ui.PointerDataPacket(data: <ui.PointerData>[
-      _pointerData(PointerChange.add, const Offset(0.0, 101.0)),
       _pointerData(PointerChange.hover, const Offset(1.0, 101.0)),
     ]);
 
@@ -641,7 +450,7 @@ void main() {
     _mouseTracker.detachAnnotation(annotation2);
     isInHitRegionTwo = false;
 
-    // Passes if no errors are thrown.
+    // Passes if no errors are thrown
   });
 
   test('should not call annotationFinder when no annotations are attached', () {
@@ -651,19 +460,22 @@ void main() {
     int finderCalled = 0;
     _setUpMouseAnnotationFinder((Offset position) sync* {
       finderCalled++;
-      // This annotation is never in the region.
+      // This annotation is never in the region
     });
 
     // When no annotations are attached, hovering should not call finder.
     ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
-      _pointerData(PointerChange.add, const Offset(0.0, 101.0)),
+      _pointerData(PointerChange.hover, const Offset(0.0, 101.0)),
     ]));
     expect(finderCalled, 0);
 
-    // Attaching should not call finder.
+    // Attaching should call finder during the post frame.
     _mouseTracker.attachAnnotation(annotation);
-    _binding.flushPostFrameCallbacks(Duration.zero);
     expect(finderCalled, 0);
+
+    _binding.flushPostFrameCallbacks(Duration.zero);
+    expect(finderCalled, 1);
+    finderCalled = 0;
 
     // When annotations are attached, hovering should call finder.
     ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
@@ -672,9 +484,9 @@ void main() {
     expect(finderCalled, 1);
     finderCalled = 0;
 
-    // Detaching an annotation should not call finder.
+    // Detaching an annotation should not call finder (because only history
+    // records are needed).
     _mouseTracker.detachAnnotation(annotation);
-    _binding.flushPostFrameCallbacks(Duration.zero);
     expect(finderCalled, 0);
 
     // When all annotations are detached, hovering should not call finder.
@@ -707,7 +519,7 @@ void main() {
       onHover: (PointerHoverEvent event) => logs.add('hoverB'),
     );
     _setUpMouseAnnotationFinder((Offset position) sync* {
-      // Children's annotations come before parents'.
+      // Children's annotations come before parents'
       if (isInB) {
         yield annotationB;
         yield annotationA;
@@ -716,14 +528,14 @@ void main() {
     _mouseTracker.attachAnnotation(annotationA);
     _mouseTracker.attachAnnotation(annotationB);
 
-    // Starts out of A.
+    // Starts out of A
     isInB = false;
     ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
-      _pointerData(PointerChange.add, const Offset(0.0, 1.0)),
+      _pointerData(PointerChange.hover, const Offset(0.0, 1.0)),
     ]));
     expect(logs, <String>[]);
 
-    // Moves into B within one frame.
+    // Moves into B within one frame
     isInB = true;
     ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(0.0, 10.0)),
@@ -731,7 +543,7 @@ void main() {
     expect(logs, <String>['enterA', 'enterB', 'hoverA', 'hoverB']);
     logs.clear();
 
-    // Moves out of A within one frame.
+    // Moves out of A within one frame
     isInB = false;
     ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(0.0, 20.0)),
@@ -771,16 +583,16 @@ void main() {
     _mouseTracker.attachAnnotation(annotationA);
     _mouseTracker.attachAnnotation(annotationB);
 
-    // Starts within A.
+    // Starts within A
     isInA = true;
     isInB = false;
     ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
-      _pointerData(PointerChange.add, const Offset(0.0, 1.0)),
+      _pointerData(PointerChange.hover, const Offset(0.0, 1.0)),
     ]));
-    expect(logs, <String>['enterA']);
+    expect(logs, <String>['enterA', 'hoverA']);
     logs.clear();
 
-    // Moves into B within one frame.
+    // Moves into B within one frame
     isInA = false;
     isInB = true;
     ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
@@ -789,7 +601,7 @@ void main() {
     expect(logs, <String>['exitA', 'enterB', 'hoverB']);
     logs.clear();
 
-    // Moves into A within one frame.
+    // Moves into A within one frame
     isInA = true;
     isInB = false;
     ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[

--- a/packages/flutter/test/material/ink_well_test.dart
+++ b/packages/flutter/test/material/ink_well_test.dart
@@ -385,7 +385,6 @@ void main() {
     await tester.pumpAndSettle();
     expect(focusNode.hasPrimaryFocus, isTrue);
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-    await gesture.addPointer();
     addTearDown(gesture.removePointer);
     await gesture.moveTo(tester.getCenter(find.byKey(childKey)));
     await tester.pumpAndSettle();

--- a/packages/flutter/test/material/radio_test.dart
+++ b/packages/flutter/test/material/radio_test.dart
@@ -559,3 +559,4 @@ void main() {
     expect(box.size, equals(const Size(60, 36)));
   });
 }
+

--- a/packages/flutter/test/material/switch_test.dart
+++ b/packages/flutter/test/material/switch_test.dart
@@ -749,7 +749,6 @@ void main() {
 
     // Start hovering
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-    await gesture.addPointer();
     addTearDown(gesture.removePointer);
     await gesture.moveTo(tester.getCenter(find.byType(Switch)));
 

--- a/packages/flutter/test/widgets/drawer_test.dart
+++ b/packages/flutter/test/widgets/drawer_test.dart
@@ -82,9 +82,10 @@ void main() {
     final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
     final List<String> logs = <String>[];
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-    // Start out of hoverTarget
-    await gesture.addPointer(location: const Offset(100, 100));
     addTearDown(gesture.removePointer);
+
+    // Start out of hoverTarget
+    await gesture.moveTo(const Offset(100, 100));
 
     await tester.pumpWidget(
       MaterialApp(

--- a/packages/flutter/test/widgets/listener_deprecated_test.dart
+++ b/packages/flutter/test/widgets/listener_deprecated_test.dart
@@ -145,7 +145,7 @@ void main() {
       expect(exit, isNotNull);
       expect(exit.position, equals(const Offset(1.0, 1.0)));
     });
-    testWidgets('does not detect pointer exit when widget disappears', (WidgetTester tester) async {
+    testWidgets('detects pointer exit when widget disappears', (WidgetTester tester) async {
       PointerEnterEvent enter;
       PointerHoverEvent move;
       PointerExitEvent exit;
@@ -177,7 +177,8 @@ void main() {
           height: 100.0,
         ),
       ));
-      expect(exit, isNull);
+      expect(exit, isNotNull);
+      expect(exit.position, equals(const Offset(400.0, 300.0)));
       expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener.hoverAnnotation), isFalse);
     });
     testWidgets('Hover works with nested listeners', (WidgetTester tester) async {
@@ -528,15 +529,14 @@ void main() {
       );
       await tester.pump();
       expect(HoverClientState.numEntries, equals(1));
-      // Unmounting a MouseRegion doesn't trigger onExit
-      expect(HoverClientState.numExits, equals(0));
+      expect(HoverClientState.numExits, equals(1));
 
       await tester.pumpWidget(
         const Center(child: HoverFeedback()),
       );
       await tester.pump();
       expect(HoverClientState.numEntries, equals(2));
-      expect(HoverClientState.numExits, equals(0));
+      expect(HoverClientState.numExits, equals(1));
     });
 
     testWidgets("Listener activate/deactivate don't duplicate annotations", (WidgetTester tester) async {
@@ -559,15 +559,14 @@ void main() {
         Center(child: Container(child: HoverFeedback(key: feedbackKey))),
       );
       await tester.pump();
-      expect(HoverClientState.numEntries, equals(1));
-      expect(HoverClientState.numExits, equals(0));
+      expect(HoverClientState.numEntries, equals(2));
+      expect(HoverClientState.numExits, equals(1));
       await tester.pumpWidget(
         Container(),
       );
       await tester.pump();
-      expect(HoverClientState.numEntries, equals(1));
-      // Unmounting a MouseRegion doesn't trigger onExit
-      expect(HoverClientState.numExits, equals(0));
+      expect(HoverClientState.numEntries, equals(2));
+      expect(HoverClientState.numExits, equals(2));
     });
 
     testWidgets('Exit event when unplugging mouse should have a position', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/mouse_region_test.dart
+++ b/packages/flutter/test/widgets/mouse_region_test.dart
@@ -172,7 +172,8 @@ void main() {
         height: 100.0,
       ),
     ));
-    expect(exit, isNull);
+    expect(exit, isNotNull);
+    expect(exit.position, equals(const Offset(400.0, 300.0)));
     expect(tester.binding.mouseTracker.isAnnotationAttached(renderListener.hoverAnnotation), isFalse);
   });
 
@@ -486,6 +487,7 @@ void main() {
     expect(bottomLeft.dy - topLeft.dy, scaleFactor * localHeight);
 
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(gesture.removePointer);
     await gesture.addPointer();
     addTearDown(gesture.removePointer);
     await gesture.moveTo(topLeft - const Offset(1, 1));
@@ -514,6 +516,7 @@ void main() {
   testWidgets('needsCompositing updates correctly and is respected', (WidgetTester tester) async {
     // Pretend that we have a mouse connected.
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(gesture.removePointer);
     await gesture.addPointer();
     addTearDown(gesture.removePointer);
 
@@ -599,7 +602,7 @@ void main() {
     );
     await tester.pump();
     expect(numEntries, equals(1));
-    expect(numExits, equals(0));
+    expect(numExits, equals(1));
 
     await tester.pumpWidget(
       Center(
@@ -610,12 +613,13 @@ void main() {
     );
     await tester.pump();
     expect(numEntries, equals(2));
-    expect(numExits, equals(0));
+    expect(numExits, equals(1));
   });
 
   testWidgets("MouseRegion activate/deactivate don't duplicate annotations", (WidgetTester tester) async {
     final GlobalKey feedbackKey = GlobalKey();
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(gesture.removePointer);
     await gesture.addPointer();
     addTearDown(gesture.removePointer);
 
@@ -647,14 +651,14 @@ void main() {
       ))),
     );
     await tester.pump();
-    expect(numEntries, equals(1));
-    expect(numExits, equals(0));
+    expect(numEntries, equals(2));
+    expect(numExits, equals(1));
     await tester.pumpWidget(
       Container(),
     );
     await tester.pump();
-    expect(numEntries, equals(1));
-    expect(numExits, equals(0));
+    expect(numEntries, equals(2));
+    expect(numExits, equals(2));
   });
 
   testWidgets('Exit event when unplugging mouse should have a position', (WidgetTester tester) async {
@@ -764,151 +768,6 @@ void main() {
     expect(paintCount, 1);
   });
 
-  testWidgets('A MouseRegion mounted under the pointer should should take effect in the next postframe', (WidgetTester tester) async {
-    bool hovered = false;
-
-    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-    await gesture.addPointer(location: const Offset(5, 5));
-    addTearDown(gesture.removePointer);
-
-    await tester.pumpWidget(
-      StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
-        return _ColumnContainer(
-          children: <Widget>[
-            Text(hovered ? 'hover outer' : 'unhover outer'),
-          ],
-        );
-      }),
-    );
-
-    expect(find.text('unhover outer'), findsOneWidget);
-
-    await tester.pumpWidget(
-      StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
-        return _ColumnContainer(
-          children: <Widget>[
-            HoverClient(
-              onHover: (bool value) { setState(() { hovered = value; }); },
-              child: Text(hovered ? 'hover inner' : 'unhover inner'),
-            ),
-            Text(hovered ? 'hover outer' : 'unhover outer'),
-          ],
-        );
-      }),
-    );
-
-    expect(find.text('unhover outer'), findsOneWidget);
-    expect(find.text('unhover inner'), findsOneWidget);
-
-    await tester.pump();
-
-    expect(find.text('hover outer'), findsOneWidget);
-    expect(find.text('hover inner'), findsOneWidget);
-    expect(tester.binding.hasScheduledFrame, isFalse);
-  });
-
-  testWidgets('A MouseRegion unmounted under the pointer should not trigger state change', (WidgetTester tester) async {
-    bool hovered = true;
-
-    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-    await gesture.addPointer(location: const Offset(5, 5));
-    addTearDown(gesture.removePointer);
-
-    await tester.pumpWidget(
-      StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
-        return _ColumnContainer(
-          children: <Widget>[
-            HoverClient(
-              onHover: (bool value) { setState(() { hovered = value; }); },
-              child: Text(hovered ? 'hover inner' : 'unhover inner'),
-            ),
-            Text(hovered ? 'hover outer' : 'unhover outer'),
-          ],
-        );
-      }),
-    );
-
-    expect(find.text('hover outer'), findsOneWidget);
-    expect(find.text('hover inner'), findsOneWidget);
-    expect(tester.binding.hasScheduledFrame, isTrue);
-
-    await tester.pump();
-    expect(find.text('hover outer'), findsOneWidget);
-    expect(find.text('hover inner'), findsOneWidget);
-    expect(tester.binding.hasScheduledFrame, isFalse);
-
-    await tester.pumpWidget(
-      StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
-        return _ColumnContainer(
-          children: <Widget> [
-            Text(hovered ? 'hover outer' : 'unhover outer'),
-          ],
-        );
-      }),
-    );
-
-    expect(find.text('hover outer'), findsOneWidget);
-    expect(tester.binding.hasScheduledFrame, isFalse);
-  });
-
-  testWidgets('A MouseRegion moved into the mouse should take effect in the next postframe', (WidgetTester tester) async {
-    bool hovered = false;
-    final List<bool> logHovered = <bool>[];
-    bool moved = false;
-    StateSetter mySetState;
-
-    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-    await gesture.addPointer(location: const Offset(5, 5));
-    addTearDown(gesture.removePointer);
-
-    await tester.pumpWidget(
-      StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
-        mySetState = setState;
-        return _ColumnContainer(
-          children: <Widget>[
-            Container(
-              height: 100,
-              width: 10,
-              alignment: moved ? Alignment.topLeft : Alignment.bottomLeft,
-              child: Container(
-                height: 10,
-                width: 10,
-                child: HoverClient(
-                  onHover: (bool value) {
-                    setState(() { hovered = value; });
-                    logHovered.add(value);
-                  },
-                  child: Text(hovered ? 'hover inner' : 'unhover inner'),
-                ),
-              ),
-            ),
-            Text(hovered ? 'hover outer' : 'unhover outer'),
-          ],
-        );
-      }),
-    );
-
-    expect(find.text('unhover inner'), findsOneWidget);
-    expect(find.text('unhover outer'), findsOneWidget);
-    expect(logHovered, isEmpty);
-    expect(tester.binding.hasScheduledFrame, isFalse);
-
-    mySetState(() { moved = true; });
-    // The first frame is for the widget movement to take effect.
-    await tester.pump();
-    expect(find.text('unhover inner'), findsOneWidget);
-    expect(find.text('unhover outer'), findsOneWidget);
-    expect(logHovered, <bool>[true]);
-    logHovered.clear();
-
-    // The second frame is for the mouse hover to take effect.
-    await tester.pump();
-    expect(find.text('hover inner'), findsOneWidget);
-    expect(find.text('hover outer'), findsOneWidget);
-    expect(logHovered, isEmpty);
-    expect(tester.binding.hasScheduledFrame, isFalse);
-  });
-
   group('MouseRegion respects opacity:', () {
 
     // A widget that contains 3 MouseRegions:
@@ -990,37 +849,37 @@ void main() {
       addTearDown(gesture.removePointer);
       await tester.pumpAndSettle();
 
-      // Move to the overlapping area.
+      // Move to the overlapping area
       await gesture.moveTo(const Offset(75, 75));
       await tester.pumpAndSettle();
       expect(logs, <String>['enterA', 'enterB', 'enterC']);
       logs.clear();
 
-      // Move to the B only area.
+      // Move to the B only area
       await gesture.moveTo(const Offset(25, 75));
       await tester.pumpAndSettle();
       expect(logs, <String>['exitC']);
       logs.clear();
 
-      // Move back to the overlapping area.
+      // Move back to the overlapping area
       await gesture.moveTo(const Offset(75, 75));
       await tester.pumpAndSettle();
       expect(logs, <String>['enterC']);
       logs.clear();
 
-      // Move to the C only area.
+      // Move to the C only area
       await gesture.moveTo(const Offset(125, 75));
       await tester.pumpAndSettle();
       expect(logs, <String>['exitB']);
       logs.clear();
 
-      // Move back to the overlapping area.
+      // Move back to the overlapping area
       await gesture.moveTo(const Offset(75, 75));
       await tester.pumpAndSettle();
       expect(logs, <String>['enterB']);
       logs.clear();
 
-      // Move out.
+      // Move out
       await gesture.moveTo(const Offset(160, 160));
       await tester.pumpAndSettle();
       expect(logs, <String>['exitC', 'exitB', 'exitA']);
@@ -1038,37 +897,37 @@ void main() {
       addTearDown(gesture.removePointer);
       await tester.pumpAndSettle();
 
-      // Move to the overlapping area.
+      // Move to the overlapping area
       await gesture.moveTo(const Offset(75, 75));
       await tester.pumpAndSettle();
       expect(logs, <String>['enterA', 'enterC']);
       logs.clear();
 
-      // Move to the B only area.
+      // Move to the B only area
       await gesture.moveTo(const Offset(25, 75));
       await tester.pumpAndSettle();
       expect(logs, <String>['exitC', 'enterB']);
       logs.clear();
 
-      // Move back to the overlapping area.
+      // Move back to the overlapping area
       await gesture.moveTo(const Offset(75, 75));
       await tester.pumpAndSettle();
       expect(logs, <String>['exitB', 'enterC']);
       logs.clear();
 
-      // Move to the C only area.
+      // Move to the C only area
       await gesture.moveTo(const Offset(125, 75));
       await tester.pumpAndSettle();
       expect(logs, <String>[]);
       logs.clear();
 
-      // Move back to the overlapping area.
+      // Move back to the overlapping area
       await gesture.moveTo(const Offset(75, 75));
       await tester.pumpAndSettle();
       expect(logs, <String>[]);
       logs.clear();
 
-      // Move out.
+      // Move out
       await gesture.moveTo(const Offset(160, 160));
       await tester.pumpAndSettle();
       expect(logs, <String>['exitC', 'exitA']);
@@ -1086,13 +945,13 @@ void main() {
       addTearDown(gesture.removePointer);
       await tester.pumpAndSettle();
 
-      // Move to the overlapping area.
+      // Move to the overlapping area
       await gesture.moveTo(const Offset(75, 75));
       await tester.pumpAndSettle();
       expect(logs, <String>['enterA', 'enterC']);
       logs.clear();
 
-      // Move out.
+      // Move out
       await gesture.moveTo(const Offset(160, 160));
       await tester.pumpAndSettle();
       expect(logs, <String>['exitC', 'exitA']);
@@ -1202,7 +1061,7 @@ void main() {
   });
 }
 
-// This widget allows you to send a callback that is called during `onPaint`.
+// This widget allows you to send a callback that is called during `onPaint.
 @immutable
 class _PaintDelegateWidget extends SingleChildRenderObjectWidget {
   const _PaintDelegateWidget({
@@ -1271,27 +1130,6 @@ class _HoverClientWithClosuresState extends State<_HoverClientWithClosures> {
           });
         },
         child: Text(_hovering ? 'HOVERING' : 'not hovering'),
-      ),
-    );
-  }
-}
-
-// A column that aligns to the top left.
-class _ColumnContainer extends StatelessWidget {
-  const _ColumnContainer({
-    @required this.children,
-  }) : assert(children != null);
-
-  final List<Widget> children;
-
-  @override
-  Widget build(BuildContext context) {
-    return Directionality(
-      textDirection: TextDirection.ltr,
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.start,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: children,
       ),
     );
   }


### PR DESCRIPTION
This PR reverts https://github.com/flutter/flutter/pull/44631 because of https://github.com/flutter/flutter/issues/46162.