### PR TITLE
Fix SnackBar clipping when it is floating due to FloatingActionButton positioning

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -547,9 +547,13 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
       if (snackBarSize == Size.zero) {
         snackBarSize = layoutChild(_ScaffoldSlot.snackBar, fullWidthConstraints);
       }
-      final double snackBarYOffsetBase = floatingActionButtonRect != null && isSnackBarFloating
-        ? floatingActionButtonRect.top
-        : contentBottom;
+
+      double snackBarYOffsetBase;
+      if (floatingActionButtonRect.size != Size.zero && isSnackBarFloating)
+        snackBarYOffsetBase = floatingActionButtonRect.top;
+      else
+        snackBarYOffsetBase = contentBottom;
+
       positionChild(_ScaffoldSlot.snackBar, Offset(0.0, snackBarYOffsetBase - snackBarSize.height));
     }
 

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -561,17 +561,25 @@ void main() {
       ),
     ));
 
-    final Offset floatingActionButtonOriginBottomCenter = tester.getCenter(find.byType(FloatingActionButton));
+    // Get the Rect of the FAB to compare after the SnackBar appears.
+    final Rect originalFabRect = tester.getRect(find.byType(FloatingActionButton));
 
     await tester.tap(find.text('X'));
     await tester.pump(); // start animation
     await tester.pump(const Duration(milliseconds: 750)); // Animation last frame.
 
-    final Offset snackBarTopCenter = tester.getCenter(find.byType(SnackBar));
-    final Offset floatingActionButtonBottomCenter = tester.getCenter(find.byType(FloatingActionButton));
+    final Rect fabRect = tester.getRect(find.byType(FloatingActionButton));
 
