### PR TITLE
[flutter_tool] Improve iOS mDNS failure error message

### DIFF
--- a/packages/flutter_tools/lib/src/mdns_discovery.dart
+++ b/packages/flutter_tools/lib/src/mdns_discovery.dart
@@ -193,7 +193,9 @@ class MDnsObservatoryDiscovery {
         UsageEvent('ios-mdns', 'no-ipv4-link-local').send();
         printError(
           'The mDNS query for an attached iOS device failed. It may '
-          'be necessary to disable the "Personal Hotspot" on the device. '
+          'be necessary to disable the "Personal Hotspot" on the device, and '
+          'to ensure that the "Disable unless needed" setting is unchecked '
+          'under System Preferences > Network > iPhone USB.'
           'See https://github.com/flutter/flutter/issues/46698 for details.'
         );
         break;


### PR DESCRIPTION
## Description

Improves the error message added in https://github.com/flutter/flutter/pull/47157 with some additional info from https://github.com/flutter/flutter/issues/46705.

## Related Issues

https://github.com/flutter/flutter/issues/46705
https://github.com/flutter/flutter/issues/46698
https://github.com/flutter/flutter/issues/47224

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.