### PR TITLE
Implement AlertDialog.actionsPadding and AlertDialog.buttonPadding

### DIFF
--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -293,10 +293,10 @@ class AlertDialog extends StatelessWidget {
 
   /// Padding around the the set of [actions] at the bottom of the dialog.
   ///
-  /// Typically used to provide padding to the button bar between the edge
-  /// of the dialog.
+  /// Typically used to provide padding to the button bar between the button bar
+  /// and the edges of the dialog.
   ///
-  /// If there is no [actions], no padding will be provided. The padding around
+  /// If are no [actions], then no padding will be included. The padding around
   /// the button bar defaults to zero. It is also important to note that
   /// [buttonPadding] may contribute to the padding on the edges of [actions] as
   /// well.
@@ -317,7 +317,10 @@ class AlertDialog extends StatelessWidget {
   /// {@end-tool}
   final EdgeInsetsGeometry actionsPadding;
 
-  /// Defines the padding for a button's child (typically the button's label).
+  /// The padding that surrounds each button in [actions].
+  ///
+  /// This is different from [actionsPadding], which defines the padding
+  /// between the entire button bar and the edges of the dialog.
   ///
   /// If this property is null, then it will use the surrounding
   /// [ButtonBarTheme.buttonPadding]. If that is null, it will default to

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -312,7 +312,7 @@ class AlertDialog extends StatelessWidget {
   ///     RaisedButton(onPressed: () {}, child: Text('Button 2')),
   ///   ],
   ///   actionsPadding: EdgeInsets.symmetric(horizontal: 8.0),
-  /// );
+  /// )
   /// ```
   /// {@end-tool}
   final EdgeInsetsGeometry actionsPadding;

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -297,7 +297,9 @@ class AlertDialog extends StatelessWidget {
   /// of the dialog.
   ///
   /// If there is no [actions], no padding will be provided. The padding around
-  /// the button bar defaults to zero.
+  /// the button bar defaults to zero. It is also important to note that
+  /// [buttonPadding] may contribute to the padding on the edges of [actions] as
+  /// well.
   ///
   /// {@tool sample}
   /// This is an example of a set of actions aligned with the content widget.
@@ -317,9 +319,9 @@ class AlertDialog extends StatelessWidget {
 
   /// Defines the padding for a button's child (typically the button's label).
   ///
-  /// If null then it will use the surrounding [ButtonBarTheme.buttonPadding].
-  /// If that is null, it will default to 8.0 logical pixels on the left
-  /// and right.
+  /// If this property is null, then it will use the surrounding
+  /// [ButtonBarTheme.buttonPadding]. If that is null, it will default to
+  /// 8.0 logical pixels on the left and right.
   final EdgeInsetsGeometry buttonPadding;
 
   /// {@macro flutter.material.dialog.backgroundColor}

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -221,6 +221,8 @@ class AlertDialog extends StatelessWidget {
     this.contentPadding = const EdgeInsets.fromLTRB(24.0, 20.0, 24.0, 24.0),
     this.contentTextStyle,
     this.actions,
+    this.actionsPadding = EdgeInsets.zero,
+    this.buttonPadding,
     this.backgroundColor,
     this.elevation,
     this.semanticLabel,
@@ -289,6 +291,37 @@ class AlertDialog extends StatelessWidget {
   /// from the [actions].
   final List<Widget> actions;
 
+  /// Padding around the the set of [actions] at the bottom of the dialog.
+  ///
+  /// Typically used to provide padding to the button bar between the edge
+  /// of the dialog.
+  ///
+  /// If there is no [actions], no padding will be provided. The padding around
+  /// the button bar defaults to zero.
+  ///
+  /// {@tool sample}
+  /// This is an example of a set of actions aligned with the content widget.
+  /// ```dart
+  /// AlertDialog(
+  ///   title: Text('Title'),
+  ///   content: Container(width: 200, height: 200, color: Colors.green),
+  ///   actions: <Widget>[
+  ///     RaisedButton(onPressed: () {}, child: Text('Button 1')),
+  ///     RaisedButton(onPressed: () {}, child: Text('Button 2')),
+  ///   ],
+  ///   actionsPadding: EdgeInsets.symmetric(horizontal: 8.0),
+  /// );
+  /// ```
+  /// {@end-tool}
+  final EdgeInsetsGeometry actionsPadding;
+
+  /// Defines the padding for a button's child (typically the button's label).
+  ///
+  /// If null then it will use the surrounding [ButtonBarTheme.buttonPadding].
+  /// If that is null, it will default to 8.0 logical pixels on the left
+  /// and right.
+  final EdgeInsetsGeometry buttonPadding;
+
   /// {@macro flutter.material.dialog.backgroundColor}
   final Color backgroundColor;
 
@@ -349,6 +382,7 @@ class AlertDialog extends StatelessWidget {
 
     Widget titleWidget;
     Widget contentWidget;
+    Widget actionsWidget;
     if (title != null)
      titleWidget = Padding(
         padding: titlePadding ?? EdgeInsets.fromLTRB(24.0, 24.0, 24.0, content == null ? 20.0 : 0.0),
@@ -371,6 +405,15 @@ class AlertDialog extends StatelessWidget {
         ),
       );
 
+    if (actions != null)
+      actionsWidget = Padding(
+        padding: actionsPadding,
+        child: ButtonBar(
+          buttonPadding: buttonPadding,
+          children: actions,
+        ),
+      );
+
     List<Widget> columnChildren;
     if (scrollable) {
       columnChildren = <Widget>[
@@ -390,7 +433,7 @@ class AlertDialog extends StatelessWidget {
             ),
           ),
         if (actions != null)
-          ButtonBar(children: actions),
+          actionsWidget,
       ];
     } else {
       columnChildren = <Widget>[
@@ -399,7 +442,7 @@ class AlertDialog extends StatelessWidget {
         if (content != null)
           Flexible(child: contentWidget),
         if (actions != null)
-          ButtonBar(children: actions),
+          actionsWidget,
       ];
     }
 

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -407,6 +407,130 @@ void main() {
     expect(actionsSize.width, dialogSize.width - (30.0 * 2));
   });
 
+  testWidgets('AlertDialog.buttonPadding defaults to 8.0 on every side', (WidgetTester tester) async {
+    final GlobalKey key1 = GlobalKey();
+    final GlobalKey key2 = GlobalKey();
+
+    final AlertDialog dialog = AlertDialog(
+      title: const Text('title'),
+      content: const Text('content'),
+      actions: <Widget>[
+        RaisedButton(
+          key: key1,
+          onPressed: () {},
+          child: const Text('button 1'),
+        ),
+        RaisedButton(
+          key: key2,
+          onPressed: () {},
+          child: const Text('button 2'),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      _appWithAlertDialog(tester, dialog),
+    );
+
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
+
+    // Padding between both buttons
+    expect(
+      tester.getBottomLeft(find.byKey(key2)).dx,
+      tester.getBottomRight(find.byKey(key1)).dx + 8.0,
+    );
+
+    // Padding between button and edges of the button bar
+    // First button
+    expect(
+      tester.getTopRight(find.byKey(key1)).dy,
+      tester.getTopRight(find.byType(ButtonBar)).dy + 8.0,
+    ); // top
+    expect(
+      tester.getBottomRight(find.byKey(key1)).dy,
+      tester.getBottomRight(find.byType(ButtonBar)).dy - 8.0,
+    ); // bottom
+
+    // Second button
+    expect(
+      tester.getTopRight(find.byKey(key2)).dy,
+      tester.getTopRight(find.byType(ButtonBar)).dy + 8.0,
+    ); // top
+    expect(
+      tester.getBottomRight(find.byKey(key2)).dy,
+      tester.getBottomRight(find.byType(ButtonBar)).dy - 8.0,
+    ); // bottom
+    expect(
+      tester.getBottomRight(find.byKey(key2)).dx,
+      tester.getBottomRight(find.byType(ButtonBar)).dx - 8.0,
+    ); // right
+  });
+
+  testWidgets('AlertDialog.buttonPadding custom values', (WidgetTester tester) async {
+    final GlobalKey key1 = GlobalKey();
+    final GlobalKey key2 = GlobalKey();
+
+    final AlertDialog dialog = AlertDialog(
+      title: const Text('title'),
+      content: const Text('content'),
+      actions: <Widget>[
+        RaisedButton(
+          key: key1,
+          onPressed: () {},
+          child: const Text('button 1'),
+        ),
+        RaisedButton(
+          key: key2,
+          onPressed: () {},
+          child: const Text('button 2'),
+        ),
+      ],
+      buttonPadding: const EdgeInsets.only(
+        left: 10.0,
+        right: 20.0,
+      ),
+    );
+
+    await tester.pumpWidget(
+      _appWithAlertDialog(tester, dialog),
+    );
+
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
+
+    // Padding between both buttons
+    expect(
+      tester.getBottomLeft(find.byKey(key2)).dx,
+      tester.getBottomRight(find.byKey(key1)).dx + ((10.0 + 20.0) / 2),
+    );
+
+    // Padding between button and edges of the button bar
+    // First button
+    expect(
+      tester.getTopRight(find.byKey(key1)).dy,
+      tester.getTopRight(find.byType(ButtonBar)).dy + ((10.0 + 20.0) / 2),
+    ); // top
+    expect(
+      tester.getBottomRight(find.byKey(key1)).dy,
+      tester.getBottomRight(find.byType(ButtonBar)).dy - ((10.0 + 20.0) / 2),
+    ); // bottom
+
+    // Second button
+    expect(
+      tester.getTopRight(find.byKey(key2)).dy,
+      tester.getTopRight(find.byType(ButtonBar)).dy + ((10.0 + 20.0) / 2),
+    ); // top
+    expect(
+      tester.getBottomRight(find.byKey(key2)).dy,
+      tester.getBottomRight(find.byType(ButtonBar)).dy - ((10.0 + 20.0) / 2),
+    ); // bottom
+    expect(
+      tester.getBottomRight(find.byKey(key2)).dx,
+      tester.getBottomRight(find.byType(ButtonBar)).dx - ((10.0 + 20.0) / 2),
+    ); // right
+  });
+
   testWidgets('Dialogs removes MediaQuery padding and view insets', (WidgetTester tester) async {
     BuildContext outerContext;
     BuildContext routeContext;

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -13,26 +13,26 @@ import '../widgets/semantics_tester.dart';
 
 MaterialApp _appWithAlertDialog(WidgetTester tester, AlertDialog dialog, { ThemeData theme }) {
   return MaterialApp(
-      theme: theme,
-      home: Material(
-        child: Builder(
-          builder: (BuildContext context) {
-            return Center(
-              child: RaisedButton(
-                child: const Text('X'),
-                onPressed: () {
-                  showDialog<void>(
-                    context: context,
-                    builder: (BuildContext context) {
-                      return dialog;
-                    },
-                  );
-                },
-              ),
-            );
-          }
-        ),
+    theme: theme,
+    home: Material(
+      child: Builder(
+        builder: (BuildContext context) {
+          return Center(
+            child: RaisedButton(
+              child: const Text('X'),
+              onPressed: () {
+                showDialog<void>(
+                  context: context,
+                  builder: (BuildContext context) {
+                    return dialog;
+                  },
+                );
+              },
+            ),
+          );
+        }
       ),
+    ),
   );
 }
 
@@ -338,6 +338,73 @@ void main() {
     expect(semantics, isNot(includesNodeWith(label: buttonText)));
 
     semantics.dispose();
+  });
+
+  testWidgets('AlertDialog.actionsPadding defaults to zero', (WidgetTester tester) async {
+    final AlertDialog dialog = AlertDialog(
+      title: const Text('title'),
+      content: const Text('content'),
+      actions: <Widget>[
+        RaisedButton(
+          onPressed: () {},
+          child: const Text('button'),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      _appWithAlertDialog(tester, dialog),
+    );
+
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
+
+    // The [AlertDialog] is the entire screen, since it also contains the scrim.
+    // The first [Material] child of [AlertDialog] is the actual dialog
+    // itself.
+    final Size dialogSize = tester.getSize(
+      find.descendant(
+        of: find.byType(AlertDialog),
+        matching: find.byType(Material),
+      ).first,
+    );
+    final Size actionsSize = tester.getSize(find.byType(ButtonBar));
+
+    expect(actionsSize.width, dialogSize.width);
+  });
+
+  testWidgets('AlertDialog.actionsPadding surrounds actions with padding', (WidgetTester tester) async {
+    final AlertDialog dialog = AlertDialog(
+      title: const Text('title'),
+      content: const Text('content'),
+      actions: <Widget>[
+        RaisedButton(
+          onPressed: () {},
+          child: const Text('button'),
+        ),
+      ],
+      actionsPadding: const EdgeInsets.all(30.0), // custom padding value
+    );
+
+    await tester.pumpWidget(
+      _appWithAlertDialog(tester, dialog),
+    );
+
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
+
+    // The [AlertDialog] is the entire screen, since it also contains the scrim.
+    // The first [Material] child of [AlertDialog] is the actual dialog
+    // itself.
+    final Size dialogSize = tester.getSize(
+      find.descendant(
+        of: find.byType(AlertDialog),
+        matching: find.byType(Material),
+      ).first,
+    );
+    final Size actionsSize = tester.getSize(find.byType(ButtonBar));
+
+    expect(actionsSize.width, dialogSize.width - (30.0 * 2));
   });
 
   testWidgets('Dialogs removes MediaQuery padding and view insets', (WidgetTester tester) async {

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -340,7 +340,7 @@ void main() {
     semantics.dispose();
   });
 
-  testWidgets('AlertDialog.actionsPadding defaults to zero', (WidgetTester tester) async {
+  testWidgets('AlertDialog.actionsPadding defaults', (WidgetTester tester) async {
     final AlertDialog dialog = AlertDialog(
       title: const Text('title'),
       content: const Text('content'),
@@ -407,7 +407,7 @@ void main() {
     expect(actionsSize.width, dialogSize.width - (30.0 * 2));
   });
 
-  testWidgets('AlertDialog.buttonPadding defaults to 8.0 on every side', (WidgetTester tester) async {
+  testWidgets('AlertDialog.buttonPadding defaults', (WidgetTester tester) async {
     final GlobalKey key1 = GlobalKey();
     final GlobalKey key2 = GlobalKey();
 


### PR DESCRIPTION
## Description

Introduces AlertDialog.actionsPadding and AlertDialog.buttonPadding properties to allow for customization of the actions at the bottom of AlertDialog. 

### Discussion
Currently, there is no clean way to provide padding between buttons that does not interfere with the overall padding due to AlertDialog's dependency on ButtonBar. For example, if actionsPadding was set to 8.0 and buttonPadding to 10.0, there will be a total of 18.0 pixels of padding between the edge of the dialog and the start of the buttons, since they are added together. This means that setting padding for individual buttons forces additional padding along the edges of the ButtonBar

## Related Issues

Fixes https://github.com/flutter/flutter/issues/47708

## Tests

- Tests for default actionsPadding and buttonPadding
- Tests for custom actionsPadding and buttonPadding

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
