### PR TITLE
Fix CupertinoContextMenuAction color behavior

### DIFF
--- a/packages/flutter/lib/src/cupertino/context_menu_action.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu_action.dart
@@ -135,7 +135,7 @@ class _CupertinoContextMenuActionState extends State<CupertinoContextMenuAction>
                   if (widget.trailingIcon != null)
                     Icon(
                       widget.trailingIcon,
-                      color: CupertinoColors.destructiveRed,
+                      color: _textStyle.color,
                     ),
                 ],
               ),

--- a/packages/flutter/test/cupertino/context_menu_action_test.dart
+++ b/packages/flutter/test/cupertino/context_menu_action_test.dart
@@ -9,13 +9,19 @@ void main() {
   // Constants taken from _ContextMenuActionState.
   const Color _kBackgroundColor = Color(0xFFEEEEEE);
   const Color _kBackgroundColorPressed = Color(0xFFDDDDDD);
+  const Color _kRegularActionColor = CupertinoColors.black;
+  const Color _kDestructiveActionColor = CupertinoColors.destructiveRed;
+  const FontWeight _kDefaultActionWeight = FontWeight.w600;
 
-  Widget _getApp([VoidCallback onPressed]) {
+  Widget _getApp({VoidCallback onPressed, bool isDestructiveAction = false, bool isDefaultAction = false}) {
     final UniqueKey actionKey = UniqueKey();
     final CupertinoContextMenuAction action = CupertinoContextMenuAction(
       key: actionKey,
       child: const Text('I am a CupertinoContextMenuAction'),
       onPressed: onPressed,
+      trailingIcon: CupertinoIcons.home,
+      isDestructiveAction: isDestructiveAction,
+      isDefaultAction: isDefaultAction,
     );
 
     return CupertinoApp(
@@ -37,9 +43,29 @@ void main() {
     return container.decoration;
   }
 
+  TextStyle _getTextStyle(WidgetTester tester) {
+    final Finder finder = find.descendant(
+      of: find.byType(CupertinoContextMenuAction),
+      matching: find.byType(DefaultTextStyle),
+    );
+    expect(finder, findsOneWidget);
+    final DefaultTextStyle defaultStyle = tester.widget(finder);
+    return defaultStyle.style;
+  }
+
+  Icon _getIcon(WidgetTester tester) {
+    final Finder finder = find.descendant(
+      of: find.byType(CupertinoContextMenuAction),
+      matching: find.byType(Icon),
+    );
+    expect(finder, findsOneWidget);
+    final Icon icon = tester.widget(finder);
+    return icon;
+  }
+
   testWidgets('responds to taps', (WidgetTester tester) async {
     bool wasPressed = false;
-    await tester.pumpWidget(_getApp(() {
+    await tester.pumpWidget(_getApp(onPressed: () {
       wasPressed = true;
     }));
 
@@ -61,4 +87,22 @@ void main() {
     await tester.pump();
     expect(_getDecoration(tester).color, _kBackgroundColor);
   });
+
+  testWidgets('icon and textStyle colors are right out of the box',(WidgetTester tester) async {
+    await tester.pumpWidget(_getApp());
+    expect(_getTextStyle(tester).color, _kRegularActionColor);
+    expect(_getIcon(tester).color, _kRegularActionColor);
+  });
+
+  testWidgets('icon and textStyle colors are right for destructive actions',(WidgetTester tester) async {
+    await tester.pumpWidget(_getApp(isDestructiveAction: true));
+    expect(_getTextStyle(tester).color, _kDestructiveActionColor);
+    expect(_getIcon(tester).color, _kDestructiveActionColor);
+  });
+
+  testWidgets('textStyle is right for defaultAction',(WidgetTester tester) async {
+    await tester.pumpWidget(_getApp(isDefaultAction: true));
+    expect(_getTextStyle(tester).fontWeight, _kDefaultActionWeight);
+  });
+
 }

--- a/packages/flutter/test/cupertino/context_menu_action_test.dart
+++ b/packages/flutter/test/cupertino/context_menu_action_test.dart
@@ -88,19 +88,19 @@ void main() {
     expect(_getDecoration(tester).color, _kBackgroundColor);
   });
 
-  testWidgets('icon and textStyle colors are right out of the box',(WidgetTester tester) async {
+  testWidgets('icon and textStyle colors are correct out of the box', (WidgetTester tester) async {
     await tester.pumpWidget(_getApp());
     expect(_getTextStyle(tester).color, _kRegularActionColor);
     expect(_getIcon(tester).color, _kRegularActionColor);
   });
 
-  testWidgets('icon and textStyle colors are right for destructive actions',(WidgetTester tester) async {
+  testWidgets('icon and textStyle colors are correct for destructive actions', (WidgetTester tester) async {
     await tester.pumpWidget(_getApp(isDestructiveAction: true));
     expect(_getTextStyle(tester).color, _kDestructiveActionColor);
     expect(_getIcon(tester).color, _kDestructiveActionColor);
   });
 
-  testWidgets('textStyle is right for defaultAction',(WidgetTester tester) async {
+  testWidgets('textStyle is correct for defaultAction', (WidgetTester tester) async {
     await tester.pumpWidget(_getApp(isDefaultAction: true));
     expect(_getTextStyle(tester).fontWeight, _kDefaultActionWeight);
   });


### PR DESCRIPTION
## Description

Documentation states the trailingIcon 'Will be colored in the same way as the [TextStyle] used for [child]', but it was using destructiveRed unconditionally as of now. This pull request fixes this behavior.

Also added tests for both regular and destructive colors, and for the default textStyle weight, to ensure there isn't an regression leading to this again in the future.

[Before (Broken)](https://dartpad.dev/34fe8198644eefee9f4b543868793c6f) -> [After (Fixed)](https://dartpad.dartlang.org/9e56ebd7bde4aeaa6ad59eb4b10db6d0)

## Related Issues

#47150 

## Tests

I added the following tests:

packages/flutter/lib/cupertino/context_menu_action.dart:

- icon and textStyle colors are right out of the box
- icon and textStyle colors are right for destructive actions
- textStyle is right for defaultAction

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.
<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
