### PR TITLE
Fix ShaderWarmUp docs

### DIFF
--- a/packages/flutter/lib/src/painting/shader_warm_up.dart
+++ b/packages/flutter/lib/src/painting/shader_warm_up.dart
@@ -32,8 +32,9 @@ import 'package:flutter/foundation.dart';
 /// `CircularRRectOp`) would suggest Xyz draw operations are causing the
 /// shaders to be compiled. A useful shader warm-up draw operation would
 /// eliminate such long compilation calls in the animation. To double-check
-/// the warm-up, trace with `flutter run --profile --trace-skia --start-
-/// paused`. The `GrGLProgramBuilder` with the associated `XyzOp` should
+/// the warm-up, trace with
+/// `flutter run --profile --trace-skia --start-paused`.
+/// The `GrGLProgramBuilder` with the associated `XyzOp` should
 /// appear during startup rather than in the middle of a later animation.
 
 ///
@@ -67,8 +68,9 @@ abstract class ShaderWarmUp {
   /// compilation cache.
   ///
   /// To decide which draw operations to be added to your custom warm up
-  /// process, try capture an skp using `flutter screenshot --observatory-
-  /// port=<port> --type=skia` and analyze it with https://debugger.skia.org.
+  /// process, try capture an skp using
+  /// `flutter screenshot --observatory-uri=<uri> --type=skia`
+  /// and analyze it with https://debugger.skia.org.
   /// Alternatively, one may run the app with `flutter run --trace-skia` and
   /// then examine the GPU thread in the observatory timeline to see which
   /// Skia draw operations are commonly used, and which shader compilations


### PR DESCRIPTION
## Description

Two of the `flutter` commands had a space in them, i.e. one in `--observatory- port` and one in `--start- paused`, because of how line breaks in the documentation are rendered to HTML.  
Additionally, `--observatory-port` is not an option anymore. It was replaced by `--observatory-uri`.

## Tests

No tests necessary for documentation-only changes.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.