### PR TITLE
Fix for #44795

### DIFF
--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1104,10 +1104,9 @@ class TerminalHandler {
 
   void registerSignalHandlers() {
     assert(residentRunner.stayResident);
-
     _addSignalHandler(io.ProcessSignal.SIGINT, _cleanUp);
     _addSignalHandler(io.ProcessSignal.SIGTERM, _cleanUp);
-    if (!residentRunner.supportsServiceProtocol || !residentRunner.supportsRestart) {
+    if ((!residentRunner.canHotReload) && (!residentRunner.canHotRestart  || !residentRunner.hotMode)) {
       return;
     }
     _addSignalHandler(io.ProcessSignal.SIGUSR1, _handleSignal);


### PR DESCRIPTION

## Description

#44795 Fix

## Related Issues

This PR is to fix the suggestion in [PR: 44795](https://github.com/flutter/flutter/issues/44795#issuecomment-553240855
).

## Tests
None.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] All existing tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
Did any tests fail when you ran them? Please read [Handling breaking changes].
- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
