### PR TITLE
Support for ImageFiltered widget to apply ImageFilter to children.

### DIFF
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -1548,6 +1548,48 @@ class ColorFilterLayer extends ContainerLayer {
   }
 }
 
+/// A composite layer that applies an [ImageFilter] to its children.
+class ImageFilterLayer extends ContainerLayer {
+  /// Creates a layer that applies an [ImageFilter] to its children.
+  ///
+  /// The [imageFilter] property must be non-null before the compositing phase
+  /// of the pipeline.
+  ImageFilterLayer({
+                     ui.ImageFilter imageFilter,
+                   }) : _imageFilter = imageFilter;
+
+  /// The image filter to apply to children.
+  ///
+  /// The scene must be explicitly recomposited after this property is changed
+  /// (as described at [Layer]).
+  ui.ImageFilter get imageFilter => _imageFilter;
+  ui.ImageFilter _imageFilter;
+  set imageFilter(ui.ImageFilter value) {
+    assert(value != null);
+    if (value != _imageFilter) {
+      _imageFilter = value;
+      markNeedsAddToScene();
+    }
+  }
+
+  @override
+  void addToScene(ui.SceneBuilder builder, [ Offset layerOffset = Offset.zero ]) {
+    assert(imageFilter != null);
+    engineLayer = builder.pushImageFilter(
+      imageFilter,
+      oldLayer: _engineLayer as ui.ImageFilterEngineLayer,
+    );
+    addChildrenToScene(builder, layerOffset);
+    builder.pop();
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<ui.ImageFilter>('imageFilter', imageFilter));
+  }
+}
+
 /// A composited layer that applies a given transformation matrix to its
 /// children.
 ///

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -1555,8 +1555,8 @@ class ImageFilterLayer extends ContainerLayer {
   /// The [imageFilter] property must be non-null before the compositing phase
   /// of the pipeline.
   ImageFilterLayer({
-                     ui.ImageFilter imageFilter,
-                   }) : _imageFilter = imageFilter;
+    ui.ImageFilter imageFilter,
+  }) : _imageFilter = imageFilter;
 
   /// The image filter to apply to children.
   ///

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:developer';
-import 'dart:ui' as ui show PictureRecorder, ImageFilter;
+import 'dart:ui' as ui show PictureRecorder;
 
 import 'package:flutter/animation.dart';
 import 'package:flutter/foundation.dart';
@@ -544,30 +544,6 @@ class PaintingContext extends ClipContext {
     assert(colorFilter != null);
     final ColorFilterLayer layer = oldLayer ?? ColorFilterLayer();
     layer.colorFilter = colorFilter;
-    pushLayer(layer, painter, offset);
-    return layer;
-  }
-
-  /// Blend further painting with an image filter.
-  ///
-  /// {@macro flutter.rendering.object.pushLayer.offset}
-  ///
-  /// The `imageFilter` argument is the [ImageFilter] value to use when blending
-  /// the painting done by `painter`.
-  ///
-  /// The `painter` callback will be called while the `imageFilter` is applied.
-  /// It is called synchronously during the call to [pushImageFilter].
-  ///
-  /// {@macro flutter.rendering.object.oldLayer}
-  ///
-  /// A [RenderObject] that uses this function is very likely to require its
-  /// [RenderObject.alwaysNeedsCompositing] property to return true. That informs
-  /// ancestor render objects that this render object will include a composited
-  /// layer, which, for example, causes them to use composited clips.
-  ImageFilterLayer pushImageFilter(Offset offset, ui.ImageFilter imageFilter, PaintingContextCallback painter, { ImageFilterLayer oldLayer }) {
-    assert(imageFilter != null);
-    final ImageFilterLayer layer = oldLayer ?? ImageFilterLayer();
-    layer.imageFilter = imageFilter;
     pushLayer(layer, painter, offset);
     return layer;
   }

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:developer';
-import 'dart:ui' as ui show PictureRecorder;
+import 'dart:ui' as ui show PictureRecorder, ImageFilter;
 
 import 'package:flutter/animation.dart';
 import 'package:flutter/foundation.dart';
