### PR TITLE
Allow for customizable ModalRoute barrierTween

### DIFF
--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -58,6 +58,9 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   final bool maintainState;
 
   @override
+  Duration get transitionDuration => const Duration(milliseconds: 300);
+
+  @override
   Color get barrierColor => null;
 
   @override

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -44,14 +44,11 @@ class MaterialPageRoute<T> extends PageRoute<T> {
     @required this.builder,
     RouteSettings settings,
     this.maintainState = true,
-    Duration transitionDuration = const Duration(milliseconds: 300),
     bool fullscreenDialog = false,
   }) : assert(builder != null),
        assert(maintainState != null),
-       assert(transitionDuration != null),
        assert(fullscreenDialog != null),
        assert(opaque),
-       _transitionDuration = transitionDuration,
        super(settings: settings, fullscreenDialog: fullscreenDialog);
 
   /// Builds the primary contents of the route.
@@ -59,10 +56,6 @@ class MaterialPageRoute<T> extends PageRoute<T> {
 
   @override
   final bool maintainState;
-
-  @override
-  Duration get transitionDuration => _transitionDuration;
-  final Duration _transitionDuration;
 
   @override
   Color get barrierColor => null;

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -44,11 +44,14 @@ class MaterialPageRoute<T> extends PageRoute<T> {
     @required this.builder,
     RouteSettings settings,
     this.maintainState = true,
+    Duration transitionDuration = const Duration(milliseconds: 300),
     bool fullscreenDialog = false,
   }) : assert(builder != null),
        assert(maintainState != null),
+       assert(transitionDuration != null),
        assert(fullscreenDialog != null),
        assert(opaque),
+       _transitionDuration = transitionDuration,
        super(settings: settings, fullscreenDialog: fullscreenDialog);
 
   /// Builds the primary contents of the route.
