### PR TITLE
[flutter_tool] Don't use context in ProcessUtils

### DIFF
--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -255,7 +255,7 @@ Future<int> _exit(int code) async {
   }
 
   // Run shutdown hooks before flushing logs
-  await runShutdownHooks();
+  await shutdownHooks.runShutdownHooks();
 
   final Completer<void> completer = Completer<void>();
 

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -907,7 +907,7 @@ Directory _getLocalEngineRepo({
     .createTempSync('flutter_tool_local_engine_repo.');
 
   // Remove the local engine repo before the tool exits.
-  addShutdownHook(
+  shutdownHooks.addShutdownHook(
     () => localEngineRepo.deleteSync(recursive: true),
     ShutdownStage.CLEANUP,
   );

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -288,7 +288,7 @@ abstract class IOSApp extends ApplicationPackage {
     } else {
       // Try to unpack as an ipa.
       final Directory tempDir = globals.fs.systemTempDirectory.createTempSync('flutter_app.');
-      addShutdownHook(() async {
+      shutdownHooks.addShutdownHook(() async {
         await tempDir.delete(recursive: true);
       }, ShutdownStage.STILL_RECORDING);
       os.unzip(globals.fs.file(applicationBinary), tempDir);

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -120,8 +120,12 @@ Future<T> runInContext<T>(
       OperatingSystemUtils: () => OperatingSystemUtils(),
       PersistentToolState: () => PersistentToolState(),
       ProcessInfo: () => ProcessInfo(),
-      ProcessUtils: () => ProcessUtils(),
+      ProcessUtils: () => ProcessUtils(
+        processManager: globals.processManager,
+        logger: globals.logger,
+      ),
       Pub: () => const Pub(),
+      ShutdownHooks: () => ShutdownHooks(logger: globals.logger),
       Signals: () => Signals(),
       SimControl: () => SimControl(),
       Stdio: () => const Stdio(),

--- a/packages/flutter_tools/test/general.shard/base/process_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/process_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:platform/platform.dart';
 import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:mockito/mockito.dart';
@@ -15,49 +16,59 @@ import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/mocks.dart' show MockProcess,
                                    MockProcessManager,
+                                   MockStdio,
                                    flakyProcessFactory;
+
+class MockLogger extends Mock implements Logger {}
 
 void main() {
   group('process exceptions', () {
     ProcessManager mockProcessManager;
+    ProcessUtils processUtils;
 
     setUp(() {
       mockProcessManager = PlainMockProcessManager();
+      processUtils = ProcessUtils(
+        processManager: mockProcessManager,
+        logger: MockLogger(),
+      );
     });
 
-    testUsingContext('runAsync throwOnError: exceptions should be ProcessException objects', () async {
+    testWithoutContext('runAsync throwOnError: exceptions should be ProcessException objects', () async {
       when(mockProcessManager.run(<String>['false'])).thenAnswer(
           (Invocation invocation) => Future<ProcessResult>.value(ProcessResult(0, 1, '', '')));
       expect(() async => await processUtils.run(<String>['false'], throwOnError: true),
              throwsA(isInstanceOf<ProcessException>()));
-    }, overrides: <Type, Generator>{ProcessManager: () => mockProcessManager});
+    });
   });
 
   group('shutdownHooks', () {
-    testUsingContext('runInExpectedOrder', () async {
+    testWithoutContext('runInExpectedOrder', () async {
       int i = 1;
       int serializeRecording1;
       int serializeRecording2;
       int postProcessRecording;
       int cleanup;
 
-      addShutdownHook(() async {
+      final ShutdownHooks shutdownHooks = ShutdownHooks(logger: MockLogger());
+
+      shutdownHooks.addShutdownHook(() async {
         serializeRecording1 = i++;
       }, ShutdownStage.SERIALIZE_RECORDING);
 
-      addShutdownHook(() async {
+      shutdownHooks.addShutdownHook(() async {
         cleanup = i++;
       }, ShutdownStage.CLEANUP);
 
-      addShutdownHook(() async {
+      shutdownHooks.addShutdownHook(() async {
         postProcessRecording = i++;
       }, ShutdownStage.POST_PROCESS_RECORDING);
 
-      addShutdownHook(() async {
+      shutdownHooks.addShutdownHook(() async {
         serializeRecording2 = i++;
       }, ShutdownStage.SERIALIZE_RECORDING);
 
-      await runShutdownHooks();
+      await shutdownHooks.runShutdownHooks();
 
       expect(serializeRecording1, lessThanOrEqualTo(2));
       expect(serializeRecording2, lessThanOrEqualTo(2));
@@ -68,30 +79,42 @@ void main() {
 
   group('output formatting', () {
     MockProcessManager mockProcessManager;
+    ProcessUtils processUtils;
+    BufferLogger mockLogger;
 
     setUp(() {
       mockProcessManager = MockProcessManager();
+      mockLogger = BufferLogger(
+        terminal: AnsiTerminal(
+          stdio: MockStdio(),
+          platform: FakePlatform.fromPlatform(const LocalPlatform())..stdoutSupportsAnsi = false,
+        ),
+        outputPreferences: OutputPreferences(wrapText: true, wrapColumn: 40),
+      );
+      processUtils = ProcessUtils(
+        processManager: mockProcessManager,
+        logger: mockLogger,
+      );
     });
 
-    MockProcess Function(List<String>) processMetaFactory(List<String> stdout, { List<String> stderr = const <String>[] }) {
-      final Stream<List<int>> stdoutStream =
-          Stream<List<int>>.fromIterable(stdout.map<List<int>>((String s) => s.codeUnits));
-      final Stream<List<int>> stderrStream =
-      Stream<List<int>>.fromIterable(stderr.map<List<int>>((String s) => s.codeUnits));
+    MockProcess Function(List<String>) processMetaFactory(List<String> stdout, {
+      List<String> stderr = const <String>[],
+    }) {
+      final Stream<List<int>> stdoutStream = Stream<List<int>>.fromIterable(
+        stdout.map<List<int>>((String s) => s.codeUnits,
+      ));
+      final Stream<List<int>> stderrStream = Stream<List<int>>.fromIterable(
+        stderr.map<List<int>>((String s) => s.codeUnits,
+      ));
       return (List<String> command) => MockProcess(stdout: stdoutStream, stderr: stderrStream);
     }
 
-    testUsingContext('Command output is not wrapped.', () async {
+    testWithoutContext('Command output is not wrapped.', () async {
       final List<String> testString = <String>['0123456789' * 10];
       mockProcessManager.processFactory = processMetaFactory(testString, stderr: testString);
       await processUtils.stream(<String>['command']);
-
-      expect(testLogger.statusText, equals('${testString[0]}\n'));
-      expect(testLogger.errorText, equals('${testString[0]}\n'));
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-      OutputPreferences: () => OutputPreferences(wrapText: true, wrapColumn: 40),
-      Platform: () => FakePlatform.fromPlatform(const LocalPlatform())..stdoutSupportsAnsi = false,
+      expect(mockLogger.statusText, equals('${testString[0]}\n'));
+      expect(mockLogger.errorText, equals('${testString[0]}\n'));
     });
   });
 
@@ -99,43 +122,47 @@ void main() {
     const Duration delay = Duration(seconds: 2);
     MockProcessManager flakyProcessManager;
     ProcessManager mockProcessManager;
+    ProcessUtils processUtils;
+    ProcessUtils flakyProcessUtils;
 
     setUp(() {
       // MockProcessManager has an implementation of start() that returns the
       // result of processFactory.
       flakyProcessManager = MockProcessManager();
       mockProcessManager = MockProcessManager();
+      processUtils = ProcessUtils(
+        processManager: mockProcessManager,
+        logger: MockLogger(),
+      );
+      flakyProcessUtils = ProcessUtils(
+        processManager: flakyProcessManager,
+        logger: MockLogger(),
+      );
     });
 
-    testUsingContext(' succeeds on success', () async {
+    testWithoutContext(' succeeds on success', () async {
       when(mockProcessManager.run(<String>['whoohoo'])).thenAnswer((_) {
         return Future<ProcessResult>.value(ProcessResult(0, 0, '', ''));
       });
       expect((await processUtils.run(<String>['whoohoo'])).exitCode, 0);
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
     });
 
-    testUsingContext(' fails on failure', () async {
+    testWithoutContext(' fails on failure', () async {
       when(mockProcessManager.run(<String>['boohoo'])).thenAnswer((_) {
         return Future<ProcessResult>.value(ProcessResult(0, 1, '', ''));
       });
       expect((await processUtils.run(<String>['boohoo'])).exitCode, 1);
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
     });
 
-    testUsingContext(' throws on failure with throwOnError', () async {
+    testWithoutContext(' throws on failure with throwOnError', () async {
       when(mockProcessManager.run(<String>['kaboom'])).thenAnswer((_) {
         return Future<ProcessResult>.value(ProcessResult(0, 1, '', ''));
       });
       expect(() => processUtils.run(<String>['kaboom'], throwOnError: true),
              throwsA(isA<ProcessException>()));
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
     });
 
-    testUsingContext(' does not throw on failure with whitelist', () async {
+    testWithoutContext(' does not throw on failure with whitelist', () async {
       when(mockProcessManager.run(<String>['kaboom'])).thenAnswer((_) {
         return Future<ProcessResult>.value(ProcessResult(0, 1, '', ''));
       });
@@ -145,12 +172,11 @@ void main() {
           throwOnError: true,
           whiteListFailures: (int c) => c == 1,
         )).exitCode,
-        1);
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
+        1,
+      );
     });
 
-    testUsingContext(' throws on failure when not in whitelist', () async {
+    testWithoutContext(' throws on failure when not in whitelist', () async {
       when(mockProcessManager.run(<String>['kaboom'])).thenAnswer((_) {
         return Future<ProcessResult>.value(ProcessResult(0, 2, '', ''));
       });
@@ -160,41 +186,36 @@ void main() {
           throwOnError: true,
           whiteListFailures: (int c) => c == 1,
         ),
-        throwsA(isA<ProcessException>()));
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
+        throwsA(isA<ProcessException>()),
+      );
     });
 
-    testUsingContext(' flaky process fails without retry', () async {
+    testWithoutContext(' flaky process fails without retry', () async {
       flakyProcessManager.processFactory = flakyProcessFactory(
         flakes: 1,
         delay: delay,
       );
-      final RunResult result = await processUtils.run(
+      final RunResult result = await flakyProcessUtils.run(
         <String>['dummy'],
         timeout: delay + const Duration(seconds: 1),
       );
       expect(result.exitCode, -9);
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => flakyProcessManager,
     });
 
-    testUsingContext(' flaky process succeeds with retry', () async {
+    testWithoutContext(' flaky process succeeds with retry', () async {
       flakyProcessManager.processFactory = flakyProcessFactory(
         flakes: 1,
         delay: delay,
       );
-      final RunResult result = await processUtils.run(
+      final RunResult result = await flakyProcessUtils.run(
         <String>['dummy'],
         timeout: delay - const Duration(milliseconds: 500),
         timeoutRetries: 1,
       );
       expect(result.exitCode, 0);
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => flakyProcessManager,
     });
 
-    testUsingContext(' flaky process generates ProcessException on timeout', () async {
+    testWithoutContext(' flaky process generates ProcessException on timeout', () async {
       final Completer<List<int>> flakyStderr = Completer<List<int>>();
       final Completer<List<int>> flakyStdout = Completer<List<int>>();
       flakyProcessManager.processFactory = flakyProcessFactory(
@@ -211,52 +232,57 @@ void main() {
         flakyStdout.complete(<int>[]);
         return true;
       });
-      expect(() => processUtils.run(
+      expect(() => flakyProcessUtils.run(
         <String>['dummy'],
         timeout: delay - const Duration(milliseconds: 500),
         timeoutRetries: 0,
       ), throwsA(isInstanceOf<ProcessException>()));
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => flakyProcessManager,
     });
   });
 
   group('runSync', () {
     ProcessManager mockProcessManager;
+    ProcessUtils processUtils;
+    BufferLogger testLogger;
 
     setUp(() {
       mockProcessManager = MockProcessManager();
+      testLogger = BufferLogger(
+        terminal: AnsiTerminal(
+          stdio: MockStdio(),
+          platform: FakePlatform.fromPlatform(const LocalPlatform())..stdoutSupportsAnsi = false,
+        ),
+        outputPreferences: OutputPreferences(wrapText: true, wrapColumn: 40),
+      );
+      processUtils = ProcessUtils(
+        processManager: mockProcessManager,
+        logger: testLogger,
+      );
     });
 
-    testUsingContext(' succeeds on success', () async {
+    testWithoutContext(' succeeds on success', () async {
       when(mockProcessManager.runSync(<String>['whoohoo'])).thenReturn(
         ProcessResult(0, 0, '', '')
       );
       expect(processUtils.runSync(<String>['whoohoo']).exitCode, 0);
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
     });
 
-    testUsingContext(' fails on failure', () async {
+    testWithoutContext(' fails on failure', () async {
       when(mockProcessManager.runSync(<String>['boohoo'])).thenReturn(
         ProcessResult(0, 1, '', '')
       );
       expect(processUtils.runSync(<String>['boohoo']).exitCode, 1);
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
     });
 
-    testUsingContext(' throws on failure with throwOnError', () async {
+    testWithoutContext(' throws on failure with throwOnError', () async {
       when(mockProcessManager.runSync(<String>['kaboom'])).thenReturn(
         ProcessResult(0, 1, '', '')
       );
       expect(() => processUtils.runSync(<String>['kaboom'], throwOnError: true),
              throwsA(isA<ProcessException>()));
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
     });
 
-    testUsingContext(' does not throw on failure with whitelist', () async {
+    testWithoutContext(' does not throw on failure with whitelist', () async {
       when(mockProcessManager.runSync(<String>['kaboom'])).thenReturn(
         ProcessResult(0, 1, '', '')
       );
@@ -267,11 +293,9 @@ void main() {
           whiteListFailures: (int c) => c == 1,
         ).exitCode,
         1);
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
     });
 
-    testUsingContext(' throws on failure when not in whitelist', () async {
+    testWithoutContext(' throws on failure when not in whitelist', () async {
       when(mockProcessManager.runSync(<String>['kaboom'])).thenReturn(
         ProcessResult(0, 2, '', '')
       );
@@ -282,22 +306,18 @@ void main() {
           whiteListFailures: (int c) => c == 1,
         ),
         throwsA(isA<ProcessException>()));
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
     });
 
-    testUsingContext(' prints stdout and stderr to trace on success', () async {
+    testWithoutContext(' prints stdout and stderr to trace on success', () async {
       when(mockProcessManager.runSync(<String>['whoohoo'])).thenReturn(
         ProcessResult(0, 0, 'stdout', 'stderr')
       );
       expect(processUtils.runSync(<String>['whoohoo']).exitCode, 0);
       expect(testLogger.traceText, contains('stdout'));
       expect(testLogger.traceText, contains('stderr'));
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
     });
 
-    testUsingContext(' prints stdout to status and stderr to error on failure with throwOnError', () async {
+    testWithoutContext(' prints stdout to status and stderr to error on failure with throwOnError', () async {
       when(mockProcessManager.runSync(<String>['kaboom'])).thenReturn(
         ProcessResult(0, 1, 'stdout', 'stderr')
       );
@@ -305,71 +325,69 @@ void main() {
              throwsA(isA<ProcessException>()));
       expect(testLogger.statusText, contains('stdout'));
       expect(testLogger.errorText, contains('stderr'));
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
     });
 
-    testUsingContext(' does not print stdout with hideStdout', () async {
+    testWithoutContext(' does not print stdout with hideStdout', () async {
       when(mockProcessManager.runSync(<String>['whoohoo'])).thenReturn(
         ProcessResult(0, 0, 'stdout', 'stderr')
       );
       expect(processUtils.runSync(<String>['whoohoo'], hideStdout: true).exitCode, 0);
       expect(testLogger.traceText.contains('stdout'), isFalse);
       expect(testLogger.traceText, contains('stderr'));
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
     });
   });
 
   group('exitsHappySync', () {
     ProcessManager mockProcessManager;
+    ProcessUtils processUtils;
 
     setUp(() {
       mockProcessManager = MockProcessManager();
+      processUtils = ProcessUtils(
+        processManager: mockProcessManager,
+        logger: MockLogger(),
+      );
     });
 
-    testUsingContext(' succeeds on success', () async {
+    testWithoutContext(' succeeds on success', () async {
       when(mockProcessManager.runSync(<String>['whoohoo'])).thenReturn(
         ProcessResult(0, 0, '', '')
       );
       expect(processUtils.exitsHappySync(<String>['whoohoo']), isTrue);
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
     });
 
-    testUsingContext(' fails on failure', () async {
+    testWithoutContext(' fails on failure', () async {
       when(mockProcessManager.runSync(<String>['boohoo'])).thenReturn(
         ProcessResult(0, 1, '', '')
       );
       expect(processUtils.exitsHappySync(<String>['boohoo']), isFalse);
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
     });
   });
 
   group('exitsHappy', () {
     ProcessManager mockProcessManager;
+    ProcessUtils processUtils;
 
     setUp(() {
       mockProcessManager = MockProcessManager();
+      processUtils = ProcessUtils(
+        processManager: mockProcessManager,
+        logger: MockLogger(),
+      );
     });
 
-    testUsingContext(' succeeds on success', () async {
+    testWithoutContext(' succeeds on success', () async {
       when(mockProcessManager.run(<String>['whoohoo'])).thenAnswer((_) {
         return Future<ProcessResult>.value(ProcessResult(0, 0, '', ''));
       });
       expect(await processUtils.exitsHappy(<String>['whoohoo']), isTrue);
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
     });
 
-    testUsingContext(' fails on failure', () async {
+    testWithoutContext(' fails on failure', () async {
       when(mockProcessManager.run(<String>['boohoo'])).thenAnswer((_) {
         return Future<ProcessResult>.value(ProcessResult(0, 1, '', ''));
       });
       expect(await processUtils.exitsHappy(<String>['boohoo']), isFalse);
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
     });
   });
 


### PR DESCRIPTION
## Description

Refactors `ProcessUtils` to remove references to the global context.

## Tests

I added the following tests:

Updated process_test.dart

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

(The updated tests were tests of a non-public API.)
