### PR TITLE
Add padEnds option to SliverFillViewport

### DIFF
--- a/packages/flutter/lib/src/widgets/sliver_fill.dart
+++ b/packages/flutter/lib/src/widgets/sliver_fill.dart
@@ -30,9 +30,11 @@ class SliverFillViewport extends StatelessWidget {
     Key key,
     @required this.delegate,
     this.viewportFraction = 1.0,
+    this.padEnds = true,
   }) : assert(viewportFraction != null),
-      assert(viewportFraction > 0.0),
-      super(key: key);
+       assert(viewportFraction > 0.0),
+       assert(padEnds != null),
+       super(key: key);
 
   /// The fraction of the viewport that each child should fill in the main axis.
   ///
@@ -41,13 +43,26 @@ class SliverFillViewport extends StatelessWidget {
   /// the viewport in the main axis.
   final double viewportFraction;
 
+  /// Whether to add padding to both ends of the list.
+  ///
+  /// If this is set to true and [viewportFraction] < 1.0, padding will be added
+  /// such that the first and last child slivers will be in the center of
+  /// the viewport when scrolled all the way to the start or end, respectively.
+  /// You may want to set this to false if this [SliverFillViewport] is not the only
+  /// widget along this main axis, such as in a [CustomScrollView] with multiple
+  /// children.
+  ///
+  /// This option cannot be [null]. If [viewportFraction] >= 1.0, this option has no
+  /// effect. Defaults to [true].
+  final bool padEnds;
+
   /// {@macro flutter.widgets.sliverMultiBoxAdaptor.delegate}
   final SliverChildDelegate delegate;
 
   @override
   Widget build(BuildContext context) {
     return _SliverFractionalPadding(
-      viewportFraction: (1 - viewportFraction).clamp(0, 1) / 2,
+      viewportFraction: padEnds ? (1 - viewportFraction).clamp(0, 1) / 2 : 0,
       sliver: _SliverFillViewportRenderObjectWidget(
         viewportFraction: viewportFraction,
         delegate: delegate,

--- a/packages/flutter/test/widgets/sliver_fill_viewport_test.dart
+++ b/packages/flutter/test/widgets/sliver_fill_viewport_test.dart
@@ -171,7 +171,7 @@ void main() {
       ),
     );
 
-    final RenderSliver boxWithPadding = tester.renderObject<RenderSliver>(find.byType(SliverFillViewport).first);
+    final RenderSliver boxWithPadding = tester.renderObject<RenderSliver>(find.byType(SliverFillViewport));
     expect(boxWithPadding.geometry.paintExtent, equals(600.0));
 
     await tester.pumpWidget(
@@ -189,7 +189,7 @@ void main() {
       ),
     );
 
-    final RenderSliver boxWithoutPadding = tester.renderObject<RenderSliver>(find.byType(SliverFillViewport).first);
+    final RenderSliver boxWithoutPadding = tester.renderObject<RenderSliver>(find.byType(SliverFillViewport));
     expect(boxWithoutPadding.geometry.paintExtent, equals(300.0));
   });
 }

--- a/packages/flutter/test/widgets/sliver_fill_viewport_test.dart
+++ b/packages/flutter/test/widgets/sliver_fill_viewport_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 
@@ -144,5 +145,51 @@ void main() {
         ''
       ),
     );
+  });
+
+  testWidgets('SliverFillViewport padding test', (WidgetTester tester) async {
+    final SliverChildListDelegate delegate = SliverChildListDelegate(
+      <Widget>[
+        Container(child: const Text('0')),
+      ],
+      addAutomaticKeepAlives: false,
+      addSemanticIndexes: false,
+    );
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: CustomScrollView(
+          slivers: <Widget>[
+            SliverFillViewport(
+              padEnds: true,
+              viewportFraction: 0.5,
+              delegate: delegate,
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final RenderSliver boxWithPadding = tester.renderObject<RenderSliver>(find.byType(SliverFillViewport).first);
+    expect(boxWithPadding.geometry.paintExtent, equals(600.0));
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: CustomScrollView(
+          slivers: <Widget>[
+            SliverFillViewport(
+              padEnds: false,
+              viewportFraction: 0.5,
+              delegate: delegate,
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final RenderSliver boxWithoutPadding = tester.renderObject<RenderSliver>(find.byType(SliverFillViewport).first);
+    expect(boxWithoutPadding.geometry.paintExtent, equals(300.0));
   });
 }


### PR DESCRIPTION
## Description

Adds the `padEnds` option to SliverFillViewport. 

`padEnds` configures whether or not padding should be added to the end of the SliverFillViewport to make the first and last elements be centered when scrolled all the way to one end of the list. Previously this padding was always added, but in some cases it can be undesirable. Setting `padEnds` to `false` removes this padding entirely. `padEnds` defaults to `true` to ensure this change doesn't break any existing code.

### Example Use

I encountered this padding when writing a calendar application. I'm using the trick of having two opposite-direction lists (in this case SliverFillViewports with `viewportFraction=1/5`, because I want the viewport to show 5 weeks) in a viewport to create an infinitely-scrolling list of weeks in both directions. However, the padding added by SliverFillViewport creates an unseemly gap between the two lists:

<img width="400" alt="image" src="https://user-images.githubusercontent.com/42569602/71780458-80d3ad00-2fba-11ea-8158-a512f64308bb.png">

This is the desired appearance, achieved by setting `padEnds` to `false`:

<img width="400" alt="image" src="https://user-images.githubusercontent.com/42569602/71780504-3e5ea000-2fbb-11ea-9612-1402e650f304.png">

## Related Issues

https://github.com/flutter/flutter/issues/48252

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
