### PR TITLE
fix initial routes do not run secondary animation when pops

### DIFF
--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -259,8 +259,8 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
   // A callback method that disposes existing train hopping animation and
   // removes its listener.
   //
-  // The caller must reset this property to null once it is called, and this
-  // property is non-null if there is a train hopping in progress
+  // This property is non-null if there is a train hopping in progress, and the
+  // caller must reset this property to null after it is called.
   VoidCallback _trainHoppingListenerRemover;
 
   void _updateSecondaryAnimation(Route<dynamic> nextRoute) {

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -256,13 +256,27 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
     super.didChangeNext(nextRoute);
   }
 
+  bool _shouldJumpTrain(Animation<double> firstTrain, Animation<double> secondTrain) {
+    // We should jump to the other train if two trains will never cross in the
+    // future.
+    if (firstTrain.value == secondTrain.value)
+      return true;
+    else if (firstTrain.value < secondTrain.value)
+      return firstTrain.status != AnimationStatus.forward &&
+             secondTrain.status != AnimationStatus.reverse;
+    else
+      return firstTrain.status != AnimationStatus.reverse &&
+             secondTrain.status != AnimationStatus.forward;
+  }
+
+
   void _updateSecondaryAnimation(Route<dynamic> nextRoute) {
     if (nextRoute is TransitionRoute<dynamic> && canTransitionTo(nextRoute) && nextRoute.canTransitionFrom(this)) {
       final Animation<double> current = _secondaryAnimation.parent;
       if (current != null) {
         final Animation<double> currentTrain = current is TrainHoppingAnimation ? current.currentTrain : current;
         final Animation<double> nextTrain = nextRoute._animation;
-        if (currentTrain.value == nextTrain.value) {
+        if (_shouldJumpTrain(currentTrain, nextTrain)) {
           _setSecondaryAnimation(nextTrain, nextRoute.completed);
         } else {
           TrainHoppingAnimation newAnimation;

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -259,7 +259,8 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
   // A callback method that disposes existing train hopping animation and
   // removes its listener.
   //
-  // This field is non-null if there is a train hopping in progress.
+  // The caller must reset this property to null once it is called, and this
+  // property is non-null if there is a train hopping in progress
   VoidCallback _trainHoppingListenerRemover;
 
   void _updateSecondaryAnimation(Route<dynamic> nextRoute) {
@@ -267,6 +268,7 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
     // dispose current train hopping animation until we replace it with a new
     // animation.
     final VoidCallback previousTrainHoppingListenerRemover = _trainHoppingListenerRemover;
+    _trainHoppingListenerRemover = null;
 
     if (nextRoute is TransitionRoute<dynamic> && canTransitionTo(nextRoute) && nextRoute.canTransitionFrom(this)) {
       final Animation<double> current = _secondaryAnimation.parent;
@@ -287,9 +289,9 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
           //  2. There is no chance to hop on nextTrain because two trains never
           //     cross each other. We have to directly set the animation to
           //     nextTrain once the nextTrain stops animating.
-          //  3. A new update secondary animation is called before train hopping
+          //  3. A new _updateSecondaryAnimation is called before train hopping
           //     finishes. We leave a listener remover for the next call to
-          //     properly clean up the existing train hopping
+          //     properly clean up the existing train hopping.
           TrainHoppingAnimation newAnimation;
           void _jumpOnAnimationEnd(AnimationStatus status) {
             switch (status) {
@@ -338,11 +340,9 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
       _setSecondaryAnimation(kAlwaysDismissedAnimation);
     }
     // Finally, we dispose any previous train hopping animation because it
-    // should be successfully updated at this point.
+    // has been successfully updated at this point.
     if (previousTrainHoppingListenerRemover != null) {
       previousTrainHoppingListenerRemover();
-      if (previousTrainHoppingListenerRemover == _trainHoppingListenerRemover)
-        _trainHoppingListenerRemover = null;
     }
   }
 

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -337,8 +337,8 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
     } else {
       _setSecondaryAnimation(kAlwaysDismissedAnimation);
     }
-    // Finally, we can dispose any previous train hopping animation because it
-    // shoulbe be successfully updated at this point.
+    // Finally, we dispose any previous train hopping animation because it
+    // should be successfully updated at this point.
     if (previousTrainHoppingListenerRemover != null) {
       previousTrainHoppingListenerRemover();
       if (previousTrainHoppingListenerRemover == _trainHoppingListenerRemover)

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -256,8 +256,8 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
     super.didChangeNext(nextRoute);
   }
 
-  // A callback method to remove existing status listener added while waiting
-  // for train hopping in _updateSecondaryAnimation.
+  // A callback method that removes existing status listener added while waiting
+  // for train to hop in _updateSecondaryAnimation.
   //
   // This field is non-null if there is a train hopping in progress.
   VoidCallback _nextTrainStatusListenerRemover;
@@ -282,14 +282,14 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
         } else {
           // Two trains animate at different values. We have to do train hopping.
           // There are three possibilities of train hopping:
-          //  - We hop on the nextTrain when two trains meet in the middle using
-          //    TrainHoppingAnimation.
-          //  - There is no chance to hop on nextTrain because two trains never
-          //    cross each other. We have to directly set the animation to
-          //    nextTrain once the nextTrain stops animating.
-          //  - A new update secondary animation is called before train hopping
-          //    finishes. We leave a listener remover for the next call to
-          //    properly clean up the existing train hopping
+          //  1. We hop on the nextTrain when two trains meet in the middle using
+          //     TrainHoppingAnimation.
+          //  2. There is no chance to hop on nextTrain because two trains never
+          //     cross each other. We have to directly set the animation to
+          //     nextTrain once the nextTrain stops animating.
+          //  3. A new update secondary animation is called before train hopping
+          //     finishes. We leave a listener remover for the next call to
+          //     properly clean up the existing train hopping
           TrainHoppingAnimation newAnimation;
           void _jumpOnAnimationEnd(AnimationStatus status) {
             switch (status) {
@@ -340,7 +340,7 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
 
   void _setSecondaryAnimation(Animation<double> animation, [Future<dynamic> disposed]) {
     _secondaryAnimation.parent = animation;
-    // Release the reference to the next route's animation when that route
+    // Releases the reference to the next route's animation when that route
     // is disposed.
     disposed?.then((dynamic _) {
       if (_secondaryAnimation.parent == animation) {

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -779,13 +779,9 @@ void main() {
       // Pop page three while replacement push is ongoing.
       navigator.currentState.pop();
       await tester.pump();
-      expect(secondaryAnimationPageOne.parent, isA<TrainHoppingAnimation>());
-      final TrainHoppingAnimation trainHopper2 = secondaryAnimationPageOne.parent as TrainHoppingAnimation;
-      expect(trainHopper2.currentTrain, animationPageTwo.parent);
-      expect(trainHopper.currentTrain, isNull); // Has been disposed.
-      await tester.pumpAndSettle();
-      expect(secondaryAnimationPageOne.parent, kAlwaysDismissedAnimation);
-      expect(trainHopper2.currentTrain, isNull); // Has been disposed.
+      // It should jump to the other train because train hopping will never
+      // happen
+      expect(secondaryAnimationPageOne.parent, isA<CurvedAnimation>());
     });
 
     testWidgets('secondary animation is triggered when pop initial route', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -790,8 +790,8 @@ void main() {
 
     testWidgets('secondary animation is triggered when pop initial route', (WidgetTester tester) async {
       final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
-      ProxyAnimation secondaryAnimationOfRouteOne;
-      ProxyAnimation primaryAnimationOfRouteTwo;
+      Animation<double> secondaryAnimationOfRouteOne;
+      Animation<double> primaryAnimationOfRouteTwo;
       await tester.pumpWidget(
         MaterialApp(
           navigatorKey: navigator,

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -810,8 +810,8 @@ void main() {
           initialRoute: '/a',
         )
       );
-      // secondary animation of bottom route should be chained with the primary
-      // animation of top most route.
+      // The secondary animation of the bottom route should be chained with the
+      // primary animation of top most route.
       expect(secondaryAnimationOfRouteOne.value, 1.0);
       expect(secondaryAnimationOfRouteOne.value, primaryAnimationOfRouteTwo.value);
       // Pops the top most route and verifies two routes are still chained.

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -788,6 +788,43 @@ void main() {
       expect(trainHopper2.currentTrain, isNull); // Has been disposed.
     });
 
+    testWidgets('secondary animation is triggered when pop initial route', (WidgetTester tester) async {
+      final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+      ProxyAnimation secondaryAnimationOfRouteOne;
+      ProxyAnimation primaryAnimationOfRouteTwo;
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: navigator,
+          onGenerateRoute: (RouteSettings settings) {
+            return PageRouteBuilder<void>(
+              settings: settings,
+              pageBuilder: (_, Animation<double> animation, Animation<double> secondaryAnimation) {
+                if (settings.name == '/')
+                  secondaryAnimationOfRouteOne = secondaryAnimation;
+                else
+                  primaryAnimationOfRouteTwo = animation;
+                return const Text('Page');
+              },
+            );
+          },
+          initialRoute: '/a',
+        )
+      );
+      // secondary animation of bottom route should be chained with the primary
+      // animation of top most route.
+      expect(secondaryAnimationOfRouteOne.value, 1.0);
+      expect(secondaryAnimationOfRouteOne.value, primaryAnimationOfRouteTwo.value);
+      // Pops the top most route and verifies two routes are still chained.
+      navigator.currentState.pop();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 30));
+      expect(secondaryAnimationOfRouteOne.value, 0.9);
+      expect(secondaryAnimationOfRouteOne.value, primaryAnimationOfRouteTwo.value);
+      await tester.pumpAndSettle();
+      expect(secondaryAnimationOfRouteOne.value, 0.0);
+      expect(secondaryAnimationOfRouteOne.value, primaryAnimationOfRouteTwo.value);
+    });
+
     testWidgets('showGeneralDialog uses root navigator by default', (WidgetTester tester) async {
       final DialogObserver rootObserver = DialogObserver();
       final DialogObserver nestedObserver = DialogObserver();

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -779,9 +779,13 @@ void main() {
       // Pop page three while replacement push is ongoing.
       navigator.currentState.pop();
       await tester.pump();
-      // It should jump to the other train because train hopping will never
-      // happen
-      expect(secondaryAnimationPageOne.parent, isA<CurvedAnimation>());
+      expect(secondaryAnimationPageOne.parent, isA<TrainHoppingAnimation>());
+      final TrainHoppingAnimation trainHopper2 = secondaryAnimationPageOne.parent as TrainHoppingAnimation;
+      expect(trainHopper2.currentTrain, animationPageTwo.parent);
+      expect(trainHopper.currentTrain, isNull); // Has been disposed.
+      await tester.pumpAndSettle();
+      expect(secondaryAnimationPageOne.parent, kAlwaysDismissedAnimation);
+      expect(trainHopper2.currentTrain, isNull); // Has been disposed.
     });
 
     testWidgets('secondary animation is triggered when pop initial route', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

Whenever a new route pushed on top of another route, it will chains the secondary animation of bottom route with the primary animation of top route. However, there is a bug in the method that chain them together. In the method, we try to do train hopping if the two animations does not have the same values. It is possible that the two animations are animating with different directions and the hopping will never happen, and that introduce this bug.

here are the steps, assume initial route is routeA/routeB
1, routeA pushed with pri-animation=1.0, sec-animation=0.0
2, routeB pushed with pri-animation=1.0, and it try to do train hopping on sec-animation of routeA which never happen. The sec-animation of routeA stay at 0.0
3, when routeB pop, the routeA didpopnext will try to do the train hopping again with sec-animation of routeA = 0.0 and pri-animation of routeB =1.0 in reverse order. This is wrong because the sec-animation of routeA should be 1.0 at this moment and animate with pri-animation of routeB.

## Related Issues

Closes https://github.com/flutter/flutter/issues/46000
## Tests

I added the following tests:
"secondary animation is triggered when pop initial route"

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
