### PR TITLE
Only set `flutter run` usage values for targeted device platforms

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -255,12 +255,11 @@ class RunCommand extends RunCommandBase {
         }
       }
     }
-    final String modeName = getBuildInfo().modeName;
-    AndroidProject androidProject;
+
     String androidEmbeddingVersion;
     final List<String> hostLanguage = <String>[];
     if (anyAndroidDevices) {
-      androidProject = FlutterProject.current().android;
+      final AndroidProject androidProject = FlutterProject.current().android;
       if (androidProject != null && androidProject.existsSync()) {
         hostLanguage.add(androidProject.isKotlin ? 'kotlin' : 'java');
         androidEmbeddingVersion = androidProject.getEmbeddingVersion().toString().split('.').last;
@@ -278,6 +277,7 @@ class RunCommand extends RunCommandBase {
       }
     }
 
+    final String modeName = getBuildInfo().modeName;
     return <CustomDimensions, String>{
       CustomDimensions.commandRunIsEmulator: '$isEmulator',
       CustomDimensions.commandRunTargetName: deviceType,

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -228,29 +228,55 @@ class RunCommand extends RunCommandBase {
   Future<Map<CustomDimensions, String>> get usageValues async {
     String deviceType, deviceOsVersion;
     bool isEmulator;
+    bool anyAndroidDevices = false;
+    bool anyIOSDevices = false;
 
     if (devices == null || devices.isEmpty) {
       deviceType = 'none';
       deviceOsVersion = 'none';
       isEmulator = false;
     } else if (devices.length == 1) {
-      deviceType = getNameForTargetPlatform(await devices[0].targetPlatform);
+      final TargetPlatform platform = await devices[0].targetPlatform;
+      anyAndroidDevices = platform == TargetPlatform.android;
+      anyIOSDevices = platform == TargetPlatform.ios;
+      deviceType = getNameForTargetPlatform(platform);
       deviceOsVersion = await devices[0].sdkNameAndVersion;
       isEmulator = await devices[0].isLocalEmulator;
     } else {
       deviceType = 'multiple';
       deviceOsVersion = 'multiple';
       isEmulator = false;
+      for (Device device in devices) {
+        final TargetPlatform platform = await device.targetPlatform;
+        anyAndroidDevices = anyAndroidDevices || (platform == TargetPlatform.android);
+        anyIOSDevices = anyIOSDevices || (platform == TargetPlatform.ios);
+        if (anyAndroidDevices && anyIOSDevices) {
+          break;
+        }
+      }
     }
     final String modeName = getBuildInfo().modeName;
-    final AndroidProject androidProject = FlutterProject.current().android;
-    final IosProject iosProject = FlutterProject.current().ios;
-    final List<String> hostLanguage = <String>[
-      if (androidProject != null && androidProject.existsSync())
-        if (androidProject.isKotlin) 'kotlin' else 'java',
-      if (iosProject != null && iosProject.exists)
-        if (await iosProject.isSwift) 'swift' else 'objc',
-    ];
+    AndroidProject androidProject;
+    String androidEmbeddingVersion;
+    final List<String> hostLanguage = <String>[];
+    if (anyAndroidDevices) {
+      androidProject = FlutterProject.current().android;
+      if (androidProject != null && androidProject.existsSync()) {
+        hostLanguage.add(androidProject.isKotlin ? 'kotlin' : 'java');
+        androidEmbeddingVersion = androidProject.getEmbeddingVersion().toString().split('.').last;
+      }
+    }
+    if (anyIOSDevices) {
+      final IosProject iosProject = FlutterProject.current().ios;
+      if (iosProject != null && iosProject.exists) {
+        final Iterable<File> files = iosProject.hostAppRoot
+            .listSync(recursive: true, followLinks: false)
+            .whereType<File>()
+            .where((File file) => fs.path.extension(file.path) == '.swift');
+        final bool isSwift = files.isNotEmpty;
+        hostLanguage.add(isSwift ? 'swift' : 'objc');
+      }
+    }
 
     return <CustomDimensions, String>{
       CustomDimensions.commandRunIsEmulator: '$isEmulator',
@@ -259,7 +285,8 @@ class RunCommand extends RunCommandBase {
       CustomDimensions.commandRunModeName: modeName,
       CustomDimensions.commandRunProjectModule: '${FlutterProject.current().isModule}',
       CustomDimensions.commandRunProjectHostLanguage: hostLanguage.join(','),
-      CustomDimensions.commandRunAndroidEmbeddingVersion: androidProject.getEmbeddingVersion().toString().split('.').last,
+      if (androidEmbeddingVersion != null)
+        CustomDimensions.commandRunAndroidEmbeddingVersion: androidEmbeddingVersion,
     };
   }
 

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -268,12 +268,11 @@ class RunCommand extends RunCommandBase {
     if (anyIOSDevices) {
       final IosProject iosProject = FlutterProject.current().ios;
       if (iosProject != null && iosProject.exists) {
-        final Iterable<File> files = iosProject.hostAppRoot
+        final Iterable<File> swiftFiles = iosProject.hostAppRoot
             .listSync(recursive: true, followLinks: false)
             .whereType<File>()
             .where((File file) => fs.path.extension(file.path) == '.swift');
-        final bool isSwift = files.isNotEmpty;
-        hostLanguage.add(isSwift ? 'swift' : 'objc');
+        hostLanguage.add(swiftFiles.isNotEmpty ? 'swift' : 'objc');
       }
     }
 

--- a/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
@@ -36,7 +36,6 @@ Future<void> processPodsIfNeeded(XcodeBasedProject xcodeProject, String buildDir
   final bool didPodInstall = await cocoaPods.processPods(
     xcodeProject: xcodeProject,
     engineDir: flutterFrameworkDir(buildMode),
-    isSwift: await xcodeProject.isSwift,
     dependenciesChanged: !fingerprinter.doesFingerprintMatch(),
   );
   if (didPodInstall) {

--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -138,7 +138,6 @@ class CocoaPods {
     @required XcodeBasedProject xcodeProject,
     // For backward compatibility with previously created Podfile only.
     @required String engineDir,
-    bool isSwift = false,
     bool dependenciesChanged = true,
   }) async {
     if (!xcodeProject.podfile.existsSync()) {

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -292,9 +292,6 @@ abstract class XcodeBasedProject {
   /// The CocoaPods 'Manifest.lock'.
   File get podManifestLock;
 
-  /// True if the host app project is using Swift.
-  Future<bool> get isSwift;
-
   /// Directory containing symlinks to pub cache plugins source generated on `pod install`.
   Directory get symlinks;
 }
@@ -409,10 +406,6 @@ class IosProject implements XcodeBasedProject {
     }
     return null;
   }
-
-  @override
-  Future<bool> get isSwift async =>
-    (await buildSettings)?.containsKey('SWIFT_VERSION') ?? false;
 
   /// The build settings for the host app of this project, as a detached map.
   ///
@@ -819,9 +812,6 @@ class MacOSProject implements XcodeBasedProject {
 
   @override
   Directory get symlinks => ephemeralDirectory.childDirectory('.symlinks');
-
-  @override
-  Future<bool> get isSwift async => true;
 
   /// The file where the Xcode build will write the name of the built app.
   ///

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -292,13 +292,13 @@ void main() {
         expect(captures[0], 'run');
         final Map<String, String> parameters = captures[1] as Map<String, String>;
 
-        expect(parameters['cd3'], 'false'); // commandRunIsEmulator
-        expect(parameters['cd4'], 'ios'); // commandRunTargetName
-        expect(parameters['cd15'], 'swift'); // commandRunProjectHostLanguage
-        expect(parameters['cd22'], 'iOS 13'); // commandRunTargetOsVersion
-        expect(parameters['cd23'], 'debug'); // commandRunModeName
-        expect(parameters['cd18'], 'false'); // commandRunProjectModule
-        expect(parameters.containsKey('cd45'), false); // commandRunAndroidEmbeddingVersion
+        expect(parameters[cdKey(CustomDimensions.commandRunIsEmulator)], 'false');
+        expect(parameters[cdKey(CustomDimensions.commandRunTargetName)], 'ios');
+        expect(parameters[cdKey(CustomDimensions.commandRunProjectHostLanguage)], 'swift');
+        expect(parameters[cdKey(CustomDimensions.commandRunTargetOsVersion)], 'iOS 13');
+        expect(parameters[cdKey(CustomDimensions.commandRunModeName)], 'debug');
+        expect(parameters[cdKey(CustomDimensions.commandRunProjectModule)], 'false');
+        expect(parameters.containsKey(cdKey(CustomDimensions.commandRunAndroidEmbeddingVersion)), false);
       }, overrides: <Type, Generator>{
         ApplicationPackageFactory: () => mockApplicationPackageFactory,
         Artifacts: () => mockArtifacts,

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -237,6 +237,7 @@ void main() {
         when(mockDevice.isLocalEmulator).thenAnswer((Invocation invocation) => Future<bool>.value(false));
         when(mockDevice.getLogReader(app: anyNamed('app'))).thenReturn(MockDeviceLogReader());
         when(mockDevice.supportsFastStart).thenReturn(true);
+        when(mockDevice.sdkNameAndVersion).thenAnswer((Invocation invocation) => Future<String>.value('iOS 13'));
         // App fails to start because we're only interested in usage
         when(mockDevice.startApp(
           any,
@@ -262,6 +263,15 @@ void main() {
           (Invocation invocation) => Future<List<Device>>.value(<Device>[mockDevice])
         );
 
+        final Directory tempDir = fs.systemTempDirectory.createTempSync('flutter_run_test.');
+        tempDir.childDirectory('ios').childFile('AppDelegate.swift').createSync(recursive: true);
+        tempDir.childFile('.packages').createSync();
+        tempDir.childDirectory('lib').childFile('main.dart').createSync(recursive: true);
+        tempDir.childFile('pubspec.yaml')
+          ..createSync()
+          ..writeAsStringSync('# Hello, World');
+        fs.currentDirectory = tempDir;
+
         try {
           await createTestCommandRunner(command).run(<String>[
             'run',
@@ -281,7 +291,14 @@ void main() {
         )).captured;
         expect(captures[0], 'run');
         final Map<String, String> parameters = captures[1] as Map<String, String>;
-        expect(parameters['cd4'], 'ios');
+
+        expect(parameters['cd3'], 'false'); // commandRunIsEmulator
+        expect(parameters['cd4'], 'ios'); // commandRunTargetName
+        expect(parameters['cd15'], 'swift'); // commandRunProjectHostLanguage
+        expect(parameters['cd22'], 'iOS 13'); // commandRunTargetOsVersion
+        expect(parameters['cd23'], 'debug'); // commandRunModeName
+        expect(parameters['cd18'], 'false'); // commandRunProjectModule
+        expect(parameters.containsKey('cd45'), false); // commandRunAndroidEmbeddingVersion
       }, overrides: <Type, Generator>{
         ApplicationPackageFactory: () => mockApplicationPackageFactory,
         Artifacts: () => mockArtifacts,

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -304,19 +304,12 @@ void main() {
 
       testInMemory('default host app language', () async {
         final FlutterProject project = await someProject();
-        expect(await project.ios.isSwift, isFalse);
         expect(project.android.isKotlin, isFalse);
       });
 
-      testUsingContext('swift and kotlin host app language', () async {
+      testUsingContext('kotlin host app language', () async {
         final FlutterProject project = await someProject();
 
-        when(mockXcodeProjectInterpreter.getBuildSettings(any, any)).thenAnswer(
-          (_) {
-            return Future<Map<String, String>>.value(<String, String>{
-              'SWIFT_VERSION': '5.0',
-            });
-        });
         addAndroidGradleFile(project.directory,
           gradleFileContent: () {
             return '''
@@ -324,7 +317,6 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 ''';
         });
-        expect(await project.ios.isSwift, isTrue);
         expect(project.android.isKotlin, isTrue);
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,


### PR DESCRIPTION
## Description

- Remove `isSwift` getter since it was only used for calculating usage values
- Don't pass iOS `flutter run` usage values if only Android devices are targeted, and vice versa.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/46910

## Tests

- Updated run_test and project_test.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. 
