### PR TITLE
allow for caller to style the action label

### DIFF
--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -84,10 +84,12 @@ class SnackBarAction extends StatefulWidget {
     Key key,
     this.textColor,
     this.disabledTextColor,
+    this.labelStyle,
     @required this.label,
     @required this.onPressed,
   }) : assert(label != null),
        assert(onPressed != null),
+       assert(textColor == null || labelStyle == null),
        super(key: key);
 
   /// The button label color. If not provided, defaults to [accentColor].
@@ -99,6 +101,10 @@ class SnackBarAction extends StatefulWidget {
 
   /// The button label.
   final String label;
+
+  /// The button label style. If not provided, defaults to [textColor].
+  /// It is an error to provide [textColor] and [labelStyle].
+  final TextStyle labelStyle;
 
   /// The callback to be called when the button is pressed. Must not be null.
   ///
@@ -112,6 +118,7 @@ class SnackBarAction extends StatefulWidget {
 
 class _SnackBarActionState extends State<SnackBarAction> {
   bool _haveTriggeredAction = false;
+  TextStyle _labelStyle;
 
   void _handlePressed() {
     if (_haveTriggeredAction)
@@ -124,14 +131,27 @@ class _SnackBarActionState extends State<SnackBarAction> {
   }
 
   @override
+  void initState() {
+    super.initState();
+
+    if (widget.labelStyle != null) {
+      _labelStyle = widget.labelStyle;
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     final SnackBarThemeData snackBarTheme = Theme.of(context).snackBarTheme;
     final Color textColor = widget.textColor ?? snackBarTheme.actionTextColor;
     final Color disabledTextColor = widget.disabledTextColor ?? snackBarTheme.disabledActionTextColor;
 
+    if (_labelStyle != null && _haveTriggeredAction) {
+      _labelStyle = _labelStyle.copyWith(color: disabledTextColor);
+    }
+
     return FlatButton(
       onPressed: _haveTriggeredAction ? null : _handlePressed,
-      child: Text(widget.label),
+      child: Text(widget.label, style: _labelStyle),
       textColor: textColor,
       disabledTextColor: disabledTextColor,
     );

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -423,6 +423,130 @@ void main() {
     }
   });
 
+  testWidgets('Snackbar labels can be styled', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+              builder: (BuildContext context) {
+                return GestureDetector(
+                  onTap: () {
+                    Scaffold.of(context).showSnackBar(
+                      SnackBar(
+                        content: const Text('I am a snack bar.'),
+                        duration: const Duration(seconds: 2),
+                        action: SnackBarAction(
+                          label: 'ACTION',
+                          labelStyle: const TextStyle(color: Colors.green),
+                          onPressed: () { },
+                        ),
+                      ),
+                    );
+                  },
+                  child: const Text('X'),
+                );
+              }
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('X'));
+    await tester.pump(); // start animation
+    await tester.pump(const Duration(milliseconds: 750));
+
+    final Element actionTextBox = tester.element(find.text('ACTION'));
+    final Widget textWidget = actionTextBox.widget;
+    final DefaultTextStyle defaultTextStyle = DefaultTextStyle.of(actionTextBox);
+    if (textWidget is Text) {
+      TextStyle effectiveStyle = textWidget.style;
+      effectiveStyle = defaultTextStyle.style.merge(textWidget.style);
+      expect(effectiveStyle.color, Colors.green);
+    } else {
+      expect(false, true);
+    }
+  });
+
+  testWidgets('SnackBar labels change to disabled color after being pressed', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+              builder: (BuildContext context) {
+                return GestureDetector(
+                  onTap: () {
+                    Scaffold.of(context).showSnackBar(
+                      SnackBar(
+                        content: const Text('I am a snack bar.'),
+                        duration: const Duration(seconds: 2),
+                        action: SnackBarAction(
+                          label: 'ACTION',
+                          labelStyle: const TextStyle(color: Colors.green),
+                          disabledTextColor: Colors.red,
+                          onPressed: () { },
+                        ),
+                      ),
+                    );
+                  },
+                  child: const Text('X'),
+                );
+              }
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('X'));
+    await tester.pump(); // start animation
+    await tester.pump(const Duration(milliseconds: 750));
+
+    await tester.tap(find.text('ACTION'));
+    await tester.pump();
+
+    final Element actionTextBox = tester.element(find.text('ACTION'));
+    final Widget textWidget = actionTextBox.widget;
+    final DefaultTextStyle defaultTextStyle = DefaultTextStyle.of(actionTextBox);
+    if (textWidget is Text) {
+      TextStyle effectiveStyle = textWidget.style;
+      effectiveStyle = defaultTextStyle.style.merge(textWidget.style);
+      expect(effectiveStyle.color, Colors.red);
+    } else {
+      expect(false, true);
+    }
+  });
+
+  testWidgets('Snackbar asserts if passed textColor and labelStyle', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+              builder: (BuildContext context) {
+                return GestureDetector(
+                  onTap: () {
+                    Scaffold.of(context).showSnackBar(
+                      SnackBar(
+                        content: const Text('I am a snack bar.'),
+                        duration: const Duration(seconds: 2),
+                        action: SnackBarAction(
+                          label: 'ACTION',
+                          labelStyle: const TextStyle(color: Colors.green),
+                          textColor: Colors.blue,
+                          onPressed: () { },
+                        ),
+                      ),
+                    );
+                  },
+                  child: const Text('X'),
+                );
+              }
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('X'));
+    expect(tester.takeException(), isNotNull);
+  });
+
   testWidgets('SnackBar button text alignment', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
       home: MediaQuery(


### PR DESCRIPTION
## Description

This PR allows for the user to style the text of the action label. Currently, the user can specify `textColor` and `disabledColor`, but not things like font size, font family, etc. Going forward, the user will specify either `textColor` or `labelStyle` and the SnackBarAction widget will pass that info along to the underlying `Text` widget. It is an error to provide both `textColor` and `labelStyle` because there is no way for the system to determine what color the user actually intended.

## Related Issues

[#46599](https://github.com/flutter/flutter/issues/46599)
[#20928](https://github.com/flutter/flutter/issues/20928)

## Tests

I added the following tests:

flutter/material/snack_bar_test.dart:
- 'Snackbar labels can be styled'
- 'SnackBar labels change to disabled color after being pressed'
- 'Snackbar asserts if passed textColor and labelStyle'

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
