### PR TITLE
Remove direct usage of linter in the flutter_tools

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -4,8 +4,6 @@
 
 import 'dart:async';
 
-import 'package:linter/src/rules/pub/package_names.dart' as package_names; // ignore: implementation_imports
-import 'package:linter/src/utils.dart' as linter_utils; // ignore: implementation_imports
 import 'package:yaml/yaml.dart' as yaml;
 
 import '../android/android.dart' as android;
@@ -749,12 +747,94 @@ const Set<String> _packageDependencies = <String>{
   'yaml',
 };
 
+// A valid Dart identifier.
+// https://dart.dev/guides/language/language-tour#important-concepts
+final RegExp _identifierRegExp = RegExp('[a-zA-Z_][a-zA-Z0-9_]*');
+
+// non-contextual dart keywords.
+//' https://dart.dev/guides/language/language-tour#keywords
+const Set<String> _keywords = <String>{
+  'abstract',
+  'as',
+  'assert',
+  'async',
+  'await',
+  'break',
+  'case',
+  'catch',
+  'class',
+  'const',
+  'continue',
+  'covariant',
+  'default',
+  'deferred',
+  'do',
+  'dynamic',
+  'else',
+  'enum',
+  'export',
+  'extends',
+  'extension',
+  'external',
+  'factory',
+  'false',
+  'final',
+  'finally',
+  'for',
+  'function',
+  'get',
+  'hide',
+  'if',
+  'implements',
+  'import',
+  'in',
+  'inout',
+  'interface',
+  'is',
+  'late',
+  'library',
+  'mixin',
+  'native',
+  'new',
+  'null',
+  'of',
+  'on',
+  'operator',
+  'out',
+  'part',
+  'patch',
+  'required',
+  'rethrow',
+  'return',
+  'set',
+  'show',
+  'source',
+  'static',
+  'super',
+  'switch',
+  'sync',
+  'this',
+  'throw',
+  'true',
+  'try',
+  'typedef',
+  'var',
+  'void',
+  'while',
+  'with',
+  'yield',
+};
+bool _isValidPackageName(String name) {
+  return _identifierRegExp.hasMatch(name) != null &&
+    !_keywords.contains(name);
+}
+
 /// Return null if the project name is legal. Return a validation message if
 /// we should disallow the project name.
 String _validateProjectName(String projectName) {
-  if (!linter_utils.isValidPackageName(projectName)) {
-    final String packageNameDetails = package_names.PubPackageNames().details;
-    return '"$projectName" is not a valid Dart package name.\n\n$packageNameDetails';
+  if (!_isValidPackageName(projectName)) {
+    return '"$projectName" is not a valid Dart package name.\n\n'
+      'See https://dart.dev/tools/pub/pubspec#name for more information.';
   }
   if (_packageDependencies.contains(projectName)) {
     return "Invalid project name: '$projectName' - this will conflict with Flutter "

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:meta/meta.dart';
 import 'package:yaml/yaml.dart' as yaml;
 
 import '../android/android.dart' as android;
@@ -824,15 +825,18 @@ const Set<String> _keywords = <String>{
   'with',
   'yield',
 };
-bool _isValidPackageName(String name) {
-  return _identifierRegExp.hasMatch(name) != null &&
-    !_keywords.contains(name);
+
+/// Whether [name] is a valid Pub package.
+@visibleForTesting
+bool isValidPackageName(String name) {
+  final Match match = _identifierRegExp.matchAsPrefix(name);
+  return match != null && match.end == name.length && !_keywords.contains(name);
 }
 
 /// Return null if the project name is legal. Return a validation message if
 /// we should disallow the project name.
 String _validateProjectName(String projectName) {
-  if (!_isValidPackageName(projectName)) {
+  if (!isValidPackageName(projectName)) {
     return '"$projectName" is not a valid Dart package name.\n\n'
       'See https://dart.dev/tools/pub/pubspec#name for more information.';
   }

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -1114,16 +1114,6 @@ void main() {
     Pub: () => const Pub(),
   });
 
-  testUsingContext('fails when invalid package name', () async {
-    Cache.flutterRoot = '../..';
-    final CreateCommand command = CreateCommand();
-    final CommandRunner<void> runner = createTestCommandRunner(command);
-    expect(
-      runner.run(<String>['create', fs.path.join(projectDir.path, 'invalidName')]),
-      throwsToolExit(message: '"invalidName" is not a valid Dart package name.'),
-    );
-  });
-
   testUsingContext(
     'invokes pub offline when requested',
     () async {

--- a/packages/flutter_tools/test/general.shard/create_config_test.dart
+++ b/packages/flutter_tools/test/general.shard/create_config_test.dart
@@ -1,0 +1,20 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tools/src/commands/create.dart';
+
+import '../src/common.dart';
+
+void main() {
+
+  test('Validates Pub package name', () {
+    expect(isValidPackageName('is'), false);
+    expect(isValidPackageName('92'), false);
+    expect(isValidPackageName('a-b-c'), false);
+
+    expect(isValidPackageName('foo_bar'), true);
+    expect(isValidPackageName('_foo_bar'), true);
+    expect(isValidPackageName('fizz93'), true);
+  });
+}


### PR DESCRIPTION
## Description

This package is one source of our transitive analyzer dependencies and should be removed. https://github.com/flutter/flutter/issues/47162

The functionality brought in from the analyzer/linter here is fairly trivial and can be recreated with links to existing documentation,

Note: I did not remove linter from the pubspec to avoid needing update-packages --force-upgrade in this PR