### PR TITLE
ImageStreamCompleter always cache previous error

### DIFF
--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -321,8 +321,8 @@ class ImageStream extends Diagnosticable {
 /// configure it with the right [ImageStreamCompleter] when possible.
 abstract class ImageStreamCompleter extends Diagnosticable {
   final List<ImageStreamListener> _listeners = <ImageStreamListener>[];
-  ImageInfo _currentImage;
-  FlutterErrorDetails _currentError;
+  ImageInfo currentImage;
+  FlutterErrorDetails currentError;
 
   /// Whether any listeners are currently registered.
   ///
@@ -353,9 +353,9 @@ abstract class ImageStreamCompleter extends Diagnosticable {
   /// {@macro flutter.painting.imageStream.addListener}
   void addListener(ImageStreamListener listener) {
     _listeners.add(listener);
-    if (_currentImage != null) {
+    if (currentImage != null) {
       try {
-        listener.onImage(_currentImage, true);
+        listener.onImage(currentImage, true);
       } catch (exception, stack) {
         reportError(
           context: ErrorDescription('by a synchronously-called image listener'),
@@ -364,9 +364,9 @@ abstract class ImageStreamCompleter extends Diagnosticable {
         );
       }
     }
-    if (_currentError != null && listener.onError != null) {
+    if (currentError != null && listener.onError != null) {
       try {
-        listener.onError(_currentError.exception, _currentError.stack);
+        listener.onError(currentError.exception, currentError.stack);
       } catch (exception, stack) {
         FlutterError.reportError(
           FlutterErrorDetails(
@@ -396,7 +396,7 @@ abstract class ImageStreamCompleter extends Diagnosticable {
   /// Calls all the registered listeners to notify them of a new image.
   @protected
   void setImage(ImageInfo image) {
-    _currentImage = image;
+    currentImage = image;
     if (_listeners.isEmpty)
       return;
     // Make a copy to allow for concurrent modification.
@@ -451,7 +451,7 @@ abstract class ImageStreamCompleter extends Diagnosticable {
     InformationCollector informationCollector,
     bool silent = false,
   }) {
-    _currentError = FlutterErrorDetails(
+    currentError = FlutterErrorDetails(
       exception: exception,
       stack: stack,
       library: 'image resource service',
@@ -467,7 +467,7 @@ abstract class ImageStreamCompleter extends Diagnosticable {
         .toList();
 
     if (localErrorListeners.isEmpty) {
-      FlutterError.reportError(_currentError);
+      FlutterError.reportError(currentError);
     } else {
       for (ImageErrorListener errorListener in localErrorListeners) {
         try {
@@ -491,7 +491,7 @@ abstract class ImageStreamCompleter extends Diagnosticable {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
-    description.add(DiagnosticsProperty<ImageInfo>('current', _currentImage, ifNull: 'unresolved', showName: false));
+    description.add(DiagnosticsProperty<ImageInfo>('current', currentImage, ifNull: 'unresolved', showName: false));
     description.add(ObjectFlagProperty<List<ImageStreamListener>>(
       'listeners',
       _listeners,


### PR DESCRIPTION
When I reuse an **ImageStreamCompleter** picked from **ImageCache** and add a **listener** to it, the **listener.onError** will be called immediately if **ImageStreamCompleter** has called its member function **reportError** previously.  Actually, **ImageStreamCompleter** always caches previous error in its private property **_currentError**. In some situation, I want to reuse the cached ImageStreamCompleter, and reload the image if the ImageStreamCompleter has encountered error previously. Due to the cached **_currentError**, the error will always be shown before successful reload. What's worse, the property **_currentError** is private and I can do nothing to change it. The code below cause this issue:
```
void addListener(ImageStreamListener listener) {
    _listeners.add(listener);
    if (currentImage != null) {
      try {
        listener.onImage(currentImage, true);
      } catch (exception, stack) {
        reportError(
          context: ErrorDescription('by a synchronously-called image listener'),
          exception: exception,
          stack: stack,
        );
      }
    }
    if (currentError != null && listener.onError != null) {
      try {
        listener.onError(currentError.exception, currentError.stack);
      } catch (exception, stack) {
        FlutterError.reportError(
          FlutterErrorDetails(
            exception: exception,
            library: 'image resource service',
            context: ErrorDescription('by a synchronously-called image error listener'),
            stack: stack,
          ),
        );
      }
    }
  }
```
If the property _currentError is public, then I can do something like clearing its last value.