### PR TITLE
Add FormField validation states (touched, saved, etc) with ErrorStateMatcher

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1394,6 +1394,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
     this.decoration = const InputDecoration(),
     FormFieldSetter<T> onSaved,
     FormFieldValidator<T> validator,
+    ErrorStateMatcher<T> errorStateMatcher,
     bool autovalidate = false,
     Widget disabledHint,
     int elevation = 8,
@@ -1425,13 +1426,16 @@ class DropdownButtonFormField<T> extends FormField<T> {
          onSaved: onSaved,
          initialValue: value,
          validator: validator,
+         errorStateMatcher: errorStateMatcher,
          autovalidate: autovalidate,
          builder: (FormFieldState<T> field) {
            final InputDecoration effectiveDecoration = decoration.applyDefaults(
              Theme.of(field.context).inputDecorationTheme,
            );
            return InputDecorator(
-             decoration: effectiveDecoration.copyWith(errorText: field.errorText),
+             decoration: field.isErrorState
+                 ? effectiveDecoration.copyWith(errorText: field.errorText)
+                 : effectiveDecoration,
              isEmpty: value == null,
              child: DropdownButtonHideUnderline(
                child: DropdownButton<T>(

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -115,6 +115,7 @@ class TextFormField extends FormField<String> {
     ValueChanged<String> onFieldSubmitted,
     FormFieldSetter<String> onSaved,
     FormFieldValidator<String> validator,
+    ErrorStateMatcher<String> errorStateMatcher,
     List<TextInputFormatter> inputFormatters,
     bool enabled = true,
     double cursorWidth = 2.0,
@@ -153,6 +154,7 @@ class TextFormField extends FormField<String> {
     initialValue: controller != null ? controller.text : (initialValue ?? ''),
     onSaved: onSaved,
     validator: validator,
+    errorStateMatcher: errorStateMatcher,
     autovalidate: autovalidate,
     enabled: enabled,
     builder: (FormFieldState<String> field) {
@@ -168,7 +170,9 @@ class TextFormField extends FormField<String> {
       return TextField(
         controller: state._effectiveController,
         focusNode: focusNode,
-        decoration: effectiveDecoration.copyWith(errorText: field.errorText),
+        decoration: field.isErrorState
+            ? effectiveDecoration.copyWith(errorText: field.errorText)
+            : effectiveDecoration,
         keyboardType: keyboardType,
         textInputAction: textInputAction,
         style: style,

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -703,6 +703,63 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('DropdownButtonFormField creates InputDecorator with decoration indicating error state', (WidgetTester tester) async {
+    const UnderlineInputBorder border = UnderlineInputBorder(
+      borderSide: BorderSide(width: 42599.0),
+    );
+    await tester.pumpWidget(TestApp(
+      textDirection: TextDirection.ltr,
+      child: Material(
+        child: DropdownButtonFormField<String>(
+          hint: const Text('Dropdown Form Field'),
+          value: 'hideError',
+          autovalidate: true,
+          validator: (String value) => 'errorMessage',
+          errorStateMatcher: (FormFieldState<String> state) =>
+              state.value == 'showError',
+          decoration: const InputDecoration(border: border),
+          onChanged: (_) {},
+          items: const <DropdownMenuItem<String>>[
+            DropdownMenuItem<String>(
+              value: 'hideError',
+              child: Text('Hide Error'),
+            ),
+            DropdownMenuItem<String>(
+              value: 'showError',
+              child: Text('Show Error'),
+            ),
+          ],
+        ),
+      ),
+    ));
+
+    final Finder inputDecoratorFinder = find.byType(InputDecorator);
+    expect(inputDecoratorFinder, findsOneWidget);
+
+    // Initial value is 'hideError'.
+    final InputDecorator inputDecorator = tester.widget(inputDecoratorFinder);
+    expect(inputDecorator.decoration.border, border);
+    expect(inputDecorator.decoration.errorText, null);
+
+    // Tap on 'Show Error' and the decoration.errorText becomes 'errorMessage'
+    await tester.tap(find.text('Dropdown Form Field'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Show Error').last);
+    await tester.pumpAndSettle();
+    final InputDecorator showErrorInputDecorator = tester.widget(inputDecoratorFinder);
+    expect(showErrorInputDecorator.decoration.border, border);
+    expect(showErrorInputDecorator.decoration.errorText, 'errorMessage');
+
+    // Tap on 'Hide Error' and the decoration.errorText goes back to null
+    await tester.tap(find.text('Dropdown Form Field'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Hide Error').last);
+    await tester.pumpAndSettle();
+    final InputDecorator hideErrorInputDecorator = tester.widget(inputDecoratorFinder);
+    expect(hideErrorInputDecorator.decoration.border, border);
+    expect(hideErrorInputDecorator.decoration.errorText, null);
+  });
+
   testWidgets('Dropdown menu scrolls to first item in long lists', (WidgetTester tester) async {
     // Open the dropdown menu
     final Key buttonKey = UniqueKey();

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -74,6 +74,40 @@ void main() {
     expect(textFieldWidget.textInputAction, TextInputAction.next);
   });
 
+  testWidgets('Passes decoration to underlying TextField', (WidgetTester tester) async {
+    const UnderlineInputBorder border = UnderlineInputBorder(
+      borderSide: BorderSide(width: 4259.0),
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: TextFormField(
+              autovalidate: true,
+              validator: (String value) => 'errorMessage',
+              errorStateMatcher: (FormFieldState<String> state) =>
+                  state.value == 'showError',
+              decoration: const InputDecoration(border: border),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Finder textFieldFinder = find.byType(TextField);
+    expect(textFieldFinder, findsOneWidget);
+
+    final TextField textFieldWidget = tester.widget(textFieldFinder);
+    expect(textFieldWidget.decoration.border, border);
+    expect(textFieldWidget.decoration.errorText, null);
+
+    await tester.enterText(textFieldFinder, 'showError');
+    await tester.pump();
+    final TextField newTextFieldWidget = tester.widget(textFieldFinder);
+    expect(newTextFieldWidget.decoration.border, border);
+    expect(newTextFieldWidget.decoration.errorText, 'errorMessage');
+  });
+
   testWidgets('Passes onEditingComplete to underlying TextField', (WidgetTester tester) async {
     final VoidCallback onEditingComplete = () { };
 
@@ -216,6 +250,30 @@ void main() {
     await tester.enterText(find.byType(TextField), 'a');
     await tester.pump();
     expect(_validateCalled, 2);
+  });
+
+  testWidgets('errorStateMatcher is called', (WidgetTester tester) async {
+    int _errorStateMatcherCalled = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: TextFormField(
+              errorStateMatcher: (FormFieldState<String> state) {
+                _errorStateMatcherCalled += 1;
+                return true;
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(_errorStateMatcherCalled, 1);
+    await tester.enterText(find.byType(TextField), 'a');
+    await tester.pump();
+    expect(_errorStateMatcherCalled, 2);
   });
 
   testWidgets('passing a buildCounter shows returned widget', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/form_test.dart
+++ b/packages/flutter/test/widgets/form_test.dart
@@ -83,6 +83,107 @@ void main() {
     await checkText('');
   });
 
+  testWidgets('touched is updated', (WidgetTester tester) async {
+    final GlobalKey<FormFieldState<String>> formFieldKey = GlobalKey<FormFieldState<String>>();
+
+    Widget builder() {
+      return MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(devicePixelRatio: 1.0),
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Center(
+              child: Material(
+                child: Form(
+                  child: TextFormField(
+                    key: formFieldKey,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(builder());
+
+    expect(formFieldKey.currentState.touched, false);
+    await tester.enterText(find.byType(TextFormField), 'test');
+    expect(formFieldKey.currentState.touched, true);
+    formFieldKey.currentState.reset();
+    expect(formFieldKey.currentState.touched, false);
+  });
+
+  testWidgets('saved is updated', (WidgetTester tester) async {
+    final GlobalKey<FormFieldState<String>> formFieldKey = GlobalKey<FormFieldState<String>>();
+
+    Widget builder() {
+      return MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(devicePixelRatio: 1.0),
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Center(
+              child: Material(
+                child: Form(
+                  child: TextFormField(
+                    key: formFieldKey,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(builder());
+
+    expect(formFieldKey.currentState.saved, false);
+    formFieldKey.currentState.save();
+    expect(formFieldKey.currentState.saved, true);
+    formFieldKey.currentState.reset();
+    expect(formFieldKey.currentState.saved, false);
+  });
+
+  testWidgets('isErrorState returns result from errorStateMatcher', (WidgetTester tester) async {
+    final GlobalKey<FormFieldState<String>> formFieldKey = GlobalKey<FormFieldState<String>>();
+
+    Widget builder(ErrorStateMatcher<String> errorStateMatcher) {
+      return MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(devicePixelRatio: 1.0),
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Center(
+              child: Material(
+                child: Form(
+                  child: TextFormField(
+                    key: formFieldKey,
+                    errorStateMatcher: errorStateMatcher,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    // With null errorStateMatcher
+    await tester.pumpWidget(builder(null));
+    expect(formFieldKey.currentState.isErrorState, false);
+
+    // Perpetual true errorStateMatcher
+    await tester.pumpWidget(builder((FormFieldState<String> state) => true));
+    expect(formFieldKey.currentState.isErrorState, true);
+
+    // Perpetual false errorStateMatcher
+    await tester.pumpWidget(builder((FormFieldState<String> state) => false));
+    expect(formFieldKey.currentState.isErrorState, false);
+  });
+
   testWidgets('Validator sets the error text only when validate is called', (WidgetTester tester) async {
     final GlobalKey<FormState> formKey = GlobalKey<FormState>();
     String errorText(String value) => value + '/error';


### PR DESCRIPTION
## Description

This PR addresses the issue with `FormField` where if `autovalidate` and `validator` are set, its initial state will be immediately validated, and could be marked as in error state and display `errorText` to the user when the user has not touched the form field at all. It would be nice to provide a way to define when the error message should be shown, so the error can be hidden at the initial state.

The proposed solution here is to add an `isErrorState` property to the `FormField` and give the ability for a custom defined `ErrorStateMatcher` (named after Angular equivalent [ErrorStateMatcher](https://material.angular.io/components/input/overview#changing-when-error-messages-are-shown)) that determines whether errors should be shown.

| No ErrorStateMatcher | Custom ErrorStateMatcher |
| :-----: | :-----:|
| Errors shown immediately to the user on initial state | Errors only shown when a custom defined  `ErrorStateMatcher` returns `true` |
|  ![before](https://user-images.githubusercontent.com/10954839/71755302-d9ebf580-2e81-11ea-84c4-0c8a7825c0b2.gif) | ![after](https://user-images.githubusercontent.com/10954839/71755307-deb0a980-2e81-11ea-958e-c7517cd97b1f.gif) |
| `errorStateMatcher: null`  or  `errorStateMatcher: (_) => true`  |  `errorStateMatcher: (field) => field.touched`|

This approach separates the UI error showing logic (whether errors should be shown to UI) from the validation logic (whether field is valid), so we don't have to mix the logic and perform UI-related checks (e.g. `touched` or `saved`) in `validator`.

### Comparison with validator

|                 | validator | errorStateMatcher |
| -------- | --------- | ------------------ |
| Defines | whether field is valid. | whether errors should be shown to the UI. |
| Determines | `hasError` | `isErrorState` |
| Example | `validator: (password) => password.length < 6 ? "Error" : null,` | `errorStateMatcher: (field) => field.touched,` |

An example of a password field could use both:

```dart
TextFormField(
      autovalidate: true,
      obscureText: true,
      validator: (password) => password.length < 6 ? "Error msg" : null,
      errorStateMatcher: (field) => field.touched,
);
```

## Related Issues

Fix #18885

## Tests

I added the following tests:

- In `form_test.dart`:
  - touched is updated
  - saved is updated
  - isErrorState returns result from errorStateMatcher
- In `text_form_field_test.dart`:
  - Passes decoration to underlying TextField
  - errorStateMatcher is called
- In `dropdown_test.dart`:
  - DropdownButtonFormField creates InputDecorator with decoration indicating error state

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
