### PR TITLE
Fix isDense default for DropdownButtonFormField

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1402,7 +1402,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
     Color iconDisabledColor,
     Color iconEnabledColor,
     double iconSize = 24.0,
-    bool isDense = false,
+    bool isDense = true,
     bool isExpanded = false,
     double itemHeight,
   }) : assert(items == null || items.isEmpty || value == null ||

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -13,6 +13,10 @@ import '../rendering/mock_canvas.dart';
 
 const List<String> menuItems = <String>['one', 'two', 'three', 'four'];
 final ValueChanged<String> onChanged = (_) { };
+final Type dropdownButtonType = DropdownButton<String>(
+  onChanged: (_) { },
+  items: const <DropdownMenuItem<String>>[],
+).runtimeType;
 
 Finder _iconRichText(Key iconKey) {
   return find.descendant(
@@ -31,7 +35,7 @@ Widget buildFormFrame({
   Color iconDisabledColor,
   Color iconEnabledColor,
   double iconSize = 24.0,
-  bool isDense = false,
+  bool isDense = true,
   bool isExpanded = false,
   Widget hint,
   Widget disabledHint,
@@ -227,7 +231,6 @@ void main() {
       buildFormFrame(
         buttonKey: buttonKey,
         value: value,
-        isDense: true,
         onChanged: onChanged,
       ),
     );
@@ -260,6 +263,35 @@ void main() {
       final Offset itemBoxCenter = itemBox.size.center(itemBox.localToGlobal(Offset.zero));
       expect(buttonBoxCenter.dy, equals(itemBoxCenter.dy));
     }
+  });
+
+  testWidgets('DropdownButtonFormField.isDense is true by default', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/46844
+    final Key buttonKey = UniqueKey();
+    const String value = 'two';
+
+    await tester.pumpWidget(
+      TestApp(
+        textDirection: TextDirection.ltr,
+        child: Material(
+          child: DropdownButtonFormField<String>(
+            key: buttonKey,
+            value: value,
+            onChanged: onChanged,
+            items: menuItems.map<DropdownMenuItem<String>>((String item) {
+              return DropdownMenuItem<String>(
+                key: ValueKey<String>(item),
+                value: item,
+                child: Text(item, key: ValueKey<String>(item + 'Text')),
+              );
+            }).toList(),
+          ),
+        ),
+      ),
+    );
+
+    final RenderBox box = tester.renderObject<RenderBox>(find.byType(dropdownButtonType));
+    expect(box.size.height, 24.0);
   });
 
   testWidgets('DropdownButtonFormField - custom text style', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

Fixes a regression to the vertical size of DropdownButtonFormField caused by a change in the default value of `isDense`:

**After Upgrading to Flutter v1.12.13+hotfix.5**

<img src="https://imgur.com/NFf75Qy.png" />

**Before Upgrading to v1.12.13+hotfix.5**

<img src="https://imgur.com/YyMp7BA.png" />

## Related Issues

Fixes https://github.com/flutter/flutter/issues/46844

## Tests

I added the following tests:

- A test to ensure that DropdownButtonFormField.isDense is true by default.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
