### PR TITLE
[flutter_tool] experimental resident web runner is not debuggable

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -372,6 +372,9 @@ class _ExperimentalResidentWebRunner extends ResidentWebRunner {
         );
 
   @override
+  bool get debuggingEnabled => false;
+
+  @override
   Future<int> run({
     Completer<DebugConnectionInfo> connectionInfoCompleter,
     Completer<void> appStartedCompleter,

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -486,6 +486,12 @@ void main() {
     FeatureFlags: () => TestFeatureFlags(isWebIncrementalCompilerEnabled: true),
   }));
 
+  test('experimental resident runner is not debuggable', () => testbed.run(() {
+    expect(residentWebRunner.debuggingEnabled, false);
+  }, overrides: <Type, Generator>{
+    FeatureFlags: () => TestFeatureFlags(isWebIncrementalCompilerEnabled: true),
+  }));
+
   test('Can hot restart after attaching', () => testbed.run(() async {
     _setupMocks();
     final Completer<DebugConnectionInfo> connectionInfoCompleter = Completer<DebugConnectionInfo>();


### PR DESCRIPTION
## Description

Since we don't return any device info, ensure the daemon does not expect ports/wsuri.

Fixes https://github.com/flutter/flutter/issues/46914