### PR TITLE
Add HeroMode widget

### DIFF
--- a/packages/flutter/lib/src/cupertino/tab_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/tab_scaffold.dart
@@ -576,15 +576,18 @@ class _TabSwitchingViewState extends State<_TabSwitchingView> {
         final bool active = index == widget.currentTabIndex;
         shouldBuildTab[index] = active || shouldBuildTab[index];
 
-        return Offstage(
-          offstage: !active,
-          child: TickerMode(
-            enabled: active,
-            child: FocusScope(
-              node: tabFocusNodes[index],
-              child: Builder(builder: (BuildContext context) {
-                return shouldBuildTab[index] ? widget.tabBuilder(context, index) : Container();
-              }),
+        return HeroMode(
+          enabled: active,
+          child: Offstage(
+            offstage: !active,
+            child: TickerMode(
+              enabled: active,
+              child: FocusScope(
+                node: tabFocusNodes[index],
+                child: Builder(builder: (BuildContext context) {
+                  return shouldBuildTab[index] ? widget.tabBuilder(context, index) : Container();
+                }),
+              ),
             ),
           ),
         );

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -921,6 +921,12 @@ class HeroController extends NavigatorObserver {
 }
 
 /// Enables or disables [Hero]es in the widget subtree.
+///
+/// When [enabled] is false, all Hero widgets in this subtree will not be
+/// considered for Hero animations.
+///
+/// When [enabled] is true (the default), Hero widgets may be involved in a
+/// Hero animation, like normal.
 class HeroMode extends StatelessWidget {
   /// Creates a widget that enables or disables [Hero]es.
   ///

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -925,7 +925,7 @@ class HeroController extends NavigatorObserver {
 /// When [enabled] is false, all [Hero] widgets in this subtree will not be
 /// involved in hero animations.
 ///
-/// When [enabled] is true (the default), [Hero] widgets may be involved in a
+/// When [enabled] is true (the default), [Hero] widgets may be involved in
 /// hero animations, as usual.
 class HeroMode extends StatelessWidget {
   /// Creates a widget that enables or disables [Hero]es.

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -305,10 +305,8 @@ class Hero extends StatefulWidget {
             inviteHero(hero, tag);
           }
         }
-      } else if (widget is HeroMode) {
-        if (!widget.enabled) {
-          return;
-        }
+      } else if (widget is HeroMode && !widget.enabled) {
+        return;
       }
       element.visitChildren(visitor);
     }

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -922,11 +922,11 @@ class HeroController extends NavigatorObserver {
 
 /// Enables or disables [Hero]es in the widget subtree.
 ///
-/// When [enabled] is false, all Hero widgets in this subtree will not be
-/// considered for Hero animations.
+/// When [enabled] is false, all [Hero] widgets in this subtree will not be
+/// involved in hero animations.
 ///
-/// When [enabled] is true (the default), Hero widgets may be involved in a
-/// Hero animation, like normal.
+/// When [enabled] is true (the default), [Hero] widgets may be involved in a
+/// hero animations, as usual.
 class HeroMode extends StatelessWidget {
   /// Creates a widget that enables or disables [Hero]es.
   ///
@@ -944,9 +944,8 @@ class HeroMode extends StatelessWidget {
 
   /// Whether or not [Hero]es are enabled in this subtree.
   ///
-  /// If true, then the [Hero]es in this subtree will animate as usual.
-  ///
-  /// If false, then the [Hero]es in this subtree will not animate.
+  /// If this property is false, the [Hero]es in this subtree will not animate
+  /// on route changes. Otherwise, they will animate as usual.
   ///
   /// Defaults to true and must not be null.
   final bool enabled;

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -951,9 +951,7 @@ class HeroMode extends StatelessWidget {
   final bool enabled;
 
   @override
-  Widget build(BuildContext context) {
-    return child;
-  }
+  Widget build(BuildContext context) => child;
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -305,6 +305,10 @@ class Hero extends StatefulWidget {
             inviteHero(hero, tag);
           }
         }
+      } else if (widget is HeroMode) {
+        if (!widget.enabled) {
+          return;
+        }
       }
       element.visitChildren(visitor);
     }
@@ -916,4 +920,39 @@ class HeroController extends NavigatorObserver {
     final Hero toHero = toHeroContext.widget as Hero;
     return toHero.child;
   };
+}
+
+/// Enables or disables heroes in the widget subtree.
+class HeroMode extends StatelessWidget {
+  /// Creates a widget that enables or disables heroes.
+  ///
+  /// The [enabled] argument must not be null.
+  const HeroMode({
+    Key key,
+    @required this.child,
+    this.enabled = true,
+  }) : assert(child != null),
+       assert(enabled != null),
+       super(key: key);
+
+  /// The subtree to place inside the [HeroMode].
+  final Widget child;
+
+  /// The current hero mode of this subtree.
+  ///
+  /// If true, then heroes in this subtree will perform.
+  ///
+  /// If false, then heroes in this subtree will not perform.
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    return child;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(FlagProperty('mode', value: enabled, ifTrue: 'enabled', ifFalse: 'disabled', showName: true));
+  }
 }

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -932,8 +932,8 @@ class HeroMode extends StatelessWidget {
   ///
   /// The [child] and [enabled] arguments must not be null.
   const HeroMode({
-    Key key,
-    @required this.child,
+    Key? key,
+    required this.child,
     this.enabled = true,
   }) : assert(child != null),
        assert(enabled != null),

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -922,11 +922,11 @@ class HeroController extends NavigatorObserver {
   };
 }
 
-/// Enables or disables heroes in the widget subtree.
+/// Enables or disables [Hero]es in the widget subtree.
 class HeroMode extends StatelessWidget {
-  /// Creates a widget that enables or disables heroes.
+  /// Creates a widget that enables or disables [Hero]es.
   ///
-  /// The [enabled] argument must not be null.
+  /// The [child] and [enabled] arguments must not be null.
   const HeroMode({
     Key key,
     @required this.child,
@@ -938,11 +938,13 @@ class HeroMode extends StatelessWidget {
   /// The subtree to place inside the [HeroMode].
   final Widget child;
 
-  /// The current hero mode of this subtree.
+  /// Whether or not [Hero]es are enabled in this subtree.
   ///
-  /// If true, then heroes in this subtree will perform.
+  /// If true, then the [Hero]es in this subtree will animate as usual.
   ///
-  /// If false, then heroes in this subtree will not perform.
+  /// If false, then the [Hero]es in this subtree will not animate.
+  ///
+  /// Defaults to true and must not be null.
   final bool enabled;
 
   @override

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -2069,7 +2069,7 @@ Future<void> main() async {
     // Root hero is not in the tree.
     expect(find.byKey(rootRouteHero), findsNothing);
 
-    rootNavigator.currentState.push(
+    rootNavigator.currentState!.push(
       MaterialPageRoute<void>(
         builder: (BuildContext context) => Hero(
           tag: heroTag,
@@ -2094,7 +2094,7 @@ Future<void> main() async {
     // Doesn't crash.
     expect(tester.takeException(), isNull);
 
-    rootNavigator.currentState.pop();
+    rootNavigator.currentState!.pop();
     await tester.pumpAndSettle();
 
     // Root hero is not in the tree

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -2054,19 +2054,19 @@ Future<void> main() async {
       ),
     );
 
-    // Show both tabs to init
+    // Show both tabs to init.
     await tester.tap(find.byIcon(Icons.home));
     await tester.pump();
 
     await tester.tap(find.byIcon(Icons.favorite));
     await tester.pump();
 
-    // Inner heroes are in the tree, one is offstage
+    // Inner heroes are in the tree, one is offstage.
     expect(find.byKey(nestedRouteHeroTwo), findsOneWidget);
     expect(find.byKey(nestedRouteHeroOne), findsNothing);
     expect(find.byKey(nestedRouteHeroOne, skipOffstage: false), findsOneWidget);
 
-    // Root hero is not in the tree
+    // Root hero is not in the tree.
     expect(find.byKey(rootRouteHero), findsNothing);
 
     rootNavigator.currentState.push(
@@ -2088,7 +2088,7 @@ Future<void> main() async {
     expect(find.byKey(nestedRouteHeroOne, skipOffstage: false), findsOneWidget);
     expect(find.byKey(nestedRouteHeroTwo, skipOffstage: false), findsOneWidget);
 
-    // Root hero is in the tree
+    // Root hero is in the tree.
     expect(find.byKey(rootRouteHero), findsOneWidget);
 
     // Doesn't crash.

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -2022,6 +2022,90 @@ Future<void> main() async {
     expect(tester.takeException(), isAssertionError);
   });
 
+  testWidgets('Can push/pop on outer Navigator if nested Navigators contains same Heroes', (WidgetTester tester) async {
+    const String heroTag = 'foo';
+    final GlobalKey<NavigatorState> rootNavigator = GlobalKey();
+    final Key rootRouteHero = UniqueKey();
+    final Key nestedRouteHeroOne = UniqueKey();
+    final Key nestedRouteHeroTwo = UniqueKey();
+    final List<Key> keys = <Key>[nestedRouteHeroOne, nestedRouteHeroTwo];
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        navigatorKey: rootNavigator,
+        home: CupertinoTabScaffold(
+          tabBar: CupertinoTabBar(
+            items: <BottomNavigationBarItem>[
+              BottomNavigationBarItem(icon: Icon(Icons.home)),
+              BottomNavigationBarItem(icon: Icon(Icons.favorite)),
+            ],
+          ),
+          tabBuilder: (BuildContext context, int index) {
+            return CupertinoTabView(
+              builder: (BuildContext context) => Hero(
+                tag: heroTag,
+                child: Placeholder(
+                  key: keys[index],
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    // Show both tabs to init
+    await tester.tap(find.byIcon(Icons.home));
+    await tester.pump();
+
+    await tester.tap(find.byIcon(Icons.favorite));
+    await tester.pump();
+
+    // Inner heroes are in the tree, one is offstage
+    expect(find.byKey(nestedRouteHeroTwo), findsOneWidget);
+    expect(find.byKey(nestedRouteHeroOne), findsNothing);
+    expect(find.byKey(nestedRouteHeroOne, skipOffstage: false), findsOneWidget);
+
+    // Root hero is not in the tree
+    expect(find.byKey(rootRouteHero), findsNothing);
+
+    rootNavigator.currentState.push(
+      MaterialPageRoute<void>(
+        builder: (BuildContext context) => Hero(
+          tag: heroTag,
+          child: Placeholder(
+            key: rootRouteHero,
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    // Inner heroes are still in the tree, both are offstage.
+    expect(find.byKey(nestedRouteHeroOne), findsNothing);
+    expect(find.byKey(nestedRouteHeroTwo), findsNothing);
+    expect(find.byKey(nestedRouteHeroOne, skipOffstage: false), findsOneWidget);
+    expect(find.byKey(nestedRouteHeroTwo, skipOffstage: false), findsOneWidget);
+
+    // Root hero is in the tree
+    expect(find.byKey(rootRouteHero), findsOneWidget);
+
+    // Doesn't crash.
+    expect(tester.takeException(), isNull);
+
+    rootNavigator.currentState.pop();
+    await tester.pumpAndSettle();
+
+    // Root hero is not in the tree
+    expect(find.byKey(rootRouteHero), findsNothing);
+
+    // Both heroes are in the tree, one is offstage
+    expect(find.byKey(nestedRouteHeroTwo), findsOneWidget);
+    expect(find.byKey(nestedRouteHeroOne), findsNothing);
+    expect(find.byKey(nestedRouteHeroOne, skipOffstage: false), findsOneWidget);
+  });
+
   testWidgets('Hero within a Hero subtree, throws', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
@@ -2545,5 +2629,155 @@ Future<void> main() async {
     await tester.pump(const Duration(milliseconds: 75)); // 25% of 300ms
     heroSize = tester.getSize(find.byKey(container1));
     expect(heroSize, tween.transform(1.0));
+  });
+
+  testWidgets('Heroes in enabled HeroMode do transition', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Material(
+        child: Column(
+          children: <Widget>[
+            HeroMode(
+              enabled: true,
+              child: Card(
+                child: Hero(
+                  tag: 'a',
+                  child: SizedBox(
+                    height: 100.0,
+                    width: 100.0,
+                    key: firstKey,
+                  ),
+                ),
+              ),
+            ),
+            Builder(
+              builder: (BuildContext context) {
+                return FlatButton(
+                  child: const Text('push'),
+                  onPressed: () {
+                    Navigator.push(context, PageRouteBuilder<void>(
+                      pageBuilder: (BuildContext context, Animation<double> _, Animation<double> __) {
+                        return Card(
+                          child: Hero(
+                            tag: 'a',
+                            child: SizedBox(
+                              height: 150.0,
+                              width: 150.0,
+                              key: secondKey,
+                            ),
+                          ),
+                        );
+                      },
+                    ));
+                  },
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    ));
+
+    expect(find.byKey(firstKey), isOnstage);
+    expect(find.byKey(firstKey), isInCard);
+    expect(find.byKey(secondKey), findsNothing);
+
+    await tester.tap(find.text('push'));
+    await tester.pump();
+
+    expect(find.byKey(firstKey), isOnstage);
+    expect(find.byKey(firstKey), isInCard);
+    expect(find.byKey(secondKey, skipOffstage: false), isOffstage);
+    expect(find.byKey(secondKey, skipOffstage: false), isInCard);
+
+    await tester.pump();
+
+    expect(find.byKey(firstKey), findsNothing);
+    expect(find.byKey(secondKey), findsOneWidget);
+    expect(find.byKey(secondKey), isNotInCard);
+    expect(find.byKey(secondKey), isOnstage);
+
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.byKey(firstKey), findsNothing);
+    expect(find.byKey(secondKey), isOnstage);
+    expect(find.byKey(secondKey), isInCard);
+  });
+
+  testWidgets('Heroes in disabled HeroMode do not transition', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Material(
+        child: Column(
+          children: <Widget>[
+            HeroMode(
+              enabled: false,
+              child: Card(
+                child: Hero(
+                  tag: 'a',
+                  child: SizedBox(
+                    height: 100.0,
+                    width: 100.0,
+                    key: firstKey,
+                  ),
+                ),
+              ),
+            ),
+            Builder(
+              builder: (BuildContext context) {
+                return FlatButton(
+                  child: const Text('push'),
+                  onPressed: () {
+                    Navigator.push(context, PageRouteBuilder<void>(
+                      pageBuilder: (BuildContext context, Animation<double> _, Animation<double> __) {
+                        return Card(
+                          child: Hero(
+                            tag: 'a',
+                            child: SizedBox(
+                              height: 150.0,
+                              width: 150.0,
+                              key: secondKey,
+                            ),
+                          ),
+                        );
+                      },
+                    ));
+                  },
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    ));
+
+    expect(find.byKey(firstKey), isOnstage);
+    expect(find.byKey(firstKey), isInCard);
+    expect(find.byKey(secondKey), findsNothing);
+
+    await tester.tap(find.text('push'));
+    await tester.pump();
+
+    expect(find.byKey(firstKey), isOnstage);
+    expect(find.byKey(firstKey), isInCard);
+    expect(find.byKey(secondKey, skipOffstage: false), isOffstage);
+    expect(find.byKey(secondKey, skipOffstage: false), isInCard);
+
+    await tester.pump();
+
+    // When HeroMode is disabled, heroes will not move.
+    // So the original page contains the hero.
+    expect(find.byKey(firstKey), findsOneWidget);
+
+    // The hero should be in the new page, onstage, soon.
+    expect(find.byKey(secondKey), findsOneWidget);
+    expect(find.byKey(secondKey), isInCard);
+    expect(find.byKey(secondKey), isOnstage);
+
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.byKey(firstKey), findsNothing);
+
+    expect(find.byKey(secondKey), findsOneWidget);
+    expect(find.byKey(secondKey), isInCard);
+    expect(find.byKey(secondKey), isOnstage);
   });
 }

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -2024,7 +2024,7 @@ Future<void> main() async {
 
   testWidgets('Can push/pop on outer Navigator if nested Navigators contains same Heroes', (WidgetTester tester) async {
     const String heroTag = 'foo';
-    final GlobalKey<NavigatorState> rootNavigator = GlobalKey();
+    final GlobalKey<NavigatorState> rootNavigator = GlobalKey<NavigatorState>();
     final Key rootRouteHero = UniqueKey();
     final Key nestedRouteHeroOne = UniqueKey();
     final Key nestedRouteHeroTwo = UniqueKey();

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -2035,7 +2035,7 @@ Future<void> main() async {
         navigatorKey: rootNavigator,
         home: CupertinoTabScaffold(
           tabBar: CupertinoTabBar(
-            items: <BottomNavigationBarItem>[
+            items: const <BottomNavigationBarItem>[
               BottomNavigationBarItem(icon: Icon(Icons.home)),
               BottomNavigationBarItem(icon: Icon(Icons.favorite)),
             ],


### PR DESCRIPTION
## Description

When there are multiple Navigators like CupertinoPageScaffold, I want to disable heroes in the page that is not displayed.

HeroMode widget provides a means to control whether heroes is enabled or disabled.

### Error

current Flutter, An error occurs in the following step:

* Nested Navigators, such as CupertinoPageScaffold
* Inner CupertinoTabViews has the same name Heroes
* Show both inner CupertinoTabViews to init
* Push route that has the same name Hero to root Navigator

```dart
import 'package:flutter/cupertino.dart';
import 'package:flutter/material.dart';

const String kHeroTag = "hero tag";

void main() => runApp(CupertinoApp(
      title: 'Hero with CupertinoTabScaffold',
      home: HomePage(),
    ));

class HomePage extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return CupertinoTabScaffold(
      tabBar: CupertinoTabBar(
        items: <BottomNavigationBarItem>[
          BottomNavigationBarItem(icon: Icon(Icons.home)),
          BottomNavigationBarItem(icon: Icon(Icons.favorite)),
        ],
      ),
      tabBuilder: (BuildContext context, int index) {
        return CupertinoTabView(
          builder: (BuildContext context) => FirstPage(),
        );
      },
    );
  }
}

class FirstPage extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return CupertinoPageScaffold(
      navigationBar: CupertinoNavigationBar(),
      child: Center(
        child: Column(
          mainAxisAlignment: MainAxisAlignment.center,
          children: <Widget>[
            Hero(
              tag: kHeroTag,
              child: Container(
                width: 100,
                height: 100,
                color: Colors.red,
              ),
            ),
            RaisedButton(
              onPressed: () {
                Navigator.of(context, rootNavigator: false).push(
                  CupertinoPageRoute(
                    builder: (BuildContext context) => NextPage(),
                  ),
                );
              },
              child: Text("Next in tab"),
            ),
            RaisedButton(
              onPressed: () {
                Navigator.of(context, rootNavigator: true).push(
                  CupertinoPageRoute(
                    builder: (BuildContext context) => NextPage(),
                  ),
                );
              },
              child: Text("Next out tab"),
            ),
          ],
        ),
      ),
    );
  }
}

class NextPage extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return CupertinoPageScaffold(
      navigationBar: CupertinoNavigationBar(),
      child: Center(
        child: Hero(
          tag: kHeroTag,
          child: Container(
            width: 100,
            height: 100,
            color: Colors.red,
          ),
        ),
      ),
    );
  }
}
```

## Related Issues

https://github.com/flutter/flutter/pull/44890
https://github.com/flutter/flutter/issues/28042

## Tests

I added the following tests:

* test/widgets/heroes_test.dart
  * Can push/pop on outer Navigator if nested Navigators contains same Heroes
  * Heroes in enabled HeroMode do transition
  * Heroes in disabled HeroMode do not transition

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

This is the addition of a new widget, will not break existing apps.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
