### PR TITLE
[flutter_tools] Add violating plugin name to validation errors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -48,3 +48,4 @@ Rody Davis Jr <rody.davis.jr@gmail.com>
 Robin Jespersen <info@unitedpartners.de>
 Jefferson Quesado <jeff.quesado@gmail.com>
 Mark Diener <rpzrpzrpz@gmail.com>
+Alek Åström <alek.astrom@gmail.com>

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -74,7 +74,7 @@ class Plugin {
   ) {
     final List<String> errors = validatePluginYaml(pluginYaml);
     if (errors.isNotEmpty) {
-      throwToolExit('Invalid plugin specification.\n${errors.join('\n')}');
+      throwToolExit('Invalid plugin specification $name.\n${errors.join('\n')}');
     }
     if (pluginYaml != null && pluginYaml['platforms'] != null) {
       return Plugin._fromMultiPlatformYaml(name, path, pluginYaml, dependencies);
@@ -89,11 +89,11 @@ class Plugin {
     List<String> dependencies,
   ) {
     assert (pluginYaml != null && pluginYaml['platforms'] != null,
-            'Invalid multi-platform plugin specification.');
+            'Invalid multi-platform plugin specification $name.');
     final YamlMap platformsYaml = pluginYaml['platforms'] as YamlMap;
 
     assert (_validateMultiPlatformYaml(platformsYaml).isEmpty,
-            'Invalid multi-platform plugin specification.');
+            'Invalid multi-platform plugin specification $name.');
 
     final Map<String, PluginPlatform> platforms = <String, PluginPlatform>{};
 

--- a/packages/flutter_tools/test/general.shard/plugin_parsing_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugin_parsing_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/platform_plugins.dart';
 import 'package:flutter_tools/src/plugins.dart';
 import 'package:yaml/yaml.dart';
@@ -130,8 +129,10 @@ void main() {
           '  package: com.flutter.dev\n';
 
       final YamlMap pluginYaml = loadYaml(pluginYamlRaw) as YamlMap;
-      final Plugin Function() parsePlugin = () => Plugin.fromYaml(_kTestPluginName, _kTestPluginPath, pluginYaml, const <String>[]);
-      expect(parsePlugin, throwsA(predicate<ToolExit>((ToolExit e) => e.message.contains(_kTestPluginName))));
+      expect(
+        () => Plugin.fromYaml(_kTestPluginName, _kTestPluginPath, pluginYaml, const <String>[]),
+        throwsToolExit(message: _kTestPluginName),
+      );
     });
 
     test('A default_package field is allowed', () {

--- a/packages/flutter_tools/test/general.shard/plugin_parsing_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugin_parsing_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/platform_plugins.dart';
 import 'package:flutter_tools/src/plugins.dart';
 import 'package:yaml/yaml.dart';
@@ -120,6 +121,17 @@ void main() {
       expect(webPlugin.pluginClass, 'WebSamplePlugin');
       expect(webPlugin.fileName, 'web_plugin.dart');
       expect(windowsPlugin.pluginClass, 'WinSamplePlugin');
+    });
+
+    test('Legacy Format and Multi-Platform Format together is not allowed and error message contains plugin name', () {
+      const String pluginYamlRaw = 'androidPackage: com.flutter.dev\n'
+          'platforms:\n'
+          ' android:\n'
+          '  package: com.flutter.dev\n';
+
+      final YamlMap pluginYaml = loadYaml(pluginYamlRaw) as YamlMap;
+      final Plugin Function() parsePlugin = () => Plugin.fromYaml(_kTestPluginName, _kTestPluginPath, pluginYaml, const <String>[]);
+      expect(parsePlugin, throwsA(predicate<ToolExit>((ToolExit e) => e.message.contains(_kTestPluginName))));
     });
 
     test('A default_package field is allowed', () {


### PR DESCRIPTION
## Description

Adds the name of the violating plugin to error messages when validating plugin specifications in `flutter packages get`, etc so it's easier to track down which is the violating plugin.

Console output from `flutter packages get` before:

```
Invalid plugin specification.
```

After:

```
Invalid plugin specification test_plugin_name.
```

## Tests

I added the following tests:

- `Legacy Format and Multi-Platform Format together is not allowed and error message contains plugin name` in `plugin_parsing_test.dart`
## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [X] No, no existing tests failed, so this is _not_ a breaking change.