### PR TITLE
Skip plugins that don't have an android impl when building AARs

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -709,6 +709,10 @@ Future<void> buildPluginsAsAar(
     assert(pluginDirectory.existsSync());
 
     final String pluginName = pluginParts.first;
+    if (!pluginDirectory.childDirectory('android').existsSync()) {
+      printTrace('Skipping plugin $pluginName since it doesn\'t have an android directory');
+      continue;
+    }
     logger.printStatus('Building plugin $pluginName...');
     try {
       await buildGradleAar(

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -997,6 +997,9 @@ flutter:
   plugin:
     androidPackage: irrelevant
 ''');
+
+      plugin1.childDirectory('android').createSync();
+
       final Directory plugin2 = fs.directory('plugin2.');
       plugin2
         ..createSync()
@@ -1007,6 +1010,8 @@ flutter:
   plugin:
     androidPackage: irrelevant
 ''');
+
+      plugin2.childDirectory('android').createSync();
 
       androidDirectory
         .childFile('.flutter-plugins')
@@ -1028,8 +1033,13 @@ plugin2=${plugin2.path}
       );
 
       final String flutterRoot = fs.path.absolute(Cache.flutterRoot);
-      final String initScript = fs.path.join(flutterRoot, 'packages',
-          'flutter_tools', 'gradle', 'aar_init_script.gradle');
+      final String initScript = fs.path.join(
+        flutterRoot,
+        'packages',
+        'flutter_tools',
+        'gradle',
+        'aar_init_script.gradle',
+      );
       verify(mockProcessManager.run(
         <String>[
           'gradlew',
@@ -1058,6 +1068,70 @@ plugin2=${plugin2.path}
         workingDirectory: plugin2.childDirectory('android').path),
       ).called(1);
 
+    }, overrides: <Type, Generator>{
+      AndroidSdk: () => mockAndroidSdk,
+      FileSystem: () => fs,
+      ProcessManager: () => mockProcessManager,
+      GradleUtils: () => FakeGradleUtils(),
+    });
+
+    testUsingContext('skips plugin without an android directory', () async {
+      final Directory androidDirectory = fs.directory('android.');
+      androidDirectory.createSync();
+      androidDirectory
+        .childFile('pubspec.yaml')
+        .writeAsStringSync('name: irrelevant');
+
+      final Directory plugin1 = fs.directory('plugin1.');
+      plugin1
+        ..createSync()
+        ..childFile('pubspec.yaml')
+        .writeAsStringSync('''
+name: irrelevant
+flutter:
+  plugin:
+    androidPackage: irrelevant
+''');
+
+      androidDirectory
+        .childFile('.flutter-plugins')
+        .writeAsStringSync('''
+plugin1=${plugin1.path}
+''');
+      final Directory buildDirectory = androidDirectory.childDirectory('build');
+
+      buildDirectory
+        .childDirectory('outputs')
+        .childDirectory('repo')
+        .createSync(recursive: true);
+
+      await buildPluginsAsAar(
+        FlutterProject.fromPath(androidDirectory.path),
+        const AndroidBuildInfo(BuildInfo.release),
+        buildDirectory: buildDirectory,
+      );
+
+      final String flutterRoot = fs.path.absolute(Cache.flutterRoot);
+      final String initScript = fs.path.join(
+        flutterRoot,
+        'packages',
+        'flutter_tools',
+        'gradle',
+        'aar_init_script.gradle',
+      );
+      verifyNever(mockProcessManager.run(
+        <String>[
+          'gradlew',
+          '-I=$initScript',
+          '-Pflutter-root=$flutterRoot',
+          '-Poutput-dir=${buildDirectory.path}',
+          '-Pis-plugin=true',
+          '-Ptarget-platform=android-arm,android-arm64,android-x64',
+          'assembleAarRelease',
+        ],
+        environment: anyNamed('environment'),
+        workingDirectory: plugin1.childDirectory('android').path),
+      );
     }, overrides: <Type, Generator>{
       AndroidSdk: () => mockAndroidSdk,
       FileSystem: () => fs,


### PR DESCRIPTION
## Description

When the tool builds the plugins as AAR, it doesn't skip plugins that don't have an android implementation.

## Related Issues

https://github.com/flutter/flutter/issues/46807
https://github.com/flutter/flutter/issues/46790

## Tests

I added the following tests: Unit test.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
