### PR TITLE
AppBar can now have custom titleHeight

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -23,20 +23,23 @@ import 'tabs.dart';
 import 'text_theme.dart';
 import 'theme.dart';
 
-const double _kLeadingWidth = kToolbarHeight; // So the leading button is square.
+const double _kLeadingWidth =
+    kToolbarHeight; // So the leading button is square.
 
 // Bottom justify the kToolbarHeight child which may overflow the top.
 class _ToolbarContainerLayout extends SingleChildLayoutDelegate {
-  const _ToolbarContainerLayout();
+  const _ToolbarContainerLayout({this.titleHeight});
+
+  final double titleHeight;
 
   @override
   BoxConstraints getConstraintsForChild(BoxConstraints constraints) {
-    return constraints.tighten(height: kToolbarHeight);
+    return constraints.tighten(height: titleHeight ?? kToolbarHeight);
   }
 
   @override
   Size getSize(BoxConstraints constraints) {
-    return Size(constraints.maxWidth, kToolbarHeight);
+    return Size(constraints.maxWidth, titleHeight ?? kToolbarHeight);
   }
 
   @override
@@ -45,7 +48,8 @@ class _ToolbarContainerLayout extends SingleChildLayoutDelegate {
   }
 
   @override
-  bool shouldRelayout(_ToolbarContainerLayout oldDelegate) => false;
+  bool shouldRelayout(_ToolbarContainerLayout oldDelegate) =>
+      this.titleHeight != oldDelegate.titleHeight;
 }
 
 // TODO(eseidel): Toolbar needs to change size based on orientation:
@@ -194,16 +198,18 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
     this.primary = true,
     this.centerTitle,
     this.titleSpacing = NavigationToolbar.kMiddleSpacing,
+    this.titleHeight,
     this.toolbarOpacity = 1.0,
     this.bottomOpacity = 1.0,
-  }) : assert(automaticallyImplyLeading != null),
-       assert(elevation == null || elevation >= 0.0),
-       assert(primary != null),
-       assert(titleSpacing != null),
-       assert(toolbarOpacity != null),
-       assert(bottomOpacity != null),
-       preferredSize = Size.fromHeight(kToolbarHeight + (bottom?.preferredSize?.height ?? 0.0)),
-       super(key: key);
+  })  : assert(automaticallyImplyLeading != null),
+        assert(elevation == null || elevation >= 0.0),
+        assert(primary != null),
+        assert(titleSpacing != null),
+        assert(toolbarOpacity != null),
+        assert(bottomOpacity != null),
+        preferredSize = Size.fromHeight((titleHeight ?? kToolbarHeight) +
+            (bottom?.preferredSize?.height ?? 0.0)),
+        super(key: key);
 
   /// A widget to display before the [title].
   ///
@@ -359,6 +365,11 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// Defaults to [NavigationToolbar.kMiddleSpacing].
   final double titleSpacing;
 
+  /// The amount of height to be used for the [title].
+  ///
+  /// If not provided, then defaults to [kToolbarHeight].
+  final double titleHeight;
+
   /// How opaque the toolbar part of the app bar is.
   ///
   /// A value of 1.0 is fully opaque, and a value of 0.0 is fully transparent.
@@ -377,7 +388,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// bar is scrolled.
   final double bottomOpacity;
 
-  /// A size whose height is the sum of [kToolbarHeight] and the [bottom] widget's
+  /// A size whose height is the sum of [kToolbarHeight] (or [titleHeight], if given) and the [bottom] widget's
   /// preferred height.
   ///
   /// [Scaffold] uses this size to set its app bar's height.
