### PR TITLE
support endless recorder for timeline

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -583,6 +583,8 @@ class AndroidDevice extends Device {
         ...<String>['--ez', 'trace-skia', 'true'],
       if (debuggingOptions.traceSystrace)
         ...<String>['--ez', 'trace-systrace', 'true'],
+      if (debuggingOptions.endlessTraceBuffer)
+        ...<String>['--ez', 'endless-trace-buffer', 'true'],
       if (debuggingOptions.dumpSkpOnShaderCompilation)
         ...<String>['--ez', 'dump-skp-on-shader-compilation', 'true'],
       if (debuggingOptions.cacheSkSL)

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -105,7 +105,7 @@ class RunCommand extends RunCommandBase {
       )
       ..addFlag('endless-trace-buffer',
         negatable: false,
-        help: 'Enable tracing to the endless tracer. This is usefull when '
+        help: 'Enable tracing to the endless tracer. This is useful when '
               'recording huge amounts of traces. If we need to use endless buffer to '
               'record startup traces, we can combine the ("--trace-startup"). '
               'For exemple, flutter run --trace-startup --endless-trace-buffer. ',

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -103,6 +103,13 @@ class RunCommand extends RunCommandBase {
         help: 'Enable tracing of Skia code. This is useful when debugging '
               'the GPU thread. By default, Flutter will not log skia code.',
       )
+      ..addFlag('endless-trace-buffer',
+        negatable: false,
+        help: 'Enable tracing to the endless tracer. This is usefull when '
+              'recording huge amounts of traces. If we need to use endless buffer to '
+              'record startup traces, we can combine the ("--trace-startup"). '
+              'For exemple, flutter run --trace-startup --endless-trace-buffer. ',
+      )
       ..addFlag('trace-systrace',
         negatable: false,
         help: 'Enable tracing to the system tracer. This is only useful on '
@@ -353,6 +360,7 @@ class RunCommand extends RunCommandBase {
         skiaDeterministicRendering: boolArg('skia-deterministic-rendering'),
         traceSkia: boolArg('trace-skia'),
         traceSystrace: boolArg('trace-systrace'),
+        endlessTraceBuffer: boolArg('endless-trace-buffer'),
         dumpSkpOnShaderCompilation: dumpSkpOnShaderCompilation,
         cacheSkSL: cacheSkSL,
         deviceVmServicePort: deviceVmservicePort,

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -527,6 +527,7 @@ class DebuggingOptions {
     this.skiaDeterministicRendering = false,
     this.traceSkia = false,
     this.traceSystrace = false,
+    this.endlessTraceBuffer = false,
     this.dumpSkpOnShaderCompilation = false,
     this.cacheSkSL = false,
     this.useTestFonts = false,
@@ -556,6 +557,7 @@ class DebuggingOptions {
       skiaDeterministicRendering = false,
       traceSkia = false,
       traceSystrace = false,
+      endlessTraceBuffer = false,
       dumpSkpOnShaderCompilation = false,
       verboseSystemLogs = false,
       hostVmServicePort = null,
@@ -573,6 +575,7 @@ class DebuggingOptions {
   final bool skiaDeterministicRendering;
   final bool traceSkia;
   final bool traceSystrace;
+  final bool endlessTraceBuffer;
   final bool dumpSkpOnShaderCompilation;
   final bool cacheSkSL;
   final bool useTestFonts;

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -342,6 +342,7 @@ class IOSDevice extends Device {
       if (debuggingOptions.enableSoftwareRendering) '--enable-software-rendering',
       if (debuggingOptions.skiaDeterministicRendering) '--skia-deterministic-rendering',
       if (debuggingOptions.traceSkia) '--trace-skia',
+      if (debuggingOptions.endlessTraceBuffer) '----endless-trace-buffer',
       if (debuggingOptions.dumpSkpOnShaderCompilation) '--dump-skp-on-shader-compilation',
       if (debuggingOptions.verboseSystemLogs) '--verbose-logging',
       if (debuggingOptions.cacheSkSL) '--cache-sksl',

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -342,7 +342,7 @@ class IOSDevice extends Device {
       if (debuggingOptions.enableSoftwareRendering) '--enable-software-rendering',
       if (debuggingOptions.skiaDeterministicRendering) '--skia-deterministic-rendering',
       if (debuggingOptions.traceSkia) '--trace-skia',
-      if (debuggingOptions.endlessTraceBuffer) '----endless-trace-buffer',
+      if (debuggingOptions.endlessTraceBuffer) '--endless-trace-buffer',
       if (debuggingOptions.dumpSkpOnShaderCompilation) '--dump-skp-on-shader-compilation',
       if (debuggingOptions.verboseSystemLogs) '--verbose-logging',
       if (debuggingOptions.cacheSkSL) '--cache-sksl',


### PR DESCRIPTION
Timeline use TimelineEventRingRecorder by default.
If we set trace-systrace, using TimelineEventSystraceRecorder.
If set endless-trace-buffer, we need support  using TimelineEventEndlessRecorder.

in file third_party/dart/runtime/vm/timeline.cc
```
static TimelineEventRecorder* CreateTimelineRecorder() {
  const bool use_endless_recorder =
      (FLAG_timeline_dir != NULL) || FLAG_timing || FLAG_complete_timeline;

  const bool use_startup_recorder = FLAG_startup_timeline;
  const bool use_systrace_recorder = FLAG_systrace_timeline;
  const char* flag = FLAG_timeline_recorder;

  if (use_systrace_recorder || (flag != NULL)) {
    if (use_systrace_recorder || (strcmp("systrace", flag) == 0)) {
#if defined(HOST_OS_LINUX) || defined(HOST_OS_ANDROID)
      return new TimelineEventSystraceRecorder();
#elif defined(HOST_OS_FUCHSIA)
      return new TimelineEventFuchsiaRecorder();
#else
      OS::PrintErr(
          "Warning: The systrace timeline recorder is equivalent to the"
          "ring recorder on this platform.");
      return new TimelineEventRingRecorder();
#endif
    }
  }

  if (use_endless_recorder || (flag != NULL)) {
    if (use_endless_recorder || (strcmp("endless", flag) == 0)) {
      return new TimelineEventEndlessRecorder();
    }
  }

  if (use_startup_recorder || (flag != NULL)) {
    if (use_startup_recorder || (strcmp("startup", flag) == 0)) {
      return new TimelineEventStartupRecorder();
    }
  }
  return new TimelineEventRingRecorder();
}
```