### PR TITLE
Add highContrast to FakeAccessibilityFeatures test

### DIFF
--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -124,7 +124,7 @@ class MediaQueryData {
       invertColors = window.accessibilityFeatures.invertColors,
       disableAnimations = window.accessibilityFeatures.disableAnimations,
       boldText = window.accessibilityFeatures.boldText,
-      highContrast = false,
+      highContrast = window.accessibilityFeatures.highContrast,
       alwaysUse24HourFormat = window.alwaysUse24HourFormat;
 
   /// The size of the media in logical pixels (e.g, the size of the screen).

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -124,7 +124,7 @@ class MediaQueryData {
       invertColors = window.accessibilityFeatures.invertColors,
       disableAnimations = window.accessibilityFeatures.disableAnimations,
       boldText = window.accessibilityFeatures.boldText,
-      highContrast = window.accessibilityFeatures.highContrast,
+      highContrast = false,
       alwaysUse24HourFormat = window.alwaysUse24HourFormat;
 
   /// The size of the media in logical pixels (e.g, the size of the screen).

--- a/packages/flutter_test/test/window_test.dart
+++ b/packages/flutter_test/test/window_test.dart
@@ -256,6 +256,7 @@ class FakeAccessibilityFeatures implements AccessibilityFeatures {
     this.disableAnimations = false,
     this.boldText = false,
     this.reduceMotion = false,
+    this.highContrast = false,
   });
 
   @override
@@ -272,4 +273,7 @@ class FakeAccessibilityFeatures implements AccessibilityFeatures {
 
   @override
   final bool reduceMotion;
+
+  @override
+  final bool highContrast;
 }

--- a/packages/flutter_test/test/window_test.dart
+++ b/packages/flutter_test/test/window_test.dart
@@ -275,4 +275,12 @@ class FakeAccessibilityFeatures implements AccessibilityFeatures {
   final bool reduceMotion;
 
   final bool highContrast;
+
+  /// This gives us some grace time when the dart:ui side adds something to
+  /// [AccessibilityFeatures], and makes things easier when we do rolls to
+  /// give us time to catch up.
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    return null;
+  }
 }

--- a/packages/flutter_test/test/window_test.dart
+++ b/packages/flutter_test/test/window_test.dart
@@ -274,6 +274,5 @@ class FakeAccessibilityFeatures implements AccessibilityFeatures {
   @override
   final bool reduceMotion;
 
-  @override
   final bool highContrast;
 }


### PR DESCRIPTION
## Description

Add the `highContrast` property to the `FakeAccessibilityFeatures` class.

The `highContrast` is going to be added to the class `AccessibilityFeatures` in the PR: https://github.com/flutter/engine/pull/15343

Design change document: https://docs.google.com/document/d/1kePVlqWvJu5Ph0RL6wgg67F3SATmsJ8QY5N0S1MvaGg/edit

## Related Issues

Related to https://github.com/flutter/flutter/issues/48418
Depends on https://github.com/flutter/engine/pull/15343

## Tests

- The value is added to `FakeAccessibilityFeatures` which is used in the Window and MediaQueryData tests.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

I don't know how to use Flutter Analyze with a custom Flutter Engine, so I can't make it pass.

Test pass when I use my custom Flutter Engine.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [x] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [x] I wrote a design doc: https://docs.google.com/document/d/1kePVlqWvJu5Ph0RL6wgg67F3SATmsJ8QY5N0S1MvaGg/edit#
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*