-    expect(floatingActionButtonOriginBottomCenter.dy > floatingActionButtonBottomCenter.dy, true);
-    expect(snackBarTopCenter.dy > floatingActionButtonBottomCenter.dy, true);
+    // FAB should shift upwards after SnackBar appears.
+    expect(fabRect.center.dy, lessThan(originalFabRect.center.dy));
+
+    final Offset snackBarTopRight = tester.getTopRight(find.byType(SnackBar));
+
+    // FAB's surrounding padding is set to [kFloatingActionButtonMargin] in floating_action_button_location.dart by default.
+    const int defaultFabPadding = 16;
+
+    // FAB should be positioned above the SnackBar by the default padding.
+    expect(fabRect.bottomRight.dy, snackBarTopRight.dy - defaultFabPadding);
   });
 
   testWidgets('Floating SnackBar button text alignment', (WidgetTester tester) async {

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -470,58 +470,62 @@ void main() {
     expect(snackBarBottomRight.dy - actionTextBottomRight.dy, 17.0 + 40.0); // margin + bottom padding
   }, skip: isBrowser);
 
-  testWidgets('SnackBar is positioned above BottomNavigationBar', (WidgetTester tester) async {
-    await tester.pumpWidget(MaterialApp(
-      home: MediaQuery(
-        data: const MediaQueryData(
-          padding: EdgeInsets.only(
-            left: 10.0,
-            top: 20.0,
-            right: 30.0,
-            bottom: 40.0,
+  testWidgets(
+    'Custom padding between SnackBar and its contents when set to SnackBarBehavior.fixed',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(
+            padding: EdgeInsets.only(
+              left: 10.0,
+              top: 20.0,
+              right: 30.0,
+              bottom: 40.0,
+            ),
+          ),
+          child: Scaffold(
+            bottomNavigationBar: BottomNavigationBar(
+              items: const <BottomNavigationBarItem>[
+                BottomNavigationBarItem(icon: Icon(Icons.favorite), title: Text('Animutation')),
+                BottomNavigationBarItem(icon: Icon(Icons.block), title: Text('Zombo.com')),
+              ],
+            ),
+            body: Builder(
+              builder: (BuildContext context) {
+                return GestureDetector(
+                  onTap: () {
+                    Scaffold.of(context).showSnackBar(SnackBar(
+                      content: const Text('I am a snack bar.'),
+                      duration: const Duration(seconds: 2),
+                      action: SnackBarAction(label: 'ACTION', onPressed: () {}),
+                    ));
+                  },
+                  child: const Text('X'),
+                );
+              }
+            ),
           ),
         ),
-        child: Scaffold(
-          bottomNavigationBar: BottomNavigationBar(
-            items: const <BottomNavigationBarItem>[
-              BottomNavigationBarItem(icon: Icon(Icons.favorite), title: Text('Animutation')),
-              BottomNavigationBarItem(icon: Icon(Icons.block), title: Text('Zombo.com')),
-            ],
-          ),
-          body: Builder(
-            builder: (BuildContext context) {
-              return GestureDetector(
-                onTap: () {
-                  Scaffold.of(context).showSnackBar(SnackBar(
-                    content: const Text('I am a snack bar.'),
-                    duration: const Duration(seconds: 2),
-                    action: SnackBarAction(label: 'ACTION', onPressed: () { }),
-                  ));
-                },
-                child: const Text('X'),
-              );
-            }
-          ),
-        ),
-      ),
-    ));
-    await tester.tap(find.text('X'));
-    await tester.pump(); // start animation
-    await tester.pump(const Duration(milliseconds: 750)); // Animation last frame.
+      ));
+      await tester.tap(find.text('X'));
+      await tester.pump(); // start animation
+      await tester.pump(const Duration(milliseconds: 750)); // Animation last frame.
 
-    final Offset textBottomLeft = tester.getBottomLeft(find.text('I am a snack bar.'));
-    final Offset textBottomRight = tester.getBottomRight(find.text('I am a snack bar.'));
-    final Offset actionTextBottomLeft = tester.getBottomLeft(find.text('ACTION'));
-    final Offset actionTextBottomRight = tester.getBottomRight(find.text('ACTION'));
-    final Offset snackBarBottomLeft = tester.getBottomLeft(find.byType(SnackBar));
-    final Offset snackBarBottomRight = tester.getBottomRight(find.byType(SnackBar));
+      final Offset textBottomLeft = tester.getBottomLeft(find.text('I am a snack bar.'));
+      final Offset textBottomRight = tester.getBottomRight(find.text('I am a snack bar.'));
+      final Offset actionTextBottomLeft = tester.getBottomLeft(find.text('ACTION'));
+      final Offset actionTextBottomRight = tester.getBottomRight(find.text('ACTION'));
+      final Offset snackBarBottomLeft = tester.getBottomLeft(find.byType(SnackBar));
+      final Offset snackBarBottomRight = tester.getBottomRight(find.byType(SnackBar));
 
-    expect(textBottomLeft.dx - snackBarBottomLeft.dx, 24.0 + 10.0); // margin + left padding
-    expect(snackBarBottomLeft.dy - textBottomLeft.dy, 17.0); // margin (with no bottom padding)
-    expect(actionTextBottomLeft.dx - textBottomRight.dx, 24.0);
-    expect(snackBarBottomRight.dx - actionTextBottomRight.dx, 24.0 + 30.0); // margin + right padding
-    expect(snackBarBottomRight.dy - actionTextBottomRight.dy, 17.0); // margin (with no bottom padding)
-  }, skip: isBrowser);
+      expect(textBottomLeft.dx - snackBarBottomLeft.dx, 24.0 + 10.0); // margin + left padding
+      expect(snackBarBottomLeft.dy - textBottomLeft.dy, 17.0); // margin (with no bottom padding)
+      expect(actionTextBottomLeft.dx - textBottomRight.dx, 24.0);
+      expect(snackBarBottomRight.dx - actionTextBottomRight.dx, 24.0 + 30.0); // margin + right padding
+      expect(snackBarBottomRight.dy - actionTextBottomRight.dy, 17.0); // margin (with no bottom padding)
+    },
+    skip: isBrowser,
+  );
 
   testWidgets('SnackBar should push FloatingActionButton above', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
@@ -620,61 +624,65 @@ void main() {
     expect(snackBarBottomRight.dy - actionTextBottomRight.dy, 27.0); // margin (with no bottom padding)
   }, skip: isBrowser);
 
