### PR TITLE
Build iOS frameworks with relative output path

### DIFF
--- a/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
@@ -45,19 +45,20 @@ Future<void> main() async {
       // This builds all build modes' frameworks by default
       section('Build frameworks');
 
+      const String outputDirectoryName = 'flutter-frameworks';
+
       await inDirectory(projectDir, () async {
         await flutter(
           'build',
-          options: <String>['ios-framework'],
+          options: <String>[
+            'ios-framework',
+            '--xcframework',
+            '--output=$outputDirectoryName'
+          ],
         );
       });
 
-      final String outputPath = path.join(
-        projectDir.path,
-        'build',
-        'ios',
-        'framework',
-      );
+      final String outputPath = path.join(projectDir.path, outputDirectoryName);
 
       section('Check debug build has Dart snapshot as asset');
 
@@ -157,6 +158,22 @@ Future<void> main() async {
           'Flutter.framework',
           'Flutter',
         ));
+        checkFileExists(path.join(
+          outputPath,
+          mode,
+          'Flutter.xcframework',
+          'ios-armv7_arm64',
+          'Flutter.framework',
+          'Flutter',
+        ));
+        checkFileExists(path.join(
+          outputPath,
+          mode,
+          'Flutter.xcframework',
+          'ios-x86_64-simulator',
+          'Flutter.framework',
+          'Flutter',
+        ));
       }
 
       section("Check all modes' engine header");
@@ -177,6 +194,22 @@ Future<void> main() async {
           'device_info.framework',
           'device_info',
         ));
+        checkFileExists(path.join(
+          outputPath,
+          mode,
+          'device_info.xcframework',
+          'ios-armv7_arm64',
+          'device_info.framework',
+          'device_info',
+        ));
+        checkFileExists(path.join(
+          outputPath,
+          mode,
+          'device_info.xcframework',
+          'ios-x86_64-simulator',
+          'device_info.framework',
+          'device_info',
+        ));
       }
 
       section("Check all modes' have generated plugin registrant");
@@ -185,6 +218,24 @@ Future<void> main() async {
         checkFileExists(path.join(
           outputPath,
           mode,
+          'FlutterPluginRegistrant.framework',
+          'Headers',
+          'GeneratedPluginRegistrant.h',
+        ));
+        checkFileExists(path.join(
+          outputPath,
+          mode,
+          'FlutterPluginRegistrant.xcframework',
+          'ios-armv7_arm64',
+          'FlutterPluginRegistrant.framework',
+          'Headers',
+          'GeneratedPluginRegistrant.h',
+        ));
+        checkFileExists(path.join(
+          outputPath,
+          mode,
+          'FlutterPluginRegistrant.xcframework',
+          'ios-x86_64-simulator',
           'FlutterPluginRegistrant.framework',
           'Headers',
           'GeneratedPluginRegistrant.h',


### PR DESCRIPTION
## Description

- Handle relative output paths
- Better error messages and early exits for sub-process failures
- Wrap `Status` starts and stops in `try`-`finally`s to fix up status indicators on exceptions

## Related Issues

Fixes https://github.com/flutter/flutter/issues/46993

## Tests

Updated build_ios_framework_module_test for outputPath and xcframeworks

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*