### PR TITLE
flutter build ios-framework generate Flutter.podspec

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -235,6 +235,34 @@ class Cache {
   }
   String _engineRevision;
 
+  String get storageBaseUrl {
+    final String overrideUrl = platform.environment['FLUTTER_STORAGE_BASE_URL'];
+    if (overrideUrl == null) {
+      return 'https://storage.googleapis.com';
+    }
+    // verify that this is a valid URI.
+    try {
+      Uri.parse(overrideUrl);
+    } on FormatException catch (err) {
+      throwToolExit('"FLUTTER_STORAGE_BASE_URL" contains an invalid URI:\n$err');
+    }
+    _maybeWarnAboutStorageOverride(overrideUrl);
+    return overrideUrl;
+  }
+
+  bool _hasWarnedAboutStorageOverride = false;
+
+  void _maybeWarnAboutStorageOverride(String overrideUrl) {
+    if (_hasWarnedAboutStorageOverride) {
+      return;
+    }
+    logger.printStatus(
+      'Flutter assets will be downloaded from $overrideUrl. Make sure you trust this source!',
+      emphasis: true,
+    );
+    _hasWarnedAboutStorageOverride = true;
+  }
+
   static Cache get instance => context.get<Cache>();
 
   /// Return the top-level directory in the cache; this is `bin/cache`.
