### PR TITLE
Add error message for flutter_gallery transitions_perf test.

### DIFF
--- a/examples/flutter_gallery/test_driver/transitions_perf_test.dart
+++ b/examples/flutter_gallery/test_driver/transitions_perf_test.dart
@@ -93,6 +93,8 @@ Future<void> saveDurationsHistogram(List<Map<String, dynamic>> events, String ou
 
   if (unexpectedValueCounts.isNotEmpty) {
     final StringBuffer error = StringBuffer('Some routes recorded wrong number of values (expected 2 values/route):\n\n');
+    // When run with --trace-startup, the VM stores trace events in an endless buffer instead of a ring buffer.
+    error.write('You must add the --trace-startup parameter to run the test. \n\n');
     unexpectedValueCounts.forEach((String routeName, int count) {
       error.writeln(' - $routeName recorded $count values.');
     });


### PR DESCRIPTION
## Description

when i try to run as follows:
```
flutter drive --profile -t test_driver/transitions_perf.dart
```
> test_driver is a test of flutter_gallery.

The crash message as follows:
```
00:25 +0 -1: flutter gallery transitions all demos [E]

  Some routes recorded wrong number of values (expected 2 values/route):

   - /material/dialog recorded 1 values.

  Full event sequence:

   - Frame  ...............
   - Start Transition /material/dialog .
   - Frame  .........................................................................
   - Start Transition /material/date-and-time-pickers .
   - Frame  ...............................
   - Start Transition /material/date-and-time-pickers .
   - Frame  ..................................

  test_driver/transitions_perf_test.dart 122:5                  saveDurationsHistogram
  test_driver/transitions_perf_test.dart 223:13                 main.<fn>.<fn>
```

The reason I found this problem was that the VM’s trace events buffer overflowed.
We can also find the corresponding comments on the line 19, as follows:
> code file: flutter/examples/flutter_gallery/test_driver/transitions_perf_test.dart
```
// Warning: The number of tests executed with timeline collection enabled
// significantly impacts heap size of the running app. When run with
// --trace-startup, as we do in this test, the VM stores trace events in an
// endless buffer instead of a ring buffer.
//
// These names must match GalleryItem titles from kAllGalleryDemos
// in examples/flutter_gallery/lib/gallery/demos.dart
const List<String> kProfiledDemos = <String>[
  'Shrine@Studies',
  'Contact profile@Studies',
  'Animation@Studies',
  'Bottom navigation@Material',
  'Buttons@Material',
  'Cards@Material',
  'Chips@Material',
  'Dialogs@Material',
  'Pickers@Material',
];
```

So,  we must add  '--trace-startup' to run the test.

Why not add message to  tell the user that you must add the --trace-startup parameter？


## Related Issues

*Fixes https://github.com/flutter/flutter/issues/47768.*

## Tests

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.


<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
