### PR TITLE
[flutter_tool][wip] cache some expensive filesystem operations

### DIFF
--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -611,6 +611,7 @@ abstract class ResidentRunner {
     if (!artifactDirectory.existsSync()) {
       artifactDirectory.createSync(recursive: true);
     }
+    _defaultDillPath = fs.path.join(artifactDirectory.path, 'app.dill');
     // TODO(jonahwilliams): this is a temporary work around to regain some of
     // the initialize from dill performance. Longer term, we should have a
     // better way to determine where the appropriate dill file is, as this
@@ -651,7 +652,8 @@ abstract class ResidentRunner {
     });
   }
 
-  String get dillOutputPath => _dillOutputPath ?? fs.path.join(artifactDirectory.path, 'app.dill');
+  String _defaultDillPath;
+  String get dillOutputPath => _dillOutputPath ?? _defaultDillPath;
   String getReloadPath({ bool fullRestart }) => mainPath + (fullRestart ? '' : '.incremental') + '.dill';
 
   bool get debuggingEnabled => debuggingOptions.debuggingEnabled;


### PR DESCRIPTION
## Description

Small performance improvements to hot reload. In the no-op case (no files dirty) on my local laptop, the average of 18 reloads improved from 73.6 ms to 63.1 ms, approximately a 10 ms reduction. This was achieved by comparing the CPU flame charts in the devtools (shout out to devtools!) and identifying several cases of unnecessary slowness:

1. Remove extra refreshViews RPC. This is called once at the beginning of the hot reload, it doesn't need to be performed again after the compile.

2. (WIP) Cache the packageUri mapper. This needs to read and parse the .packages file so it is a fairly expensive operation. Unfortunately I still need to find a way to invalidate it if the .packages changes, so it might need a re-configuration. 

3. Only compute assetDirectory and assetDirectory if an asset is dirty. This does a surprisingly large amount of filesystem and uri operations.

4. Cache the _defaultDillPath, this doesn't ever change but again requires a surprisingly expensive filesystem/uri operations.

5. Remove some out of date comments that refer to running from source - this hasn't been correct since dart 1