@@ -58,7 +61,8 @@ class MaterialPageRoute<T> extends PageRoute<T> {
   final bool maintainState;
 
   @override
-  Duration get transitionDuration => const Duration(milliseconds: 300);
+  Duration get transitionDuration => _transitionDuration;
+  final Duration _transitionDuration;
 
   @override
   Color get barrierColor => null;

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1072,18 +1072,19 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   /// While the route is animating into position, the color is animated from
   /// transparent to the specified color.
   ///
-  /// If this getter would ever start returning a different tween,
+  /// If this getter would ever start returning a different curve,
   /// [changedInternalState] should be invoked so that the change can take
   /// effect.
   ///
-  /// It defaults to a [CurveTween] with a [Curves.ease] curve.
+  /// It defaults to [Curves.ease].
   ///
   /// See also:
   ///
   ///  * [barrierColor], which determines the color that the modal transitions
   ///    to.
+  ///  * [Curves] for collection of common curves.
   ///  * [AnimatedModalBarrier], the widget that implements this feature.
-  Animatable<double> get barrierTween => CurveTween(curve: Curves.ease);
+  Curve get barrierCurve => Curves.ease;
 
   /// Whether the route should remain in memory when it is inactive.
   ///
@@ -1303,8 +1304,8 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
       final Animation<Color> color = animation.drive(
         ColorTween(
           begin: _kTransparent,
-          end: barrierColor, // changedInternalState is called if this updates
-        ).chain(barrierTween),
+          end: barrierColor, // changedInternalState is called if barrierColor updates
+        ).chain(CurveTween(curve: barrierCurve)), // changedInternalState is called if barrierCurve
       );
       barrier = AnimatedModalBarrier(
         color: color,

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1305,7 +1305,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
         ColorTween(
           begin: _kTransparent,
           end: barrierColor, // changedInternalState is called if barrierColor updates
-        ).chain(CurveTween(curve: barrierCurve)), // changedInternalState is called if barrierCurve
+        ).chain(CurveTween(curve: barrierCurve)), // changedInternalState is called if barrierCurve updates
       );
       barrier = AnimatedModalBarrier(
         color: color,

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -985,7 +985,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   ///
   /// If [barrierDismissible] is false, then tapping the barrier has no effect.
   ///
-  /// If this getter would ever start returning a different color,
+  /// If this getter would ever start return a different value,
   /// [changedInternalState] should be invoked so that the change can take
   /// effect.
   ///
@@ -1049,7 +1049,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   /// For example, when a dialog is on the screen, the page below the dialog is
   /// usually darkened by the modal barrier.
   ///
-  /// If this getter would ever start returning a different color,
+  /// If this getter would ever start returning a different label,
   /// [changedInternalState] should be invoked so that the change can take
   /// effect.
   ///
@@ -1072,7 +1072,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   /// While the route is animating into position, the color is animated from
   /// transparent to the specified color.
   ///
-  /// If this getter would ever start returning a different color,
+  /// If this getter would ever start returning a different tween,
   /// [changedInternalState] should be invoked so that the change can take
   /// effect.
   ///
@@ -1298,7 +1298,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   OverlayEntry _modalBarrier;
   Widget _buildModalBarrier(BuildContext context) {
     Widget barrier;
-    if (barrierColor != null && !offstage) { // changedInternalState is called if these update
+    if (barrierColor != null && !offstage) { // changedInternalState is called if barrierColor or offstage updates
       assert(barrierColor != _kTransparent);
       final Animation<Color> color = animation.drive(
         ColorTween(
@@ -1308,14 +1308,14 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
       );
       barrier = AnimatedModalBarrier(
         color: color,
-        dismissible: barrierDismissible, // changedInternalState is called if this updates
-        semanticsLabel: barrierLabel, // changedInternalState is called if this updates
+        dismissible: barrierDismissible, // changedInternalState is called if barrierDismissible updates
+        semanticsLabel: barrierLabel, // changedInternalState is called if barrierLabel updates
         barrierSemanticsDismissible: semanticsDismissible,
       );
     } else {
       barrier = ModalBarrier(
-        dismissible: barrierDismissible, // changedInternalState is called if this updates
-        semanticsLabel: barrierLabel, // changedInternalState is called if this updates
+        dismissible: barrierDismissible, // changedInternalState is called if barrierDismissible updates
+        semanticsLabel: barrierLabel, // changedInternalState is called if barrierLabel updates
         barrierSemanticsDismissible: semanticsDismissible,
       );
     }
@@ -1326,7 +1326,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
       );
     }
     return IgnorePointer(
-      ignoring: animation.status == AnimationStatus.reverse || // changedInternalState is called when this updates
+      ignoring: animation.status == AnimationStatus.reverse || // changedInternalState is called when animation.status updates
                 animation.status == AnimationStatus.dismissed, // dismissed is possible when doing a manual pop gesture
       child: barrier,
     );

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1060,6 +1060,31 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   ///  * [ModalBarrier], the widget that implements this feature.
   String get barrierLabel;
 
+  /// The tween that is used for animating the modal barrier in and out.
+  ///
+  /// The modal barrier is the scrim that is rendered behind each route, which
+  /// generally prevents the user from interacting with the route below the
+  /// current route, and normally partially obscures such routes.
+  ///
+  /// For example, when a dialog is on the screen, the page below the dialog is
+  /// usually darkened by the modal barrier.
+  ///
+  /// While the route is animating into position, the color is animated from
+  /// transparent to the specified color.
+  ///
+  /// If this getter would ever start returning a different color,
+  /// [changedInternalState] should be invoked so that the change can take
+  /// effect.
+  ///
+  /// It defaults to a [CurveTween] with a [Curves.ease] curve.
+  ///
+  /// See also:
+  ///
+  ///  * [barrierColor], which determines the color that the modal transitions
+  ///    to.
+  ///  * [AnimatedModalBarrier], the widget that implements this feature.
+  Animatable<double> barrierTween = CurveTween(curve: Curves.ease);
+
   /// Whether the route should remain in memory when it is inactive.
   ///
   /// If this is true, then the route is maintained, so that any futures it is
@@ -1269,8 +1294,6 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   final GlobalKey _subtreeKey = GlobalKey();
   final PageStorageBucket _storageBucket = PageStorageBucket();
 
-  static final Animatable<double> _easeCurveTween = CurveTween(curve: Curves.ease);
-
   // one of the builders
   OverlayEntry _modalBarrier;
   Widget _buildModalBarrier(BuildContext context) {
@@ -1281,7 +1304,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
         ColorTween(
           begin: _kTransparent,
           end: barrierColor, // changedInternalState is called if this updates
-        ).chain(_easeCurveTween),
+        ).chain(barrierTween),
       );
       barrier = AnimatedModalBarrier(
         color: color,

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1083,7 +1083,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   ///  * [barrierColor], which determines the color that the modal transitions
   ///    to.
   ///  * [AnimatedModalBarrier], the widget that implements this feature.
-  Animatable<double> barrierTween = CurveTween(curve: Curves.ease);
+  Animatable<double> get barrierTween => CurveTween(curve: Curves.ease);
 
   /// Whether the route should remain in memory when it is inactive.
   ///

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1070,7 +1070,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   /// usually darkened by the modal barrier.
   ///
   /// While the route is animating into position, the color is animated from
-  /// transparent to the specified color.
+  /// transparent to the specified [barrierColor].
   ///
   /// If this getter would ever start returning a different curve,
   /// [changedInternalState] should be invoked so that the change can take
@@ -1082,7 +1082,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   ///
   ///  * [barrierColor], which determines the color that the modal transitions
   ///    to.
-  ///  * [Curves] for collection of common curves.
+  ///  * [Curves] for a collection of common curves.
   ///  * [AnimatedModalBarrier], the widget that implements this feature.
   Curve get barrierCurve => Curves.ease;
 

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1060,7 +1060,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   ///  * [ModalBarrier], the widget that implements this feature.
   String get barrierLabel;
 
-  /// The tween that is used for animating the modal barrier in and out.
+  /// The curve that is used for animating the modal barrier in and out.
   ///
   /// The modal barrier is the scrim that is rendered behind each route, which
   /// generally prevents the user from interacting with the route below the

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -985,7 +985,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   ///
   /// If [barrierDismissible] is false, then tapping the barrier has no effect.
   ///
-  /// If this getter would ever start return a different value,
+  /// If this getter would ever start returning a different value,
   /// [changedInternalState] should be invoked so that the change can take
   /// effect.
   ///

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -940,13 +940,13 @@ void main() {
                     Navigator.of(context).push<void>(
                       _TestDialogRouteWithCustomBarrierTween<void>(
                         child: const Text('Hello World'),
-                        barrierTween: CurveTween(curve: Curves.linear),
-                      )
+                        barrierCurve: Curves.linear,
+                      ),
                     );
                   },
                 ),
               );
