### PR TITLE
Add optional `endian` argument for WriteBuffer/ReadBuffer

### DIFF
--- a/packages/flutter/lib/src/foundation/serialization.dart
+++ b/packages/flutter/lib/src/foundation/serialization.dart
@@ -30,33 +30,33 @@ class WriteBuffer {
   }
 
   /// Write a Uint16 into the buffer.
-  void putUint16(int value) {
-    _eightBytes.setUint16(0, value, Endian.host);
+  void putUint16(int value, [Endian endian]) {
+    _eightBytes.setUint16(0, value, endian ?? Endian.host);
     _buffer.addAll(_eightBytesAsList, 0, 2);
   }
 
   /// Write a Uint32 into the buffer.
-  void putUint32(int value) {
-    _eightBytes.setUint32(0, value, Endian.host);
+  void putUint32(int value, [Endian endian]) {
+    _eightBytes.setUint32(0, value, endian ?? Endian.host);
     _buffer.addAll(_eightBytesAsList, 0, 4);
   }
 
   /// Write an Int32 into the buffer.
-  void putInt32(int value) {
-    _eightBytes.setInt32(0, value, Endian.host);
+  void putInt32(int value, [Endian endian]) {
+    _eightBytes.setInt32(0, value, endian ?? Endian.host);
     _buffer.addAll(_eightBytesAsList, 0, 4);
   }
 
   /// Write an Int64 into the buffer.
-  void putInt64(int value) {
-    _eightBytes.setInt64(0, value, Endian.host);
+  void putInt64(int value, [Endian endian]) {
+    _eightBytes.setInt64(0, value, endian ?? Endian.host);
     _buffer.addAll(_eightBytesAsList, 0, 8);
   }
 
   /// Write an Float64 into the buffer.
-  void putFloat64(double value) {
+  void putFloat64(double value, [Endian endian]) {
     _alignTo(8);
-    _eightBytes.setFloat64(0, value, Endian.host);
+    _eightBytes.setFloat64(0, value, endian ?? Endian.host);
     _buffer.addAll(_eightBytesAsList);
   }
 
@@ -122,37 +122,37 @@ class ReadBuffer {
   }
 
   /// Reads a Uint16 from the buffer.
-  int getUint16() {
-    final int value = data.getUint16(_position, Endian.host);
+  int getUint16([Endian endian]) {
+    final int value = data.getUint16(_position, endian ?? Endian.host);
     _position += 2;
     return value;
   }
 
   /// Reads a Uint32 from the buffer.
-  int getUint32() {
-    final int value = data.getUint32(_position, Endian.host);
+  int getUint32([Endian endian]) {
+    final int value = data.getUint32(_position, endian ?? Endian.host);
     _position += 4;
     return value;
   }
 
   /// Reads an Int32 from the buffer.
-  int getInt32() {
-    final int value = data.getInt32(_position, Endian.host);
+  int getInt32([Endian endian]) {
+    final int value = data.getInt32(_position, endian ?? Endian.host);
     _position += 4;
     return value;
   }
 
   /// Reads an Int64 from the buffer.
-  int getInt64() {
-    final int value = data.getInt64(_position, Endian.host);
+  int getInt64([Endian endian]) {
+    final int value = data.getInt64(_position, endian ?? Endian.host);
     _position += 8;
     return value;
   }
 
   /// Reads a Float64 from the buffer.
-  double getFloat64() {
+  double getFloat64([Endian endian]) {
     _alignTo(8);
-    final double value = data.getFloat64(_position, Endian.host);
+    final double value = data.getFloat64(_position, endian ?? Endian.host);
     _position += 8;
     return value;
   }

--- a/packages/flutter/lib/src/foundation/serialization.dart
+++ b/packages/flutter/lib/src/foundation/serialization.dart
@@ -30,31 +30,31 @@ class WriteBuffer {
   }
 
   /// Write a Uint16 into the buffer.
-  void putUint16(int value, [Endian endian]) {
+  void putUint16(int value, {Endian endian}) {
     _eightBytes.setUint16(0, value, endian ?? Endian.host);
     _buffer.addAll(_eightBytesAsList, 0, 2);
   }
 
   /// Write a Uint32 into the buffer.
-  void putUint32(int value, [Endian endian]) {
+  void putUint32(int value, {Endian endian}) {
     _eightBytes.setUint32(0, value, endian ?? Endian.host);
     _buffer.addAll(_eightBytesAsList, 0, 4);
   }
 
   /// Write an Int32 into the buffer.
-  void putInt32(int value, [Endian endian]) {
+  void putInt32(int value, {Endian endian}) {
     _eightBytes.setInt32(0, value, endian ?? Endian.host);
     _buffer.addAll(_eightBytesAsList, 0, 4);
   }
 
   /// Write an Int64 into the buffer.
-  void putInt64(int value, [Endian endian]) {
+  void putInt64(int value, {Endian endian}) {
     _eightBytes.setInt64(0, value, endian ?? Endian.host);
     _buffer.addAll(_eightBytesAsList, 0, 8);
   }
 
   /// Write an Float64 into the buffer.
-  void putFloat64(double value, [Endian endian]) {
+  void putFloat64(double value, {Endian endian}) {
     _alignTo(8);
     _eightBytes.setFloat64(0, value, endian ?? Endian.host);
     _buffer.addAll(_eightBytesAsList);
@@ -122,35 +122,35 @@ class ReadBuffer {
   }
 
   /// Reads a Uint16 from the buffer.
-  int getUint16([Endian endian]) {
+  int getUint16({Endian endian}) {
     final int value = data.getUint16(_position, endian ?? Endian.host);
     _position += 2;
     return value;
   }
 
   /// Reads a Uint32 from the buffer.
-  int getUint32([Endian endian]) {
+  int getUint32({Endian endian}) {
     final int value = data.getUint32(_position, endian ?? Endian.host);
     _position += 4;
     return value;
   }
 
   /// Reads an Int32 from the buffer.
-  int getInt32([Endian endian]) {
+  int getInt32({Endian endian}) {
     final int value = data.getInt32(_position, endian ?? Endian.host);
     _position += 4;
     return value;
   }
 
   /// Reads an Int64 from the buffer.
-  int getInt64([Endian endian]) {
+  int getInt64({Endian endian}) {
     final int value = data.getInt64(_position, endian ?? Endian.host);
     _position += 8;
     return value;
   }
 
   /// Reads a Float64 from the buffer.
-  double getFloat64([Endian endian]) {
+  double getFloat64({Endian endian}) {
     _alignTo(8);
     final double value = data.getFloat64(_position, endian ?? Endian.host);
     _position += 8;

--- a/packages/flutter/test/foundation/serialization_test.dart
+++ b/packages/flutter/test/foundation/serialization_test.dart
@@ -29,11 +29,11 @@ void main() {
     });
     test('of 32-bit integer in big endian', () {
       final WriteBuffer write = WriteBuffer();
-      write.putInt32(-9, Endian.big);
+      write.putInt32(-9, endian: Endian.big);
       final ByteData written = write.done();
       expect(written.lengthInBytes, equals(4));
       final ReadBuffer read = ReadBuffer(written);
-      expect(read.getInt32(Endian.big), equals(-9));
+      expect(read.getInt32(endian: Endian.big), equals(-9));
     });
     test('of 64-bit integer', () {
       final WriteBuffer write = WriteBuffer();
@@ -45,11 +45,11 @@ void main() {
     });
     test('of 64-bit integer in big endian', () {
       final WriteBuffer write = WriteBuffer();
-      write.putInt64(-9000000000000, Endian.big);
+      write.putInt64(-9000000000000, endian: Endian.big);
       final ByteData written = write.done();
       expect(written.lengthInBytes, equals(8));
       final ReadBuffer read = ReadBuffer(written);
-      expect(read.getInt64(Endian.big), equals(-9000000000000));
+      expect(read.getInt64(endian: Endian.big), equals(-9000000000000));
     });
     test('of double', () {
       final WriteBuffer write = WriteBuffer();
@@ -61,11 +61,11 @@ void main() {
     });
     test('of double in big endian', () {
       final WriteBuffer write = WriteBuffer();
-      write.putFloat64(3.14, Endian.big);
+      write.putFloat64(3.14, endian: Endian.big);
       final ByteData written = write.done();
       expect(written.lengthInBytes, equals(8));
       final ReadBuffer read = ReadBuffer(written);
-      expect(read.getFloat64(Endian.big), equals(3.14));
+      expect(read.getFloat64(endian: Endian.big), equals(3.14));
     });
     test('of 32-bit int list when unaligned', () {
       final Int32List integers = Int32List.fromList(<int>[-99, 2, 99]);

--- a/packages/flutter/test/foundation/serialization_test.dart
+++ b/packages/flutter/test/foundation/serialization_test.dart
@@ -27,6 +27,14 @@ void main() {
       final ReadBuffer read = ReadBuffer(written);
       expect(read.getInt32(), equals(-9));
     });
+    test('of 32-bit integer in big endian', () {
+      final WriteBuffer write = WriteBuffer();
+      write.putInt32(-9, Endian.big);
+      final ByteData written = write.done();
+      expect(written.lengthInBytes, equals(4));
+      final ReadBuffer read = ReadBuffer(written);
+      expect(read.getInt32(Endian.big), equals(-9));
+    });
     test('of 64-bit integer', () {
       final WriteBuffer write = WriteBuffer();
       write.putInt64(-9000000000000);
@@ -35,6 +43,14 @@ void main() {
       final ReadBuffer read = ReadBuffer(written);
       expect(read.getInt64(), equals(-9000000000000));
     });
+    test('of 64-bit integer in big endian', () {
+      final WriteBuffer write = WriteBuffer();
+      write.putInt64(-9000000000000, Endian.big);
+      final ByteData written = write.done();
+      expect(written.lengthInBytes, equals(8));
+      final ReadBuffer read = ReadBuffer(written);
+      expect(read.getInt64(Endian.big), equals(-9000000000000));
+    });
     test('of double', () {
       final WriteBuffer write = WriteBuffer();
       write.putFloat64(3.14);
@@ -42,6 +58,14 @@ void main() {
       expect(written.lengthInBytes, equals(8));
       final ReadBuffer read = ReadBuffer(written);
       expect(read.getFloat64(), equals(3.14));
+    });
+    test('of double in big endian', () {
+      final WriteBuffer write = WriteBuffer();
+      write.putFloat64(3.14, Endian.big);
+      final ByteData written = write.done();
+      expect(written.lengthInBytes, equals(8));
+      final ReadBuffer read = ReadBuffer(written);
+      expect(read.getFloat64(Endian.big), equals(3.14));
     });
     test('of 32-bit int list when unaligned', () {
       final Int32List integers = Int32List.fromList(<int>[-99, 2, 99]);


### PR DESCRIPTION
Signed-off-by: sunbreak <sunbreak.wang@gmail.com>

## Description

**This PR add an optional `endian` to WriteBuffer/ReadBuffer class for convenience**

I'm a IoT developer, writing applications via BLE protocol as below
https://github.com/woodemi/notepad-core-flutter/blob/develop/lib/woodemi/WoodemiClient.dart#L455-L465

```dart
var imageId = fileInfo.item1;
var byteData = ByteData(imageId.length + 4 + 4 + 2 + 1 + 2);
var position = 0;
for (var b in imageId)
  byteData.setInt8(position++, b);
byteData.setUint32(position, currentPos, Endian.little);
byteData.setUint32(position += 4, blockSize, Endian.little);
byteData.setUint16(position += 4, maxChunkSize, Endian.little);
byteData.setUint8(position += 2, transferMethod);
byteData.setUint16(position += 1, l2capChannelOrPsm, Endian.little);
var request = Uint8List.fromList([0x04] + byteData.buffer.asUint8List());
```

I find WriteBuffer/ReadBuffer in `package:flutter/foundation` with similiar methods, except for the endians

With this PR merged

```dart
var writeBuffer = WriteBuffer();
writeBuffer.putUint8List(imageId);
writeBuffer.putUint32(currentPos, Endian.little);
writeBuffer.putUint32(blockSize, Endian.little);
writeBuffer.putUint16(maxChunkSize, Endian.little);
writeBuffer.putUint8(transferMethod);
writeBuffer.putUint16(l2capChannelOrPsm, Endian.little);
var request = Uint8List.fromList([0x04] + writeBuffer.done().buffer.asUint8List());
```

## Related Issues

- https://github.com/dart-lang/sdk/issues/16130
- https://stackoverflow.com/questions/51801051/how-to-use-bytedata-and-bytebuffer-in-flutter-without-mirror-package

## Tests

I added the following tests:

- **of 32-bit integer in big endian**
- **of 64-bit integer in big endian**
- **of double in big endian**

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
