### PR TITLE
Step 2 of 2: Remove Flutter's FloatingActionButton dependency on ThemeData accent properties

### DIFF
--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -444,7 +444,6 @@ class FloatingActionButton extends StatelessWidget {
 
     final Color foregroundColor = this.foregroundColor
       ?? floatingActionButtonTheme.foregroundColor
-      ?? theme.accentIconTheme.color
       ?? theme.colorScheme.onSecondary;
     final Color backgroundColor = this.backgroundColor
       ?? floatingActionButtonTheme.backgroundColor
@@ -475,7 +474,7 @@ class FloatingActionButton extends StatelessWidget {
       ?? _defaultHighlightElevation;
     final MaterialTapTargetSize materialTapTargetSize = this.materialTapTargetSize
       ?? theme.materialTapTargetSize;
-    final TextStyle textStyle = theme.accentTextTheme.button.copyWith(
+    final TextStyle textStyle = theme.textTheme.button.copyWith(
       color: foregroundColor,
       letterSpacing: 1.2,
     );

--- a/packages/flutter/test/material/floating_action_button_theme_test.dart
+++ b/packages/flutter/test/material/floating_action_button_theme_test.dart
@@ -118,38 +118,6 @@ void main() {
     expect(_getRawMaterialButton(tester).splashColor, splashColor);
   });
 
-  // The feature checked by this test has been deprecated, see
-  // https://flutter.dev/go/remove-fab-accent-theme-dependency. This test will be
-  // removed in the future.
-  testWidgets('FloatingActionButton foreground color uses iconAccentTheme if no widget or widget theme color is specified', (WidgetTester tester) async {
-    final DebugPrintCallback oldPrint = debugPrint;
-    final List<String> log = <String>[];
-    debugPrint = (String message, { int wrapWidth }) {
-      log.add(message);
-    };
-
-    await tester.pumpWidget(MaterialApp(
-      home: Scaffold(
-        floatingActionButton: Theme(
-          data: ThemeData().copyWith(
-            accentIconTheme: const IconThemeData(color: Color(0xFACEFACE)),
-          ),
-          child: FloatingActionButton(
-            onPressed: () { },
-            child: const Icon(Icons.add),
-          ),
-        ),
-      ),
-    ));
-
-    debugPrint = oldPrint;
-
-    // Verify that a warning message is generated.
-    expect(log.first, contains('https://flutter.dev/docs/release/breaking-changes/fab_accent_dependency'));
-
-    expect(_getRichText(tester).text.style.color, const Color(0xFACEFACE));
-  });
-
   testWidgets('FloatingActionButton uses a custom shape when specified in the theme', (WidgetTester tester) async {
     const ShapeBorder customShape = BeveledRectangleBorder();
 


### PR DESCRIPTION
Remove FloatingActionButton's dependency on the ThemeData accentIconTheme and accentTextTheme properties. Apps can configure the appearance of FloatingActionButtons using the theme's FloatingActionButtonTheme instead. 

Step 1 of this change was https://github.com/flutter/flutter/pull/48435.

## Context

This is a small part of the "Update Material Theme System" project, [flutter.dev/go/material-theme-system-updates](flutter.dev/go/material-theme-system-updates).

Currently, the ThemeData accentIconTheme property is only used by [FloatingActionButton](https://api.flutter.dev/flutter/material/FloatingActionButton/foregroundColor.html). It's the default color of the text or icons that appear within the button. 

FloatingActionButton also uses ThemeData accentTextTheme property, however this dependency is undocumented and unnecessary.

Both of these dependencies are apt to be confusing. For example if one configures the Theme's accentIconTheme to change the appearance of floating action buttons, it's difficult to know what other components will be affected. Or might be affected in the future.

The [Material Design spec](https://material.io/design/color) no longer includes an "accent" color. The ColorScheme's [secondary color](https://material.io/design/color/the-color-system.html#color-theme-creation) is now used instead.

Currently applications can configure the color of text and icons within FloatingActionButtons with the widget's foregroundColor property or with the FloatingActionButtonTheme's foregroundColor. If neither foregroundColor property is specified the foreground color currently defaults to the  accentIconTheme's color. This PR will cause the default to be the color scheme's onSecondary color instead.

## Description of change

Currently the accentIconTheme provides a default for the FloatingActionButton's foregroundColor property:
```dart
    final Color foregroundColor = this.foregroundColor
      ?? floatingActionButtonTheme.foregroundColor
      ?? theme.accentIconTheme.color // To be removed.
      ?? theme.colorScheme.onSecondary;
```

Apps that currently configure their theme's accentIconTheme to effectively configure the foregroundColor of all floating action buttons, can get the same effect by configuring the foregroundColor of their theme's floatingActionButtonTheme. This PR removes the line that contains accentIconTheme.

The FloatingActionButton's foregroundColor is used to configure the textStyle of the RawMaterialButton created by FloatingActionButton. Currently, this text style is based on the button style of ThemeData.accentTextTheme:
```
// theme.accentTextTheme will become theme.textTheme
final TextStyle textStyle = theme.accentTextTheme.button.copyWith( 
  color: foregroundColor,
  letterSpacing: 1.2,
);

```
Except in a case where an app has explicitly configured the accentTextTheme to take advantage of this undocumented dependency, this use of accentTextTheme is unnecessary. This PR replaces this use of accentTextTheme with textTheme.

## Migration guide

To configure the FloatingActionButton's foregroundColor for all FABs, apps can configure the theme's floatingActionButtonTheme instead of its accentIconTheme.

### Before

```dart
MaterialApp(
  theme: ThemeData(
    accentIconTheme: IconThemeData(color: Colors.red),
  ),
)
```

### After

```dart

MaterialApp(
  theme: ThemeData(
    floatingActionButtonTheme: FloatingActionButtonThemeData(
      foregroundColor: Colors.red,
    ),
  ),
)
```