@@ -385,8 +396,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   final Size preferredSize;
 
   bool _getEffectiveCenterTitle(ThemeData theme) {
-    if (centerTitle != null)
-      return centerTitle;
+    if (centerTitle != null) return centerTitle;
     assert(theme.platform != null);
     switch (theme.platform) {
       case TargetPlatform.android:
@@ -426,33 +436,35 @@ class _AppBarState extends State<AppBar> {
     final bool hasDrawer = scaffold?.hasDrawer ?? false;
     final bool hasEndDrawer = scaffold?.hasEndDrawer ?? false;
     final bool canPop = parentRoute?.canPop ?? false;
-    final bool useCloseButton = parentRoute is PageRoute<dynamic> && parentRoute.fullscreenDialog;
+    final bool useCloseButton =
+        parentRoute is PageRoute<dynamic> && parentRoute.fullscreenDialog;
 
-    IconThemeData overallIconTheme = widget.iconTheme
-      ?? appBarTheme.iconTheme
-      ?? theme.primaryIconTheme;
-    IconThemeData actionsIconTheme = widget.actionsIconTheme
-      ?? appBarTheme.actionsIconTheme
-      ?? overallIconTheme;
-    TextStyle centerStyle = widget.textTheme?.title
-      ?? appBarTheme.textTheme?.title
-      ?? theme.primaryTextTheme.title;
-    TextStyle sideStyle = widget.textTheme?.body1
-      ?? appBarTheme.textTheme?.body1
-      ?? theme.primaryTextTheme.body1;
+    IconThemeData overallIconTheme =
+        widget.iconTheme ?? appBarTheme.iconTheme ?? theme.primaryIconTheme;
+    IconThemeData actionsIconTheme = widget.actionsIconTheme ??
+        appBarTheme.actionsIconTheme ??
+        overallIconTheme;
+    TextStyle centerStyle = widget.textTheme?.title ??
+        appBarTheme.textTheme?.title ??
+        theme.primaryTextTheme.title;
+    TextStyle sideStyle = widget.textTheme?.body1 ??
+        appBarTheme.textTheme?.body1 ??
+        theme.primaryTextTheme.body1;
 
     if (widget.toolbarOpacity != 1.0) {
-      final double opacity = const Interval(0.25, 1.0, curve: Curves.fastOutSlowIn).transform(widget.toolbarOpacity);
+      final double opacity =
+          const Interval(0.25, 1.0, curve: Curves.fastOutSlowIn)
+              .transform(widget.toolbarOpacity);
       if (centerStyle?.color != null)
-        centerStyle = centerStyle.copyWith(color: centerStyle.color.withOpacity(opacity));
+        centerStyle =
+            centerStyle.copyWith(color: centerStyle.color.withOpacity(opacity));
       if (sideStyle?.color != null)
-        sideStyle = sideStyle.copyWith(color: sideStyle.color.withOpacity(opacity));
+        sideStyle =
+            sideStyle.copyWith(color: sideStyle.color.withOpacity(opacity));
       overallIconTheme = overallIconTheme.copyWith(
-        opacity: opacity * (overallIconTheme.opacity ?? 1.0)
-      );
+          opacity: opacity * (overallIconTheme.opacity ?? 1.0));
       actionsIconTheme = actionsIconTheme.copyWith(
-        opacity: opacity * (actionsIconTheme.opacity ?? 1.0)
-      );
+          opacity: opacity * (actionsIconTheme.opacity ?? 1.0));
     }
 
     Widget leading = widget.leading;
@@ -530,11 +542,11 @@ class _AppBarState extends State<AppBar> {
       middleSpacing: widget.titleSpacing,
     );
 
-    // If the toolbar is allocated less than kToolbarHeight make it
+    // If the toolbar is allocated less than kToolbarHeight (or titleHeight, if given)  make it
     // appear to scroll upwards within its shrinking container.
     Widget appBar = ClipRect(
       child: CustomSingleChildLayout(
-        delegate: const _ToolbarContainerLayout(),
+        delegate: _ToolbarContainerLayout(titleHeight: widget.titleHeight),
         child: IconTheme.merge(
           data: overallIconTheme,
           child: DefaultTextStyle(
@@ -550,7 +562,8 @@ class _AppBarState extends State<AppBar> {
         children: <Widget>[
           Flexible(
             child: ConstrainedBox(
-              constraints: const BoxConstraints(maxHeight: kToolbarHeight),
+              constraints: BoxConstraints(
+                  maxHeight: (widget.titleHeight ?? kToolbarHeight)),
               child: appBar,
             ),
           ),
@@ -558,7 +571,8 @@ class _AppBarState extends State<AppBar> {
             widget.bottom
           else
             Opacity(
-              opacity: const Interval(0.25, 1.0, curve: Curves.fastOutSlowIn).transform(widget.bottomOpacity),
+              opacity: const Interval(0.25, 1.0, curve: Curves.fastOutSlowIn)
+                  .transform(widget.bottomOpacity),
               child: widget.bottom,
             ),
         ],
@@ -587,24 +601,22 @@ class _AppBarState extends State<AppBar> {
         ],
       );
     }
-    final Brightness brightness = widget.brightness
-      ?? appBarTheme.brightness
-      ?? theme.primaryColorBrightness;
+    final Brightness brightness = widget.brightness ??
+        appBarTheme.brightness ??
+        theme.primaryColorBrightness;
     final SystemUiOverlayStyle overlayStyle = brightness == Brightness.dark
-      ? SystemUiOverlayStyle.light
-      : SystemUiOverlayStyle.dark;
+        ? SystemUiOverlayStyle.light
+        : SystemUiOverlayStyle.dark;
 
     return Semantics(
       container: true,
       child: AnnotatedRegion<SystemUiOverlayStyle>(
         value: overlayStyle,
         child: Material(
-          color: widget.backgroundColor
-            ?? appBarTheme.color
-            ?? theme.primaryColor,
-          elevation: widget.elevation
-            ?? appBarTheme.elevation
-            ?? _defaultElevation,
+          color:
+              widget.backgroundColor ?? appBarTheme.color ?? theme.primaryColor,
+          elevation:
+              widget.elevation ?? appBarTheme.elevation ?? _defaultElevation,
           shape: widget.shape,
           child: Semantics(
             explicitChildNodes: true,
@@ -617,7 +629,7 @@ class _AppBarState extends State<AppBar> {
 }
 
 class _FloatingAppBar extends StatefulWidget {
-  const _FloatingAppBar({ Key key, this.child }) : super(key: key);
+  const _FloatingAppBar({Key key, this.child}) : super(key: key);
 
   final Widget child;
 
@@ -648,12 +660,12 @@ class _FloatingAppBarState extends State<_FloatingAppBar> {
   }
 
   RenderSliverFloatingPersistentHeader _headerRenderer() {
-    return context.findAncestorRenderObjectOfType<RenderSliverFloatingPersistentHeader>();
+    return context
+        .findAncestorRenderObjectOfType<RenderSliverFloatingPersistentHeader>();
   }
 
   void _isScrollingListener() {
-    if (_position == null)
-      return;
+    if (_position == null) return;
 
     // When a scroll stops, then maybe snap the appbar into view.
     // Similarly, when a scroll starts, then maybe stop the snap animation.
@@ -686,6 +698,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
     @required this.primary,
     @required this.centerTitle,
     @required this.titleSpacing,
+    this.titleHeight,
     @required this.expandedHeight,
     @required this.collapsedHeight,
     @required this.topPadding,
@@ -694,8 +707,8 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
     @required this.snapConfiguration,
     @required this.stretchConfiguration,
     @required this.shape,
-  }) : assert(primary || topPadding == 0.0),
-       _bottomHeight = bottom?.preferredSize?.height ?? 0.0;
+  })  : assert(primary || topPadding == 0.0),
+        _bottomHeight = bottom?.preferredSize?.height ?? 0.0;
 
   final Widget leading;
   final bool automaticallyImplyLeading;
@@ -713,6 +726,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
   final bool primary;
   final bool centerTitle;
   final double titleSpacing;
+  final double titleHeight;
   final double expandedHeight;
   final double collapsedHeight;
   final double topPadding;
@@ -723,10 +737,15 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
   final double _bottomHeight;
 
   @override
-  double get minExtent => collapsedHeight ?? (topPadding + kToolbarHeight + _bottomHeight);
+  double get minExtent =>
+      collapsedHeight ??
+      (topPadding + (titleHeight ?? kToolbarHeight) + _bottomHeight);
 
   @override
-  double get maxExtent => math.max(topPadding + (expandedHeight ?? kToolbarHeight + _bottomHeight), minExtent);
+  double get maxExtent => math.max(
+      topPadding +
+          (expandedHeight ?? (titleHeight ?? kToolbarHeight) + _bottomHeight),
+      minExtent);
 
   @override
   final FloatingHeaderSnapConfiguration snapConfiguration;
@@ -735,7 +754,8 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
   final OverScrollHeaderStretchConfiguration stretchConfiguration;
 
   @override
-  Widget build(BuildContext context, double shrinkOffset, bool overlapsContent) {
+  Widget build(
+      BuildContext context, double shrinkOffset, bool overlapsContent) {
     final double visibleMainHeight = maxExtent - shrinkOffset - topPadding;
 
     // Truth table for `toolbarOpacity`:
@@ -750,8 +770,10 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
     //    1   |    1     |        0       ||  1.0
     //    1   |    1     |        1       ||  fade
     final double toolbarOpacity = !pinned || (floating && bottom != null)
-      ? ((visibleMainHeight - _bottomHeight) / kToolbarHeight).clamp(0.0, 1.0) as double
-      : 1.0;
+        ? ((visibleMainHeight - _bottomHeight) /
+                (titleHeight ?? kToolbarHeight))
+            .clamp(0.0, 1.0) as double
+        : 1.0;
 
     final Widget appBar = FlexibleSpaceBar.createSettings(
       minExtent: minExtent,
@@ -764,10 +786,14 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
         title: title,
         actions: actions,
         flexibleSpace: (title == null && flexibleSpace != null)
-          ? Semantics(child: flexibleSpace, header: true)
-          : flexibleSpace,
+            ? Semantics(child: flexibleSpace, header: true)
+            : flexibleSpace,
         bottom: bottom,
-        elevation: forceElevated || overlapsContent || (pinned && shrinkOffset > maxExtent - minExtent) ? elevation ?? 4.0 : 0.0,
+        elevation: forceElevated ||
+                overlapsContent ||
+                (pinned && shrinkOffset > maxExtent - minExtent)
+            ? elevation ?? 4.0
+            : 0.0,
         backgroundColor: backgroundColor,
         brightness: brightness,
         iconTheme: iconTheme,
@@ -776,9 +802,12 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
         primary: primary,
         centerTitle: centerTitle,
         titleSpacing: titleSpacing,
+        titleHeight: titleHeight,
         shape: shape,
         toolbarOpacity: toolbarOpacity,
-        bottomOpacity: pinned ? 1.0 : ((visibleMainHeight / _bottomHeight).clamp(0.0, 1.0) as double),
+        bottomOpacity: pinned
+            ? 1.0
+            : ((visibleMainHeight / _bottomHeight).clamp(0.0, 1.0) as double),
       ),
     );
     return floating ? _FloatingAppBar(child: appBar) : appBar;
@@ -786,28 +815,29 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 
   @override
   bool shouldRebuild(covariant _SliverAppBarDelegate oldDelegate) {
-    return leading != oldDelegate.leading
-        || automaticallyImplyLeading != oldDelegate.automaticallyImplyLeading
-        || title != oldDelegate.title
-        || actions != oldDelegate.actions
-        || flexibleSpace != oldDelegate.flexibleSpace
-        || bottom != oldDelegate.bottom
-        || _bottomHeight != oldDelegate._bottomHeight
-        || elevation != oldDelegate.elevation
-        || backgroundColor != oldDelegate.backgroundColor
-        || brightness != oldDelegate.brightness
-        || iconTheme != oldDelegate.iconTheme
-        || actionsIconTheme != oldDelegate.actionsIconTheme
-        || textTheme != oldDelegate.textTheme
-        || primary != oldDelegate.primary
-        || centerTitle != oldDelegate.centerTitle
-        || titleSpacing != oldDelegate.titleSpacing
-        || expandedHeight != oldDelegate.expandedHeight
-        || topPadding != oldDelegate.topPadding
-        || pinned != oldDelegate.pinned
-        || floating != oldDelegate.floating
-        || snapConfiguration != oldDelegate.snapConfiguration
-        || stretchConfiguration != oldDelegate.stretchConfiguration;
+    return leading != oldDelegate.leading ||
+        automaticallyImplyLeading != oldDelegate.automaticallyImplyLeading ||
+        title != oldDelegate.title ||
+        actions != oldDelegate.actions ||
+        flexibleSpace != oldDelegate.flexibleSpace ||
+        bottom != oldDelegate.bottom ||
+        _bottomHeight != oldDelegate._bottomHeight ||
+        elevation != oldDelegate.elevation ||
+        backgroundColor != oldDelegate.backgroundColor ||
+        brightness != oldDelegate.brightness ||
+        iconTheme != oldDelegate.iconTheme ||
+        actionsIconTheme != oldDelegate.actionsIconTheme ||
+        textTheme != oldDelegate.textTheme ||
+        primary != oldDelegate.primary ||
+        centerTitle != oldDelegate.centerTitle ||
+        titleSpacing != oldDelegate.titleSpacing ||
+        titleHeight != oldDelegate.titleHeight ||
+        expandedHeight != oldDelegate.expandedHeight ||
+        topPadding != oldDelegate.topPadding ||
+        pinned != oldDelegate.pinned ||
+        floating != oldDelegate.floating ||
+        snapConfiguration != oldDelegate.snapConfiguration ||
+        stretchConfiguration != oldDelegate.stretchConfiguration;
   }
 
   @override
@@ -917,6 +947,7 @@ class SliverAppBar extends StatefulWidget {
     this.primary = true,
     this.centerTitle,
     this.titleSpacing = NavigationToolbar.kMiddleSpacing,
+    this.titleHeight,
     this.expandedHeight,
     this.floating = false,
     this.pinned = false,
@@ -925,17 +956,18 @@ class SliverAppBar extends StatefulWidget {
     this.stretchTriggerOffset = 100.0,
     this.onStretchTrigger,
     this.shape,
-  }) : assert(automaticallyImplyLeading != null),
-       assert(forceElevated != null),
-       assert(primary != null),
-       assert(titleSpacing != null),
-       assert(floating != null),
-       assert(pinned != null),
-       assert(snap != null),
-       assert(stretch != null),
-       assert(floating || !snap, 'The "snap" argument only makes sense for floating app bars.'),
-       assert(stretchTriggerOffset > 0.0),
-       super(key: key);
+  })  : assert(automaticallyImplyLeading != null),
+        assert(forceElevated != null),
+        assert(primary != null),
+        assert(titleSpacing != null),
+        assert(floating != null),
+        assert(pinned != null),
+        assert(snap != null),
+        assert(stretch != null),
+        assert(floating || !snap,
+            'The "snap" argument only makes sense for floating app bars.'),
+        assert(stretchTriggerOffset > 0.0),
+        super(key: key);
 
   /// A widget to display before the [title].
   ///
@@ -1087,6 +1119,11 @@ class SliverAppBar extends StatefulWidget {
   /// Defaults to [NavigationToolbar.kMiddleSpacing].
   final double titleSpacing;
 
+  /// The amount of height to be used for the [title].
+  ///
+  /// If not provided, then defaults to [kToolbarHeight].
+  final double titleHeight;
+
   /// The size of the app bar when it is fully expanded.
   ///
   /// By default, the total height of the toolbar and the bottom widget (if
@@ -1197,7 +1234,8 @@ class SliverAppBar extends StatefulWidget {
 
 // This class is only Stateful because it owns the TickerProvider used
 // by the floating appbar snap animation (via FloatingHeaderSnapConfiguration).
-class _SliverAppBarState extends State<SliverAppBar> with TickerProviderStateMixin {
+class _SliverAppBarState extends State<SliverAppBar>
+    with TickerProviderStateMixin {
   FloatingHeaderSnapConfiguration _snapConfiguration;
   OverScrollHeaderStretchConfiguration _stretchConfiguration;
 
@@ -1236,16 +1274,18 @@ class _SliverAppBarState extends State<SliverAppBar> with TickerProviderStateMix
     super.didUpdateWidget(oldWidget);
     if (widget.snap != oldWidget.snap || widget.floating != oldWidget.floating)
       _updateSnapConfiguration();
-    if (widget.stretch != oldWidget.stretch)
-      _updateStretchConfiguration();
+    if (widget.stretch != oldWidget.stretch) _updateStretchConfiguration();
   }
 
   @override
   Widget build(BuildContext context) {
     assert(!widget.primary || debugCheckHasMediaQuery(context));
-    final double topPadding = widget.primary ? MediaQuery.of(context).padding.top : 0.0;
-    final double collapsedHeight = (widget.pinned && widget.floating && widget.bottom != null)
-      ? widget.bottom.preferredSize.height + topPadding : null;
+    final double topPadding =
+        widget.primary ? MediaQuery.of(context).padding.top : 0.0;
+    final double collapsedHeight =
+        (widget.pinned && widget.floating && widget.bottom != null)
+            ? widget.bottom.preferredSize.height + topPadding
+            : null;
 
     return MediaQuery.removePadding(
       context: context,
@@ -1270,6 +1310,7 @@ class _SliverAppBarState extends State<SliverAppBar> with TickerProviderStateMix
           primary: widget.primary,
           centerTitle: widget.centerTitle,
           titleSpacing: widget.titleSpacing,
+          titleHeight: widget.titleHeight,
           expandedHeight: widget.expandedHeight,
           collapsedHeight: collapsedHeight,
           topPadding: topPadding,
@@ -1288,7 +1329,9 @@ class _SliverAppBarState extends State<SliverAppBar> with TickerProviderStateMix
 // center it within its (NavigationToolbar) parent, and allow the
 // parent to constrain the title's actual height.
 class _AppBarTitleBox extends SingleChildRenderObjectWidget {
-  const _AppBarTitleBox({ Key key, @required Widget child }) : assert(child != null), super(key: key, child: child);
+  const _AppBarTitleBox({Key key, @required Widget child})
+      : assert(child != null),
+        super(key: key, child: child);
 
   @override
   _RenderAppBarTitleBox createRenderObject(BuildContext context) {
@@ -1298,7 +1341,8 @@ class _AppBarTitleBox extends SingleChildRenderObjectWidget {
   }
 
   @override
-  void updateRenderObject(BuildContext context, _RenderAppBarTitleBox renderObject) {
+  void updateRenderObject(
+      BuildContext context, _RenderAppBarTitleBox renderObject) {
     renderObject.textDirection = Directionality.of(context);
   }
 }
@@ -1307,11 +1351,15 @@ class _RenderAppBarTitleBox extends RenderAligningShiftedBox {
   _RenderAppBarTitleBox({
     RenderBox child,
     TextDirection textDirection,
-  }) : super(child: child, alignment: Alignment.center, textDirection: textDirection);
+  }) : super(
+            child: child,
+            alignment: Alignment.center,
+            textDirection: textDirection);
 
   @override
   void performLayout() {
-    final BoxConstraints innerConstraints = constraints.copyWith(maxHeight: double.infinity);
+    final BoxConstraints innerConstraints =
+        constraints.copyWith(maxHeight: double.infinity);
     child.layout(innerConstraints, parentUsesSize: true);
     size = constraints.constrain(child.size);
     alignChild();

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -4,6 +4,7 @@
 
 import 'dart:math' as math;
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
@@ -49,7 +50,7 @@ class _ToolbarContainerLayout extends SingleChildLayoutDelegate {
 
   @override
   bool shouldRelayout(_ToolbarContainerLayout oldDelegate) =>
-      this.titleHeight != oldDelegate.titleHeight;
+      titleHeight != oldDelegate.titleHeight;
 }
 
 // TODO(eseidel): Toolbar needs to change size based on orientation:
@@ -199,12 +200,14 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
     this.centerTitle,
     this.titleSpacing = NavigationToolbar.kMiddleSpacing,
     this.titleHeight,
+    this.centerIcons = true,
     this.toolbarOpacity = 1.0,
     this.bottomOpacity = 1.0,
   })  : assert(automaticallyImplyLeading != null),
         assert(elevation == null || elevation >= 0.0),
         assert(primary != null),
         assert(titleSpacing != null),
+        assert(centerIcons != null),
         assert(toolbarOpacity != null),
         assert(bottomOpacity != null),
         preferredSize = Size.fromHeight((titleHeight ?? kToolbarHeight) +
@@ -370,6 +373,16 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// If not provided, then defaults to [kToolbarHeight].
   final double titleHeight;
 
+  /// Specifies whether the [AppBar.leading] and [AppBar.actions] should always be placed vertically center of the AppBar.
+  /// If you don't use [AppBar.titleHeight] exclusively, this option has NO effect.
+  ///
+  /// If you plan to set AppBar height manually (by specifying [AppBar.titleHeight]), the icons ([AppBar.leading] and [AppBar.actions]) are always placed vertically center of the AppBar.
+  ///
+  /// If this is set to false, the icons will be placed on top (as you had not specified titleHeight).
+  ///
+  /// Defaults to true.
+  final bool centerIcons;
+
   /// How opaque the toolbar part of the app bar is.
   ///
   /// A value of 1.0 is fully opaque, and a value of 0.0 is fully transparent.
@@ -396,7 +409,9 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   final Size preferredSize;
 
   bool _getEffectiveCenterTitle(ThemeData theme) {
-    if (centerTitle != null) return centerTitle;
+    if (centerTitle != null) {
+      return centerTitle;
+    }
     assert(theme.platform != null);
     switch (theme.platform) {
       case TargetPlatform.android:
@@ -540,6 +555,7 @@ class _AppBarState extends State<AppBar> {
       trailing: actions,
       centerMiddle: widget._getEffectiveCenterTitle(theme),
       middleSpacing: widget.titleSpacing,
+      centerIcons: widget.centerIcons,
     );
 
     // If the toolbar is allocated less than kToolbarHeight (or titleHeight, if given)  make it
@@ -563,7 +579,7 @@ class _AppBarState extends State<AppBar> {
           Flexible(
             child: ConstrainedBox(
               constraints: BoxConstraints(
-                  maxHeight: (widget.titleHeight ?? kToolbarHeight)),
+                  maxHeight: widget.titleHeight ?? kToolbarHeight),
               child: appBar,
             ),
           ),
@@ -665,7 +681,9 @@ class _FloatingAppBarState extends State<_FloatingAppBar> {
   }
 
   void _isScrollingListener() {
-    if (_position == null) return;
+    if (_position == null) {
+      return;
+    }
 
     // When a scroll stops, then maybe snap the appbar into view.
     // Similarly, when a scroll starts, then maybe stop the snap animation.
@@ -698,7 +716,8 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
     @required this.primary,
     @required this.centerTitle,
     @required this.titleSpacing,
-    this.titleHeight,
+    @required this.titleHeight,
+    @required this.centerIcons,
     @required this.expandedHeight,
     @required this.collapsedHeight,
     @required this.topPadding,
@@ -727,6 +746,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
   final bool centerTitle;
   final double titleSpacing;
   final double titleHeight;
+  final bool centerIcons;
   final double expandedHeight;
   final double collapsedHeight;
   final double topPadding;
@@ -803,6 +823,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
         centerTitle: centerTitle,
         titleSpacing: titleSpacing,
         titleHeight: titleHeight,
+        centerIcons: centerIcons,
         shape: shape,
         toolbarOpacity: toolbarOpacity,
         bottomOpacity: pinned
@@ -832,6 +853,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
         centerTitle != oldDelegate.centerTitle ||
         titleSpacing != oldDelegate.titleSpacing ||
         titleHeight != oldDelegate.titleHeight ||
+        centerIcons != oldDelegate.centerIcons ||
         expandedHeight != oldDelegate.expandedHeight ||
         topPadding != oldDelegate.topPadding ||
         pinned != oldDelegate.pinned ||
@@ -948,6 +970,7 @@ class SliverAppBar extends StatefulWidget {
     this.centerTitle,
     this.titleSpacing = NavigationToolbar.kMiddleSpacing,
     this.titleHeight,
+    this.centerIcons = true,
     this.expandedHeight,
     this.floating = false,
     this.pinned = false,
@@ -960,6 +983,7 @@ class SliverAppBar extends StatefulWidget {
         assert(forceElevated != null),
         assert(primary != null),
         assert(titleSpacing != null),
+        assert(centerIcons != null),
         assert(floating != null),
         assert(pinned != null),
         assert(snap != null),
@@ -1124,6 +1148,16 @@ class SliverAppBar extends StatefulWidget {
   /// If not provided, then defaults to [kToolbarHeight].
   final double titleHeight;
 
+  /// Specifies whether the [AppBar.leading] and [AppBar.actions] should always be placed vertically center of the AppBar.
+  /// If you don't use [AppBar.titleHeight] exclusively, this option has NO effect.
+  ///
+  /// If you plan to set AppBar height manually (by specifying [AppBar.titleHeight]), the icons ([AppBar.leading] and [AppBar.actions]) are always placed vertically center of the AppBar.
+  ///
+  /// If this is set to false, the icons will be placed on top (as you had not specified titleHeight).
+  ///
+  /// Defaults to true.
+  final bool centerIcons;
+
   /// The size of the app bar when it is fully expanded.
   ///
   /// By default, the total height of the toolbar and the bottom widget (if
@@ -1274,7 +1308,9 @@ class _SliverAppBarState extends State<SliverAppBar>
     super.didUpdateWidget(oldWidget);
     if (widget.snap != oldWidget.snap || widget.floating != oldWidget.floating)
       _updateSnapConfiguration();
-    if (widget.stretch != oldWidget.stretch) _updateStretchConfiguration();
+    if (widget.stretch != oldWidget.stretch) {
+      _updateStretchConfiguration();
+    }
   }
 
   @override
@@ -1311,6 +1347,7 @@ class _SliverAppBarState extends State<SliverAppBar>
           centerTitle: widget.centerTitle,
           titleSpacing: widget.titleSpacing,
           titleHeight: widget.titleHeight,
+          centerIcons: widget.centerIcons,
           expandedHeight: widget.expandedHeight,
           collapsedHeight: collapsedHeight,
           topPadding: topPadding,

--- a/packages/flutter/lib/src/widgets/navigation_toolbar.dart
+++ b/packages/flutter/lib/src/widgets/navigation_toolbar.dart
@@ -5,8 +5,8 @@
 import 'dart:math' as math;
 import 'dart:math';
 
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/src/material/constants.dart';
 
 import 'basic.dart';
 import 'debug.dart';

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -9,7 +9,8 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/semantics_tester.dart';
 
-Widget buildSliverAppBarApp({ bool floating, bool pinned, double expandedHeight, bool snap = false }) {
+Widget buildSliverAppBarApp(
+    {bool floating, bool pinned, double expandedHeight, bool snap = false}) {
   return Localizations(
     locale: const Locale('en', 'US'),
     delegates: const <LocalizationsDelegate<dynamic>>[
@@ -33,7 +34,9 @@ Widget buildSliverAppBarApp({ bool floating, bool pinned, double expandedHeight,
                   expandedHeight: expandedHeight,
                   snap: snap,
                   bottom: TabBar(
-                    tabs: <String>['A','B','C'].map<Widget>((String t) => Tab(text: 'TAB $t')).toList(),
+                    tabs: <String>['A', 'B', 'C']
+                        .map<Widget>((String t) => Tab(text: 'TAB $t'))
+                        .toList(),
                   ),
                 ),
                 SliverToBoxAdapter(
@@ -52,14 +55,21 @@ Widget buildSliverAppBarApp({ bool floating, bool pinned, double expandedHeight,
 }
 
 ScrollController primaryScrollController(WidgetTester tester) {
-  return PrimaryScrollController.of(tester.element(find.byType(CustomScrollView)));
+  return PrimaryScrollController.of(
+      tester.element(find.byType(CustomScrollView)));
 }
 
-double appBarHeight(WidgetTester tester) => tester.getSize(find.byType(AppBar, skipOffstage: false)).height;
-double appBarTop(WidgetTester tester) => tester.getTopLeft(find.byType(AppBar, skipOffstage: false)).dy;
-double appBarBottom(WidgetTester tester) => tester.getBottomLeft(find.byType(AppBar, skipOffstage: false)).dy;
+double appBarHeight(WidgetTester tester) =>
+    tester.getSize(find.byType(AppBar, skipOffstage: false)).height;
 
-double tabBarHeight(WidgetTester tester) => tester.getSize(find.byType(TabBar, skipOffstage: false)).height;
+double appBarTop(WidgetTester tester) =>
+    tester.getTopLeft(find.byType(AppBar, skipOffstage: false)).dy;
+
+double appBarBottom(WidgetTester tester) =>
+    tester.getBottomLeft(find.byType(AppBar, skipOffstage: false)).dy;
+
+double tabBarHeight(WidgetTester tester) =>
+    tester.getSize(find.byType(TabBar, skipOffstage: false)).height;
 
 void main() {
   setUp(() {
@@ -145,7 +155,8 @@ void main() {
     expect(center.dx, lessThan(400 - size.width / 2.0));
   });
 
-  testWidgets('AppBar centerTitle:true centers on Android', (WidgetTester tester) async {
+  testWidgets('AppBar centerTitle:true centers on Android',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(platform: TargetPlatform.android),
@@ -165,7 +176,8 @@ void main() {
     expect(center.dx, lessThan(400 + size.width / 2.0));
   });
 
-  testWidgets('AppBar centerTitle:false title start edge is 16.0 (LTR)', (WidgetTester tester) async {
+  testWidgets('AppBar centerTitle:false title start edge is 16.0 (LTR)',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
@@ -182,7 +194,8 @@ void main() {
     expect(tester.getTopRight(titleWidget).dx, 800 - 16.0);
   });
 
-  testWidgets('AppBar centerTitle:false title start edge is 16.0 (RTL)', (WidgetTester tester) async {
+  testWidgets('AppBar centerTitle:false title start edge is 16.0 (RTL)',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Directionality(
@@ -202,7 +215,8 @@ void main() {
     expect(tester.getTopLeft(titleWidget).dx, 16.0);
   });
 
-  testWidgets('AppBar titleSpacing:32 title start edge is 32.0 (LTR)', (WidgetTester tester) async {
+  testWidgets('AppBar titleSpacing:32 title start edge is 32.0 (LTR)',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
@@ -220,7 +234,8 @@ void main() {
     expect(tester.getTopRight(titleWidget).dx, 800 - 32.0);
   });
 
-  testWidgets('AppBar titleSpacing:32 title start edge is 32.0 (RTL)', (WidgetTester tester) async {
+  testWidgets('AppBar titleSpacing:32 title start edge is 32.0 (RTL)',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Directionality(
@@ -242,11 +257,32 @@ void main() {
   });
 
   testWidgets(
-    'AppBar centerTitle:false leading button title left edge is 72.0 (LTR)',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
+      'AppBar centerTitle:false leading button title left edge is 72.0 (LTR)',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(
+            centerTitle: false,
+            title: const Text('X'),
+          ),
+          // A drawer causes a leading hamburger.
+          drawer: const Drawer(),
+        ),
+      ),
+    );
+
+    expect(tester.getTopLeft(find.text('X')).dx, 72.0);
+  });
+
+  testWidgets(
+      'AppBar centerTitle:false leading button title left edge is 72.0 (RTL)',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Directionality(
+          textDirection: TextDirection.rtl,
+          child: Scaffold(
             appBar: AppBar(
               centerTitle: false,
               title: const Text('X'),
@@ -255,34 +291,14 @@ void main() {
             drawer: const Drawer(),
           ),
         ),
-      );
+      ),
+    );
 
-      expect(tester.getTopLeft(find.text('X')).dx, 72.0);
-    });
+    expect(tester.getTopRight(find.text('X')).dx, 800.0 - 72.0);
+  });
 
-  testWidgets(
-    'AppBar centerTitle:false leading button title left edge is 72.0 (RTL)',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Directionality(
-            textDirection: TextDirection.rtl,
-            child: Scaffold(
-              appBar: AppBar(
-                centerTitle: false,
-                title: const Text('X'),
-              ),
-              // A drawer causes a leading hamburger.
-              drawer: const Drawer(),
-            ),
-          ),
-        ),
-      );
-
-      expect(tester.getTopRight(find.text('X')).dx, 800.0 - 72.0);
-    });
-
-  testWidgets('AppBar centerTitle:false title overflow OK', (WidgetTester tester) async {
+  testWidgets('AppBar centerTitle:false title overflow OK',
+      (WidgetTester tester) async {
     // The app bar's title should be constrained to fit within the available space
     // between the leading and actions widgets.
 
@@ -310,11 +326,15 @@ void main() {
 
     final Finder title = find.byKey(titleKey);
     expect(tester.getTopLeft(title).dx, 72.0);
-    expect(tester.getSize(title).width, equals(
-        800.0 // Screen width.
-        - 56.0 // Leading button width.
-        - 16.0 // Leading button to title padding.
-        - 16.0)); // Title right side padding.
+    expect(
+        tester.getSize(title).width,
+        equals(800.0 // Screen width.
+            -
+            56.0 // Leading button width.
+            -
+            16.0 // Leading button to title padding.
+            -
+            16.0)); // Title right side padding.
 
     actions = <Widget>[
       const SizedBox(width: 100.0),
@@ -324,21 +344,28 @@ void main() {
 
     expect(tester.getTopLeft(title).dx, 72.0);
     // The title shrinks by 200.0 to allow for the actions widgets.
-    expect(tester.getSize(title).width, equals(
-        800.0 // Screen width.
-        - 56.0 // Leading button width.
-        - 16.0 // Leading button to title padding.
-        - 16.0 // Title to actions padding
-        - 200.0)); // Actions' width.
+    expect(
+        tester.getSize(title).width,
+        equals(800.0 // Screen width.
+            -
+            56.0 // Leading button width.
+            -
+            16.0 // Leading button to title padding.
+            -
+            16.0 // Title to actions padding
+            -
+            200.0)); // Actions' width.
 
     leading = Container(); // AppBar will constrain the width to 24.0
     await tester.pumpWidget(buildApp());
     expect(tester.getTopLeft(title).dx, 72.0);
     // Adding a leading widget shouldn't effect the title's size
-    expect(tester.getSize(title).width, equals(800.0 - 56.0 - 16.0 - 16.0 - 200.0));
+    expect(tester.getSize(title).width,
+        equals(800.0 - 56.0 - 16.0 - 16.0 - 200.0));
   });
 
-  testWidgets('AppBar centerTitle:true title overflow OK (LTR)', (WidgetTester tester) async {
+  testWidgets('AppBar centerTitle:true title overflow OK (LTR)',
+      (WidgetTester tester) async {
     // The app bar's title should be constrained to fit within the available space
     // between the leading and actions widgets. When it's also centered it may
     // also be start or end justified if it doesn't fit in the overall center.
@@ -390,7 +417,8 @@ void main() {
     expect(tester.getSize(title).width, equals(620.0));
   });
 
-  testWidgets('AppBar centerTitle:true title overflow OK (RTL)', (WidgetTester tester) async {
+  testWidgets('AppBar centerTitle:true title overflow OK (RTL)',
+      (WidgetTester tester) async {
     // The app bar's title should be constrained to fit within the available space
     // between the leading and actions widgets. When it's also centered it may
     // also be start or end justified if it doesn't fit in the overall center.
@@ -486,7 +514,8 @@ void main() {
     expect(tester.getSize(title).isEmpty, isTrue);
   });
 
-  testWidgets('AppBar actions are vertically centered', (WidgetTester tester) async {
+  testWidgets('AppBar actions are vertically centered',
+      (WidgetTester tester) async {
     final UniqueKey appBarKey = UniqueKey();
     final UniqueKey leadingKey = UniqueKey();
     final UniqueKey titleKey = UniqueKey();
@@ -518,7 +547,8 @@ void main() {
     expect(yCenter(appBarKey), equals(yCenter(action1Key)));
   });
 
-  testWidgets('leading button extends to edge and is square', (WidgetTester tester) async {
+  testWidgets('leading button extends to edge and is square',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(platform: TargetPlatform.android),
@@ -526,7 +556,8 @@ void main() {
           appBar: AppBar(
             title: const Text('X'),
           ),
-          drawer: Column(), // Doesn't really matter. Triggers a hamburger regardless.
+          drawer:
+              Column(), // Doesn't really matter. Triggers a hamburger regardless.
         ),
       ),
     );
@@ -536,14 +567,15 @@ void main() {
     expect(tester.getSize(hamburger), const Size(56.0, 56.0));
   });
 
-  testWidgets('test action is 4dp from edge and 48dp min', (WidgetTester tester) async {
+  testWidgets('test action is 4dp from edge and 48dp min',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(platform: TargetPlatform.android),
         home: Scaffold(
           appBar: AppBar(
             title: const Text('X'),
-            actions: const <Widget> [
+            actions: const <Widget>[
               IconButton(
                 icon: Icon(Icons.share),
                 onPressed: null,
@@ -572,7 +604,8 @@ void main() {
     expect(tester.getSize(shareButton), const Size(48.0, 56.0));
   });
 
-  testWidgets('SliverAppBar default configuration', (WidgetTester tester) async {
+  testWidgets('SliverAppBar default configuration',
+      (WidgetTester tester) async {
     await tester.pumpWidget(buildSliverAppBarApp(
       floating: false,
       pinned: false,
@@ -608,8 +641,8 @@ void main() {
     expect(tabBarHeight(tester), initialTabBarHeight);
   });
 
-  testWidgets('SliverAppBar expandedHeight, pinned', (WidgetTester tester) async {
-
+  testWidgets('SliverAppBar expandedHeight, pinned',
+      (WidgetTester tester) async {
     await tester.pumpWidget(buildSliverAppBarApp(
       floating: false,
       pinned: true,
@@ -641,8 +674,8 @@ void main() {
     expect(tabBarHeight(tester), initialTabBarHeight);
   });
 
-  testWidgets('SliverAppBar expandedHeight, pinned and floating', (WidgetTester tester) async {
-
+  testWidgets('SliverAppBar expandedHeight, pinned and floating',
+      (WidgetTester tester) async {
     await tester.pumpWidget(buildSliverAppBarApp(
       floating: true,
       pinned: true,
@@ -674,7 +707,8 @@ void main() {
     expect(tabBarHeight(tester), initialTabBarHeight);
   });
 
-  testWidgets('SliverAppBar expandedHeight, floating with snap:true', (WidgetTester tester) async {
+  testWidgets('SliverAppBar expandedHeight, floating with snap:true',
+      (WidgetTester tester) async {
     await tester.pumpWidget(buildSliverAppBarApp(
       floating: true,
       pinned: false,
@@ -687,7 +721,8 @@ void main() {
     expect(appBarBottom(tester), 128.0);
 
     // Scroll to the middle of the list. The (floating) appbar is no longer visible.
-    final ScrollPosition position = tester.state<ScrollableState>(find.byType(Scrollable)).position;
+    final ScrollPosition position =
+        tester.state<ScrollableState>(find.byType(Scrollable)).position;
     position.jumpTo(256.00);
     await tester.pumpAndSettle();
     expect(find.byType(SliverAppBar), findsNothing);
@@ -696,7 +731,8 @@ void main() {
     // Drag the scrollable up and down. The app bar should not snap open, its
     // height should just track the drag offset.
     TestGesture gesture = await tester.startGesture(const Offset(50.0, 256.0));
-    await gesture.moveBy(const Offset(0.0, 128.0)); // drag the appbar all the way open
+    await gesture
+        .moveBy(const Offset(0.0, 128.0)); // drag the appbar all the way open
     await tester.pump();
     expect(appBarTop(tester), 0.0);
     expect(appBarHeight(tester), 128.0);
@@ -755,7 +791,8 @@ void main() {
     expect(appBarBottom(tester), lessThanOrEqualTo(0.0));
   });
 
-  testWidgets('SliverAppBar expandedHeight, floating and pinned with snap:true', (WidgetTester tester) async {
+  testWidgets('SliverAppBar expandedHeight, floating and pinned with snap:true',
+      (WidgetTester tester) async {
     await tester.pumpWidget(buildSliverAppBarApp(
       floating: true,
       pinned: true,
@@ -769,7 +806,8 @@ void main() {
 
     // Scroll to the middle of the list. The only the tab bar is visible
     // because this is a pinned appbar.
-    final ScrollPosition position = tester.state<ScrollableState>(find.byType(Scrollable)).position;
+    final ScrollPosition position =
+        tester.state<ScrollableState>(find.byType(Scrollable)).position;
     position.jumpTo(256.0);
     await tester.pumpAndSettle();
     expect(find.byType(SliverAppBar), findsOneWidget);
@@ -841,17 +879,18 @@ void main() {
     expect(appBarBottom(tester), kTextTabBarHeight);
   });
 
-  testWidgets('AppBar dimensions, with and without bottom, primary', (WidgetTester tester) async {
-    const MediaQueryData topPadding100 = MediaQueryData(padding: EdgeInsets.only(top: 100.0));
+  testWidgets('AppBar dimensions, with and without bottom, primary',
+      (WidgetTester tester) async {
+    const MediaQueryData topPadding100 =
+        MediaQueryData(padding: EdgeInsets.only(top: 100.0));
 
-    await tester.pumpWidget(
-      Localizations(
-        locale: const Locale('en', 'US'),
-        delegates: const <LocalizationsDelegate<dynamic>>[
-          DefaultMaterialLocalizations.delegate,
-          DefaultWidgetsLocalizations.delegate,
-        ],
-        child: Directionality(
+    await tester.pumpWidget(Localizations(
+      locale: const Locale('en', 'US'),
+      delegates: const <LocalizationsDelegate<dynamic>>[
+        DefaultMaterialLocalizations.delegate,
+        DefaultWidgetsLocalizations.delegate,
+      ],
+      child: Directionality(
         textDirection: TextDirection.ltr,
         child: MediaQuery(
           data: topPadding100,
@@ -865,20 +904,19 @@ void main() {
     expect(appBarTop(tester), 0.0);
     expect(appBarHeight(tester), kToolbarHeight);
 
-    await tester.pumpWidget(
-      Localizations(
-        locale: const Locale('en', 'US'),
-        delegates: const <LocalizationsDelegate<dynamic>>[
-          DefaultMaterialLocalizations.delegate,
-          DefaultWidgetsLocalizations.delegate,
-        ],
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: MediaQuery(
-            data: topPadding100,
-            child: Scaffold(
-              primary: true,
-              appBar: AppBar(title: const Text('title')),
+    await tester.pumpWidget(Localizations(
+      locale: const Locale('en', 'US'),
+      delegates: const <LocalizationsDelegate<dynamic>>[
+        DefaultMaterialLocalizations.delegate,
+        DefaultWidgetsLocalizations.delegate,
+      ],
+      child: Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: topPadding100,
+          child: Scaffold(
+            primary: true,
+            appBar: AppBar(title: const Text('title')),
           ),
         ),
       ),
@@ -887,23 +925,22 @@ void main() {
     expect(tester.getTopLeft(find.text('title')).dy, greaterThan(100.0));
     expect(appBarHeight(tester), kToolbarHeight + 100.0);
 
-    await tester.pumpWidget(
-      Localizations(
-        locale: const Locale('en', 'US'),
-        delegates: const <LocalizationsDelegate<dynamic>>[
-          DefaultMaterialLocalizations.delegate,
-          DefaultWidgetsLocalizations.delegate,
-        ],
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: MediaQuery(
-            data: topPadding100,
-            child: Scaffold(
-              primary: false,
-              appBar: AppBar(
-                bottom: PreferredSize(
-                  preferredSize: const Size.fromHeight(200.0),
-                  child: Container(),
+    await tester.pumpWidget(Localizations(
+      locale: const Locale('en', 'US'),
+      delegates: const <LocalizationsDelegate<dynamic>>[
+        DefaultMaterialLocalizations.delegate,
+        DefaultWidgetsLocalizations.delegate,
+      ],
+      child: Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: topPadding100,
+          child: Scaffold(
+            primary: false,
+            appBar: AppBar(
+              bottom: PreferredSize(
+                preferredSize: const Size.fromHeight(200.0),
+                child: Container(),
               ),
             ),
           ),
@@ -913,14 +950,13 @@ void main() {
     expect(appBarTop(tester), 0.0);
     expect(appBarHeight(tester), kToolbarHeight + 200.0);
 
-    await tester.pumpWidget(
-      Localizations(
-        locale: const Locale('en', 'US'),
-        delegates: const <LocalizationsDelegate<dynamic>>[
-          DefaultMaterialLocalizations.delegate,
-          DefaultWidgetsLocalizations.delegate,
-        ],
-        child: Directionality(
+    await tester.pumpWidget(Localizations(
+      locale: const Locale('en', 'US'),
+      delegates: const <LocalizationsDelegate<dynamic>>[
+        DefaultMaterialLocalizations.delegate,
+        DefaultWidgetsLocalizations.delegate,
+      ],
+      child: Directionality(
         textDirection: TextDirection.ltr,
         child: MediaQuery(
           data: topPadding100,
@@ -962,7 +998,8 @@ void main() {
     expect(tester.getTopLeft(find.text('title')).dy, lessThan(100.0));
   });
 
-  testWidgets('AppBar updates when you add a drawer', (WidgetTester tester) async {
+  testWidgets('AppBar updates when you add a drawer',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
@@ -982,7 +1019,9 @@ void main() {
     expect(find.byIcon(Icons.menu), findsOneWidget);
   });
 
-  testWidgets('AppBar does not draw menu for drawer if automaticallyImplyLeading is false', (WidgetTester tester) async {
+  testWidgets(
+      'AppBar does not draw menu for drawer if automaticallyImplyLeading is false',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
@@ -992,6 +1031,34 @@ void main() {
       ),
     );
     expect(find.byIcon(Icons.menu), findsNothing);
+  });
+
+  testWidgets('AppBar sizes according to titleHeight',
+      (WidgetTester tester) async {
+    final GlobalKey key = GlobalKey();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: AppBar(
+            leading: Placeholder(key: key),
+            title: const Text('Abc'),
+            titleHeight: 100,
+            actions: const <Widget>[
+              Placeholder(fallbackWidth: 10.0),
+              Placeholder(fallbackWidth: 10.0),
+              Placeholder(fallbackWidth: 10.0),
+            ],
+          ),
+        ),
+      ),
+    );
+    expect(
+        tester
+            .renderObject<RenderBox>(find.byKey(key))
+            .localToGlobal(Offset.zero),
+        const Offset(0.0, 0.0));
+    expect(tester.renderObject<RenderBox>(find.byKey(key)).size,
+        const Size(56.0, 100.0));
   });
 
   testWidgets('AppBar handles loose children 0', (WidgetTester tester) async {
@@ -1011,8 +1078,13 @@ void main() {
         ),
       ),
     );
-    expect(tester.renderObject<RenderBox>(find.byKey(key)).localToGlobal(Offset.zero), const Offset(0.0, 0.0));
-    expect(tester.renderObject<RenderBox>(find.byKey(key)).size, const Size(56.0, 56.0));
+    expect(
+        tester
+            .renderObject<RenderBox>(find.byKey(key))
+            .localToGlobal(Offset.zero),
+        const Offset(0.0, 0.0));
+    expect(tester.renderObject<RenderBox>(find.byKey(key)).size,
+        const Size(56.0, 56.0));
   });
 
   testWidgets('AppBar handles loose children 1', (WidgetTester tester) async {
@@ -1041,8 +1113,13 @@ void main() {
         ),
       ),
     );
-    expect(tester.renderObject<RenderBox>(find.byKey(key)).localToGlobal(Offset.zero), const Offset(0.0, 0.0));
-    expect(tester.renderObject<RenderBox>(find.byKey(key)).size, const Size(56.0, 56.0));
+    expect(
+        tester
+            .renderObject<RenderBox>(find.byKey(key))
+            .localToGlobal(Offset.zero),
+        const Offset(0.0, 0.0));
+    expect(tester.renderObject<RenderBox>(find.byKey(key)).size,
+        const Size(56.0, 56.0));
   });
 
   testWidgets('AppBar handles loose children 2', (WidgetTester tester) async {
@@ -1082,8 +1159,13 @@ void main() {
         ),
       ),
     );
-    expect(tester.renderObject<RenderBox>(find.byKey(key)).localToGlobal(Offset.zero), const Offset(0.0, 0.0));
-    expect(tester.renderObject<RenderBox>(find.byKey(key)).size, const Size(56.0, 56.0));
+    expect(
+        tester
+            .renderObject<RenderBox>(find.byKey(key))
+            .localToGlobal(Offset.zero),
+        const Offset(0.0, 0.0));
+    expect(tester.renderObject<RenderBox>(find.byKey(key)).size,
+        const Size(56.0, 56.0));
   });
 
   testWidgets('AppBar handles loose children 3', (WidgetTester tester) async {
@@ -1114,41 +1196,52 @@ void main() {
         ),
       ),
     );
-    expect(tester.renderObject<RenderBox>(find.byKey(key)).localToGlobal(Offset.zero), const Offset(0.0, 0.0));
-    expect(tester.renderObject<RenderBox>(find.byKey(key)).size, const Size(56.0, 56.0));
+    expect(
+        tester
+            .renderObject<RenderBox>(find.byKey(key))
+            .localToGlobal(Offset.zero),
+        const Offset(0.0, 0.0));
+    expect(tester.renderObject<RenderBox>(find.byKey(key)).size,
+        const Size(56.0, 56.0));
   });
 
-  testWidgets('AppBar positioning of leading and trailing widgets with top padding', (WidgetTester tester) async {
-    const MediaQueryData topPadding100 = MediaQueryData(padding: EdgeInsets.only(top: 100));
+  testWidgets(
+      'AppBar positioning of leading and trailing widgets with top padding',
+      (WidgetTester tester) async {
+    const MediaQueryData topPadding100 =
+        MediaQueryData(padding: EdgeInsets.only(top: 100));
 
     final Key leadingKey = UniqueKey();
     final Key titleKey = UniqueKey();
     final Key trailingKey = UniqueKey();
 
-    await tester.pumpWidget(
-      Localizations(
-        locale: const Locale('en', 'US'),
-        delegates: const <LocalizationsDelegate<dynamic>>[
-          DefaultMaterialLocalizations.delegate,
-          DefaultWidgetsLocalizations.delegate,
-        ],
-        child: Directionality(
+    await tester.pumpWidget(Localizations(
+      locale: const Locale('en', 'US'),
+      delegates: const <LocalizationsDelegate<dynamic>>[
+        DefaultMaterialLocalizations.delegate,
+        DefaultWidgetsLocalizations.delegate,
+      ],
+      child: Directionality(
         textDirection: TextDirection.rtl,
         child: MediaQuery(
           data: topPadding100,
           child: Scaffold(
             primary: false,
             appBar: AppBar(
-              leading: Placeholder(key: leadingKey), // Forced to 56x56, see _kLeadingWidth in app_bar.dart.
+              leading: Placeholder(key: leadingKey),
+              // Forced to 56x56, see _kLeadingWidth in app_bar.dart.
               title: Placeholder(key: titleKey, fallbackHeight: kToolbarHeight),
-              actions: <Widget>[ Placeholder(key: trailingKey, fallbackWidth: 10) ],
+              actions: <Widget>[
+                Placeholder(key: trailingKey, fallbackWidth: 10)
+              ],
             ),
           ),
         ),
       ),
     ));
     expect(tester.getTopLeft(find.byType(AppBar)), const Offset(0, 0));
-    expect(tester.getTopLeft(find.byKey(leadingKey)), const Offset(800.0 - 56.0, 100));
+    expect(tester.getTopLeft(find.byKey(leadingKey)),
+        const Offset(800.0 - 56.0, 100));
     expect(tester.getTopLeft(find.byKey(trailingKey)), const Offset(0.0, 100));
 
     // Because the topPadding eliminates the vertical space for the
@@ -1158,24 +1251,27 @@ void main() {
     // (-28). The top of the toolbar is at (screen coordinates) y=100, so the
     // top of the title is 100 + -28 = 72. The toolbar clips its contents
     // so the title isn't actually visible.
-    expect(tester.getTopLeft(find.byKey(titleKey)), const Offset(10 + NavigationToolbar.kMiddleSpacing, 72));
+    expect(tester.getTopLeft(find.byKey(titleKey)),
+        const Offset(10 + NavigationToolbar.kMiddleSpacing, 72));
   });
 
-  testWidgets('SliverAppBar positioning of leading and trailing widgets with top padding', (WidgetTester tester) async {
-    const MediaQueryData topPadding100 = MediaQueryData(padding: EdgeInsets.only(top: 100.0));
+  testWidgets(
+      'SliverAppBar positioning of leading and trailing widgets with top padding',
+      (WidgetTester tester) async {
+    const MediaQueryData topPadding100 =
+        MediaQueryData(padding: EdgeInsets.only(top: 100.0));
 
     final Key leadingKey = UniqueKey();
     final Key titleKey = UniqueKey();
     final Key trailingKey = UniqueKey();
 
-    await tester.pumpWidget(
-      Localizations(
-        locale: const Locale('en', 'US'),
-        delegates: const <LocalizationsDelegate<dynamic>>[
-          DefaultMaterialLocalizations.delegate,
-          DefaultWidgetsLocalizations.delegate,
-        ],
-        child: Directionality(
+    await tester.pumpWidget(Localizations(
+      locale: const Locale('en', 'US'),
+      delegates: const <LocalizationsDelegate<dynamic>>[
+        DefaultMaterialLocalizations.delegate,
+        DefaultWidgetsLocalizations.delegate,
+      ],
+      child: Directionality(
         textDirection: TextDirection.rtl,
         child: MediaQuery(
           data: topPadding100,
@@ -1184,8 +1280,9 @@ void main() {
             slivers: <Widget>[
               SliverAppBar(
                 leading: Placeholder(key: leadingKey),
-                title: Placeholder(key: titleKey, fallbackHeight: kToolbarHeight),
-                actions: <Widget>[ Placeholder(key: trailingKey) ],
+                title:
+                    Placeholder(key: titleKey, fallbackHeight: kToolbarHeight),
+                actions: <Widget>[Placeholder(key: trailingKey)],
               ),
             ],
           ),
@@ -1193,26 +1290,30 @@ void main() {
       ),
     ));
     expect(tester.getTopLeft(find.byType(AppBar)), const Offset(0.0, 0.0));
-    expect(tester.getTopLeft(find.byKey(leadingKey)), const Offset(800.0 - 56.0, 100.0));
+    expect(tester.getTopLeft(find.byKey(leadingKey)),
+        const Offset(800.0 - 56.0, 100.0));
     expect(tester.getTopLeft(find.byKey(titleKey)), const Offset(416.0, 100.0));
-    expect(tester.getTopLeft(find.byKey(trailingKey)), const Offset(0.0, 100.0));
+    expect(
+        tester.getTopLeft(find.byKey(trailingKey)), const Offset(0.0, 100.0));
   });
 
-  testWidgets('SliverAppBar positioning of leading and trailing widgets with bottom padding', (WidgetTester tester) async {
-    const MediaQueryData topPadding100 = MediaQueryData(padding: EdgeInsets.only(top: 100.0, bottom: 50.0));
+  testWidgets(
+      'SliverAppBar positioning of leading and trailing widgets with bottom padding',
+      (WidgetTester tester) async {
+    const MediaQueryData topPadding100 =
+        MediaQueryData(padding: EdgeInsets.only(top: 100.0, bottom: 50.0));
 
     final Key leadingKey = UniqueKey();
     final Key titleKey = UniqueKey();
     final Key trailingKey = UniqueKey();
 
-    await tester.pumpWidget(
-      Localizations(
-        locale: const Locale('en', 'US'),
-        delegates: const <LocalizationsDelegate<dynamic>>[
-          DefaultMaterialLocalizations.delegate,
-          DefaultWidgetsLocalizations.delegate,
-        ],
-        child: Directionality(
+    await tester.pumpWidget(Localizations(
+      locale: const Locale('en', 'US'),
+      delegates: const <LocalizationsDelegate<dynamic>>[
+        DefaultMaterialLocalizations.delegate,
+        DefaultWidgetsLocalizations.delegate,
+      ],
+      child: Directionality(
         textDirection: TextDirection.rtl,
         child: MediaQuery(
           data: topPadding100,
@@ -1222,19 +1323,23 @@ void main() {
               SliverAppBar(
                 leading: Placeholder(key: leadingKey),
                 title: Placeholder(key: titleKey),
-                actions: <Widget>[ Placeholder(key: trailingKey) ],
+                actions: <Widget>[Placeholder(key: trailingKey)],
               ),
             ],
           ),
         ),
       ),
     ));
-    expect(tester.getRect(find.byType(AppBar)), const Rect.fromLTRB(0.0, 0.0, 800.00, 100.0 + 56.0));
-    expect(tester.getRect(find.byKey(leadingKey)), const Rect.fromLTRB(800.0 - 56.0, 100.0, 800.0, 100.0 + 56.0));
-    expect(tester.getRect(find.byKey(trailingKey)), const Rect.fromLTRB(0.0, 100.0, 400.0, 100.0 + 56.0));
+    expect(tester.getRect(find.byType(AppBar)),
+        const Rect.fromLTRB(0.0, 0.0, 800.00, 100.0 + 56.0));
+    expect(tester.getRect(find.byKey(leadingKey)),
+        const Rect.fromLTRB(800.0 - 56.0, 100.0, 800.0, 100.0 + 56.0));
+    expect(tester.getRect(find.byKey(trailingKey)),
+        const Rect.fromLTRB(0.0, 100.0, 400.0, 100.0 + 56.0));
   });
 
-  testWidgets('SliverAppBar provides correct semantics in LTR', (WidgetTester tester) async {
+  testWidgets('SliverAppBar provides correct semantics in LTR',
+      (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
 
     await tester.pumpWidget(
@@ -1257,43 +1362,47 @@ void main() {
       ),
     );
 
-    expect(semantics, hasSemantics(
-      TestSemantics.root(
-        children: <TestSemantics>[
-          TestSemantics(
+    expect(
+        semantics,
+        hasSemantics(
+          TestSemantics.root(
             children: <TestSemantics>[
               TestSemantics(
-                flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
                 children: <TestSemantics>[
                   TestSemantics(
+                    flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
                     children: <TestSemantics>[
                       TestSemantics(
-                        label: 'Leading',
-                        textDirection: TextDirection.ltr,
-                      ),
-                      TestSemantics(
-                        flags: <SemanticsFlag>[
-                          SemanticsFlag.namesRoute,
-                          SemanticsFlag.isHeader,
+                        children: <TestSemantics>[
+                          TestSemantics(
+                            label: 'Leading',
+                            textDirection: TextDirection.ltr,
+                          ),
+                          TestSemantics(
+                            flags: <SemanticsFlag>[
+                              SemanticsFlag.namesRoute,
+                              SemanticsFlag.isHeader,
+                            ],
+                            label: 'Title',
+                            textDirection: TextDirection.ltr,
+                          ),
+                          TestSemantics(
+                            label: 'Action 1',
+                            textDirection: TextDirection.ltr,
+                          ),
+                          TestSemantics(
+                            label: 'Action 2',
+                            textDirection: TextDirection.ltr,
+                          ),
+                          TestSemantics(
+                            label: 'Action 3',
+                            textDirection: TextDirection.ltr,
+                          ),
+                          TestSemantics(
+                            label: 'Bottom',
+                            textDirection: TextDirection.ltr,
+                          ),
                         ],
-                        label: 'Title',
-                        textDirection: TextDirection.ltr,
-                      ),
-                      TestSemantics(
-                        label: 'Action 1',
-                        textDirection: TextDirection.ltr,
-                      ),
-                      TestSemantics(
-                        label: 'Action 2',
-                        textDirection: TextDirection.ltr,
-                      ),
-                      TestSemantics(
-                        label: 'Action 3',
-                        textDirection: TextDirection.ltr,
-                      ),
-                      TestSemantics(
-                        label: 'Bottom',
-                        textDirection: TextDirection.ltr,
                       ),
                     ],
                   ),
@@ -1301,17 +1410,16 @@ void main() {
               ),
             ],
           ),
-        ],
-      ),
-      ignoreRect: true,
-      ignoreTransform: true,
-      ignoreId: true,
-    ));
+          ignoreRect: true,
+          ignoreTransform: true,
+          ignoreId: true,
+        ));
 
     semantics.dispose();
   });
 
-  testWidgets('SliverAppBar provides correct semantics in RTL', (WidgetTester tester) async {
+  testWidgets('SliverAppBar provides correct semantics in RTL',
+      (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
 
     await tester.pumpWidget(
@@ -1340,46 +1448,50 @@ void main() {
       ),
     );
 
-    expect(semantics, hasSemantics(
-      TestSemantics.root(
-        children: <TestSemantics>[
-          TestSemantics(
+    expect(
+        semantics,
+        hasSemantics(
+          TestSemantics.root(
             children: <TestSemantics>[
               TestSemantics(
-                flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
                 children: <TestSemantics>[
                   TestSemantics(
-                    textDirection: TextDirection.rtl,
+                    flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
                     children: <TestSemantics>[
                       TestSemantics(
+                        textDirection: TextDirection.rtl,
                         children: <TestSemantics>[
                           TestSemantics(
-                            label: 'Leading',
-                            textDirection: TextDirection.rtl,
-                          ),
-                          TestSemantics(
-                            flags: <SemanticsFlag>[
-                              SemanticsFlag.namesRoute,
-                              SemanticsFlag.isHeader,
+                            children: <TestSemantics>[
+                              TestSemantics(
+                                label: 'Leading',
+                                textDirection: TextDirection.rtl,
+                              ),
+                              TestSemantics(
+                                flags: <SemanticsFlag>[
+                                  SemanticsFlag.namesRoute,
+                                  SemanticsFlag.isHeader,
+                                ],
+                                label: 'Title',
+                                textDirection: TextDirection.rtl,
+                              ),
+                              TestSemantics(
+                                label: 'Action 1',
+                                textDirection: TextDirection.rtl,
+                              ),
+                              TestSemantics(
+                                label: 'Action 2',
+                                textDirection: TextDirection.rtl,
+                              ),
+                              TestSemantics(
+                                label: 'Action 3',
+                                textDirection: TextDirection.rtl,
+                              ),
+                              TestSemantics(
+                                label: 'Bottom',
+                                textDirection: TextDirection.rtl,
+                              ),
                             ],
-                            label: 'Title',
-                            textDirection: TextDirection.rtl,
-                          ),
-                          TestSemantics(
-                            label: 'Action 1',
-                            textDirection: TextDirection.rtl,
-                          ),
-                          TestSemantics(
-                            label: 'Action 2',
-                            textDirection: TextDirection.rtl,
-                          ),
-                          TestSemantics(
-                            label: 'Action 3',
-                            textDirection: TextDirection.rtl,
-                          ),
-                          TestSemantics(
-                            label: 'Bottom',
-                            textDirection: TextDirection.rtl,
                           ),
                         ],
                       ),
@@ -1389,17 +1501,16 @@ void main() {
               ),
             ],
           ),
-        ],
-      ),
-      ignoreRect: true,
-      ignoreTransform: true,
-      ignoreId: true,
-    ));
+          ignoreRect: true,
+          ignoreTransform: true,
+          ignoreId: true,
+        ));
 
     semantics.dispose();
   });
 
-  testWidgets('AppBar draws a light system bar for a dark background', (WidgetTester tester) async {
+  testWidgets('AppBar draws a light system bar for a dark background',
+      (WidgetTester tester) async {
     final ThemeData darkTheme = ThemeData.dark();
     await tester.pumpWidget(MaterialApp(
       theme: darkTheme,
@@ -1409,13 +1520,16 @@ void main() {
     ));
 
     expect(darkTheme.primaryColorBrightness, Brightness.dark);
-    expect(SystemChrome.latestStyle, const SystemUiOverlayStyle(
-      statusBarBrightness: Brightness.dark,
-      statusBarIconBrightness: Brightness.light,
-    ));
+    expect(
+        SystemChrome.latestStyle,
+        const SystemUiOverlayStyle(
+          statusBarBrightness: Brightness.dark,
+          statusBarIconBrightness: Brightness.light,
+        ));
   });
 
-  testWidgets('AppBar draws a dark system bar for a light background', (WidgetTester tester) async {
+  testWidgets('AppBar draws a dark system bar for a light background',
+      (WidgetTester tester) async {
     final ThemeData lightTheme = ThemeData(primaryColor: Colors.white);
     await tester.pumpWidget(MaterialApp(
       theme: lightTheme,
@@ -1425,13 +1539,16 @@ void main() {
     ));
 
     expect(lightTheme.primaryColorBrightness, Brightness.light);
-    expect(SystemChrome.latestStyle, const SystemUiOverlayStyle(
-      statusBarBrightness: Brightness.light,
-      statusBarIconBrightness: Brightness.dark,
-    ));
+    expect(
+        SystemChrome.latestStyle,
+        const SystemUiOverlayStyle(
+          statusBarBrightness: Brightness.light,
+          statusBarIconBrightness: Brightness.dark,
+        ));
   });
 
-  testWidgets('Changing SliverAppBar snap from true to false', (WidgetTester tester) async {
+  testWidgets('Changing SliverAppBar snap from true to false',
+      (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/17598
     const double appBarHeight = 256.0;
     bool snap = true;
@@ -1509,14 +1626,15 @@ void main() {
     expect(getAppBarWidget(appBarFinder).shape, null);
 
     final Finder materialFinder = find.byType(Material);
-    Material getMaterialWidget(Finder finder) => tester.widget<Material>(finder);
+    Material getMaterialWidget(Finder finder) =>
+        tester.widget<Material>(finder);
     expect(getMaterialWidget(materialFinder).shape, null);
   });
 
   testWidgets('AppBar with shape', (WidgetTester tester) async {
-    const RoundedRectangleBorder roundedRectangleBorder = RoundedRectangleBorder(
-      borderRadius: BorderRadius.all(Radius.circular(15.0))
-    );
+    const RoundedRectangleBorder roundedRectangleBorder =
+        RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(15.0)));
     await tester.pumpWidget(
       MaterialApp(
         home: AppBar(
@@ -1533,7 +1651,8 @@ void main() {
     expect(getAppBarWidget(appBarFinder).shape, roundedRectangleBorder);
 
     final Finder materialFinder = find.byType(Material);
-    Material getMaterialWidget(Finder finder) => tester.widget<Material>(finder);
+    Material getMaterialWidget(Finder finder) =>
+        tester.widget<Material>(finder);
     expect(getMaterialWidget(materialFinder).shape, roundedRectangleBorder);
   });
 
@@ -1553,16 +1672,19 @@ void main() {
     );
 
     final Finder sliverAppBarFinder = find.byType(SliverAppBar);
-    SliverAppBar getSliverAppBarWidget(Finder finder) => tester.widget<SliverAppBar>(finder);
+    SliverAppBar getSliverAppBarWidget(Finder finder) =>
+        tester.widget<SliverAppBar>(finder);
     expect(getSliverAppBarWidget(sliverAppBarFinder).shape, null);
 
     final Finder materialFinder = find.byType(Material);
-    Material getMaterialWidget(Finder finder) => tester.widget<Material>(finder);
+    Material getMaterialWidget(Finder finder) =>
+        tester.widget<Material>(finder);
     expect(getMaterialWidget(materialFinder).shape, null);
   });
 
   testWidgets('SliverAppBar with shape', (WidgetTester tester) async {
-    const RoundedRectangleBorder roundedRectangleBorder = RoundedRectangleBorder(
+    const RoundedRectangleBorder roundedRectangleBorder =
+        RoundedRectangleBorder(
       borderRadius: BorderRadius.all(Radius.circular(15.0)),
     );
     await tester.pumpWidget(
@@ -1581,15 +1703,19 @@ void main() {
     );
 
     final Finder sliverAppBarFinder = find.byType(SliverAppBar);
-    SliverAppBar getSliverAppBarWidget(Finder finder) => tester.widget<SliverAppBar>(finder);
-    expect(getSliverAppBarWidget(sliverAppBarFinder).shape, roundedRectangleBorder);
+    SliverAppBar getSliverAppBarWidget(Finder finder) =>
+        tester.widget<SliverAppBar>(finder);
+    expect(getSliverAppBarWidget(sliverAppBarFinder).shape,
+        roundedRectangleBorder);
 
     final Finder materialFinder = find.byType(Material);
-    Material getMaterialWidget(Finder finder) => tester.widget<Material>(finder);
+    Material getMaterialWidget(Finder finder) =>
+        tester.widget<Material>(finder);
     expect(getMaterialWidget(materialFinder).shape, roundedRectangleBorder);
   });
 
-  testWidgets('AppBars with jumbo titles, textScaleFactor = 3, 3.5, 4', (WidgetTester tester) async {
+  testWidgets('AppBars with jumbo titles, textScaleFactor = 3, 3.5, 4',
+      (WidgetTester tester) async {
     double textScaleFactor;
     TextDirection textDirection;
     bool centerTitle;
@@ -1601,7 +1727,8 @@ void main() {
             return Directionality(
               textDirection: textDirection,
               child: MediaQuery(
-                data: MediaQuery.of(context).copyWith(textScaleFactor: textScaleFactor),
+                data: MediaQuery.of(context)
+                    .copyWith(textScaleFactor: textScaleFactor),
                 child: Builder(
                   builder: (BuildContext context) {
                     return Scaffold(
@@ -1648,14 +1775,17 @@ void main() {
     expect(tester.getRect(appBarTitle), const Rect.fromLTRB(16, -12, 416, 68));
     expect(tester.getCenter(appBarTitle).dy, tester.getCenter(toolbar).dy);
 
-    textDirection = TextDirection.rtl; // Changed to rtl. "Jumbo" title is still 400x80.
+    textDirection =
+        TextDirection.rtl; // Changed to rtl. "Jumbo" title is still 400x80.
     await tester.pumpWidget(buildFrame());
-    expect(tester.getRect(appBarTitle), const Rect.fromLTRB(800.0 - 400.0 - 16.0, -12, 800.0 - 16.0, 68));
+    expect(tester.getRect(appBarTitle),
+        const Rect.fromLTRB(800.0 - 400.0 - 16.0, -12, 800.0 - 16.0, 68));
     expect(tester.getCenter(appBarTitle).dy, tester.getCenter(toolbar).dy);
 
     centerTitle = true; // Changed to true. "Jumbo" title is still 400x80.
     await tester.pumpWidget(buildFrame());
-    expect(tester.getRect(appBarTitle), const Rect.fromLTRB(200, -12, 800.0 - 200.0, 68));
+    expect(tester.getRect(appBarTitle),
+        const Rect.fromLTRB(200, -12, 800.0 - 200.0, 68));
     expect(tester.getCenter(appBarTitle).dy, tester.getCenter(toolbar).dy);
   });
 }

--- a/packages/flutter/test/material/floating_action_button_location_test.dart
+++ b/packages/flutter/test/material/floating_action_button_location_test.dart
@@ -10,70 +10,86 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('Basic floating action button locations', () {
-    testWidgets('still animates motion when the floating action button is null', (WidgetTester tester) async {
+    testWidgets('still animates motion when the floating action button is null',
+        (WidgetTester tester) async {
       await tester.pumpWidget(buildFrame(fab: null, location: null));
 
       expect(find.byType(FloatingActionButton), findsNothing);
       expect(tester.binding.transientCallbackCount, 0);
 
-      await tester.pumpWidget(buildFrame(fab: null, location: FloatingActionButtonLocation.endFloat));
+      await tester.pumpWidget(buildFrame(
+          fab: null, location: FloatingActionButtonLocation.endFloat));
 
       expect(find.byType(FloatingActionButton), findsNothing);
       expect(tester.binding.transientCallbackCount, greaterThan(0));
 
-      await tester.pumpWidget(buildFrame(fab: null, location: FloatingActionButtonLocation.centerFloat));
+      await tester.pumpWidget(buildFrame(
+          fab: null, location: FloatingActionButtonLocation.centerFloat));
 
       expect(find.byType(FloatingActionButton), findsNothing);
       expect(tester.binding.transientCallbackCount, greaterThan(0));
     });
 
-    testWidgets('moves fab from center to end and back', (WidgetTester tester) async {
-      await tester.pumpWidget(buildFrame(location: FloatingActionButtonLocation.endFloat));
+    testWidgets('moves fab from center to end and back',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+          buildFrame(location: FloatingActionButtonLocation.endFloat));
 
-      expect(tester.getCenter(find.byType(FloatingActionButton)), const Offset(756.0, 356.0));
+      expect(tester.getCenter(find.byType(FloatingActionButton)),
+          const Offset(756.0, 356.0));
       expect(tester.binding.transientCallbackCount, 0);
 
-      await tester.pumpWidget(buildFrame(location: FloatingActionButtonLocation.centerFloat));
+      await tester.pumpWidget(
+          buildFrame(location: FloatingActionButtonLocation.centerFloat));
 
       expect(tester.binding.transientCallbackCount, greaterThan(0));
 
       await tester.pumpAndSettle();
 
-      expect(tester.getCenter(find.byType(FloatingActionButton)), const Offset(400.0, 356.0));
+      expect(tester.getCenter(find.byType(FloatingActionButton)),
+          const Offset(400.0, 356.0));
       expect(tester.binding.transientCallbackCount, 0);
 
-      await tester.pumpWidget(buildFrame(location: FloatingActionButtonLocation.endFloat));
+      await tester.pumpWidget(
+          buildFrame(location: FloatingActionButtonLocation.endFloat));
 
       expect(tester.binding.transientCallbackCount, greaterThan(0));
 
       await tester.pumpAndSettle();
 
-      expect(tester.getCenter(find.byType(FloatingActionButton)), const Offset(756.0, 356.0));
+      expect(tester.getCenter(find.byType(FloatingActionButton)),
+          const Offset(756.0, 356.0));
       expect(tester.binding.transientCallbackCount, 0);
     });
 
-    testWidgets('moves to and from custom-defined positions', (WidgetTester tester) async {
-      await tester.pumpWidget(buildFrame(location: const _StartTopFloatingActionButtonLocation()));
+    testWidgets('moves to and from custom-defined positions',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+          buildFrame(location: const _StartTopFloatingActionButtonLocation()));
 
-      expect(tester.getCenter(find.byType(FloatingActionButton)), const Offset(44.0, 56.0));
+      expect(tester.getCenter(find.byType(FloatingActionButton)),
+          const Offset(44.0, 56.0));
 
-      await tester.pumpWidget(buildFrame(location: FloatingActionButtonLocation.centerFloat));
+      await tester.pumpWidget(
+          buildFrame(location: FloatingActionButtonLocation.centerFloat));
       expect(tester.binding.transientCallbackCount, greaterThan(0));
 
       await tester.pumpAndSettle();
 
-      expect(tester.getCenter(find.byType(FloatingActionButton)), const Offset(400.0, 356.0));
+      expect(tester.getCenter(find.byType(FloatingActionButton)),
+          const Offset(400.0, 356.0));
       expect(tester.binding.transientCallbackCount, 0);
 
-      await tester.pumpWidget(buildFrame(location: const _StartTopFloatingActionButtonLocation()));
+      await tester.pumpWidget(
+          buildFrame(location: const _StartTopFloatingActionButtonLocation()));
 
       expect(tester.binding.transientCallbackCount, greaterThan(0));
 
       await tester.pumpAndSettle();
 
-      expect(tester.getCenter(find.byType(FloatingActionButton)), const Offset(44.0, 56.0));
+      expect(tester.getCenter(find.byType(FloatingActionButton)),
+          const Offset(44.0, 56.0));
       expect(tester.binding.transientCallbackCount, 0);
-
     });
 
     group('interrupts in-progress animations without jumps', () {
@@ -127,15 +143,19 @@ void main() {
           //
           // Note that there may be multiple transitions all active at
           // the same time. We are concerned only with the closest one.
-          final Iterable<RotationTransition> rotationTransitions = tester.widgetList(
+          final Iterable<RotationTransition> rotationTransitions =
+              tester.widgetList(
             find.byType(RotationTransition),
           );
-          final Iterable<double> currentRotations = rotationTransitions.map(
-              (RotationTransition t) => t.turns.value);
+          final Iterable<double> currentRotations =
+              rotationTransitions.map((RotationTransition t) => t.turns.value);
 
-          if (previousRotations != null && previousRotations.isNotEmpty
-              && currentRotations != null && currentRotations.isNotEmpty
-              && previousRect != null && currentRect != null) {
+          if (previousRotations != null &&
+              previousRotations.isNotEmpty &&
+              currentRotations != null &&
+              currentRotations.isNotEmpty &&
+              previousRect != null &&
+              currentRect != null) {
             final List<double> deltas = <double>[];
             for (final double currentRotation in currentRotations) {
               double minDelta;
@@ -147,12 +167,16 @@ void main() {
               deltas.add(minDelta);
             }
 
-            if (deltas.where((double delta) => delta < maxDeltaRotation).isEmpty) {
-              fail("The Floating Action Button's rotation should not change "
-                  'faster than $maxDeltaRotation per animation step.\n'
-                  'Detected deltas were: $deltas\n'
-                  'Previous values: $previousRotations, current values: $currentRotations\n'
-                  'Prevous rect: $previousRect, current rect: $currentRect',);
+            if (deltas
+                .where((double delta) => delta < maxDeltaRotation)
+                .isEmpty) {
+              fail(
+                "The Floating Action Button's rotation should not change "
+                'faster than $maxDeltaRotation per animation step.\n'
+                'Detected deltas were: $deltas\n'
+                'Previous values: $previousRotations, current values: $currentRotations\n'
+                'Prevous rect: $previousRect, current rect: $currentRect',
+              );
             }
           }
           previousRotations = currentRotations;
@@ -175,33 +199,50 @@ void main() {
 
       testWidgets('moving the fab to centerFloat', (WidgetTester tester) async {
         // Create a scaffold with the fab at endFloat
-        await tester.pumpWidget(buildFrame(location: FloatingActionButtonLocation.endFloat, listener: geometryListener));
+        await tester.pumpWidget(buildFrame(
+            location: FloatingActionButtonLocation.endFloat,
+            listener: geometryListener));
         setupListener(tester);
 
         // Move the fab to centerFloat'
-        await tester.pumpWidget(buildFrame(location: FloatingActionButtonLocation.centerFloat, listener: geometryListener));
+        await tester.pumpWidget(buildFrame(
+            location: FloatingActionButtonLocation.centerFloat,
+            listener: geometryListener));
         await tester.pumpAndSettle();
       });
 
-      testWidgets('interrupting motion towards the StartTop location.', (WidgetTester tester) async {
-        await tester.pumpWidget(buildFrame(location: FloatingActionButtonLocation.centerFloat, listener: geometryListener));
+      testWidgets('interrupting motion towards the StartTop location.',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildFrame(
+            location: FloatingActionButtonLocation.centerFloat,
+            listener: geometryListener));
         setupListener(tester);
 
         // Move the fab to the top start after creating the fab.
-        await tester.pumpWidget(buildFrame(location: const _StartTopFloatingActionButtonLocation(), listener: geometryListener));
+        await tester.pumpWidget(buildFrame(
+            location: const _StartTopFloatingActionButtonLocation(),
+            listener: geometryListener));
         await tester.pump(kFloatingActionButtonSegue ~/ 2);
 
         // Interrupt motion to move to the end float
-        await tester.pumpWidget(buildFrame(location: FloatingActionButtonLocation.endFloat, listener: geometryListener));
+        await tester.pumpWidget(buildFrame(
+            location: FloatingActionButtonLocation.endFloat,
+            listener: geometryListener));
         await tester.pumpAndSettle();
       });
 
-      testWidgets('interrupting entrance to remove the fab.', (WidgetTester tester) async {
-        await tester.pumpWidget(buildFrame(fab: null, location: FloatingActionButtonLocation.centerFloat, listener: geometryListener));
+      testWidgets('interrupting entrance to remove the fab.',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildFrame(
+            fab: null,
+            location: FloatingActionButtonLocation.centerFloat,
+            listener: geometryListener));
         setupListener(tester);
 
         // Animate the fab in.
-        await tester.pumpWidget(buildFrame(location: FloatingActionButtonLocation.endFloat, listener: geometryListener));
+        await tester.pumpWidget(buildFrame(
+            location: FloatingActionButtonLocation.endFloat,
+            listener: geometryListener));
         await tester.pump(kFloatingActionButtonSegue ~/ 2);
 
         // Remove the fab.
@@ -215,7 +256,8 @@ void main() {
         await tester.pumpAndSettle();
       }, skip: isBrowser);
 
-      testWidgets('interrupting entrance of a new fab.', (WidgetTester tester) async {
+      testWidgets('interrupting entrance of a new fab.',
+          (WidgetTester tester) async {
         await tester.pumpWidget(
           buildFrame(
             fab: null,
@@ -226,7 +268,9 @@ void main() {
         setupListener(tester);
 
         // Bring in a new fab.
-        await tester.pumpWidget(buildFrame(location: FloatingActionButtonLocation.centerFloat, listener: geometryListener));
+        await tester.pumpWidget(buildFrame(
+            location: FloatingActionButtonLocation.centerFloat,
+            listener: geometryListener));
         await tester.pump(kFloatingActionButtonSegue ~/ 2);
 
         // Interrupt motion to move the fab.
@@ -241,7 +285,8 @@ void main() {
     }, skip: isBrowser);
   });
 
-  testWidgets('Docked floating action button locations', (WidgetTester tester) async {
+  testWidgets('Docked floating action button locations',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       buildFrame(
         location: FloatingActionButtonLocation.endDocked,
@@ -252,7 +297,8 @@ void main() {
 
     // Scaffold 800x600, FAB is 56x56, BAB is 800x100, FAB's center is
     // at the top of the BAB.
-    expect(tester.getCenter(find.byType(FloatingActionButton)), const Offset(756.0, 500.0));
+    expect(tester.getCenter(find.byType(FloatingActionButton)),
+        const Offset(756.0, 500.0));
 
     await tester.pumpWidget(
       buildFrame(
@@ -262,8 +308,8 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    expect(tester.getCenter(find.byType(FloatingActionButton)), const Offset(400.0, 500.0));
-
+    expect(tester.getCenter(find.byType(FloatingActionButton)),
+        const Offset(400.0, 500.0));
 
     await tester.pumpWidget(
       buildFrame(
@@ -273,17 +319,20 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    expect(tester.getCenter(find.byType(FloatingActionButton)), const Offset(756.0, 500.0));
+    expect(tester.getCenter(find.byType(FloatingActionButton)),
+        const Offset(756.0, 500.0));
   }, skip: isBrowser);
 
-  testWidgets('Docked floating action button locations: no BAB, small BAB', (WidgetTester tester) async {
+  testWidgets('Docked floating action button locations: no BAB, small BAB',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       buildFrame(
         location: FloatingActionButtonLocation.endDocked,
         viewInsets: EdgeInsets.zero,
       ),
     );
-    expect(tester.getCenter(find.byType(FloatingActionButton)), const Offset(756.0, 572.0));
+    expect(tester.getCenter(find.byType(FloatingActionButton)),
+        const Offset(756.0, 572.0));
 
     await tester.pumpWidget(
       buildFrame(
@@ -292,16 +341,20 @@ void main() {
         viewInsets: EdgeInsets.zero,
       ),
     );
-    expect(tester.getCenter(find.byType(FloatingActionButton)), const Offset(756.0, 572.0));
+    expect(tester.getCenter(find.byType(FloatingActionButton)),
+        const Offset(756.0, 572.0));
   }, skip: isBrowser);
 
-  testWidgets('Mini-start-top floating action button location', (WidgetTester tester) async {
+  testWidgets('Mini-start-top floating action button location',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
           appBar: AppBar(),
-          floatingActionButton: FloatingActionButton(onPressed: () { }, mini: true),
-          floatingActionButtonLocation: FloatingActionButtonLocation.miniStartTop,
+          floatingActionButton:
+              FloatingActionButton(onPressed: () {}, mini: true),
+          floatingActionButtonLocation:
+              FloatingActionButtonLocation.miniStartTop,
           body: Column(
             children: const <Widget>[
               ListTile(
@@ -312,11 +365,42 @@ void main() {
         ),
       ),
     );
-    expect(tester.getCenter(find.byType(FloatingActionButton)).dx, tester.getCenter(find.byType(CircleAvatar)).dx);
-    expect(tester.getCenter(find.byType(FloatingActionButton)).dy, kToolbarHeight);
+    expect(tester.getCenter(find.byType(FloatingActionButton)).dx,
+        tester.getCenter(find.byType(CircleAvatar)).dx);
+    expect(
+        tester.getCenter(find.byType(FloatingActionButton)).dy, kToolbarHeight);
   }, skip: isBrowser);
 
-  testWidgets('Start-top floating action button location LTR', (WidgetTester tester) async {
+  testWidgets(
+      'Mini-start-top floating action button location, when custom titleHeight given',
+      (WidgetTester tester) async {
+    const double customTitleHeight = 128.0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(titleHeight: customTitleHeight),
+          floatingActionButton:
+              FloatingActionButton(onPressed: () {}, mini: true),
+          floatingActionButtonLocation:
+              FloatingActionButtonLocation.miniStartTop,
+          body: Column(
+            children: const <Widget>[
+              ListTile(
+                leading: CircleAvatar(),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    expect(tester.getCenter(find.byType(FloatingActionButton)).dx,
+        tester.getCenter(find.byType(CircleAvatar)).dx);
+    expect(tester.getCenter(find.byType(FloatingActionButton)).dy,
+        customTitleHeight);
+  }, skip: isBrowser);
+
+  testWidgets('Start-top floating action button location LTR',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
@@ -326,10 +410,12 @@ void main() {
         ),
       ),
     );
-    expect(tester.getRect(find.byType(FloatingActionButton)), rectMoreOrLessEquals(const Rect.fromLTWH(16.0, 28.0, 56.0, 56.0)));
+    expect(tester.getRect(find.byType(FloatingActionButton)),
+        rectMoreOrLessEquals(const Rect.fromLTWH(16.0, 28.0, 56.0, 56.0)));
   }, skip: isBrowser);
 
-  testWidgets('End-top floating action button location RTL', (WidgetTester tester) async {
+  testWidgets('End-top floating action button location RTL',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Directionality(
@@ -342,10 +428,12 @@ void main() {
         ),
       ),
     );
-    expect(tester.getRect(find.byType(FloatingActionButton)), rectMoreOrLessEquals(const Rect.fromLTWH(16.0, 28.0, 56.0, 56.0)));
+    expect(tester.getRect(find.byType(FloatingActionButton)),
+        rectMoreOrLessEquals(const Rect.fromLTWH(16.0, 28.0, 56.0, 56.0)));
   }, skip: isBrowser);
 
-  testWidgets('Start-top floating action button location RTL', (WidgetTester tester) async {
+  testWidgets('Start-top floating action button location RTL',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Directionality(
@@ -358,10 +446,14 @@ void main() {
         ),
       ),
     );
-    expect(tester.getRect(find.byType(FloatingActionButton)), rectMoreOrLessEquals(const Rect.fromLTWH(800.0 - 56.0 - 16.0, 28.0, 56.0, 56.0)));
+    expect(
+        tester.getRect(find.byType(FloatingActionButton)),
+        rectMoreOrLessEquals(
+            const Rect.fromLTWH(800.0 - 56.0 - 16.0, 28.0, 56.0, 56.0)));
   }, skip: isBrowser);
 
-  testWidgets('End-top floating action button location LTR', (WidgetTester tester) async {
+  testWidgets('End-top floating action button location LTR',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
@@ -371,10 +463,12 @@ void main() {
         ),
       ),
     );
-    expect(tester.getRect(find.byType(FloatingActionButton)), rectMoreOrLessEquals(const Rect.fromLTWH(800.0 - 56.0 - 16.0, 28.0, 56.0, 56.0)));
+    expect(
+        tester.getRect(find.byType(FloatingActionButton)),
+        rectMoreOrLessEquals(
+            const Rect.fromLTWH(800.0 - 56.0 - 16.0, 28.0, 56.0, 56.0)));
   }, skip: isBrowser);
 }
-
 
 class _GeometryListener extends StatefulWidget {
   @override
@@ -384,9 +478,7 @@ class _GeometryListener extends StatefulWidget {
 class _GeometryListenerState extends State<_GeometryListener> {
   @override
   Widget build(BuildContext context) {
-    return CustomPaint(
-      painter: cache
-    );
+    return CustomPaint(painter: cache);
   }
 
   int numNotifications = 0;
@@ -396,9 +488,9 @@ class _GeometryListenerState extends State<_GeometryListener> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final ValueListenable<ScaffoldGeometry> newListenable = Scaffold.geometryOf(context);
-    if (geometryListenable == newListenable)
-      return;
+    final ValueListenable<ScaffoldGeometry> newListenable =
+        Scaffold.geometryOf(context);
+    if (geometryListenable == newListenable) return;
 
     if (geometryListenable != null)
       geometryListenable.removeListener(onGeometryChanged);
@@ -413,12 +505,12 @@ class _GeometryListenerState extends State<_GeometryListener> {
   }
 }
 
-
 // The Scaffold.geometryOf() value is only available at paint time.
 // To fetch it for the tests we implement this CustomPainter that just
 // caches the ScaffoldGeometry value in its paint method.
 class _GeometryCachePainter extends CustomPainter {
-  _GeometryCachePainter(this.geometryListenable) : super(repaint: geometryListenable);
+  _GeometryCachePainter(this.geometryListenable)
+      : super(repaint: geometryListenable);
 
   final ValueListenable<ScaffoldGeometry> geometryListenable;
 
@@ -446,27 +538,28 @@ Widget buildFrame({
   Widget bab,
 }) {
   return Localizations(
-    locale: const Locale('en', 'us'),
-    delegates: const <LocalizationsDelegate<dynamic>>[
-      DefaultWidgetsLocalizations.delegate,
-      DefaultMaterialLocalizations.delegate,
-    ],
-    child: Directionality(
-    textDirection: textDirection,
-    child: MediaQuery(
-      data: MediaQueryData(viewInsets: viewInsets),
-      child: Scaffold(
-        appBar: AppBar(title: const Text('FabLocation Test')),
-        floatingActionButtonLocation: location,
-        floatingActionButton: fab,
-        bottomNavigationBar: bab,
-        body: listener,
-      ),
-    ),
-  ));
+      locale: const Locale('en', 'us'),
+      delegates: const <LocalizationsDelegate<dynamic>>[
+        DefaultWidgetsLocalizations.delegate,
+        DefaultMaterialLocalizations.delegate,
+      ],
+      child: Directionality(
+        textDirection: textDirection,
+        child: MediaQuery(
+          data: MediaQueryData(viewInsets: viewInsets),
+          child: Scaffold(
+            appBar: AppBar(title: const Text('FabLocation Test')),
+            floatingActionButtonLocation: location,
+            floatingActionButton: fab,
+            bottomNavigationBar: bab,
+            body: listener,
+          ),
+        ),
+      ));
 }
 
-class _StartTopFloatingActionButtonLocation extends FloatingActionButtonLocation {
+class _StartTopFloatingActionButtonLocation
+    extends FloatingActionButtonLocation {
   const _StartTopFloatingActionButtonLocation();
 
   @override
@@ -475,15 +568,20 @@ class _StartTopFloatingActionButtonLocation extends FloatingActionButtonLocation
     assert(scaffoldGeometry.textDirection != null);
     switch (scaffoldGeometry.textDirection) {
       case TextDirection.rtl:
-        final double startPadding = kFloatingActionButtonMargin + scaffoldGeometry.minInsets.right;
-        fabX = scaffoldGeometry.scaffoldSize.width - scaffoldGeometry.floatingActionButtonSize.width - startPadding;
+        final double startPadding =
+            kFloatingActionButtonMargin + scaffoldGeometry.minInsets.right;
+        fabX = scaffoldGeometry.scaffoldSize.width -
+            scaffoldGeometry.floatingActionButtonSize.width -
+            startPadding;
         break;
       case TextDirection.ltr:
-        final double startPadding = kFloatingActionButtonMargin + scaffoldGeometry.minInsets.left;
+        final double startPadding =
+            kFloatingActionButtonMargin + scaffoldGeometry.minInsets.left;
         fabX = startPadding;
         break;
     }
-    final double fabY = scaffoldGeometry.contentTop - (scaffoldGeometry.floatingActionButtonSize.height / 2.0);
+    final double fabY = scaffoldGeometry.contentTop -
+        (scaffoldGeometry.floatingActionButtonSize.height / 2.0);
     return Offset(fabX, fabY);
   }
 }

--- a/packages/flutter/test/material/floating_action_button_location_test.dart
+++ b/packages/flutter/test/material/floating_action_button_location_test.dart
@@ -490,7 +490,9 @@ class _GeometryListenerState extends State<_GeometryListener> {
     super.didChangeDependencies();
     final ValueListenable<ScaffoldGeometry> newListenable =
         Scaffold.geometryOf(context);
-    if (geometryListenable == newListenable) return;
+    if (geometryListenable == newListenable) {
+      return;
+    }
 
     if (geometryListenable != null)
       geometryListenable.removeListener(onGeometryChanged);
@@ -515,6 +517,7 @@ class _GeometryCachePainter extends CustomPainter {
   final ValueListenable<ScaffoldGeometry> geometryListenable;
 
   ScaffoldGeometry value;
+
   @override
   void paint(Canvas canvas, Size size) {
     value = geometryListenable.value;

--- a/packages/flutter/test/widgets/scrollable_semantics_test.dart
+++ b/packages/flutter/test/widgets/scrollable_semantics_test.dart
@@ -19,28 +19,45 @@ void main() {
     debugResetSemanticsIdCounter();
   });
 
-  testWidgets('scrollable exposes the correct semantic actions', (WidgetTester tester) async {
+  testWidgets('scrollable exposes the correct semantic actions',
+      (WidgetTester tester) async {
     semantics = SemanticsTester(tester);
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: ListView(children: List<Widget>.generate(80, (int i) => Text('$i'))),
+        child: ListView(
+            children: List<Widget>.generate(80, (int i) => Text('$i'))),
       ),
     );
 
-    expect(semantics,includesNodeWith(actions: <SemanticsAction>[SemanticsAction.scrollUp]));
+    expect(semantics,
+        includesNodeWith(actions: <SemanticsAction>[SemanticsAction.scrollUp]));
 
     await flingUp(tester);
-    expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.scrollUp, SemanticsAction.scrollDown]));
+    expect(
+        semantics,
+        includesNodeWith(actions: <SemanticsAction>[
+          SemanticsAction.scrollUp,
+          SemanticsAction.scrollDown
+        ]));
 
     await flingDown(tester, repetitions: 2);
-    expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.scrollUp]));
+    expect(semantics,
+        includesNodeWith(actions: <SemanticsAction>[SemanticsAction.scrollUp]));
 
     await flingUp(tester, repetitions: 5);
-    expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.scrollDown]));
+    expect(
+        semantics,
+        includesNodeWith(
+            actions: <SemanticsAction>[SemanticsAction.scrollDown]));
 
     await flingDown(tester);
-    expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.scrollUp, SemanticsAction.scrollDown]));
+    expect(
+        semantics,
+        includesNodeWith(actions: <SemanticsAction>[
+          SemanticsAction.scrollUp,
+          SemanticsAction.scrollDown
+        ]));
 
     semantics.dispose();
   });
@@ -50,12 +67,14 @@ void main() {
 
     const double kItemHeight = 40.0;
 
-    final List<Widget> containers = List<Widget>.generate(80, (int i) => MergeSemantics(
-      child: Container(
-        height: kItemHeight,
-        child: Text('container $i', textDirection: TextDirection.ltr),
-      ),
-    ));
+    final List<Widget> containers = List<Widget>.generate(
+        80,
+        (int i) => MergeSemantics(
+              child: Container(
+                height: kItemHeight,
+                child: Text('container $i', textDirection: TextDirection.ltr),
+              ),
+            ));
 
     final ScrollController scrollController = ScrollController(
       initialScrollOffset: kItemHeight / 2,
@@ -73,8 +92,10 @@ void main() {
 
     expect(scrollController.offset, kItemHeight / 2);
 
-    final int firstContainerId = tester.renderObject(find.byWidget(containers.first)).debugSemantics.id;
-    tester.binding.pipelineOwner.semanticsOwner.performAction(firstContainerId, SemanticsAction.showOnScreen);
+    final int firstContainerId =
+        tester.renderObject(find.byWidget(containers.first)).debugSemantics.id;
+    tester.binding.pipelineOwner.semanticsOwner
+        .performAction(firstContainerId, SemanticsAction.showOnScreen);
     await tester.pump();
     await tester.pump(const Duration(seconds: 5));
 
@@ -83,18 +104,21 @@ void main() {
     semantics.dispose();
   });
 
-  testWidgets('showOnScreen works with pinned app bar and sliver list', (WidgetTester tester) async {
+  testWidgets('showOnScreen works with pinned app bar and sliver list',
+      (WidgetTester tester) async {
     semantics = SemanticsTester(tester); // enables semantics tree generation
 
     const double kItemHeight = 100.0;
     const double kExpandedAppBarHeight = 56.0;
 
-    final List<Widget> containers = List<Widget>.generate(80, (int i) => MergeSemantics(
-      child: Container(
-        height: kItemHeight,
-        child: Text('container $i'),
-      ),
-    ));
+    final List<Widget> containers = List<Widget>.generate(
+        80,
+        (int i) => MergeSemantics(
+              child: Container(
+                height: kItemHeight,
+                child: Text('container $i'),
+              ),
+            ));
 
     final ScrollController scrollController = ScrollController(
       initialScrollOffset: kItemHeight / 2,
@@ -110,46 +134,49 @@ void main() {
         ],
         child: MediaQuery(
           data: const MediaQueryData(),
-            child: Scrollable(
-            controller: scrollController,
-            viewportBuilder: (BuildContext context, ViewportOffset offset) {
-              return Viewport(
-                offset: offset,
-                slivers: <Widget>[
-                  const SliverAppBar(
-                    pinned: true,
-                    expandedHeight: kExpandedAppBarHeight,
-                    flexibleSpace: FlexibleSpaceBar(
-                      title: Text('App Bar'),
+          child: Scrollable(
+              controller: scrollController,
+              viewportBuilder: (BuildContext context, ViewportOffset offset) {
+                return Viewport(
+                  offset: offset,
+                  slivers: <Widget>[
+                    const SliverAppBar(
+                      pinned: true,
+                      expandedHeight: kExpandedAppBarHeight,
+                      flexibleSpace: FlexibleSpaceBar(
+                        title: Text('App Bar'),
+                      ),
                     ),
-                  ),
-                  SliverList(
-                    delegate: SliverChildListDelegate(containers),
-                  ),
-                ],
-              );
-            }),
-          ),
+                    SliverList(
+                      delegate: SliverChildListDelegate(containers),
+                    ),
+                  ],
+                );
+              }),
+        ),
       ),
     ));
 
     expect(scrollController.offset, kItemHeight / 2);
 
-    final int firstContainerId = tester.renderObject(find.byWidget(containers.first)).debugSemantics.id;
-    tester.binding.pipelineOwner.semanticsOwner.performAction(firstContainerId, SemanticsAction.showOnScreen);
+    final int firstContainerId =
+        tester.renderObject(find.byWidget(containers.first)).debugSemantics.id;
+    tester.binding.pipelineOwner.semanticsOwner
+        .performAction(firstContainerId, SemanticsAction.showOnScreen);
     await tester.pump();
     await tester.pump(const Duration(seconds: 5));
-    expect(tester.getTopLeft(find.byWidget(containers.first)).dy, kExpandedAppBarHeight);
+    expect(tester.getTopLeft(find.byWidget(containers.first)).dy,
+        kExpandedAppBarHeight);
 
     semantics.dispose();
   });
 
-  testWidgets('showOnScreen works with pinned app bar and individual slivers', (WidgetTester tester) async {
+  testWidgets('showOnScreen works with pinned app bar and individual slivers',
+      (WidgetTester tester) async {
     semantics = SemanticsTester(tester); // enables semantics tree generation
 
     const double kItemHeight = 100.0;
     const double kExpandedAppBarHeight = 256.0;
-
 
     final List<Widget> children = <Widget>[];
     final List<Widget> slivers = List<Widget>.generate(30, (int i) {
@@ -203,11 +230,87 @@ void main() {
 
     expect(scrollController.offset, 2.5 * kItemHeight);
 
-    final int id0 = tester.renderObject(find.byWidget(children[0])).debugSemantics.id;
-    tester.binding.pipelineOwner.semanticsOwner.performAction(id0, SemanticsAction.showOnScreen);
+    final int id0 =
+        tester.renderObject(find.byWidget(children[0])).debugSemantics.id;
+    tester.binding.pipelineOwner.semanticsOwner
+        .performAction(id0, SemanticsAction.showOnScreen);
     await tester.pump();
     await tester.pump(const Duration(seconds: 5));
     expect(tester.getTopLeft(find.byWidget(children[0])).dy, kToolbarHeight);
+
+    semantics.dispose();
+  });
+
+  testWidgets(
+      'showOnScreen works with pinned app bar and individual slivers, when custom titleHeight given',
+      (WidgetTester tester) async {
+    semantics = SemanticsTester(tester); // enables semantics tree generation
+
+    const double kItemHeight = 100.0;
+    const double kExpandedAppBarHeight = 256.0;
+
+    final List<Widget> children = <Widget>[];
+    final List<Widget> slivers = List<Widget>.generate(30, (int i) {
+      final Widget child = MergeSemantics(
+        child: Container(
+          child: Text('Item $i'),
+          height: 72.0,
+        ),
+      );
+      children.add(child);
+      return SliverToBoxAdapter(
+        child: child,
+      );
+    });
+
+    final ScrollController scrollController = ScrollController(
+      initialScrollOffset: 2.5 * kItemHeight,
+    );
+
+    const double customTitleHeight = 128.0;
+
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: MediaQuery(
+        data: const MediaQueryData(),
+        child: Localizations(
+          locale: const Locale('en', 'us'),
+          delegates: const <LocalizationsDelegate<dynamic>>[
+            DefaultWidgetsLocalizations.delegate,
+            DefaultMaterialLocalizations.delegate,
+          ],
+          child: Scrollable(
+            controller: scrollController,
+            viewportBuilder: (BuildContext context, ViewportOffset offset) {
+              return Viewport(
+                offset: offset,
+                slivers: <Widget>[
+                  const SliverAppBar(
+                    titleHeight: customTitleHeight,
+                    pinned: true,
+                    expandedHeight: kExpandedAppBarHeight,
+                    flexibleSpace: FlexibleSpaceBar(
+                      title: Text('App Bar'),
+                    ),
+                  ),
+                  ...slivers,
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    ));
+
+    expect(scrollController.offset, 2.5 * kItemHeight);
+
+    final int id0 =
+        tester.renderObject(find.byWidget(children[0])).debugSemantics.id;
+    tester.binding.pipelineOwner.semanticsOwner
+        .performAction(id0, SemanticsAction.showOnScreen);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 5));
+    expect(tester.getTopLeft(find.byWidget(children[0])).dy, customTitleHeight);
 
     semantics.dispose();
   });
@@ -217,45 +320,53 @@ void main() {
 
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
-      child: ListView(children: List<Widget>.generate(80, (int i) => Text('$i'))),
+      child:
+          ListView(children: List<Widget>.generate(80, (int i) => Text('$i'))),
     ));
 
-    expect(semantics, includesNodeWith(
-      scrollExtentMin: 0.0,
-      scrollPosition: 0.0,
-      scrollExtentMax: 520.0,
-      actions: <SemanticsAction>[
-        SemanticsAction.scrollUp,
-      ],
-    ));
+    expect(
+        semantics,
+        includesNodeWith(
+          scrollExtentMin: 0.0,
+          scrollPosition: 0.0,
+          scrollExtentMax: 520.0,
+          actions: <SemanticsAction>[
+            SemanticsAction.scrollUp,
+          ],
+        ));
 
     await flingUp(tester);
 
-    expect(semantics, includesNodeWith(
-      scrollExtentMin: 0.0,
-      scrollPosition: 380.2,
-      scrollExtentMax: 520.0,
-      actions: <SemanticsAction>[
-        SemanticsAction.scrollUp,
-        SemanticsAction.scrollDown,
-      ],
-    ));
+    expect(
+        semantics,
+        includesNodeWith(
+          scrollExtentMin: 0.0,
+          scrollPosition: 380.2,
+          scrollExtentMax: 520.0,
+          actions: <SemanticsAction>[
+            SemanticsAction.scrollUp,
+            SemanticsAction.scrollDown,
+          ],
+        ));
 
     await flingUp(tester);
 
-    expect(semantics, includesNodeWith(
-      scrollExtentMin: 0.0,
-      scrollPosition: 520.0,
-      scrollExtentMax: 520.0,
-      actions: <SemanticsAction>[
-        SemanticsAction.scrollDown,
-      ],
-    ));
+    expect(
+        semantics,
+        includesNodeWith(
+          scrollExtentMin: 0.0,
+          scrollPosition: 520.0,
+          scrollExtentMax: 520.0,
+          actions: <SemanticsAction>[
+            SemanticsAction.scrollDown,
+          ],
+        ));
 
     semantics.dispose();
   }, skip: isBrowser);
 
-  testWidgets('correct scrollProgress for unbound', (WidgetTester tester) async {
+  testWidgets('correct scrollProgress for unbound',
+      (WidgetTester tester) async {
     semantics = SemanticsTester(tester);
 
     await tester.pumpWidget(Directionality(
@@ -269,49 +380,58 @@ void main() {
       ),
     ));
 
-    expect(semantics, includesNodeWith(
-      scrollExtentMin: 0.0,
-      scrollPosition: 0.0,
-      scrollExtentMax: double.infinity,
-      actions: <SemanticsAction>[
-        SemanticsAction.scrollUp,
-      ],
-    ));
+    expect(
+        semantics,
+        includesNodeWith(
+          scrollExtentMin: 0.0,
+          scrollPosition: 0.0,
+          scrollExtentMax: double.infinity,
+          actions: <SemanticsAction>[
+            SemanticsAction.scrollUp,
+          ],
+        ));
 
     await flingUp(tester);
 
-    expect(semantics, includesNodeWith(
-      scrollExtentMin: 0.0,
-      scrollPosition: 380.2,
-      scrollExtentMax: double.infinity,
-      actions: <SemanticsAction>[
-        SemanticsAction.scrollUp,
-        SemanticsAction.scrollDown,
-      ],
-    ));
+    expect(
+        semantics,
+        includesNodeWith(
+          scrollExtentMin: 0.0,
+          scrollPosition: 380.2,
+          scrollExtentMax: double.infinity,
+          actions: <SemanticsAction>[
+            SemanticsAction.scrollUp,
+            SemanticsAction.scrollDown,
+          ],
+        ));
 
     await flingUp(tester);
 
-    expect(semantics, includesNodeWith(
-      scrollExtentMin: 0.0,
-      scrollPosition: 760.4,
-      scrollExtentMax: double.infinity,
-      actions: <SemanticsAction>[
-        SemanticsAction.scrollUp,
-        SemanticsAction.scrollDown,
-      ],
-    ));
+    expect(
+        semantics,
+        includesNodeWith(
+          scrollExtentMin: 0.0,
+          scrollPosition: 760.4,
+          scrollExtentMax: double.infinity,
+          actions: <SemanticsAction>[
+            SemanticsAction.scrollUp,
+            SemanticsAction.scrollDown,
+          ],
+        ));
 
     semantics.dispose();
   });
 
-  testWidgets('Semantics tree is populated mid-scroll', (WidgetTester tester) async {
+  testWidgets('Semantics tree is populated mid-scroll',
+      (WidgetTester tester) async {
     semantics = SemanticsTester(tester);
 
-    final List<Widget> children = List<Widget>.generate(80, (int i) => Container(
-      child: Text('Item $i'),
-      height: 40.0,
-    ));
+    final List<Widget> children = List<Widget>.generate(
+        80,
+        (int i) => Container(
+              child: Text('Item $i'),
+              height: 40.0,
+            ));
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
@@ -319,7 +439,8 @@ void main() {
       ),
     );
 
-    final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byType(ListView)));
+    final TestGesture gesture =
+        await tester.startGesture(tester.getCenter(find.byType(ListView)));
     await gesture.moveBy(const Offset(0.0, -40.0));
     await tester.pump();
 
@@ -330,7 +451,8 @@ void main() {
     semantics.dispose();
   });
 
-  testWidgets('Can toggle semantics on, off, on without crash', (WidgetTester tester) async {
+  testWidgets('Can toggle semantics on, off, on without crash',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
@@ -383,7 +505,10 @@ void main() {
     semantics = SemanticsTester(tester);
     await tester.pumpAndSettle();
     expect(tester.binding.pipelineOwner.semanticsOwner, isNotNull);
-    expect(semantics, hasSemantics(expectedSemantics, ignoreId: true, ignoreRect: true, ignoreTransform: true));
+    expect(
+        semantics,
+        hasSemantics(expectedSemantics,
+            ignoreId: true, ignoreRect: true, ignoreTransform: true));
 
     // Semantics off
     semantics.dispose();
@@ -394,13 +519,15 @@ void main() {
     semantics = SemanticsTester(tester);
     await tester.pumpAndSettle();
     expect(tester.binding.pipelineOwner.semanticsOwner, isNotNull);
-    expect(semantics, hasSemantics(expectedSemantics, ignoreId: true, ignoreRect: true, ignoreTransform: true));
+    expect(
+        semantics,
+        hasSemantics(expectedSemantics,
+            ignoreId: true, ignoreRect: true, ignoreTransform: true));
 
     semantics.dispose();
   }, semanticsEnabled: false);
 
   group('showOnScreen', () {
-
     const double kItemHeight = 100.0;
 
     List<Widget> children;
@@ -433,18 +560,20 @@ void main() {
           ),
         ),
       );
-
     });
 
-    testWidgets('brings item above leading edge to leading edge', (WidgetTester tester) async {
+    testWidgets('brings item above leading edge to leading edge',
+        (WidgetTester tester) async {
       semantics = SemanticsTester(tester); // enables semantics tree generation
 
       await tester.pumpWidget(widgetUnderTest);
 
       expect(scrollController.offset, kItemHeight / 2);
 
-      final int firstContainerId = tester.renderObject(find.byWidget(children.first)).debugSemantics.id;
-      tester.binding.pipelineOwner.semanticsOwner.performAction(firstContainerId, SemanticsAction.showOnScreen);
+      final int firstContainerId =
+          tester.renderObject(find.byWidget(children.first)).debugSemantics.id;
+      tester.binding.pipelineOwner.semanticsOwner
+          .performAction(firstContainerId, SemanticsAction.showOnScreen);
       await tester.pumpAndSettle();
 
       expect(scrollController.offset, 0.0);
@@ -452,15 +581,18 @@ void main() {
       semantics.dispose();
     });
 
-    testWidgets('brings item below trailing edge to trailing edge', (WidgetTester tester) async {
+    testWidgets('brings item below trailing edge to trailing edge',
+        (WidgetTester tester) async {
       semantics = SemanticsTester(tester); // enables semantics tree generation
 
       await tester.pumpWidget(widgetUnderTest);
 
       expect(scrollController.offset, kItemHeight / 2);
 
-      final int firstContainerId = tester.renderObject(find.byWidget(children[2])).debugSemantics.id;
-      tester.binding.pipelineOwner.semanticsOwner.performAction(firstContainerId, SemanticsAction.showOnScreen);
+      final int firstContainerId =
+          tester.renderObject(find.byWidget(children[2])).debugSemantics.id;
+      tester.binding.pipelineOwner.semanticsOwner
+          .performAction(firstContainerId, SemanticsAction.showOnScreen);
       await tester.pumpAndSettle();
 
       expect(scrollController.offset, kItemHeight);
@@ -468,15 +600,18 @@ void main() {
       semantics.dispose();
     });
 
-    testWidgets('does not change position of items already fully on-screen', (WidgetTester tester) async {
+    testWidgets('does not change position of items already fully on-screen',
+        (WidgetTester tester) async {
       semantics = SemanticsTester(tester); // enables semantics tree generation
 
       await tester.pumpWidget(widgetUnderTest);
 
       expect(scrollController.offset, kItemHeight / 2);
 
-      final int firstContainerId = tester.renderObject(find.byWidget(children[1])).debugSemantics.id;
-      tester.binding.pipelineOwner.semanticsOwner.performAction(firstContainerId, SemanticsAction.showOnScreen);
+      final int firstContainerId =
+          tester.renderObject(find.byWidget(children[1])).debugSemantics.id;
+      tester.binding.pipelineOwner.semanticsOwner
+          .performAction(firstContainerId, SemanticsAction.showOnScreen);
       await tester.pumpAndSettle();
 
       expect(scrollController.offset, kItemHeight / 2);
@@ -538,18 +673,22 @@ void main() {
           ),
         ),
       );
-
     });
 
-    testWidgets('brings item above leading edge to leading edge', (WidgetTester tester) async {
+    testWidgets('brings item above leading edge to leading edge',
+        (WidgetTester tester) async {
       semantics = SemanticsTester(tester); // enables semantics tree generation
 
       await tester.pumpWidget(widgetUnderTest);
 
       expect(scrollController.offset, -250.0);
 
-      final int firstContainerId = tester.renderObject(find.byKey(const ValueKey<int>(2))).debugSemantics.id;
-      tester.binding.pipelineOwner.semanticsOwner.performAction(firstContainerId, SemanticsAction.showOnScreen);
+      final int firstContainerId = tester
+          .renderObject(find.byKey(const ValueKey<int>(2)))
+          .debugSemantics
+          .id;
+      tester.binding.pipelineOwner.semanticsOwner
+          .performAction(firstContainerId, SemanticsAction.showOnScreen);
       await tester.pumpAndSettle();
 
       expect(scrollController.offset, -300.0);
@@ -557,15 +696,20 @@ void main() {
       semantics.dispose();
     });
 
-    testWidgets('brings item below trailing edge to trailing edge', (WidgetTester tester) async {
+    testWidgets('brings item below trailing edge to trailing edge',
+        (WidgetTester tester) async {
       semantics = SemanticsTester(tester); // enables semantics tree generation
 
       await tester.pumpWidget(widgetUnderTest);
 
       expect(scrollController.offset, -250.0);
 
-      final int firstContainerId = tester.renderObject(find.byKey(const ValueKey<int>(4))).debugSemantics.id;
-      tester.binding.pipelineOwner.semanticsOwner.performAction(firstContainerId, SemanticsAction.showOnScreen);
+      final int firstContainerId = tester
+          .renderObject(find.byKey(const ValueKey<int>(4)))
+          .debugSemantics
+          .id;
+      tester.binding.pipelineOwner.semanticsOwner
+          .performAction(firstContainerId, SemanticsAction.showOnScreen);
       await tester.pumpAndSettle();
 
       expect(scrollController.offset, -200.0);
@@ -573,34 +717,40 @@ void main() {
       semantics.dispose();
     });
 
-    testWidgets('does not change position of items already fully on-screen', (WidgetTester tester) async {
+    testWidgets('does not change position of items already fully on-screen',
+        (WidgetTester tester) async {
       semantics = SemanticsTester(tester); // enables semantics tree generation
 
       await tester.pumpWidget(widgetUnderTest);
 
       expect(scrollController.offset, -250.0);
 
-      final int firstContainerId = tester.renderObject(find.byKey(const ValueKey<int>(3))).debugSemantics.id;
-      tester.binding.pipelineOwner.semanticsOwner.performAction(firstContainerId, SemanticsAction.showOnScreen);
+      final int firstContainerId = tester
+          .renderObject(find.byKey(const ValueKey<int>(3)))
+          .debugSemantics
+          .id;
+      tester.binding.pipelineOwner.semanticsOwner
+          .performAction(firstContainerId, SemanticsAction.showOnScreen);
       await tester.pumpAndSettle();
 
       expect(scrollController.offset, -250.0);
 
       semantics.dispose();
     });
-
   });
-
-
 }
 
-Future<void> flingUp(WidgetTester tester, { int repetitions = 1 }) => fling(tester, const Offset(0.0, -200.0), repetitions);
+Future<void> flingUp(WidgetTester tester, {int repetitions = 1}) =>
+    fling(tester, const Offset(0.0, -200.0), repetitions);
 
-Future<void> flingDown(WidgetTester tester, { int repetitions = 1 }) => fling(tester, const Offset(0.0, 200.0), repetitions);
+Future<void> flingDown(WidgetTester tester, {int repetitions = 1}) =>
+    fling(tester, const Offset(0.0, 200.0), repetitions);
 
-Future<void> flingRight(WidgetTester tester, { int repetitions = 1 }) => fling(tester, const Offset(200.0, 0.0), repetitions);
+Future<void> flingRight(WidgetTester tester, {int repetitions = 1}) =>
+    fling(tester, const Offset(200.0, 0.0), repetitions);
 
-Future<void> flingLeft(WidgetTester tester, { int repetitions = 1 }) => fling(tester, const Offset(-200.0, 0.0), repetitions);
+Future<void> flingLeft(WidgetTester tester, {int repetitions = 1}) =>
+    fling(tester, const Offset(-200.0, 0.0), repetitions);
 
 Future<void> fling(WidgetTester tester, Offset offset, int repetitions) async {
   while (repetitions-- > 0) {


### PR DESCRIPTION
Allows AppBar (and SliverAppBar) to have any height we specify.

## Description


Previously, AppBar's height was limited to 56.0 using a constant `kToolbarHeight`. This allows us to change AppBar's height using `titleHeight` parameter. If we omit this parameter, it fallbacks to `kToolbarHeight` (the default behavior), otherwise acts accordingly.

## Related Issues

#23373 solved here
#7330 looks related

### EDIT: About second commit:
- When we specify `titleHeight`, the icons (`leading` and `actions`) are also centered. So, this commit introduces a boolean `centerIcons`, which when set to `false`, the icons stay on top.
- Also fixes some analyzer warnings


## Tests

I added the following tests:

- Added test in `app_bar_test.dart` so that we can check custom title height provided.
- Added test in `floating_action_button_location_test.dart` so that we can check mini-start top FAB location.
- Added test in `scrollable_semantics_test.dart` so that showOnScreen works with pinned app bar.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   
<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
