### PR TITLE
Fixing PageScrollPhysics to get along with NestedScrollView

### DIFF
--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -471,19 +471,19 @@ class PageScrollPhysics extends ScrollPhysics {
     return PageScrollPhysics(parent: buildParent(ancestor));
   }
 
-  double _getPage(ScrollPosition position) {
+  double _getPage(ScrollMetrics position) {
     if (position is _PagePosition)
       return position.page;
     return position.pixels / position.viewportDimension;
   }
 
-  double _getPixels(ScrollPosition position, double page) {
+  double _getPixels(ScrollMetrics position, double page) {
     if (position is _PagePosition)
       return position.getPixelsFromPage(page);
     return page * position.viewportDimension;
   }
 
-  double _getTargetPixels(ScrollPosition position, Tolerance tolerance, double velocity) {
+  double _getTargetPixels(ScrollMetrics position, Tolerance tolerance, double velocity) {
     double page = _getPage(position);
     if (velocity < -tolerance.velocity)
       page -= 0.5;
@@ -500,7 +500,7 @@ class PageScrollPhysics extends ScrollPhysics {
         (velocity >= 0.0 && position.pixels >= position.maxScrollExtent))
       return super.createBallisticSimulation(position, velocity);
     final Tolerance tolerance = this.tolerance;
-    final double target = _getTargetPixels(position as ScrollPosition, tolerance, velocity);
+    final double target = _getTargetPixels(position, tolerance, velocity);
     if (target != position.pixels)
       return ScrollSpringSimulation(spring, position.pixels, target, velocity, tolerance: tolerance);
     return null;


### PR DESCRIPTION
## Description

This fixes PageScrollPhysics to take ScrollMetrics instead of a ScrollPosition when creating ballistic simulations. Using ScrollPosition throws an exception when PageScrollPhysics are used in a NestedScrollView. I've also checked the other ScrollPhysics to confirm they also use ScrollMetrics instead of ScrollPosition, as metrics are mixed in with position anyways. :) 

## Related Issues

Fixes #47850 

## Tests

Added a regression test that uses PageScrollPhysics in a NestedScrollView

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
