### PR TITLE
Transform mouse events to the local coordinate system

### DIFF
--- a/packages/flutter/lib/src/gestures/mouse_tracking.dart
+++ b/packages/flutter/lib/src/gestures/mouse_tracking.dart
@@ -464,7 +464,8 @@ class MouseTracker extends ChangeNotifier {
       // [MouseRegion.onExit] for details.
       if (annotation.onExit != null && attached) {
         if (annotation.getTransform != null) {
-          annotation.onExit(PointerExitEvent.fromMouseEvent(unhandledEvent).transformed(annotation.getTransform()..invert()));
+          final Matrix4 inverse = Matrix4.identity()..copyInverse(annotation.getTransform());
+          annotation.onExit(PointerExitEvent.fromMouseEvent(unhandledEvent).transformed(inverse));
         } else {
           annotation.onExit(PointerExitEvent.fromMouseEvent(unhandledEvent));
         }
@@ -477,9 +478,12 @@ class MouseTracker extends ChangeNotifier {
     for (final MouseTrackerAnnotation annotation in enteringAnnotations) {
       assert(trackedAnnotations.contains(annotation));
       if (annotation.onEnter != null) {
-        annotation.onEnter(PointerEnterEvent.fromMouseEvent(unhandledEvent).transformed(annotation.getTransform()..invert()));
-      } else {
-        annotation.onEnter(PointerEnterEvent.fromMouseEvent(unhandledEvent));
+        if (annotation.getTransform != null) {
+          final Matrix4 inverse = Matrix4.identity()..copyInverse(annotation.getTransform());
+          annotation.onEnter(PointerEnterEvent.fromMouseEvent(unhandledEvent).transformed(inverse));
+        } else {
+          annotation.onEnter(PointerEnterEvent.fromMouseEvent(unhandledEvent));
+        }
       }
     }
 
@@ -497,7 +501,8 @@ class MouseTracker extends ChangeNotifier {
             || lastHoverPosition != unhandledEvent.position) {
           if (annotation.onHover != null) {
             if (annotation.getTransform != null) {
-              annotation.onHover(unhandledEvent.transformed(annotation.getTransform()..invert()));
+              final Matrix4 inverse = Matrix4.identity()..copyInverse(annotation.getTransform());
+              annotation.onHover(unhandledEvent.transformed(inverse));
             } else {
               annotation.onHover(unhandledEvent);
             }

--- a/packages/flutter/lib/src/gestures/mouse_tracking.dart
+++ b/packages/flutter/lib/src/gestures/mouse_tracking.dart
@@ -7,6 +7,7 @@ import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:vector_math/vector_math_64.dart';
 
 import 'events.dart';
 import 'pointer_router.dart';
@@ -26,6 +27,8 @@ typedef PointerExitEventListener = void Function(PointerExitEvent event);
 /// Used by [MouseTrackerAnnotation], [MouseRegion] and [RenderMouseRegion].
 typedef PointerHoverEventListener = void Function(PointerHoverEvent event);
 
+typedef PointTransform = Matrix4 Function();
+
 /// The annotation object used to annotate layers that are interested in mouse
 /// movements.
 ///
@@ -33,7 +36,11 @@ typedef PointerHoverEventListener = void Function(PointerHoverEvent event);
 class MouseTrackerAnnotation {
   /// Creates an annotation that can be used to find layers interested in mouse
   /// movements.
-  const MouseTrackerAnnotation({this.onEnter, this.onHover, this.onExit});
+  const MouseTrackerAnnotation({this.onEnter, this.onHover, this.onExit, this.getTransform});
+
+  /// A function that returns the local transform of the client that this
+  /// annotation is attached to.
+  final PointTransform getTransform;
 
   /// Triggered when a mouse pointer, with or without buttons pressed, has
   /// entered the annotated region.
@@ -456,7 +463,11 @@ class MouseTracker extends ChangeNotifier {
       // trigger may cause exceptions and has safer alternatives. See
       // [MouseRegion.onExit] for details.
       if (annotation.onExit != null && attached) {
-        annotation.onExit(PointerExitEvent.fromMouseEvent(unhandledEvent));
+        if (annotation.getTransform != null) {
+          annotation.onExit(PointerExitEvent.fromMouseEvent(unhandledEvent).transformed(annotation.getTransform()..invert()));
+        } else {
+          annotation.onExit(PointerExitEvent.fromMouseEvent(unhandledEvent));
+        }
       }
     }
 
@@ -464,8 +475,9 @@ class MouseTracker extends ChangeNotifier {
     final Iterable<MouseTrackerAnnotation> enteringAnnotations =
       nextAnnotations.difference(lastAnnotations).toList().reversed;
     for (final MouseTrackerAnnotation annotation in enteringAnnotations) {
-      assert(trackedAnnotations.contains(annotation));
       if (annotation.onEnter != null) {
+        annotation.onEnter(PointerEnterEvent.fromMouseEvent(unhandledEvent).transformed(annotation.getTransform()..invert()));
+      } else {
         annotation.onEnter(PointerEnterEvent.fromMouseEvent(unhandledEvent));
       }
     }
@@ -483,7 +495,11 @@ class MouseTracker extends ChangeNotifier {
         if (!lastAnnotations.contains(annotation)
             || lastHoverPosition != unhandledEvent.position) {
           if (annotation.onHover != null) {
-            annotation.onHover(unhandledEvent);
+            if (annotation.getTransform != null) {
+              annotation.onHover(unhandledEvent.transformed(annotation.getTransform()..invert()));
+            } else {
+              annotation.onHover(unhandledEvent);
+            }
           }
         }
       }

--- a/packages/flutter/lib/src/gestures/mouse_tracking.dart
+++ b/packages/flutter/lib/src/gestures/mouse_tracking.dart
@@ -475,6 +475,7 @@ class MouseTracker extends ChangeNotifier {
     final Iterable<MouseTrackerAnnotation> enteringAnnotations =
       nextAnnotations.difference(lastAnnotations).toList().reversed;
     for (final MouseTrackerAnnotation annotation in enteringAnnotations) {
+      assert(trackedAnnotations.contains(annotation));
       if (annotation.onEnter != null) {
         annotation.onEnter(PointerEnterEvent.fromMouseEvent(unhandledEvent).transformed(annotation.getTransform()..invert()));
       } else {

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2669,6 +2669,7 @@ class RenderMouseRegion extends RenderProxyBox {
       onEnter: _handleEnter,
       onHover: _handleHover,
       onExit: _handleExit,
+      getTransform: () => getTransformTo(null),
     );
   }
 


### PR DESCRIPTION
## Description

This fills in the `localPosition` for hover events with the actual local position, rather than the global position which is currently being passed.

## Related Issues

- Fixes https://github.com/flutter/flutter/issues/33675

## Tests

- Added tests for transformed mouse events.

## Breaking Change

- [X] No, this is *not* a breaking change.