### PR TITLE
Revert "Document reasoning for why CustomMultiChildLayout size can't …

### DIFF
--- a/packages/flutter/lib/src/rendering/custom_layout.dart
+++ b/packages/flutter/lib/src/rendering/custom_layout.dart
@@ -29,15 +29,7 @@ class MultiChildLayoutParentData extends ContainerBoxParentData<RenderBox> {
 /// given the previous instance.
 ///
 /// Override [getSize] to control the overall size of the layout. The size of
-/// the layout cannot depend on layout properties of the children. This was
-/// a design decision to simplify the delegate implementations: This way,
-/// the delegate implementations do not have to also handle various intrinsic
-/// sizing functions if the parent's size depended on the children.  
-/// If you want to build a custom layout where you define the size of that widget
-/// based on its children, then you will have to create a custom render object.
-/// See [MultiChildRenderObjectWidget] with [ContainerRenderObjectMixin] and
-/// [RenderBoxContainerDefaultsMixin] to get started or [RenderStack] for an
-/// example implementation.
+/// the layout cannot depend on layout properties of the children.
 ///
 /// Override [performLayout] to size and position the children. An
 /// implementation of [performLayout] must call [layoutChild] exactly once for

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1955,7 +1955,7 @@ class LayoutId extends ParentDataWidget<CustomMultiChildLayout> {
 /// the children.
 ///
 /// [CustomMultiChildLayout] is appropriate when there are complex relationships
-/// between the size and positioning of multiple widgets. To control the
+/// between the size and positioning of a multiple widgets. To control the
 /// layout of a single child, [CustomSingleChildLayout] is more appropriate. For
 /// simple cases, such as aligning a widget to one or another edge, the [Stack]
 /// widget is more appropriate.


### PR DESCRIPTION
…depend on children and how to do it (#47797)"

This reverts commit de2514c0e2631e33996d131e8743fbcb7bbd57c4 as it breaks analyze-linux and web_tests-0-linux checks.
