### PR TITLE
ImageCache: allow it to hold onto one image larger than the cache

### DIFF
--- a/packages/flutter/lib/src/painting/image_cache.dart
+++ b/packages/flutter/lib/src/painting/image_cache.dart
@@ -170,12 +170,6 @@ class ImageCache {
       // Images that fail to load don't contribute to cache size.
       final int imageSize = info?.image == null ? 0 : info.image.height * info.image.width * 4;
       final _CachedImage image = _CachedImage(result, imageSize);
-      // If the image is bigger than the maximum cache size, and the cache size
-      // is not zero, then increase the cache size to the size of the image plus
-      // some change.
-      if (maximumSizeBytes > 0 && imageSize > maximumSizeBytes) {
-        _maximumSizeBytes = imageSize + 1000;
-      }
       _currentSizeBytes += imageSize;
       final _PendingImage pendingImage = _pendingImages.remove(key);
       if (pendingImage != null) {
@@ -197,7 +191,7 @@ class ImageCache {
   // Remove images from the cache until both the length and bytes are below
   // maximum, or the cache is empty.
   void _checkCacheSize() {
-    while (_currentSizeBytes > _maximumSizeBytes || _cache.length > _maximumSize) {
+    while (_cache.length > 1 && (_currentSizeBytes > _maximumSizeBytes || _cache.length > _maximumSize)) {
       final Object key = _cache.keys.first;
       final _CachedImage image = _cache[key];
       _currentSizeBytes -= image.sizeBytes;
@@ -205,7 +199,6 @@ class ImageCache {
     }
     assert(_currentSizeBytes >= 0);
     assert(_cache.length <= maximumSize);
-    assert(_currentSizeBytes <= maximumSizeBytes);
   }
 }
 

--- a/packages/flutter/test/painting/image_cache_test.dart
+++ b/packages/flutter/test/painting/image_cache_test.dart
@@ -121,14 +121,14 @@ void main() {
       expect(imageCache.currentSizeBytes, 256);
     });
 
-    test('Increases cache size if an image is loaded that is larger then the maximum size', () async {
+    test('Holds onto at least one image even if its size is larger than the maximum byte size.', () async {
       const TestImage testImage = TestImage(width: 8, height: 8);
 
       imageCache.maximumSizeBytes = 1;
       await extractOneFrame(const TestImageProvider(1, 1, image: testImage).resolve(ImageConfiguration.empty));
       expect(imageCache.currentSize, 1);
       expect(imageCache.currentSizeBytes, 256);
-      expect(imageCache.maximumSizeBytes, 256 + 1000);
+      expect(imageCache.maximumSizeBytes, 1);
     });
 
     test('Returns null if an error is caught resolving an image', () {


### PR DESCRIPTION
## Description

Changed the caching logic so that images that could never fit in the cache are held onto without increasing the maximum cache byte size.

## Related Issues

https://github.com/flutter/flutter/issues/45643

## Tests

I added the following tests:

Updated the test in image_cache.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [x] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [x] I wrote a design doc: (google internal) https://docs.google.com/document/d/11hF86LxFBTU2fc_2Pn5WjBug9UACLnY2l51oLG7_mf0/edit
   - [x] I got input from the developer relations team, specifically from: hixie
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
