### PR TITLE
Fix to slider tick mark alignment (issue #48304)

### DIFF
--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -1125,7 +1125,7 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
         isEnabled: isInteractive,
         sliderTheme: _sliderTheme,
       ).width;
-      final double adjustedTrackWidth = trackRect.width - tickMarkWidth;
+      final double adjustedTrackWidth = trackRect.width;
       // If the tick marks would be too dense, don't bother painting them.
       if (adjustedTrackWidth / divisions >= 3.0 * tickMarkWidth) {
         final double dy = trackRect.center.dy;
@@ -1133,7 +1133,7 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
           final double value = i / divisions;
           // The ticks are mapped to be within the track, so the tick mark width
           // must be subtracted from the track width.
-          final double dx = trackRect.left + value * adjustedTrackWidth + tickMarkWidth / 2;
+          final double dx = trackRect.left + value * adjustedTrackWidth;
           final Offset tickMarkOffset = Offset(dx, dy);
           _sliderTheme.tickMarkShape.paint(
             context,


### PR DESCRIPTION
## Description

This change fixes the alignment of slider tick marks with the slider's thumb. The issue becomes apparent when large values are used for the height of the slider's track and the ticks marks' width. The tick marks will be shifted toward the center of the track and therefore not align properly with the thumb.

The change results in proper alignment of the tick marks' and the thumb's centers in all positions.
