### PR TITLE
Upgrade dartdoc to 0.30.0+1

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -111,7 +111,7 @@ if [[ -d "$FLUTTER_PUB_CACHE" ]]; then
 fi
 
 # Install and activate dartdoc.
-"$PUB" global activate dartdoc 0.29.3
+"$PUB" global activate dartdoc 0.30.0
 
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc.

--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -111,7 +111,7 @@ if [[ -d "$FLUTTER_PUB_CACHE" ]]; then
 fi
 
 # Install and activate dartdoc.
-"$PUB" global activate dartdoc 0.30.0
+"$PUB" global activate dartdoc 0.30.0+1
 
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc.


### PR DESCRIPTION
Release notes:  [v0.30.0](https://github.com/dart-lang/dartdoc/releases/tag/v0.30.0)

Since flutter does post-processing on docs I have looked for any breakage introduced by the removal of `base href`, but could not find any.  I will verify with master branch docs after the change lands and uploading is complete that nothing unexpected happens with the final publishing phase.