### PR TITLE
DO NOT SUBMIT: [flutter_tool] Plumb ipv6 flag to mDNS client

### DIFF
--- a/packages/flutter_tools/lib/src/mdns_discovery.dart
+++ b/packages/flutter_tools/lib/src/mdns_discovery.dart
@@ -51,10 +51,17 @@ class MDnsObservatoryDiscovery {
   /// it will return that instance's information regardless of what application
   /// the Observatory instance is for.
   // TODO(jonahwilliams): use `deviceVmservicePort` to filter mdns results.
-  Future<MDnsObservatoryDiscoveryResult> query({String applicationId, int deviceVmservicePort}) async {
+  Future<MDnsObservatoryDiscoveryResult> query({
+    bool usesIpv6 = false,
+    String applicationId,
+    int deviceVmservicePort,
+  }) async {
     printTrace('Checking for advertised Dart observatories...');
     try {
-      await client.start();
+      final InternetAddress listenAddress = usesIpv6
+        ? InternetAddress.anyIPv6
+        : InternetAddress.anyIPv4;
+      await client.start(listenAddress: listenAddress);
       final List<PtrResourceRecord> pointerRecords = await client
           .lookup<PtrResourceRecord>(
             ResourceRecordQuery.serverPointer(dartObservatoryName),
@@ -143,6 +150,7 @@ class MDnsObservatoryDiscovery {
     int deviceVmservicePort,
   }) async {
     final MDnsObservatoryDiscoveryResult result = await query(
+      usesIpv6: usesIpv6,
       applicationId: applicationId,
       deviceVmservicePort: deviceVmservicePort,
     );


### PR DESCRIPTION
This PR will depend on getting some combo of `dart:io` and `package:multicast_dns` to speak ipv6 properly.

## Description

If `flutter run` or `flutter attach` are invoked with the `--ipv6` flag, then use ipv6 for the mDNS client as well.

## Related Issues

https://github.com/flutter/flutter/issues/46698

## Tests

I added the following tests:

Added a test that ensures that when the ipv6 flag is true for `startApp()` it is also true for `getObservatoryUri()` on the mDNS client, and a test that when the ipv6 flag is true for `getObservatoryUri()` then it is also true for the mDNS client `query()`.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.