-            }
+            },
           ),
         ),
       ));
@@ -1052,9 +1052,9 @@ class _TestDialogRoute<T> extends PopupRoute<T> {
 class _TestDialogRouteWithCustomBarrierTween<T> extends PopupRoute<T> {
   _TestDialogRouteWithCustomBarrierTween({
     @required Widget child,
-    @required Animatable<double> barrierTween,
-  }) : assert(barrierTween != null),
-       _barrierTween = barrierTween,
+    @required Curve barrierCurve,
+  }) : assert(barrierCurve != null),
+       _barrierCurve = barrierCurve,
        _child = child;
 
   final Widget _child;
@@ -1069,8 +1069,8 @@ class _TestDialogRouteWithCustomBarrierTween<T> extends PopupRoute<T> {
   Color get barrierColor => Colors.black; // easier value to test against
 
   @override
-  Animatable<double> get barrierTween => _barrierTween;
-  final Animatable<double> _barrierTween;
+  Curve get barrierCurve => _barrierCurve;
+  final Curve _barrierCurve;
 
   @override
   Duration get transitionDuration => const Duration(milliseconds: 100); // easier value to test against

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -888,9 +888,9 @@ void main() {
         ),
       ));
 
-      final CurveTween _defaultBarrierCurve = CurveTween(curve: Curves.ease);
-      double _getBarrierCurveAlphaValue(double t) {
-        return _defaultBarrierCurve.transform(t) * 255;
+      final CurveTween _defaultBarrierTween = CurveTween(curve: Curves.ease);
+      double _getBarrierTweenAlphaValue(double t) {
+        return _defaultBarrierTween.transform(t) * 255;
       }
 
       await tester.tap(find.text('X'));
@@ -906,21 +906,21 @@ void main() {
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
       expect(
         modalBarrierAnimation.value.alpha,
-        closeTo(_getBarrierCurveAlphaValue(0.25), 1.0),
+        closeTo(_getBarrierTweenAlphaValue(0.25), 1.0),
       );
 
       await tester.pump(const Duration(milliseconds: 25));
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
       expect(
         modalBarrierAnimation.value.alpha,
-        closeTo(_getBarrierCurveAlphaValue(0.50), 1.0),
+        closeTo(_getBarrierTweenAlphaValue(0.50), 1.0),
       );
 
       await tester.pump(const Duration(milliseconds: 25));
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
       expect(
         modalBarrierAnimation.value.alpha,
-        closeTo(_getBarrierCurveAlphaValue(0.75), 1.0),
+        closeTo(_getBarrierTweenAlphaValue(0.75), 1.0),
       );
 
       await tester.pumpAndSettle();
@@ -951,9 +951,9 @@ void main() {
         ),
       ));
 
