### PR TITLE
Added API docs on only opening a Scaffold's drawer programmatically

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -1094,12 +1094,12 @@ class Scaffold extends StatefulWidget {
   ///
   /// Typically a [Drawer].
   ///
-  /// To open the drawer manually, use the [ScaffoldState.openDrawer] function.
+  /// To open the drawer programmatically, use the [ScaffoldState.openDrawer]
+  /// function.
   ///
   /// {@tool snippet --template=stateful_widget_material}
   /// To disable the drawer edge swipe, set the [Scaffold.drawerEdgeWidth]
-  /// to 0. Then, use [ScaffoldState.openDrawer] to programmatically open the
-  /// drawer.
+  /// to 0. Then, use [ScaffoldState.openDrawer] to open the drawer.
   ///
   /// ```dart
   /// final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
@@ -1122,7 +1122,7 @@ class Scaffold extends StatefulWidget {
   ///     drawer: Drawer(
   ///       child: Center(child: Text('This is the Drawer')),
   ///     ),
-  ///     drawerEdgeDragWidth: 0.0,
+  ///     drawerEdgeDragWidth: 0.0, // Disable opening the drawer with a swipe gesture.
   ///   );
   /// }
   /// ```
@@ -1135,13 +1135,12 @@ class Scaffold extends StatefulWidget {
   ///
   /// Typically a [Drawer].
   ///
-  /// To open the drawer manually, use the [ScaffoldState.openEndDrawer]
+  /// To open the drawer programmatically, use the [ScaffoldState.openEndDrawer]
   /// function.
   ///
   /// {@tool snippet --template=stateful_widget_material}
   /// To disable the drawer edge swipe, set the [Scaffold.drawerEdgeWidth]
-  /// to 0. Then, use [ScaffoldState.openEndDrawer] to programmatically open
-  /// the drawer.
+  /// to 0. Then, use [ScaffoldState.openEndDrawer] to open the drawer.
   ///
   /// ```dart
   /// final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
@@ -1164,7 +1163,7 @@ class Scaffold extends StatefulWidget {
   ///     endDrawer: Drawer(
   ///       child: Center(child: Text('This is the Drawer')),
   ///     ),
-  ///     drawerEdgeDragWidth: 0.0,
+  ///     drawerEdgeDragWidth: 0.0, // Disable opening the drawer with a swipe gesture.
   ///   );
   /// }
   /// ```

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -1092,20 +1092,82 @@ class Scaffold extends StatefulWidget {
   /// devices. Swipes in from either left-to-right ([TextDirection.ltr]) or
   /// right-to-left ([TextDirection.rtl])
   ///
-  /// In the uncommon case that you wish to open the drawer manually, use the
-  /// [ScaffoldState.openDrawer] function.
-  ///
   /// Typically a [Drawer].
+  ///
+  /// To open the drawer manually, use the [ScaffoldState.openDrawer] function.
+  ///
+  /// {@tool snippet --template=stateful_widget_material}
+  /// To disable the drawer edge swipe, set the [Scaffold.drawerEdgeWidth]
+  /// to 0. Then, use [ScaffoldState.openDrawer] to programmatically open the
+  /// drawer.
+  ///
+  /// ```dart
+  /// final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
+  ///
+  /// void _openDrawer() {
+  ///   _scaffoldKey.currentState.openDrawer();
+  /// }
+  ///
+  /// @override
+  /// Widget build(BuildContext context) {
+  ///   return Scaffold(
+  ///     key: _scaffoldKey,
+  ///     appBar: AppBar(title: Text('Drawer Demo')),
+  ///     body: Center(
+  ///       child: RaisedButton(
+  ///         onPressed: _openDrawer,
+  ///         child: Text('Open Drawer'),
+  ///       ),
+  ///     ),
+  ///     drawer: Drawer(
+  ///       child: Center(child: Text('This is the Drawer')),
+  ///     ),
+  ///     drawerEdgeDragWidth: 0.0,
+  ///   );
+  /// }
+  /// ```
+  /// {@end-tool}
   final Widget drawer;
 
   /// A panel displayed to the side of the [body], often hidden on mobile
   /// devices. Swipes in from right-to-left ([TextDirection.ltr]) or
   /// left-to-right ([TextDirection.rtl])
   ///
-  /// In the uncommon case that you wish to open the drawer manually, use the
-  /// [ScaffoldState.openEndDrawer] function.
-  ///
   /// Typically a [Drawer].
+  ///
+  /// To open the drawer manually, use the [ScaffoldState.openDrawer] function.
+  ///
+  /// {@tool snippet --template=stateful_widget_material}
+  /// To disable the drawer edge swipe, set the [Scaffold.drawerEdgeWidth]
+  /// to 0. Then, use [ScaffoldState.openDrawer] to programmatically open the
+  /// drawer.
+  ///
+  /// ```dart
+  /// final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
+  ///
+  /// void _openDrawer() {
+  ///   _scaffoldKey.currentState.openDrawer();
+  /// }
+  ///
+  /// @override
+  /// Widget build(BuildContext context) {
+  ///   return Scaffold(
+  ///     key: _scaffoldKey,
+  ///     appBar: AppBar(title: Text('Drawer Demo')),
+  ///     body: Center(
+  ///       child: RaisedButton(
+  ///         onPressed: _openEndDrawer,
+  ///         child: Text('Open End Drawer'),
+  ///       ),
+  ///     ),
+  ///     endDrawer: Drawer(
+  ///       child: Center(child: Text('This is the Drawer')),
+  ///     ),
+  ///     drawerEdgeDragWidth: 0.0,
+  ///   );
+  /// }
+  /// ```
+  /// {@end-tool}
   final Widget endDrawer;
 
   /// The color to use for the scrim that obscures primary content while a drawer is open.

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -1135,18 +1135,19 @@ class Scaffold extends StatefulWidget {
   ///
   /// Typically a [Drawer].
   ///
-  /// To open the drawer manually, use the [ScaffoldState.openDrawer] function.
+  /// To open the drawer manually, use the [ScaffoldState.openEndDrawer]
+  /// function.
   ///
   /// {@tool snippet --template=stateful_widget_material}
   /// To disable the drawer edge swipe, set the [Scaffold.drawerEdgeWidth]
-  /// to 0. Then, use [ScaffoldState.openDrawer] to programmatically open the
-  /// drawer.
+  /// to 0. Then, use [ScaffoldState.openEndDrawer] to programmatically open
+  /// the drawer.
   ///
   /// ```dart
   /// final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
   ///
-  /// void _openDrawer() {
-  ///   _scaffoldKey.currentState.openDrawer();
+  /// void _openEndDrawer() {
+  ///   _scaffoldKey.currentState.openEndDrawer();
   /// }
   ///
   /// @override


### PR DESCRIPTION
## Description
There was an issue requesting for a feature to open drawers only programmatically, meaning that edge swipes from the left/right sides of the screen should not open a drawer. 

This PR introduces some samples on how to achieve this effect with existing APIs, particularly, `Scaffold.drawerEdgeDragWidth` and `ScaffoldState.openDrawer`.

## Related Issues
Fixes https://github.com/flutter/flutter/issues/31127

## Tests
n/a - API doc sample

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
