### PR TITLE
Upgrade dartdoc to 0.29.3.

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -111,7 +111,7 @@ if [[ -d "$FLUTTER_PUB_CACHE" ]]; then
 fi
 
 # Install and activate dartdoc.
-"$PUB" global activate dartdoc 0.29.2
+"$PUB" global activate dartdoc 0.29.3
 
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc.


### PR DESCRIPTION
This release has one known P2 [regression](https://github.com/dart-lang/dartdoc/issues/2097) for Flutter since 0.29.2, but is needed to incorporate upcoming analyzer changes.  The regression is in an unnecessary warning and doesn't impact generated docs.

Release notes:  https://github.com/dart-lang/dartdoc/releases/tag/v0.29.3

