### PR TITLE
Flexible padding (header height) for expanded panels

### DIFF
--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -227,7 +227,7 @@ class ExpansionPanelList extends StatefulWidget {
     this.children = const <ExpansionPanel>[],
     this.expansionCallback,
     this.animationDuration = kThemeAnimationDuration,
-    this.expandedPadding = _kPanelHeaderExpandedDefaultPadding
+    this.expandedHeaderPadding = _kPanelHeaderExpandedDefaultPadding
   }) : assert(children != null),
        assert(animationDuration != null),
        _allowOnlyOnePanelOpen = false,
@@ -316,7 +316,7 @@ class ExpansionPanelList extends StatefulWidget {
     this.expansionCallback,
     this.animationDuration = kThemeAnimationDuration,
     this.initialOpenPanelValue,
-    this.expandedPadding = _kPanelHeaderExpandedDefaultPadding
+    this.expandedHeaderPadding = _kPanelHeaderExpandedDefaultPadding
   }) : assert(children != null),
        assert(animationDuration != null),
        _allowOnlyOnePanelOpen = true,
@@ -360,7 +360,7 @@ class ExpansionPanelList extends StatefulWidget {
   /// during expansion.
   /// This property can be used to adjust this behavior, for example to achieve
   /// a more compact representation or an indentation of the header.
-  final EdgeInsets expandedPadding;
+  final EdgeInsets expandedHeaderPadding;
 
   @override
   State<StatefulWidget> createState() => _ExpansionPanelListState();
@@ -483,7 +483,7 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
             child: AnimatedContainer(
               duration: widget.animationDuration,
               curve: Curves.fastOutSlowIn,
-              margin: _isChildExpanded(index) ? widget.expandedPadding : EdgeInsets.zero,
+              margin: _isChildExpanded(index) ? widget.expandedHeaderPadding : EdgeInsets.zero,
               child: ConstrainedBox(
                 constraints: const BoxConstraints(minHeight: _kPanelHeaderCollapsedHeight),
                 child: headerWidget,

--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -13,7 +13,9 @@ import 'mergeable_material.dart';
 import 'theme.dart';
 
 const double _kPanelHeaderCollapsedHeight = kMinInteractiveDimension;
-const double _kPanelHeaderExpandedHeight = 64.0;
+const EdgeInsets _kPanelExpandedDefaultPadding = EdgeInsets.symmetric(
+    vertical: 64.0 - _kPanelHeaderCollapsedHeight
+);
 
 class _SaltedKey<S, V> extends LocalKey {
   const _SaltedKey(this.salt, this.value);
@@ -225,6 +227,7 @@ class ExpansionPanelList extends StatefulWidget {
     this.children = const <ExpansionPanel>[],
     this.expansionCallback,
     this.animationDuration = kThemeAnimationDuration,
+    this.expandedPadding = _kPanelExpandedDefaultPadding
   }) : assert(children != null),
        assert(animationDuration != null),
        _allowOnlyOnePanelOpen = false,
@@ -313,6 +316,7 @@ class ExpansionPanelList extends StatefulWidget {
     this.expansionCallback,
     this.animationDuration = kThemeAnimationDuration,
     this.initialOpenPanelValue,
+    this.expandedPadding = _kPanelExpandedDefaultPadding
   }) : assert(children != null),
        assert(animationDuration != null),
        _allowOnlyOnePanelOpen = true,
@@ -350,6 +354,9 @@ class ExpansionPanelList extends StatefulWidget {
   /// only used when initializing with the [ExpansionPanelList.radio]
   /// constructor.)
   final Object initialOpenPanelValue;
+
+  /// Padding is applied to entire panel when expanded
+  final EdgeInsets expandedPadding;
 
   @override
   State<StatefulWidget> createState() => _ExpansionPanelListState();
@@ -437,9 +444,6 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
   @override
   Widget build(BuildContext context) {
     final List<MergeableMaterialItem> items = <MergeableMaterialItem>[];
-    const EdgeInsets kExpandedEdgeInsets = EdgeInsets.symmetric(
-      vertical: _kPanelHeaderExpandedHeight - _kPanelHeaderCollapsedHeight
-    );
 
     for (int index = 0; index < widget.children.length; index += 1) {
       if (_isChildExpanded(index) && index != 0 && !_isChildExpanded(index - 1))
@@ -475,7 +479,7 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
             child: AnimatedContainer(
               duration: widget.animationDuration,
               curve: Curves.fastOutSlowIn,
-              margin: _isChildExpanded(index) ? kExpandedEdgeInsets : EdgeInsets.zero,
+              margin: _isChildExpanded(index) ? widget.expandedPadding : EdgeInsets.zero,
               child: ConstrainedBox(
                 constraints: const BoxConstraints(minHeight: _kPanelHeaderCollapsedHeight),
                 child: headerWidget,

--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -227,7 +227,7 @@ class ExpansionPanelList extends StatefulWidget {
     this.children = const <ExpansionPanel>[],
     this.expansionCallback,
     this.animationDuration = kThemeAnimationDuration,
-    this.expandedHeaderPadding = _kPanelHeaderExpandedDefaultPadding
+    this.expandedHeaderPadding = _kPanelHeaderExpandedDefaultPadding,
   }) : assert(children != null),
        assert(animationDuration != null),
        _allowOnlyOnePanelOpen = false,
@@ -316,7 +316,7 @@ class ExpansionPanelList extends StatefulWidget {
     this.expansionCallback,
     this.animationDuration = kThemeAnimationDuration,
     this.initialOpenPanelValue,
-    this.expandedHeaderPadding = _kPanelHeaderExpandedDefaultPadding
+    this.expandedHeaderPadding = _kPanelHeaderExpandedDefaultPadding,
   }) : assert(children != null),
        assert(animationDuration != null),
        _allowOnlyOnePanelOpen = true,
@@ -355,11 +355,10 @@ class ExpansionPanelList extends StatefulWidget {
   /// constructor.)
   final Object initialOpenPanelValue;
 
-  /// Padding is applied to panel header when expanded.
-  /// By default, some space is added to the header vertically above and below
+  /// The padding that surrounds the panel header when expanded.
+  ///
+  /// By default, 16px of space is added to the header vertically (above and below)
   /// during expansion.
-  /// This property can be used to adjust this behavior, for example to achieve
-  /// a more compact representation or an indentation of the header.
   final EdgeInsets expandedHeaderPadding;
 
   @override

--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -355,7 +355,11 @@ class ExpansionPanelList extends StatefulWidget {
   /// constructor.)
   final Object initialOpenPanelValue;
 
-  /// Padding is applied to entire panel when expanded
+  /// Padding is applied to panel header when expanded.
+  /// By default, some space is added to the header vertically above and below
+  /// during expansion.
+  /// This property can be used to adjust this behavior, for example to achieve
+  /// a more compact representation or an indentation of the header.
   final EdgeInsets expandedPadding;
 
   @override

--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -13,7 +13,7 @@ import 'mergeable_material.dart';
 import 'theme.dart';
 
 const double _kPanelHeaderCollapsedHeight = kMinInteractiveDimension;
-const EdgeInsets _kPanelExpandedDefaultPadding = EdgeInsets.symmetric(
+const EdgeInsets _kPanelHeaderExpandedDefaultPadding = EdgeInsets.symmetric(
     vertical: 64.0 - _kPanelHeaderCollapsedHeight
 );
 
@@ -227,7 +227,7 @@ class ExpansionPanelList extends StatefulWidget {
     this.children = const <ExpansionPanel>[],
     this.expansionCallback,
     this.animationDuration = kThemeAnimationDuration,
-    this.expandedPadding = _kPanelExpandedDefaultPadding
+    this.expandedPadding = _kPanelHeaderExpandedDefaultPadding
   }) : assert(children != null),
        assert(animationDuration != null),
        _allowOnlyOnePanelOpen = false,
@@ -316,7 +316,7 @@ class ExpansionPanelList extends StatefulWidget {
     this.expansionCallback,
     this.animationDuration = kThemeAnimationDuration,
     this.initialOpenPanelValue,
-    this.expandedPadding = _kPanelExpandedDefaultPadding
+    this.expandedPadding = _kPanelHeaderExpandedDefaultPadding
   }) : assert(children != null),
        assert(animationDuration != null),
        _allowOnlyOnePanelOpen = true,

--- a/packages/flutter/test/material/expansion_panel_test.dart
+++ b/packages/flutter/test/material/expansion_panel_test.dart
@@ -1275,7 +1275,7 @@ void main() {
         home: SingleChildScrollView(
           child: SimpleExpansionPanelListTestWidget(
             firstPanelKey: firstPanelKey,
-            canTapOnHeader: true
+            canTapOnHeader: true,
           ),
         ),
       ),

--- a/packages/flutter/test/material/expansion_panel_test.dart
+++ b/packages/flutter/test/material/expansion_panel_test.dart
@@ -5,7 +5,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-
 class SimpleExpansionPanelListTestWidget extends StatefulWidget {
   const SimpleExpansionPanelListTestWidget({
     Key key,
@@ -19,7 +18,7 @@ class SimpleExpansionPanelListTestWidget extends StatefulWidget {
   final Key secondPanelKey;
   final bool canTapOnHeader;
 
-  /// If null the below default is applied
+  /// If null, the default [ExpansionPanelList]'s expanded header padding value is applied via [defaultExpandedHeaderPadding]
   final EdgeInsets expandedHeaderPadding;
 
   /// Mirrors the default expanded header padding as its source constants are private
@@ -1275,8 +1274,8 @@ void main() {
       const MaterialApp(
         home: SingleChildScrollView(
           child: SimpleExpansionPanelListTestWidget(
-              firstPanelKey: firstPanelKey,
-              canTapOnHeader: true
+            firstPanelKey: firstPanelKey,
+            canTapOnHeader: true
           ),
         ),
       ),

--- a/packages/flutter/test/material/expansion_panel_test.dart
+++ b/packages/flutter/test/material/expansion_panel_test.dart
@@ -57,7 +57,7 @@ class _SimpleExpansionPanelListTestWidgetState extends State<SimpleExpansionPane
 
     return widget.expandedHeaderPadding == null
         ? ExpansionPanelList(expansionCallback: expansionPanelCallback, children: children)
-        : ExpansionPanelList(expansionCallback: expansionPanelCallback, children: children, expandedPadding: widget.expandedHeaderPadding);
+        : ExpansionPanelList(expansionCallback: expansionPanelCallback, children: children, expandedHeaderPadding: widget.expandedHeaderPadding);
   }
 }
 

--- a/packages/flutter/test/material/expansion_panel_test.dart
+++ b/packages/flutter/test/material/expansion_panel_test.dart
@@ -1255,4 +1255,60 @@ void main() {
     expect(find.text('C'), findsOneWidget);
     expect(find.text('D'), findsNothing);
   });
+
+  testWidgets('Correct custom expanded padding', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SingleChildScrollView(
+          child: ExpansionPanelList(
+            expansionCallback: (int _index, bool _isExpanded) {},
+            children: <ExpansionPanel>[
+              ExpansionPanel(
+                headerBuilder: (BuildContext context, bool isExpanded) {
+                  return Text(isExpanded ? 'B' : 'A');
+                },
+                body: const SizedBox(height: 100.0),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('A'), findsOneWidget);
+    expect(find.text('B'), findsNothing);
+    RenderBox box = tester.renderObject(find.byType(ExpansionPanelList));
+    final double oldHeight = box.size.height;
+    expect(box.size.height, equals(oldHeight));
+
+    // Now, expand the child panel.
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SingleChildScrollView(
+          child: ExpansionPanelList(
+            expansionCallback: (int _index, bool _isExpanded) {},
+            expandedPadding: const EdgeInsets.symmetric(vertical: 40.0),
+            children: <ExpansionPanel>[
+              ExpansionPanel(
+                headerBuilder: (BuildContext context, bool isExpanded) {
+                  return Text(isExpanded ? 'B' : 'A');
+                },
+                body: const SizedBox(height: 100.0),
+                isExpanded: true, // this is the addition
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(find.text('A'), findsNothing);
+    expect(find.text('B'), findsOneWidget);
+    box = tester.renderObject(find.byType(ExpansionPanelList));
+
+    final double heightDelta = box.size.height - oldHeight;
+    expect(heightDelta, greaterThanOrEqualTo(170.0));
+    expect(heightDelta, lessThanOrEqualTo(180.0));
+  });
 }


### PR DESCRIPTION
## Description

Adds a flexible padding property for expanded panels for solving hardcoded header height described in #24071.
I'm unsure if this property belongs to the list or panel itself. I preferred the list, as the behavior for all children is considered equally.
Due to my low flutter experience feedback is highly welcome. 

## Related Issues

* #24071

## Tests

I added a test for asserting that custom padding is applied correctly for expanded panels.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
