### PR TITLE
Is executable doesn't mean a+x

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle_utils.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_utils.dart
@@ -158,7 +158,7 @@ bool _hasExecutePermission(File executable) {
   final FileStat stat = executable.statSync();
   assert(stat.type != FileSystemEntityType.notFound);
   printTrace('${executable.path} mode: ${stat.mode} ${stat.modeString()}.');
-  return stat.mode & _kExecPermissionMask == _kExecPermissionMask;
+  return stat.mode & _kExecPermissionMask != 0;
 }
 
 /// Gives execute permission to [executable] if it doesn't have it already.

--- a/packages/flutter_tools/lib/src/android/gradle_utils.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_utils.dart
@@ -107,7 +107,7 @@ class GradleUtils {
         return !destinationFile.existsSync();
       },
       onFileCopied: (File sourceFile, File destinationFile) {
-        if (_hasExecutePermission(sourceFile)) {
+        if (_hasAnyExecutableFlagSet(sourceFile)) {
           _giveExecutePermissionIfNeeded(destinationFile);
         }
       },
@@ -153,8 +153,16 @@ String getGradleVersionForAndroidPlugin(Directory directory) {
 
 const int _kExecPermissionMask = 0x49; // a+x
 
-/// Returns [true] if [executable] has execute permission.
-bool _hasExecutePermission(File executable) {
+/// Returns [true] if [executable] has all executable flag set.
+bool _hasAllExecutableFlagSet(File executable) {
+  final FileStat stat = executable.statSync();
+  assert(stat.type != FileSystemEntityType.notFound);
+  printTrace('${executable.path} mode: ${stat.mode} ${stat.modeString()}.');
+  return stat.mode & _kExecPermissionMask == _kExecPermissionMask;
+}
+
+/// Returns [true] if [executable] has any executable flag set.
+bool _hasAnyExecutableFlagSet(File executable) {
   final FileStat stat = executable.statSync();
   assert(stat.type != FileSystemEntityType.notFound);
   printTrace('${executable.path} mode: ${stat.mode} ${stat.modeString()}.');
@@ -163,7 +171,7 @@ bool _hasExecutePermission(File executable) {
 
 /// Gives execute permission to [executable] if it doesn't have it already.
 void _giveExecutePermissionIfNeeded(File executable) {
-  if (!_hasExecutePermission(executable)) {
+  if (!_hasAllExecutableFlagSet(executable)) {
     printTrace('Trying to give execute permission to ${executable.path}.');
     os.makeExecutable(executable);
   }

--- a/packages/flutter_tools/test/general.shard/android/gradle_utils_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_utils_test.dart
@@ -285,6 +285,37 @@ void main() {
       GradleUtils: () => gradleUtils,
     });
 
+    testUsingContext('gives execute permission to gradle even when not all permission flags are set', () {
+      final FlutterProject flutterProject = MockFlutterProject();
+      final AndroidProject androidProject = MockAndroidProject();
+      when(flutterProject.android).thenReturn(androidProject);
+
+      final FileStat gradleStat = MockFileStat();
+      when(gradleStat.mode).thenReturn(400);
+
+      final File gradlew = MockFile();
+      when(gradlew.path).thenReturn('gradlew');
+      when(gradlew.absolute).thenReturn(gradlew);
+      when(gradlew.statSync()).thenReturn(gradleStat);
+      when(gradlew.existsSync()).thenReturn(true);
+
+      final Directory androidDirectory = MockDirectory();
+      when(androidDirectory.childFile(gradlewFilename)).thenReturn(gradlew);
+      when(androidProject.hostAppGradleRoot).thenReturn(androidDirectory);
+
+      when(gradleUtils.injectGradleWrapperIfNeeded(any)).thenReturn(null);
+      when(gradleUtils.migrateToR8(any)).thenReturn(null);
+
+      GradleUtils().getExecutable(flutterProject);
+
+      verify(operatingSystemUtils.makeExecutable(gradlew)).called(1);
+    }, overrides: <Type, Generator>{
+      FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
+      OperatingSystemUtils: () => operatingSystemUtils,
+      GradleUtils: () => gradleUtils,
+    });
+
     testUsingContext('doesn\'t give execute permission to gradle if not needed', () {
       final FlutterProject flutterProject = MockFlutterProject();
       final AndroidProject androidProject = MockAndroidProject();


### PR DESCRIPTION
Seen this issue:
```Oops; flutter has exited unexpectedly: "ProcessException: Permission denied
  Command: /tmp/flutter_gradle_wrapper.CKEZBO/gradlew -b /usr/local/google/home/chingjun/test/flutter/packages/flutter_tools/gradle/resolve_dependencies.gradle --project-cache-dir
  /tmp/flutter_gradle_wrapper.CKEZBO resolveDependencies".
```

Flutter doctor pointed me to https://github.com/flutter/flutter/issues/6207, which doesn't help.

Turns out the problem was because the permission on gradlew was `rwxr-x---`, which is not `a+x`.

The code before https://github.com/flutter/flutter/commit/354f80b84a9b30ec3b49d8fed81bce772a1bc8e8 was:
```
final String modes = sourceFile.statSync().modeString();
if (modes != null && modes.contains('x')) {
  os.makeExecutable(destinationFile);
}
```

Which is technically the same as my change here.