@@ -544,6 +544,30 @@ class PaintingContext extends ClipContext {
     assert(colorFilter != null);
     final ColorFilterLayer layer = oldLayer ?? ColorFilterLayer();
     layer.colorFilter = colorFilter;
+    pushLayer(layer, painter, offset);
+    return layer;
+  }
+
+  /// Blend further painting with an image filter.
+  ///
+  /// {@macro flutter.rendering.object.pushLayer.offset}
+  ///
+  /// The `imageFilter` argument is the [ImageFilter] value to use when blending
+  /// the painting done by `painter`.
+  ///
+  /// The `painter` callback will be called while the `imageFilter` is applied.
+  /// It is called synchronously during the call to [pushImageFilter].
+  ///
+  /// {@macro flutter.rendering.object.oldLayer}
+  ///
+  /// A [RenderObject] that uses this function is very likely to require its
+  /// [RenderObject.alwaysNeedsCompositing] property to return true. That informs
+  /// ancestor render objects that this render object will include a composited
+  /// layer, which, for example, causes them to use composited clips.
+  ImageFilterLayer pushImageFilter(Offset offset, ui.ImageFilter imageFilter, PaintingContextCallback painter, { ImageFilterLayer oldLayer }) {
+    assert(imageFilter != null);
+    final ImageFilterLayer layer = oldLayer ?? ImageFilterLayer();
+    layer.imageFilter = imageFilter;
     pushLayer(layer, painter, offset);
     return layer;
   }

--- a/packages/flutter/lib/src/widgets/image_filter.dart
+++ b/packages/flutter/lib/src/widgets/image_filter.dart
@@ -55,6 +55,15 @@ class _ImageFilterRenderObject extends RenderProxyBox {
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    layer = context.pushImageFilter(offset, imageFilter, super.paint, oldLayer: layer as ImageFilterLayer);
+    assert(imageFilter != null);
+    if (layer == null) {
+      layer = ImageFilterLayer(imageFilter: imageFilter);
+    } else {
+      final ImageFilterLayer filterLayer = layer as ImageFilterLayer;
+      filterLayer
+        ..imageFilter = imageFilter;
+    }
+    context.pushLayer(layer, super.paint, offset);
+    assert(layer != null);
   }
 }

--- a/packages/flutter/lib/src/widgets/image_filter.dart
+++ b/packages/flutter/lib/src/widgets/image_filter.dart
@@ -15,9 +15,12 @@ class ImageFiltered extends SingleChildRenderObjectWidget {
   /// Creates a widget that applies an [ImageFilter] to its child.
   ///
   /// The [imageFilter] must not be null.
-  const ImageFiltered({@required this.imageFilter, Widget child, Key key})
-      : assert(imageFilter != null),
-        super(key: key, child: child);
+  const ImageFiltered({
+    Key key,
+    @required this.imageFilter,
+    Widget child,
+  }) : assert(imageFilter != null),
+       super(key: key, child: child);
 
   /// The image filter to apply to the child of this widget.
   final ImageFilter imageFilter;

--- a/packages/flutter/lib/src/widgets/image_filter.dart
+++ b/packages/flutter/lib/src/widgets/image_filter.dart
@@ -1,0 +1,60 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
+
+import 'framework.dart';
+
+/// Applies an [ImageFilter] to its child.
+@immutable
+class ImageFiltered extends SingleChildRenderObjectWidget {
+  /// Creates a widget that applies an [ImageFilter] to its child.
+  ///
+  /// The [imageFilter] must not be null.
+  const ImageFiltered({@required this.imageFilter, Widget child, Key key})
+      : assert(imageFilter != null),
+        super(key: key, child: child);
+
+  /// The image filter to apply to the child of this widget.
+  final ImageFilter imageFilter;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) => _ImageFilterRenderObject(imageFilter);
+
+  @override
+  void updateRenderObject(BuildContext context, _ImageFilterRenderObject renderObject) {
+    renderObject..imageFilter = imageFilter;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<ImageFilter>('imageFilter', imageFilter));
+  }
+}
+
+class _ImageFilterRenderObject extends RenderProxyBox {
+  _ImageFilterRenderObject(this._imageFilter);
+
+  ImageFilter get imageFilter => _imageFilter;
+  ImageFilter _imageFilter;
+  set imageFilter(ImageFilter value) {
+    assert(value != null);
+    if (value != _imageFilter) {
+      _imageFilter = value;
+      markNeedsPaint();
+    }
+  }
+
+  @override
+  bool get alwaysNeedsCompositing => child != null;
+
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    layer = context.pushImageFilter(offset, imageFilter, super.paint, oldLayer: layer as ImageFilterLayer);
+  }
+}

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -48,6 +48,7 @@ export 'src/widgets/icon_data.dart';
 export 'src/widgets/icon_theme.dart';
 export 'src/widgets/icon_theme_data.dart';
 export 'src/widgets/image.dart';
