### PR TITLE
Revert "flutter_tools: Remove unused //ignore comments; change flutter-specific ones to "ignore_for_flutter""

### DIFF
--- a/packages/flutter_tools/bin/tool_backend.dart
+++ b/packages/flutter_tools/bin/tool_backend.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io'; // ignore_for_flutter: dart_io_import.
-import 'package:path/path.dart' as path; // ignore_for_flutter: package_path_import.
+import 'dart:io'; // ignore: dart_io_import.
+import 'package:path/path.dart' as path; // ignore: package_path_import.
 
 /// Executes the required flutter tasks for a desktop build.
 Future<void> main(List<String> arguments) async {

--- a/packages/flutter_tools/lib/src/build_runner/build_script.dart
+++ b/packages/flutter_tools/lib/src/build_runner/build_script.dart
@@ -3,10 +3,6 @@
 // found in the LICENSE file.
 
 // ignore_for_file: implementation_imports
-// The "// ignore:" comments found in strings in this file are counted as _actual_ ignore comments.
-// Since the "// ignore:" comments found in strings don't actually ignore anythin in _this_ file,
-// we must allow them to be "unused." See https://github.com/dart-lang/sdk/issues/39607.
-// ignore_for_file: unused_ignore_code
 import 'dart:async';
 import 'dart:isolate';
 
@@ -26,7 +22,7 @@ import 'package:build_test/src/debug_test_builder.dart';
 import 'package:build_web_compilers/build_web_compilers.dart';
 import 'package:build_web_compilers/builders.dart';
 import 'package:build_web_compilers/src/dev_compiler_bootstrap.dart';
-import 'package:path/path.dart' as path; // ignore_for_flutter: package_path_import
+import 'package:path/path.dart' as path; // ignore: package_path_import
 import 'package:test_core/backend.dart'; // ignore: deprecated_member_use
 
 const String ddcBootstrapExtension = '.dart.bootstrap.js';

--- a/packages/flutter_tools/lib/src/build_runner/web_compilation_delegate.dart
+++ b/packages/flutter_tools/lib/src/build_runner/web_compilation_delegate.dart
@@ -2,8 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// ignore_for_file: implementation_imports
 import 'dart:async';
-import 'dart:io' as io; // ignore_for_flutter: dart_io_import
+import 'dart:io' as io; // ignore: dart_io_import
 
 import 'package:build/build.dart';
 import 'package:build_daemon/client.dart';

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -159,8 +159,8 @@ String generateTestBootstrap({
   final StringBuffer buffer = StringBuffer();
   buffer.write('''
 import 'dart:async';
-import 'dart:convert';  // ignore_for_flutter: dart_convert_import
-import 'dart:io';  // ignore_for_flutter: dart_io_import
+import 'dart:convert';  // ignore: dart_convert_import
+import 'dart:io';  // ignore: dart_io_import
 import 'dart:isolate';
 
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -9,7 +9,7 @@ import 'dart:typed_data';
 
 import 'package:async/async.dart';
 import 'package:http_multi_server/http_multi_server.dart';
-import 'package:path/path.dart' as p; // ignore_for_flutter: package_path_import
+import 'package:path/path.dart' as p; // ignore: package_path_import
 import 'package:pool/pool.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf/shelf_io.dart' as shelf_io;

--- a/packages/flutter_tools/test/general.shard/dart/sdk_validation_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/sdk_validation_test.dart
@@ -2,10 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// The "// ignore:" comments found in strings in this file are counted as _actual_ ignore comments.
-// Since the "// ignore:" comments found in strings don't actually ignore anythin in _this_ file,
-// we must allow them to be "unused." See https://github.com/dart-lang/sdk/issues/39607.
-// ignore_for_file: unused_ignore_code
 import 'dart:async';
 
 import 'package:flutter_tools/src/base/file_system.dart';

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io'; // ignore_for_flutter: dart_io_import
+import 'dart:io'; // ignore: dart_io_import
 
 import 'package:file/file.dart';
 import 'package:file/memory.dart';

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
@@ -230,7 +230,7 @@ flutter:
       expect(fooFontAsset1.style, 'italic');
 
       final Font barFont = fonts[1];
-      const String fontDescriptor = '{family: bar, fonts: [{asset: a/baz}, {weight: 400, style: italic, asset: a/baz}]}';
+      const String fontDescriptor = '{family: bar, fonts: [{asset: a/baz}, {weight: 400, style: italic, asset: a/baz}]}'; // ignore: always_specify_types
       expect(barFont.descriptor.toString(), fontDescriptor);
       expect(barFont.familyName, 'bar');
       final List<FontAsset> barAssets = barFont.fontAssets;

--- a/packages/flutter_tools/test/general.shard/forbidden_imports_test.dart
+++ b/packages/flutter_tools/test/general.shard/forbidden_imports_test.dart
@@ -52,7 +52,7 @@ void main() {
       for (File file in files) {
         for (String line in file.readAsLinesSync()) {
           if (line.startsWith(RegExp(r'import.*dart:io')) &&
-              !line.contains('ignore_for_flutter: dart_io_import')) {
+              !line.contains('ignore: dart_io_import')) {
             final String relativePath = fs.path.relative(file.path, from:flutterTools);
             fail("$relativePath imports 'dart:io'; import 'lib/src/base/io.dart' instead");
           }
@@ -99,7 +99,7 @@ void main() {
       for (File file in files) {
         for (String line in file.readAsLinesSync()) {
           if (line.startsWith(RegExp(r'import.*package:path/path.dart')) &&
-              !line.contains('ignore_for_flutter: package_path_import')) {
+              !line.contains('ignore: package_path_import')) {
             final String relativePath = fs.path.relative(file.path, from:flutterTools);
             fail("$relativePath imports 'package:path/path.dart'; use 'fs.path' instead");
           }
@@ -124,7 +124,7 @@ void main() {
       for (File file in files) {
         for (String line in file.readAsLinesSync()) {
           if (line.startsWith(RegExp(r'import.*dart:convert')) &&
-              !line.contains('ignore_for_flutter: dart_convert_import')) {
+              !line.contains('ignore: dart_convert_import')) {
             final String relativePath = fs.path.relative(file.path, from:flutterTools);
             fail("$relativePath imports 'dart:convert'; import 'lib/src/convert.dart' instead");
           }

--- a/packages/flutter_tools/tool/tool_coverage.dart
+++ b/packages/flutter_tools/tool/tool_coverage.dart
@@ -2,10 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// The "// ignore:" comments found in strings in this file are counted as _actual_ ignore comments.
-// Since the "// ignore:" comments found in strings don't actually ignore anythin in _this_ file,
-// we must allow them to be "unused." See https://github.com/dart-lang/sdk/issues/39607.
-// ignore_for_file: unused_ignore_code
 import 'dart:async';
 import 'dart:developer';
 import 'dart:io';


### PR DESCRIPTION
Reverts flutter/flutter#45917

It broke forbidden_imports_test, which uses a custom ignore directive.

https://cirrus-ci.com/task/5320647412023296?command=main#L820
