### PR TITLE
Add buildNumber param to "flutter build aar" command

### DIFF
--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -623,14 +623,14 @@ Uri parseServiceUri(String line, {
 /// Checks that the file exists, otherwise throws a [FileSystemException].
 void checkFileExists(String file) {
   if (!exists(File(file))) {
-    throw FileSystemException('Expected file to exit.', file);
+    throw FileSystemException('Expected file to exist.', file);
   }
 }
 
 /// Checks that the file does not exists, otherwise throws a [FileSystemException].
 void checkFileNotExists(String file) {
   if (exists(File(file))) {
-    throw FileSystemException('Expected file to exit.', file);
+    throw FileSystemException('Expected file to not exist.', file);
   }
 }
 

--- a/packages/flutter_tools/gradle/aar_init_script.gradle
+++ b/packages/flutter_tools/gradle/aar_init_script.gradle
@@ -20,15 +20,20 @@ void configureProject(Project project, String outputDir) {
 
     project.apply plugin: "maven"
 
-    project.android.libraryVariants.all { variant ->
-        addAarTask(project, variant)
-    }
     // Snapshot versions include the timestamp in the artifact name.
     // Therefore, remove the snapshot part, so new runs of `flutter build aar` overrides existing artifacts.
     // This version isn't relevant in Flutter since the pub version is used
     // to resolve dependencies.
     project.version = project.version.replace("-SNAPSHOT", "")
 
+    if (project.hasProperty("buildNumber")) {
+        project.version = project.property("buildNumber")
+    }
+
+    project.android.libraryVariants.all { variant ->
+        addAarTask(project, variant)
+    }
+    
     project.uploadArchives {
         repositories {
             mavenDeployer {
@@ -39,6 +44,7 @@ void configureProject(Project project, String outputDir) {
     if (!project.property("is-plugin").toBoolean()) {
         return
     }
+
     if (project.hasProperty('localEngineOut')) {
         // TODO(egarciad): Support local engine.
         // This most likely requires refactoring `flutter.gradle`, so the logic can be reused.

--- a/packages/flutter_tools/lib/src/android/android_builder.dart
+++ b/packages/flutter_tools/lib/src/android/android_builder.dart
@@ -29,6 +29,7 @@ abstract class AndroidBuilder {
     @required Set<AndroidBuildInfo> androidBuildInfo,
     @required String target,
     @required String outputDirectoryPath,
+    @required String buildNumber,
   });
 
   /// Builds an APK artifact.
@@ -57,6 +58,7 @@ class _AndroidBuilderImpl extends AndroidBuilder {
     @required Set<AndroidBuildInfo> androidBuildInfo,
     @required String target,
     @required String outputDirectoryPath,
+    @required String buildNumber,
   }) async {
     try {
       Directory outputDirectory =
@@ -71,6 +73,7 @@ class _AndroidBuilderImpl extends AndroidBuilder {
           androidBuildInfo: androidBuildInfo,
           target: target,
           outputDirectory: outputDirectory,
+          buildNumber: buildNumber,
         );
       }
       printHowToConsumeAar(
@@ -80,6 +83,7 @@ class _AndroidBuilderImpl extends AndroidBuilder {
           }).toSet(),
         androidPackage: project.manifest.androidPackage,
         repoDirectory: getRepoDirectory(outputDirectory),
+        buildNumber: buildNumber,
       );
     } finally {
       androidSdk.reinitialize();

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -477,11 +477,13 @@ Future<void> buildGradleApp({
 /// * [project] is typically [FlutterProject.current()].
 /// * [androidBuildInfo] is the build configuration.
 /// * [outputDir] is the destination of the artifacts,
+/// * [buildNumber] is the build number of the output aar,
 Future<void> buildGradleAar({
   @required FlutterProject project,
   @required AndroidBuildInfo androidBuildInfo,
   @required String target,
   @required Directory outputDirectory,
+  @required String buildNumber,
 }) async {
   assert(project != null);
   assert(target != null);
@@ -491,6 +493,7 @@ Future<void> buildGradleAar({
   if (androidSdk == null) {
     exitWithNoSdkMessage();
   }
+
   final FlutterManifest manifest = project.manifest;
   if (!manifest.isModule && !manifest.isPlugin) {
     throwToolExit('AARs can only be built for plugin or module projects.');
@@ -517,6 +520,7 @@ Future<void> buildGradleAar({
     '-Pflutter-root=$flutterRoot',
     '-Poutput-dir=${outputDirectory.path}',
     '-Pis-plugin=${manifest.isPlugin}',
+    '-PbuildNumber=$buildNumber'
   ];
 
   if (target != null && target.isNotEmpty) {
@@ -587,10 +591,12 @@ void printHowToConsumeAar({
   @required Set<String> buildModes,
   @required String androidPackage,
   @required Directory repoDirectory,
+  String buildNumber,
 }) {
   assert(buildModes != null && buildModes.isNotEmpty);
   assert(androidPackage != null);
   assert(repoDirectory != null);
+  buildNumber ??= '1.0';
 
   printStatus('''
 
@@ -613,7 +619,7 @@ ${terminal.bolden('Consuming the Module')}
 
   for (String buildMode in buildModes) {
     printStatus('''
-      ${buildMode}Implementation '$androidPackage:flutter_$buildMode:1.0''');
+      ${buildMode}Implementation '$androidPackage:flutter_$buildMode:$buildNumber''');
   }
 
 printStatus('''
@@ -721,6 +727,7 @@ Future<void> buildPluginsAsAar(
         ),
         target: '',
         outputDirectory: buildDirectory,
+        buildNumber: '1.0'
       );
     } on ToolExit {
       // Log the entire plugin entry in `.flutter-plugins` since it

--- a/packages/flutter_tools/lib/src/commands/build_aar.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aar.dart
@@ -33,6 +33,7 @@ class BuildAarCommand extends BuildSubCommand {
         help: 'Build a release version of the current project.',
       );
     usesFlavorOption();
+    usesBuildNumberOption();
     usesPubOption();
     argParser
       ..addMultiOption(
@@ -85,17 +86,22 @@ class BuildAarCommand extends BuildSubCommand {
   @override
   Future<FlutterCommandResult> runCommand() async {
     final Set<AndroidBuildInfo> androidBuildInfo = <AndroidBuildInfo>{};
-    final Iterable<AndroidArch> targetArchitectures = stringsArg('target-platform')
-      .map<AndroidArch>(getAndroidArchForName);
+
+    final Iterable<AndroidArch> targetArchitectures =
+        stringsArg('target-platform').map<AndroidArch>(getAndroidArchForName);
+
+    final String buildNumber = argParser.options.containsKey('build-number')
+      && stringArg('build-number') != null
+      && stringArg('build-number').isNotEmpty
+      ? stringArg('build-number')
+      : '1.0';
 
     for (String buildMode in const <String>['debug', 'profile', 'release']) {
       if (boolArg(buildMode)) {
-        androidBuildInfo.add(
-          AndroidBuildInfo(
-            BuildInfo(BuildMode.fromName(buildMode), stringArg('flavor')),
-            targetArchs: targetArchitectures,
-          )
-        );
+        androidBuildInfo.add(AndroidBuildInfo(
+          BuildInfo(BuildMode.fromName(buildMode), stringArg('flavor')),
+          targetArchs: targetArchitectures,
+        ));
       }
     }
     if (androidBuildInfo.isEmpty) {
@@ -106,6 +112,7 @@ class BuildAarCommand extends BuildSubCommand {
       target: '', // Not needed because this command only builds Android's code.
       androidBuildInfo: androidBuildInfo,
       outputDirectoryPath: stringArg('output-dir'),
+      buildNumber: buildNumber,
     );
     return null;
   }

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -936,6 +936,7 @@ plugin2=${plugin2.path}
           '-Pflutter-root=$flutterRoot',
           '-Poutput-dir=${buildDirectory.path}',
           '-Pis-plugin=true',
+          '-PbuildNumber=1.0',
           '-Ptarget-platform=android-arm,android-arm64,android-x64',
           'assembleAarRelease',
         ],
@@ -950,6 +951,7 @@ plugin2=${plugin2.path}
           '-Pflutter-root=$flutterRoot',
           '-Poutput-dir=${buildDirectory.path}',
           '-Pis-plugin=true',
+          '-PbuildNumber=1.0',
           '-Ptarget-platform=android-arm,android-arm64,android-x64',
           'assembleAarRelease',
         ],
@@ -1548,6 +1550,7 @@ plugin2=${plugin2.path}
         project: FlutterProject.current(),
         outputDirectory: fs.directory('build/'),
         target: '',
+        buildNumber: '1.0',
       );
 
       expect(
@@ -1710,6 +1713,7 @@ plugin2=${plugin2.path}
         project: FlutterProject.current(),
         outputDirectory: fs.directory('build/'),
         target: '',
+        buildNumber: '2.0',
       );
 
       final List<String> actualGradlewCall = verify(
@@ -1724,6 +1728,7 @@ plugin2=${plugin2.path}
       expect(actualGradlewCall, contains('-Plocal-engine-out=out/android_arm'));
       expect(actualGradlewCall, contains('-Plocal-engine-repo=/.tmp_rand0/flutter_tool_local_engine_repo.rand0'));
       expect(actualGradlewCall, contains('-Plocal-engine-build-mode=release'));
+      expect(actualGradlewCall, contains('-PbuildNumber=2.0'));
 
     }, overrides: <Type, Generator>{
       AndroidSdk: () => mockAndroidSdk,
@@ -1742,6 +1747,7 @@ plugin2=${plugin2.path}
         buildModes: const <String>{'release', 'debug', 'profile'},
         androidPackage: 'com.mycompany',
         repoDirectory: fs.directory('build/'),
+        buildNumber: '2.2',
       );
 
       expect(
@@ -1764,9 +1770,9 @@ plugin2=${plugin2.path}
           '  3. Make the host app depend on the Flutter module:\n'
           '\n'
           '    dependencies {\n'
-          '      releaseImplementation \'com.mycompany:flutter_release:1.0\n'
-          '      debugImplementation \'com.mycompany:flutter_debug:1.0\n'
-          '      profileImplementation \'com.mycompany:flutter_profile:1.0\n'
+          '      releaseImplementation \'com.mycompany:flutter_release:2.2\n'
+          '      debugImplementation \'com.mycompany:flutter_debug:2.2\n'
+          '      profileImplementation \'com.mycompany:flutter_profile:2.2\n'
           '    }\n'
           '\n'
           '\n'
@@ -1872,6 +1878,7 @@ plugin2=${plugin2.path}
         buildModes: const <String>{'profile'},
         androidPackage: 'com.mycompany',
         repoDirectory: fs.directory('build/'),
+        buildNumber: '1.0',
       );
 
       expect(

--- a/packages/flutter_tools/test/src/android_common.dart
+++ b/packages/flutter_tools/test/src/android_common.dart
@@ -16,6 +16,7 @@ class FakeAndroidBuilder implements AndroidBuilder {
     @required Set<AndroidBuildInfo> androidBuildInfo,
     @required String target,
     @required String outputDirectoryPath,
+    @required String buildNumber,
   }) async {}
 
   @override


### PR DESCRIPTION
## Description

We are building flutter aars to publish to Maven to be consumed by our android application and flutter build aar only allows us to output it as a "1.0" version, you can confirm this by looking at the tests.

This change adds the `--build-number` option to the AAR build command. Example: `flutter build aar --build-number 2.0.0`

## Related Issues

Adds #46108

## Tests

I added the following tests:

I modified existing tests to fit the scenario.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes