### PR TITLE
WIP Create .flutter-plugins file per platform

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -400,7 +400,7 @@ class FlutterPlugin implements Plugin<Project> {
         // This means, `plugin-a` depends on `plugin-b` and `plugin-c`.
         // `plugin-b` depends on `plugin-c`.
         // `plugin-c` doesn't depend on anything.
-        File pluginsDependencyFile = new File(project.projectDir.parentFile.parentFile, '.flutter-plugins-dependencies')
+        File pluginsDependencyFile = new File(project.projectDir, '.flutter-plugins-dependencies')
         if (pluginsDependencyFile.exists()) {
             def object = new JsonSlurper().parseText(pluginsDependencyFile.text)
             assert object instanceof Map

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -372,7 +372,7 @@ class FlutterPlugin implements Plugin<Project> {
     }
 
     private Properties getPluginList() {
-        File pluginsFile = new File(project.projectDir.parentFile.parentFile, '.flutter-plugins')
+        File pluginsFile = new File(project.projectDir, '.flutter-plugins')
         Properties allPlugins = readPropertiesIfExist(pluginsFile)
         Properties androidPlugins = new Properties()
         allPlugins.each { name, path ->

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -362,7 +362,7 @@ class FlutterPlugin implements Plugin<Project> {
     }
 
     private Properties getPluginList() {
-        File pluginsFile = new File(project.projectDir, '.flutter-plugins')
+        File pluginsFile = new File(project.projectDir.parentFile.parentFile, '.flutter-plugins')
         Properties allPlugins = readPropertiesIfExist(pluginsFile)
         Properties androidPlugins = new Properties()
         allPlugins.each { name, path ->
@@ -400,7 +400,7 @@ class FlutterPlugin implements Plugin<Project> {
         // This means, `plugin-a` depends on `plugin-b` and `plugin-c`.
         // `plugin-b` depends on `plugin-c`.
         // `plugin-c` doesn't depend on anything.
-        File pluginsDependencyFile = new File(project.projectDir, '.flutter-plugins-dependencies')
+        File pluginsDependencyFile = new File(project.projectDir.parentFile.parentFile, '.flutter-plugins-dependencies')
         if (pluginsDependencyFile.exists()) {
             def object = new JsonSlurper().parseText(pluginsDependencyFile.text)
             assert object instanceof Map

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -362,7 +362,7 @@ class FlutterPlugin implements Plugin<Project> {
     }
 
     private Properties getPluginList() {
-        File pluginsFile = new File(project.projectDir.parentFile.parentFile, '.flutter-plugins')
+        File pluginsFile = new File(project.projectDir, '.flutter-plugins')
         Properties allPlugins = readPropertiesIfExist(pluginsFile)
         Properties androidPlugins = new Properties()
         allPlugins.each { name, path ->

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -372,7 +372,7 @@ class FlutterPlugin implements Plugin<Project> {
     }
 
     private Properties getPluginList() {
-        File pluginsFile = new File(project.projectDir, '.flutter-plugins')
+        File pluginsFile = new File(project.projectDir.parentFile.parentFile, '.flutter-plugins')
         Properties allPlugins = readPropertiesIfExist(pluginsFile)
         Properties androidPlugins = new Properties()
         allPlugins.each { name, path ->
@@ -409,7 +409,7 @@ class FlutterPlugin implements Plugin<Project> {
         // This means, `plugin-a` depends on `plugin-b` and `plugin-c`.
         // `plugin-b` depends on `plugin-c`.
         // `plugin-c` doesn't depend on anything.
-        File pluginsDependencyFile = new File(project.projectDir, '.flutter-plugins-dependencies')
+        File pluginsDependencyFile = new File(project.projectDir.parentFile.parentFile, '.flutter-plugins-dependencies')
         if (pluginsDependencyFile.exists()) {
             def object = new JsonSlurper().parseText(pluginsDependencyFile.text)
             assert object instanceof Map

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -409,7 +409,7 @@ class FlutterPlugin implements Plugin<Project> {
         // This means, `plugin-a` depends on `plugin-b` and `plugin-c`.
         // `plugin-b` depends on `plugin-c`.
         // `plugin-c` doesn't depend on anything.
-        File pluginsDependencyFile = new File(project.projectDir.parentFile.parentFile, '.flutter-plugins-dependencies')
+        File pluginsDependencyFile = new File(project.projectDir, '.flutter-plugins-dependencies')
         if (pluginsDependencyFile.exists()) {
             def object = new JsonSlurper().parseText(pluginsDependencyFile.text)
             assert object instanceof Map

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -362,6 +362,7 @@ bool _writeFlutterPluginsList(FlutterProject project, List<Plugin> plugins) {
 }
 
 bool _writeFlutterPlatformPluginsList(PlatformProject project, List<Plugin> plugins) {
+  // Gets only the plugins supported by the project platform.
   final Iterable<Plugin> platformPlugins = plugins.where((Plugin p) {
     return p.platforms.containsKey(project.pluginConfigKey);
   });
@@ -835,8 +836,6 @@ Future<void> _writeWebPluginRegistrant(FlutterProject project, List<Plugin> plug
 /// Assumes `pub get` has been executed since last change to `pubspec.yaml`.
 void refreshPluginsList(FlutterProject project, {bool checkProjects = false}) {
   final List<Plugin> plugins = findPlugins(project);
-  // Write legacy.
-  // _writeFlutterPluginsList(project, plugins);
   if (project.web.existsSync()) {
     _writeFlutterPlatformPluginsList(project.web, plugins);
   }
@@ -849,20 +848,13 @@ void refreshPluginsList(FlutterProject project, {bool checkProjects = false}) {
   if (project.android.existsSync()) {
     _writeFlutterPlatformPluginsList(project.android, plugins);
   }
+  if (project.macos.existsSync()) {
+    _writeFlutterPlatformPluginsList(project.macos, plugins);
+  }
   if (project.ios.existsSync()) {
     final bool changed = _writeFlutterPlatformPluginsList(project.ios, plugins);
-    if (changed) {
-      if (!checkProjects) {
-        cocoaPods.invalidatePodInstallOutput(project.ios);
-      }
-    }
-  }
-  if (project.macos.existsSync()) {
-    final bool changed = _writeFlutterPlatformPluginsList(project.macos, plugins);
-    if (changed) {
-      // TODO(stuartmorgan): Potentially add checkProjects once a decision has
-      // made about how to handle macOS in existing projects.
-      cocoaPods.invalidatePodInstallOutput(project.macos);
+    if (changed && !checkProjects) {
+      cocoaPods.invalidatePodInstallOutput(project.ios);
     }
   }
 }

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -335,10 +335,10 @@ bool _writeFlutterPluginsListAndDependencyGraph(Iterable<Plugin>platformPlugins,
   final StringBuffer flutterPluginsBuffer = StringBuffer('# $info\n');
 
   final Set<String> pluginNames = <String>{};
-  for (Plugin plugin in platformPlugins) {
+  for (final Plugin plugin in platformPlugins) {
     pluginNames.add(plugin.name);
   }
-  for (Plugin plugin in platformPlugins) {
+  for (final Plugin plugin in platformPlugins) {
     flutterPluginsBuffer.write('${plugin.name}=${escapePath(plugin.path)}\n');
     directAppDependencies.add(<String, dynamic>{
       'name': plugin.name,

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -310,25 +310,16 @@ List<Plugin> findPlugins(FlutterProject project) {
   return plugins;
 }
 
-Iterable<Plugin> _pluginsForPlatform(List<Plugin>plugins, String platform) {
-  return plugins.where((Plugin p) {
-    return p.platforms.containsKey(platform);
-  });
-}
-
 /// Writes the .flutter-plugins and .flutter-plugins-dependencies files based on the list of plugins for
 /// a given [PlatformProject]. If there aren't any plugins, then the files aren't written to disk.
-/// 
-/// Set [filter] to [false] to use all the plugins in the Flutter project.
-/// This is used for Android since the whole dependency graph is passed to gradle to configure the project.
 ///
 /// Finally, returns [true] if .flutter-plugins or .flutter-plugins-dependencies have changed,
 /// otherwise returns [false].
-bool _writeFlutterPlatformPluginsList(PlatformProject project, List<Plugin> plugins, [bool filter = true]) {
+bool _writeFlutterPlatformPluginsList(PlatformProject project, List<Plugin> plugins) {
   // Gets only the plugins supported by the project platform.
-  final Iterable<Plugin> platformPlugins = filter ?
-     _pluginsForPlatform(plugins, project.pluginConfigKey) :
-     plugins;
+  final Iterable<Plugin> platformPlugins = plugins.where((Plugin p) {
+    return p.platforms.containsKey(project.pluginConfigKey);
+  });
 
   final List<dynamic> directAppDependencies = <dynamic>[];
   const String info = 'This is a generated file; do not edit or check into version control.';
@@ -809,7 +800,7 @@ void refreshPluginsList(FlutterProject project, {bool checkProjects = false}) {
     _writeFlutterPlatformPluginsList(project.linux, plugins);
   }
   if (project.android.existsSync()) {
-    _writeFlutterPlatformPluginsList(project.android, plugins, false);
+    _writeFlutterPlatformPluginsList(project.android, plugins);
   }
   if (project.ios.existsSync()) {
     final bool changed = _writeFlutterPlatformPluginsList(project.ios, plugins);

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -827,7 +827,7 @@ void refreshPluginsList(FlutterProject project, {bool checkProjects = false}) {
     if (changed) {
       // TODO(stuartmorgan): Potentially add checkProjects once a decision has
       // made about how to handle macOS in existing projects.
-      cocoaPods.invalidatePodInstallOutput(project.ios);
+      cocoaPods.invalidatePodInstallOutput(project.macos);
     }
   }
 }

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -386,6 +386,9 @@ bool _writeFlutterPlatformPluginsList(PlatformProject project, List<Plugin> plug
   final String oldPluginFileContent = _readFileContent(pluginsFile);
   final String pluginFileContent = flutterPluginsBuffer.toString();
   if (pluginNames.isNotEmpty) {
+    if (!pluginsFile.existsSync()) {
+      pluginsFile.createSync(recursive: true);
+    }
     pluginsFile.writeAsStringSync(pluginFileContent, flush: true);
   } else {
     if (pluginsFile.existsSync()) {
@@ -833,7 +836,7 @@ Future<void> _writeWebPluginRegistrant(FlutterProject project, List<Plugin> plug
 void refreshPluginsList(FlutterProject project, {bool checkProjects = false}) {
   final List<Plugin> plugins = findPlugins(project);
   // Write legacy.
-  _writeFlutterPluginsList(project, plugins);
+  // _writeFlutterPluginsList(project, plugins);
   if (project.web.existsSync()) {
     _writeFlutterPlatformPluginsList(project.web, plugins);
   }

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -315,7 +315,7 @@ List<Plugin> findPlugins(FlutterProject project) {
 ///
 /// Finally, returns [true] if .flutter-plugins or .flutter-plugins-dependencies have changed,
 /// otherwise returns [false].
-bool _writeFlutterPluginsList(FlutterProject project, List<Plugin> plugins) {
+bool _legacyWriteFlutterPluginsList(FlutterProject project, List<Plugin> plugins) {
   final List<dynamic> directAppDependencies = <dynamic>[];
   const String info = 'This is a generated file; do not edit or check into version control.';
   final StringBuffer flutterPluginsBuffer = StringBuffer('# $info\n');
@@ -836,6 +836,12 @@ Future<void> _writeWebPluginRegistrant(FlutterProject project, List<Plugin> plug
 /// Assumes `pub get` has been executed since last change to `pubspec.yaml`.
 void refreshPluginsList(FlutterProject project, {bool checkProjects = false}) {
   final List<Plugin> plugins = findPlugins(project);
+
+  // TODO(franciscojma): Using the legacy method for Android since there is some
+  // gradle work to be done (update the generated settins.gradle on projects).
+  if (project.android.existsSync()) {
+    _legacyWriteFlutterPluginsList(project, plugins);
+  }
   if (project.web.existsSync()) {
     _writeFlutterPlatformPluginsList(project.web, plugins);
   }
@@ -844,9 +850,6 @@ void refreshPluginsList(FlutterProject project, {bool checkProjects = false}) {
   }
   if (project.linux.existsSync()) {
     _writeFlutterPlatformPluginsList(project.linux, plugins);
-  }
-  if (project.android.existsSync()) {
-    _writeFlutterPlatformPluginsList(project.android, plugins);
   }
   if (project.macos.existsSync()) {
     _writeFlutterPlatformPluginsList(project.macos, plugins);

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -264,7 +264,9 @@ abstract class PlatformProject {
   /// The file containing the platform-specific plugins list.
   File get platformPluginsFile;
 
-  File get legacyPluginsFile;
+  /// The `.flutter-plugins-dependencies` file of this project,
+  /// which contains the dependencies each plugin depends on.
+  File get flutterPluginsDependenciesFile;
 }
 
 /// Represents an Xcode-based sub-project.
@@ -346,8 +348,8 @@ class IosProject implements XcodeBasedProject, PlatformProject {
   @override
   File get platformPluginsFile => _flutterLibRoot.childDirectory('Flutter').childFile('.flutter-plugins');
 
-  @override 
-  File get legacyPluginsFile => parent.flutterPluginsFile;
+  @override
+  File get flutterPluginsDependenciesFile => parent.flutterPluginsDependenciesFile;
 
   /// The root directory of the iOS wrapping of Flutter and plugins. This is the
   /// parent of the `Flutter/` folder into which Flutter artifacts are written
@@ -576,8 +578,8 @@ class AndroidProject implements PlatformProject {
   @override
   File get platformPluginsFile => hostAppGradleRoot.childFile('.flutter-plugins');
 
-  @override 
-  File get legacyPluginsFile => parent.flutterPluginsFile;
+  @override
+  File get flutterPluginsDependenciesFile => parent.flutterPluginsDependenciesFile;
 
   /// The Gradle root directory of the Android wrapping of Flutter and plugins.
   /// This is the same as [hostAppGradleRoot] except when the project is
@@ -762,8 +764,8 @@ class WebProject implements PlatformProject {
   @override
   File get platformPluginsFile => directory.childFile('.flutter-plugins');
 
-  @override 
-  File get legacyPluginsFile => parent.flutterPluginsFile;
+  @override
+  File get flutterPluginsDependenciesFile => parent.flutterPluginsDependenciesFile;
 
   /// The 'lib' directory for the application.
   Directory get libDirectory => parent.directory.childDirectory('lib');
@@ -821,8 +823,8 @@ class MacOSProject implements XcodeBasedProject, PlatformProject {
   @override
   File get platformPluginsFile => ephemeralDirectory.childFile('.flutter-plugins');
 
-  @override 
-  File get legacyPluginsFile => parent.flutterPluginsFile;
+  @override
+  File get flutterPluginsDependenciesFile => parent.flutterPluginsDependenciesFile;
 
   Directory get _macOSDirectory => parent.directory.childDirectory('macos');
 
@@ -915,8 +917,8 @@ class WindowsProject implements PlatformProject {
   @override
   File get platformPluginsFile => ephemeralDirectory.childFile('.flutter-plugins');
 
-  @override 
-  File get legacyPluginsFile => project.flutterPluginsFile;
+  @override
+  File get flutterPluginsDependenciesFile => project.flutterPluginsDependenciesFile;
 
   Directory get _editableDirectory => project.directory.childDirectory('windows');
 
@@ -960,8 +962,8 @@ class LinuxProject implements PlatformProject {
   @override
   File get platformPluginsFile => ephemeralDirectory.childFile('.flutter-plugins');
 
-  @override 
-  File get legacyPluginsFile => project.flutterPluginsFile;
+  @override
+  File get flutterPluginsDependenciesFile => project.flutterPluginsDependenciesFile;
 
   Directory get _editableDirectory => project.directory.childDirectory('linux');
 

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -570,10 +570,10 @@ class AndroidProject implements PlatformProject {
   String get pluginConfigKey => AndroidPlugin.kConfigKey;
 
   @override
-  File get platformPluginsFile => hostAppGradleRoot.childFile('.flutter-plugins');
+  File get platformPluginsFile => parent.flutterPluginsFile;
 
   @override
-  File get flutterPluginsDependenciesFile => hostAppGradleRoot.childFile('.flutter-plugins-dependencies');
+  File get flutterPluginsDependenciesFile => parent.flutterPluginsDependenciesFile;
 
   /// The Gradle root directory of the Android wrapping of Flutter and plugins.
   /// This is the same as [hostAppGradleRoot] except when the project is

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -255,9 +255,6 @@ class FlutterProject {
 
 /// Represents a platform-specific sub-component of a FlutterProject.
 abstract class PlatformProject {
-  // The parent project of this platform project
-  FlutterProject get parent;
-
   /// Whether the subproject exists in the Flutter project.
   bool existsSync();
 
@@ -276,6 +273,9 @@ abstract class PlatformProject {
 ///
 /// This defines interfaces common to iOS and macOS projects.
 abstract class XcodeBasedProject {
+  /// The parent of this project.
+  FlutterProject get parent;
+
   /// Whether the subproject (either iOS or macOS) exists in the Flutter project.
   bool existsSync();
 
@@ -549,7 +549,6 @@ class AndroidProject implements PlatformProject {
   AndroidProject._(this.parent);
 
   /// The parent of this project.
-  @override
   final FlutterProject parent;
 
   static final RegExp _applicationIdPattern = RegExp('^\\s*applicationId\\s+[\'\"](.*)[\'\"]\\s*\$');
@@ -568,11 +567,7 @@ class AndroidProject implements PlatformProject {
 
   @override
   String get pluginConfigKey => AndroidPlugin.kConfigKey;
-<<<<<<< HEAD
 
-=======
-
->>>>>>> 71ed112c0329fffc9e80f7f3a3d3fbea7ec55029
   // TODO(franciscojma): Change this values to the location of the android project. Currently setting
   // to the parent's value to avoid breaking changes in the gradle setup.
   @override
@@ -751,7 +746,6 @@ enum AndroidEmbeddingVersion {
 class WebProject implements PlatformProject {
   WebProject._(this.parent);
 
-  @override
   final FlutterProject parent;
 
   /// Whether this flutter project has a web sub-project.
@@ -904,10 +898,9 @@ class MacOSProject implements XcodeBasedProject, PlatformProject {
 
 /// The Windows sub project
 class WindowsProject implements PlatformProject {
-  WindowsProject._(this.parent);
+  WindowsProject._(this.project);
 
-  @override
-  final FlutterProject parent;
+  final FlutterProject project;
 
   @override
   bool existsSync() => _editableDirectory.existsSync();
@@ -921,7 +914,7 @@ class WindowsProject implements PlatformProject {
   @override
   File get flutterPluginsDependenciesFile => ephemeralDirectory.childFile('.flutter-plugins-dependencies');
 
-  Directory get _editableDirectory => parent.directory.childDirectory('windows');
+  Directory get _editableDirectory => project.directory.childDirectory('windows');
 
   /// The directory in the project that is managed by Flutter. As much as
   /// possible, files that are edited by Flutter tooling after initial project
@@ -955,8 +948,7 @@ class WindowsProject implements PlatformProject {
 class LinuxProject implements PlatformProject {
   LinuxProject._(this.project);
 
-  @override
-  final FlutterProject parent;
+  final FlutterProject project;
 
   @override
   String get pluginConfigKey => LinuxPlugin.kConfigKey;
@@ -967,7 +959,7 @@ class LinuxProject implements PlatformProject {
   @override
   File get flutterPluginsDependenciesFile => ephemeralDirectory.childFile('.flutter-plugins-dependencies');
 
-  Directory get _editableDirectory => parent.directory.childDirectory('linux');
+  Directory get _editableDirectory => project.directory.childDirectory('linux');
 
   /// The directory in the project that is managed by Flutter. As much as
   /// possible, files that are edited by Flutter tooling after initial project
@@ -994,13 +986,13 @@ class LinuxProject implements PlatformProject {
 
 /// The Fuchsia sub project
 class FuchsiaProject {
-  FuchsiaProject._(this.parent);
+  FuchsiaProject._(this.project);
 
-  final FlutterProject parent;
+  final FlutterProject project;
 
   Directory _editableHostAppDirectory;
   Directory get editableHostAppDirectory =>
-      _editableHostAppDirectory ??= parent.directory.childDirectory('fuchsia');
+      _editableHostAppDirectory ??= project.directory.childDirectory('fuchsia');
 
   bool existsSync() => editableHostAppDirectory.existsSync();
 

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -349,7 +349,7 @@ class IosProject implements XcodeBasedProject, PlatformProject {
   File get platformPluginsFile => _flutterLibRoot.childDirectory('Flutter').childFile('.flutter-plugins');
 
   @override
-  File get flutterPluginsDependenciesFile => parent.flutterPluginsDependenciesFile;
+  File get flutterPluginsDependenciesFile => _flutterLibRoot.childDirectory('Flutter').childFile('.flutter-plugins-dependencies');
 
   /// The root directory of the iOS wrapping of Flutter and plugins. This is the
   /// parent of the `Flutter/` folder into which Flutter artifacts are written
@@ -579,7 +579,7 @@ class AndroidProject implements PlatformProject {
   File get platformPluginsFile => hostAppGradleRoot.childFile('.flutter-plugins');
 
   @override
-  File get flutterPluginsDependenciesFile => parent.flutterPluginsDependenciesFile;
+  File get flutterPluginsDependenciesFile => hostAppGradleRoot.childFile('.flutter-plugins-dependencies');
 
   /// The Gradle root directory of the Android wrapping of Flutter and plugins.
   /// This is the same as [hostAppGradleRoot] except when the project is
@@ -765,7 +765,7 @@ class WebProject implements PlatformProject {
   File get platformPluginsFile => directory.childFile('.flutter-plugins');
 
   @override
-  File get flutterPluginsDependenciesFile => parent.flutterPluginsDependenciesFile;
+  File get flutterPluginsDependenciesFile => directory.childFile('.flutter-plugins-dependencies');
 
   /// The 'lib' directory for the application.
   Directory get libDirectory => parent.directory.childDirectory('lib');
@@ -824,7 +824,7 @@ class MacOSProject implements XcodeBasedProject, PlatformProject {
   File get platformPluginsFile => ephemeralDirectory.childFile('.flutter-plugins');
 
   @override
-  File get flutterPluginsDependenciesFile => parent.flutterPluginsDependenciesFile;
+  File get flutterPluginsDependenciesFile => ephemeralDirectory.childFile('.flutter-plugins-dependencies');
 
   Directory get _macOSDirectory => parent.directory.childDirectory('macos');
 
@@ -918,7 +918,7 @@ class WindowsProject implements PlatformProject {
   File get platformPluginsFile => ephemeralDirectory.childFile('.flutter-plugins');
 
   @override
-  File get flutterPluginsDependenciesFile => project.flutterPluginsDependenciesFile;
+  File get flutterPluginsDependenciesFile => ephemeralDirectory.childFile('.flutter-plugins-dependencies');
 
   Directory get _editableDirectory => project.directory.childDirectory('windows');
 
@@ -963,7 +963,7 @@ class LinuxProject implements PlatformProject {
   File get platformPluginsFile => ephemeralDirectory.childFile('.flutter-plugins');
 
   @override
-  File get flutterPluginsDependenciesFile => project.flutterPluginsDependenciesFile;
+  File get flutterPluginsDependenciesFile => ephemeralDirectory.childFile('.flutter-plugins-dependencies');
 
   Directory get _editableDirectory => project.directory.childDirectory('linux');
 

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -265,7 +265,9 @@ abstract class PlatformProject {
   /// The file containing the platform-specific plugins list.
   File get platformPluginsFile;
 
-  File get legacyPluginsFile;
+  /// The `.flutter-plugins-dependencies` file of this project,
+  /// which contains the dependencies each plugin depends on.
+  File get flutterPluginsDependenciesFile;
 }
 
 /// Represents an Xcode-based sub-project.
@@ -344,8 +346,8 @@ class IosProject implements XcodeBasedProject, PlatformProject {
   @override
   File get platformPluginsFile => _flutterLibRoot.childDirectory('Flutter').childFile('.flutter-plugins');
 
-  @override 
-  File get legacyPluginsFile => parent.flutterPluginsFile;
+  @override
+  File get flutterPluginsDependenciesFile => parent.flutterPluginsDependenciesFile;
 
   /// The root directory of the iOS wrapping of Flutter and plugins. This is the
   /// parent of the `Flutter/` folder into which Flutter artifacts are written
@@ -570,8 +572,8 @@ class AndroidProject implements PlatformProject {
   @override
   File get platformPluginsFile => hostAppGradleRoot.childFile('.flutter-plugins');
 
-  @override 
-  File get legacyPluginsFile => parent.flutterPluginsFile;
+  @override
+  File get flutterPluginsDependenciesFile => parent.flutterPluginsDependenciesFile;
 
   /// The Gradle root directory of the Android wrapping of Flutter and plugins.
   /// This is the same as [hostAppGradleRoot] except when the project is
@@ -756,8 +758,8 @@ class WebProject implements PlatformProject {
   @override
   File get platformPluginsFile => directory.childFile('.flutter-plugins');
 
-  @override 
-  File get legacyPluginsFile => parent.flutterPluginsFile;
+  @override
+  File get flutterPluginsDependenciesFile => parent.flutterPluginsDependenciesFile;
 
   /// The 'lib' directory for the application.
   Directory get libDirectory => parent.directory.childDirectory('lib');
@@ -815,8 +817,8 @@ class MacOSProject implements XcodeBasedProject, PlatformProject {
   @override
   File get platformPluginsFile => ephemeralDirectory.childFile('.flutter-plugins');
 
-  @override 
-  File get legacyPluginsFile => parent.flutterPluginsFile;
+  @override
+  File get flutterPluginsDependenciesFile => parent.flutterPluginsDependenciesFile;
 
   Directory get _macOSDirectory => parent.directory.childDirectory('macos');
 
@@ -906,8 +908,8 @@ class WindowsProject implements PlatformProject {
   @override
   File get platformPluginsFile => ephemeralDirectory.childFile('.flutter-plugins');
 
-  @override 
-  File get legacyPluginsFile => project.flutterPluginsFile;
+  @override
+  File get flutterPluginsDependenciesFile => project.flutterPluginsDependenciesFile;
 
   Directory get _editableDirectory => project.directory.childDirectory('windows');
 
@@ -951,8 +953,8 @@ class LinuxProject implements PlatformProject {
   @override
   File get platformPluginsFile => ephemeralDirectory.childFile('.flutter-plugins');
 
-  @override 
-  File get legacyPluginsFile => project.flutterPluginsFile;
+  @override
+  File get flutterPluginsDependenciesFile => project.flutterPluginsDependenciesFile;
 
   Directory get _editableDirectory => project.directory.childDirectory('linux');
 

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -576,10 +576,10 @@ class AndroidProject implements PlatformProject {
   String get pluginConfigKey => AndroidPlugin.kConfigKey;
 
   @override
-  File get platformPluginsFile => hostAppGradleRoot.childFile('.flutter-plugins');
+  File get platformPluginsFile => parent.flutterPluginsFile;
 
   @override
-  File get flutterPluginsDependenciesFile => hostAppGradleRoot.childFile('.flutter-plugins-dependencies');
+  File get flutterPluginsDependenciesFile => parent.flutterPluginsDependenciesFile;
 
   /// The Gradle root directory of the Android wrapping of Flutter and plugins.
   /// This is the same as [hostAppGradleRoot] except when the project is

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -263,6 +263,8 @@ abstract class PlatformProject {
 
   /// The file containing the platform-specific plugins list.
   File get platformPluginsFile;
+
+  File get legacyPluginsFile;
 }
 
 /// Represents an Xcode-based sub-project.
@@ -343,6 +345,9 @@ class IosProject implements XcodeBasedProject, PlatformProject {
 
   @override
   File get platformPluginsFile => _flutterLibRoot.childDirectory('Flutter').childFile('.flutter-plugins');
+
+  @override 
+  File get legacyPluginsFile => parent.flutterPluginsFile;
 
   /// The root directory of the iOS wrapping of Flutter and plugins. This is the
   /// parent of the `Flutter/` folder into which Flutter artifacts are written
@@ -571,6 +576,9 @@ class AndroidProject implements PlatformProject {
   @override
   File get platformPluginsFile => hostAppGradleRoot.childFile('.flutter-plugins');
 
+  @override 
+  File get legacyPluginsFile => parent.flutterPluginsFile;
+
   /// The Gradle root directory of the Android wrapping of Flutter and plugins.
   /// This is the same as [hostAppGradleRoot] except when the project is
   /// a Flutter module with an editable host app.
@@ -754,6 +762,9 @@ class WebProject implements PlatformProject {
   @override
   File get platformPluginsFile => directory.childFile('.flutter-plugins');
 
+  @override 
+  File get legacyPluginsFile => parent.flutterPluginsFile;
+
   /// The 'lib' directory for the application.
   Directory get libDirectory => parent.directory.childDirectory('lib');
 
@@ -809,6 +820,9 @@ class MacOSProject implements XcodeBasedProject, PlatformProject {
 
   @override
   File get platformPluginsFile => ephemeralDirectory.childFile('.flutter-plugins');
+
+  @override 
+  File get legacyPluginsFile => parent.flutterPluginsFile;
 
   Directory get _macOSDirectory => parent.directory.childDirectory('macos');
 
@@ -901,6 +915,8 @@ class WindowsProject implements PlatformProject {
   @override
   File get platformPluginsFile => ephemeralDirectory.childFile('.flutter-plugins');
 
+  @override 
+  File get legacyPluginsFile => project.flutterPluginsFile;
 
   Directory get _editableDirectory => project.directory.childDirectory('windows');
 
@@ -943,6 +959,9 @@ class LinuxProject implements PlatformProject {
 
   @override
   File get platformPluginsFile => ephemeralDirectory.childFile('.flutter-plugins');
+
+  @override 
+  File get legacyPluginsFile => project.flutterPluginsFile;
 
   Directory get _editableDirectory => project.directory.childDirectory('linux');
 

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -264,6 +264,8 @@ abstract class PlatformProject {
 
   /// The file containing the platform-specific plugins list.
   File get platformPluginsFile;
+
+  File get legacyPluginsFile;
 }
 
 /// Represents an Xcode-based sub-project.
@@ -341,6 +343,9 @@ class IosProject implements XcodeBasedProject, PlatformProject {
 
   @override
   File get platformPluginsFile => _flutterLibRoot.childDirectory('Flutter').childFile('.flutter-plugins');
+
+  @override 
+  File get legacyPluginsFile => parent.flutterPluginsFile;
 
   /// The root directory of the iOS wrapping of Flutter and plugins. This is the
   /// parent of the `Flutter/` folder into which Flutter artifacts are written
@@ -565,6 +570,9 @@ class AndroidProject implements PlatformProject {
   @override
   File get platformPluginsFile => hostAppGradleRoot.childFile('.flutter-plugins');
 
+  @override 
+  File get legacyPluginsFile => parent.flutterPluginsFile;
+
   /// The Gradle root directory of the Android wrapping of Flutter and plugins.
   /// This is the same as [hostAppGradleRoot] except when the project is
   /// a Flutter module with an editable host app.
@@ -748,6 +756,9 @@ class WebProject implements PlatformProject {
   @override
   File get platformPluginsFile => directory.childFile('.flutter-plugins');
 
+  @override 
+  File get legacyPluginsFile => parent.flutterPluginsFile;
+
   /// The 'lib' directory for the application.
   Directory get libDirectory => parent.directory.childDirectory('lib');
 
@@ -803,6 +814,9 @@ class MacOSProject implements XcodeBasedProject, PlatformProject {
 
   @override
   File get platformPluginsFile => ephemeralDirectory.childFile('.flutter-plugins');
+
+  @override 
+  File get legacyPluginsFile => parent.flutterPluginsFile;
 
   Directory get _macOSDirectory => parent.directory.childDirectory('macos');
 
@@ -892,6 +906,8 @@ class WindowsProject implements PlatformProject {
   @override
   File get platformPluginsFile => ephemeralDirectory.childFile('.flutter-plugins');
 
+  @override 
+  File get legacyPluginsFile => project.flutterPluginsFile;
 
   Directory get _editableDirectory => project.directory.childDirectory('windows');
 
@@ -934,6 +950,9 @@ class LinuxProject implements PlatformProject {
 
   @override
   File get platformPluginsFile => ephemeralDirectory.childFile('.flutter-plugins');
+
+  @override 
+  File get legacyPluginsFile => project.flutterPluginsFile;
 
   Directory get _editableDirectory => project.directory.childDirectory('linux');
 

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -21,6 +21,7 @@ import 'flutter_manifest.dart';
 import 'globals.dart';
 import 'ios/plist_parser.dart';
 import 'ios/xcodeproj.dart' as xcode;
+import 'platform_plugins.dart';
 import 'plugins.dart';
 import 'template.dart';
 
@@ -251,6 +252,19 @@ class FlutterProject {
   }
 }
 
+/// Represents a platform-specific sub-component of a FlutterProject.
+abstract class PlatformProject {
+  /// Whether the subproject exists in the Flutter project.
+  bool existsSync();
+
+  /// The pubspec.yaml key for a plugin configuration corresponding to this
+  /// platform.
+  String get pluginConfigKey;
+
+  /// The file containing the platform-specific plugins list.
+  File get platformPluginsFile;
+}
+
 /// Represents an Xcode-based sub-project.
 ///
 /// This defines interfaces common to iOS and macOS projects.
@@ -303,7 +317,7 @@ abstract class XcodeBasedProject {
 ///
 /// Instances will reflect the contents of the `ios/` sub-folder of
 /// Flutter applications and the `.ios/` sub-folder of Flutter module projects.
-class IosProject implements XcodeBasedProject {
+class IosProject implements XcodeBasedProject, PlatformProject {
   IosProject.fromFlutter(this.parent);
 
   @override
@@ -323,6 +337,12 @@ class IosProject implements XcodeBasedProject {
     }
     return ephemeralDirectory;
   }
+
+  @override
+  String get pluginConfigKey => IOSPlugin.kConfigKey;
+
+  @override
+  File get platformPluginsFile => _flutterLibRoot.childDirectory('Flutter').childFile('.flutter-plugins');
 
   /// The root directory of the iOS wrapping of Flutter and plugins. This is the
   /// parent of the `Flutter/` folder into which Flutter artifacts are written
@@ -525,7 +545,7 @@ class IosProject implements XcodeBasedProject {
 ///
 /// Instances will reflect the contents of the `android/` sub-folder of
 /// Flutter applications and the `.android/` sub-folder of Flutter module projects.
-class AndroidProject {
+class AndroidProject implements PlatformProject {
   AndroidProject._(this.parent);
 
   /// The parent of this project.
@@ -544,6 +564,12 @@ class AndroidProject {
     }
     return ephemeralDirectory;
   }
+
+  @override
+  String get pluginConfigKey => AndroidPlugin.kConfigKey;
+
+  @override
+  File get platformPluginsFile => hostAppGradleRoot.childFile('.flutter-plugins');
 
   /// The Gradle root directory of the Android wrapping of Flutter and plugins.
   /// This is the same as [hostAppGradleRoot] except when the project is
@@ -578,6 +604,7 @@ class AndroidProject {
   }
 
   /// Whether the current flutter project has an Android sub-project.
+  @override
   bool existsSync() {
     return parent.isModule || _editableHostAppDirectory.existsSync();
   }
@@ -709,16 +736,23 @@ enum AndroidEmbeddingVersion {
 }
 
 /// Represents the web sub-project of a Flutter project.
-class WebProject {
+class WebProject implements PlatformProject {
   WebProject._(this.parent);
 
   final FlutterProject parent;
 
   /// Whether this flutter project has a web sub-project.
+  @override
   bool existsSync() {
     return parent.directory.childDirectory('web').existsSync()
       && indexFile.existsSync();
   }
+
+  @override
+  String get pluginConfigKey => WebPlugin.kConfigKey;
+
+  @override
+  File get platformPluginsFile => directory.childFile('.flutter-plugins');
 
   /// The 'lib' directory for the application.
   Directory get libDirectory => parent.directory.childDirectory('lib');
@@ -759,7 +793,7 @@ Match _firstMatchInFile(File file, RegExp regExp) {
 }
 
 /// The macOS sub project.
-class MacOSProject implements XcodeBasedProject {
+class MacOSProject implements XcodeBasedProject, PlatformProject {
   MacOSProject._(this.parent);
 
   @override
@@ -769,6 +803,12 @@ class MacOSProject implements XcodeBasedProject {
 
   @override
   bool existsSync() => _macOSDirectory.existsSync();
+
+  @override
+  String get pluginConfigKey => MacOSPlugin.kConfigKey;
+
+  @override
+  File get platformPluginsFile => ephemeralDirectory.childFile('.flutter-plugins');
 
   Directory get _macOSDirectory => parent.directory.childDirectory('macos');
 
@@ -847,12 +887,20 @@ class MacOSProject implements XcodeBasedProject {
 }
 
 /// The Windows sub project
-class WindowsProject {
+class WindowsProject implements PlatformProject {
   WindowsProject._(this.project);
 
   final FlutterProject project;
 
+  @override
   bool existsSync() => _editableDirectory.existsSync();
+
+  @override
+  String get pluginConfigKey => WindowsPlugin.kConfigKey;
+
+  @override
+  File get platformPluginsFile => ephemeralDirectory.childFile('.flutter-plugins');
+
 
   Directory get _editableDirectory => project.directory.childDirectory('windows');
 
@@ -885,10 +933,16 @@ class WindowsProject {
 }
 
 /// The Linux sub project.
-class LinuxProject {
+class LinuxProject implements PlatformProject {
   LinuxProject._(this.project);
 
   final FlutterProject project;
+
+  @override
+  String get pluginConfigKey => LinuxPlugin.kConfigKey;
+
+  @override
+  File get platformPluginsFile => ephemeralDirectory.childFile('.flutter-plugins');
 
   Directory get _editableDirectory => project.directory.childDirectory('linux');
 
@@ -902,6 +956,7 @@ class LinuxProject {
   /// checked in should live here.
   Directory get ephemeralDirectory => managedDirectory.childDirectory('ephemeral');
 
+  @override
   bool existsSync() => _editableDirectory.existsSync();
 
   /// The Linux project makefile.

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -264,8 +264,7 @@ abstract class PlatformProject {
   /// The file containing the platform-specific plugins list.
   File get platformPluginsFile;
 
-  /// The `.flutter-plugins-dependencies` file of this project,
-  /// which contains the dependencies each plugin depends on.
+  /// The file containing the platform-specific plugins dependencies graph.
   File get flutterPluginsDependenciesFile;
 }
 
@@ -574,10 +573,14 @@ class AndroidProject implements PlatformProject {
 
   @override
   String get pluginConfigKey => AndroidPlugin.kConfigKey;
-
+  
+  // TODO(franciscojma): Change this values to the location of the android project. Currently setting
+  // to the parent's value to avoid breaking changes in the gradle setup.
   @override
   File get platformPluginsFile => parent.flutterPluginsFile;
 
+  // TODO(franciscojma): Change this values to the location of the android project. Currently setting
+  // to the parent's value to avoid breaking changes in the gradle setup.
   @override
   File get flutterPluginsDependenciesFile => parent.flutterPluginsDependenciesFile;
 

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -347,7 +347,7 @@ class IosProject implements XcodeBasedProject, PlatformProject {
   File get platformPluginsFile => _flutterLibRoot.childDirectory('Flutter').childFile('.flutter-plugins');
 
   @override
-  File get flutterPluginsDependenciesFile => parent.flutterPluginsDependenciesFile;
+  File get flutterPluginsDependenciesFile => _flutterLibRoot.childDirectory('Flutter').childFile('.flutter-plugins-dependencies');
 
   /// The root directory of the iOS wrapping of Flutter and plugins. This is the
   /// parent of the `Flutter/` folder into which Flutter artifacts are written
@@ -573,7 +573,7 @@ class AndroidProject implements PlatformProject {
   File get platformPluginsFile => hostAppGradleRoot.childFile('.flutter-plugins');
 
   @override
-  File get flutterPluginsDependenciesFile => parent.flutterPluginsDependenciesFile;
+  File get flutterPluginsDependenciesFile => hostAppGradleRoot.childFile('.flutter-plugins-dependencies');
 
   /// The Gradle root directory of the Android wrapping of Flutter and plugins.
   /// This is the same as [hostAppGradleRoot] except when the project is
@@ -759,7 +759,7 @@ class WebProject implements PlatformProject {
   File get platformPluginsFile => directory.childFile('.flutter-plugins');
 
   @override
-  File get flutterPluginsDependenciesFile => parent.flutterPluginsDependenciesFile;
+  File get flutterPluginsDependenciesFile => directory.childFile('.flutter-plugins-dependencies');
 
   /// The 'lib' directory for the application.
   Directory get libDirectory => parent.directory.childDirectory('lib');
@@ -818,7 +818,7 @@ class MacOSProject implements XcodeBasedProject, PlatformProject {
   File get platformPluginsFile => ephemeralDirectory.childFile('.flutter-plugins');
 
   @override
-  File get flutterPluginsDependenciesFile => parent.flutterPluginsDependenciesFile;
+  File get flutterPluginsDependenciesFile => ephemeralDirectory.childFile('.flutter-plugins-dependencies');
 
   Directory get _macOSDirectory => parent.directory.childDirectory('macos');
 
@@ -909,7 +909,7 @@ class WindowsProject implements PlatformProject {
   File get platformPluginsFile => ephemeralDirectory.childFile('.flutter-plugins');
 
   @override
-  File get flutterPluginsDependenciesFile => project.flutterPluginsDependenciesFile;
+  File get flutterPluginsDependenciesFile => ephemeralDirectory.childFile('.flutter-plugins-dependencies');
 
   Directory get _editableDirectory => project.directory.childDirectory('windows');
 
@@ -954,7 +954,7 @@ class LinuxProject implements PlatformProject {
   File get platformPluginsFile => ephemeralDirectory.childFile('.flutter-plugins');
 
   @override
-  File get flutterPluginsDependenciesFile => project.flutterPluginsDependenciesFile;
+  File get flutterPluginsDependenciesFile => ephemeralDirectory.childFile('.flutter-plugins-dependencies');
 
   Directory get _editableDirectory => project.directory.childDirectory('linux');
 

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -265,8 +265,7 @@ abstract class PlatformProject {
   /// The file containing the platform-specific plugins list.
   File get platformPluginsFile;
 
-  /// The `.flutter-plugins-dependencies` file of this project,
-  /// which contains the dependencies each plugin depends on.
+  /// The file containing the platform-specific plugins dependencies graph.
   File get flutterPluginsDependenciesFile;
 }
 
@@ -568,10 +567,14 @@ class AndroidProject implements PlatformProject {
 
   @override
   String get pluginConfigKey => AndroidPlugin.kConfigKey;
-
+  
+  // TODO(franciscojma): Change this values to the location of the android project. Currently setting
+  // to the parent's value to avoid breaking changes in the gradle setup.
   @override
   File get platformPluginsFile => parent.flutterPluginsFile;
 
+  // TODO(franciscojma): Change this values to the location of the android project. Currently setting
+  // to the parent's value to avoid breaking changes in the gradle setup.
   @override
   File get flutterPluginsDependenciesFile => parent.flutterPluginsDependenciesFile;
 

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -255,6 +255,9 @@ class FlutterProject {
 
 /// Represents a platform-specific sub-component of a FlutterProject.
 abstract class PlatformProject {
+  // The parent project of this platform project
+  FlutterProject get parent;
+
   /// Whether the subproject exists in the Flutter project.
   bool existsSync();
 
@@ -273,9 +276,6 @@ abstract class PlatformProject {
 ///
 /// This defines interfaces common to iOS and macOS projects.
 abstract class XcodeBasedProject {
-  /// The parent of this project.
-  FlutterProject get parent;
-
   /// Whether the subproject (either iOS or macOS) exists in the Flutter project.
   bool existsSync();
 
@@ -549,6 +549,7 @@ class AndroidProject implements PlatformProject {
   AndroidProject._(this.parent);
 
   /// The parent of this project.
+  @override
   final FlutterProject parent;
 
   static final RegExp _applicationIdPattern = RegExp('^\\s*applicationId\\s+[\'\"](.*)[\'\"]\\s*\$');
@@ -567,7 +568,7 @@ class AndroidProject implements PlatformProject {
 
   @override
   String get pluginConfigKey => AndroidPlugin.kConfigKey;
-  
+
   // TODO(franciscojma): Change this values to the location of the android project. Currently setting
   // to the parent's value to avoid breaking changes in the gradle setup.
   @override
@@ -746,6 +747,7 @@ enum AndroidEmbeddingVersion {
 class WebProject implements PlatformProject {
   WebProject._(this.parent);
 
+  @override
   final FlutterProject parent;
 
   /// Whether this flutter project has a web sub-project.
@@ -898,9 +900,10 @@ class MacOSProject implements XcodeBasedProject, PlatformProject {
 
 /// The Windows sub project
 class WindowsProject implements PlatformProject {
-  WindowsProject._(this.project);
+  WindowsProject._(this.parent);
 
-  final FlutterProject project;
+  @override
+  final FlutterProject parent;
 
   @override
   bool existsSync() => _editableDirectory.existsSync();
@@ -914,7 +917,7 @@ class WindowsProject implements PlatformProject {
   @override
   File get flutterPluginsDependenciesFile => ephemeralDirectory.childFile('.flutter-plugins-dependencies');
 
-  Directory get _editableDirectory => project.directory.childDirectory('windows');
+  Directory get _editableDirectory => parent.directory.childDirectory('windows');
 
   /// The directory in the project that is managed by Flutter. As much as
   /// possible, files that are edited by Flutter tooling after initial project
@@ -948,7 +951,8 @@ class WindowsProject implements PlatformProject {
 class LinuxProject implements PlatformProject {
   LinuxProject._(this.project);
 
-  final FlutterProject project;
+  @override
+  final FlutterProject parent;
 
   @override
   String get pluginConfigKey => LinuxPlugin.kConfigKey;
@@ -959,7 +963,7 @@ class LinuxProject implements PlatformProject {
   @override
   File get flutterPluginsDependenciesFile => ephemeralDirectory.childFile('.flutter-plugins-dependencies');
 
-  Directory get _editableDirectory => project.directory.childDirectory('linux');
+  Directory get _editableDirectory => parent.directory.childDirectory('linux');
 
   /// The directory in the project that is managed by Flutter. As much as
   /// possible, files that are edited by Flutter tooling after initial project
@@ -986,13 +990,13 @@ class LinuxProject implements PlatformProject {
 
 /// The Fuchsia sub project
 class FuchsiaProject {
-  FuchsiaProject._(this.project);
+  FuchsiaProject._(this.parent);
 
-  final FlutterProject project;
+  final FlutterProject parent;
 
   Directory _editableHostAppDirectory;
   Directory get editableHostAppDirectory =>
-      _editableHostAppDirectory ??= project.directory.childDirectory('fuchsia');
+      _editableHostAppDirectory ??= parent.directory.childDirectory('fuchsia');
 
   bool existsSync() => editableHostAppDirectory.existsSync();
 

--- a/packages/flutter_tools/templates/cocoapods/Podfile-ios-objc
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-ios-objc
@@ -67,7 +67,7 @@ target 'Runner' do
   # referring to absolute paths on developers' machines.
   system('rm -rf .symlinks')
   system('mkdir -p .symlinks/plugins')
-  plugin_pods = parse_KV_file('../.flutter-plugins')
+  plugin_pods = parse_KV_file('./Flutter/.flutter-plugins')
   plugin_pods.each do |name, path|
     symlink = File.join('.symlinks', 'plugins', name)
     File.symlink(path, symlink)

--- a/packages/flutter_tools/templates/cocoapods/Podfile-ios-swift
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-ios-swift
@@ -70,7 +70,7 @@ target 'Runner' do
   # referring to absolute paths on developers' machines.
   system('rm -rf .symlinks')
   system('mkdir -p .symlinks/plugins')
-  plugin_pods = parse_KV_file('../.flutter-plugins')
+  plugin_pods = parse_KV_file('./Flutter/.flutter-plugins')
   plugin_pods.each do |name, path|
     symlink = File.join('.symlinks', 'plugins', name)
     File.symlink(path, symlink)

--- a/packages/flutter_tools/templates/cocoapods/Podfile-macos
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-macos
@@ -57,7 +57,7 @@ target 'Runner' do
   }
 
   # Plugin Pods
-  plugin_pods = parse_KV_file('.Flutter/ephemeral/.flutter-plugins')
+  plugin_pods = parse_KV_file('./Flutter/ephemeral/.flutter-plugins')
   plugin_pods.map { |p|
     symlink = File.join(symlink_plugins_dir, p[:name])
     File.symlink(p[:path], symlink)

--- a/packages/flutter_tools/templates/cocoapods/Podfile-macos
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-macos
@@ -57,7 +57,7 @@ target 'Runner' do
   }
 
   # Plugin Pods
-  plugin_pods = parse_KV_file('./Flutter/ephemeral/.flutter-plugins')
+  plugin_pods = parse_KV_file(File.join(ephemeral_dir, '.flutter-plugins'))
   plugin_pods.map { |p|
     symlink = File.join(symlink_plugins_dir, p[:name])
     File.symlink(p[:path], symlink)

--- a/packages/flutter_tools/templates/cocoapods/Podfile-macos
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-macos
@@ -31,17 +31,6 @@ def parse_KV_file(file, separator='=')
   return pods_ary
 end
 
-def pubspec_supports_macos(file)
-  file_abs_path = File.expand_path(file)
-  if !File.exists? file_abs_path
-    return false;
-  end
-  File.foreach(file_abs_path) { |line|
-    return true if line =~ /^\s*macos:/
-  }
-  return false
-end
-
 target 'Runner' do
   use_frameworks!
   use_modular_headers!
@@ -68,13 +57,11 @@ target 'Runner' do
   }
 
   # Plugin Pods
-  plugin_pods = parse_KV_file('../.flutter-plugins')
+  plugin_pods = parse_KV_file('.Flutter/ephemeral/.flutter-plugins')
   plugin_pods.map { |p|
     symlink = File.join(symlink_plugins_dir, p[:name])
     File.symlink(p[:path], symlink)
-    if pubspec_supports_macos(File.join(symlink, 'pubspec.yaml'))
-      pod p[:name], :path => File.join(symlink, 'macos')
-    end
+    pod p[:name], :path => File.join(symlink, 'macos')
   }
 end
 

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -44,13 +44,15 @@ void main() {
       when(iosProject.existsSync()).thenReturn(true);
       when(iosProject.platformPluginsFile).thenReturn(flutterProject.directory.childDirectory('ios').childDirectory('Flutter').childFile('.flutter-plugins'));
       when(iosProject.flutterPluginsDependenciesFile).thenReturn(flutterProject.directory.childDirectory('ios').childDirectory('Flutter').childFile('.flutter-plugins-dependencies'));
+      when(iosProject.pluginConfigKey).thenReturn('ios');
       macosProject = MockMacOSProject();
       when(flutterProject.macos).thenReturn(macosProject);
       when(macosProject.podfile).thenReturn(flutterProject.directory.childDirectory('macos').childFile('Podfile'));
       when(macosProject.podManifestLock).thenReturn(flutterProject.directory.childDirectory('macos').childFile('Podfile.lock'));
       when(macosProject.existsSync()).thenReturn(true);
-      when(macosProject.platformPluginsFile).thenReturn(flutterProject.directory.childDirectory('Flutter').childFile('.flutter-plugins'));
-      when(macosProject.flutterPluginsDependenciesFile).thenReturn(flutterProject.directory.childDirectory('macos').childDirectory('Flutter').childFile('.flutter-plugins-dependencies'));
+      when(macosProject.platformPluginsFile).thenReturn(flutterProject.directory.childDirectory('macos').childDirectory('Flutter').childDirectory('ephemeral').childFile('.flutter-plugins'));
+      when(macosProject.flutterPluginsDependenciesFile).thenReturn(flutterProject.directory.childDirectory('macos').childDirectory('Flutter').childDirectory('ephemeral').childFile('.flutter-plugins-dependencies'));
+      when(macosProject.pluginConfigKey).thenReturn('macos');
       androidProject = MockAndroidProject();
       when(flutterProject.android).thenReturn(androidProject);
       when(androidProject.pluginRegistrantHost).thenReturn(flutterProject.directory.childDirectory('android').childDirectory('app'));
@@ -58,22 +60,26 @@ void main() {
       when(androidProject.existsSync()).thenReturn(true);
       when(androidProject.platformPluginsFile).thenReturn(flutterProject.flutterPluginsFile);
       when(androidProject.flutterPluginsDependenciesFile).thenReturn(flutterProject.flutterPluginsDependenciesFile);
+      when(androidProject.pluginConfigKey).thenReturn('android');
       webProject = MockWebProject();
       when(flutterProject.web).thenReturn(webProject);
       when(webProject.libDirectory).thenReturn(flutterProject.directory.childDirectory('lib'));
       when(webProject.existsSync()).thenReturn(true);
       when(webProject.platformPluginsFile).thenReturn(flutterProject.directory.childDirectory('web').childFile('.flutter-plugins'));
       when(webProject.flutterPluginsDependenciesFile).thenReturn(flutterProject.directory.childDirectory('web').childFile('.flutter-plugins-dependencies'));
+      when(webProject.pluginConfigKey).thenReturn('web');
       windowsProject = MockWindowsProject();
       when(flutterProject.windows).thenReturn(windowsProject);
       when(windowsProject.existsSync()).thenReturn(true);
-      when(windowsProject.platformPluginsFile).thenReturn(flutterProject.directory.childDirectory('flutter').childDirectory('ephemeral').childFile('.flutter-plugins'));
+      when(windowsProject.platformPluginsFile).thenReturn(flutterProject.directory.childDirectory('windows').childDirectory('flutter').childDirectory('ephemeral').childFile('.flutter-plugins'));
       when(windowsProject.flutterPluginsDependenciesFile).thenReturn(flutterProject.directory.childDirectory('windows').childDirectory('flutter').childDirectory('ephemeral').childFile('.flutter-plugins-dependencies'));
+      when(windowsProject.pluginConfigKey).thenReturn('windows');
       linuxProject = MockLinuxProject();
       when(flutterProject.linux).thenReturn(linuxProject);
       when(linuxProject.existsSync()).thenReturn(true);
-      when(linuxProject.platformPluginsFile).thenReturn(flutterProject.directory.childDirectory('flutter').childDirectory('ephemeral').childFile('.flutter-plugins'));
+      when(linuxProject.platformPluginsFile).thenReturn(flutterProject.directory.childDirectory('linux').childDirectory('flutter').childDirectory('ephemeral').childFile('.flutter-plugins'));
       when(linuxProject.flutterPluginsDependenciesFile).thenReturn(flutterProject.directory.childDirectory('linux').childDirectory('flutter').childDirectory('ephemeral').childFile('.flutter-plugins-dependencies'));
+      when(linuxProject.pluginConfigKey).thenReturn('linux');
 
       // Set up a simple .packages file for all the tests to use, pointing to one package.
       dummyPackageDirectory = fs.directory('/pubcache/apackage/lib/');
@@ -92,8 +98,16 @@ void main() {
           pluginClass: FLESomePlugin
         macos:
           pluginClass: FLESomePlugin
+        windows:
+          pluginClass: FLESomePlugin
+        linux:
+          pluginClass: FLESomePlugin
         web:
           pluginClass: SomePlugin
+          fileName: lib/SomeFile.dart
+        android:
+          pluginClass: SomePlugin
+          package: AndroidPackage
   ''');
     }
 
@@ -310,12 +324,14 @@ dependencies:
 
       testUsingContext('Refreshing the plugin list creates a plugin directory when there are plugins', () {
         configureDummyPackageAsPlugin();
-        when(iosProject.existsSync()).thenReturn(false);
-        when(macosProject.existsSync()).thenReturn(false);
-        when(androidProject.existsSync()).thenReturn(false);
-        when(webProject.existsSync()).thenReturn(false);
-        when(windowsProject.existsSync()).thenReturn(false);
-        when(linuxProject.existsSync()).thenReturn(false);
+        // Setting Android as false since 
+        when(androidProject.existsSync()).thenReturn(true);
+        when(iosProject.existsSync()).thenReturn(true);
+        when(macosProject.existsSync()).thenReturn(true);
+
+        when(webProject.existsSync()).thenReturn(true);
+        when(windowsProject.existsSync()).thenReturn(true);
+        when(linuxProject.existsSync()).thenReturn(true);
 
         refreshPluginsList(flutterProject);
         // TODO(franciscojma): Remove once legacy support for a root-project-level plugins file is removed.
@@ -326,14 +342,14 @@ dependencies:
         expect(iosProject.flutterPluginsDependenciesFile.existsSync(), true);
         expect(macosProject.platformPluginsFile.existsSync(), true);
         expect(macosProject.flutterPluginsDependenciesFile.existsSync(), true);
-        expect(androidProject.platformPluginsFile.existsSync(), false);
-        expect(androidProject.flutterPluginsDependenciesFile.existsSync(), false);
+        expect(androidProject.platformPluginsFile.existsSync(), true);
+        expect(androidProject.flutterPluginsDependenciesFile.existsSync(), true);
         expect(webProject.platformPluginsFile.existsSync(), true);
         expect(webProject.flutterPluginsDependenciesFile.existsSync(), true);
-        expect(windowsProject.platformPluginsFile.existsSync(), false);
-        expect(windowsProject.flutterPluginsDependenciesFile.existsSync(), false);
-        expect(linuxProject.platformPluginsFile.existsSync(), false);
-        expect(linuxProject.flutterPluginsDependenciesFile.existsSync(), false);
+        expect(windowsProject.platformPluginsFile.existsSync(), true);
+        expect(windowsProject.flutterPluginsDependenciesFile.existsSync(), true);
+        expect(linuxProject.platformPluginsFile.existsSync(), true);
+        expect(linuxProject.flutterPluginsDependenciesFile.existsSync(), true);
 
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
@@ -396,6 +412,20 @@ dependencies:
         ProcessManager: () => FakeProcessManager.any(),
       });
     });
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
     group('injectPlugins', () {
       MockFeatureFlags featureFlags;


### PR DESCRIPTION
## Description

Creates a `.flutter-plugins` and a `.flutter-plugins-dependencies` file for each platform project instead of in the Flutter root project for all platforms except for Android.

## Related Issues

https://github.com/flutter/flutter/issues/46618

## Tests

Tests remaining 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*
