### PR TITLE
remove test_api dependency from flutter_tools/base/io

### DIFF
--- a/packages/flutter_tools/lib/src/base/io.dart
+++ b/packages/flutter_tools/lib/src/base/io.dart
@@ -30,7 +30,6 @@ import 'dart:io' as io show exit, IOSink, Process, ProcessInfo, ProcessSignal,
     stderr, stdin, Stdin, StdinException, Stdout, stdout;
 
 import 'package:meta/meta.dart';
-import 'package:test_api/test_api.dart'; // ignore: deprecated_member_use
 
 import 'context.dart';
 import 'platform.dart';
@@ -112,13 +111,7 @@ ExitFunction get exit {
 
 // Whether the tool is executing in a unit test.
 bool _inUnitTest() {
-  try {
-    expect(true, true);
-  } on StateError {
-    // If a StateError is caught, then this is not a unit test.
-    return false;
-  }
-  return true;
+  return Zone.current[#test.declarer] != null;
 }
 
 /// Sets the [exit] function to a function that throws an exception rather

--- a/packages/flutter_tools/test/general.shard/base/io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/io_test.dart
@@ -78,6 +78,10 @@ void main() {
 
     expect(() => exit(0), returnsNormally);
   });
+
+  test('test_api defines the Declarer in a known place', () {
+    expect(Zone.current[#test.declarer], isNotNull);
+  });
 }
 
 class MockIoProcessSignal extends Mock implements io.ProcessSignal {}

--- a/packages/flutter_tools/test/general.shard/forbidden_imports_test.dart
+++ b/packages/flutter_tools/test/general.shard/forbidden_imports_test.dart
@@ -60,6 +60,33 @@ void main() {
     }
   });
 
+  test('no unauthorized imports of test_api', () {
+    final List<String> whitelistedPaths = <String>[
+      fs.path.join(flutterTools, 'lib', 'src', 'build_runner', 'build_script.dart'),
+      fs.path.join(flutterTools, 'lib', 'src', 'test', 'flutter_platform.dart'),
+      fs.path.join(flutterTools, 'lib', 'src', 'test', 'flutter_web_platform.dart'),
+      fs.path.join(flutterTools, 'lib', 'src', 'test', 'runner.dart'),
+    ];
+    bool _isNotWhitelisted(FileSystemEntity entity) => whitelistedPaths.every((String path) => path != entity.path);
+
+    for (String dirName in <String>['lib']) {
+      final Iterable<File> files = fs.directory(fs.path.join(flutterTools, dirName))
+        .listSync(recursive: true)
+        .where(_isDartFile)
+        .where(_isNotWhitelisted)
+        .map(_asFile);
+      for (File file in files) {
+        for (String line in file.readAsLinesSync()) {
+          if (line.startsWith(RegExp(r'import.*package:test_api')) &&
+              !line.contains('ignore: test_api_import')) {
+            final String relativePath = fs.path.relative(file.path, from:flutterTools);
+            fail("$relativePath imports 'package:test_api/test_api.dart';");
+          }
+        }
+      }
+    }
+  });
+
   test('no unauthorized imports of package:path', () {
     final String whitelistedPath = fs.path.join(flutterTools, 'lib', 'src', 'build_runner', 'web_compilation_delegate.dart');
     for (String dirName in <String>['lib', 'bin', 'test']) {


### PR DESCRIPTION
## Description


using the test library here breaks the library structure of the google3 usage of the flutter tool, which restricts imports of test libraries. Instead, use the symbol trick