### PR TITLE
fix io_test

### DIFF
--- a/packages/flutter_tools/test/general.shard/base/io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/io_test.dart
@@ -77,6 +77,7 @@ void main() {
     setExitFunctionForTests((int value) {});
 
     expect(() => exit(0), returnsNormally);
+    restoreExitFunction();
   });
 
   test('test_api defines the Declarer in a known place', () {


### PR DESCRIPTION
Reset global state after test that  modifies it.

Part of making https://github.com/flutter/flutter/pull/47963 work

