### PR TITLE
[flutter_tool] Use the delegate's toString in the ErrorHandlingFileSystem

### DIFF
--- a/packages/flutter_tools/lib/src/base/error_handling_file_system.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_file_system.dart
@@ -52,6 +52,9 @@ class ErrorHandlingFileSystem extends ForwardingFileSystem {
     _cachedPath = null;
     delegate.currentDirectory = path;
   }
+
+  @override
+  String toString() => delegate.toString();
 }
 
 class ErrorHandlingFile
@@ -140,6 +143,9 @@ class ErrorHandlingFile
       failureMessage: 'Flutter failed to write to a file at "${delegate.path}"',
     );
   }
+
+  @override
+  String toString() => delegate.toString();
 
   Future<T> _run<T>(Future<T> Function() op, { String failureMessage }) async {
     try {
@@ -230,6 +236,9 @@ class ErrorHandlingDirectory
   @override
   Link childLink(String basename) =>
     wrapLink(fileSystem.directory(delegate).childLink(basename));
+
+  @override
+  String toString() => delegate.toString();
 }
 
 class ErrorHandlingLink
@@ -254,4 +263,7 @@ class ErrorHandlingLink
   @override
   Link wrapLink(io.Link delegate) =>
     ErrorHandlingLink(fileSystem, delegate);
+
+  @override
+  String toString() => delegate.toString();
 }

--- a/packages/flutter_tools/test/general.shard/base/error_handling_file_system_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_file_system_test.dart
@@ -118,4 +118,24 @@ void main() {
 
     expect(identical(firstPath, fs.path), false);
   });
+
+  group('toString() gives toString() of delegate', () {
+    test('ErrorHandlingFileSystem', () {
+      final MockFileSystem mockFileSystem = MockFileSystem();
+      final FileSystem fs = ErrorHandlingFileSystem(mockFileSystem);
+
+      expect(mockFileSystem.toString(), isNotNull);
+      expect(fs.toString(), equals(mockFileSystem.toString()));
+    });
+
+    test('ErrorHandlingFile', () {
+      final MockFileSystem mockFileSystem = MockFileSystem();
+      final FileSystem fs = ErrorHandlingFileSystem(mockFileSystem);
+      final MockFile mockFile = MockFile();
+      when(mockFileSystem.file(any)).thenReturn(mockFile);
+
+      expect(mockFile.toString(), isNotNull);
+      expect(fs.file('file').toString(), equals(mockFile.toString()));
+    });
+  });
 }


### PR DESCRIPTION
## Description

Without delegating to the underlying filesystem and file for toString(), error messages can contain unhelpful 'instance of ...' instead of a path.

## Related Issues

https://github.com/flutter/flutter/issues/48165

## Tests

I added the following tests:

Added tests to error_handling_file_system_test.dart

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.