### PR TITLE
Revert "prevent accidental calls to io.exit when asserts are active."

### DIFF
--- a/packages/flutter_tools/lib/src/base/io.dart
+++ b/packages/flutter_tools/lib/src/base/io.dart
@@ -26,7 +26,7 @@
 /// increase the API surface that we have to test in Flutter tools, and the APIs
 /// in `dart:io` can sometimes be hard to use in tests.
 import 'dart:async';
-import 'dart:io' as io show exit, IOSink, Platform, Process, ProcessInfo, ProcessSignal,
+import 'dart:io' as io show exit, IOSink, Process, ProcessInfo, ProcessSignal,
     stderr, stdin, Stdin, StdinException, Stdout, stdout;
 
 import 'package:meta/meta.dart';
@@ -92,26 +92,12 @@ ExitFunction _exitFunction = _defaultExitFunction;
 
 /// Exits the process.
 ///
-/// Throws [StateError] if assertions are enabled and the dart:io exit
-/// is still active when called. This may indicate exit was called in
-/// a test without being configured correctly. This behavior can be
-/// removed by setting the `FLUTTER_TEST` environment
-/// variable to a non-null string.
-///
 /// This is analogous to the `exit` function in `dart:io`, except that this
 /// function may be set to a testing-friendly value by calling
 /// [setExitFunctionForTests] (and then restored to its default implementation
 /// with [restoreExitFunction]). The default implementation delegates to
 /// `dart:io`.
-ExitFunction get exit {
-  assert(
-    _exitFunction != io.exit || io.Platform.environment['FLUTTER_TEST'] != null,
-    'io.exit was called with assertions active. If this is an integration test, '
-    'ensure that the environment variable FLUTTER_TEST is set '
-    'to a non-null String.',
-  );
-  return _exitFunction;
-}
+ExitFunction get exit => _exitFunction;
 
 /// Sets the [exit] function to a function that throws an exception rather
 /// than exiting the process; this is intended for testing purposes.

--- a/packages/flutter_tools/test/general.shard/base/io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/io_test.dart
@@ -68,16 +68,6 @@ void main() {
   testUsingContext('ProcessSignal toString() works', () async {
     expect(io.ProcessSignal.sigint.toString(), ProcessSignal.SIGINT.toString());
   });
-
-  test('exit throws a StateError if called without being overriden', () {
-    expect(() => exit(0), throwsA(isInstanceOf<AssertionError>()));
-  });
-
-  test('exit does not throw a StateError if overriden', () {
-    setExitFunctionForTests((int value) {});
-
-    expect(() => exit(0), returnsNormally);
-  });
 }
 
 class MockIoProcessSignal extends Mock implements io.ProcessSignal {}

--- a/packages/flutter_tools/test/integration.shard/daemon_mode_test.dart
+++ b/packages/flutter_tools/test/integration.shard/daemon_mode_test.dart
@@ -29,9 +29,6 @@ void main() {
     final Process process = await processManager.start(
       <String>[flutterBin, '--show-test-device', 'daemon'],
       workingDirectory: tempDir.path,
-      environment: <String, String>{
-        'FLUTTER_TEST': 'true',
-      }
     );
 
     final StreamController<String> stdout = StreamController<String>.broadcast();

--- a/packages/flutter_tools/test/integration.shard/test_utils.dart
+++ b/packages/flutter_tools/test/integration.shard/test_utils.dart
@@ -46,12 +46,7 @@ Future<void> getPackages(String folder) async {
     'pub',
     'get',
   ];
-  final ProcessResult result = await processManager.run(command,
-    workingDirectory: folder,
-    environment: <String, String>{
-    'FLUTTER_TEST': 'true'
-    },
-  );
+  final ProcessResult result = await processManager.run(command, workingDirectory: folder);
   if (result.exitCode != 0) {
     throw Exception('flutter pub get failed: ${result.stderr}\n${result.stdout}');
   }


### PR DESCRIPTION
Reverts flutter/flutter#46210

Breaks test on postsubmit:

```
01:10 +30 ~2 -1: test/analyze-sample-code_test.dart: analyze-sample-code [E]                                                                                                                           
  Expected: [
              'known_broken_documentation.dart:30:9: new Opacity(',
              '>>> Unnecessary new keyword (unnecessary_new)',
              'known_broken_documentation.dart:62:9: new Opacity(',
              '>>> Unnecessary new keyword (unnecessary_new)',
              '',
              'Found 1 sample code errors.',
              ''
            ]
    Actual: [
              'Unhandled exception:',
              'Cannot analyze dartdocs; unexpected error output:',
              '[17 issues found. (ran in 14.1s), Unhandled exception:, \'package:flutter_tools/src/base/io.dart\': Failed assertion: line 108 pos 5: \'_exitFunction != io.exit || io.Platform.environment[\'FLUTTER_TEST\'] != null\': io.exit was called with assertions active. If this is an integration test, ensure that the environment variable FLUTTER_TEST is set to a non-null String., #0      _AssertionError._doThrowNew (dart:core-patch/errors_patch.dart:42:39), #1      _AssertionError._throwNew (dart:core-patch/errors_patch.dart:38:5), #2      exit (package:flutter_tools/src/base/io.dart:108:5), #3      _exit.<anonymous closure> (package:flutter_tools/runner.dart:262:7), #4      _rootRun (dart:async/zone.dart:1122:38), #5      _CustomZone.run (dart:async/zone.dart:1023:19), #6      _CustomZone.runGuarded (dart:async/zone.dart:925:7), #7      _CustomZone.bindCallbackGuarded.<anonymous closure> (dart:async/zone.dart:965:23), #8      _rootRun (dart:async/zone.dart:1126:13), #9      _CustomZone.run (dart:async/zone.dart:1023:19), #10     _CustomZone.bindCallback.<anonymous closure> (dart:async/zone.dart:949:23), #11     Timer._createTimer.<anonymous closure> (dart:async-patch/timer_patch.dart:23:15), #12     _Timer._runTimers (dart:isolate-patch/timer_impl.dart:384:19), #13     _Timer._handleMessage (dart:isolate-patch/timer_impl.dart:418:5), #14     _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:174:12)]',
              '#0      SampleChecker._runAnalyzer (file:///tmp/flutter%20sdk/dev/bots/analyze-sample-code.dart:579:7)',
              '#1      SampleChecker._analyze (file:///tmp/flutter%20sdk/dev/bots/analyze-sample-code.dart:598:33)',
              '#2      SampleChecker.checkSamples (file:///tmp/flutter%20sdk/dev/bots/analyze-sample-code.dart:251:16)',
              '#3      main (file:///tmp/flutter%20sdk/dev/bots/analyze-sample-code.dart:114:7)',
              '#4      _startIsolate.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:305:32)',
              '#5      _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:174:12)',
              ''
            ]
     Which: was 'Unhandled exception:' instead of 'known_broken_documentation.dart:30:9: new Opacity(' at location [0]
  package:test_api                         expect
  test/analyze-sample-code_test.dart 19:5  main.<fn>
01:10 +30 ~2 -1: Some tests failed.                                                                                                                                                                    
▌21:07:41▐ ELAPSED TIME: 1min 39.078s for ../../bin/cache/dart-sdk/bin/pub run test -rcompact -j3 --no-color in dev/bots
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
ERROR: Last command exited with 1 (expected: zero).
Command: ../../bin/cache/dart-sdk/bin/pub run test -rcompact -j3 --no-color
Relative working directory: dev/bots
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```