### PR TITLE
Rename conditional imported files to match convention

### DIFF
--- a/packages/flutter_driver/lib/src/extension/_extension_io.dart
+++ b/packages/flutter_driver/lib/src/extension/_extension_io.dart
@@ -6,7 +6,7 @@
 ///
 /// See also:
 ///
-///  * [_web_extension.dart], which has the dart:html implementation
+///  * [_extension_web.dart], which has the dart:html implementation
 void registerWebServiceExtension(Future<Map<String, dynamic>> Function(Map<String, String>) call) {
   throw UnsupportedError('Use registerServiceExtension instead');
 }

--- a/packages/flutter_driver/lib/src/extension/_extension_web.dart
+++ b/packages/flutter_driver/lib/src/extension/_extension_web.dart
@@ -17,7 +17,7 @@ import 'dart:js_util' as js_util;
 ///
 /// See also:
 ///
-///  * [_io_extension.dart], which has the dart:io implementation
+///  * [_extension_io.dart], which has the dart:io implementation
 void registerWebServiceExtension(Future<Map<String, dynamic>> Function(Map<String, String>) call) {
   js_util.setProperty(html.window, '\$flutterDriver', allowInterop((dynamic message) async {
     // ignore: undefined_function, undefined_identifier

--- a/packages/flutter_driver/lib/src/extension/extension.dart
+++ b/packages/flutter_driver/lib/src/extension/extension.dart
@@ -30,7 +30,7 @@ import '../common/request_data.dart';
 import '../common/semantics.dart';
 import '../common/text.dart';
 import '../common/wait.dart';
-import '_io_extension.dart' if (dart.library.html) '_web_extension.dart';
+import '_extension_io.dart' if (dart.library.html) '_extension_web.dart';
 import 'wait_conditions.dart';
 
 const String _extensionMethodName = 'driver';

--- a/packages/flutter_driver/test/src/real_tests/io_extension_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/io_extension_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter_driver/src/extension/_io_extension.dart';
+import 'package:flutter_driver/src/extension/_extension_io.dart';
 
 import '../../common.dart';
 

--- a/packages/flutter_driver/test/src/web_tests/web_extension_test.dart
+++ b/packages/flutter_driver/test/src/web_tests/web_extension_test.dart
@@ -4,7 +4,7 @@
 
 import 'dart:js' as js;
 
-import 'package:flutter_driver/src/extension/_web_extension.dart';
+import 'package:flutter_driver/src/extension/_extension_web.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {


### PR DESCRIPTION
Our convention for conditionally imported files is `_*_{io,web}.dart`, renaming the files here to make it easier for us when they're imported internally.

cc @angjieli since for some reason I couldn't add you as a reviewer