### PR TITLE
Registering multiple transformed events should work

### DIFF
--- a/packages/flutter/lib/src/gestures/pointer_signal_resolver.dart
+++ b/packages/flutter/lib/src/gestures/pointer_signal_resolver.dart
@@ -10,6 +10,10 @@ import 'events.dart';
 /// interest in a pointer signal event.
 typedef PointerSignalResolvedCallback = void Function(PointerSignalEvent event);
 
+bool _isSameEvent(PointerSignalEvent event1, PointerSignalEvent event2) {
+  return (event1.original ?? event1) == (event2.original ?? event2);
+}
+
 /// An resolver for pointer signal events.
 ///
 /// Objects interested in a [PointerSignalEvent] should register a callback to
@@ -29,7 +33,7 @@ class PointerSignalResolver {
   void register(PointerSignalEvent event, PointerSignalResolvedCallback callback) {
     assert(event != null);
     assert(callback != null);
-    assert(_currentEvent == null || _currentEvent == event);
+    assert(_currentEvent == null || _isSameEvent(_currentEvent, event));
     if (_firstRegisteredCallback != null) {
       return;
     }
@@ -47,7 +51,7 @@ class PointerSignalResolver {
       assert(_currentEvent == null);
       return;
     }
-    assert((_currentEvent.original ?? _currentEvent) == event);
+    assert(_isSameEvent(_currentEvent, event));
     try {
       _firstRegisteredCallback(_currentEvent);
     } catch (exception, stack) {

--- a/packages/flutter/test/gestures/pointer_signal_resolver_test.dart
+++ b/packages/flutter/test/gestures/pointer_signal_resolver_test.dart
@@ -74,14 +74,29 @@ void main() {
     const PointerScrollEvent originalEvent = PointerScrollEvent();
     final PointerSignalEvent transformedEvent = originalEvent
         .transformed(Matrix4.translationValues(10.0, 20.0, 0.0));
+    final PointerSignalEvent anotherTransformedEvent = originalEvent
+        .transformed(Matrix4.translationValues(30.0, 50.0, 0.0));
 
     expect(originalEvent, isNot(same(transformedEvent)));
     expect(transformedEvent.original, same(originalEvent));
+
+    expect(originalEvent, isNot(same(anotherTransformedEvent)));
+    expect(anotherTransformedEvent.original, same(originalEvent));
 
     final List<PointerSignalEvent> events = <PointerSignalEvent>[];
     resolver.register(transformedEvent, (PointerSignalEvent event) {
       events.add(event);
     });
+
+    // Registering a second transformed event should not throw an assertion.
+    expect(() {
+      resolver.register(anotherTransformedEvent, (PointerSignalEvent event) {
+        // This shouldn't be called because only the first registered callback is
+        // invoked.
+        events.add(event);
+      });
+    }, returnsNormally);
+
     resolver.resolve(originalEvent);
 
     expect(events.single, same(transformedEvent));


### PR DESCRIPTION
## Description

In some apps (e.g. Shrine in the flutter gallery) using the mouse wheel to scroll causes an assertion to be thrown.

This probably started happening when we started dispatching transformed events. If two hit targets receive a `PointerSignalEvent`, they both try to call `PointerSignalResolver.register()` but they pass different events (each target receives its own transformed event).

To fix this, we now compare `original` events. This way, multiple transformed events derived from the same original event work just fine.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/44037

## Tests

I added the following tests:
* `gestures/pointer_signal_resolver_test.dart`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
