### PR TITLE
Revert Switch state when it is dragged and value isn't changed

### DIFF
--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -444,11 +444,13 @@ class _RenderCupertinoSwitch extends RenderConstrainedBox {
   void _handleDragEnd(DragEndDetails details) {
     if (_position.value >= 0.5)
       _positionController.forward().whenComplete(() {
-        if (!_value) _positionController.reverse();
+        if (!_value)
+          _positionController.reverse();
       });
     else
       _positionController.reverse().whenComplete(() {
-        if (_value) _positionController.forward();
+        if (_value)
+          _positionController.forward();
       });
     _reactionController.reverse();
   }

--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -443,9 +443,13 @@ class _RenderCupertinoSwitch extends RenderConstrainedBox {
 
   void _handleDragEnd(DragEndDetails details) {
     if (_position.value >= 0.5)
-      _positionController.forward();
+      _positionController.forward().whenComplete(() {
+        if (!_value) _positionController.reverse();
+      });
     else
-      _positionController.reverse();
+      _positionController.reverse().whenComplete(() {
+        if (_value) _positionController.forward();
+      });
     _reactionController.reverse();
   }
 

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -596,11 +596,13 @@ class _RenderSwitch extends RenderToggleable {
   void _handleDragEnd(DragEndDetails details) {
     if (position.value >= 0.5)
       positionController.forward().whenComplete(() {
-        if (!value) positionController.reverse();
+        if (!value)
+          positionController.reverse();
       });
     else
       positionController.reverse().whenComplete(() {
-        if (value) positionController.forward();
+        if (value)
+          positionController.forward();
       });
     reactionController.reverse();
   }

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -595,9 +595,13 @@ class _RenderSwitch extends RenderToggleable {
 
   void _handleDragEnd(DragEndDetails details) {
     if (position.value >= 0.5)
-      positionController.forward();
+      positionController.forward().whenComplete(() {
+        if (!value) positionController.reverse();
+      });
     else
-      positionController.reverse();
+      positionController.reverse().whenComplete(() {
+        if (value) positionController.forward();
+      });
     reactionController.reverse();
   }
 


### PR DESCRIPTION
## Description
This PR reverts back the state of `Switch` and `CupertinoSwitch` when it is toggled by dragging but the `value` is not changed.

## Related Issues
Fixes #46046

## Tests

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