-      final CurveTween _customBarrierCurve = CurveTween(curve: Curves.linear);
-      double _getBarrierCurveAlphaValue(double t) {
-        return _customBarrierCurve.transform(t) * 255;
+      final CurveTween _customBarrierTween = CurveTween(curve: Curves.linear);
+      double _getBarrierTweenAlphaValue(double t) {
+        return _customBarrierTween.transform(t) * 255;
       }
 
       await tester.tap(find.text('X'));
@@ -969,21 +969,21 @@ void main() {
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
       expect(
         modalBarrierAnimation.value.alpha,
-        closeTo(_getBarrierCurveAlphaValue(0.25), 1.0),
+        closeTo(_getBarrierTweenAlphaValue(0.25), 1.0),
       );
 
       await tester.pump(const Duration(milliseconds: 25));
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
       expect(
         modalBarrierAnimation.value.alpha,
-        closeTo(_getBarrierCurveAlphaValue(0.50), 1.0),
+        closeTo(_getBarrierTweenAlphaValue(0.50), 1.0),
       );
 
       await tester.pump(const Duration(milliseconds: 25));
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
       expect(
         modalBarrierAnimation.value.alpha,
-        closeTo(_getBarrierCurveAlphaValue(0.75), 1.0),
+        closeTo(_getBarrierTweenAlphaValue(0.75), 1.0),
       );
 
       await tester.pumpAndSettle();

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -1053,7 +1053,7 @@ class _TestDialogRouteWithCustomBarrierTween<T> extends PopupRoute<T> {
   _TestDialogRouteWithCustomBarrierTween({
     @required Widget child,
     Animatable<double> barrierTween,
-  }) : assert(barrierDismissible != null, barrierTween != null),
+  }) : assert(barrierTween != null),
        _barrierTween = barrierTween,
        _child = child;
 

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -1052,7 +1052,7 @@ class _TestDialogRoute<T> extends PopupRoute<T> {
 class _TestDialogRouteWithCustomBarrierTween<T> extends PopupRoute<T> {
   _TestDialogRouteWithCustomBarrierTween({
     @required Widget child,
-    Animatable<double> barrierTween,
+    @required Animatable<double> barrierTween,
   }) : assert(barrierTween != null),
        _barrierTween = barrierTween,
        _child = child;

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -866,7 +866,7 @@ void main() {
   });
 
   group('ModalRoute', () {
-    testWidgets('default barrierTween', (WidgetTester tester) async {
+    testWidgets('default barrierCurve', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         home: Material(
           child: Builder(
@@ -888,9 +888,9 @@ void main() {
         ),
       ));
 
-      final CurveTween _defaultBarrierTween = CurveTween(curve: Curves.ease);
-      double _getBarrierTweenAlphaValue(double t) {
-        return _defaultBarrierTween.transform(t) * 255;
+      final CurveTween _defaultBarrierCurve = CurveTween(curve: Curves.ease);
+      double _getBarrierCurveAlphaValue(double t) {
+        return _defaultBarrierCurve.transform(t) * 255;
       }
 
       await tester.tap(find.text('X'));
@@ -906,21 +906,21 @@ void main() {
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
       expect(
         modalBarrierAnimation.value.alpha,
-        closeTo(_getBarrierTweenAlphaValue(0.25), 1.0),
+        closeTo(_getBarrierCurveAlphaValue(0.25), 1.0),
       );
 
       await tester.pump(const Duration(milliseconds: 25));
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
       expect(
         modalBarrierAnimation.value.alpha,
-        closeTo(_getBarrierTweenAlphaValue(0.50), 1.0),
+        closeTo(_getBarrierCurveAlphaValue(0.50), 1.0),
       );
 
       await tester.pump(const Duration(milliseconds: 25));
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
       expect(
         modalBarrierAnimation.value.alpha,
-        closeTo(_getBarrierTweenAlphaValue(0.75), 1.0),
+        closeTo(_getBarrierCurveAlphaValue(0.75), 1.0),
       );
 
       await tester.pumpAndSettle();
@@ -928,7 +928,7 @@ void main() {
       expect(modalBarrierAnimation.value, Colors.black);
     });
 
-    testWidgets('custom barrierTween', (WidgetTester tester) async {
+    testWidgets('custom barrierCurve', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         home: Material(
           child: Builder(
@@ -938,7 +938,7 @@ void main() {
                   child: const Text('X'),
                   onPressed: () {
                     Navigator.of(context).push<void>(
-                      _TestDialogRouteWithCustomBarrierTween<void>(
+                      _TestDialogRouteWithCustomBarrierCurve<void>(
                         child: const Text('Hello World'),
                         barrierCurve: Curves.linear,
                       ),
@@ -951,9 +951,9 @@ void main() {
         ),
       ));
 
-      final CurveTween _customBarrierTween = CurveTween(curve: Curves.linear);
-      double _getBarrierTweenAlphaValue(double t) {
-        return _customBarrierTween.transform(t) * 255;
+      final CurveTween _customBarrierCurve = CurveTween(curve: Curves.linear);
+      double _getBarrierCurveAlphaValue(double t) {
+        return _customBarrierCurve.transform(t) * 255;
       }
 
       await tester.tap(find.text('X'));
@@ -969,21 +969,21 @@ void main() {
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
       expect(
         modalBarrierAnimation.value.alpha,
-        closeTo(_getBarrierTweenAlphaValue(0.25), 1.0),
+        closeTo(_getBarrierCurveAlphaValue(0.25), 1.0),
       );
 
       await tester.pump(const Duration(milliseconds: 25));
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
       expect(
         modalBarrierAnimation.value.alpha,
-        closeTo(_getBarrierTweenAlphaValue(0.50), 1.0),
+        closeTo(_getBarrierCurveAlphaValue(0.50), 1.0),
       );
 
       await tester.pump(const Duration(milliseconds: 25));
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
       expect(
         modalBarrierAnimation.value.alpha,
-        closeTo(_getBarrierTweenAlphaValue(0.75), 1.0),
+        closeTo(_getBarrierCurveAlphaValue(0.75), 1.0),
       );
 
       await tester.pumpAndSettle();
@@ -1049,8 +1049,8 @@ class _TestDialogRoute<T> extends PopupRoute<T> {
   }
 }
 
-class _TestDialogRouteWithCustomBarrierTween<T> extends PopupRoute<T> {
-  _TestDialogRouteWithCustomBarrierTween({
+class _TestDialogRouteWithCustomBarrierCurve<T> extends PopupRoute<T> {
+  _TestDialogRouteWithCustomBarrierCurve({
     @required Widget child,
     @required Curve barrierCurve,
   }) : assert(barrierCurve != null),

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -1023,36 +1023,21 @@ class DialogObserver extends NavigatorObserver {
 class _CustomDialogRoute<T> extends PopupRoute<T> {
   _CustomDialogRoute({
     @required Widget child,
-    bool barrierDismissible = true,
-    String barrierLabel,
-    Color barrierColor = Colors.black, // easier value to test against
-    Duration transitionDuration = const Duration(milliseconds: 100), // easier value to test against
-    RouteSettings settings,
-  }) : assert(barrierDismissible != null, barrierTween != null),
-       _child = child,
-       _barrierDismissible = barrierDismissible,
-       _barrierLabel = barrierLabel,
-       _barrierColor = barrierColor,
-       _transitionDuration = transitionDuration,
-       super(settings: settings);
+  }) : _child = child;
 
   final Widget _child;
 
   @override
-  bool get barrierDismissible => _barrierDismissible;
-  final bool _barrierDismissible;
+  bool get barrierDismissible => true;
 
   @override
-  String get barrierLabel => _barrierLabel;
-  final String _barrierLabel;
+  String get barrierLabel => null;
 
   @override
-  Color get barrierColor => _barrierColor;
-  final Color _barrierColor;
+  Color get barrierColor => Colors.black; // easier value to test against
 
   @override
-  Duration get transitionDuration => _transitionDuration;
-  final Duration _transitionDuration;
+  Duration get transitionDuration => const Duration(milliseconds: 100); // easier value to test against
 
   @override
   Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
@@ -1067,42 +1052,28 @@ class _CustomDialogRoute<T> extends PopupRoute<T> {
 class _DialogRouteWithCustomBarrierTween<T> extends PopupRoute<T> {
   _DialogRouteWithCustomBarrierTween({
     @required Widget child,
-    bool barrierDismissible = true,
-    String barrierLabel,
-    Color barrierColor = Colors.black, // easier value to test against
     Animatable<double> barrierTween,
-    Duration transitionDuration = const Duration(milliseconds: 100), // easier value to test against
-    RouteSettings settings,
   }) : assert(barrierDismissible != null, barrierTween != null),
-       _child = child,
-       _barrierDismissible = barrierDismissible,
-       _barrierLabel = barrierLabel,
-       _barrierColor = barrierColor,
        _barrierTween = barrierTween,
-       _transitionDuration = transitionDuration,
-       super(settings: settings);
+       _child = child;
 
   final Widget _child;
 
   @override
-  bool get barrierDismissible => _barrierDismissible;
-  final bool _barrierDismissible;
+  bool get barrierDismissible => true;
 
   @override
-  String get barrierLabel => _barrierLabel;
-  final String _barrierLabel;
+  String get barrierLabel => null;
 
   @override
-  Color get barrierColor => _barrierColor;
-  final Color _barrierColor;
+  Color get barrierColor => Colors.black; // easier value to test against
 
   @override
   Animatable<double> get barrierTween => _barrierTween;
   final Animatable<double> _barrierTween;
 
   @override
-  Duration get transitionDuration => _transitionDuration;
-  final Duration _transitionDuration;
+  Duration get transitionDuration => const Duration(milliseconds: 100); // easier value to test against
 
   @override
   Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -876,7 +876,7 @@ void main() {
                   child: const Text('X'),
                   onPressed: () {
                     Navigator.of(context).push<void>(
-                      _CustomDialogRoute<void>(
+                      _TestDialogRoute<void>(
                         child: const Text('Hello World'),
                       )
                     );
@@ -938,7 +938,7 @@ void main() {
                   child: const Text('X'),
                   onPressed: () {
                     Navigator.of(context).push<void>(
-                      _DialogRouteWithCustomBarrierTween<void>(
+                      _TestDialogRouteWithCustomBarrierTween<void>(
                         child: const Text('Hello World'),
                         barrierTween: CurveTween(curve: Curves.linear),
                       )
@@ -1020,8 +1020,8 @@ class DialogObserver extends NavigatorObserver {
   }
 }
 
-class _CustomDialogRoute<T> extends PopupRoute<T> {
-  _CustomDialogRoute({
+class _TestDialogRoute<T> extends PopupRoute<T> {
+  _TestDialogRoute({
     @required Widget child,
   }) : _child = child;
 
@@ -1049,8 +1049,8 @@ class _CustomDialogRoute<T> extends PopupRoute<T> {
   }
 }
 
-class _DialogRouteWithCustomBarrierTween<T> extends PopupRoute<T> {
-  _DialogRouteWithCustomBarrierTween({
+class _TestDialogRouteWithCustomBarrierTween<T> extends PopupRoute<T> {
+  _TestDialogRouteWithCustomBarrierTween({
     @required Widget child,
     Animatable<double> barrierTween,
   }) : assert(barrierDismissible != null, barrierTween != null),

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -863,8 +863,10 @@ void main() {
       expect(rootObserver.dialogCount, 0);
       expect(nestedObserver.dialogCount, 1);
     });
+  });
 
-    testWidgets('ModalRoute default barrierTween', (WidgetTester tester) async {
+  group('ModalRoute', () {
+    testWidgets('default barrierTween', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         home: Material(
           child: Builder(
@@ -926,7 +928,7 @@ void main() {
       expect(modalBarrierAnimation.value, Colors.black);
     });
 
-    testWidgets('ModalRoute custom barrierTween', (WidgetTester tester) async {
+    testWidgets('custom barrierTween', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         home: Material(
           child: Builder(

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -876,7 +876,7 @@ void main() {
                   child: const Text('X'),
                   onPressed: () {
                     Navigator.of(context).push<void>(
-                      _TestDialogRoute<void>(
+                      _TestDialogRouteWithCustomBarrierCurve<void>(
                         child: const Text('Hello World'),
                       )
                     );
@@ -889,8 +889,8 @@ void main() {
       ));
 
       final CurveTween _defaultBarrierTween = CurveTween(curve: Curves.ease);
-      double _getBarrierTweenAlphaValue(double t) {
-        return _defaultBarrierTween.transform(t) * 255;
+      int _getExpectedBarrierTweenAlphaValue(double t) {
+        return Color.getAlphaFromOpacity(_defaultBarrierTween.transform(t));
       }
 
       await tester.tap(find.text('X'));
@@ -906,21 +906,21 @@ void main() {
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
       expect(
         modalBarrierAnimation.value.alpha,
-        closeTo(_getBarrierTweenAlphaValue(0.25), 1.0),
+        closeTo(_getExpectedBarrierTweenAlphaValue(0.25), 1.0),
       );
 
       await tester.pump(const Duration(milliseconds: 25));
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
       expect(
         modalBarrierAnimation.value.alpha,
-        closeTo(_getBarrierTweenAlphaValue(0.50), 1.0),
+        closeTo(_getExpectedBarrierTweenAlphaValue(0.50), 1.0),
       );
 
       await tester.pump(const Duration(milliseconds: 25));
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
       expect(
         modalBarrierAnimation.value.alpha,
-        closeTo(_getBarrierTweenAlphaValue(0.75), 1.0),
+        closeTo(_getExpectedBarrierTweenAlphaValue(0.75), 1.0),
       );
 
       await tester.pumpAndSettle();
@@ -952,8 +952,8 @@ void main() {
       ));
 
       final CurveTween _customBarrierTween = CurveTween(curve: Curves.linear);
-      double _getBarrierTweenAlphaValue(double t) {
-        return _customBarrierTween.transform(t) * 255;
+      int _getExpectedBarrierTweenAlphaValue(double t) {
+        return Color.getAlphaFromOpacity(_customBarrierTween.transform(t));
       }
 
       await tester.tap(find.text('X'));
@@ -969,21 +969,21 @@ void main() {
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
       expect(
         modalBarrierAnimation.value.alpha,
-        closeTo(_getBarrierTweenAlphaValue(0.25), 1.0),
+        closeTo(_getExpectedBarrierTweenAlphaValue(0.25), 1.0),
       );
 
       await tester.pump(const Duration(milliseconds: 25));
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
       expect(
         modalBarrierAnimation.value.alpha,
-        closeTo(_getBarrierTweenAlphaValue(0.50), 1.0),
+        closeTo(_getExpectedBarrierTweenAlphaValue(0.50), 1.0),
       );
 
       await tester.pump(const Duration(milliseconds: 25));
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
       expect(
         modalBarrierAnimation.value.alpha,
-        closeTo(_getBarrierTweenAlphaValue(0.75), 1.0),
+        closeTo(_getExpectedBarrierTweenAlphaValue(0.75), 1.0),
       );
 
       await tester.pumpAndSettle();
@@ -1020,41 +1020,11 @@ class DialogObserver extends NavigatorObserver {
   }
 }
 
-class _TestDialogRoute<T> extends PopupRoute<T> {
-  _TestDialogRoute({
-    @required Widget child,
-  }) : _child = child;
-
-  final Widget _child;
-
-  @override
-  bool get barrierDismissible => true;
-
-  @override
-  String get barrierLabel => null;
-
-  @override
-  Color get barrierColor => Colors.black; // easier value to test against
-
-  @override
-  Duration get transitionDuration => const Duration(milliseconds: 100); // easier value to test against
-
-  @override
-  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
-    return Semantics(
-      child: _child,
-      scopesRoute: true,
-      explicitChildNodes: true,
-    );
-  }
-}
-
 class _TestDialogRouteWithCustomBarrierCurve<T> extends PopupRoute<T> {
   _TestDialogRouteWithCustomBarrierCurve({
     @required Widget child,
-    @required Curve barrierCurve,
-  }) : assert(barrierCurve != null),
-       _barrierCurve = barrierCurve,
+    Curve barrierCurve,
+  }) : _barrierCurve = barrierCurve,
        _child = child;
 
   final Widget _child;
@@ -1069,7 +1039,12 @@ class _TestDialogRouteWithCustomBarrierCurve<T> extends PopupRoute<T> {
   Color get barrierColor => Colors.black; // easier value to test against
 
   @override
-  Curve get barrierCurve => _barrierCurve;
+  Curve get barrierCurve {
+    if (_barrierCurve == null) {
+      return super.barrierCurve;
+    }
+    return _barrierCurve;
+  }
   final Curve _barrierCurve;
 
   @override


### PR DESCRIPTION
## Description

This allows you to customize the barrier tween for any ModalRoute. It currently only defaults to `Curves.ease`. This allows for any subclass of ModalRoute to implement its own `barrierCurve`.

```dart
class _DialogRouteWithCustomBarrierCurve<T> extends PopupRoute<T> {
  _DialogRouteWithCustomBarrierCurve({
    Animatable<double> barrierCurve,
    // ...
  }) : assert(barrierCurve!= null),
       // ...
       _barrierCurve = barrierCurve,
  // ...

  @override
  Animatable<double> get barrierCurve => barrierCurve;
  final Animatable<double> _barrierCurve;

  // ...
```

## Related Issues

n/a

## Tests

I added the following tests:

- A test to validate that the default barrier tween remains as `CurveTween(curve: Curves.ease)`
- A test to validate that a custom barrier tween is honored.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
