### PR TITLE
Call setEditingState when text changes.

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1217,7 +1217,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         _obscureLatestCharIndex = _value.selection.baseOffset;
       }
     }
-    _lastKnownRemoteTextEditingValue = value;
     _formatAndSetValue(value);
 
     // To keep the cursor from blinking while typing, we want to restart the

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -2961,7 +2961,7 @@ void main() {
         ),
       ),
     );
-    expect(tester.testTextInput.editingState['text'], isEmpty);
+    expect(tester.testTextInput.editingState, isNull);
 
     // Initial state with null controller.
     await tester.tap(find.byType(TextField));

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4004,6 +4004,7 @@ void main() {
       expect(m.method, logOrder[index]);
       index++;
     }
+    expect(tester.testTextInput.editingState['text'], '...');
   });
 }
 

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -3928,10 +3928,6 @@ void main() {
   });
 
   testWidgets('input imm channel calls are ordered correctly', (WidgetTester tester) async {
-    final List<MethodCall> log = <MethodCall>[];
-    SystemChannels.textInput.setMockMethodCallHandler((MethodCall methodCall) async {
-      log.add(methodCall);
-    });
     const String testText = 'flutter is the best!';
     final TextEditingController controller = TextEditingController(text: testText);
     final EditableText et = EditableText(
@@ -3956,11 +3952,55 @@ void main() {
     ));
 
     await tester.showKeyboard(find.byType(EditableText));
-    expect(log.length, 7);
     // TextInput.show should be before TextInput.setEditingState
     final List<String> logOrder = <String>['TextInput.setClient', 'TextInput.show', 'TextInput.setEditableSizeAndTransform', 'TextInput.setStyle', 'TextInput.setEditingState', 'TextInput.setEditingState', 'TextInput.show'];
+    expect(tester.testTextInput.log.length, 7);
     int index = 0;
-    for (MethodCall m in log) {
+    for (MethodCall m in tester.testTextInput.log) {
+      expect(m.method, logOrder[index]);
+      index++;
+    }
+  });
+
+  testWidgets('setEditingState is called when text changes', (WidgetTester tester) async {
+    const String testText = 'flutter is the best!';
+    final TextEditingController controller = TextEditingController(text: testText);
+    final EditableText et = EditableText(
+      showSelectionHandles: true,
+      maxLines: 2,
+      controller: controller,
+      focusNode: FocusNode(),
+      cursorColor: Colors.red,
+      backgroundCursorColor: Colors.blue,
+      style: Typography(platform: TargetPlatform.android).black.subhead.copyWith(fontFamily: 'Roboto'),
+      keyboardType: TextInputType.text,
+    );
+
+    await tester.pumpWidget(MaterialApp(
+      home: Align(
+        alignment: Alignment.topLeft,
+        child: SizedBox(
+          width: 100,
+          child: et,
+        ),
+      ),
+    ));
+
+    await tester.enterText(find.byType(EditableText), '...');
+
+    final List<String> logOrder = <String>[
+      'TextInput.setClient',
+      'TextInput.show',
+      'TextInput.setEditableSizeAndTransform',
+      'TextInput.setStyle',
+      'TextInput.setEditingState',
+      'TextInput.setEditingState',
+      'TextInput.show',
+      'TextInput.setEditingState',
+    ];
+    expect(tester.testTextInput.log.length, logOrder.length);
+    int index = 0;
+    for (MethodCall m in tester.testTextInput.log) {
       expect(m.method, logOrder[index]);
       index++;
     }

--- a/packages/flutter_test/lib/src/test_text_input.dart
+++ b/packages/flutter_test/lib/src/test_text_input.dart
@@ -8,7 +8,6 @@ import 'dart:typed_data';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/foundation.dart';
-import 'package:pedantic/pedantic.dart';
 
 import 'widget_tester.dart';
 

--- a/packages/flutter_test/lib/src/test_text_input.dart
+++ b/packages/flutter_test/lib/src/test_text_input.dart
@@ -77,7 +77,6 @@ class TestTextInput {
     return true;
   }
 
-
   /// Whether there are any active clients listening to text input.
   bool get hasAnyClients => _client > 0;
 

--- a/packages/flutter_test/lib/src/test_text_input.dart
+++ b/packages/flutter_test/lib/src/test_text_input.dart
@@ -69,7 +69,7 @@ class TestTextInput {
   // immediately if we are registered since that method does no real async work.
   bool get isRegistered {
     final int oldLogLength = log.length;
-    SystemChannels.textInput.invokeMethod<void>('__isRegistered');
+    unawaited(SystemChannels.textInput.invokeMethod<void>('__isRegistered'));
     if (log.length == oldLogLength) {
       return false;
     }

--- a/packages/flutter_test/lib/src/test_text_input.dart
+++ b/packages/flutter_test/lib/src/test_text_input.dart
@@ -43,6 +43,7 @@ class TestTextInput {
   /// Installs this object as a mock handler for [SystemChannels.textInput].
   void register() {
     SystemChannels.textInput.setMockMethodCallHandler(_handleTextInputCall);
+    _isRegistered = true;
   }
 
   /// Removes this object as a mock handler for [SystemChannels.textInput].
@@ -52,6 +53,7 @@ class TestTextInput {
   /// on-screen keyboard provided by the operating system.
   void unregister() {
     SystemChannels.textInput.setMockMethodCallHandler(null);
+    _isRegistered = false;
   }
 
   /// Log for method calls.
@@ -63,19 +65,8 @@ class TestTextInput {
   /// Whether this [TestTextInput] is registered with [SystemChannels.textInput].
   ///
   /// Use [register] and [unregister] methods to control this value.
-  // Someone could have unregistered us by calling
-  // `SystemChannels.textInput.setMockMethodCallHandler` in the test. Actually
-  // check if we're registered by calling the method, which should work
-  // immediately if we are registered since that method does no real async work.
-  bool get isRegistered {
-    final int oldLogLength = log.length;
-    unawaited(SystemChannels.textInput.invokeMethod<void>('__isRegistered'));
-    if (log.length == oldLogLength) {
-      return false;
-    }
-    log.removeLast();
-    return true;
-  }
+  bool get isRegistered => _isRegistered;
+  bool _isRegistered = false;
 
   /// Whether there are any active clients listening to text input.
   bool get hasAnyClients => _client > 0;

--- a/packages/flutter_test/lib/src/test_text_input.dart
+++ b/packages/flutter_test/lib/src/test_text_input.dart
@@ -39,6 +39,18 @@ class TestTextInput {
   /// The messenger which sends the bytes for this channel, not null.
   BinaryMessenger get _binaryMessenger => ServicesBinding.instance.defaultBinaryMessenger;
 
+  /// Resets any internal state of this object and calls [register].
+  ///
+  /// This method is invoked by the testing framework between tests. It should
+  /// not ordinarily be called by tests directly.
+  void resetAndRegister() {
+    log.clear();
+    editingState = null;
+    setClientArgs = null;
+    _client = 0;
+    _isVisible = false;
+    register();
+  }
   /// Installs this object as a mock handler for [SystemChannels.textInput].
   void register() {
     SystemChannels.textInput.setMockMethodCallHandler(_handleTextInputCall);

--- a/packages/flutter_test/lib/src/test_text_input.dart
+++ b/packages/flutter_test/lib/src/test_text_input.dart
@@ -64,6 +64,7 @@ class TestTextInput {
   /// Whether this [TestTextInput] is registered with [SystemChannels.textInput].
   ///
   /// Use [register] and [unregister] methods to control this value.
+  // TODO(dnfield): This is unreliable. https://github.com/flutter/flutter/issues/47180
   bool get isRegistered => _isRegistered;
   bool _isRegistered = false;
 

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -701,8 +701,7 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
   /// [testTextInput] regains control and the log is fresh for the new test.
   /// It should not typically need to be called by tests.
   void resetTestTextInput() {
-    testTextInput.register();
-    testTextInput.log.clear();
+    testTextInput.resetAndRegister();
   }
 
   /// Give the text input widget specified by [finder] the focus, as if the

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -121,8 +121,7 @@ void testWidgets(
       return binding.runTest(
         () async {
           debugResetSemanticsIdCounter();
-          tester.testTextInput.register();
-          tester.testTextInput.log.clear();
+          tester.resetTestTextInput();
           await callback(tester);
           semanticsHandle?.dispose();
         },
@@ -693,6 +692,18 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
   /// Typical app tests will not need to use this value. To add text to widgets
   /// like [TextField] or [TextFormField], call [enterText].
   TestTextInput get testTextInput => binding.testTextInput;
+
+  /// Ensures that [testTextInput] is registered and [TestTextInput.log] is
+  /// reset.
+  ///
+  /// This is called by the testing framework before test runs, so that if a
+  /// test has set its own handler on [SystemChannels.textInput], the
+  /// [testTextInput] regains control and the log is fresh for the new test.
+  /// It should not typically need to be called by tests.
+  void resetTestTextInput() {
+    testTextInput.register();
+    testTextInput.log.clear();
+  }
 
   /// Give the text input widget specified by [finder] the focus, as if the
   /// onscreen keyboard had appeared.

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -697,7 +697,7 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
   /// reset.
   ///
   /// This is called by the testing framework before test runs, so that if a
-  /// test has set its own handler on [SystemChannels.textInput], the
+  /// previous test has set its own handler on [SystemChannels.textInput], the
   /// [testTextInput] regains control and the log is fresh for the new test.
   /// It should not typically need to be called by tests.
   void resetTestTextInput() {

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -121,6 +121,8 @@ void testWidgets(
       return binding.runTest(
         () async {
           debugResetSemanticsIdCounter();
+          tester.testTextInput.register();
+          tester.testTextInput.log.clear();
           await callback(tester);
           semanticsHandle?.dispose();
         },


### PR DESCRIPTION
## Description

The removed line prevents us from mutating the tracking variable too early (it gets mutated by a later function anyway, but mutating it this early means we don't end up notifying the engine side of changes). This wasn't a problem before because the engine stayed running when the app was backgrounded, which meant the state was never really lost.  Now that the engine detaches, we lose the state and need to have it to send it up again.

This results in https://github.com/flutter/flutter/issues/47137.

I also found that some tests were mutating global state, so I updated those, and I updated the `tester` harness to reset some global state between tests to make it more useful (this is now asserted by those tests).  I also noticed that `isRegistered` was not trustworthy because of this global state it's connected to, so I tried to make it work better.

## Related Issues

fixes https://github.com/flutter/flutter/issues/47137

## Tests

I added the following tests:

Assert the expected textInput method call is made (setEditingState) after mutating the text.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [x] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [x] I wrote a migration guide: https://flutter.dev/docs/release/breaking-changes/test-text-input

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