-  testWidgets('Floating SnackBar is positioned above BottomNavigationBar', (WidgetTester tester) async {
-    await tester.pumpWidget(MaterialApp(
-      theme: ThemeData(
-        snackBarTheme: const SnackBarThemeData(behavior: SnackBarBehavior.floating,)
-      ),
-      home: MediaQuery(
-        data: const MediaQueryData(
-          padding: EdgeInsets.only(
-            left: 10.0,
-            top: 20.0,
-            right: 30.0,
-            bottom: 40.0,
+  testWidgets(
+    'Custom padding between SnackBar and its contents when set to SnackBarBehavior.floating',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        theme: ThemeData(
+          snackBarTheme: const SnackBarThemeData(behavior: SnackBarBehavior.floating,)
+        ),
+        home: MediaQuery(
+          data: const MediaQueryData(
+            padding: EdgeInsets.only(
+              left: 10.0,
+              top: 20.0,
+              right: 30.0,
+              bottom: 40.0,
+            ),
+          ),
+          child: Scaffold(
+            bottomNavigationBar: BottomNavigationBar(
+              items: const <BottomNavigationBarItem>[
+                BottomNavigationBarItem(icon: Icon(Icons.favorite), title: Text('Animutation')),
+                BottomNavigationBarItem(icon: Icon(Icons.block), title: Text('Zombo.com')),
+              ],
+            ),
+            body: Builder(
+              builder: (BuildContext context) {
+                return GestureDetector(
+                  onTap: () {
+                    Scaffold.of(context).showSnackBar(SnackBar(
+                      content: const Text('I am a snack bar.'),
+                      duration: const Duration(seconds: 2),
+                      action: SnackBarAction(label: 'ACTION', onPressed: () {}),
+                    ));
+                  },
+                  child: const Text('X'),
+                );
+              }
+            ),
           ),
         ),
-        child: Scaffold(
-          bottomNavigationBar: BottomNavigationBar(
-            items: const <BottomNavigationBarItem>[
-              BottomNavigationBarItem(icon: Icon(Icons.favorite), title: Text('Animutation')),
-              BottomNavigationBarItem(icon: Icon(Icons.block), title: Text('Zombo.com')),
-            ],
-          ),
-          body: Builder(
-            builder: (BuildContext context) {
-              return GestureDetector(
-                onTap: () {
-                  Scaffold.of(context).showSnackBar(SnackBar(
-                    content: const Text('I am a snack bar.'),
-                    duration: const Duration(seconds: 2),
-                    action: SnackBarAction(label: 'ACTION', onPressed: () {}),
-                  ));
-                },
-                child: const Text('X'),
-              );
-            }
-          ),
-        ),
-      ),
-    ));
-    await tester.tap(find.text('X'));
-    await tester.pump(); // start animation
-    await tester.pump(const Duration(milliseconds: 750)); // Animation last frame.
+      ));
+      await tester.tap(find.text('X'));
+      await tester.pump(); // start animation
+      await tester.pump(const Duration(milliseconds: 750)); // Animation last frame.
 
-    final Offset textBottomLeft = tester.getBottomLeft(find.text('I am a snack bar.'));
-    final Offset textBottomRight = tester.getBottomRight(find.text('I am a snack bar.'));
-    final Offset actionTextBottomLeft = tester.getBottomLeft(find.text('ACTION'));
-    final Offset actionTextBottomRight = tester.getBottomRight(find.text('ACTION'));
-    final Offset snackBarBottomLeft = tester.getBottomLeft(find.byType(SnackBar));
-    final Offset snackBarBottomRight = tester.getBottomRight(find.byType(SnackBar));
+      final Offset textBottomLeft = tester.getBottomLeft(find.text('I am a snack bar.'));
+      final Offset textBottomRight = tester.getBottomRight(find.text('I am a snack bar.'));
+      final Offset actionTextBottomLeft = tester.getBottomLeft(find.text('ACTION'));
+      final Offset actionTextBottomRight = tester.getBottomRight(find.text('ACTION'));
+      final Offset snackBarBottomLeft = tester.getBottomLeft(find.byType(SnackBar));
+      final Offset snackBarBottomRight = tester.getBottomRight(find.byType(SnackBar));
 
-    expect(textBottomLeft.dx - snackBarBottomLeft.dx, 31.0 + 10.0); // margin + left padding
-    expect(snackBarBottomLeft.dy - textBottomLeft.dy, 27.0); // margin (with no bottom padding)
-    expect(actionTextBottomLeft.dx - textBottomRight.dx, 16.0);
-    expect(snackBarBottomRight.dx - actionTextBottomRight.dx, 31.0 + 30.0); // margin + right padding
-    expect(snackBarBottomRight.dy - actionTextBottomRight.dy, 27.0); // margin (with no bottom padding)
-  }, skip: isBrowser);
+      expect(textBottomLeft.dx - snackBarBottomLeft.dx, 31.0 + 10.0); // margin + left padding
+      expect(snackBarBottomLeft.dy - textBottomLeft.dy, 27.0); // margin (with no bottom padding)
+      expect(actionTextBottomLeft.dx - textBottomRight.dx, 16.0);
+      expect(snackBarBottomRight.dx - actionTextBottomRight.dx, 31.0 + 30.0); // margin + right padding
+      expect(snackBarBottomRight.dy - actionTextBottomRight.dy, 27.0); // margin (with no bottom padding)
+    },
+    skip: isBrowser,
+  );
 
   testWidgets('Floating SnackBar is positioned above FloatingActionButton', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -692,54 +692,6 @@ void main() {
     skip: isBrowser,
   );
 
-  testWidgets('Floating SnackBar is positioned above FloatingActionButton', (WidgetTester tester) async {
-    await tester.pumpWidget(MaterialApp(
-      theme: ThemeData(
-        snackBarTheme: const SnackBarThemeData(behavior: SnackBarBehavior.floating,)
-      ),
-      home: MediaQuery(
-        data: const MediaQueryData(
-          padding: EdgeInsets.only(
-            left: 10.0,
-            top: 20.0,
-            right: 30.0,
-            bottom: 40.0,
-          ),
-        ),
-        child: Scaffold(
-          floatingActionButton: FloatingActionButton(
-            child: const Icon(Icons.send),
-            onPressed: () {},
-          ),
-          body: Builder(
-            builder: (BuildContext context) {
-              return GestureDetector(
-                onTap: () {
-                  Scaffold.of(context).showSnackBar(SnackBar(
-                    content: const Text('I am a snack bar.'),
-                    duration: const Duration(seconds: 2),
-                    action: SnackBarAction(label: 'ACTION', onPressed: () {}),
-                  ));
-                },
-                child: const Text('X'),
-              );
-            }
-          ),
-        ),
-      ),
-    ));
-    await tester.tap(find.text('X'));
-    await tester.pump(); // start animation
-    await tester.pump(const Duration(milliseconds: 750)); // Animation last frame.
-
-    final Offset snackBarBottomCenter = tester.getBottomLeft(find.byType(SnackBar));
-    final Offset floatingActionButtonTopCenter = tester.getTopLeft(find.byType(FloatingActionButton));
-
-    // Since padding and margin is handled inside snackBarBox,
-    // the bottom offset of snackbar should equal with top offset of FAB
-    expect(snackBarBottomCenter.dy == floatingActionButtonTopCenter.dy, true);
-  });
-
   testWidgets('SnackBar bottom padding is not consumed by viewInsets', (WidgetTester tester) async {
     final Widget child = Directionality(
       textDirection: TextDirection.ltr,
@@ -1263,6 +1215,47 @@ void main() {
         final Offset scaffoldBottomLeft = tester.getBottomLeft(find.byType(Scaffold));
 
         expect(snackBarBottomLeft, equals(scaffoldBottomLeft));
+      },
+    );
+
+    testWidgets(
+      '${SnackBarBehavior.floating} should align SnackBar with the top of FloatingActionButton'
+      'when Scaffold has a FloatingActionButton',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(MaterialApp(
+          home: Scaffold(
+            floatingActionButton: FloatingActionButton(
+              child: const Icon(Icons.send),
+              onPressed: () {},
+            ),
+            body: Builder(
+              builder: (BuildContext context) {
+                return GestureDetector(
+                  onTap: () {
+                    Scaffold.of(context).showSnackBar(SnackBar(
+                      content: const Text('I am a snack bar.'),
+                      duration: const Duration(seconds: 2),
+                      action: SnackBarAction(label: 'ACTION', onPressed: () {}),
+                      behavior: SnackBarBehavior.floating,
+                    ));
+                  },
+                  child: const Text('X'),
+                );
+              },
+            ),
+          ),
+        ));
+        await tester.tap(find.text('X'));
+        await tester.pumpAndSettle(); // Have the SnackBar fully animate out.
+
+        final Offset snackBarBottomLeft = tester.getBottomLeft(find.byType(SnackBar));
+        final Offset floatingActionButtonTopLeft = tester.getTopLeft(
+          find.byType(FloatingActionButton),
+        );
+
+        // Since padding between the SnackBar and the FAB is created by the SnackBar,
+        // the bottom offset of the SnackBar should be equal to the top offset of the FAB
+        expect(snackBarBottomLeft.dy, floatingActionButtonTopLeft.dy);
       },
     );
 

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -637,7 +637,7 @@ void main() {
     (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         theme: ThemeData(
-          snackBarTheme: const SnackBarThemeData(behavior: SnackBarBehavior.floating,)
+          snackBarTheme: const SnackBarThemeData(behavior: SnackBarBehavior.floating)
         ),
         home: MediaQuery(
           data: const MediaQueryData(
@@ -708,8 +708,8 @@ void main() {
         ),
         child: Scaffold(
           floatingActionButton: FloatingActionButton(
-              child: const Icon(Icons.send),
-              onPressed: () {},
+            child: const Icon(Icons.send),
+            onPressed: () {},
           ),
           body: Builder(
             builder: (BuildContext context) {
@@ -1161,5 +1161,178 @@ void main() {
 
     expect(find.text('hello'), findsOneWidget);
     expect(called, 1);
+  });
+
+  group('SnackBar position', () {
+    for (final SnackBarBehavior behavior in SnackBarBehavior.values) {
+      final SnackBar snackBar = SnackBar(
+        content: const Text('SnackBar text'),
+        behavior: behavior,
+      );
+
+      testWidgets(
+        '$behavior should align SnackBar with the bottom of Scaffold '
+        'when Scaffold has no other elements',
+        (WidgetTester tester) async {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: Container(),
+              ),
+            ),
+          );
+
+          final ScaffoldState scaffoldState = tester.state(find.byType(Scaffold));
+          scaffoldState.showSnackBar(snackBar);
+
+          await tester.pumpAndSettle(); // Have the SnackBar fully animate out.
+
+          final Offset snackBarBottomRight = tester.getBottomRight(find.byType(SnackBar));
+          final Offset scaffoldBottomRight = tester.getBottomRight(find.byType(Scaffold));
+
+          expect(snackBarBottomRight, equals(scaffoldBottomRight));
+
+          final Offset snackBarBottomLeft = tester.getBottomLeft(find.byType(SnackBar));
+          final Offset scaffoldBottomLeft = tester.getBottomLeft(find.byType(Scaffold));
+
+          expect(snackBarBottomLeft, equals(scaffoldBottomLeft));
+        },
+      );
+
+      testWidgets(
+        '$behavior should align SnackBar with the top of BottomNavigationBar '
+        'when Scaffold has no FloatingActionButton',
+        (WidgetTester tester) async {
+          final UniqueKey boxKey = UniqueKey();
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: Container(),
+                bottomNavigationBar: SizedBox(key: boxKey, width: 800, height: 60),
+              ),
+            ),
+          );
+
+          final ScaffoldState scaffoldState = tester.state(find.byType(Scaffold));
+          scaffoldState.showSnackBar(snackBar);
+
+          await tester.pumpAndSettle(); // Have the SnackBar fully animate out.
+
+          final Offset snackBarBottomRight = tester.getBottomRight(find.byType(SnackBar));
+          final Offset bottomNavigationBarTopRight = tester.getTopRight(find.byKey(boxKey));
+
+          expect(snackBarBottomRight, equals(bottomNavigationBarTopRight));
+
+          final Offset snackBarBottomLeft = tester.getBottomLeft(find.byType(SnackBar));
+          final Offset bottomNavigationBarTopLeft = tester.getTopLeft(find.byKey(boxKey));
+
+          expect(snackBarBottomLeft, equals(bottomNavigationBarTopLeft));
+        },
+      );
+    }
+
+    testWidgets(
+      '${SnackBarBehavior.fixed} should align SnackBar with the bottom of Scaffold '
+      'when Scaffold has a FloatingActionButton',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Container(),
+              floatingActionButton: FloatingActionButton(onPressed: () {}),
+            ),
+          ),
+        );
+
+        final ScaffoldState scaffoldState = tester.state(find.byType(Scaffold));
+        scaffoldState.showSnackBar(
+          const SnackBar(
+            content: Text('Snackbar text'),
+            behavior: SnackBarBehavior.fixed,
+          ),
+        );
+
+        await tester.pumpAndSettle(); // Have the SnackBar fully animate out.
+
+        final Offset snackBarBottomRight = tester.getBottomRight(find.byType(SnackBar));
+        final Offset scaffoldBottomRight = tester.getBottomRight(find.byType(Scaffold));
+
+        expect(snackBarBottomRight, equals(scaffoldBottomRight));
+
+        final Offset snackBarBottomLeft = tester.getBottomLeft(find.byType(SnackBar));
+        final Offset scaffoldBottomLeft = tester.getBottomLeft(find.byType(Scaffold));
+
+        expect(snackBarBottomLeft, equals(scaffoldBottomLeft));
+      },
+    );
+
+    testWidgets(
+      '${SnackBarBehavior.fixed} should align SnackBar with the top of BottomNavigationBar '
+      'when Scaffold has a BottomNavigationBar and FloatingActionButton',
+      (WidgetTester tester) async {
+        final UniqueKey boxKey = UniqueKey();
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Container(),
+              bottomNavigationBar: SizedBox(key: boxKey, width: 800, height: 60),
+              floatingActionButton: FloatingActionButton(onPressed: () {}),
+            ),
+          ),
+        );
+
+        final ScaffoldState scaffoldState = tester.state(find.byType(Scaffold));
+        scaffoldState.showSnackBar(
+          const SnackBar(
+            content: Text('SnackBar text'),
+            behavior: SnackBarBehavior.fixed,
+          ),
+        );
+
+        await tester.pumpAndSettle(); // Have the SnackBar fully animate out.
+
+        final Offset snackBarBottomRight = tester.getBottomRight(find.byType(SnackBar));
+        final Offset bottomNavigationBarTopRight = tester.getTopRight(find.byKey(boxKey));
+
+        expect(snackBarBottomRight, equals(bottomNavigationBarTopRight));
+
+        final Offset snackBarBottomLeft = tester.getBottomLeft(find.byType(SnackBar));
+        final Offset bottomNavigationBarTopLeft = tester.getTopLeft(find.byKey(boxKey));
+
+        expect(snackBarBottomLeft, equals(bottomNavigationBarTopLeft));
+      },
+    );
+
+    testWidgets(
+      '${SnackBarBehavior.floating} should align SnackBar with the top of FloatingActionButton '
+      'when Scaffold has BottomNavigationBar and FloatingActionButton',
+      (WidgetTester tester) async {
+        final UniqueKey boxKey = UniqueKey();
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Container(),
+              bottomNavigationBar: SizedBox(key: boxKey, width: 800, height: 60),
+              floatingActionButton: FloatingActionButton(onPressed: () {}),
+            ),
+          ),
+        );
+
+        final ScaffoldState scaffoldState = tester.state(find.byType(Scaffold));
+        scaffoldState.showSnackBar(
+          const SnackBar(
+            content: Text('SnackBar text'),
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+
+        await tester.pumpAndSettle(); // Have the SnackBar fully animate out.
+
+        final Offset snackBarBottomRight = tester.getBottomRight(find.byType(SnackBar));
+        final Offset fabTopRight = tester.getTopRight(find.byType(FloatingActionButton));
+
+        expect(snackBarBottomRight.dy, equals(fabTopRight.dy));
+      },
+    );
   });
 }


