### PR TITLE
Re-enable --no-link-platform for JIT mode

### DIFF
--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_kernel_compiler.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_kernel_compiler.dart
@@ -61,9 +61,7 @@ class FuchsiaKernelCompiler {
       // AOT/JIT:
       if (buildInfo.usesAot) ...<String>['--aot', '--tfa']
       else ...<String>[
-        // TODO(zra): Add back when this is supported again.
-        // See: https://github.com/flutter/flutter/issues/44925
-        // '--no-link-platform',
+        '--no-link-platform',
         '--split-output-by-packages',
         '--manifest', manifestPath
       ],


### PR DESCRIPTION
## Description

It looks like this can be safely re-enabled now that https://github.com/flutter/flutter/issues/44724 is fixed. I've tested it locally.

## Related Issues

https://github.com/flutter/flutter/issues/44925
https://github.com/flutter/flutter/issues/44724

## Tests

I'm not sure what tests need to be done for this. @zanderso - can you comment?

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*
