### PR TITLE
[flutter_tool] ensure extraGenSnapshotArguments are forwarded to gen_snapshot from Android builds

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -815,7 +815,7 @@ abstract class BaseFlutterTask extends DefaultTask {
                 args "-dExtraFrontEndOptions=${extraFrontEndOptions}"
             }
             if (extraGenSnapshotOptions != null) {
-                args "-dExtraGenSnapshotOptions=${extraGenSnapshotOptions}"
+                args "--ExtraGenSnapshotOptions=${extraGenSnapshotOptions}"
             }
             args ruleNames
         }

--- a/packages/flutter_tools/lib/src/build_system/targets/android.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/android.dart
@@ -208,6 +208,8 @@ class AndroidAot extends AotElfBase {
     if (!output.existsSync()) {
       output.createSync(recursive: true);
     }
+    final List<String> extraGenSnapshotOptions = environment.defines[kExtraGenSnapshotOptions]?.split(',')
+      ?? const <String>[];
     final BuildMode buildMode = getBuildModeForName(environment.defines[kBuildMode]);
     final int snapshotExitCode = await snapshotter.build(
       platform: targetPlatform,
@@ -216,6 +218,7 @@ class AndroidAot extends AotElfBase {
       packagesPath: environment.projectDir.childFile('.packages').path,
       outputPath: output.path,
       bitcode: false,
+      extraGenSnapshotOptions: extraGenSnapshotOptions,
     );
     if (snapshotExitCode != 0) {
       throw Exception('AOT snapshotter exited with code $snapshotExitCode');

--- a/packages/flutter_tools/lib/src/build_system/targets/dart.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/dart.dart
@@ -253,6 +253,8 @@ abstract class AotElfBase extends Target {
     if (environment.defines[kTargetPlatform] == null) {
       throw MissingDefineException(kTargetPlatform, 'aot_elf');
     }
+    final List<String> extraGenSnapshotOptions = environment.defines[kExtraGenSnapshotOptions]?.split(',')
+      ?? <String>[];
     final BuildMode buildMode = getBuildModeForName(environment.defines[kBuildMode]);
     final TargetPlatform targetPlatform = getTargetPlatformForName(environment.defines[kTargetPlatform]);
     final int snapshotExitCode = await snapshotter.build(
@@ -262,6 +264,7 @@ abstract class AotElfBase extends Target {
       packagesPath: environment.projectDir.childFile('.packages').path,
       outputPath: outputPath,
       bitcode: false,
+      extraGenSnapshotOptions: extraGenSnapshotOptions,
     );
     if (snapshotExitCode != 0) {
       throw Exception('AOT snapshotter exited with code $snapshotExitCode');

--- a/packages/flutter_tools/lib/src/build_system/targets/dart.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/dart.dart
@@ -254,7 +254,7 @@ abstract class AotElfBase extends Target {
       throw MissingDefineException(kTargetPlatform, 'aot_elf');
     }
     final List<String> extraGenSnapshotOptions = environment.defines[kExtraGenSnapshotOptions]?.split(',')
-      ?? <String>[];
+      ?? const <String>[];
     final BuildMode buildMode = getBuildModeForName(environment.defines[kBuildMode]);
     final TargetPlatform targetPlatform = getTargetPlatformForName(environment.defines[kTargetPlatform]);
     final int snapshotExitCode = await snapshotter.build(

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -77,6 +77,7 @@ class AssembleCommand extends FlutterCommand {
         'files will be written. Must be either absolute or relative from the '
         'root of the current Flutter project.',
     );
+    argParser.addOption(kExtraGenSnapshotOptions);
     argParser.addOption(
       'resource-pool-size',
       help: 'The maximum number of concurrent tasks the build system will run.',
@@ -150,16 +151,20 @@ class AssembleCommand extends FlutterCommand {
     return result;
   }
 
-  static Map<String, String> _parseDefines(List<String> values) {
+  Map<String, String> _parseDefines(List<String> values) {
     final Map<String, String> results = <String, String>{};
     for (String chunk in values) {
-      final List<String> parts = chunk.split('=');
-      if (parts.length != 2) {
+      final int indexEquals = chunk.indexOf('=');
+      if (indexEquals == -1) {
         throwToolExit('Improperly formatted define flag: $chunk');
       }
-      final String key = parts[0];
-      final String value = parts[1];
+      final String key = chunk.substring(0, indexEquals);
+      final String value = chunk.substring(indexEquals + 1);
       results[key] = value;
+    }
+    // Workaround for extraGenSnapshot formatting.
+    if (argResults.wasParsed(kExtraGenSnapshotOptions)) {
+      results[kExtraGenSnapshotOptions] = argResults[kExtraGenSnapshotOptions] as String;
     }
     return results;
   }

--- a/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
@@ -32,6 +32,18 @@ void main() {
     expect(testLogger.traceText, contains('build succeeded.'));
   });
 
+  testbed.test('Can parse defines whose values contain =', () async {
+    when(buildSystem.build(any, any, buildSystemConfig: anyNamed('buildSystemConfig')))
+      .thenAnswer((Invocation invocation) async {
+        expect((invocation.positionalArguments[1] as Environment).defines, containsPair('FooBar', 'fizz=2'));
+        return BuildResult(success: true);
+      });
+    final CommandRunner<void> commandRunner = createTestCommandRunner(AssembleCommand());
+    await commandRunner.run(<String>['assemble', '-o Output', '-dFooBar=fizz=2', 'debug_macos_bundle_flutter_assets']);
+
+    expect(testLogger.traceText, contains('build succeeded.'));
+  });
+
   testbed.test('Throws ToolExit if not provided with output', () async {
     when(buildSystem.build(any, any, buildSystemConfig: anyNamed('buildSystemConfig')))
       .thenAnswer((Invocation invocation) async {

--- a/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
@@ -413,10 +413,32 @@ flutter_tools:lib/''');
 
     expect(androidEnvironment.outputDir.childFile('app.so').existsSync(), true);
   }));
+
+  test('kExtraGenSnapshotOptions passes values to gen_snapshot', () => testbed.run(() async {
+    androidEnvironment.defines[kExtraGenSnapshotOptions] = 'foo,bar,baz';
+
+    when(genSnapshot.run(
+      snapshotType: anyNamed('snapshotType'),
+      darwinArch: anyNamed('darwinArch'),
+      additionalArgs: captureAnyNamed('additionalArgs'),
+    )).thenAnswer((Invocation invocation) async {
+      expect(invocation.namedArguments[#additionalArgs], containsAll(<String>[
+        'foo',
+        'bar',
+        'baz',
+      ]));
+      return 0;
+    });
+
+
+    await const AotElfRelease().build(androidEnvironment);
+  }, overrides: <Type, Generator>{
+    GenSnapshot: () => MockGenSnapshot(),
+  }));
 }
 
 class MockProcessManager extends Mock implements ProcessManager {}
-
+class MockGenSnapshot extends Mock implements GenSnapshot {}
 class MockXcode extends Mock implements Xcode {}
 
 class FakeGenSnapshot implements GenSnapshot {

--- a/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
@@ -415,7 +415,7 @@ flutter_tools:lib/''');
   }));
 
   test('kExtraGenSnapshotOptions passes values to gen_snapshot', () => testbed.run(() async {
-    androidEnvironment.defines[kExtraGenSnapshotOptions] = 'foo,bar,baz';
+    androidEnvironment.defines[kExtraGenSnapshotOptions] = 'foo,bar,baz=2';
 
     when(genSnapshot.run(
       snapshotType: anyNamed('snapshotType'),
@@ -425,7 +425,7 @@ flutter_tools:lib/''');
       expect(invocation.namedArguments[#additionalArgs], containsAll(<String>[
         'foo',
         'bar',
-        'baz',
+        'baz=2',
       ]));
       return 0;
     });


### PR DESCRIPTION
## Description

During the assemble migration, this functionality was not correctly wired up to the new rules.

 Fixes https://github.com/flutter/flutter/issues/47049