### PR DESCRIPTION
## Description
### Screenshots
#### Before fix
<img width="200" src="https://user-images.githubusercontent.com/17338801/72678400-15203280-3ad8-11ea-8f0c-106b64f500f9.png">
<img width="200" src="https://user-images.githubusercontent.com/17338801/72678404-223d2180-3ad8-11ea-878a-b898c94dc7d4.png">

#### After fix
<img width="200" src="https://user-images.githubusercontent.com/17338801/72678418-4567d100-3ad8-11ea-9326-ddaca97a59b9.png">
<img width="200" src="https://user-images.githubusercontent.com/17338801/72678421-48fb5800-3ad8-11ea-989f-1f1373851a6e.png">

### Bug cause
`Scaffold` always wraps a `FloatingActionButton`(`FAB`) in a private widget `_FloatingActionButtonTransition`, even if the `FAB` is null (to animate the appearance of the `FAB`).
Thus, `Scaffold` always has a `FAB` and calculates an area for it. Before calculating the position of the `SnackBar`, `Scaffold` verifies the area of `FAB` on `null`. If the area is not `null`, then `SnackBar` will be positioned above it. Since `FAB` and its area is never `null`, `SnackBar` is always on top (This bug works only for `SnackBar` with floating behavior)

### Solution
If the `FAB` is null, then `FloatingActionButtonArea` has a size equal to `Size.zero`. Consequently, if the size of `FloatingActionButtonArea` is zero, then `FAB` won't show and `SnackBar` will be laid out on top of the other content.

### Tests
This PR also adds tests to ensure that the `SnackBar` is positioned in the right places given the many configurations of `Scaffold`

## Related Issues
Fixes #47202
Fixes #43716

## Tests
This PR include parameterized test (to avoid two identical tests differing in one detail). But if it is not ok, i'll split them. 

I added the following tests:

- Snackbar Position (group test)
    - behavior is fixed and scaffold has no other elements 
    - behavior is floating and scaffold has no other elements
    - behavior is fixed and scaffold has bottom navigation bar
    - behavior is floating and scaffold has bottom navigation bar
    - behavior is fixed and scaffold has floating action button
    - behavior is floating and scaffold has floating action button
    - behavior is fixed and scaffold has FAB and bottom navigation bar
    - behavior is floating and scaffold has FAB and bottom navigation bar

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.