### PR TITLE
Remove simulator arch in Profile and Release, App.xcframework

### DIFF
--- a/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
@@ -80,61 +80,51 @@ Future<void> main() async {
         'App',
       ));
 
-      final String appFrameworkPath = path.join(
+      final String debugAppFrameworkPath = path.join(
         outputPath,
         'Debug',
         'App.framework',
         'App',
       );
-      final String aotSymbols = await dylibSymbols(appFrameworkPath);
+      final String aotSymbols = await dylibSymbols(debugAppFrameworkPath);
 
       if (aotSymbols.contains('architecture') ||
           aotSymbols.contains('_kDartVmSnapshot')) {
         throw TaskResult.failure('Debug App.framework contains AOT');
       }
+      await _checkFrameworkArchs(debugAppFrameworkPath, 'Debug');
 
-      final String debugAppArchs = await fileType(appFrameworkPath);
+      checkFileExists(path.join(
+        outputPath,
+        'Debug',
+        'App.xcframework',
+        'ios-armv7_arm64',
+        'App.framework',
+        'App',
+      ));
 
-      if (!debugAppArchs.contains('armv7')) {
-        throw TaskResult.failure('Debug App.framework armv7 architecture missing');
-      }
-
-      if (!debugAppArchs.contains('arm64')) {
-        throw TaskResult.failure('Debug App.framework arm64 architecture missing');
-      }
-
-      if (!debugAppArchs.contains('x86_64')) {
-        throw TaskResult.failure('Debug App.framework x86_64 architecture missing');
-      }
+      checkFileExists(path.join(
+        outputPath,
+        'Debug',
+        'App.xcframework',
+        'ios-x86_64-simulator',
+        'App.framework',
+        'App',
+      ));
 
       section('Check profile, release builds has Dart AOT dylib');
 
       for (String mode in <String>['Profile', 'Release']) {
-        checkFileExists(path.join(
+        final String appFrameworkPath = path.join(
           outputPath,
           mode,
           'App.framework',
           'App',
-        ));
+        );
 
-        final String aotSymbols = await dylibSymbols(path.join(
-          outputPath,
-          mode,
-          'App.framework',
-          'App',
-        ));
+        await _checkFrameworkArchs(appFrameworkPath, mode);
 
-        if (!aotSymbols.contains('armv7')) {
-          throw TaskResult.failure('$mode App.framework armv7 architecture missing');
-        }
-
-        if (!aotSymbols.contains('arm64')) {
-          throw TaskResult.failure('$mode App.framework arm64 architecture missing');
-        }
-
-        if (aotSymbols.contains('x86_64')) {
-          throw TaskResult.failure('$mode App.framework contains x86_64 architecture');
-        }
+        final String aotSymbols = await dylibSymbols(appFrameworkPath);
 
         if (!aotSymbols.contains('_kDartVmSnapshot')) {
           throw TaskResult.failure('$mode App.framework missing Dart AOT');
@@ -147,17 +137,38 @@ Future<void> main() async {
           'flutter_assets',
           'vm_snapshot_data',
         ));
+
+        checkFileExists(path.join(
+          outputPath,
+          mode,
+          'App.xcframework',
+          'ios-armv7_arm64',
+          'App.framework',
+          'App',
+        ));
+
+        checkFileNotExists(path.join(
+          outputPath,
+          mode,
+          'App.xcframework',
+          'ios-x86_64-simulator',
+          'App.framework',
+          'App',
+        ));
       }
 
       section("Check all modes' engine dylib");
 
       for (String mode in <String>['Debug', 'Profile', 'Release']) {
-        checkFileExists(path.join(
+        final String engineFrameworkPath = path.join(
           outputPath,
           mode,
           'Flutter.framework',
           'Flutter',
-        ));
+        );
+
+        await _checkFrameworkArchs(engineFrameworkPath, mode);
+
         checkFileExists(path.join(
           outputPath,
           mode,
@@ -166,14 +177,19 @@ Future<void> main() async {
           'Flutter.framework',
           'Flutter',
         ));
-        checkFileExists(path.join(
+        final String simulatorFrameworkPath = path.join(
           outputPath,
           mode,
           'Flutter.xcframework',
           'ios-x86_64-simulator',
           'Flutter.framework',
           'Flutter',
-        ));
+        );
+        if (mode == 'Debug') {
+          checkFileExists(simulatorFrameworkPath);
+        } else {
+          checkFileNotExists(simulatorFrameworkPath);
+        }
       }
 
       section("Check all modes' engine header");
@@ -188,12 +204,14 @@ Future<void> main() async {
       section("Check all modes' have plugin dylib");
 
       for (String mode in <String>['Debug', 'Profile', 'Release']) {
-        checkFileExists(path.join(
+        final String pluginFrameworkPath = path.join(
           outputPath,
           mode,
           'device_info.framework',
           'device_info',
-        ));
+        );
+        await _checkFrameworkArchs(pluginFrameworkPath, mode);
+
         checkFileExists(path.join(
           outputPath,
           mode,
@@ -202,19 +220,33 @@ Future<void> main() async {
           'device_info.framework',
           'device_info',
         ));
-        checkFileExists(path.join(
+        final String simulatorFrameworkPath = path.join(
           outputPath,
           mode,
           'device_info.xcframework',
           'ios-x86_64-simulator',
           'device_info.framework',
           'device_info',
-        ));
+        );
+        if (mode == 'Debug') {
+          checkFileExists(simulatorFrameworkPath);
+        } else {
+          checkFileNotExists(simulatorFrameworkPath);
+        }
       }
 
       section("Check all modes' have generated plugin registrant");
 
       for (String mode in <String>['Debug', 'Profile', 'Release']) {
+        final String registrantFrameworkPath = path.join(
+          outputPath,
+          mode,
+          'FlutterPluginRegistrant.framework',
+          'FlutterPluginRegistrant'
+        );
+
+        await _checkFrameworkArchs(registrantFrameworkPath, mode);
+
         checkFileExists(path.join(
           outputPath,
           mode,
@@ -231,7 +263,7 @@ Future<void> main() async {
           'Headers',
           'GeneratedPluginRegistrant.h',
         ));
-        checkFileExists(path.join(
+        final String simulatorHeaderPath = path.join(
           outputPath,
           mode,
           'FlutterPluginRegistrant.xcframework',
@@ -239,7 +271,12 @@ Future<void> main() async {
           'FlutterPluginRegistrant.framework',
           'Headers',
           'GeneratedPluginRegistrant.h',
-        ));
+        );
+        if (mode == 'Debug') {
+          checkFileExists(simulatorHeaderPath);
+        } else {
+          checkFileNotExists(simulatorHeaderPath);
+        }
       }
 
       return TaskResult.success(null);
@@ -251,4 +288,25 @@ Future<void> main() async {
       rmTree(tempDir);
     }
   });
+}
+
+Future<void> _checkFrameworkArchs(String frameworkPath, String mode) async {
+  checkFileExists(frameworkPath);
+
+  final String archs = await fileType(frameworkPath);
+  if (!archs.contains('armv7')) {
+    throw TaskResult.failure('$mode $frameworkPath armv7 architecture missing');
+  }
+
+  if (!archs.contains('arm64')) {
+    throw TaskResult.failure('$mode $frameworkPath arm64 architecture missing');
+  }
+  final bool containsSimulator = archs.contains('x86_64');
+  final bool isDebug = mode == 'Debug';
+
+  // Debug should contain the simulator archs.
+  // Release and Profile should not.
+  if (containsSimulator != isDebug) {
+    throw TaskResult.failure('$mode $frameworkPath x86_64 architecture ${isDebug ? 'missing' : 'present'}');
+  }
 }


### PR DESCRIPTION
## Description

- Create App.xcframework
- Strip x86_64 from all frameworks in Profile and Release. This allows the frameworks to be codesigned during archive.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/44492
Fixes https://github.com/flutter/flutter/issues/47930

## Tests

Added cases to build_ios_framework_module_test.dart

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*