### PR TITLE
[flutter_tool] Print a helpful message on some mDNS failures

### DIFF
--- a/packages/flutter_tools/lib/src/base/io.dart
+++ b/packages/flutter_tools/lib/src/base/io.dart
@@ -26,8 +26,22 @@
 /// increase the API surface that we have to test in Flutter tools, and the APIs
 /// in `dart:io` can sometimes be hard to use in tests.
 import 'dart:async';
-import 'dart:io' as io show exit, IOSink, Process, ProcessInfo, ProcessSignal,
-    stderr, stdin, Stdin, StdinException, Stdout, stdout;
+import 'dart:io' as io
+  show
+    exit,
+    InternetAddress,
+    InternetAddressType,
+    IOSink,
+    NetworkInterface,
+    Process,
+    ProcessInfo,
+    ProcessSignal,
+    stderr,
+    stdin,
+    Stdin,
+    StdinException,
+    Stdout,
+    stdout;
 
 import 'package:meta/meta.dart';
 
@@ -60,6 +74,7 @@ export 'dart:io'
         IOException,
         IOSink,
         // Link              NO! Use `file_system.dart`
+        // NetworkInterface  NO! Use `io.dart`
         pid,
         // Platform          NO! use `platform.dart`
         Process,
@@ -258,4 +273,67 @@ class _DefaultProcessInfo implements ProcessInfo {
 
   @override
   int get maxRss => io.ProcessInfo.maxRss;
+}
+
+/// The return type for [listNetworkInterfaces].
+class NetworkInterface implements io.NetworkInterface {
+  NetworkInterface(this._delegate);
+
+  final io.NetworkInterface _delegate;
+
+  @override
+  List<io.InternetAddress> get addresses => _delegate.addresses;
+
+  @override
+  int get index => _delegate.index;
+
+  @override
+  String get name => _delegate.name;
+
+  @override
+  String toString() => "NetworkInterface('$name', $addresses)";
+}
+
+typedef NetworkInterfaceLister = Future<List<NetworkInterface>> Function({
+  bool includeLoopback,
+  bool includeLinkLocal,
+  io.InternetAddressType type,
+});
+
+NetworkInterfaceLister _networkInterfaceListerOverride;
+
+// Tests can set up a non-default network interface lister.
+@visibleForTesting
+void setNetworkInterfaceLister(NetworkInterfaceLister lister) {
+  _networkInterfaceListerOverride = lister;
+}
+
+@visibleForTesting
+void resetNetworkInterfaceLister() {
+  _networkInterfaceListerOverride = null;
+}
+
+/// This calls [NetworkInterface.list] from `dart:io` unless it is overridden by
+/// [setNetworkInterfaceLister] for a test. If it is overridden for a test,
+/// it should be reset with [resetNetworkInterfaceLister].
+Future<List<NetworkInterface>> listNetworkInterfaces({
+  bool includeLoopback = false,
+  bool includeLinkLocal = false,
+  io.InternetAddressType type = io.InternetAddressType.any,
+}) async {
+  if (_networkInterfaceListerOverride != null) {
+    return _networkInterfaceListerOverride(
+      includeLoopback: includeLoopback,
+      includeLinkLocal: includeLinkLocal,
+      type: type,
+    );
+  }
+  final List<io.NetworkInterface> interfaces = await io.NetworkInterface.list(
+    includeLoopback: includeLoopback,
+    includeLinkLocal: includeLinkLocal,
+    type: type,
+  );
+  return interfaces.map(
+    (io.NetworkInterface interface) => NetworkInterface(interface),
+  ).toList();
 }

--- a/packages/flutter_tools/test/general.shard/base/io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/io_test.dart
@@ -82,6 +82,20 @@ void main() {
   test('test_api defines the Declarer in a known place', () {
     expect(Zone.current[#test.declarer], isNotNull);
   });
+
+  test('listNetworkInterfaces() uses overrides', () async {
+    setNetworkInterfaceLister(
+      ({
+        bool includeLoopback,
+        bool includeLinkLocal,
+        InternetAddressType type,
+      }) async => <NetworkInterface>[],
+    );
+
+    expect(await listNetworkInterfaces(), isEmpty);
+
+    resetNetworkInterfaceLister();
+  });
 }
 
 class MockIoProcessSignal extends Mock implements io.ProcessSignal {}


### PR DESCRIPTION
## Description

When "Personal Hotspot" is enabled on an iOS device, the device (connected by USB) is not available through a link local interface on the host. This change detects the absence of a link local ipv4 interface after an mDNS lookup failure, and prints advice to disable the "Personal Hotspot" option.

## Related Issues

https://github.com/flutter/flutter/issues/46698

## Tests

I added the following tests:

Test in mdns_discovery.dart that the error message is printed in the right conditions.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
