### PR TITLE
Updated .gitignore for Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ unlinked.ds
 unlinked_spec.ds
 
 # Android related
+**/android/app/release/
 **/android/**/gradle-wrapper.jar
 **/android/.gradle
 **/android/captures/


### PR DESCRIPTION
Updated .gitignore for /android/app/release/ directory

## Description

When building with Android Studio,  .apk, .aab and .json files are added to this directory, which causes it to be uploaded to git.