### PR TITLE
Have the FontLoader tell the PaintingBinding _systemFonts to notify its listeners

### DIFF
--- a/packages/flutter/lib/src/services/font_loader.dart
+++ b/packages/flutter/lib/src/services/font_loader.dart
@@ -7,7 +7,10 @@ import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/services.dart';
+
+import 'binding.dart';
+import 'platform_channel.dart';
+import 'system_channels.dart';
 
 /// A class that enables the dynamic loading of fonts at runtime.
 ///

--- a/packages/flutter/test/services/font_loader_test.dart
+++ b/packages/flutter/test/services/font_loader_test.dart
@@ -57,7 +57,6 @@ void main() {
     }
     expect(notifiedRebuild, false);
     await tfl.load();
-
     expect(notifiedRebuild, true);
   });
 }


### PR DESCRIPTION
## Description

FontLoader does not notifies flutter to rebuild when the font is loaded. This pr make sure FontLoader sends font change system message after font is loaded.

## Related Issues

https://github.com/flutter/flutter/issues/44460

## Tests

I added the following tests:

"Font loader notifies system channel to rebuild"

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
