### PR TITLE
give flex widgets the ability to take up the whole cross axis

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -28,6 +28,7 @@ export 'package:flutter/rendering.dart' show
   Axis,
   BoxConstraints,
   CrossAxisAlignment,
+  CrossAxisSize,
   CustomClipper,
   CustomPainter,
   CustomPainterSemantics,
@@ -3745,8 +3746,12 @@ class PositionedDirectional extends StatelessWidget {
 ///    allocated space), and children with [Flexible.fit] properties that are
 ///    [FlexFit.loose] are given loose constraints (i.e., not forced to fill the
 ///    allocated space).
-/// 4. The cross axis extent of the [Flex] is the maximum cross axis extent of
-///    the children (which will always satisfy the incoming constraints).
+/// 4. The cross axis extent of the [Flex] is determined by the [crossAxisSize]
+///    property. If the [crossAxisSize] property is [CrossAxisSize.max], then the
+///    cross axis extent of the [Flex] is the max extent of the incoming cross
+///    axis constraints. If the [crossAxisSize] property is [CrossAxisSize.min],
+///    then the main axis extent of the [Flex] is the max of the cross axis
+///    extents of the children (subject to the incoming constraints).
 /// 5. The main axis extent of the [Flex] is determined by the [mainAxisSize]
 ///    property. If the [mainAxisSize] property is [MainAxisSize.max], then the
 ///    main axis extent of the [Flex] is the max extent of the incoming main
@@ -3788,6 +3793,7 @@ class Flex extends MultiChildRenderObjectWidget {
     this.mainAxisAlignment = MainAxisAlignment.start,
     this.mainAxisSize = MainAxisSize.max,
     this.crossAxisAlignment = CrossAxisAlignment.center,
+    this.crossAxisSize = CrossAxisSize.min,
     this.textDirection,
     this.verticalDirection = VerticalDirection.down,
     this.textBaseline,
@@ -3832,6 +3838,18 @@ class Flex extends MultiChildRenderObjectWidget {
   /// For example, [CrossAxisAlignment.center], the default, centers the
   /// children in the cross axis (e.g., horizontally for a [Column]).
   final CrossAxisAlignment crossAxisAlignment;
+
+  /// How much space should be occupied in the cross axis.
+  ///
+  /// After allocating space to children, there might be some remaining free
+  /// space. This value controls whether to maximize or minimize the amount of
+  /// free space, subject to the incoming layout constraints.
+  ///
+  /// If some children have a non-zero flex factors (and none have a fit of
+  /// [FlexFit.loose]), they will expand to consume all the available space and
+  /// there will be no remaining free space to maximize or minimize, making this
+  /// value irrelevant to the final layout.
+  final CrossAxisSize crossAxisSize;
 
   /// Determines the order to lay children out horizontally and how to interpret
   /// `start` and `end` in the horizontal direction.
@@ -3922,6 +3940,7 @@ class Flex extends MultiChildRenderObjectWidget {
       mainAxisAlignment: mainAxisAlignment,
       mainAxisSize: mainAxisSize,
       crossAxisAlignment: crossAxisAlignment,
+      crossAxisSize: crossAxisSize,
       textDirection: getEffectiveTextDirection(context),
       verticalDirection: verticalDirection,
       textBaseline: textBaseline,
@@ -3935,6 +3954,7 @@ class Flex extends MultiChildRenderObjectWidget {
       ..mainAxisAlignment = mainAxisAlignment
       ..mainAxisSize = mainAxisSize
       ..crossAxisAlignment = crossAxisAlignment
+      ..crossAxisSize = crossAxisSize
       ..textDirection = getEffectiveTextDirection(context)
       ..verticalDirection = verticalDirection
       ..textBaseline = textBaseline;
@@ -3947,6 +3967,7 @@ class Flex extends MultiChildRenderObjectWidget {
     properties.add(EnumProperty<MainAxisAlignment>('mainAxisAlignment', mainAxisAlignment));
     properties.add(EnumProperty<MainAxisSize>('mainAxisSize', mainAxisSize, defaultValue: MainAxisSize.max));
     properties.add(EnumProperty<CrossAxisAlignment>('crossAxisAlignment', crossAxisAlignment));
+    properties.add(EnumProperty<CrossAxisSize>('crossAxisSize', crossAxisSize, defaultValue: CrossAxisSize.min));
     properties.add(EnumProperty<TextDirection>('textDirection', textDirection, defaultValue: null));
     properties.add(EnumProperty<VerticalDirection>('verticalDirection', verticalDirection, defaultValue: VerticalDirection.down));
     properties.add(EnumProperty<TextBaseline>('textBaseline', textBaseline, defaultValue: null));
@@ -4126,6 +4147,7 @@ class Row extends Flex {
     MainAxisAlignment mainAxisAlignment = MainAxisAlignment.start,
     MainAxisSize mainAxisSize = MainAxisSize.max,
     CrossAxisAlignment crossAxisAlignment = CrossAxisAlignment.center,
+    CrossAxisSize crossAxisSize = CrossAxisSize.min,
     TextDirection textDirection,
     VerticalDirection verticalDirection = VerticalDirection.down,
     TextBaseline textBaseline,
@@ -4137,6 +4159,7 @@ class Row extends Flex {
     mainAxisAlignment: mainAxisAlignment,
     mainAxisSize: mainAxisSize,
     crossAxisAlignment: crossAxisAlignment,
+    crossAxisSize: crossAxisSize,
     textDirection: textDirection,
     verticalDirection: verticalDirection,
     textBaseline: textBaseline,
@@ -4326,6 +4349,7 @@ class Column extends Flex {
     MainAxisAlignment mainAxisAlignment = MainAxisAlignment.start,
     MainAxisSize mainAxisSize = MainAxisSize.max,
     CrossAxisAlignment crossAxisAlignment = CrossAxisAlignment.center,
+    CrossAxisSize crossAxisSize = CrossAxisSize.min,
     TextDirection textDirection,
     VerticalDirection verticalDirection = VerticalDirection.down,
     TextBaseline textBaseline,
@@ -4337,6 +4361,7 @@ class Column extends Flex {
     mainAxisAlignment: mainAxisAlignment,
     mainAxisSize: mainAxisSize,
     crossAxisAlignment: crossAxisAlignment,
+    crossAxisSize: crossAxisSize,
     textDirection: textDirection,
     verticalDirection: verticalDirection,
     textBaseline: textBaseline,

--- a/packages/flutter/test/rendering/flex_test.dart
+++ b/packages/flutter/test/rendering/flex_test.dart
@@ -130,6 +130,7 @@ void main() {
         '   mainAxisAlignment: start\n'
         '   mainAxisSize: max\n'
         '   crossAxisAlignment: center\n'
+        '   crossAxisSize: min\n'
         '   verticalDirection: down\n'
       ),
     );
@@ -437,6 +438,68 @@ void main() {
     expect(box1.size, const Size(100.0, 100.0));
     expect(box2.size, const Size(100.0, 100.0));
     expect(box3.size, const Size(100.0, 100.0));
+  });
+
+  test('Flexible with CrossAxisSize.max horizontal', () {
+    final RenderConstrainedBox box1 = RenderConstrainedBox(additionalConstraints: const BoxConstraints.tightFor(width: 100.0, height: 100.0));
+    final RenderConstrainedBox box2 = RenderConstrainedBox(additionalConstraints: const BoxConstraints.tightFor(width: 100.0, height: 100.0));
+    final RenderConstrainedBox box3 = RenderConstrainedBox(additionalConstraints: const BoxConstraints.tightFor(width: 100.0, height: 100.0));
+    final RenderFlex flex = RenderFlex(
+      textDirection: TextDirection.ltr,
+      crossAxisSize: CrossAxisSize.max,
+    );
+    flex.addAll(<RenderBox>[box1, box2, box3]);
+    layout(flex, constraints: const BoxConstraints(
+        minWidth: 0.0, maxWidth: 500.0, minHeight: 0.0, maxHeight: 400.0),
+    );
+
+    expect(flex.size.height, 400.0);
+  });
+
+  test('Flexible with CrossAxisSize.max vertical', () {
+    final RenderConstrainedBox box1 = RenderConstrainedBox(additionalConstraints: const BoxConstraints.tightFor(width: 100.0, height: 100.0));
+    final RenderConstrainedBox box2 = RenderConstrainedBox(additionalConstraints: const BoxConstraints.tightFor(width: 100.0, height: 100.0));
+    final RenderConstrainedBox box3 = RenderConstrainedBox(additionalConstraints: const BoxConstraints.tightFor(width: 100.0, height: 100.0));
+    final RenderFlex flex = RenderFlex(
+      direction: Axis.vertical,
+      crossAxisSize: CrossAxisSize.max,
+    );
+    flex.addAll(<RenderBox>[box1, box2, box3]);
+    layout(flex, constraints: const BoxConstraints(
+        minWidth: 0.0, maxWidth: 500.0, minHeight: 0.0, maxHeight: 400.0),
+    );
+
+    expect(flex.size.width, 500.0);
+  });
+
+  test('Flexible with CrossAxisSize.min horizontal', () {
+    final RenderConstrainedBox box1 = RenderConstrainedBox(additionalConstraints: const BoxConstraints.tightFor(width: 100.0, height: 100.0));
+    final RenderConstrainedBox box2 = RenderConstrainedBox(additionalConstraints: const BoxConstraints.tightFor(width: 100.0, height: 100.0));
+    final RenderConstrainedBox box3 = RenderConstrainedBox(additionalConstraints: const BoxConstraints.tightFor(width: 100.0, height: 100.0));
+    final RenderFlex flex = RenderFlex(
+      textDirection: TextDirection.ltr,
+    );
+    flex.addAll(<RenderBox>[box1, box2, box3]);
+    layout(flex, constraints: const BoxConstraints(
+        minWidth: 0.0, maxWidth: 500.0, minHeight: 0.0, maxHeight: 400.0),
+    );
+
+    expect(flex.size.height, 100.0);
+  });
+
+  test('Flexible with CrossAxisSize.min vertical', () {
+    final RenderConstrainedBox box1 = RenderConstrainedBox(additionalConstraints: const BoxConstraints.tightFor(width: 100.0, height: 100.0));
+    final RenderConstrainedBox box2 = RenderConstrainedBox(additionalConstraints: const BoxConstraints.tightFor(width: 100.0, height: 100.0));
+    final RenderConstrainedBox box3 = RenderConstrainedBox(additionalConstraints: const BoxConstraints.tightFor(width: 100.0, height: 100.0));
+    final RenderFlex flex = RenderFlex(
+      direction: Axis.vertical,
+    );
+    flex.addAll(<RenderBox>[box1, box2, box3]);
+    layout(flex, constraints: const BoxConstraints(
+        minWidth: 0.0, maxWidth: 500.0, minHeight: 0.0, maxHeight: 400.0),
+    );
+
+    expect(flex.size.width, 100.0);
   });
 
   test('Flex RTL', () {

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -8,6 +8,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/rendering.dart';
 
+import 'framework_test.dart';
+
 void main() {
   group('PhysicalShape', () {
     testWidgets('properties', (WidgetTester tester) async {
@@ -214,6 +216,57 @@ void main() {
       const UnconstrainedBox(constrainedAxis: Axis.horizontal, textDirection: TextDirection.rtl, alignment: Alignment.topRight).toString(),
       equals('UnconstrainedBox(alignment: topRight, constrainedAxis: horizontal, textDirection: rtl)'),
     );
+  });
+
+  test('Flex has crossAxisSize', () {
+    final Flex flex = Flex(
+      direction: Axis.vertical,
+      crossAxisSize: CrossAxisSize.max,
+    );
+
+    expect(flex.crossAxisSize, CrossAxisSize.max);
+  });
+
+  test('Flex defaults crossAxisSize to CrossAxisSize.min', () {
+    final Flex flex = Flex(direction: Axis.vertical);
+
+    expect(flex.crossAxisSize, CrossAxisSize.min);
+  });
+
+  test('Flex creates RenderFlex with crossAxisSize', () {
+    final Flex flex = Flex(
+      direction: Axis.vertical,
+      crossAxisSize: CrossAxisSize.max,
+    );
+    final BuildContext buildContext = NullChildElement(Container());
+    final RenderFlex renderFlex = flex.createRenderObject(buildContext);
+
+    expect(renderFlex.crossAxisSize, CrossAxisSize.max);
+  });
+
+  test('Flex updates RenderFlex with crossAxisSize', () {
+    final Flex flex = Flex(
+      direction: Axis.vertical,
+      crossAxisSize: CrossAxisSize.max,
+    );
+    final RenderFlex renderFlex = RenderFlex();
+    final BuildContext buildContext = NullChildElement(Container());
+
+    flex.updateRenderObject(buildContext, renderFlex);
+
+    expect(renderFlex.crossAxisSize, CrossAxisSize.max);
+  });
+
+  test('Column has crossAxisSize', () {
+    final Column column = Column(crossAxisSize: CrossAxisSize.max);
+
+    expect(column.crossAxisSize, CrossAxisSize.max);
+  });
+
+  test('Row has crossAxisSize', () {
+    final Row row = Row(crossAxisSize: CrossAxisSize.max);
+
+    expect(row.crossAxisSize, CrossAxisSize.max);
   });
 }
 


### PR DESCRIPTION
## Description

This PR gives the ability to specify whether the Flex should take up as much space as it can, or should take up as much space as it need. Currently, the size of the cross axis depends on the children. The greatest cross axis extent will be the cross axis size of the parent Flex. Moving forward, Column and Row will take a CrossAxisSize (min, max), where min means to keep the previous behavior and max means to expand as far as possible in the cross axis. The default if not provided is CrossAxisSize.min


For example: 
```
import 'package:flutter/material.dart';

void main() {
  runApp(
    MaterialApp(
      home: Scaffold(
        body: SafeArea(
          child: Container(
            decoration: BoxDecoration(border: Border.all()),
            child: Column(
              mainAxisAlignment: MainAxisAlignment.center,
              crossAxisAlignment: CrossAxisAlignment.center,
              children: const <Widget>[
                Text('a'),
                Text('aaa'),
                Text('aaaaa'),
                Text('aaaaaaa'),
                Text('aaaaa'),
                Text('aaa'),
                Text('a'),
              ],
            ),
          ),
        ),
      ),
    ),
  );
}
```
![image](https://user-images.githubusercontent.com/3748720/70858828-9f1c2080-1ec6-11ea-9659-8cf35ff7cdc3.png)
```
import 'package:flutter/material.dart';

void main() {
  runApp(
    MaterialApp(
      home: Scaffold(
        body: SafeArea(
          child: Container(
            decoration: BoxDecoration(border: Border.all()),
            child: Column(
              mainAxisAlignment: MainAxisAlignment.center,
              crossAxisAlignment: CrossAxisAlignment.center,
              crossAxisSize: CrossAxisSize.max,
              children: const <Widget>[
                Text('a'),
                Text('aaa'),
                Text('aaaaa'),
                Text('aaaaaaa'),
                Text('aaaaa'),
                Text('aaa'),
                Text('a'),
              ],
            ),
          ),
        ),
      ),
    ),
  );
}
```
![image](https://user-images.githubusercontent.com/3748720/70858836-cecb2880-1ec6-11ea-844f-81b2afddb0f5.png)

## Related Issues

[#45544](https://github.com/flutter/flutter/issues/45544)

## Tests

I added the following tests:

flex_test.dart:

- 'Flexible with CrossAxisSize.max horizontal'
- 'Flexible with CrossAxisSize.max vertical'
- 'Flexible with CrossAxisSize.min horizontal'
- 'Flexible with CrossAxisSize.min vertical'

basic_test.dart:

- 'Flex has crossAxisSize'
- 'Flex defaults crossAxisSize to CrossAxisSize.min'
- 'Flex creates RenderFlex with crossAxisSize'
- 'Flex updates RenderFlex with crossAxisSize'
- 'Column has crossAxisSize'
- 'Row has crossAxisSize'

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
