### PR TITLE
sort channels by stability upon running flutter channel

### DIFF
--- a/packages/flutter_tools/lib/src/commands/channel.dart
+++ b/packages/flutter_tools/lib/src/commands/channel.dart
@@ -55,7 +55,7 @@ class ChannelCommand extends FlutterCommand {
     // Beware: currentBranch could contain PII. See getBranchName().
     final String currentChannel = FlutterVersion.instance.channel;
     final String currentBranch = FlutterVersion.instance.getBranchName();
-    final Set<String> seenChannels = <String>{};
+    final Set<String> seenUnofficialChannels = <String>{};
     final List<String> rawOutput = <String>[];
 
     showAll = showAll || currentChannel != currentBranch;
@@ -72,45 +72,45 @@ class ChannelCommand extends FlutterCommand {
     if (result != 0) {
       final String details = verbose ? '\n${rawOutput.join('\n')}' : '';
       throwToolExit('List channels failed: $result$details', exitCode: result);
-    } else {
-      // show channels sorted by stability
-      final List<String> officialChannels = FlutterVersion.officialChannels.toList(growable: false);
-      final List<bool> availableChannels = List<bool>.generate(officialChannels.length, (_)=>false, growable: false);
+    }
 
-      for (final String line in rawOutput) {
-          final List<String> split = line.split('/');
-          if (split.length > 1) {
-            final int index = officialChannels.indexOf(split[1]);
+    final List<String> officialChannels = FlutterVersion.officialChannels.toList();
+    final List<bool> availableChannels = List<bool>.filled(officialChannels.length, false);
 
-            if (index != -1) { // Mark all available channels official channels from output
-              availableChannels[index] = true;
-            }
-            else if (showAll && !seenChannels.contains(split[1])) {
-            // add other branches to seenChannels if --all flag is given (to print later)
-              seenChannels.add(split[1]);
-            }
-          }
-      }
+    for (final String line in rawOutput) {
+      final List<String> split = line.split('/');
+      final String branch = split[1];
+      if (split.length > 1) {
+        final int index = officialChannels.indexOf(branch);
 
-      // print all available official channels in sorted manner
-      for (int i = 0; i < officialChannels.length; i++) {
-        // only print non-missing channels
-        if (availableChannels[i]) {
-          String currentIndicator = ' ';
-          if(officialChannels[i] == currentChannel){
-            currentIndicator = '*';
-          }
-          globals.printStatus('$currentIndicator ${officialChannels[i]}');
+        if (index != -1) { // Mark all available channels official channels from output
+          availableChannels[index] = true;
+        } else if (showAll && !seenUnofficialChannels.contains(branch)) {
+        // add other branches to seenUnofficialChannels if --all flag is given (to print later)
+          seenUnofficialChannels.add(branch);
         }
       }
+    }
 
-      if (showAll) {
-        for (final String branch in seenChannels){
-          if(currentBranch == branch){
+    // print all available official channels in sorted manner
+    for (int i = 0; i < officialChannels.length; i++) {
+      // only print non-missing channels
+      if (availableChannels[i]) {
+        String currentIndicator = ' ';
+        if (officialChannels[i] == currentChannel){
+          currentIndicator = '*';
+        }
+        globals.printStatus('$currentIndicator ${officialChannels[i]}');
+      }
+    }
+
+    // print all remaining channels if showAll is true
+    if (showAll) {
+      for (final String branch in seenUnofficialChannels) {
+        if (currentBranch == branch){
           globals.printStatus('* $branch');
-          } else if (!branch.startsWith('HEAD ')) {
+        } else if (!branch.startsWith('HEAD ')) {
           globals.printStatus('  $branch');
-          }
         }
       }
     }

--- a/packages/flutter_tools/lib/src/commands/channel.dart
+++ b/packages/flutter_tools/lib/src/commands/channel.dart
@@ -107,7 +107,7 @@ class ChannelCommand extends FlutterCommand {
     // print all remaining channels if showAll is true
     if (showAll) {
       for (final String branch in seenUnofficialChannels) {
-        if (currentBranch == branch){
+        if (currentBranch == branch) {
           globals.printStatus('* $branch');
         } else if (!branch.startsWith('HEAD ')) {
           globals.printStatus('  $branch');

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -37,6 +37,7 @@ class FlutterVersion {
     return !<String>['dev', 'beta', 'stable'].contains(branchName);
   }
 
+  // Beware: Keep order in accordance with stability
   static const Set<String> officialChannels = <String>{
     'master',
     'dev',

--- a/packages/flutter_tools/test/general.shard/channel_test.dart
+++ b/packages/flutter_tools/test/general.shard/channel_test.dart
@@ -46,6 +46,97 @@ void main() {
       await simpleChannelTest(<String>['channel', '-v']);
     });
 
+    testUsingContext('sorted by stability', () async {
+      final Process processAll = createMockProcess(
+          stdout: 'origin/beta\n'
+                  'origin/master\n'
+                  'origin/dev\n'
+                  'origin/stable\n');
+      final Process processWithExtra = createMockProcess(
+          stdout: 'origin/beta\n'
+                  'origin/master\n'
+                  'origin/dependabot/bundler\n'
+                  'origin/dev\n'
+                  'origin/v1.4.5-hotfixes\n'
+                  'origin/stable\n');
+      final Process processWithMissing = createMockProcess(
+          stdout: 'origin/beta\n'
+                  'origin/dependabot/bundler\n'
+                  'origin/v1.4.5-hotfixes\n'
+                  'origin/stable\n');
+
+      final ChannelCommand command = ChannelCommand();
+      final CommandRunner<void> runner = createTestCommandRunner(command);
+
+      when(mockProcessManager.start(
+        <String>['git', 'branch', '-r'],
+        workingDirectory: anyNamed('workingDirectory'),
+        environment: anyNamed('environment'),
+      )).thenAnswer((_) => Future<Process>.value(processAll));
+      await runner.run(<String>['channel']);
+      verify(mockProcessManager.start(
+        <String>['git', 'branch', '-r'],
+        workingDirectory: anyNamed('workingDirectory'),
+        environment: anyNamed('environment'),
+      )).called(1);
+      expect(testLogger.errorText, hasLength(0));
+      // format the status text for a simpler assertion.
+      final Iterable<String> rows = testLogger.statusText
+        .split('\n')
+        .map((String line) => line.substring(2)); // remove '* ' or '  ' from output
+      expect(rows, containsAllInOrder(FlutterVersion.officialChannels));
+
+      // clear buffer for next process
+      testLogger.clear();
+
+      when(mockProcessManager.start(
+        <String>['git', 'branch', '-r'],
+        workingDirectory: anyNamed('workingDirectory'),
+        environment: anyNamed('environment'),
+      )).thenAnswer((_) => Future<Process>.value(processWithExtra));
+      await runner.run(<String>['channel']);
+      verify(mockProcessManager.start(
+        <String>['git', 'branch', '-r'],
+        workingDirectory: anyNamed('workingDirectory'),
+        environment: anyNamed('environment'),
+      )).called(1);
+      expect(testLogger.errorText, hasLength(0));
+      // format the status text for a simpler assertion.
+      final Iterable<String> rows2 = testLogger.statusText
+        .split('\n')
+        .map((String line) => line.substring(2)); // remove '* ' or '  ' from output
+      expect(rows2, containsAllInOrder(FlutterVersion.officialChannels));
+
+      // clear buffer for next process
+      testLogger.clear();
+
+      when(mockProcessManager.start(
+        <String>['git', 'branch', '-r'],
+        workingDirectory: anyNamed('workingDirectory'),
+        environment: anyNamed('environment'),
+      )).thenAnswer((_) => Future<Process>.value(processWithMissing));
+      await runner.run(<String>['channel']);
+      verify(mockProcessManager.start(
+        <String>['git', 'branch', '-r'],
+        workingDirectory: anyNamed('workingDirectory'),
+        environment: anyNamed('environment'),
+      )).called(1);
+      expect(testLogger.errorText, hasLength(0));
+      // check if available official channels are in order of stability
+      int prev = -1;
+      int next = -1;
+      for (final String branch in FlutterVersion.officialChannels) {
+        next = testLogger.statusText.indexOf(branch);
+        if (next != -1) {
+          expect(prev < next, isTrue);
+          prev = next;
+        }
+      }
+
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+    });
+
     testUsingContext('removes duplicates', () async {
       final Process process = createMockProcess(
           stdout: 'origin/dev\n'


### PR DESCRIPTION
## Description

Sorted Official Flutter Channels in accordance with stability upon running the `flutter channel` command. E.g ->
```
Flutter channels:
* master
  dev
  beta
  stable
```

## Related Issues

#31014

## Tests

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
