### PR TITLE
Transform mouse events to the local coordinate system

### DIFF
--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -10,6 +10,8 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 
+import 'package:vector_math/vector_math_64.dart' show Matrix4;
+
 import 'binding.dart';
 import 'box.dart';
 import 'layer.dart';
@@ -811,6 +813,10 @@ mixin _PlatformViewGestureMixin on RenderBox {
 
   _PlatformViewGestureRecognizer _gestureRecognizer;
 
+  Matrix4 _eventTransformer() {
+    return Matrix4.inverted(getTransformTo(null));
+  }
+
   @override
   bool hitTest(BoxHitTestResult result, { Offset position }) {
     if (hitTestBehavior == PlatformViewHitTestBehavior.transparent || !size.contains(position)) {
@@ -836,7 +842,7 @@ mixin _PlatformViewGestureMixin on RenderBox {
     assert(_hoverAnnotation == null);
     _hoverAnnotation = MouseTrackerAnnotation(onHover: (PointerHoverEvent event) {
       if (_handlePointerEvent != null)
-        _handlePointerEvent(event);
+        _handlePointerEvent(event.transformed(_eventTransformer()));
     });
     RendererBinding.instance.mouseTracker.attachAnnotation(_hoverAnnotation);
   }

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -12,7 +12,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter/semantics.dart';
 
-import 'package:vector_math/vector_math_64.dart';
+import 'package:vector_math/vector_math_64.dart' show Matrix4;
 
 import 'binding.dart';
 import 'box.dart';
@@ -2707,7 +2707,7 @@ class RenderMouseRegion extends RenderProxyBox {
   PointerEnterEventListener _onEnter;
   void _handleEnter(PointerEnterEvent event) {
     if (_onEnter != null)
-      _onEnter(event);
+      _onEnter(event.transformed(_eventTransformer()));
   }
 
   /// Called when a pointer changes position without buttons pressed and the end
@@ -2722,7 +2722,7 @@ class RenderMouseRegion extends RenderProxyBox {
   PointerHoverEventListener _onHover;
   void _handleHover(PointerHoverEvent event) {
     if (_onHover != null)
-      _onHover(event);
+      _onHover(event.transformed(_eventTransformer()));
   }
 
   /// Called when a pointer leaves the region (with or without buttons pressed)
@@ -2737,7 +2737,7 @@ class RenderMouseRegion extends RenderProxyBox {
   PointerExitEventListener _onExit;
   void _handleExit(PointerExitEvent event) {
     if (_onExit != null)
-      _onExit(event);
+      _onExit(event.transformed(_eventTransformer()));
   }
 
   // Object used for annotation of the layer used for hover hit detection.
@@ -2749,6 +2749,10 @@ class RenderMouseRegion extends RenderProxyBox {
   /// in other contexts.
   @visibleForTesting
   MouseTrackerAnnotation get hoverAnnotation => _hoverAnnotation;
+
+  Matrix4 _eventTransformer() {
+    return Matrix4.inverted(getTransformTo(null));
+  }
 
   void _updateAnnotations() {
     final bool annotationWasActive = _annotationIsActive;

--- a/packages/flutter/test/rendering/platform_view_test.dart
+++ b/packages/flutter/test/rendering/platform_view_test.dart
@@ -70,15 +70,19 @@ void main() {
       semanticsHandle.dispose();
     });
 
-    testGesture('hover events are dispatched via PlatformViewController.dispatchPointerEvent', (GestureTester tester) {
-      layout(platformViewRenderBox);
+    testGesture('hover events are dispatched via PlatformViewController.dispatchPointerEvent with correct parameter', (GestureTester tester) {
+      layout(platformViewRenderBox, constraints: BoxConstraints.tight(const Size(100, 100)));
       pumpFrame(phase: EnginePhase.flushSemantics);
 
       final TestPointer pointer = TestPointer(1, PointerDeviceKind.mouse);
       tester.route(pointer.addPointer());
-      tester.route(pointer.hover(const Offset(10, 10)));
+      tester.route(pointer.hover(const Offset(400, 310)));
 
-      expect(fakePlatformViewController.dispatchedPointerEvents, isNotEmpty);
+      expect(fakePlatformViewController.dispatchedPointerEvents, hasLength(1));
+      final PointerEvent event = fakePlatformViewController.dispatchedPointerEvents[0];
+      expect(event is PointerHoverEvent, true);
+      expect(event.position, const Offset(400, 310));
+      expect(event.localPosition, const Offset(50, 60));
     });
 
   }, skip: isBrowser); // TODO(yjbanov): fails on Web with obscured stack trace: https://github.com/flutter/flutter/issues/42770


### PR DESCRIPTION
## Description

This PR fixes the issue that mouse events from callbacks (`onEnter`, `onHover`, `onExit`) don't have correct local information, i.e. `localPosition` and `localDelta`.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from our [issue database]. Indicate, which of these issues are resolved or fixed by this PR. There should be at least one issue listed here.*

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behaviour with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
