### PR TITLE
Adds shadowColor property to the Card widget

### DIFF
--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -101,6 +101,7 @@ class Card extends StatelessWidget {
   const Card({
     Key key,
     this.color,
+    this.shadowColor,
     this.elevation,
     this.shape,
     this.borderOnForeground = true,
@@ -119,6 +120,11 @@ class Card extends StatelessWidget {
   /// If this property is null then [ThemeData.cardTheme.color] is used,
   /// if that's null then [ThemeData.cardColor] is used.
   final Color color;
+
+  /// The color to paint the shadow below the card.
+  ///
+  /// Defaults to fully opaque black.
+  final Color shadowColor;
 
   /// The z-coordinate at which to place this card. This controls the size of
   /// the shadow below the card.
@@ -189,6 +195,7 @@ class Card extends StatelessWidget {
         margin: margin ?? cardTheme.margin ?? const EdgeInsets.all(4.0),
         child: Material(
           type: MaterialType.card,
+          shadowColor: shadowColor ?? cardTheme.shadowColor ?? const Color(0xFF000000),
           color: color ?? cardTheme.color ?? Theme.of(context).cardColor,
           elevation: elevation ?? cardTheme.elevation ?? _defaultElevation,
           shape: shape ?? cardTheme.shape ?? const RoundedRectangleBorder(

--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/widgets.dart';
 
 import 'card_theme.dart';
+import 'colors.dart';
 import 'material.dart';
 import 'theme.dart';
 
@@ -123,7 +124,8 @@ class Card extends StatelessWidget {
 
   /// The color to paint the shadow below the card.
   ///
-  /// Defaults to fully opaque black.
+  /// If null then the ambient [CardTheme]'s shadowColor is used.
+  /// If that's null too, then the default is fully opaque black.
   final Color shadowColor;
 
   /// The z-coordinate at which to place this card. This controls the size of
@@ -195,7 +197,7 @@ class Card extends StatelessWidget {
         margin: margin ?? cardTheme.margin ?? const EdgeInsets.all(4.0),
         child: Material(
           type: MaterialType.card,
-          shadowColor: shadowColor ?? cardTheme.shadowColor ?? const Color(0xFF000000),
+          shadowColor: shadowColor ?? cardTheme.shadowColor ?? Colors.black,
           color: color ?? cardTheme.color ?? Theme.of(context).cardColor,
           elevation: elevation ?? cardTheme.elevation ?? _defaultElevation,
           shape: shape ?? cardTheme.shape ?? const RoundedRectangleBorder(

--- a/packages/flutter/lib/src/material/card_theme.dart
+++ b/packages/flutter/lib/src/material/card_theme.dart
@@ -34,6 +34,7 @@ class CardTheme extends Diagnosticable {
   const CardTheme({
     this.clipBehavior,
     this.color,
+    this.shadowColor,
     this.elevation,
     this.margin,
     this.shape,
@@ -48,6 +49,11 @@ class CardTheme extends Diagnosticable {
   ///
   /// If null, [Card] uses [ThemeData.cardColor].
   final Color color;
+
+  /// Default value for [Card.shadowColor].
+  ///
+  /// If null, [Card] defaults to fully opaque black.
+  final Color shadowColor;
 
   /// Default value for [Card.elevation].
   ///
@@ -71,6 +77,7 @@ class CardTheme extends Diagnosticable {
   CardTheme copyWith({
     Clip clipBehavior,
     Color color,
+    Color shadowColor,
     double elevation,
     EdgeInsetsGeometry margin,
     ShapeBorder shape,
@@ -78,6 +85,7 @@ class CardTheme extends Diagnosticable {
     return CardTheme(
       clipBehavior: clipBehavior ?? this.clipBehavior,
       color: color ?? this.color,
+      shadowColor: shadowColor ?? this.shadowColor,
       elevation: elevation ?? this.elevation,
       margin: margin ?? this.margin,
       shape: shape ?? this.shape,
@@ -99,6 +107,7 @@ class CardTheme extends Diagnosticable {
     return CardTheme(
       clipBehavior: t < 0.5 ? a?.clipBehavior : b?.clipBehavior,
       color: Color.lerp(a?.color, b?.color, t),
+      shadowColor: Color.lerp(a?.shadowColor, b?.shadowColor, t),
       elevation: lerpDouble(a?.elevation, b?.elevation, t),
       margin: EdgeInsetsGeometry.lerp(a?.margin, b?.margin, t),
       shape: ShapeBorder.lerp(a?.shape, b?.shape, t),
@@ -110,6 +119,7 @@ class CardTheme extends Diagnosticable {
     return hashValues(
       clipBehavior,
       color,
+      shadowColor,
       elevation,
       margin,
       shape,
@@ -125,6 +135,7 @@ class CardTheme extends Diagnosticable {
     return other is CardTheme
         && other.clipBehavior == clipBehavior
         && other.color == color
+        && other.shadowColor == shadowColor
         && other.elevation == elevation
         && other.margin == margin
         && other.shape == shape;
@@ -135,6 +146,7 @@ class CardTheme extends Diagnosticable {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<Clip>('clipBehavior', clipBehavior, defaultValue: null));
     properties.add(ColorProperty('color', color, defaultValue: null));
+    properties.add(ColorProperty('shadowColor', shadowColor, defaultValue: null));
     properties.add(DiagnosticsProperty<double>('elevation', elevation, defaultValue: null));
     properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('margin', margin, defaultValue: null));
     properties.add(DiagnosticsProperty<ShapeBorder>('shape', shape, defaultValue: null));

--- a/packages/flutter/test/material/card_test.dart
+++ b/packages/flutter/test/material/card_test.dart
@@ -198,7 +198,7 @@ void main() {
     expect(_getCardMaterial(tester).shadowColor, const Color(0xFF000000));
 
     await tester.pumpWidget(
-      Card(
+      const Card(
         shadowColor: Colors.red,
       ),
     );

--- a/packages/flutter/test/material/card_test.dart
+++ b/packages/flutter/test/material/card_test.dart
@@ -11,6 +11,21 @@ import 'package:flutter_test/flutter_test.dart';
 import '../widgets/semantics_tester.dart';
 
 void main() {
+  Material _getCardMaterial(WidgetTester tester) {
+    return tester.widget<Material>(
+      find.descendant(
+        of: find.byType(Card),
+        matching: find.byType(Material),
+      ),
+    );
+  }
+
+  Card _getCard(WidgetTester tester) {
+    return tester.widget<Card>(
+        find.byType(Card)
+    );
+  }
+
   testWidgets('Card can take semantic text from multiple children', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
     await tester.pumpWidget(
@@ -206,20 +221,4 @@ void main() {
     expect(_getCardMaterial(tester).shadowColor, _getCard(tester).shadowColor);
     expect(_getCardMaterial(tester).shadowColor, Colors.red);
   });
-}
-
-
-Material _getCardMaterial(WidgetTester tester) {
-  return tester.widget<Material>(
-    find.descendant(
-      of: find.byType(Card),
-      matching: find.byType(Material),
-    ),
-  );
-}
-
-Card _getCard(WidgetTester tester) {
-  return tester.widget<Card>(
-    find.byType(Card)
-  );
 }

--- a/packages/flutter/test/material/card_test.dart
+++ b/packages/flutter/test/material/card_test.dart
@@ -11,21 +11,6 @@ import 'package:flutter_test/flutter_test.dart';
 import '../widgets/semantics_tester.dart';
 
 void main() {
-  Material _getCardMaterial(WidgetTester tester) {
-    return tester.widget<Material>(
-      find.descendant(
-        of: find.byType(Card),
-        matching: find.byType(Material),
-      ),
-    );
-  }
-
-  Card _getCard(WidgetTester tester) {
-    return tester.widget<Card>(
-        find.byType(Card)
-    );
-  }
-
   testWidgets('Card can take semantic text from multiple children', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
     await tester.pumpWidget(
@@ -205,6 +190,21 @@ void main() {
   });
 
   testWidgets('Card shadowColor', (WidgetTester tester) async {
+    Material _getCardMaterial(WidgetTester tester) {
+      return tester.widget<Material>(
+        find.descendant(
+          of: find.byType(Card),
+          matching: find.byType(Material),
+        ),
+      );
+    }
+
+    Card _getCard(WidgetTester tester) {
+      return tester.widget<Card>(
+          find.byType(Card)
+      );
+    }
+
     await tester.pumpWidget(
       const Card(),
     );

--- a/packages/flutter/test/material/card_test.dart
+++ b/packages/flutter/test/material/card_test.dart
@@ -188,4 +188,38 @@ void main() {
     }));
     expect(tester.widget<Material>(find.byType(Material)).clipBehavior, Clip.antiAliasWithSaveLayer);
   });
+
+  testWidgets('Card shadowColor', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Card(),
+    );
+
+    expect(_getCard(tester).shadowColor, null);
+    expect(_getCardMaterial(tester).shadowColor, const Color(0xFF000000));
+
+    await tester.pumpWidget(
+      Card(
+        shadowColor: Colors.red,
+      ),
+    );
+
+    expect(_getCardMaterial(tester).shadowColor, _getCard(tester).shadowColor);
+    expect(_getCardMaterial(tester).shadowColor, Colors.red);
+  });
+}
+
+
+Material _getCardMaterial(WidgetTester tester) {
+  return tester.widget<Material>(
+    find.descendant(
+      of: find.byType(Card),
+      matching: find.byType(Material),
+    ),
+  );
+}
+
+Card _getCard(WidgetTester tester) {
+  return tester.widget<Card>(
+    find.byType(Card)
+  );
 }

--- a/packages/flutter/test/material/card_theme_test.dart
+++ b/packages/flutter/test/material/card_theme_test.dart
@@ -46,6 +46,7 @@ void main() {
 
     expect(material.clipBehavior, cardTheme.clipBehavior);
     expect(material.color, cardTheme.color);
+    expect(material.shadowColor, cardTheme.shadowColor);
     expect(material.elevation, cardTheme.elevation);
     expect(container.margin, cardTheme.margin);
     expect(material.shape, cardTheme.shape);
@@ -146,6 +147,7 @@ CardTheme _cardTheme() {
   return const CardTheme(
     clipBehavior: Clip.antiAlias,
     color: Colors.green,
+    shadowColor: Colors.red,
     elevation: 6.0,
     margin: EdgeInsets.all(7.0),
     shape: RoundedRectangleBorder(


### PR DESCRIPTION
## Description

Adds a new shadowColor property to the Card widget, to allow customizing the shadow color.

## Related Issues

https://github.com/flutter/flutter/issues/47272
https://github.com/flutter/flutter/pull/33257

## Tests

I added the following tests:

`card_test.dart` - added a test that ensures the cards default shadow color is black, and that if a shadowColor is set, the Material shadowColor gets that value.

`card_theme_test.dart` - modified tests to check that the material gets the shadow color from the card theme.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.