### PR TITLE
Add newlines between plugin names in GitHub template

### DIFF
--- a/packages/flutter_tools/lib/src/reporting/github_template.dart
+++ b/packages/flutter_tools/lib/src/reporting/github_template.dart
@@ -102,7 +102,7 @@ class GitHubTemplateCreator {
           if (pluginParts.length != 2) {
             continue;
           }
-          description += pluginParts.first;
+          description += '${pluginParts.first}\n';
         }
       }
 

--- a/packages/flutter_tools/lib/src/reporting/github_template.dart
+++ b/packages/flutter_tools/lib/src/reporting/github_template.dart
@@ -41,26 +41,26 @@ class GitHubTemplateCreator {
     ) async {
     final String title = '[tool_crash] $errorString';
     final String body = '''## Command
-  ```
-  $command
-  ```
+```
+$command
+```
 
-  ## Steps to Reproduce
-  1. ...
-  2. ...
-  3. ...
+## Steps to Reproduce
+1. ...
+2. ...
+3. ...
 
-  ## Logs
-  $exception
-  ```
-  ${LineSplitter.split(stackTrace.toString()).take(20).join('\n')}
-  ```
-  ```
-  $doctorText
-  ```
+## Logs
+$exception
+```
+${LineSplitter.split(stackTrace.toString()).take(20).join('\n')}
+```
+```
+$doctorText
+```
 
-  ## Flutter Application Metadata
-  ${_projectMetadataInformation()}
+## Flutter Application Metadata
+${_projectMetadataInformation()}
 ''';
 
     final String fullURL = 'https://github.com/flutter/flutter/issues/new?'

--- a/packages/flutter_tools/lib/src/reporting/github_template.dart
+++ b/packages/flutter_tools/lib/src/reporting/github_template.dart
@@ -61,7 +61,7 @@ class GitHubTemplateCreator {
 
   ## Flutter Application Metadata
   ${_projectMetadataInformation()}
-  ''';
+''';
 
     final String fullURL = 'https://github.com/flutter/flutter/issues/new?'
       'title=${Uri.encodeQueryComponent(title)}'
@@ -85,14 +85,14 @@ class GitHubTemplateCreator {
       if (project == null || manifest == null || manifest.isEmpty) {
         return 'No pubspec in working directory.';
       }
-      final StringBuffer description = StringBuffer();
-      description.writeln('**Version**: ${manifest.appVersion}');
-      description.writeln('**Material**: ${manifest.usesMaterialDesign}');
-      description.writeln('**Android X**: ${manifest.usesAndroidX}');
-      description.writeln('**Module**: ${manifest.isModule}');
-      description.writeln('**Plugin**: ${manifest.isPlugin}');
-      description.writeln('**Android package**: ${manifest.androidPackage}');
-      description.writeln('**iOS bundle identifier**: ${manifest.iosBundleIdentifier}');
+      final StringBuffer description = StringBuffer()
+        ..writeln('**Version**: ${manifest.appVersion}')
+        ..writeln('**Material**: ${manifest.usesMaterialDesign}')
+        ..writeln('**Android X**: ${manifest.usesAndroidX}')
+        ..writeln('**Module**: ${manifest.isModule}')
+        ..writeln('**Plugin**: ${manifest.isPlugin}')
+        ..writeln('**Android package**: ${manifest.androidPackage}')
+        ..writeln('**iOS bundle identifier**: ${manifest.iosBundleIdentifier}');
 
       final File file = project.flutterPluginsFile;
       if (file.existsSync()) {

--- a/packages/flutter_tools/test/general.shard/github_template_test.dart
+++ b/packages/flutter_tools/test/general.shard/github_template_test.dart
@@ -16,12 +16,6 @@ const String _kShortURL = 'https://www.example.com/short';
 
 void main() {
   group('GitHub template creator', () {
-    FileSystem fs;
-
-    setUp(() async {
-      fs = MemoryFileSystem();
-    });
-
     testUsingContext('similar issues URL', () async {
       final GitHubTemplateCreator creator = GitHubTemplateCreator();
       expect(
@@ -52,9 +46,11 @@ void main() {
       const String errorString = 'this is a 100% error';
       const String exception = 'failing to succeed!!!';
       const String doctorText = ' [✓] Flutter (Channel report';
+      FileSystem fs;
 
       setUp(() async {
         stackTrace = StackTrace.fromString('trace');
+        fs = MemoryFileSystem();
       });
 
       testUsingContext('shortened', () async {

--- a/packages/flutter_tools/test/general.shard/github_template_test.dart
+++ b/packages/flutter_tools/test/general.shard/github_template_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/net.dart';
 import 'package:flutter_tools/src/reporting/github_template.dart';
@@ -14,6 +16,11 @@ const String _kShortURL = 'https://www.example.com/short';
 
 void main() {
   group('GitHub template creator', () {
+    FileSystem fs;
+
+    setUp(() async {
+      fs = MemoryFileSystem();
+    });
 
     testUsingContext('similar issues URL', () async {
       final GitHubTemplateCreator creator = GitHubTemplateCreator();
@@ -23,6 +30,8 @@ void main() {
       );
     }, overrides: <Type, Generator>{
       HttpClientFactory: () => () => SuccessShortenURLFakeHttpClient(),
+      FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager.any(),
     });
 
     testUsingContext('similar issues URL with network failure', () async {
@@ -33,45 +42,89 @@ void main() {
       );
     }, overrides: <Type, Generator>{
       HttpClientFactory: () => () => FakeHttpClient(),
+      FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager.any(),
     });
 
-    testUsingContext('new issue template URL', () async {
-      final GitHubTemplateCreator creator = GitHubTemplateCreator();
+    group('new issue template URL', () {
+      StackTrace stackTrace;
       const String command = 'flutter test';
       const String errorString = 'this is a 100% error';
       const String exception = 'failing to succeed!!!';
-      final StackTrace stackTrace = StackTrace.fromString('trace');
       const String doctorText = ' [✓] Flutter (Channel report';
 
-      expect(
-        await creator.toolCrashIssueTemplateGitHubURL(command, errorString, exception, stackTrace, doctorText),
-        _kShortURL
-      );
-    }, overrides: <Type, Generator>{
-      HttpClientFactory: () => () => SuccessShortenURLFakeHttpClient(),
-    });
+      setUp(() async {
+        stackTrace = StackTrace.fromString('trace');
+      });
 
-    testUsingContext('new issue template URL with network failure', () async {
-      final GitHubTemplateCreator creator = GitHubTemplateCreator();
-      const String command = 'flutter test';
-      const String errorString = 'this is a 100% error';
-      const String exception = 'failing to succeed!!!';
-      final StackTrace stackTrace = StackTrace.fromString('trace');
-      const String doctorText = ' [✓] Flutter (Channel report';
+      testUsingContext('shortened', () async {
+        final GitHubTemplateCreator creator = GitHubTemplateCreator();
+        expect(
+            await creator.toolCrashIssueTemplateGitHubURL(command, errorString, exception, stackTrace, doctorText),
+            _kShortURL
+        );
+      }, overrides: <Type, Generator>{
+        HttpClientFactory: () => () => SuccessShortenURLFakeHttpClient(),
+        FileSystem: () => MemoryFileSystem(),
+        ProcessManager: () => FakeProcessManager.any(),
+      });
 
-      expect(
-        await creator.toolCrashIssueTemplateGitHubURL(command, errorString, exception, stackTrace, doctorText),
-        'https://github.com/flutter/flutter/issues/new?title=%5Btool_crash%5D+this+is+a+100%25+error&body=%23%'
-          '23+Command%0A++%60%60%60%0A++flutter+test%0A++%60%60%60%0A%0A++%23%23+Steps+to+Reproduce%0A++1.+...'
-          '%0A++2.+...%0A++3.+...%0A%0A++%23%23+Logs%0A++failing+to+succeed%21%21%21%0A++%60%60%60%0A++trace%0A'
-          '++%60%60%60%0A++%60%60%60%0A+++%5B%E2%9C%93%5D+Flutter+%28Channel+report%0A++%60%60%60%0A%0A++%23%23'
-          '+Flutter+Application+Metadata%0A++%2A%2AVersion%2A%2A%3A+null%0A%2A%2AMaterial%2A%2A%3A+false%0A%2A'
-          '%2AAndroid+X%2A%2A%3A+false%0A%2A%2AModule%2A%2A%3A+false%0A%2A%2APlugin%2A%2A%3A+false%0A%2A%2AAndr'
-          'oid+package%2A%2A%3A+null%0A%2A%2AiOS+bundle+identifier%2A%2A%3A+null%0A%0A++&labels=tool%2Csevere%3'
-          'A+crash'
-      );
-    }, overrides: <Type, Generator>{
-      HttpClientFactory: () => () => FakeHttpClient(),
+      testUsingContext('with network failure', () async {
+        final GitHubTemplateCreator creator = GitHubTemplateCreator();
+        expect(
+            await creator.toolCrashIssueTemplateGitHubURL(command, errorString, exception, stackTrace, doctorText),
+            'https://github.com/flutter/flutter/issues/new?title=%5Btool_crash%5D+this+is+a+100%25+error&body=%23%'
+                '23+Command%0A++%60%60%60%0A++flutter+test%0A++%60%60%60%0A%0A++%23%23+Steps+to+Reproduce%0A++1.+...'
+                '%0A++2.+...%0A++3.+...%0A%0A++%23%23+Logs%0A++failing+to+succeed%21%21%21%0A++%60%60%60%0A++trace%0A'
+                '++%60%60%60%0A++%60%60%60%0A+++%5B%E2%9C%93%5D+Flutter+%28Channel+report%0A++%60%60%60%0A%0A++%23%23'
+                '+Flutter+Application+Metadata%0A++No+pubspec+in+working+directory.%0A++&labels=tool%2Csevere%3A+crash'
+        );
+      }, overrides: <Type, Generator>{
+        HttpClientFactory: () => () => FakeHttpClient(),
+        FileSystem: () => MemoryFileSystem(),
+        ProcessManager: () => FakeProcessManager.any(),
+      });
+
+      testUsingContext('app metadata', () async {
+        final GitHubTemplateCreator creator = GitHubTemplateCreator();
+        final Directory projectDirectory = fs.currentDirectory;
+        final File pluginsFile = projectDirectory.childFile('.flutter-plugins');
+
+        projectDirectory
+            .childFile('pubspec.yaml')
+            .writeAsStringSync('''
+name: failing_app
+version: 2.0.1+100
+flutter:
+  uses-material-design: true
+  module:
+    androidX: true
+    androidPackage: com.example.failing.android
+    iosBundleIdentifier: com.example.failing.ios
+''');
+
+        pluginsFile
+            .writeAsStringSync('''
+camera=/fake/pub.dartlang.org/camera-0.5.7+2/
+device_info=/fake/pub.dartlang.org/pub.dartlang.org/device_info-0.4.1+4/
+        ''');
+
+        final String actualURL = await creator.toolCrashIssueTemplateGitHubURL(command, errorString, exception, stackTrace, doctorText);
+        final String body = Uri.parse(actualURL).queryParameters['body'];
+        expect(body, contains('**Version**: 2.0.1+100\n'));
+        expect(body, contains('**Material**: true\n'));
+        expect(body, contains('**Android X**: true\n'));
+        expect(body, contains('**Module**: true\n'));
+        expect(body, contains('**Plugin**: false\n'));
+        expect(body, contains('**Android package**: com.example.failing.android\n'));
+        expect(body, contains('**iOS bundle identifier**: com.example.failing.ios\n'));
+        expect(body, contains('camera-0.5.7+2\n'));
+        expect(body, contains('device_info-0.4.1+4\n'));
+      }, overrides: <Type, Generator>{
+        HttpClientFactory: () => () => FakeHttpClient(),
+        FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager.any(),
+      });
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/github_template_test.dart
+++ b/packages/flutter_tools/test/general.shard/github_template_test.dart
@@ -73,7 +73,7 @@ void main() {
                 '23+Command%0A++%60%60%60%0A++flutter+test%0A++%60%60%60%0A%0A++%23%23+Steps+to+Reproduce%0A++1.+...'
                 '%0A++2.+...%0A++3.+...%0A%0A++%23%23+Logs%0A++failing+to+succeed%21%21%21%0A++%60%60%60%0A++trace%0A'
                 '++%60%60%60%0A++%60%60%60%0A+++%5B%E2%9C%93%5D+Flutter+%28Channel+report%0A++%60%60%60%0A%0A++%23%23'
-                '+Flutter+Application+Metadata%0A++No+pubspec+in+working+directory.%0A++&labels=tool%2Csevere%3A+crash'
+                '+Flutter+Application+Metadata%0A++No+pubspec+in+working+directory.%0A&labels=tool%2Csevere%3A+crash'
         );
       }, overrides: <Type, Generator>{
         HttpClientFactory: () => () => FakeHttpClient(),
@@ -106,16 +106,41 @@ device_info=/fake/pub.dartlang.org/pub.dartlang.org/device_info-0.4.1+4/
         ''');
 
         final String actualURL = await creator.toolCrashIssueTemplateGitHubURL(command, errorString, exception, stackTrace, doctorText);
-        final String body = Uri.parse(actualURL).queryParameters['body'];
-        expect(body, contains('**Version**: 2.0.1+100\n'));
-        expect(body, contains('**Material**: true\n'));
-        expect(body, contains('**Android X**: true\n'));
-        expect(body, contains('**Module**: true\n'));
-        expect(body, contains('**Plugin**: false\n'));
-        expect(body, contains('**Android package**: com.example.failing.android\n'));
-        expect(body, contains('**iOS bundle identifier**: com.example.failing.ios\n'));
-        expect(body, contains('camera-0.5.7+2\n'));
-        expect(body, contains('device_info-0.4.1+4\n'));
+        final String actualBody = Uri.parse(actualURL).queryParameters['body'];
+        const String expectedBody = '''## Command
+  ```
+  flutter test
+  ```
+
+  ## Steps to Reproduce
+  1. ...
+  2. ...
+  3. ...
+
+  ## Logs
+  failing to succeed!!!
+  ```
+  trace
+  ```
+  ```
+   [✓] Flutter (Channel report
+  ```
+
+  ## Flutter Application Metadata
+  **Version**: 2.0.1+100
+**Material**: true
+**Android X**: true
+**Module**: true
+**Plugin**: false
+**Android package**: com.example.failing.android
+**iOS bundle identifier**: com.example.failing.ios
+### Plugins
+camera-0.5.7+2
+device_info-0.4.1+4
+
+''';
+
+        expect(actualBody, expectedBody);
       }, overrides: <Type, Generator>{
         HttpClientFactory: () => () => FakeHttpClient(),
         FileSystem: () => fs,

--- a/packages/flutter_tools/test/general.shard/github_template_test.dart
+++ b/packages/flutter_tools/test/general.shard/github_template_test.dart
@@ -70,10 +70,10 @@ void main() {
         expect(
             await creator.toolCrashIssueTemplateGitHubURL(command, errorString, exception, stackTrace, doctorText),
             'https://github.com/flutter/flutter/issues/new?title=%5Btool_crash%5D+this+is+a+100%25+error&body=%23%'
-                '23+Command%0A++%60%60%60%0A++flutter+test%0A++%60%60%60%0A%0A++%23%23+Steps+to+Reproduce%0A++1.+...'
-                '%0A++2.+...%0A++3.+...%0A%0A++%23%23+Logs%0A++failing+to+succeed%21%21%21%0A++%60%60%60%0A++trace%0A'
-                '++%60%60%60%0A++%60%60%60%0A+++%5B%E2%9C%93%5D+Flutter+%28Channel+report%0A++%60%60%60%0A%0A++%23%23'
-                '+Flutter+Application+Metadata%0A++No+pubspec+in+working+directory.%0A&labels=tool%2Csevere%3A+crash'
+                '23+Command%0A%60%60%60%0Aflutter+test%0A%60%60%60%0A%0A%23%23+Steps+to+Reproduce%0A1.+...'
+                '%0A2.+...%0A3.+...%0A%0A%23%23+Logs%0Afailing+to+succeed%21%21%21%0A%60%60%60%0Atrace%0A'
+                '%60%60%60%0A%60%60%60%0A+%5B%E2%9C%93%5D+Flutter+%28Channel+report%0A%60%60%60%0A%0A%23%23'
+                '+Flutter+Application+Metadata%0ANo+pubspec+in+working+directory.%0A&labels=tool%2Csevere%3A+crash'
         );
       }, overrides: <Type, Generator>{
         HttpClientFactory: () => () => FakeHttpClient(),
@@ -108,26 +108,26 @@ device_info=/fake/pub.dartlang.org/pub.dartlang.org/device_info-0.4.1+4/
         final String actualURL = await creator.toolCrashIssueTemplateGitHubURL(command, errorString, exception, stackTrace, doctorText);
         final String actualBody = Uri.parse(actualURL).queryParameters['body'];
         const String expectedBody = '''## Command
-  ```
-  flutter test
-  ```
+```
+flutter test
+```
 
-  ## Steps to Reproduce
-  1. ...
-  2. ...
-  3. ...
+## Steps to Reproduce
+1. ...
+2. ...
+3. ...
 
-  ## Logs
-  failing to succeed!!!
-  ```
-  trace
-  ```
-  ```
-   [✓] Flutter (Channel report
-  ```
+## Logs
+failing to succeed!!!
+```
+trace
+```
+```
+ [✓] Flutter (Channel report
+```
 
-  ## Flutter Application Metadata
-  **Version**: 2.0.1+100
+## Flutter Application Metadata
+**Version**: 2.0.1+100
 **Material**: true
 **Android X**: true
 **Module**: true


### PR DESCRIPTION
## Description

Previous template was shoving the plugin names together:
```
path_providerurl_launcherurl_launcher_macosurl_launcher_web
```

Also include the plugin version.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/46934
Similar to https://github.com/flutter/flutter/issues/36496 but on crash, not doctor.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. 