+export 'src/widgets/image_filter.dart';
 export 'src/widgets/image_icon.dart';
 export 'src/widgets/implicit_animations.dart';
 export 'src/widgets/inherited_model.dart';

--- a/packages/flutter/test/widgets/image_filter_test.dart
+++ b/packages/flutter/test/widgets/image_filter_test.dart
@@ -1,0 +1,86 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:typed_data';
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+
+void main() {
+  testWidgets('Image filter - blur', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      RepaintBoundary(
+        child: ImageFiltered(
+          imageFilter: ImageFilter.blur(sigmaX: 10.0, sigmaY: 10.0),
+          child: const Placeholder(),
+        ),
+      ),
+    );
+    await expectLater(
+      find.byType(ImageFiltered),
+      matchesGoldenFile('image_filter_blur.png'),
+    );
+  });
+
+  testWidgets('Image filter - matrix', (WidgetTester tester) async {
+    final ImageFilter matrix = ImageFilter.matrix(Float64List.fromList(<double>[
+      0.5, 0.0, 0.0, 0.0, //
+      0.0, 0.5, 0.0, 0.0, //
+      0.0, 0.0, 1.0, 0.0, //
+      0.0, 0.0, 0.0, 1.0, //
+    ]));
+    await tester.pumpWidget(
+      RepaintBoundary(
+        child: ImageFiltered(
+          imageFilter: matrix,
+          child: MaterialApp(
+            title: 'Flutter Demo',
+            theme: ThemeData(primarySwatch: Colors.blue),
+            home: Scaffold(
+              appBar: AppBar(
+                title: const Text('Matrix ImageFilter Test'),
+              ),
+              body: const Center(
+                child:Text('Hooray!'),
+              ),
+              floatingActionButton: FloatingActionButton(
+                onPressed: () { },
+                tooltip: 'Increment',
+                child: const Icon(Icons.add),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await expectLater(
+      find.byType(ImageFiltered),
+      matchesGoldenFile('image_filter_matrix.png'),
+    );
+  });
+
+  testWidgets('Image filter - reuses its layer', (WidgetTester tester) async {
+    Future<void> pumpWithSigma(double sigma) async {
+      await tester.pumpWidget(
+        RepaintBoundary(
+          child: ImageFiltered(
+            imageFilter: ImageFilter.blur(sigmaX: sigma, sigmaY: sigma),
+            child: const Placeholder(),
+          ),
+        ),
+      );
+    }
+
+    await pumpWithSigma(5.0);
+    final RenderObject renderObject = tester.firstRenderObject(find.byType(ImageFiltered));
+    final ImageFilterLayer originalLayer = renderObject.debugLayer as ImageFilterLayer;
+    expect(originalLayer, isNotNull);
+
+    // Change blur sigma to force a repaint.
+    await pumpWithSigma(10.0);
+    expect(renderObject.debugLayer, same(originalLayer));
+  });
+}

--- a/packages/flutter/test/widgets/image_filter_test.dart
+++ b/packages/flutter/test/widgets/image_filter_test.dart
@@ -60,7 +60,7 @@ void main() {
       find.byType(ImageFiltered),
       matchesGoldenFile('image_filter_matrix.png'),
     );
-  });
+  }, skip: isBrowser);
 
   testWidgets('Image filter - reuses its layer', (WidgetTester tester) async {
     Future<void> pumpWithSigma(double sigma) async {


### PR DESCRIPTION
Framework counterpart to https://github.com/flutter/engine/pull/14491
Fixes https://github.com/flutter/flutter/issues/13489

The engine PR for the C++ engine has landed, and the web_ui version of the implementation should land in the next few days. This PR cannot be pushed until minimally https://github.com/flutter/engine/commit/929b1edff5b44480f6cceb5d2bb1da596db44398 is rolled into the framework repo and it should also wait until the fix for https://github.com/flutter/flutter/issues/47163 to roll as well.

Marked as WIP until the engine rolls happen, but it is otherwise ready for reviews.