### PR TITLE
Step 1 of 2: Warn about Flutter's FloatingActionButton dependency on ThemeData accent properties

### DIFF
--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -424,7 +424,7 @@ class FloatingActionButton extends StatelessWidget {
     final FloatingActionButtonThemeData floatingActionButtonTheme = theme.floatingActionButtonTheme;
 
     // Applications should no longer use accentIconTheme's color to configure
-    // the configure of floating action buttons. For more information, see
+    // the foreground color of floating action buttons. For more information, see
     // flutter.dev/go/remove-fab-accent-theme-dependency.
     if (this.foregroundColor == null && floatingActionButtonTheme.foregroundColor == null) {
       final bool accentIsDark = theme.accentColorBrightness == Brightness.dark;

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -231,14 +231,25 @@ class FloatingActionButton extends StatelessWidget {
   /// used for accessibility.
   final String tooltip;
 
-  /// The default icon and text color.
+  /// The default foreground color for icons and text within the button.
   ///
-  /// Defaults to [ThemeData.accentIconTheme.color] for the current theme.
+  /// If this property is null, then the [Theme]'s
+  /// [ThemeData.floatingActionButtonTheme.foregroundColor] is used. If that
+  /// property is also null, then the [Theme]'s
+  /// [ThemeData.colorScheme.onSecondary] color is used.
+  ///
+  /// Although the color of theme's `accentIconTheme` currently provides a
+  /// default that supercedes the `onSecondary` color, this dependency
+  /// has been deprecated:  flutter.dev/go/remove-fab-accent-theme-dependency.
+  /// It will be removed in the future.
   final Color foregroundColor;
 
-  /// The color to use when filling the button.
+  /// The button's background color.
   ///
-  /// Defaults to [ThemeData.accentColor] for the current theme.
+  /// If this property is null, then the [Theme]'s
+  /// [ThemeData.floatingActionButtonTheme.backgroundColor] is used. If that
+  /// property is also null, then the [Theme]'s
+  /// [ThemeData.colorScheme.secondary] color is used.
   final Color backgroundColor;
 
   /// The color to use for filling the button when the button has input focus.

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -10,6 +10,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 import 'button.dart';
+import 'colors.dart';
 import 'floating_action_button_theme.dart';
 import 'scaffold.dart';
 import 'theme.dart';
@@ -410,6 +411,25 @@ class FloatingActionButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final FloatingActionButtonThemeData floatingActionButtonTheme = theme.floatingActionButtonTheme;
+
+    // Applications should no longer use accentIconTheme's color to configure
+    // the configure of floating action buttons. For more information, see
+    // flutter.dev/go/remove-fab-accent-theme-dependency.
+    if (this.foregroundColor == null && floatingActionButtonTheme.foregroundColor == null) {
+      final bool accentIsDark = theme.accentColorBrightness == Brightness.dark;
+      final Color defaultAccentIconThemeColor = accentIsDark ? Colors.white : Colors.black;
+      if (theme.accentIconTheme.color != defaultAccentIconThemeColor) {
+        debugPrint(
+          'Warning: '
+          'The support for configuring the foreground color of '
+          'FloatingActionButtons using ThemeData.accentIconTheme '
+          'has been deprecated. Please use ThemeData.floatingActionButtonTheme '
+          'instead. See '
+          'https://flutter.dev/docs/release/breaking-changes/fab_accent_dependency. '
+          'This feature was deprecated after v1.13.2.'
+        );
+      }
+    }
 
     final Color foregroundColor = this.foregroundColor
       ?? floatingActionButtonTheme.foregroundColor

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -240,7 +240,7 @@ class FloatingActionButton extends StatelessWidget {
   ///
   /// Although the color of theme's `accentIconTheme` currently provides a
   /// default that supercedes the `onSecondary` color, this dependency
-  /// has been deprecated:  flutter.dev/go/remove-fab-accent-theme-dependency.
+  /// has been deprecated:  https://flutter.dev/go/remove-fab-accent-theme-dependency.
   /// It will be removed in the future.
   final Color foregroundColor;
 
@@ -425,7 +425,7 @@ class FloatingActionButton extends StatelessWidget {
 
     // Applications should no longer use accentIconTheme's color to configure
     // the foreground color of floating action buttons. For more information, see
-    // flutter.dev/go/remove-fab-accent-theme-dependency.
+    // https://flutter.dev/go/remove-fab-accent-theme-dependency.
     if (this.foregroundColor == null && floatingActionButtonTheme.foregroundColor == null) {
       final bool accentIsDark = theme.accentColorBrightness == Brightness.dark;
       final Color defaultAccentIconThemeColor = accentIsDark ? Colors.white : Colors.black;

--- a/packages/flutter/test/material/floating_action_button_theme_test.dart
+++ b/packages/flutter/test/material/floating_action_button_theme_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -117,7 +118,17 @@ void main() {
     expect(_getRawMaterialButton(tester).splashColor, splashColor);
   });
 
+  // The feature checked by this test has been deprecated, see
+  // flutter.dev/go/remove-fab-accent-theme-dependency. This test will be
+  // removed in the future.
   testWidgets('FloatingActionButton foreground color uses iconAccentTheme if no widget or widget theme color is specified', (WidgetTester tester) async {
+    final DebugPrintCallback oldPrint = debugPrint;
+    final List<String> log = <String>[];
+    debugPrint = (String message, { int wrapWidth }) {
+      log.add(message);
+    };
+    debugPrintBuildScope = true;
+
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
         floatingActionButton: Theme(
@@ -131,6 +142,13 @@ void main() {
         ),
       ),
     ));
+
+    debugPrint = oldPrint;
+    debugPrintBuildScope = false;
+
+    // Verify that a warning message is generated.
+    expect(log, hasLength(3));
+    expect(log[1], contains('https://flutter.dev/docs/release/breaking-changes/fab_accent_dependency'));
 
     expect(_getRichText(tester).text.style.color, const Color(0xFACEFACE));
   });

--- a/packages/flutter/test/material/floating_action_button_theme_test.dart
+++ b/packages/flutter/test/material/floating_action_button_theme_test.dart
@@ -119,7 +119,7 @@ void main() {
   });
 
   // The feature checked by this test has been deprecated, see
-  // flutter.dev/go/remove-fab-accent-theme-dependency. This test will be
+  // https://flutter.dev/go/remove-fab-accent-theme-dependency. This test will be
   // removed in the future.
   testWidgets('FloatingActionButton foreground color uses iconAccentTheme if no widget or widget theme color is specified', (WidgetTester tester) async {
     final DebugPrintCallback oldPrint = debugPrint;
@@ -127,7 +127,6 @@ void main() {
     debugPrint = (String message, { int wrapWidth }) {
       log.add(message);
     };
-    debugPrintBuildScope = true;
 
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
@@ -144,11 +143,9 @@ void main() {
     ));
 
     debugPrint = oldPrint;
-    debugPrintBuildScope = false;
 
     // Verify that a warning message is generated.
-    expect(log, hasLength(3));
-    expect(log[1], contains('https://flutter.dev/docs/release/breaking-changes/fab_accent_dependency'));
+    expect(log.first, contains('https://flutter.dev/docs/release/breaking-changes/fab_accent_dependency'));
 
     expect(_getRichText(tester).text.style.color, const Color(0xFACEFACE));
   });


### PR DESCRIPTION
Generate a warning if a FloatingActionButton's foreground color has been configured with the Theme's accentIconTheme.

This feature has been deprecated: https://flutter.dev/go/remove-fab-accent-theme-dependency . Apps can configure the appearance of FloatingActionButtons using the theme's FloatingActionButtonTheme instead. Support for configuring the foreground color of FloatingActionButton with the Theme's accentIconTheme will be removed in the future, with https://github.com/flutter/flutter/pull/46923.

## Context

This is a small part of the "Update Material Theme System" project, [flutter.dev/go/material-theme-system-updates](flutter.dev/go/material-theme-system-updates).

Currently, the ThemeData accentIconTheme property is only used by [FloatingActionButton](https://api.flutter.dev/flutter/material/FloatingActionButton/foregroundColor.html). It's the default color of the text or icons that appear within the button. 

FloatingActionButton also uses ThemeData accentTextTheme property, however this dependency is undocumented and unnecessary.

Both of these dependencies are apt to be confusing. For example if one configures the Theme's accentIconTheme to change the appearance of floating action buttons, it's difficult to know what other components will be affected. Or might be affected in the future.

The [Material Design spec](https://material.io/design/color) no longer includes an "accent" color. The ColorScheme's [secondary color](https://material.io/design/color/the-color-system.html#color-theme-creation) is now used instead.

Currently applications can configure the color of text and icons within FloatingActionButtons with the widget's foregroundColor property or with the FloatingActionButtonTheme's foregroundColor. If neither foregroundColor property is specified the foreground color currently defaults to the  accentIconTheme's color. The https://github.com/flutter/flutter/pull/46923 PR will cause the default to be the color scheme's onSecondary color instead.

## Description of change

Currently the accentIconTheme provides a default for the FloatingActionButton's foregroundColor property:
```dart
    final Color foregroundColor = this.foregroundColor
      ?? floatingActionButtonTheme.foregroundColor
      ?? theme.accentIconTheme.color // To be removed.
      ?? theme.colorScheme.onSecondary;
```

Apps that currently configure their theme's accentIconTheme to effectively configure the foregroundColor of all floating action buttons, can get the same effect by configuring the foregroundColor of their theme's floatingActionButtonTheme. This PR removes the line that contains accentIconTheme.

The FloatingActionButton's foregroundColor is used to configure the textStyle of the RawMaterialButton created by FloatingActionButton. Currently, this text style is based on the button style of ThemeData.accentTextTheme:
```
// theme.accentTextTheme will become theme.textTheme
final TextStyle textStyle = theme.accentTextTheme.button.copyWith( 
  color: foregroundColor,
  letterSpacing: 1.2,
);

```
Except in a case where an app has explicitly configured the accentTextTheme to take advantage of this undocumented dependency, this use of accentTextTheme is unnecessary. The https://github.com/flutter/flutter/pull/46923 PR replaces this use of accentTextTheme with textTheme.

## Migration guide

To configure the FloatingActionButton's foregroundColor for all FABs, apps can configure the theme's floatingActionButtonTheme instead of its accentIconTheme.

### Before

```dart
MaterialApp(
  theme: ThemeData(
    accentIconTheme: IconThemeData(color: Colors.red),
  ),
)
```

### After

```dart

MaterialApp(
  theme: ThemeData(
    floatingActionButtonTheme: FloatingActionButtonThemeData(
      foregroundColor: Colors.red,
    ),
  ),
)
```

