### PR TITLE
Remove unused observer and raise the waiting time

### DIFF
--- a/dev/benchmarks/macrobenchmarks/test_memory/large_images.dart
+++ b/dev/benchmarks/macrobenchmarks/test_memory/large_images.dart
@@ -16,20 +16,9 @@ Future<void> endOfAnimation() async {
   } while (SchedulerBinding.instance.hasScheduledFrame);
 }
 
-int iteration = 0;
-
-class LifecycleObserver extends WidgetsBindingObserver {
-  @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
-    debugPrint('==== MEMORY BENCHMARK ==== $state ====');
-    debugPrint('This was lifecycle event number $iteration in this instance');
-  }
-}
-
 Future<void> main() async {
   runApp(const MacrobenchmarksApp(initialRoute: kLargeImagesRouteName));
   await endOfAnimation();
   await Future<void>.delayed(const Duration(milliseconds: 50));
   debugPrint('==== MEMORY BENCHMARK ==== READY ====');
-  WidgetsBinding.instance.addObserver(LifecycleObserver());
 }

--- a/dev/devicelab/bin/tasks/fast_scroll_large_images__memory.dart
+++ b/dev/devicelab/bin/tasks/fast_scroll_large_images__memory.dart
@@ -30,7 +30,7 @@ class FastScrollLargeImagesMemoryTest extends MemoryTest {
     await launchApp();
     await recordStart();
     await device.shellExec('input', <String>['swipe', '0 1500 0 0 50']);
-    await Future<void>.delayed(const Duration(milliseconds: 10000));
+    await Future<void>.delayed(const Duration(milliseconds: 15000));
     await recordEnd();
   }
 }


### PR DESCRIPTION
The waiting time would give our cleanup more room to finish the job, and
thus make our result more accurate.

See also https://github.com/flutter/engine/pull/14265