@@ -261,6 +289,9 @@ class Cache {
 
   /// Return the top-level mutable directory in the cache; this is `bin/cache/artifacts`.
   Directory getCacheArtifacts() => getCacheDir('artifacts');
+
+  /// Location of LICENSE file.
+  File getLicenseFile() => fs.file(fs.path.join(flutterRoot, 'LICENSE'));
 
   /// Get a named directory from with the cache's artifact directory; for example,
   /// `material_fonts` would return `bin/cache/artifacts/material_fonts`.
@@ -492,23 +523,7 @@ abstract class CachedArtifact extends ArtifactSet {
   /// Template method to perform artifact update.
   Future<void> updateInner();
 
-  @visibleForTesting
-  String get storageBaseUrl {
-    final String overrideUrl = platform.environment['FLUTTER_STORAGE_BASE_URL'];
-    if (overrideUrl == null) {
-      return 'https://storage.googleapis.com';
-    }
-    // verify that this is a valid URI.
-    try {
-      Uri.parse(overrideUrl);
-    } on FormatException catch (err) {
-      throwToolExit('"FLUTTER_STORAGE_BASE_URL" contains an invalid URI:\n$err');
-    }
-    _maybeWarnAboutStorageOverride(overrideUrl);
-    return overrideUrl;
-  }
-
-  Uri _toStorageUri(String path) => Uri.parse('$storageBaseUrl/$path');
+  Uri _toStorageUri(String path) => Uri.parse('${cache.storageBaseUrl}/$path');
 
   /// Download an archive from the given [url] and unzip it to [location].
   Future<void> _downloadArchive(String message, Uri url, Directory location, bool verifier(File f), void extractor(File f, Directory d)) {
@@ -547,19 +562,6 @@ abstract class CachedArtifact extends ArtifactSet {
     downloadedFiles.add(tempFile);
     await onTemporaryFile(tempFile);
   }
-}
-
-bool _hasWarnedAboutStorageOverride = false;
-
-void _maybeWarnAboutStorageOverride(String overrideUrl) {
-  if (_hasWarnedAboutStorageOverride) {
-    return;
-  }
-  logger.printStatus(
-    'Flutter assets will be downloaded from $overrideUrl. Make sure you trust this source!',
-    emphasis: true,
-  );
-  _hasWarnedAboutStorageOverride = true;
 }
 
 /// A cached artifact containing fonts used for Material Design.
@@ -604,7 +606,7 @@ class FlutterWebSdk extends CachedArtifact {
     } else if (platform.isWindows) {
       platformName += 'windows-x64';
     }
-    final Uri url = Uri.parse('$storageBaseUrl/flutter_infra/flutter/$version/$platformName.zip');
+    final Uri url = Uri.parse('${cache.storageBaseUrl}/flutter_infra/flutter/$version/$platformName.zip');
     await _downloadZipArchive('Downloading Web SDK...', url, location);
     // This is a temporary work-around for not being able to safely download into a shared directory.
     for (FileSystemEntity entity in location.listSync(recursive: true)) {
@@ -669,7 +671,7 @@ abstract class EngineCachedArtifact extends CachedArtifact {
 
   @override
   Future<void> updateInner() async {
-    final String url = '$storageBaseUrl/flutter_infra/flutter/$version/';
+    final String url = '${cache.storageBaseUrl}/flutter_infra/flutter/$version/';
 
     final Directory pkgDir = cache.getCacheDir('pkg');
     for (String pkgName in getPackageDirs()) {
@@ -695,7 +697,7 @@ abstract class EngineCachedArtifact extends CachedArtifact {
       }
     }
 
-    final File licenseSource = fs.file(fs.path.join(Cache.flutterRoot, 'LICENSE'));
+    final File licenseSource = cache.getLicenseFile();
     for (String licenseDir in getLicenseDirs()) {
       final String licenseDestinationPath = fs.path.join(location.path, licenseDir, 'LICENSE');
       await licenseSource.copy(licenseDestinationPath);
@@ -704,7 +706,7 @@ abstract class EngineCachedArtifact extends CachedArtifact {
 
   Future<bool> checkForArtifacts(String engineVersion) async {
     engineVersion ??= version;
-    final String url = '$storageBaseUrl/flutter_infra/flutter/$engineVersion/';
+    final String url = '${cache.storageBaseUrl}/flutter_infra/flutter/$engineVersion/';
 
     bool exists = false;
     for (String pkgName in getPackageDirs()) {
@@ -1210,7 +1212,7 @@ class IosUsbArtifacts extends CachedArtifact {
   }
 
   @visibleForTesting
-  Uri get archiveUri => Uri.parse('$storageBaseUrl/flutter_infra/ios-usb-dependencies${cache.useUnsignedMacBinaries ? '/unsigned' : ''}/$name/$version/$name.zip');
+  Uri get archiveUri => Uri.parse('${cache.storageBaseUrl}/flutter_infra/ios-usb-dependencies${cache.useUnsignedMacBinaries ? '/unsigned' : ''}/$name/$version/$name.zip');
 }
 
 // Many characters are problematic in filenames, especially on Windows.

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -20,7 +20,8 @@ import 'globals.dart';
 class FlutterVersion {
   FlutterVersion([this._clock = const SystemClock()]) {
     _frameworkRevision = _runGit(gitLog(<String>['-n', '1', '--pretty=format:%H']).join(' '));
-    _frameworkVersion = GitTagVersion.determine().frameworkVersionFor(_frameworkRevision);
+    _gitTagVersion = GitTagVersion.determine();
+    _frameworkVersion = gitTagVersion.frameworkVersionFor(_frameworkRevision);
   }
 
   final SystemClock _clock;
@@ -74,6 +75,9 @@ class FlutterVersion {
     }
     return _channel;
   }
+
+  GitTagVersion _gitTagVersion;
+  GitTagVersion get gitTagVersion => _gitTagVersion;
 
   /// The name of the local branch.
   /// Use getBranchName() to read this.

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
@@ -8,7 +8,6 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build_ios_framework.dart';
-import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/version.dart';
 import 'package:mockito/mockito.dart';

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
@@ -1,0 +1,192 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/commands/build_ios_framework.dart';
+import 'package:flutter_tools/src/base/common.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/version.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../src/common.dart';
+import '../../src/context.dart';
+
+void main() {
+  group('build ios-framework', () {
+    group('podspec', () {
+      MemoryFileSystem memoryFileSystem;
+      MockFlutterVersion mockFlutterVersion;
+      MockGitTagVersion mockGitTagVersion;
+      MockCache mockCache;
+      Directory outputDirectory;
+      const String storageBaseUrl = 'https://fake.googleapis.com';
+      const String engineRevision = '0123456789abcdef';
+      File licenseFile;
+
+      setUp(() {
+        memoryFileSystem = MemoryFileSystem();
+        mockFlutterVersion = MockFlutterVersion();
+        mockGitTagVersion = MockGitTagVersion();
+        mockCache = MockCache();
+
+        when(mockFlutterVersion.gitTagVersion).thenReturn(mockGitTagVersion);
+        outputDirectory = fs.systemTempDirectory
+            .createTempSync('flutter_build_ios_framework_test_output.')
+            .childDirectory('Debug')
+          ..createSync();
+
+        when(mockCache.storageBaseUrl).thenReturn(storageBaseUrl);
+        when(mockCache.engineRevision).thenReturn(engineRevision);
+        licenseFile = memoryFileSystem.file('LICENSE');
+        when(mockCache.getLicenseFile()).thenReturn(licenseFile);
+      });
+
+      testUsingContext('version unknown', () async {
+        const String frameworkVersion = '0.0.0-unknown';
+        when(mockFlutterVersion.frameworkVersion).thenReturn(frameworkVersion);
+
+        final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
+          flutterVersion: mockFlutterVersion,
+          cache: mockCache
+        );
+
+        expect(() => command.produceFlutterPodspec(BuildMode.debug, outputDirectory),
+            throwsToolExit(message: 'Detected version is $frameworkVersion'));
+      }, overrides: <Type, Generator>{
+        FileSystem: () => memoryFileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+      });
+
+      testUsingContext('throws when not on a released version', () async {
+        const String frameworkVersion = 'v1.13.10+hotfix-pre.2';
+        when(mockFlutterVersion.frameworkVersion).thenReturn(frameworkVersion);
+
+        when(mockGitTagVersion.x).thenReturn(1);
+        when(mockGitTagVersion.y).thenReturn(13);
+        when(mockGitTagVersion.z).thenReturn(10);
+        when(mockGitTagVersion.hotfix).thenReturn(13);
+        when(mockGitTagVersion.commits).thenReturn(2);
+
+        final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
+          flutterVersion: mockFlutterVersion,
+          cache: mockCache
+        );
+
+        expect(() => command.produceFlutterPodspec(BuildMode.debug, outputDirectory),
+            throwsToolExit(message: 'Detected version is $frameworkVersion'));
+      }, overrides: <Type, Generator>{
+        FileSystem: () => memoryFileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+      });
+
+      testUsingContext('throws when license not found', () async {
+        when(mockGitTagVersion.x).thenReturn(1);
+        when(mockGitTagVersion.y).thenReturn(13);
+        when(mockGitTagVersion.z).thenReturn(10);
+        when(mockGitTagVersion.hotfix).thenReturn(13);
+        when(mockGitTagVersion.commits).thenReturn(0);
+
+        final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
+          flutterVersion: mockFlutterVersion,
+          cache: mockCache
+        );
+
+        expect(() => command.produceFlutterPodspec(BuildMode.debug, outputDirectory),
+            throwsToolExit(message: 'Could not find license'));
+      }, overrides: <Type, Generator>{
+        FileSystem: () => memoryFileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+      });
+
+      group('is created', () {
+        const String frameworkVersion = 'v1.13.11+hotfix.13';
+        const String licenseText = 'This is the license!';
+
+        setUp(() {
+          when(mockGitTagVersion.x).thenReturn(1);
+          when(mockGitTagVersion.y).thenReturn(13);
+          when(mockGitTagVersion.z).thenReturn(11);
+          when(mockGitTagVersion.hotfix).thenReturn(13);
+          when(mockGitTagVersion.commits).thenReturn(0);
+
+          when(mockFlutterVersion.frameworkVersion).thenReturn(frameworkVersion);
+
+          licenseFile
+            ..createSync(recursive: true)
+            ..writeAsStringSync(licenseText);
+        });
+
+        testUsingContext('contains license and version', () async {
+          final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
+              flutterVersion: mockFlutterVersion,
+              cache: mockCache
+          );
+          command.produceFlutterPodspec(BuildMode.debug, outputDirectory);
+
+          final File expectedPodspec = outputDirectory.childFile('Flutter.podspec');
+          final String podspecContents = expectedPodspec.readAsStringSync();
+          expect(podspecContents, contains('\'1.13.1113\''));
+          expect(podspecContents, contains('# $frameworkVersion'));
+          expect(podspecContents, contains(licenseText));
+        }, overrides: <Type, Generator>{
+          FileSystem: () => memoryFileSystem,
+          ProcessManager: () => FakeProcessManager.any(),
+        });
+
+        testUsingContext('debug URL', () async {
+          final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
+              flutterVersion: mockFlutterVersion,
+              cache: mockCache
+          );
+          command.produceFlutterPodspec(BuildMode.debug, outputDirectory);
+
+          final File expectedPodspec = outputDirectory.childFile('Flutter.podspec');
+          final String podspecContents = expectedPodspec.readAsStringSync();
+          expect(podspecContents, contains('\'$storageBaseUrl/flutter_infra/flutter/$engineRevision/ios/artifacts.zip\''));
+        }, overrides: <Type, Generator>{
+          FileSystem: () => memoryFileSystem,
+          ProcessManager: () => FakeProcessManager.any(),
+        });
+
+        testUsingContext('profile URL', () async {
+          final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
+              flutterVersion: mockFlutterVersion,
+              cache: mockCache
+          );
+          command.produceFlutterPodspec(BuildMode.profile, outputDirectory);
+
+          final File expectedPodspec = outputDirectory.childFile('Flutter.podspec');
+          final String podspecContents = expectedPodspec.readAsStringSync();
+          expect(podspecContents, contains('\'$storageBaseUrl/flutter_infra/flutter/$engineRevision/ios-profile/artifacts.zip\''));
+        }, overrides: <Type, Generator>{
+          FileSystem: () => memoryFileSystem,
+          ProcessManager: () => FakeProcessManager.any(),
+        });
+
+        testUsingContext('release URL', () async {
+          final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
+              flutterVersion: mockFlutterVersion,
+              cache: mockCache
+          );
+          command.produceFlutterPodspec(BuildMode.release, outputDirectory);
+
+          final File expectedPodspec = outputDirectory.childFile('Flutter.podspec');
+          final String podspecContents = expectedPodspec.readAsStringSync();
+          expect(podspecContents, contains('\'$storageBaseUrl/flutter_infra/flutter/$engineRevision/ios-release/artifacts.zip\''));
+        }, overrides: <Type, Generator>{
+          FileSystem: () => memoryFileSystem,
+          ProcessManager: () => FakeProcessManager.any(),
+        });
+      });
+    });
+  });
+}
+
+class MockFlutterVersion extends Mock implements FlutterVersion {}
+class MockGitTagVersion extends Mock implements GitTagVersion {}
+class MockCache extends Mock implements Cache {}

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -230,9 +230,7 @@ void main() {
         'FLUTTER_STORAGE_BASE_URL': ' http://foo',
       });
       final Cache cache = Cache();
