### PR TITLE
L10n Currency Formatting, Fixes to Named vs Positional Parameters

### DIFF
--- a/dev/tools/localization/gen_l10n.dart
+++ b/dev/tools/localization/gen_l10n.dart
@@ -243,8 +243,8 @@ const Set<String> allowableNumberFormats = <String>{
   'simpleCurrency',
 };
 
-// A subset of [allowableNumberFormats] that takes named parameters instead
-// of positional parameters.
+// The names of the NumberFormat factory constructors which have named
+// parameters rather than positional parameters.
 //
 // This helps the tool correctly generate number formmatting code correctly.
 //

--- a/dev/tools/localization/gen_l10n.dart
+++ b/dev/tools/localization/gen_l10n.dart
@@ -232,11 +232,26 @@ const Set<String> allowableDateFormats = <String>{
 // * <https://pub.dev/documentation/intl/latest/intl/NumberFormat-class.html>
 const Set<String> allowableNumberFormats = <String>{
   'compact',
+  'compactCurrency',
+  'compactSimpleCurrency',
   'compactLong',
+  'currency',
   'decimalPattern',
   'decimalPercentPattern',
   'percentPattern',
   'scientificPattern',
+  'simpleCurrency',
+};
+
+// TODO(shihaohong): add doc on what these are
+const Set<String> numberFormatsWithNamedParameters = <String>{
+  'compact',
+  'compactCurrency',
+  'compactSimpleCurrency',
+  'compactLong',
+  'currency',
+  'decimalPercentPattern',
+  'simpleCurrency',
 };
 
 bool _isDateParameter(Map<String, dynamic> placeholderValue) => placeholderValue['type'] == 'DateTime';
@@ -330,19 +345,29 @@ String generateNumberFormattingLogic(Map<String, dynamic> arbBundle, String reso
     for (final String placeholder in placeholders.keys) {
       final dynamic value = placeholders[placeholder];
       if (value is Map<String, dynamic> && _isValidNumberFormat(value, placeholder)) {
-        if (value.containsKey('optionalParameters')) {
-          final Map<String, dynamic> optionalParameters = value['optionalParameters'] as Map<String, dynamic>;
-          for (final String parameter in optionalParameters.keys)
-            optionalParametersString.write('\n      $parameter: ${optionalParameters[parameter]},');
-        }
+        print(value['format']);
+        print(numberFormatsWithNamedParameters.contains(value['format']));
+        if (numberFormatsWithNamedParameters.contains(value['format'])) {
+          if (value.containsKey('optionalParameters')) {
+            final Map<String, dynamic> optionalParameters = value['optionalParameters'] as Map<String, dynamic>;
+            for (final String parameter in optionalParameters.keys)
+              optionalParametersString.write('\n      $parameter: ${optionalParameters[parameter]},');
+          }
 
-        result.write('''
+          result.write('''
 
     final NumberFormat ${placeholder}NumberFormat = NumberFormat.${value['format']}(
       locale: _localeName,@optionalParameters
     );
     final String ${placeholder}String = ${placeholder}NumberFormat.format($placeholder);
 ''');
+        } else {
+          result.write('''
+
+    final NumberFormat ${placeholder}NumberFormat = NumberFormat.${value['format']}(_localeName);
+    final String ${placeholder}String = ${placeholder}NumberFormat.format($placeholder);
+''');
+        }
       }
     }
 

--- a/dev/tools/localization/gen_l10n.dart
+++ b/dev/tools/localization/gen_l10n.dart
@@ -243,7 +243,18 @@ const Set<String> allowableNumberFormats = <String>{
   'simpleCurrency',
 };
 
-// TODO(shihaohong): add doc on what these are
+// A subset of [allowableNumberFormats] that takes named parameters instead
+// of positional parameters.
+//
+// This helps the tool correctly generate number formmatting code correctly.
+//
+// Example of code that uses named parameters:
+// final NumberFormat format = NumberFormat.compact(
+//   locale: _localeName,
+// );
+//
+// Example of code that uses positional parameters:
+// final NumberFormat format = NumberFormat.scientificPattern(_localeName);
 const Set<String> numberFormatsWithNamedParameters = <String>{
   'compact',
   'compactCurrency',
@@ -345,8 +356,6 @@ String generateNumberFormattingLogic(Map<String, dynamic> arbBundle, String reso
     for (final String placeholder in placeholders.keys) {
       final dynamic value = placeholders[placeholder];
       if (value is Map<String, dynamic> && _isValidNumberFormat(value, placeholder)) {
-        print(value['format']);
-        print(numberFormatsWithNamedParameters.contains(value['format']));
         if (numberFormatsWithNamedParameters.contains(value['format'])) {
           if (value.containsKey('optionalParameters')) {
             final Map<String, dynamic> optionalParameters = value['optionalParameters'] as Map<String, dynamic>;


### PR DESCRIPTION
## Description

This adds currency format handling to the l10n tool. Since currency is handled using the `NumberFormat` class, I think it made more sense to just have currency placeholders identified with the type "Number" as well. 

It also fixes an existing issue where the tool assumed that all NumberFormat constructors took named parameters, but there are some that take positional parameters. 

If there are any objections to not having currency and number types separated, please comment on the PR or the corresponding issue.

## Related Issues

Related to https://github.com/flutter/flutter/issues/47008
Related to https://github.com/flutter/flutter/issues/41437

## Tests

- Tests to ensure that named vs positional parameters for numbers/currencies are properly read. This test implicitly checks all NumberFormat constructors, so it tests for the proper parsing of the new currency formats as well.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
