### PR TITLE
Allow requestFocus on an unattached FocusNode to create a deferred focus request

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -18,7 +18,7 @@ import 'framework.dart';
 
 // Used for debugging focus code. Set to true to see highly verbose debug output
 // when focus changes occur.
-const bool _kDebugFocus = false;
+const bool _kDebugFocus = true;
 
 bool _focusDebug(String message, [Iterable<String> details]) {
   if (_kDebugFocus) {
@@ -857,6 +857,9 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
     assert(_focusDebug('Node requesting focus: $this'));
     _markAsDirty(newFocus: this);
   }
+
+  /// Requests the focus the next time this node is attached to the focus tree.
+  bool requestFocusOnAttach = false;
 
   /// Sets this node as the [FocusScopeNode.focusedChild] of the enclosing
   /// scope.

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -824,7 +824,10 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
   /// Requests the primary focus for this node, or for a supplied [node], which
   /// will also give focus to its [ancestors].
   ///
-  /// If called without a node, request focus for this node.
+  /// If called without a node, request focus for this node. If the node hasn't
+  /// been added to the focus tree yet, then defer the focus request until it
+  /// is, allowing newly created widgets to request focus as soon as they are
+  /// added.
   ///
   /// If the given [node] is not yet a part of the focus tree, then this method
   /// will add the [node] as a child of this node before requesting focus.
@@ -855,6 +858,9 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
       assert(_focusDebug('Node NOT requesting focus because canRequestFocus is false: $this'));
       return;
     }
