### PR TITLE
Button color depends on color scheme

### DIFF
--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -333,7 +333,7 @@ class ThemeData extends Diagnosticable {
 
     // Used as the default color (fill color) for RaisedButtons. Computing the
     // default for ButtonThemeData for the sake of backwards compatibility.
-    buttonColor ??= isDark ? primarySwatch[600] : Colors.grey[300];
+    buttonColor ??= primaryColor;
     focusColor ??= isDark ? Colors.white.withOpacity(0.12) : Colors.black.withOpacity(0.12);
     hoverColor ??= isDark ? Colors.white.withOpacity(0.04) : Colors.black.withOpacity(0.04);
     buttonTheme ??= ButtonThemeData(

--- a/packages/flutter/test/material/raised_button_test.dart
+++ b/packages/flutter/test/material/raised_button_test.dart
@@ -28,11 +28,23 @@ void main() {
       ),
     );
     Material material = tester.widget<Material>(rawButtonMaterial);
+    const Map<int, Color> color = {
+      50:Color.fromRGBO(227,242,253, 1.0),
+      100:Color.fromRGBO(187,222,251, 1.0),
+      200:Color.fromRGBO(144,202,249, 1.0),
+      300:Color.fromRGBO(100,181,246, 1.0),
+      400:Color.fromRGBO(66,165,245, 1.0),
+      500:Color.fromRGBO(33,150,243, 1.0),
+      600:Color.fromRGBO(30,136,229, 1.0),
+      700:Color.fromRGBO(25,118,210, 1.0),
+      800:Color.fromRGBO(21,101,192, 1.0),
+      900:Color.fromRGBO(13,71,161, 1.0)
+    };
     expect(material.animationDuration, const Duration(milliseconds: 200));
     expect(material.borderOnForeground, true);
     expect(material.borderRadius, null);
     expect(material.clipBehavior, Clip.none);
-    expect(material.color, const Color(0xffe0e0e0));
+    expect(material.color, const MaterialColor(0xff2196f3, color));
     expect(material.elevation, 2.0);
     expect(material.shadowColor, const Color(0xff000000));
     expect(material.shape, RoundedRectangleBorder(borderRadius: BorderRadius.circular(2.0)));
@@ -52,7 +64,7 @@ void main() {
     expect(material.borderOnForeground, true);
     expect(material.borderRadius, null);
     expect(material.clipBehavior, Clip.none);
-    expect(material.color, const Color(0xffe0e0e0));
+    expect(material.color, const MaterialColor(0xff2196f3, color));
     expect(material.elevation, 8.0);
     expect(material.shadowColor, const Color(0xff000000));
     expect(material.shape, RoundedRectangleBorder(borderRadius: BorderRadius.circular(2.0)));

--- a/packages/flutter/test/material/theme_defaults_test.dart
+++ b/packages/flutter/test/material/theme_defaults_test.dart
@@ -26,8 +26,21 @@ void main() {
       );
 
       final RawMaterialButton raw = tester.widget<RawMaterialButton>(find.byType(RawMaterialButton));
+      const Map<int, Color> color = {
+          50:Color.fromRGBO(227,242,253, 1.0),
+          100:Color.fromRGBO(187,222,251, 1.0),
+          200:Color.fromRGBO(144,202,249, 1.0),
+          300:Color.fromRGBO(100,181,246, 1.0),
+          400:Color.fromRGBO(66,165,245, 1.0),
+          500:Color.fromRGBO(33,150,243, 1.0),
+          600:Color.fromRGBO(30,136,229, 1.0),
+          700:Color.fromRGBO(25,118,210, 1.0),
+          800:Color.fromRGBO(21,101,192, 1.0),
+          900:Color.fromRGBO(13,71,161, 1.0)
+        };
       expect(raw.textStyle.color, const Color(0xdd000000));
-      expect(raw.fillColor, const Color(0xffe0e0e0));
+      expect(raw.fillColor, const MaterialColor(0xff2196f3, color)); // Was Color(0xffe0e0e0)
+      // expect(raw.fillColor, const Color(0xff2196f3));
       expect(raw.highlightColor, const Color(0x29000000)); // Was Color(0x66bcbcbc)
       expect(raw.splashColor, const Color(0x1f000000)); // Was Color(0x66c8c8c8)
       expect(raw.elevation, 2.0);

--- a/packages/flutter/test/material/theme_defaults_test.dart
+++ b/packages/flutter/test/material/theme_defaults_test.dart
@@ -40,7 +40,6 @@ void main() {
         };
       expect(raw.textStyle.color, const Color(0xdd000000));
       expect(raw.fillColor, const MaterialColor(0xff2196f3, color)); // Was Color(0xffe0e0e0)
-      // expect(raw.fillColor, const Color(0xff2196f3));
       expect(raw.highlightColor, const Color(0x29000000)); // Was Color(0x66bcbcbc)
       expect(raw.splashColor, const Color(0x1f000000)); // Was Color(0x66c8c8c8)
       expect(raw.elevation, 2.0);


### PR DESCRIPTION
## Description

Hello! I am a new contributor looking to understand Flutter's codebase and contribution process more thoroughly, and to attempt to work on some issues. 

This PR implements a change for ThemeData.buttonColor to depend on a passed in colorScheme as opposed to being set to primarySwatch or Colors.grey[300]. The change would set RaisedButton's default fill color to the primaryColor, which is dependent on the primarySwatch. 

The issue was originally made as passing in a colorScheme to the ThemeData.from() method wouldn't change the buttonColor to match the scheme, and it is not possible to pass in a primarySwatch in .from(). 

Notably, the primaryColor becomes a Color if a dark colorScheme is passed in, but a MaterialColor otherwise, and the change to buttonColor reflects this same issue. 


## Related Issues

#45849


## Tests

I altered the following tests:
/test/material/raised_button_test.dart
/test/material/theme_defaults_test.dart

Test raised_button_test fails line 168: 
await expectLater(tester, meetsGuideline(textContrastGuideline));
as it appears that the button no longer meets contrast guidelines, although I'm not sure how to approach this. 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [X] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
