### PR TITLE
Remove package:flutter/foundation.dart import

### DIFF
--- a/dev/integration_tests/flutter_driver_screenshot_test/test_driver/driver_screenshot_tester.dart
+++ b/dev/integration_tests/flutter_driver_screenshot_test/test_driver/driver_screenshot_tester.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:io' show File;
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/src/foundation/collections.dart';
 import 'package:flutter_driver/flutter_driver.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;

--- a/dev/integration_tests/flutter_driver_screenshot_test/test_driver/driver_screenshot_tester.dart
+++ b/dev/integration_tests/flutter_driver_screenshot_test/test_driver/driver_screenshot_tester.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 import 'dart:io' show File;
 
-import 'package:flutter/src/foundation/collections.dart';
 import 'package:flutter_driver/flutter_driver.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
@@ -42,9 +41,28 @@ class DriverScreenShotTester {
   /// The golden image should exists at `test_driver/goldens/<testName>/<deviceModel>.png`
   /// prior to this call.
   Future<bool> compareScreenshots(List<int> screenshot) async {
+    if (screenshot == null) {
+      return false;
+    }
     final File file = File(_getImageFilePath());
     final List<int> matcher = await file.readAsBytes();
-    return listEquals<int>(screenshot, matcher);
+
+    if (matcher == null) {
+      return false;
+    }
+    return _bytesEqual(screenshot, matcher);
+  }
+
+  bool _bytesEqual(List<int> a, List<int> b) {
+    if (a.length != b.length) {
+      return false;
+    }
+    for (int index = 0; index < a.length; index += 1) {
+      if (a[index] != b[index]) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /// Returns a bytes representation of a screenshot on the current screen.


### PR DESCRIPTION
## Description

foundation [was imported](
https://github.com/flutter/flutter/blob/master/dev/integration_tests/flutter_driver_screenshot_test/test_driver/driver_screenshot_tester.dart#L8) into `driver_screenshot_tester` https://github.com/flutter/flutter/pull/47199 to be able to use `listEquals`.  However, foundation depends on `dart:ui` which isn't allowed in a driver test (AFAIK - https://github.com/flutter/flutter/issues/27826)

Change this to just import the utility file instead of the whole package.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/47700.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*