### PR TITLE
Fix MediaQuery override in CupertinoDatePicker

### DIFF
--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -777,7 +777,7 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
     }
 
     return MediaQuery(
-      data: const MediaQueryData(textScaleFactor: 1.0),
+      data: MediaQuery.of(context).copyWith(textScaleFactor: 1.0),
       child: DefaultTextStyle.merge(
         style: _kDefaultPickerTextStyle,
         child: CustomMultiChildLayout(
@@ -1145,7 +1145,7 @@ class _CupertinoDatePickerDateState extends State<CupertinoDatePicker> {
     }
 
     return MediaQuery(
-      data: const MediaQueryData(textScaleFactor: 1.0),
+      data: MediaQuery.of(context).copyWith(textScaleFactor: 1.0),
       child: DefaultTextStyle.merge(
         style: _kDefaultPickerTextStyle,
         child: CustomMultiChildLayout(
@@ -1669,11 +1669,9 @@ class _CupertinoTimerPickerState extends State<CupertinoTimerPicker> {
     }
     final CupertinoThemeData themeData = CupertinoTheme.of(context);
     return MediaQuery(
-      data: const MediaQueryData(
-        // The native iOS picker's text scaling is fixed, so we will also fix it
-        // as well in our picker.
-        textScaleFactor: 1.0,
-      ),
+      // The native iOS picker's text scaling is fixed, so we will also fix it
+      // as well in our picker.
+      data: MediaQuery.of(context).copyWith(textScaleFactor: 1.0),
       child: CupertinoTheme(
         data: themeData.copyWith(
           textTheme: themeData.textTheme.copyWith(

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -1187,6 +1187,51 @@ void main() {
     handle.dispose();
   });
 
+  testWidgets('CupertinoDataPicker does not provide invalid MediaQuery', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/47989.
+    Brightness brightness = Brightness.light;
+    StateSetter setState;
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        theme: const CupertinoThemeData(
+          textTheme: CupertinoTextThemeData(
+            dateTimePickerTextStyle: TextStyle(
+              color: CupertinoDynamicColor.withBrightness(
+                color: Color(0xFFFFFFFF),
+                darkColor: Color(0xFF000000),
+              ),
+            ),
+          ),
+        ),
+        home: StatefulBuilder(builder: (BuildContext context, StateSetter stateSetter) {
+          setState = stateSetter;
+          return MediaQuery(
+            data: MediaQuery.of(context).copyWith(platformBrightness: brightness),
+            child: CupertinoDatePicker(
+              initialDateTime: DateTime(2019),
+              mode: CupertinoDatePickerMode.date,
+              onDateTimeChanged: (DateTime date) {},
+            ),
+          );
+        }),
+      ),
+    );
+
+    expect(
+      tester.widget<Text>(find.text('2019')).style.color,
+      isSameColorAs(const Color(0xFFFFFFFF)),
+    );
+
+    setState(() { brightness = Brightness.dark; });
+    await tester.pump();
+
+    expect(
+      tester.widget<Text>(find.text('2019')).style.color,
+      isSameColorAs(const Color(0xFF000000)),
+    );
+  });
+
   testWidgets('picker exports semantics', (WidgetTester tester) async {
     final SemanticsHandle handle = tester.ensureSemantics();
     debugResetSemanticsIdCounter();


### PR DESCRIPTION
## Description

Fixes `MediaQuery` override in `CupertinoDatePicker` that causes descendant widgets to receive wrong `Brightness`. Thank @owalerys for reporting this issue!

## Related Issues

Fixes https://github.com/flutter/flutter/issues/47989

## Tests

I added the following tests:

- CupertinoDataPicker does not provide invalid MediaQuery.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
