### PR TITLE
Allow Xcode project Info.plist to be moved

### DIFF
--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -444,7 +444,7 @@ apply plugin: 'kotlin-android'
         final FlutterProject project = await someProject();
         addIosProjectFile(project.directory, projectFileContent: () {
           return projectFileWithBundleId('io.flutter.someProject', qualifier: '\'');
-              });
+        });
         expect(await project.organizationNames, <String>['io.flutter']);
       });
       testInMemory('is populated from Android application ID', () async {
@@ -459,7 +459,7 @@ apply plugin: 'kotlin-android'
         final FlutterProject project = await someProject();
         addIosProjectFile(project.example.directory, projectFileContent: () {
           return projectFileWithBundleId('io.flutter.someProject', qualifier: '\'');
-              });
+        });
         expect(await project.organizationNames, <String>['io.flutter']);
       });
       testInMemory('is populated from Android application ID in plugin example', () async {
@@ -479,7 +479,7 @@ apply plugin: 'kotlin-android'
         final FlutterProject project = await someProject();
         addIosProjectFile(project.directory, projectFileContent: () {
           return projectFileWithBundleId('io.flutter.someProject');
-              });
+        });
         addAndroidGradleFile(project.directory,
           gradleFileContent: () {
             return gradleFileWithApplicationId('io.flutter.someproject');
@@ -490,7 +490,7 @@ apply plugin: 'kotlin-android'
         final FlutterProject project = await someProject();
         addIosProjectFile(project.directory, projectFileContent: () {
           return projectFileWithBundleId('io.flutter.someProject');
-              });
+        });
         addAndroidGradleFile(project.directory,
           gradleFileContent: () {
             return gradleFileWithApplicationId('io.clutter.someproject');

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -365,6 +365,14 @@ apply plugin: 'kotlin-android'
         expect(await project.ios.productBundleIdentifier, 'io.flutter.someProject');
       });
 
+      testWithMocks('from project file, if no plist or build settings', () async {
+        final FlutterProject project = await someProject();
+        addIosProjectFile(project.directory, projectFileContent: () {
+          return projectFileWithBundleId('io.flutter.someProject');
+        });
+        expect(await project.ios.productBundleIdentifier, 'io.flutter.someProject');
+      });
+
       testWithMocks('from plist, if no variables', () async {
         final FlutterProject project = await someProject();
         project.ios.defaultHostInfoPlist.createSync(recursive: true);
@@ -399,6 +407,27 @@ apply plugin: 'kotlin-android'
         when(mockPlistUtils.getValueFromFile(any, any)).thenReturn('\$(PRODUCT_BUNDLE_IDENTIFIER).\$(SUFFIX)');
         expect(await project.ios.productBundleIdentifier, 'io.flutter.someProject.suffix');
       });
+      testWithMocks('empty surrounded by quotes', () async {
+        final FlutterProject project = await someProject();
+        addIosProjectFile(project.directory, projectFileContent: () {
+          return projectFileWithBundleId('', qualifier: '"');
+        });
+        expect(await project.ios.productBundleIdentifier, '');
+      });
+      testWithMocks('surrounded by double quotes', () async {
+        final FlutterProject project = await someProject();
+        addIosProjectFile(project.directory, projectFileContent: () {
+          return projectFileWithBundleId('io.flutter.someProject', qualifier: '"');
+        });
+        expect(await project.ios.productBundleIdentifier, 'io.flutter.someProject');
+      });
+      testWithMocks('surrounded by single quotes', () async {
+        final FlutterProject project = await someProject();
+        addIosProjectFile(project.directory, projectFileContent: () {
+          return projectFileWithBundleId('io.flutter.someProject', qualifier: '\'');
+        });
+        expect(await project.ios.productBundleIdentifier, 'io.flutter.someProject');
+      });
     });
 
     group('organization names set', () {
@@ -406,25 +435,18 @@ apply plugin: 'kotlin-android'
         final FlutterProject project = await someProject();
         expect(await project.organizationNames, isEmpty);
       });
-
       testInMemory('is empty, if no platform folders exist', () async {
         final FlutterProject project = await someProject();
         project.directory.createSync();
         expect(await project.organizationNames, isEmpty);
       });