+    // If the node isn't part of the tree, then we just defer the focus request
+    // until the next time it is reparented, so that it's possible to focus
+    // newly added widgets.
     if (_parent == null) {
       _requestFocusWhenReparented = true;
       return;

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -18,7 +18,7 @@ import 'framework.dart';
 
 // Used for debugging focus code. Set to true to see highly verbose debug output
 // when focus changes occur.
-const bool _kDebugFocus = true;
+const bool _kDebugFocus = false;
 
 bool _focusDebug(String message, [Iterable<String> details]) {
   if (_kDebugFocus) {
@@ -367,13 +367,18 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
   /// Creates a focus node.
   ///
   /// The [debugLabel] is ignored on release builds.
+  ///
+  /// The [skipTraversal], [canRequestFocus], and [requestFocusWhenReparented] arguments must not
+  /// be null.
   FocusNode({
     String debugLabel,
     FocusOnKeyCallback onKey,
     bool skipTraversal = false,
     bool canRequestFocus = true,
+    this.requestFocusWhenReparented = false,
   })  : assert(skipTraversal != null),
         assert(canRequestFocus != null),
+        assert(requestFocusWhenReparented != null),
         _skipTraversal = skipTraversal,
         _canRequestFocus = canRequestFocus,
         _onKey = onKey {
@@ -776,6 +781,10 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
     if (oldScope != null && child.context != null && child.enclosingScope != oldScope) {
       DefaultFocusTraversal.of(child.context, nullOk: true)?.changedScope(node: child, oldScope: oldScope);
     }
+    if (child.requestFocusWhenReparented) {
+      child._doRequestFocus();
+      child.requestFocusWhenReparented = false;
+    }
   }
 
   /// Called by the _host_ [StatefulWidget] to attach a [FocusNode] to the
@@ -858,8 +867,26 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
     _markAsDirty(newFocus: this);
   }
 
-  /// Requests the focus the next time this node is attached to the focus tree.
-  bool requestFocusOnAttach = false;
+  /// If set to true, the node will request focus on this node the next time
+  /// this node is reparented in the focus tree.
+  ///
+  /// Once [requestFocus] has been called at the next reparenting, this value
+  /// will be reset to false.
+  ///
+  /// This will only call [requestFocus] for the node once the next time the
+  /// node is reparented. After that, [requestFocusWhenReparented] will need to
+  /// be set to true again to have it be focused again on the next reparenting.
+  ///
+  /// This is useful if you want to have a node be focused as soon as it is
+  /// added to the widget tree, specifically in the case where you are creating
+  /// new widgets that should be focused immediately after creation.
+  ///
+  /// This is similar to the [FocusScope.autofocus] method, except that it will
+  /// request focus regardless of whether another node in the scope already has
+  /// focus.
+  ///
+  /// Defaults to false and must not be null.
+  bool requestFocusWhenReparented;
 
   /// Sets this node as the [FocusScopeNode.focusedChild] of the enclosing
   /// scope.
@@ -1030,6 +1057,13 @@ class FocusScopeNode extends FocusNode {
   ///
   /// The node is notified that it has received the primary focus in a
   /// microtask, so notification may lag the request by up to one frame.
+  ///
+  /// See also:
+  ///
+  ///  - [requestFocusWhenReparented], which requests that the node be focused
+  ///    the next time it is reparented, if a less immediate focus request is
+  ///    desired (as when you are adding a new widget that needs to be focused,
+  ///    but hasn't yet been attached the widget tree).
   void autofocus(FocusNode node) {
     assert(_focusDebug('Node autofocusing: $node'));
     if (focusedChild == null) {

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -344,7 +344,6 @@ class _FocusState extends State<Focus> {
       // _createNode is overridden in _FocusScopeState.
       _internalNode ??= _createNode();
     }
-    _focusAttachment = focusNode.attach(context, onKey: widget.onKey);
     if (widget.skipTraversal != null) {
       focusNode.skipTraversal = widget.skipTraversal;
     }
@@ -353,11 +352,13 @@ class _FocusState extends State<Focus> {
     }
     _canRequestFocus = focusNode.canRequestFocus;
     _hasPrimaryFocus = focusNode.hasPrimaryFocus;
+    _focusAttachment = focusNode.attach(context, onKey: widget.onKey);
 
     // Add listener even if the _internalNode existed before, since it should
     // not be listening now if we're re-using a previous one because it should
     // have already removed its listener.
     focusNode.addListener(_handleFocusChanged);
+    _handleAttachFocus();
   }
 
   FocusNode _createNode() {
@@ -428,6 +429,18 @@ class _FocusState extends State<Focus> {
 
     if (oldWidget.autofocus != widget.autofocus) {
       _handleAutofocus();
+    }
+    _handleAttachFocus();
+  }
+  void _handleAttachFocus() {
+    if (focusNode.requestFocusOnAttach) {
+        print('Requesting focus on attach for $focusNode.');
+        focusNode.requestFocus();
+        debugDumpFocusTree();
+        focusNode.requestFocusOnAttach = false;
+    } else {
+      print('Not requesting focus for ${focusNode} because requestFocusOnAttach is false');
+      debugDumpFocusTree();
     }
   }
 

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -358,7 +358,6 @@ class _FocusState extends State<Focus> {
     // not be listening now if we're re-using a previous one because it should
     // have already removed its listener.
     focusNode.addListener(_handleFocusChanged);
-    _handleAttachFocus();
   }
 
   FocusNode _createNode() {
@@ -429,18 +428,6 @@ class _FocusState extends State<Focus> {
 
     if (oldWidget.autofocus != widget.autofocus) {
       _handleAutofocus();
-    }
-    _handleAttachFocus();
-  }
-  void _handleAttachFocus() {
-    if (focusNode.requestFocusOnAttach) {
-        print('Requesting focus on attach for $focusNode.');
-        focusNode.requestFocus();
-        debugDumpFocusTree();
-        focusNode.requestFocusOnAttach = false;
-    } else {
-      print('Not requesting focus for ${focusNode} because requestFocusOnAttach is false');
-      debugDumpFocusTree();
     }
   }
 

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -163,6 +163,25 @@ void main() {
       expect(child2.hasFocus, isTrue);
       expect(child2.hasPrimaryFocus, isTrue);
     });
+    testWidgets('Requesting focus before adding to tree results in a request after adding', (WidgetTester tester) async {
+      final BuildContext context = await setupWidget(tester);
+      final FocusScopeNode scope = FocusScopeNode();
+      final FocusAttachment scopeAttachment = scope.attach(context);
+      final FocusNode child = FocusNode();
+      child.requestFocus();
+      expect(child.hasPrimaryFocus, isFalse); // not attached yet.
+
+      scopeAttachment.reparent(parent: tester.binding.focusManager.rootScope);
+      await tester.pump();
+      expect(scope.focusedChild, isNull);
+      expect(child.hasPrimaryFocus, isFalse); // not attached yet.
+
+      final FocusAttachment childAttachment = child.attach(context);
+      expect(child.hasPrimaryFocus, isFalse); // not parented yet.
+      childAttachment.reparent(parent: scope);
+      await tester.pump();
+      expect(child.hasPrimaryFocus, isTrue); // now attached and parented, so focus finally happened.
+    });
     testWidgets('Autofocus works.', (WidgetTester tester) async {
       final BuildContext context = await setupWidget(tester);
       final FocusScopeNode scope = FocusScopeNode(debugLabel: 'Scope');

--- a/packages/flutter/test/widgets/focus_scope_test.dart
+++ b/packages/flutter/test/widgets/focus_scope_test.dart
@@ -1031,6 +1031,44 @@ void main() {
       await tester.pump();
       expect(focusNode.hasPrimaryFocus, isTrue);
     });
+    testWidgets("Won't autofocus a node if one is already focused.", (WidgetTester tester) async {
+      final FocusNode focusNodeA = FocusNode(debugLabel: 'Test Node A');
+      final FocusNode focusNodeB = FocusNode(debugLabel: 'Test Node B');
+      await tester.pumpWidget(
+        Column(
+          children: <Widget>[
+            Focus(
+              focusNode: focusNodeA,
+              autofocus: true,
+              child: Container(),
+            ),
+          ],
+        ),
+      );
+
+      await tester.pump();
+      expect(focusNodeA.hasPrimaryFocus, isTrue);
+
+      await tester.pumpWidget(
+        Column(
+          children: <Widget>[
+            Focus(
+              focusNode: focusNodeA,
+              child: Container(),
+            ),
+            Focus(
+              focusNode: focusNodeB,
+              autofocus: true,
+              child: Container(),
+            ),
+          ],
+        ),
+      );
+
+      await tester.pump();
+      expect(focusNodeB.hasPrimaryFocus, isFalse);
+      expect(focusNodeA.hasPrimaryFocus, isTrue);
+    });
   });
   group(Focus, () {
     testWidgets('Focus.of stops at the nearest Focus widget.', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

This changes the behavior of `requestFocus` when it is called on a `FocusNode` that does not yet have a parent, so that it defers requesting focus until it receives a parent. Before this change, calling `requestFocus` before it had a parent was a no-op.

This allows scenarios where a widget is newly added and wishes to immediately request the focus.  Previously, it was very hard to make that work because requesting focus before the widget's focus node had a parent was ignored, so the developer had to wait until two frames later to request focus (one for the widget's node to be added to the focus tree, and one to request the focus).

Now, in order to have a widget be focused when initially added, you just need to call `requestFocus` on its node when you create it, and as soon as it is added, it will automatically request focus.

This is different from the `autofocus` attribute on the `Focus` widget, because it unconditionally requests focus when added (`autofocus` will only request focus if nothing else in the scope has focus).

Example usage:
```dart
class ChildCreator extends StatefulWidget {
  ChildCreator({Key key, this.title}) : super(key: key);

  final String title;

  @override
  _ChildCreatorState createState() => _ChildCreatorState();
}

class _ChildCreatorState extends State<ChildCreator> {
  int focusedChild = 0;
  List<Widget> children = <Widget>[];
  List<FocusNode> childFocusNodes = <FocusNode>[];

  @override
  void initState() {
    super.initState();
    // Add the first child.
    _addChild();
  }

  @override
  void dispose() {
    super.dispose();
    childFocusNodes.forEach((FocusNode node) => node.dispose());
  }

  Widget _createChild(int index) {
    return Padding(
      padding: const EdgeInsets.all(8.0),
      child: RaisedButton(
        focusNode: childFocusNodes[index],
        focusColor: Colors.redAccent,
        child: Text(
          'CHILD $index',
        ),
        onPressed: () {},
      ),
    );
  }

  void _addChild() {

    // Calling requestFocus here creates a deferred request for focus, since the
    // node is not yet part of the focus tree.
    childFocusNodes.add(FocusNode(debugLabel: 'Child ${children.length}')..requestFocus());

    children.add(_createChild(children.length));
  }

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: Text(widget.title),
      ),
      body: Center(
        child: Wrap(
          children: children,
        ),
      ),
      floatingActionButton: FloatingActionButton(
        onPressed: () {
          setState(() {
            focusedChild = children.length;
            _addChild();
          });
        },
        child: Icon(Icons.add),
      ),
    );
  }
}
```
## Related Issues

- https://github.com/flutter/flutter/issues/45076

## Tests

- Added a test to make sure that `Focus.autofocus` only requests focus when nothing else has focus.
- Added a test to make sure that calling `FocusNode.requestFocus` defers requesting focus if it doesn't have a parent.

## Breaking Change

- [X] No, this is *not* a breaking change.