### PR TITLE
Update require.js artifact location

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -123,6 +123,7 @@ class FlutterWebPlatform extends PlatformPlugin {
         artifacts.getArtifactPath(Artifact.engineDartSdkPath),
         'lib',
         'dev_compiler',
+        'kernel',
         'amd',
         'require.js',
       ));


### PR DESCRIPTION
## Description

With the removal of the analyzer based ddc support, we need to use the require.js artifact bundled with the kernel artifacts. Other locations in flutter were already updated, but we forgot this path in the loader of for flutter test