### PR TITLE
Document reasoning for why CustomMultiChildLayout size can't depend on children and how to do it

### DIFF
--- a/packages/flutter/lib/src/rendering/custom_layout.dart
+++ b/packages/flutter/lib/src/rendering/custom_layout.dart
@@ -29,9 +29,10 @@ class MultiChildLayoutParentData extends ContainerBoxParentData<RenderBox> {
 /// given the previous instance.
 ///
 /// Override [getSize] to control the overall size of the layout. The size of
-/// the layout cannot depend on layout properties of the children because
-/// the delegate implementations should not have to also handle various
-/// intrinsic sizing functions if the parent's size depended on the children.
+/// the layout cannot depend on layout properties of the children. This was
+/// a design decision to simplify the delegate implementations: This way,
+/// the delegate implementations do not have to also handle various intrinsic
+/// sizing functions if the parent's size depended on the children.  
 /// If you want to build a custom layout where you define the size of that widget
 /// based on its children, then you will have to create a custom render object.
 /// See [MultiChildRenderObjectWidget] with [ContainerRenderObjectMixin] and

--- a/packages/flutter/lib/src/rendering/custom_layout.dart
+++ b/packages/flutter/lib/src/rendering/custom_layout.dart
@@ -30,6 +30,11 @@ class MultiChildLayoutParentData extends ContainerBoxParentData<RenderBox> {
 ///
 /// Override [getSize] to control the overall size of the layout. The size of
 /// the layout cannot depend on layout properties of the children.
+/// If you want to do build custom layout where you define the size of that widget
+/// based on its children, then you will have to create a custom render object.
+/// See [MultiChildRenderObjectWidget] with [ContainerRenderObjectMixin] and
+/// [RenderBoxContainerDefaultsMixin] to get started or [RenderStack] for an
+/// example implementation.
 ///
 /// Override [performLayout] to size and position the children. An
 /// implementation of [performLayout] must call [layoutChild] exactly once for

--- a/packages/flutter/lib/src/rendering/custom_layout.dart
+++ b/packages/flutter/lib/src/rendering/custom_layout.dart
@@ -30,7 +30,7 @@ class MultiChildLayoutParentData extends ContainerBoxParentData<RenderBox> {
 ///
 /// Override [getSize] to control the overall size of the layout. The size of
 /// the layout cannot depend on layout properties of the children.
-/// If you want to do build a custom layout where you define the size of that widget
+/// If you want to build a custom layout where you define the size of that widget
 /// based on its children, then you will have to create a custom render object.
 /// See [MultiChildRenderObjectWidget] with [ContainerRenderObjectMixin] and
 /// [RenderBoxContainerDefaultsMixin] to get started or [RenderStack] for an

--- a/packages/flutter/lib/src/rendering/custom_layout.dart
+++ b/packages/flutter/lib/src/rendering/custom_layout.dart
@@ -29,7 +29,9 @@ class MultiChildLayoutParentData extends ContainerBoxParentData<RenderBox> {
 /// given the previous instance.
 ///
 /// Override [getSize] to control the overall size of the layout. The size of
-/// the layout cannot depend on layout properties of the children.
+/// the layout cannot depend on layout properties of the children because
+/// the delegate implementations should not have to also handle various
+/// intrinsic sizing functions if the parent's size depended on the children.
 /// If you want to build a custom layout where you define the size of that widget
 /// based on its children, then you will have to create a custom render object.
 /// See [MultiChildRenderObjectWidget] with [ContainerRenderObjectMixin] and

--- a/packages/flutter/lib/src/rendering/custom_layout.dart
+++ b/packages/flutter/lib/src/rendering/custom_layout.dart
@@ -30,7 +30,7 @@ class MultiChildLayoutParentData extends ContainerBoxParentData<RenderBox> {
 ///
 /// Override [getSize] to control the overall size of the layout. The size of
 /// the layout cannot depend on layout properties of the children.
-/// If you want to do build custom layout where you define the size of that widget
+/// If you want to do build a custom layout where you define the size of that widget
 /// based on its children, then you will have to create a custom render object.
 /// See [MultiChildRenderObjectWidget] with [ContainerRenderObjectMixin] and
 /// [RenderBoxContainerDefaultsMixin] to get started or [RenderStack] for an

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1955,7 +1955,7 @@ class LayoutId extends ParentDataWidget<CustomMultiChildLayout> {
 /// the children.
 ///
 /// [CustomMultiChildLayout] is appropriate when there are complex relationships
-/// between the size and positioning of a multiple widgets. To control the
+/// between the size and positioning of multiple widgets. To control the
 /// layout of a single child, [CustomSingleChildLayout] is more appropriate. For
 /// simple cases, such as aligning a widget to one or another edge, the [Stack]
 /// widget is more appropriate.


### PR DESCRIPTION
## Description

The title is taken from https://github.com/flutter/flutter/issues/18426 because this PR does exactly what the issue is title (and fixes a typo).  

I will most likely write an article about how to use `MultiChildRenderObject` as part of the Flutter Clock challenge, but I suppose that it would be against the guidelines to link it in the docs anyway - so I hope that mentioning relevant classes, even though they lack documentation, is sufficient for now. I think that I remember learning about it as quite easy by example when I used it for the first time, which is why I also mentioned `Stack`, even though there might be easier examples because `Stack` is fairly complex.

## Related Issues

Resolves #18426.

## Tests

No tests are needed for documentation only.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.