### PR TITLE
Simplify the Shortcuts widget diagnostic output

### DIFF
--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1364,6 +1364,7 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
     assert(_debugCheckLocalizations(appLocale));
     return Shortcuts(
       shortcuts: widget.shortcuts ?? WidgetsApp.defaultShortcuts,
+      debugLabel: 'Default WidgetsApp Shortcuts',
       child: Actions(
         actions: widget.actions ?? WidgetsApp.defaultActions,
         child: DefaultFocusTraversal(

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1364,7 +1364,7 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
     assert(_debugCheckLocalizations(appLocale));
     return Shortcuts(
       shortcuts: widget.shortcuts ?? WidgetsApp.defaultShortcuts,
-//      debugLabel: '<Default WidgetsApp Shortcuts>',
+      debugLabel: '<Default WidgetsApp Shortcuts>',
       child: Actions(
         actions: widget.actions ?? WidgetsApp.defaultActions,
         child: DefaultFocusTraversal(

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1364,7 +1364,7 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
     assert(_debugCheckLocalizations(appLocale));
     return Shortcuts(
       shortcuts: widget.shortcuts ?? WidgetsApp.defaultShortcuts,
-      debugLabel: 'Default WidgetsApp Shortcuts',
+//      debugLabel: '<Default WidgetsApp Shortcuts>',
       child: Actions(
         actions: widget.actions ?? WidgetsApp.defaultActions,
         child: DefaultFocusTraversal(

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -243,6 +243,7 @@ class Shortcuts extends StatefulWidget {
     this.manager,
     this.shortcuts,
     this.child,
+    this.debugLabel,
   }) : super(key: key);
 
   /// The [ShortcutManager] that will manage the mapping between key
@@ -267,6 +268,16 @@ class Shortcuts extends StatefulWidget {
   ///
   /// {@macro flutter.widgets.child}
   final Widget child;
+
+  /// The debug label that is printed for this node when logged.
+  ///
+  /// If this label is set, then the shortcut mapping in [shortcuts] will only
+  /// be displayed if the diagnostic level is set to at least
+  /// [DiagnosticLevel.fine].
+  ///
+  /// This allows simplifying the diagnostic output to avoid cluttering it
+  /// unnecessarily with the default shortcut map.
+  final String debugLabel;
 
   /// Returns the [ActionDispatcher] that most tightly encloses the given
   /// [BuildContext].
@@ -300,7 +311,9 @@ class Shortcuts extends StatefulWidget {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<ShortcutManager>('manager', manager));
-    properties.add(DiagnosticsProperty<Map<LogicalKeySet, Intent>>('shortcuts', shortcuts));
+    final bool showDebugLabel = debugLabel != null && debugLabel.isNotEmpty;
+    properties.add(StringProperty('debugLabel', debugLabel, defaultValue: null, level: showDebugLabel ? DiagnosticLevel.info : DiagnosticLevel.hidden));
+    properties.add(DiagnosticsProperty<Map<LogicalKeySet, Intent>>('shortcuts', shortcuts, level: showDebugLabel ? DiagnosticLevel.fine : DiagnosticLevel.info));
   }
 }
 

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -166,6 +166,37 @@ class LogicalKeySet extends KeySet<LogicalKeyboardKey> with DiagnosticableMixin 
   }
 }
 
+/// Diagnostics property which handles formatting a `Map<LogicalKeySet, Intent>`
+/// (the same type as the [Shortcuts.shortcuts] property) so that it is human-readable.
+class ShortcutMapProperty extends DiagnosticsProperty<Map<LogicalKeySet, Intent>> {
+  /// Create a diagnostics property for `Map<LogicalKeySet, Intent>` objects,
+  /// which are the same type as the [Shortcuts.shortcuts] property.
+  ///
+  /// The [showName] and [level] arguments must not be null.
+  ShortcutMapProperty(
+    String name,
+    Map<LogicalKeySet, Intent> value, {
+    bool showName = true,
+    Object defaultValue = kNoDefaultValue,
+    DiagnosticLevel level = DiagnosticLevel.info,
+    String description,
+  }) : assert(showName != null),
+       assert(level != null),
+       super(
+         name,
+         value,
+         showName: showName,
+         defaultValue: defaultValue,
+         level: level,
+         description: description,
+       );
+
+  @override
+  String valueToString({ TextTreeConfiguration parentConfiguration }) {
+    return '{${value.keys.map<String>((LogicalKeySet keySet) => '{${keySet.debugDescribeKeys()}}: ${value[keySet]}').join(', ')}}';
+  }
+}
+
 /// A manager of keyboard shortcut bindings.
 ///
 /// A [ShortcutManager] is obtained by calling [Shortcuts.of] on the context of
@@ -337,13 +368,8 @@ class Shortcuts extends StatefulWidget {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-
-    final String description = debugLabel?.isNotEmpty ?? false
-        ? debugLabel
-        : '{${shortcuts.keys.map<String>((LogicalKeySet keySet) => '{${keySet.debugDescribeKeys()}}: ${shortcuts[keySet]}').join(', ')}}';
-
     properties.add(DiagnosticsProperty<ShortcutManager>('manager', manager, defaultValue: null));
-    properties.add(DiagnosticsProperty<Map<LogicalKeySet, Intent>>('shortcuts', shortcuts, description: description));
+    properties.add(ShortcutMapProperty('shortcuts', shortcuts, description: debugLabel?.isNotEmpty ?? false ? debugLabel : null));
   }
 }
 

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -146,7 +146,7 @@ void main() {
           })),
       );
     });
