### PR TITLE
[flutter_tool] remove ability to disable Fingerprinter with DISABLE_FLUTTER_BUILD_CACHE env variable

### DIFF
--- a/packages/flutter_tools/lib/src/base/fingerprint.dart
+++ b/packages/flutter_tools/lib/src/base/fingerprint.dart
@@ -10,17 +10,9 @@ import '../convert.dart' show json;
 import '../globals.dart';
 import '../version.dart';
 import 'file_system.dart';
-import 'platform.dart';
 import 'utils.dart';
 
 typedef FingerprintPathFilter = bool Function(String path);
-
-/// Whether to completely disable build caching.
-///
-/// This is done by always returning false from fingerprinter invocations. This
-/// is safe to do generally, because fingerprinting is only a performance
-/// improvement.
-bool get _disableBuildCache => platform.environment['DISABLE_FLUTTER_BUILD_CACHE']?.toLowerCase() == 'true';
 
 /// A tool that can be used to compute, compare, and write [Fingerprint]s for a
 /// set of input files and associated build settings.
@@ -57,9 +49,6 @@ class Fingerprinter {
   }
 
   bool doesFingerprintMatch() {
-    if (_disableBuildCache) {
-      return false;
-    }
     try {
       final File fingerprintFile = fs.file(fingerprintPath);
       if (!fingerprintFile.existsSync()) {

--- a/packages/flutter_tools/test/general.shard/base/fingerprint_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/fingerprint_test.dart
@@ -195,48 +195,6 @@ void main() {
       expect(fingerprinter.doesFingerprintMatch(), isTrue);
     }, overrides: contextOverrides);
 
-    final Platform mockPlatformDisabledCache = MockPlatform();
-    mockPlatformDisabledCache.environment['DISABLE_FLUTTER_BUILD_CACHE']  = 'true';
-    testUsingContext('can be disabled with an environment variable', () {
-      fs.file('a.dart').createSync();
-      fs.file('b.dart').createSync();
-
-      final Fingerprinter fingerprinter = Fingerprinter(
-        fingerprintPath: 'out.fingerprint',
-        paths: <String>['a.dart', 'b.dart'],
-        properties: <String, String>{
-          'bar': 'baz',
-          'wobble': 'womble',
-        },
-      );
-      fingerprinter.writeFingerprint();
-      expect(fingerprinter.doesFingerprintMatch(), isFalse);
-    }, overrides: <Type, Generator>{
-      Platform: () => mockPlatformDisabledCache,
-      ...contextOverrides,
-    });
-
-    final Platform mockPlatformEnabledCache = MockPlatform();
-    mockPlatformEnabledCache.environment['DISABLE_FLUTTER_BUILD_CACHE']  = 'false';
-    testUsingContext('can be not-disabled with an environment variable', () {
-      fs.file('a.dart').createSync();
-      fs.file('b.dart').createSync();
-
-      final Fingerprinter fingerprinter = Fingerprinter(
-        fingerprintPath: 'out.fingerprint',
-        paths: <String>['a.dart', 'b.dart'],
-        properties: <String, String>{
-          'bar': 'baz',
-          'wobble': 'womble',
-        },
-      );
-      fingerprinter.writeFingerprint();
-      expect(fingerprinter.doesFingerprintMatch(), isTrue);
-    }, overrides: <Type, Generator>{
-      Platform: () => mockPlatformEnabledCache,
-      ...contextOverrides,
-    });
-
     testUsingContext('fails to write fingerprint if inputs are missing', () {
       final Fingerprinter fingerprinter = Fingerprinter(
         fingerprintPath: 'out.fingerprint',


### PR DESCRIPTION
## Description

This was a short-term workaround I landed before disable all fingerprinter based caches last year. Now that we're either not using caches or have switched to assemble, the Fingerprinter is only used for some pod checking and doesn't need to be disabled.