### PR TITLE
Add `Border.symmetric` constructor

### DIFF
--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -326,6 +326,19 @@ class Border extends BoxBorder {
         bottom = side,
         left = side;
 
+  /// Creates a border with symmetrical vertical and horizontal sides.
+  ///
+  /// All arguments default to [BorderSide.none] and must not be null.
+  const Border.symmetric({
+    BorderSide vertical = BorderSide.none,
+    BorderSide horizontal = BorderSide.none,
+  }) : assert(vertical != null),
+       assert(horizontal != null),
+       left = horizontal,
+       top = vertical,
+       right = horizontal,
+       bottom = vertical;
+
   /// A uniform border with all sides the same color and width.
   ///
   /// The sides default to black solid borders, one logical pixel wide.

--- a/packages/flutter/test/painting/border_test.dart
+++ b/packages/flutter/test/painting/border_test.dart
@@ -23,6 +23,18 @@ void main() {
     expect(border.bottom, same(side));
   });
 
+  test('Border.symmetric constructor', () {
+    expect(() => Border.symmetric(vertical: nonconst(null)), throwsAssertionError);
+    expect(() => Border.symmetric(horizontal: nonconst(null)), throwsAssertionError);
+    const BorderSide side1 = BorderSide(color: Color(0xFFFFFFFF));
+    const BorderSide side2 = BorderSide(color: Color(0xFF000000));
+    const Border border = Border.symmetric(vertical: side1, horizontal: side2);
+    expect(border.left, same(side2));
+    expect(border.top, same(side1));
+    expect(border.right, same(side2));
+    expect(border.bottom, same(side1));
+  });
+
   test('Border.merge', () {
     const BorderSide magenta3 = BorderSide(color: Color(0xFFFF00FF), width: 3.0);
     const BorderSide magenta6 = BorderSide(color: Color(0xFFFF00FF), width: 6.0);


### PR DESCRIPTION
## Related Issues

Closes #45524 

## Tests

I added the following tests:

- Border.symmetric constructor

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
