### PR TITLE
Adding error handling for SocketExceptions to local comparator

### DIFF
--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -564,15 +564,15 @@ class FlutterLocalFileComparator extends FlutterGoldenFileComparator with LocalC
       return FlutterSkippingGoldenFileComparator(
         baseDirectory.uri,
         goldens,
-        'OSError was thrown retrieving baselines. There may not be a network '
-          'connection. Switching to FlutterSkippingGoldenFileComparator.',
+        'OSError occurred, could not reach Gold. '
+          'Switching to FlutterSkippingGoldenFileComparator.',
       );
     } on io.SocketException catch (_) {
       return FlutterSkippingGoldenFileComparator(
         baseDirectory.uri,
         goldens,
-        'SocketException was thrown retrieving baselines. There may not be a '
-          'network connection. Switching to FlutterSkippingGoldenFileComparator.',
+        'SocketException occurred, could not reach Gold. '
+          'Switching to FlutterSkippingGoldenFileComparator.',
       );
     }
 

--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -564,7 +564,15 @@ class FlutterLocalFileComparator extends FlutterGoldenFileComparator with LocalC
       return FlutterSkippingGoldenFileComparator(
         baseDirectory.uri,
         goldens,
-        'No network connection available for contacting Gold.',
+        'OSError was thrown retrieving baselines. There may not be a network '
+          'connection. Switching to FlutterSkippingGoldenFileComparator.',
+      );
+    } on io.SocketException catch (_) {
+      return FlutterSkippingGoldenFileComparator(
+        baseDirectory.uri,
+        goldens,
+        'SocketException was thrown retrieving baselines. There may not be a '
+          'network connection. Switching to FlutterSkippingGoldenFileComparator.',
       );
     }
 

--- a/packages/flutter_goldens/test/flutter_goldens_test.dart
+++ b/packages/flutter_goldens/test/flutter_goldens_test.dart
@@ -871,9 +871,19 @@ void main() {
         final MockDirectory mockDirectory = MockDirectory();
         when(mockDirectory.existsSync()).thenReturn(true);
         when(mockDirectory.uri).thenReturn(Uri.parse('/flutter'));
+
         when(mockSkiaClient.getExpectations())
-          .thenAnswer((_) => throw const OSError());
-        final FlutterGoldenFileComparator comparator = await FlutterLocalFileComparator.fromDefaultComparator(
+          .thenAnswer((_) => throw const OSError('Offline!'));
+        FlutterGoldenFileComparator comparator = await FlutterLocalFileComparator.fromDefaultComparator(
+          platform,
+          goldens: mockSkiaClient,
+          baseDirectory: mockDirectory,
+        );
+        expect(comparator.runtimeType, FlutterSkippingGoldenFileComparator);
+
+        when(mockSkiaClient.getExpectations())
+          .thenAnswer((_) => throw const SocketException('Offline!'));
+        comparator = await FlutterLocalFileComparator.fromDefaultComparator(
           platform,
           goldens: mockSkiaClient,
           baseDirectory: mockDirectory,

--- a/packages/flutter_goldens/test/flutter_goldens_test.dart
+++ b/packages/flutter_goldens/test/flutter_goldens_test.dart
@@ -873,7 +873,7 @@ void main() {
         when(mockDirectory.uri).thenReturn(Uri.parse('/flutter'));
 
         when(mockSkiaClient.getExpectations())
-          .thenAnswer((_) => throw const OSError('Offline!'));
+          .thenAnswer((_) => throw const OSError('Can\'t reach Gold'));
         FlutterGoldenFileComparator comparator = await FlutterLocalFileComparator.fromDefaultComparator(
           platform,
           goldens: mockSkiaClient,
@@ -882,7 +882,7 @@ void main() {
         expect(comparator.runtimeType, FlutterSkippingGoldenFileComparator);
 
         when(mockSkiaClient.getExpectations())
-          .thenAnswer((_) => throw const SocketException('Offline!'));
+          .thenAnswer((_) => throw const SocketException('Can\'t reach Gold'));
         comparator = await FlutterLocalFileComparator.fromDefaultComparator(
           platform,
           goldens: mockSkiaClient,


### PR DESCRIPTION
## Description

This adds error handling for the FlutterLocalFileComparator when retrieving golden baselines throws a socket exception. This can happen when a network connection is lost, and is not covered by the OSError that was previously put in place. In both of these exception cases, the skipping comparator will be used.

## Related Issues

Fixes #48506

## Tests

Added test for socket exception

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
