### PR TITLE
Fixing AutomaticKeepAlive Docs

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -735,7 +735,7 @@ abstract class BoxScrollView extends ScrollView {
 ///  * Using [AutomaticKeepAlive] widgets (inserted by default when
 ///    [addAutomaticKeepAlives] is true). Instead of unconditionally caching the
 ///    child element subtree when scrolling off-screen like [KeepAlive],
-///    [AutomaticKeepAlive] can let whether to cache the subtree be determined
+///    [AutomaticKeepAlive] can let know whether to cache the subtree be determined
 ///    by descendant logic in the subtree.
 ///
 ///    As an example, the [EditableText] widget signals its list child element

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -733,10 +733,10 @@ abstract class BoxScrollView extends ScrollView {
 ///    widget subtree with other widgets.
 ///
 ///  * Using [AutomaticKeepAlive] widgets (inserted by default when
-///    [addAutomaticKeepAlives] is true). Instead of unconditionally caching the
-///    child element subtree when scrolling off-screen like [KeepAlive],
-///    [AutomaticKeepAlive] can let know whether to cache the subtree be determined
-///    by descendant logic in the subtree.
+///    [addAutomaticKeepAlives] is true). [AutomaticKeepAlive] allows descendant
+///    widgets to control whether the subtree is actually kept alive or not.
+///    This behavior is in contrast with [KeepAlive], which will unconditionally keep
+///    the subtree alive.
 ///
 ///    As an example, the [EditableText] widget signals its list child element
 ///    subtree to stay alive while its text field has input focus. If it doesn't

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -93,7 +93,7 @@ int _kDefaultSemanticIndexCallback(Widget _, int localIndex) => localIndex;
 ///  * Using [AutomaticKeepAlive] widgets (inserted by default in
 ///    [SliverChildListDelegate] or [SliverChildListDelegate]). Instead of
 ///    unconditionally caching the child element subtree when scrolling
-///    off-screen like [KeepAlive], [AutomaticKeepAlive] can let whether to
+///    off-screen like [KeepAlive], [AutomaticKeepAlive] can let know whether to
 ///    cache the subtree be determined by descendant logic in the subtree.
 ///
 ///    As an example, the [EditableText] widget signals its sliver child element

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -91,10 +91,18 @@ int _kDefaultSemanticIndexCallback(Widget _, int localIndex) => localIndex;
 ///    `addRepaintBoundaries`.
 ///
 ///  * Using [AutomaticKeepAlive] widgets (inserted by default in
-///    [SliverChildListDelegate] or [SliverChildListDelegate]). Instead of
-///    unconditionally caching the child element subtree when scrolling
-///    off-screen like [KeepAlive], [AutomaticKeepAlive] can let know whether to
-///    cache the subtree be determined by descendant logic in the subtree.
+///    [SliverChildListDelegate] or [SliverChildListDelegate]). 
+///    [AutomaticKeepAlive] allows descendant widgets to control whether the 
+///    subtree is actually kept alive or not. This behavior is in contrast with
+///    [KeepAlive], which will unconditionally keep the subtree alive.
+
+///  * Using [AutomaticKeepAlive] widgets (inserted by default when
+///    [addAutomaticKeepAlives] is true). [AutomaticKeepAlive] allows descendant
+///    widgets to control whether the subtree is actually kept alive or not.
+///    This behavior is in contrast with [KeepAlive], which will unconditionally keep
+///    the subtree alive.
+
+
 ///
 ///    As an example, the [EditableText] widget signals its sliver child element
 ///    subtree to stay alive while its text field has input focus. If it doesn't

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -95,14 +95,6 @@ int _kDefaultSemanticIndexCallback(Widget _, int localIndex) => localIndex;
 ///    [AutomaticKeepAlive] allows descendant widgets to control whether the 
 ///    subtree is actually kept alive or not. This behavior is in contrast with
 ///    [KeepAlive], which will unconditionally keep the subtree alive.
-
-///  * Using [AutomaticKeepAlive] widgets (inserted by default when
-///    [addAutomaticKeepAlives] is true). [AutomaticKeepAlive] allows descendant
-///    widgets to control whether the subtree is actually kept alive or not.
-///    This behavior is in contrast with [KeepAlive], which will unconditionally keep
-///    the subtree alive.
-
-
 ///
 ///    As an example, the [EditableText] widget signals its sliver child element
 ///    subtree to stay alive while its text field has input focus. If it doesn't

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -91,8 +91,8 @@ int _kDefaultSemanticIndexCallback(Widget _, int localIndex) => localIndex;
 ///    `addRepaintBoundaries`.
 ///
 ///  * Using [AutomaticKeepAlive] widgets (inserted by default in
-///    [SliverChildListDelegate] or [SliverChildListDelegate]). 
-///    [AutomaticKeepAlive] allows descendant widgets to control whether the 
+///    [SliverChildListDelegate] or [SliverChildListDelegate]).
+///    [AutomaticKeepAlive] allows descendant widgets to control whether the
 ///    subtree is actually kept alive or not. This behavior is in contrast with
 ///    [KeepAlive], which will unconditionally keep the subtree alive.
 ///


### PR DESCRIPTION
## Description

Fixed missing word

## Related Issues

Fixes #48533

## Tests

I added the following tests:

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
  
<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