-    test('KeySet diagnostics work.', () {
+    test('LogicalKeySet diagnostics work.', () {
       final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
 
       LogicalKeySet(
@@ -162,10 +162,7 @@ void main() {
           .toList();
 
       expect(description.length, equals(1));
-      expect(
-          description[0],
-          equalsIgnoringHashCodes(
-              'keys: {LogicalKeyboardKey#00000(keyId: "0x00000061", keyLabel: "a", debugName: "Key A"), LogicalKeyboardKey#00000(keyId: "0x00000062", keyLabel: "b", debugName: "Key B")}'));
+      expect(description[0], equals('keys: Key A + Key B'));
     });
   });
   group(Shortcuts, () {
@@ -284,9 +281,13 @@ void main() {
       final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
 
       Shortcuts(shortcuts: <LogicalKeySet, Intent>{LogicalKeySet(
+        LogicalKeyboardKey.shift,
         LogicalKeyboardKey.keyA,
-        LogicalKeyboardKey.keyB,
-      ) : const Intent(ActivateAction.key)}).debugFillProperties(builder);
+      ) : const Intent(ActivateAction.key),
+        LogicalKeySet(
+        LogicalKeyboardKey.shift,
+        LogicalKeyboardKey.arrowRight,
+      ) : const DirectionalFocusIntent(TraversalDirection.right)}).debugFillProperties(builder);
 
       final List<String> description = builder.properties
           .where((DiagnosticsNode node) {
@@ -295,18 +296,17 @@ void main() {
           .map((DiagnosticsNode node) => node.toString())
           .toList();
 
-      expect(description.length, equals(2));
-      expect(description[0], equals('manager: null'));
+      expect(description.length, equals(1));
       expect(
-          description[1],
+          description[0],
           equalsIgnoringHashCodes(
-              'shortcuts: {LogicalKeySet#00000(keys: {LogicalKeyboardKey#00000(keyId: "0x00000061", keyLabel: "a", debugName: "Key A"), LogicalKeyboardKey#00000(keyId: "0x00000062", keyLabel: "b", debugName: "Key B")}): Intent#00000(key: [<ActivateAction>])}'));
+              'shortcuts: {{Shift + Key A}: Intent#00000(key: [<ActivateAction>]), {Shift + Arrow Right}: DirectionalFocusIntent#00000(key: [<DirectionalFocusAction>])}'));
     });
     test('Shortcuts diagnostics work when debugLabel specified.', () {
       final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
 
       Shortcuts(
-        debugLabel: 'Debug Label',
+        debugLabel: '<Debug Label>',
         shortcuts: <LogicalKeySet, Intent>{
           LogicalKeySet(
             LogicalKeyboardKey.keyA,
@@ -315,31 +315,15 @@ void main() {
         },
       ).debugFillProperties(builder);
 
-      List<String> description = builder.properties
+      final List<String> description = builder.properties
           .where((DiagnosticsNode node) {
         return !node.isFiltered(DiagnosticLevel.info);
       })
           .map((DiagnosticsNode node) => node.toString())
           .toList();
 
-      expect(description.length, equals(2));
-      expect(description[0], equals('manager: null'));
-      expect(description[1], equals('debugLabel: "Debug Label"'));
-
-      description = builder.properties
-          .where((DiagnosticsNode node) {
-        return !node.isFiltered(DiagnosticLevel.fine);
-      })
-          .map((DiagnosticsNode node) => node.toString())
-          .toList();
-
-      expect(description.length, equals(3));
-      expect(description[0], equals('manager: null'));
-      expect(description[1], equals('debugLabel: "Debug Label"'));
-      expect(
-          description[2],
-          equalsIgnoringHashCodes(
-              'shortcuts: {LogicalKeySet#00000(keys: {LogicalKeyboardKey#00000(keyId: "0x00000061", keyLabel: "a", debugName: "Key A"), LogicalKeyboardKey#00000(keyId: "0x00000062", keyLabel: "b", debugName: "Key B")}): Intent#00000(key: [<ActivateAction>])}'));
+      expect(description.length, equals(1));
+      expect(description[0], equals('shortcuts: <Debug Label>'));
     });
   });
 }

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -51,7 +51,7 @@ class TestShortcutManager extends ShortcutManager {
 
 void main() {
   group(LogicalKeySet, () {
-    test('$LogicalKeySet passes parameters correctly.', () {
+    test('LogicalKeySet passes parameters correctly.', () {
       final LogicalKeySet set1 = LogicalKeySet(LogicalKeyboardKey.keyA);
       final LogicalKeySet set2 = LogicalKeySet(
         LogicalKeyboardKey.keyA,
@@ -109,7 +109,7 @@ void main() {
             LogicalKeyboardKey.keyD,
           }));
     });
-    test('$LogicalKeySet works as a map key.', () {
+    test('LogicalKeySet works as a map key.', () {
       final LogicalKeySet set1 = LogicalKeySet(LogicalKeyboardKey.keyA);
       final LogicalKeySet set2 = LogicalKeySet(
         LogicalKeyboardKey.keyA,
@@ -146,7 +146,7 @@ void main() {
           })),
       );
     });
-    test('$KeySet diagnostics work.', () {
+    test('KeySet diagnostics work.', () {
       final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
 
       LogicalKeySet(
@@ -169,7 +169,7 @@ void main() {
     });
   });
   group(Shortcuts, () {
-    testWidgets('$ShortcutManager handles shortcuts', (WidgetTester tester) async {
+    testWidgets('ShortcutManager handles shortcuts', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       final List<LogicalKeyboardKey> pressedKeys = <LogicalKeyboardKey>[];
       final TestShortcutManager testManager = TestShortcutManager(pressedKeys);
@@ -202,7 +202,7 @@ void main() {
       expect(invoked, isTrue);
       expect(pressedKeys, equals(<LogicalKeyboardKey>[LogicalKeyboardKey.shiftLeft]));
     });
-    testWidgets("$Shortcuts passes to the next $Shortcuts widget if it doesn't map the key", (WidgetTester tester) async {
+    testWidgets("Shortcuts passes to the next Shortcuts widget if it doesn't map the key", (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       final List<LogicalKeyboardKey> pressedKeys = <LogicalKeyboardKey>[];
       final TestShortcutManager testManager = TestShortcutManager(pressedKeys);
@@ -240,7 +240,7 @@ void main() {
       expect(invoked, isTrue);
       expect(pressedKeys, equals(<LogicalKeyboardKey>[LogicalKeyboardKey.shiftLeft]));
     });
-    testWidgets('$Shortcuts can disable a shortcut with Intent.doNothing', (WidgetTester tester) async {
+    testWidgets('Shortcuts can disable a shortcut with Intent.doNothing', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       final List<LogicalKeyboardKey> pressedKeys = <LogicalKeyboardKey>[];
       final TestShortcutManager testManager = TestShortcutManager(pressedKeys);
@@ -279,6 +279,67 @@ void main() {
       await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
       expect(invoked, isFalse);
       expect(pressedKeys, isEmpty);
+    });
+    test('Shortcuts diagnostics work.', () {
+      final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
+
+      Shortcuts(shortcuts: <LogicalKeySet, Intent>{LogicalKeySet(
+        LogicalKeyboardKey.keyA,
+        LogicalKeyboardKey.keyB,
+      ) : const Intent(ActivateAction.key)}).debugFillProperties(builder);
+
+      final List<String> description = builder.properties
+          .where((DiagnosticsNode node) {
+        return !node.isFiltered(DiagnosticLevel.info);
+      })
+          .map((DiagnosticsNode node) => node.toString())
+          .toList();
+
+      expect(description.length, equals(2));
+      expect(description[0], equals('manager: null'));
+      expect(
+          description[1],
+          equalsIgnoringHashCodes(
+              'shortcuts: {LogicalKeySet#00000(keys: {LogicalKeyboardKey#00000(keyId: "0x00000061", keyLabel: "a", debugName: "Key A"), LogicalKeyboardKey#00000(keyId: "0x00000062", keyLabel: "b", debugName: "Key B")}): Intent#00000(key: [<ActivateAction>])}'));
+    });
+    test('Shortcuts diagnostics work when debugLabel specified.', () {
+      final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
+
+      Shortcuts(
+        debugLabel: 'Debug Label',
+        shortcuts: <LogicalKeySet, Intent>{
+          LogicalKeySet(
+            LogicalKeyboardKey.keyA,
+            LogicalKeyboardKey.keyB,
+          ): const Intent(ActivateAction.key)
+        },
+      ).debugFillProperties(builder);
+
+      List<String> description = builder.properties
+          .where((DiagnosticsNode node) {
+        return !node.isFiltered(DiagnosticLevel.info);
+      })
+          .map((DiagnosticsNode node) => node.toString())
+          .toList();
+
+      expect(description.length, equals(2));
+      expect(description[0], equals('manager: null'));
+      expect(description[1], equals('debugLabel: "Debug Label"'));
+
+      description = builder.properties
+          .where((DiagnosticsNode node) {
+        return !node.isFiltered(DiagnosticLevel.fine);
+      })
+          .map((DiagnosticsNode node) => node.toString())
+          .toList();
+
+      expect(description.length, equals(3));
+      expect(description[0], equals('manager: null'));
+      expect(description[1], equals('debugLabel: "Debug Label"'));
+      expect(
+          description[2],
+          equalsIgnoringHashCodes(
+              'shortcuts: {LogicalKeySet#00000(keys: {LogicalKeyboardKey#00000(keyId: "0x00000061", keyLabel: "a", debugName: "Key A"), LogicalKeyboardKey#00000(keyId: "0x00000062", keyLabel: "b", debugName: "Key B")}): Intent#00000(key: [<ActivateAction>])}'));
     });
   });
 }


### PR DESCRIPTION
## Description

This simplifies the diagnostic output for the `Shortcuts` widget so that if a `debugLabel` is supplied, then that is printed instead of the full list of shortcut keys in the map. Also, the output of the shortcut map is simplified to have the list of keys presented in more readable text.

Before:
```
Shortcuts(manager: null, shortcuts: {LogicalKeySet#4b55e(keys:
{LogicalKeyboardKey#70028(keyId: "0x100070028", keyLabel: null, debugName:
"Enter")}): Intent#f2511(key: [<ActivateAction>]), LogicalKeySet#d93b2(keys:
{LogicalKeyboardKey#00020(keyId: "0x00000020", keyLabel: " ", debugName:
"Space")}): Intent#f2511(key: [<ActivateAction>]), LogicalKeySet#2c1db(keys:
{LogicalKeyboardKey#7002b(keyId: "0x10007002b", keyLabel: null, debugName:
"Tab")}): Intent#e017c(key: [<NextFocusAction>]), LogicalKeySet#1212e(keys:
{LogicalKeyboardKey#700e1(keyId: "0x201000700e1", keyLabel: null, debugName:
"Shift"), LogicalKeyboardKey#7002b(keyId: "0x10007002b", keyLabel: null,
debugName: "Tab")}): Intent#9d8e3(key: [<PreviousFocusAction>]),
LogicalKeySet#56cb4(keys: {LogicalKeyboardKey#70050(keyId: "0x100070050",
keyLabel: null, debugName: "Arrow Left")}): DirectionalFocusIntent#079e6(key:
[<DirectionalFocusAction>]), LogicalKeySet#0058e(keys:
{LogicalKeyboardKey#7004f(keyId: "0x10007004f", keyLabel: null, debugName:
"Arrow Right")}): DirectionalFocusIntent#73d7c(key: [<DirectionalFocusAction>]),
LogicalKeySet#40831(keys: {LogicalKeyboardKey#70051(keyId: "0x100070051",
keyLabel: null, debugName: "Arrow Down")}): DirectionalFocusIntent#291aa(key:
[<DirectionalFocusAction>]), LogicalKeySet#a327d(keys:
{LogicalKeyboardKey#70052(keyId: "0x100070052", keyLabel: null, debugName:
"Arrow Up")}): DirectionalFocusIntent#ac1ab(key: [<DirectionalFocusAction>]),
LogicalKeySet#27a0e(keys: {LogicalKeyboardKey#700e0(keyId: "0x201000700e0",
keyLabel: null, debugName: "Control"), LogicalKeyboardKey#70052(keyId:
"0x100070052", keyLabel: null, debugName: "Arrow Up")}): ScrollIntent#1bd8f(key:
[<ScrollAction>]), LogicalKeySet#cde83(keys: {LogicalKeyboardKey#700e0(keyId:
"0x201000700e0", keyLabel: null, debugName: "Control"),
LogicalKeyboardKey#70051(keyId: "0x100070051", keyLabel: null, debugName: "Arrow
Down")}): ScrollIntent#22364(key: [<ScrollAction>]), LogicalKeySet#c97f6(keys:
{LogicalKeyboardKey#70050(keyId: "0x100070050", keyLabel: null, debugName:
"Arrow Left"), LogicalKeyboardKey#700e0(keyId: "0x201000700e0", keyLabel: null,
debugName: "Control")}): ScrollIntent#ddd53(key: [<ScrollAction>]),
LogicalKeySet#fa5ca(keys: {LogicalKeyboardKey#700e0(keyId: "0x201000700e0",
keyLabel: null, debugName: "Control"), LogicalKeyboardKey#7004f(keyId:
"0x10007004f", keyLabel: null, debugName: "Arrow Right")}):
ScrollIntent#70dab(key: [<ScrollAction>]), LogicalKeySet#a73c4(keys:
{LogicalKeyboardKey#7004b(keyId: "0x10007004b", keyLabel: null, debugName: "Page
Up")}): ScrollIntent#87ec7(key: [<ScrollAction>]), LogicalKeySet#6d93c(keys:
{LogicalKeyboardKey#7004e(keyId: "0x10007004e", keyLabel: null, debugName: "Page
Down")}): ScrollIntent#63769(key: [<ScrollAction>])}, state:
_ShortcutsState#aafdc)
```

After:
```
Shortcuts(shortcuts: <Default WidgetsApp Shortcuts>, state: _ShortcutsState#3abf9)
```

Or, if you had your own shortcut map like that that you wanted printed:
```
Shortcuts(shortcuts: {{Enter}: Intent#91378(key: [<ActivateAction>]), {Space}:
Intent#91378(key: [<ActivateAction>]), {Tab}: Intent#09b4b(key:
[<NextFocusAction>]), {Shift + Tab}: Intent#b9154(key: [<PreviousFocusAction>]),
{Arrow Left}: DirectionalFocusIntent#671e2(key: [<DirectionalFocusAction>]),
{Arrow Right}: DirectionalFocusIntent#9ddc0(key: [<DirectionalFocusAction>]),
{Arrow Down}: DirectionalFocusIntent#88a4f(key: [<DirectionalFocusAction>]),
{Arrow Up}: DirectionalFocusIntent#ca6a1(key: [<DirectionalFocusAction>]),
{Control + Arrow Up}: ScrollIntent#cefff(key: [<ScrollAction>]), {Control +
Arrow Down}: ScrollIntent#a2689(key: [<ScrollAction>]), {Control + Arrow Left}:
ScrollIntent#3760a(key: [<ScrollAction>]), {Control + Arrow Right}:
ScrollIntent#06968(key: [<ScrollAction>]), {Page Up}: ScrollIntent#28db5(key:
[<ScrollAction>]), {Page Down}: ScrollIntent#f771a(key: [<ScrollAction>])},
state: _ShortcutsState#4782d)
```

## Related Issues

https://github.com/flutter/flutter/issues/47650

## Tests

- Added tests for diagnostics on `Shortcuts` widget.