### PR TITLE
Remove unused public static members of private classes/enums

### DIFF
--- a/dev/manual_tests/lib/density.dart
+++ b/dev/manual_tests/lib/density.dart
@@ -158,8 +158,6 @@ class Options extends StatefulWidget {
 }
 
 class _OptionsState extends State<Options> {
-  static final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
-
   @override
   void initState() {
     super.initState();

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -422,7 +422,6 @@ enum _AndroidViewState {
   waitingForSize,
   creating,
   created,
-  createFailed,
   disposed,
 }
 

--- a/packages/flutter/test/foundation/bit_field_test.dart
+++ b/packages/flutter/test/foundation/bit_field_test.dart
@@ -7,7 +7,8 @@
 import 'package:flutter/foundation.dart';
 import '../flutter_test_alternative.dart';
 
-enum _TestEnum { c, d, e, }
+// ignore: unused_field
+enum _TestEnum { a, b, c, d, e, f, g, h, }
 
 void main() {
   test('BitField control test', () {

--- a/packages/flutter/test/foundation/bit_field_test.dart
+++ b/packages/flutter/test/foundation/bit_field_test.dart
@@ -7,7 +7,7 @@
 import 'package:flutter/foundation.dart';
 import '../flutter_test_alternative.dart';
 
-enum _TestEnum { a, b, c, d, e, f, g, h, }
+enum _TestEnum { c, d, e, }
 
 void main() {
   test('BitField control test', () {


### PR DESCRIPTION
## Description

Remove unused public static members of private classes/enums

## Related Issues

https://github.com/dart-lang/sdk/issues/39988

## Tests

I added no tests.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
