### PR TITLE
Fix output for golden files in a subdirectory

### DIFF
--- a/packages/flutter_test/lib/src/_goldens_io.dart
+++ b/packages/flutter_test/lib/src/_goldens_io.dart
@@ -155,7 +155,7 @@ class LocalComparisonOutput {
 
   /// Returns the appropriate file for a given diff from a [ComparisonResult].
   File getFailureFile(String failure, Uri golden, Uri basedir) {
-    final String fileName = golden.pathSegments[0];
+    final String fileName = golden.pathSegments.last;
     final String testName = fileName.split(path.extension(fileName))[0]
       + '_'
       + failure

--- a/packages/flutter_test/test/goldens_test.dart
+++ b/packages/flutter_test/test/goldens_test.dart
@@ -149,11 +149,40 @@ void main() {
 
       group('fails', () {
 
-        test('and generates correct output in the correct location', () async {
+        test('and generates correct output in the correct base location', () async {
           comparator = LocalFileComparator(Uri.parse('local_test.dart'), pathStyle: fs.path.style);
           await fs.file(fix('/golden.png')).writeAsBytes(_kColorFailurePngBytes);
           try {
             await doComparison();
+            fail('TestFailure expected but not thrown.');
+          } on TestFailure catch (error) {
+            expect(error.message, contains('% diff detected'));
+            final io.File master = fs.file(
+              fix('/failures/golden_masterImage.png')
+            );
+            final io.File test = fs.file(
+              fix('/failures/golden_testImage.png')
+            );
+            final io.File isolated = fs.file(
+              fix('/failures/golden_isolatedDiff.png')
+            );
+            final io.File masked = fs.file(
+              fix('/failures/golden_maskedDiff.png')
+            );
+            expect(master.existsSync(), isTrue);
+            expect(test.existsSync(), isTrue);
+            expect(isolated.existsSync(), isTrue);
+            expect(masked.existsSync(), isTrue);
+          }
+        });
+
+        test('and generates correct output when files are in a subdirectory', () async {
+          comparator = LocalFileComparator(Uri.parse('local_test.dart'), pathStyle: fs.path.style);
+          fs.file(fix('subdir/golden.png'))
+            ..createSync(recursive:true)
+            ..writeAsBytes(_kColorFailurePngBytes);
+          try {
+            await doComparison('subdir/golden.png');
             fail('TestFailure expected but not thrown.');
           } on TestFailure catch (error) {
             expect(error.message, contains('% diff detected'));


### PR DESCRIPTION
## Description

The local visual diff output for golden files incorrectly named files when the master images were contained in a subdirectory.

## Related Issues

Fixes #47228

## Tests

- LocalFileComparator fails and generates correct output when files are in a subdirectory

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
