### PR TITLE
[flutter_tool] Add support for --csp mode to build web

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/web_fs.dart
+++ b/packages/flutter_tools/lib/src/build_runner/web_fs.dart
@@ -150,7 +150,14 @@ class WebFs {
   /// Recompile the web application and return whether this was successful.
   Future<bool> recompile() async {
     if (!_useBuildRunner) {
-      await buildWeb(_flutterProject, _target, _buildInfo, _initializePlatform, _dartDefines);
+      await buildWeb(
+        _flutterProject,
+        _target,
+        _buildInfo,
+        _initializePlatform,
+        _dartDefines,
+        false,
+      );
       return true;
     }
     _client.startBuild();
@@ -309,7 +316,14 @@ class WebFs {
         handler = pipeline.addHandler(proxyHandler('http://localhost:$daemonAssetPort/web/'));
       }
     } else {
-      await buildWeb(flutterProject, target, buildInfo, initializePlatform, dartDefines);
+      await buildWeb(
+        flutterProject,
+        target,
+        buildInfo,
+        initializePlatform,
+        dartDefines,
+        false,
+      );
       firstBuildCompleter.complete(true);
     }
 

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -26,6 +26,9 @@ const String kHasWebPlugins = 'HasWebPlugins';
 /// Valid values are O1 (lowest, profile default) to O4 (highest, release default).
 const String kDart2jsOptimization = 'Dart2jsOptimization';
 
+/// Whether to disable dynamic generation code to satisfy csp policies.
+const String kCspMode = 'cspMode';
+
 /// Generates an entry point for a web target.
 class WebEntrypointTarget extends Target {
   const WebEntrypointTarget();
@@ -146,6 +149,7 @@ class Dart2JSTarget extends Target {
   @override
   Future<void> build(Environment environment) async {
     final String dart2jsOptimization = environment.defines[kDart2jsOptimization];
+    final bool csp = environment.defines[kCspMode] == 'true';
     final BuildMode buildMode = getBuildModeForName(environment.defines[kBuildMode]);
     final String specPath = globals.fs.path.join(globals.artifacts.getArtifactPath(Artifact.flutterWebSdk), 'libraries.json');
     final String packageFile = FlutterProject.fromDirectory(environment.projectDir).hasBuilders
@@ -170,6 +174,8 @@ class Dart2JSTarget extends Target {
         '-Ddart.vm.profile=true'
       else
         '-Ddart.vm.product=true',
+      if (csp)
+        '--csp',
       for (final String dartDefine in parseDartDefines(environment))
         '-D$dartDefine',
       environment.buildDir.childFile('main.dart').path,

--- a/packages/flutter_tools/lib/src/commands/build_web.dart
+++ b/packages/flutter_tools/lib/src/commands/build_web.dart
@@ -25,6 +25,12 @@ class BuildWebCommand extends BuildSubCommand {
         hide: true,
         help: 'Whether to automatically invoke webOnlyInitializePlatform.',
     );
+    argParser.addFlag('csp',
+      defaultsTo: false,
+      negatable: false,
+      help: 'Disable dynamic generation of code in the generated output.'
+        'This is necessary to satisfy CSP restrictions (see http://www.w3.org/TR/CSP/).'
+    );
   }
 
   @override
@@ -59,6 +65,7 @@ class BuildWebCommand extends BuildSubCommand {
       buildInfo,
       boolArg('web-initialize-platform'),
       dartDefines,
+      boolArg('csp')
     );
     return null;
   }

--- a/packages/flutter_tools/lib/src/web/compile.dart
+++ b/packages/flutter_tools/lib/src/web/compile.dart
@@ -28,6 +28,7 @@ Future<void> buildWeb(
   BuildInfo buildInfo,
   bool initializePlatform,
   List<String> dartDefines,
+  bool csp,
 ) async {
   if (!flutterProject.web.existsSync()) {
     throwToolExit('Missing index.html.');
@@ -50,6 +51,7 @@ Future<void> buildWeb(
         kInitializePlatform: initializePlatform.toString(),
         kHasWebPlugins: hasWebPlugins.toString(),
         kDartDefines: jsonEncode(dartDefines),
+        kCspMode: csp.toString(),
       },
     ));
     if (!result.success) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
@@ -59,6 +59,7 @@ void main() {
       BuildInfo.debug,
       false,
       const <String>[],
+      false,
     ), throwsA(isInstanceOf<ToolExit>()));
   }));
 


### PR DESCRIPTION
## Description

Add support for csp mode via --csp argument in build web. This is required to run the application in certain environments, like firefox extensions.

Fixes https://github.com/flutter/flutter/issues/44439