### PR TITLE
Avoid calling web-only method outside of web

### DIFF
--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -710,7 +710,11 @@ class TextInputConnection {
   ///
   /// 2. [transform]: a matrix that maps the local paint coordinate system
   ///                 to the [PipelineOwner.rootNode].
+  ///
+  /// This method should only be called for web targets, and will result in an
+  /// exception on other platforms.
   void setEditableSizeAndTransform(Size editableBoxSize, Matrix4 transform) {
+    assert(kIsWeb);
     if (editableBoxSize != _cachedSize || transform != _cachedTransform) {
       _cachedSize = editableBoxSize;
       _cachedTransform = transform;

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1725,10 +1725,10 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   }
 
   void _updateSizeAndTransform() {
-    if (_hasInputConnection) {
+    if (kIsWeb && _hasInputConnection) {
       final Size size = renderEditable.size;
       final Matrix4 transform = renderEditable.getTransformTo(null);
-      _textInputConnection.setEditableSizeAndTransform(size, transform);
+        _textInputConnection.setEditableSizeAndTransform(size, transform);
       SchedulerBinding.instance
           .addPostFrameCallback((Duration _) => _updateSizeAndTransform());
     }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1728,7 +1728,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     if (kIsWeb && _hasInputConnection) {
       final Size size = renderEditable.size;
       final Matrix4 transform = renderEditable.getTransformTo(null);
-        _textInputConnection.setEditableSizeAndTransform(size, transform);
+      _textInputConnection.setEditableSizeAndTransform(size, transform);
       SchedulerBinding.instance
           .addPostFrameCallback((Duration _) => _updateSizeAndTransform());
     }

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -3914,7 +3914,6 @@ void main() {
     ));
 
     await tester.showKeyboard(find.byType(EditableText));
-    expect(log.length, kIsWeb ? 7 : 6);
     // TextInput.show should be before TextInput.setEditingState
     final List<String> logOrder = <String>[
       'TextInput.setClient',
@@ -3925,6 +3924,7 @@ void main() {
       'TextInput.setEditingState',
       'TextInput.show',
     ];
+    expect(log.length, logOrder.length);
     int index = 0;
     for (MethodCall m in log) {
       expect(m.method, logOrder[index]);

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -1316,17 +1316,24 @@ void main() {
         },
       ),
     );
-    expect(
-      log.lastWhere((MethodCall m) => m.method == 'TextInput.setEditableSizeAndTransform'),
-      isMethodCall(
-        'TextInput.setEditableSizeAndTransform',
-        arguments: <String, dynamic>{
-          'width': 800,
-          'height': 14,
-          'transform': Matrix4.translationValues(0.0, 293.0, 0.0).storage.toList(),
-        },
-      ),
-    );
+    if (kIsWeb) {
+      expect(
+        log.lastWhere((MethodCall m) => m.method == 'TextInput.setEditableSizeAndTransform'),
+        isMethodCall(
+          'TextInput.setEditableSizeAndTransform',
+          arguments: <String, dynamic>{
+            'width': 800,
+            'height': 14,
+            'transform': Matrix4.translationValues(0.0, 293.0, 0.0).storage.toList(),
+          },
+        ),
+      );
+    } else {
+      expect(
+        log.every((MethodCall m) => m.method != 'TextInput.setEditableSizeAndTransform'),
+        true,
+      );
+    }
   });
 
   testWidgets('EditableText identifies as text field (w/ focus) in semantics', (WidgetTester tester) async {
@@ -2414,15 +2421,24 @@ void main() {
     );
 
     await tester.showKeyboard(find.byType(EditableText));
-    final MethodCall methodCall = log.firstWhere((MethodCall m) => m.method == 'TextInput.setEditableSizeAndTransform');
-    expect(
-      methodCall,
-      isMethodCall('TextInput.setEditableSizeAndTransform', arguments: <String, dynamic>{
-        'width': 800,
-        'height': 600,
-        'transform': Matrix4.identity().storage.toList(),
-      }),
-    );
+    if (kIsWeb) {
+      expect(
+        log.lastWhere((MethodCall m) => m.method == 'TextInput.setEditableSizeAndTransform'),
+        isMethodCall(
+          'TextInput.setEditableSizeAndTransform',
+          arguments: <String, dynamic>{
+            'width': 800,
+            'height': 600,
+            'transform': Matrix4.identity().storage.toList(),
+          },
+        ),
+      );
+    } else {
+      expect(
+        log.every((MethodCall m) => m.method != 'TextInput.setEditableSizeAndTransform'),
+        true,
+      );
+    }
   });
 
   testWidgets('transform and size is reset when text connection opens', (WidgetTester tester) async {
@@ -2474,43 +2490,66 @@ void main() {
     );
 
     await tester.showKeyboard(find.byKey(ValueKey<String>(controller1.text)));
-    final MethodCall methodCall = log.firstWhere((MethodCall m) => m.method == 'TextInput.setEditableSizeAndTransform');
-    expect(
-      methodCall,
-      isMethodCall('TextInput.setEditableSizeAndTransform', arguments: <String, dynamic>{
-        'width': 800,
-        'height': 14,
-        'transform': Matrix4.identity().storage.toList(),
-      }),
-    );
+    if (kIsWeb) {
+      expect(
+        log.firstWhere((MethodCall m) => m.method == 'TextInput.setEditableSizeAndTransform'),
+        isMethodCall(
+          'TextInput.setEditableSizeAndTransform',
+          arguments: <String, dynamic>{
+            'width': 800,
+            'height': 14,
+            'transform': Matrix4.identity().storage.toList(),
+          },
+        ),
+      );
+    } else {
+      expect(
+        log.every((MethodCall m) => m.method != 'TextInput.setEditableSizeAndTransform'),
+        true,
+      );
+    }
 
     log.clear();
 
     // Move to the next editable text.
     await tester.showKeyboard(find.byKey(ValueKey<String>(controller2.text)));
-    final MethodCall methodCall2 = log.firstWhere((MethodCall m) => m.method == 'TextInput.setEditableSizeAndTransform');
-    expect(
-      methodCall2,
-      isMethodCall('TextInput.setEditableSizeAndTransform', arguments: <String, dynamic>{
-        'width': 800,
-        'height': 140.0,
-        'transform': <double>[1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 214.0, 0.0, 1.0],
-      }),
-    );
+    if (kIsWeb) {
+      final MethodCall methodCall2 = log.firstWhere((MethodCall m) => m.method == 'TextInput.setEditableSizeAndTransform');
+      expect(
+        methodCall2,
+        isMethodCall('TextInput.setEditableSizeAndTransform', arguments: <String, dynamic>{
+          'width': 800,
+          'height': 140.0,
+          'transform': <double>[1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 214.0, 0.0, 1.0],
+        }),
+      );
+    } else {
+      expect(
+        log.every((MethodCall m) => m.method != 'TextInput.setEditableSizeAndTransform'),
+        true,
+      );
+    }
 
     log.clear();
 
     // Move back to the first editable text.
     await tester.showKeyboard(find.byKey(ValueKey<String>(controller1.text)));
-    final MethodCall methodCall3 = log.firstWhere((MethodCall m) => m.method == 'TextInput.setEditableSizeAndTransform');
-    expect(
-      methodCall3,
-      isMethodCall('TextInput.setEditableSizeAndTransform', arguments: <String, dynamic>{
-        'width': 800,
-        'height': 14,
-        'transform': Matrix4.identity().storage.toList(),
-      }),
-    );
+    if (kIsWeb) {
+      final MethodCall methodCall3 = log.firstWhere((MethodCall m) => m.method == 'TextInput.setEditableSizeAndTransform');
+      expect(
+        methodCall3,
+        isMethodCall('TextInput.setEditableSizeAndTransform', arguments: <String, dynamic>{
+          'width': 800,
+          'height': 14,
+          'transform': Matrix4.identity().storage.toList(),
+        }),
+      );
+    } else {
+      expect(
+        log.every((MethodCall m) => m.method != 'TextInput.setEditableSizeAndTransform'),
+        true,
+      );
+    }
   });
 
   testWidgets('size and transform are sent when they change', (WidgetTester tester) async {
@@ -2529,30 +2568,44 @@ void main() {
     );
 
     await tester.showKeyboard(find.byType(EditableText));
-    MethodCall methodCall = log.firstWhere((MethodCall m) => m.method == 'TextInput.setEditableSizeAndTransform');
-    expect(
-      methodCall,
-      isMethodCall('TextInput.setEditableSizeAndTransform', arguments: <String, dynamic>{
-        'width': 800,
-        'height': 14,
-        'transform': Matrix4.identity().storage.toList(),
-      }),
-    );
+    if (kIsWeb) {
+      final MethodCall methodCall = log.firstWhere((MethodCall m) => m.method == 'TextInput.setEditableSizeAndTransform');
+      expect(
+        methodCall,
+        isMethodCall('TextInput.setEditableSizeAndTransform', arguments: <String, dynamic>{
+          'width': 800,
+          'height': 14,
+          'transform': Matrix4.identity().storage.toList(),
+        }),
+      );
+    } else {
+      expect(
+        log.every((MethodCall m) => m.method != 'TextInput.setEditableSizeAndTransform'),
+        true,
+      );
+    }
 
     log.clear();
     await tester.tap(find.byKey(transformButtonKey));
     await tester.pumpAndSettle();
 
     // There should be a new platform message updating the transform.
-    methodCall = log.firstWhere((MethodCall m) => m.method == 'TextInput.setEditableSizeAndTransform');
-    expect(
-      methodCall,
-      isMethodCall('TextInput.setEditableSizeAndTransform', arguments: <String, dynamic>{
-        'width': 800,
-        'height': 14,
-        'transform': Matrix4.translationValues(offset.dx, offset.dy, 0.0).storage.toList(),
-      }),
-    );
+    if (kIsWeb) {
+      final MethodCall methodCall = log.firstWhere((MethodCall m) => m.method == 'TextInput.setEditableSizeAndTransform');
+      expect(
+        methodCall,
+        isMethodCall('TextInput.setEditableSizeAndTransform', arguments: <String, dynamic>{
+          'width': 800,
+          'height': 14,
+          'transform': Matrix4.translationValues(offset.dx, offset.dy, 0.0).storage.toList(),
+        }),
+      );
+    } else {
+      expect(
+        log.every((MethodCall m) => m.method != 'TextInput.setEditableSizeAndTransform'),
+        true,
+      );
+    }
   });
 
   testWidgets('text styling info is sent on show keyboard', (WidgetTester tester) async {
@@ -3861,9 +3914,17 @@ void main() {
     ));
 
     await tester.showKeyboard(find.byType(EditableText));
-    expect(log.length, 7);
+    expect(log.length, kIsWeb ? 7 : 6);
     // TextInput.show should be before TextInput.setEditingState
-    final List<String> logOrder = <String>['TextInput.setClient', 'TextInput.show', 'TextInput.setEditableSizeAndTransform', 'TextInput.setStyle', 'TextInput.setEditingState', 'TextInput.setEditingState', 'TextInput.show'];
+    final List<String> logOrder = <String>[
+      'TextInput.setClient',
+      'TextInput.show',
+      if (kIsWeb) 'TextInput.setEditableSizeAndTransform',
+      'TextInput.setStyle',
+      'TextInput.setEditingState',
+      'TextInput.setEditingState',
+      'TextInput.show',
+    ];
     int index = 0;
     for (MethodCall m in log) {
       expect(m.method, logOrder[index]);


### PR DESCRIPTION
## Description

setEditableSizeAndTransform was introduced specifically for web, and is not implemented on any other platform.  It throws an exception that gets swallowed by the framework, but ends up getting caught by developers in debugging sessions trying to catch all exceptions - it's also doing unnecessary work for non-web targets.

This patch special cases the method so that it is only called in web targets, and updates the unit tests to assert that it is not called in non-web targets.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/40427

## Tests

I added the following tests:

Updates to tests to assert that the unimplemented method is not invoked when `kIsWeb` is false.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
