### PR TITLE
[flutter_tool] fix NPE in daemon caused by returning null connection info from experimental web runner

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -535,7 +535,7 @@ class _ExperimentalResidentWebRunner extends ResidentWebRunner {
       _wipConnection = await chromeTab.connect();
     }
     appStartedCompleter?.complete();
-    connectionInfoCompleter?.complete();
+    connectionInfoCompleter?.complete(DebugConnectionInfo());
     if (stayResident) {
       await waitForAppToFinish();
     } else {

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -378,7 +378,10 @@ void main() {
     unawaited(residentWebRunner.run(
       connectionInfoCompleter: connectionInfoCompleter,
     ));
-    await connectionInfoCompleter.future;
+    final DebugConnectionInfo debugConnectionInfo = await connectionInfoCompleter.future;
+
+    expect(debugConnectionInfo, isNotNull);
+
     final OperationResult result = await residentWebRunner.restart(fullRestart: false);
 
     expect(testLogger.statusText, contains('Reloaded application in'));


### PR DESCRIPTION
## Description

The connection info completer is expected to return a non-null DebugConnectionInfo

Fixes https://github.com/flutter/flutter/issues/46908
Fixes https://github.com/flutter/flutter/issues/46574