### PR TITLE
make pub get test shufflable

### DIFF
--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -31,6 +31,10 @@ void main() {
     Cache.flutterRoot = getFlutterRoot();
   });
 
+  tearDown(() {
+    MockDirectory.findCache = false;
+  });
+
   testUsingContext('pub get 69', () async {
     String error;
 


### PR DESCRIPTION
Fixes one of the failures in https://github.com/flutter/flutter/pull/47963/

Makes sure to reset global state after each test.