### PR TITLE
[flutter_tools] Fix analytics opt out event

### DIFF
--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -115,8 +115,10 @@ class ConfigCommand extends FlutterCommand {
 
     if (argResults.wasParsed('analytics')) {
       final bool value = boolArg('analytics');
-      flutterUsage.enabled = value;
+      // We send the analytics event *before* toggling the flag intentionally
+      // to be sure that opt-out events are sent correctly.
       AnalyticsConfigEvent(enabled: value).send();
+      flutterUsage.enabled = value;
       globals.printStatus('Analytics reporting ${value ? 'enabled' : 'disabled'}.');
     }
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/config_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/config_test.dart
@@ -200,6 +200,18 @@ void main() {
       final ConfigCommand configCommand = ConfigCommand();
       final CommandRunner<void> commandRunner = createTestCommandRunner(configCommand);
 
+      when(mockUsage.sendEvent(
+        captureAny,
+        captureAny,
+        label: captureAnyNamed('label'),
+        value: anyNamed('value'),
+        parameters: anyNamed('parameters'),
+      )).thenAnswer((Invocation invocation) async {
+        expect(mockUsage.enabled, true);
+        expect(invocation.positionalArguments, <String>['analytics', 'enabled']);
+        expect(invocation.namedArguments[#label], 'false');
+      });
+
       await commandRunner.run(<String>[
         'config',
         '--no-analytics',
@@ -219,16 +231,6 @@ void main() {
         any,
         label: anyNamed('label'),
       ));
-
-      expect(verify(mockUsage.sendEvent(
-        captureAny,
-        captureAny,
-        label: captureAnyNamed('label'),
-        value: anyNamed('value'),
-        parameters: anyNamed('parameters'),
-      )).captured,
-        <dynamic>['analytics', 'enabled', 'false'],
-      );
     }, overrides: <Type, Generator>{
       Usage: () => mockUsage,
     });


### PR DESCRIPTION
## Description

Prior to this change, we toggled the flag before trying to send the event, which would lead to dropping events when toggling to false.

## Tests

I added the following tests:

Fixed a test in config_test.dart, which didn't catch this due to the misuse of a mock.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