-      final CachedArtifact artifact = MaterialFonts(cache);
-
-      expect(() => artifact.storageBaseUrl, throwsA(isInstanceOf<ToolExit>()));
+      expect(() => cache.storageBaseUrl, throwsA(isInstanceOf<ToolExit>()));
     }, overrides: <Type, Generator>{
       Platform: () => MockPlatform(),
     });

--- a/packages/flutter_tools/test/src/testbed.dart
+++ b/packages/flutter_tools/test/src/testbed.dart
@@ -681,6 +681,9 @@ class FakeFlutterVersion implements FlutterVersion {
   String get frameworkVersion => null;
 
   @override
+  GitTagVersion get gitTagVersion => null;
+
+  @override
   String getBranchName({bool redactUnknownBranches = false}) {
     return 'master';
   }
@@ -830,6 +833,9 @@ class FakeCache implements Cache {
   String get dartSdkVersion => null;
 
   @override
+  String get storageBaseUrl => null;
+
+  @override
   MapEntry<String, String> get dyLdLibEntry => null;
 
   @override
@@ -858,6 +864,11 @@ class FakeCache implements Cache {
   @override
   Directory getRoot() {
     return fs.currentDirectory;
+  }
+
+  @override
+  File getLicenseFile() {
+    return fs.currentDirectory.childFile('LICENSE');
   }
 
   @override


### PR DESCRIPTION
## Description

Add `build ios-framework --cocoapods` flag to output a Flutter.podspec pointing to the remote engine artifacts.zip instead of universal Flutter.frameworks or Flutter.xcframeworks.

Host apps that use CocoaPods can add to their Podfile
```ruby
pod 'Flutter', :podspec => 'path/to/Flutter.podspec'
```

```terminal
$ pod install
Analyzing dependencies
Fetching podspec for `Flutter` from `Flutter/Release/Flutter.podspec`
Downloading dependencies
Installing Flutter (1.13.400)
Generating Pods project
Integrating client project
Pod installation complete! There is 1 dependency from the Podfile and 1 total pod installed.
```

Developers won't have to store and distribute 30MB+ Flutter.frameworks to other developers or CI machines.

Example generated Release Flutter.podspec:
```ruby
Pod::Spec.new do |s|
  s.name                  = 'Flutter'
  s.version               = '1.13.400' # 1.13.4
  s.summary               = 'Flutter Engine Framework'
  s.description           = <<-DESC
Flutter is Google’s UI toolkit for building beautiful, natively compiled applications for mobile, web, and desktop from a single codebase.
This pod vends the iOS Flutter engine framework. It is compatible with application frameworks created with this version of the engine and tools.
The pod version matches Flutter version major.minor.(patch * 100) + hotfix.
DESC
  s.homepage              = 'https://flutter.dev'
  s.license               = { :type => 'MIT', :text => <<-LICENSE
Copyright 2014 The Flutter Authors. All rights reserved.

Redistribution and use in source and binary forms, with or without modification,
are permitted provided that the following conditions are met:

    * Redistributions of source code must retain the above copyright
      notice, this list of conditions and the following disclaimer.
    * Redistributions in binary form must reproduce the above
      copyright notice, this list of conditions and the following
      disclaimer in the documentation and/or other materials provided
      with the distribution.
    * Neither the name of Google Inc. nor the names of its
      contributors may be used to endorse or promote products derived
      from this software without specific prior written permission.

THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

LICENSE
  }
  s.author                = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
  s.source                = { :http => 'https://storage.googleapis.com/flutter_infra/flutter/854d5f8e9e7445a7863c41bced7a069e9d4d9017/ios-release/artifacts.zip' }
  s.documentation_url     = 'https://flutter.dev/docs'
  s.platform              = :ios, '8.0'
  s.vendored_frameworks   = 'Flutter.framework'
  s.prepare_command       = <<-CMD
unzip Flutter.framework -d Flutter.framework
CMD
end
```
Also moved storageBaseUrl from the CachedArtifact to Cache since the command has a cache but no cached artifacts, and the downloading logic is kind of snarled into EngineCachedArtifact.updateInner()

## Related Issues

Fixes https://github.com/flutter/flutter/issues/47548

## Tests

I added the following tests:
build_ios_framework_test.dart

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*