### PR TITLE
[flutter_tool] Add messaging to --fast-start application

### DIFF
--- a/examples/splash/lib/main.dart
+++ b/examples/splash/lib/main.dart
@@ -6,10 +6,25 @@ import 'package:flutter/material.dart';
 
 void main() {
   runApp(
-    const DecoratedBox(
+    DecoratedBox(
       decoration: BoxDecoration(color: Colors.white),
       child: Center(
-        child: FlutterLogo(size: 48),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          textDirection: TextDirection.ltr,
+          children: const <Widget>[
+            FlutterLogo(size: 48),
+            Padding(
+              padding: EdgeInsets.all(32),
+              child: Text(
+                'This app is only meant to be run under the Flutter debugger',
+                textDirection: TextDirection.ltr,
+                textAlign: TextAlign.center,
+                style: TextStyle(color: Colors.black87),
+              ),
+            ),
+          ],
+        ),
       ),
     ),
   );

--- a/examples/splash/test/splash_test.dart
+++ b/examples/splash/test/splash_test.dart
@@ -8,9 +8,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:splash/main.dart' as entrypoint;
 
 void main() {
-  testWidgets('Displays flutter logo', (WidgetTester tester) async {
+  testWidgets('Displays flutter logo and message', (WidgetTester tester) async {
     entrypoint.main();
 
     expect(find.byType(FlutterLogo), findsOneWidget);
+    expect(find.text('This app is only meant to be run under the Flutter debugger'), findsOneWidget);
   });
 }


### PR DESCRIPTION

<img src="https://user-images.githubusercontent.com/8975114/70942211-0212d200-2003-11ea-9cd4-e0fe4aabed67.png" width="250">

Add messaging to the fast-start splash application to explain what the user is seeing.