### PR TITLE
Add onScrollCancelled and onScrollStarted callback for PageView

### DIFF
--- a/packages/flutter/lib/src/physics/spring_simulation.dart
+++ b/packages/flutter/lib/src/physics/spring_simulation.dart
@@ -120,6 +120,9 @@ class SpringSimulation extends Simulation {
 
   @override
   String toString() => '$runtimeType(end: $_endPosition, $type)';
+
+  /// The end position of the simulation.
+  double get endPosition => _endPosition;
 }
 
 /// A [SpringSimulation] where the value of [x] is guaranteed to have exactly the

--- a/packages/flutter/lib/src/widgets/scroll_activity.dart
+++ b/packages/flutter/lib/src/widgets/scroll_activity.dart
@@ -106,6 +106,13 @@ abstract class ScrollActivity {
     ScrollEndNotification(metrics: metrics, context: context).dispatch(context);
   }
 
+  /// Dispatch a [ScrollCancelledNotification] with the given metrics.
+  void dispatchScrollCancelledNotification(
+      ScrollMetrics metrics, BuildContext context) {
+    ScrollCancelledNotification(metrics: metrics, context: context)
+        .dispatch(context);
+  }
+
   /// Called when the scroll view that is performing this activity changes its metrics.
   void applyNewDimensions() { }
 

--- a/packages/flutter/lib/src/widgets/scroll_notification.dart
+++ b/packages/flutter/lib/src/widgets/scroll_notification.dart
@@ -58,6 +58,8 @@ mixin ViewportNotificationMixin on Notification {
 ///    scrolling.
 ///  * A [UserScrollNotification], with a [UserScrollNotification.direction] of
 ///    [ScrollDirection.idle].
+///  * Zero or one [ScrollCancelledNotification] which indicates that the scroll
+///    is cancelled and the widget's state is not changed by the scroll.
 ///
 /// Notifications bubble up through the tree, which means a given
 /// [NotificationListener] will receive notifications for all descendant
@@ -251,6 +253,23 @@ class ScrollEndNotification extends ScrollNotification {
     if (dragDetails != null)
       description.add('$dragDetails');
   }
+}
+
+/// A notification that a [Scrollable] widget has cancelled scrolling.
+///
+/// Cancelling scroll means [Scrollable] widget restores to the state before
+/// user starts scrolling. This could happen in some widgets such as [PageView]
+/// when user doesn't scroll enough and it animates back to previous state where
+/// page is not changed.
+/// See also:
+///
+///  * [ScrollStartNotification], which indicates that scrolling has started.
+///  * [ScrollNotification], which describes the notification lifecycle.
+class ScrollCancelledNotification extends ScrollNotification {
+  ScrollCancelledNotification({
+    @required ScrollMetrics metrics,
+    @required BuildContext context,
+  }) : super(metrics: metrics, context: context);
 }
 
 /// A notification that the user has changed the direction in which they are

--- a/packages/flutter/lib/src/widgets/scroll_notification.dart
+++ b/packages/flutter/lib/src/widgets/scroll_notification.dart
@@ -266,6 +266,7 @@ class ScrollEndNotification extends ScrollNotification {
 ///  * [ScrollStartNotification], which indicates that scrolling has started.
 ///  * [ScrollNotification], which describes the notification lifecycle.
 class ScrollCancelledNotification extends ScrollNotification {
+  /// Creates a notification that a [Scrollable] widget has cancelled scrolling.
   ScrollCancelledNotification({
     @required ScrollMetrics metrics,
     @required BuildContext context,

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -157,6 +157,11 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
   bool get haveDimensions => _haveDimensions;
   bool _haveDimensions = false;
 
+  /// The initial number of pixels to offset the children in the opposite of
+  /// the axis direction when scroll starts.
+  double get initialPixels => _initialPixels;
+  double _initialPixels;
+
   /// Take any current applicable state from the given [ScrollPosition].
   ///
   /// This method is called by the constructor if it is given an `oldPosition`.
@@ -709,7 +714,9 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
 
   /// Called by [beginActivity] to report when an activity has started.
   void didStartScroll() {
-    activity.dispatchScrollStartNotification(copyWith(), context.notificationContext);
+    _initialPixels = pixels;
+    activity.dispatchScrollStartNotification(
+        copyWith(), context.notificationContext);
   }
 
   /// Called by [setPixels] to report a change to the [pixels] position.
@@ -739,6 +746,13 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
   /// Subclasses should call this function when they change [userScrollDirection].
   void didUpdateScrollDirection(ScrollDirection direction) {
     UserScrollNotification(metrics: copyWith(), context: context.notificationContext, direction: direction).dispatch(context.notificationContext);
+  }
+
+  /// Dispatches a notification that scroll is cancelled and widget's state is
+  /// not changed by scroll.
+  void didCancelScroll() {
+    activity.dispatchScrollCancelledNotification(
+        copyWith(), context.notificationContext);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/scroll_position_with_single_context.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position_with_single_context.dart
@@ -146,6 +146,12 @@ class ScrollPositionWithSingleContext extends ScrollPosition implements ScrollAc
     final Simulation simulation = physics.createBallisticSimulation(this, velocity);
     if (simulation != null) {
       beginActivity(BallisticScrollActivity(this, simulation, context.vsync));
+      if (simulation is ScrollSpringSimulation &&
+          simulation.endPosition == initialPixels) {
+        // Dispatch a scroll cancelled notification if the end position of the
+        // animation equals to the initial position before scroll starts.
+        didCancelScroll();
+      }
     } else {
       goIdle();
     }


### PR DESCRIPTION
## Description

Add onScrollCancelled and onScrollStarted callback to PageView. 
onScrollCancelled is called when user cancels scrolling and it animates back to current page.
onScrollStarted is calledn when user stats scrolling.

## Related Issues

Add an `onPageCancelled` callback to PageView widget #44623

## Tests

I added 3 tests in page_view_test.dart

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
