### PR TITLE
Implement reverseTransitionDuration for TransitionRoute

### DIFF
--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -91,8 +91,11 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
   Future<T> get completed => _transitionCompleter.future;
   final Completer<T> _transitionCompleter = Completer<T>();
 
-  /// The duration the transition lasts.
+  /// The duration the transition going forwards.
   Duration get transitionDuration;
+
+  /// The duration the transition going in reverse.
+  Duration get reverseTransitionDuration => transitionDuration;
 
   /// Whether the route obscures previous routes when the transition is complete.
   ///
@@ -127,9 +130,11 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
   AnimationController createAnimationController() {
     assert(!_transitionCompleter.isCompleted, 'Cannot reuse a $runtimeType after disposing it.');
     final Duration duration = transitionDuration;
+    final Duration reverseDuration = reverseTransitionDuration;
     assert(duration != null && duration >= Duration.zero);
     return AnimationController(
       duration: duration,
+      reverseDuration: reverseDuration,
       debugLabel: debugLabel,
       vsync: navigator,
     );

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -92,9 +92,17 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
   final Completer<T> _transitionCompleter = Completer<T>();
 
   /// The duration the transition going forwards.
+  ///
+  /// See also:
+  ///
+  /// * [reverseTransitionDuration], which controls the duration of the
+  /// transition when it is in reverse.
   Duration get transitionDuration;
 
   /// The duration the transition going in reverse.
+  ///
+  /// By default, the reverse transition duration is set to the value of
+  /// the forwards [transitionDuration].
   Duration get reverseTransitionDuration => transitionDuration;
 
   /// Whether the route obscures previous routes when the transition is complete.

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -974,18 +974,16 @@ class ModifiedReverseTransitionDurationRoute<T> extends MaterialPageRoute<T> {
   ModifiedReverseTransitionDurationRoute({
     @required WidgetBuilder builder,
     RouteSettings settings,
-    Duration reverseTransitionDuration,
+    this.reverseTransitionDuration,
     bool fullscreenDialog = false,
-  }) : _reverseTransitionDuration = reverseTransitionDuration,
-       super(
+  }) : super(
          builder: builder,
          settings: settings,
          fullscreenDialog: fullscreenDialog,
        );
 
   @override
-  Duration get reverseTransitionDuration => _reverseTransitionDuration;
-  final Duration _reverseTransitionDuration;
+  final Duration reverseTransitionDuration;
 }
 
 class MockPageRoute extends Mock implements PageRoute<dynamic> { }


### PR DESCRIPTION
## Description

This change allows developers to implement a reverse duration for a page transition. It defaults to the forward transitionDuration if it isn't specified.

```dart
// SAMPLE CLASS: 
class ModifiedReverseTransitionDurationRoute<T> extends MaterialPageRoute<T> {
  ModifiedReverseTransitionDurationRoute({
    @required WidgetBuilder builder,
    RouteSettings settings,
    Duration reverseTransitionDuration,
    bool fullscreenDialog = false,
  }) : _reverseTransitionDuration = reverseTransitionDuration,
       super(
         builder: builder,
         settings: settings,
         fullscreenDialog: fullscreenDialog,
       );

  @override
  Duration get reverseTransitionDuration => _reverseTransitionDuration;
  final Duration _reverseTransitionDuration;
}

// USAGE:
Navigator.of(context).push(
  ModifiedReverseTransitionDurationRoute<dynamic>(
    builder: (BuildContext innerContext) {
      return Container(color: Colors.green);
    },
    reverseTransitionDuration: const Duration(milliseconds: 150), // modified value
  ),
);
```

## Related Issues

n/a

## Tests

I added the following tests:

Added a test for the default reverse transition duration
Added a test for a custom reverse transition duration

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
