### PR TITLE
Change meaning of a plugin not supporting the android platform

### DIFF
--- a/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
+++ b/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
@@ -74,7 +74,9 @@ Future<void> main() async {
         );
       });
 
-      File(path.join(pluginCDirectory.path, 'android')).deleteSync(recursive: true);
+      // https://github.com/flutter/flutter/issues/46898
+      // https://github.com/flutter/flutter/issues/39657
+      File(path.join(pluginCDirectory.path, 'android', 'build.gradle')).deleteSync();
 
       final File pluginCpubspec = File(path.join(pluginCDirectory.path, 'pubspec.yaml'));
       await pluginCpubspec.writeAsString('''

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -331,15 +331,24 @@ class FlutterPlugin implements Plugin<Project> {
         }
     }
 
+    // Returns `true` if the given path contains an `android/build.gradle` file.
+    //
+    // TODO(egarciad): Fix https://github.com/flutter/flutter/issues/39657.
+    // Android Studio may create empty android directories due to the logic in <app>/android/settings.gradle,
+    // which imports all plugins regardless of whether they support the android platform.
+    private Boolean doesSupportAndroidPlatform(String path) {
+        File editableAndroidProject = new File(path, 'android' + File.separator + 'build.gradle')
+        return editableAndroidProject.exists()
+    }
+
     // Add the dependencies on other plugin projects to the plugin project.
     // A plugin A can depend on plugin B. As a result, this dependency must be surfaced by
     // making the Gradle plugin project A depend on the Gradle plugin project B.
     private void configurePluginDependencies(Object dependencyObject) {
         assert dependencyObject.name instanceof String
         Project pluginProject = project.rootProject.findProject(":${dependencyObject.name}")
-        if (pluginProject == null) {
-            // Ignore plugins that don't have a project since most likely they don't
-            // have an android/ directory.
+        if (pluginProject == null ||
+            !doesSupportAndroidPlatform(pluginProject.projectDir.parentFile.path)) {
             return
         }
         assert dependencyObject.dependencies instanceof List
@@ -349,7 +358,8 @@ class FlutterPlugin implements Plugin<Project> {
                 return
             }
             Project dependencyProject = project.rootProject.findProject(":$pluginDependencyName")
-            if (!dependencyProject.projectDir.exists() || dependencyProject == null) {
+            if (dependencyProject == null ||
+                !doesSupportAndroidPlatform(dependencyProject.projectDir.parentFile.path)) {
                 return
             }
             // Wait for the Android plugin to load and add the dependency to the plugin project.
@@ -366,8 +376,7 @@ class FlutterPlugin implements Plugin<Project> {
         Properties allPlugins = readPropertiesIfExist(pluginsFile)
         Properties androidPlugins = new Properties()
         allPlugins.each { name, path ->
-            File editableAndroidProject = new File(path, 'android' + File.separator + 'build.gradle')
-            if (editableAndroidProject.exists()) {
+            if (doesSupportAndroidPlatform(path)) {
                 androidPlugins.setProperty(name, path)
             }
             // TODO(amirh): log an error if this plugin was specified to be an Android

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -715,8 +715,9 @@ Future<void> buildPluginsAsAar(
     assert(pluginDirectory.existsSync());
 
     final String pluginName = pluginParts.first;
-    if (!pluginDirectory.childDirectory('android').existsSync()) {
-      printTrace('Skipping plugin $pluginName since it doesn\'t have an android directory');
+    final File buildGradleFile = pluginDirectory.childDirectory('android').childFile('build.gradle');
+    if (!buildGradleFile.existsSync()) {
+      printTrace('Skipping plugin $pluginName since it doesn\'t have a android/build.gradle file');
       continue;
     }
     logger.printStatus('Building plugin $pluginName...');

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -897,7 +897,10 @@ flutter:
     androidPackage: irrelevant
 ''');
 
-      plugin1.childDirectory('android').createSync();
+      plugin1
+        .childDirectory('android')
+        .childFile('build.gradle')
+        .createSync(recursive: true);
 
       final Directory plugin2 = fs.directory('plugin2.');
       plugin2
@@ -910,7 +913,10 @@ flutter:
     androidPackage: irrelevant
 ''');
 
-      plugin2.childDirectory('android').createSync();
+      plugin2
+        .childDirectory('android')
+        .childFile('build.gradle')
+        .createSync(recursive: true);
 
       androidDirectory
         .childFile('.flutter-plugins')

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -976,7 +976,7 @@ plugin2=${plugin2.path}
       GradleUtils: () => FakeGradleUtils(),
     });
 
-    testUsingContext('skips plugin without an android directory', () async {
+    testUsingContext('skips plugin without a android/build.gradle file', () async {
       final Directory androidDirectory = fs.directory('android.');
       androidDirectory.createSync();
       androidDirectory
@@ -999,6 +999,10 @@ flutter:
         .writeAsStringSync('''
 plugin1=${plugin1.path}
 ''');
+      // Create an empty android directory.
+      // https://github.com/flutter/flutter/issues/46898
+      plugin1.childDirectory('android').createSync();
+
       final Directory buildDirectory = androidDirectory.childDirectory('build');
 
       buildDirectory


### PR DESCRIPTION
## Description

As described in https://github.com/flutter/flutter/issues/46898#issuecomment-565612416. Android Studio automatically creates an empty `android` directory due to the hard-coded logic in settings.gradle, which imports all plugins.

We should probably refocus https://github.com/flutter/flutter/issues/39657, so it's about cleaning the logic in `settings.gradle`, which we didn't do in the stable release.

## Related Issues

* https://github.com/flutter/flutter/issues/46898
* https://github.com/flutter/flutter/issues/39657

## Tests

I added the following tests: changed integration test

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
