### PR TITLE
Improve error message when a plugin sets an invalid android package

### DIFF
--- a/packages/flutter_tools/lib/src/platform_plugins.dart
+++ b/packages/flutter_tools/lib/src/platform_plugins.dart
@@ -111,10 +111,12 @@ class AndroidPlugin extends PluginPlatform {
       }
     }
     if (!mainClassFound) {
+      assert(mainClassCandidates.length <= 2);
       throwToolExit(
-        'The plugin $name doesn\'t have a main class defined in ${mainClassCandidates.join(' or ')}. '
-        'This is likely to due to an incorrect `androidPackage: $package` entry in the plugin\'s pubspec.yaml. '
-        'Please contact the author of this plugin and consider using a different plugin in the meanwhile. '
+        'The plugin `$name` doesn\'t have a main class defined in ${mainClassCandidates.join(' or ')}. '
+        'This is likely to due to an incorrect `androidPackage: $package` or `mainClass` entry in the plugin\'s pubspec.yaml.\n'
+        'If you are the author of this plugin, fix the `androidPackage` entry or move the main class to any of locations used above. '
+        'Otherwise, please contact the author of this plugin and consider using a different plugin in the meanwhile. '
       );
     }
 

--- a/packages/flutter_tools/test/general.shard/forbidden_imports_test.dart
+++ b/packages/flutter_tools/test/general.shard/forbidden_imports_test.dart
@@ -111,12 +111,15 @@ void main() {
   });
 
   test('no unauthorized imports of package:path', () {
-    final String whitelistedPath = globals.fs.path.join(flutterTools, 'lib', 'src', 'build_runner', 'web_compilation_delegate.dart');
+    final List<String> whitelistedPath = <String>[
+      globals.fs.path.join(flutterTools, 'lib', 'src', 'build_runner', 'web_compilation_delegate.dart'),
+      globals.fs.path.join(flutterTools, 'test', 'general.shard', 'platform_plugins_test.dart'),
+    ];
     for (final String dirName in <String>['lib', 'bin', 'test']) {
-      final Iterable<File> files = globals.fs.directory(globals.fs.path.join(flutterTools, dirName))
+      final Iterable<File> files =  globals.fs.directory(globals.fs.path.join(flutterTools, dirName))
         .listSync(recursive: true)
         .where(_isDartFile)
-        .where((FileSystemEntity entity) => entity.path != whitelistedPath)
+        .where((FileSystemEntity entity) => !whitelistedPath.contains(entity.path))
         .map(_asFile);
       for (final File file in files) {
         for (final String line in file.readAsLinesSync()) {

--- a/packages/flutter_tools/test/general.shard/platform_plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/platform_plugins_test.dart
@@ -1,0 +1,68 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/platform_plugins.dart';
+import 'package:mockito/mockito.dart';
+import 'package:path/path.dart' as p;
+
+import '../src/common.dart';
+import '../src/context.dart';
+
+void main() {
+  group('AndroidPlugin', () {
+    MockFileSystem mockFileSystem;
+    MockPathContext pathContext;
+
+    setUp(() {
+      pathContext = MockPathContext();
+      when(pathContext.separator).thenReturn('/');
+
+      mockFileSystem = MockFileSystem();
+      when(mockFileSystem.path).thenReturn(pathContext);
+    });
+
+    testUsingContext('throws tool exit if the plugin main class can\'t be read', () {
+      when(pathContext.join('.pub_cache/plugin_a', 'android', 'src', 'main'))
+        .thenReturn('.pub_cache/plugin_a/android/src/main');
+
+      when(pathContext.join('.pub_cache/plugin_a/android/src/main', 'java', 'com/company', 'PluginA.java'))
+        .thenReturn('.pub_cache/plugin_a/android/src/main/java/com/company/PluginA.java');
+
+      when(pathContext.join('.pub_cache/plugin_a/android/src/main', 'kotlin', 'com/company', 'PluginA.kt'))
+        .thenReturn('.pub_cache/plugin_a/android/src/main/kotlin/com/company/PluginA.kt');
+
+      final MockFile pluginJavaMainClass = MockFile();
+      when(pluginJavaMainClass.existsSync()).thenReturn(true);
+      when(pluginJavaMainClass.readAsStringSync()).thenThrow(const FileSystemException());
+      when(mockFileSystem.file('.pub_cache/plugin_a/android/src/main/java/com/company/PluginA.java'))
+        .thenReturn(pluginJavaMainClass);
+
+      final MockFile pluginKotlinMainClass = MockFile();
+      when(pluginKotlinMainClass.existsSync()).thenReturn(false);
+      when(mockFileSystem.file('.pub_cache/plugin_a/android/src/main/kotlin/com/company/PluginA.kt'))
+        .thenReturn(pluginKotlinMainClass);
+
+      expect(() {
+        AndroidPlugin(
+          name: 'pluginA',
+          package: 'com.company',
+          pluginClass: 'PluginA',
+          pluginPath: '.pub_cache/plugin_a',
+        ).toMap();
+      }, throwsToolExit(
+        message: 'Couldn\'t read file null even though it exists. '
+                 'Please verify that this file has read permission and try again.'
+      ));
+    }, overrides: <Type, Generator>{
+      FileSystem: () => mockFileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
+    });
+  });
+}
+
+class MockFile extends Mock implements File {}
+class MockFileSystem extends Mock implements FileSystem {}
+class MockPathContext extends Mock implements p.Context {}
+

--- a/packages/flutter_tools/test/general.shard/platform_plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/platform_plugins_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -65,4 +65,3 @@ void main() {
 class MockFile extends Mock implements File {}
 class MockFileSystem extends Mock implements FileSystem {}
 class MockPathContext extends Mock implements p.Context {}
-

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -467,11 +467,12 @@ dependencies:
             await injectPlugins(flutterProject);
           },
           throwsToolExit(
-            message: 'The plugin plugin1 doesn\'t have a main class defined in '
-                     '/.tmp_rand0/flutter_plugin_invalid_package.rand0/android/src/main/java/plugin1/invalid/UseNewEmbedding.java or '
-                     '/.tmp_rand0/flutter_plugin_invalid_package.rand0/android/src/main/kotlin/plugin1/invalid/UseNewEmbedding.kt. '
-                     'This is likely to due to an incorrect `androidPackage: plugin1.invalid` entry in the plugin\'s pubspec.yaml. '
-                     'Please contact the author of this plugin and consider using a different plugin in the meanwhile.'
+            message: 'The plugin `plugin1` doesn\'t have a main class defined in '
+                     '/.tmp_rand2/flutter_plugin_invalid_package.rand2/android/src/main/java/plugin1/invalid/UseNewEmbedding.java or '
+                     '/.tmp_rand2/flutter_plugin_invalid_package.rand2/android/src/main/kotlin/plugin1/invalid/UseNewEmbedding.kt. '
+                     'This is likely to due to an incorrect `androidPackage: plugin1.invalid` or `mainClass` entry in the plugin\'s pubspec.yaml.\n'
+                     'If you are the author of this plugin, fix the `androidPackage` entry or move the main class to any of locations used above. '
+                     'Otherwise, please contact the author of this plugin and consider using a different plugin in the meanwhile.',
           ),
         );
       }, overrides: <Type, Generator>{
@@ -675,6 +676,7 @@ class MockAndroidProject extends Mock implements AndroidProject {}
 class MockFeatureFlags extends Mock implements FeatureFlags {}
 class MockFlutterProject extends Mock implements FlutterProject {}
 class MockFile extends Mock implements File {}
+class MockFileSystem extends Mock implements FileSystem {}
 class MockIosProject extends Mock implements IosProject {}
 class MockMacOSProject extends Mock implements MacOSProject {}
 class MockXcodeProjectInterpreter extends Mock implements XcodeProjectInterpreter {}


### PR DESCRIPTION
## Description

If a plugin contains an invalid `androidPackage` entry in pubspec.yaml, then throw a tool exits with a useful/actionable error message. 

## Related Issues

Fixes https://github.com/flutter/flutter/issues/47803
Fixes https://github.com/flutter/flutter/issues/48165

## Tests

I added the following tests: Unit test.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