-
       testInMemory('is populated from iOS bundle identifier', () async {
         final FlutterProject project = await someProject();
-        when(xcodeProjectInterpreter.getBuildSettings(project.ios.xcodeProject.path, any)).thenAnswer(
-                (_) {
-              return Future<Map<String,String>>.value(<String, String>{
-                'PRODUCT_BUNDLE_IDENTIFIER': 'io.flutter.someProject',
+        addIosProjectFile(project.directory, projectFileContent: () {
+          return projectFileWithBundleId('io.flutter.someProject', qualifier: '\'');
               });
-            }
-        );
         expect(await project.organizationNames, <String>['io.flutter']);
       });
-
       testInMemory('is populated from Android application ID', () async {
         final FlutterProject project = await someProject();
         addAndroidGradleFile(project.directory,
@@ -433,20 +455,13 @@ apply plugin: 'kotlin-android'
           });
         expect(await project.organizationNames, <String>['io.flutter']);
       });
-
       testInMemory('is populated from iOS bundle identifier in plugin example', () async {
         final FlutterProject project = await someProject();
-        when(xcodeProjectInterpreter.getBuildSettings(project.ios.xcodeProject.path, any)).thenReturn(null);
-        when(xcodeProjectInterpreter.getBuildSettings(project.example.ios.xcodeProject.path, any)).thenAnswer(
-                (_) {
-              return Future<Map<String,String>>.value(<String, String>{
-                'PRODUCT_BUNDLE_IDENTIFIER': 'io.flutter.someProject',
+        addIosProjectFile(project.example.directory, projectFileContent: () {
+          return projectFileWithBundleId('io.flutter.someProject', qualifier: '\'');
               });
-            }
-        );
         expect(await project.organizationNames, <String>['io.flutter']);
       });
-
       testInMemory('is populated from Android application ID in plugin example', () async {
         final FlutterProject project = await someProject();
         addAndroidGradleFile(project.example.directory,
@@ -455,38 +470,27 @@ apply plugin: 'kotlin-android'
           });
         expect(await project.organizationNames, <String>['io.flutter']);
       });
-
       testInMemory('is populated from Android group in plugin', () async {
         final FlutterProject project = await someProject();
         addAndroidWithGroup(project.directory, 'io.flutter.someproject');
         expect(await project.organizationNames, <String>['io.flutter']);
       });
-
       testInMemory('is singleton, if sources agree', () async {
         final FlutterProject project = await someProject();
-        when(xcodeProjectInterpreter.getBuildSettings(any, any)).thenAnswer(
-                (_) {
-              return Future<Map<String,String>>.value(<String, String>{
-                'PRODUCT_BUNDLE_IDENTIFIER': 'io.flutter.someProject',
+        addIosProjectFile(project.directory, projectFileContent: () {
+          return projectFileWithBundleId('io.flutter.someProject');
               });
-            }
-        );
         addAndroidGradleFile(project.directory,
           gradleFileContent: () {
             return gradleFileWithApplicationId('io.flutter.someproject');
           });
         expect(await project.organizationNames, <String>['io.flutter']);
       });
-
       testInMemory('is non-singleton, if sources disagree', () async {
         final FlutterProject project = await someProject();
-        when(xcodeProjectInterpreter.getBuildSettings(any, any)).thenAnswer(
-                (_) {
-              return Future<Map<String,String>>.value(<String, String>{
-                'PRODUCT_BUNDLE_IDENTIFIER': 'io.flutter.someProject',
+        addIosProjectFile(project.directory, projectFileContent: () {
+          return projectFileWithBundleId('io.flutter.someProject');
               });
-            }
-        );
         addAndroidGradleFile(project.directory,
           gradleFileContent: () {
             return gradleFileWithApplicationId('io.clutter.someproject');
@@ -621,7 +625,6 @@ void testInMemory(String description, Future<void> testMethod()) {
       .childDirectory('schema'), testFileSystem);
 
   final FlutterProjectFactory flutterProjectFactory = FlutterProjectFactory();
-  final MockXcodeProjectInterpreter mockXcodeProjectInterpreter = MockXcodeProjectInterpreter();
 
   testUsingContext(
     description,
@@ -631,7 +634,6 @@ void testInMemory(String description, Future<void> testMethod()) {
       ProcessManager: () => FakeProcessManager.any(),
       Cache: () => Cache(),
       FlutterProjectFactory: () => flutterProjectFactory,
-      XcodeProjectInterpreter: () => mockXcodeProjectInterpreter
     },
   );
 }
@@ -701,6 +703,20 @@ flutter:
     something:
   something_else:
 ''';
+
+String projectFileWithBundleId(String id, {String qualifier}) {
+  return '''
+97C147061CF9000F007C117D /* Debug */ = {
+  isa = XCBuildConfiguration;
+  baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
+  buildSettings = {
+    PRODUCT_BUNDLE_IDENTIFIER = ${qualifier ?? ''}$id${qualifier ?? ''};
+    PRODUCT_NAME = "\$(TARGET_NAME)";
+  };
+  name = Debug;
+};
+''';
+}
 
 String gradleFileWithApplicationId(String id) {
   return '''


### PR DESCRIPTION
## Description

Developers are able to change the location of Xcode project Info.plists in Xcode build settings, and can have different Info.plists for different schemes or configurations.

The Info.plist is only used to cheaply figure out a bundle identifier without parsing the build settings.

1. Check the default Info.plist location, but fall back to the build settings if it's not found.
1. Never parse the bundle identifier from the Xcode project file.  This is unsafe since there can be multiple bundle identifiers if the user adds another bundle to a project, like their own framework or a watch app, etc.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/46730
See https://github.com/flutter/flutter/issues/28895#issuecomment-552409176

## Tests

I added the following tests:

project_test

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*