### PR TITLE
[flutter_tool] Ensure dependency constraint for templates created with a driver test are correct

### DIFF
--- a/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
@@ -35,7 +35,7 @@ dev_dependencies:
 {{#withDriverTest}}
   flutter_driver:
     sdk: flutter
-  test: 1.6.2
+  test: 1.9.4
 {{/withDriverTest}}
 
 {{#withPluginHook}}

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -406,7 +406,7 @@ void main() {
     );
   }, overrides: <Type, Generator>{
     Pub: () => const Pub(),
-  }, skip: true); // https://github.com/flutter/flutter/issues/46142
+  });
 
   testUsingContext('module project with pub', () async {
     return _createProject(projectDir, <String>[
@@ -416,8 +416,6 @@ void main() {
       '.android/Flutter/build.gradle',
       '.android/Flutter/flutter.iml',
       '.android/Flutter/src/main/AndroidManifest.xml',
-      '.android/Flutter/src/main/java/io/flutter/facade/Flutter.java',
-      '.android/Flutter/src/main/java/io/flutter/facade/FlutterFragment.java',
       '.android/Flutter/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java',
       '.android/gradle.properties',
       '.android/gradle/wrapper/gradle-wrapper.jar',
@@ -438,10 +436,12 @@ void main() {
     ], unexpectedPaths: <String>[
       'android/',
       'ios/',
+      '.android/Flutter/src/main/java/io/flutter/facade/FlutterFragment.java',
+      '.android/Flutter/src/main/java/io/flutter/facade/Flutter.java',
     ]);
   }, overrides: <Type, Generator>{
     Pub: () => const Pub(),
-  }, skip: true); // https://github.com/flutter/flutter/issues/46142
+  });
 
 
   testUsingContext('androidx is used by default in an app project', () async {


### PR DESCRIPTION
## Description

Because of the accidentally skipped tool tests, we missed updates to these tests when we bumped the test version and removed the facade classes from the module