### PR TITLE
[flutter_tool] Make BotDetector context free

### DIFF
--- a/packages/flutter_tools/lib/src/base/bot_detector.dart
+++ b/packages/flutter_tools/lib/src/base/bot_detector.dart
@@ -1,0 +1,60 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:meta/meta.dart';
+import 'package:platform/platform.dart';
+
+import 'context.dart';
+
+class BotDetector {
+  BotDetector({
+    @required Platform platform,
+  }) : _platform = platform;
+
+  final Platform _platform;
+
+  bool get isRunningOnBot {
+    if (
+        // Explicitly stated to not be a bot.
+        _platform.environment['BOT'] == 'false'
+
+        // Set by the IDEs to the IDE name, so a strong signal that this is not a bot.
+        || _platform.environment.containsKey('FLUTTER_HOST')
+        // When set, GA logs to a local file (normally for tests) so we don't need to filter.
+        || _platform.environment.containsKey('FLUTTER_ANALYTICS_LOG_FILE')
+    ) {
+      return false;
+    }
+
+    return _platform.environment['BOT'] == 'true'
+
+        // https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
+        || _platform.environment['TRAVIS'] == 'true'
+        || _platform.environment['CONTINUOUS_INTEGRATION'] == 'true'
+        || _platform.environment.containsKey('CI') // Travis and AppVeyor
+
+        // https://www.appveyor.com/docs/environment-variables/
+        || _platform.environment.containsKey('APPVEYOR')
+
+        // https://cirrus-ci.org/guide/writing-tasks/#environment-variables
+        || _platform.environment.containsKey('CIRRUS_CI')
+
+        // https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
+        || (_platform.environment.containsKey('AWS_REGION') &&
+            _platform.environment.containsKey('CODEBUILD_INITIATOR'))
+
+        // https://wiki.jenkins.io/display/JENKINS/Building+a+software+project#Buildingasoftwareproject-belowJenkinsSetEnvironmentVariables
+        || _platform.environment.containsKey('JENKINS_URL')
+
+        // Properties on Flutter's Chrome Infra bots.
+        || _platform.environment['CHROME_HEADLESS'] == '1'
+        || _platform.environment.containsKey('BUILDBOT_BUILDERNAME')
+        || _platform.environment.containsKey('SWARMING_TASK_ID');
+  }
+}
+
+bool isRunningOnBot(Platform platform) {
+  final BotDetector botDetector = context.get<BotDetector>() ?? BotDetector(platform: platform);
+  return botDetector.isRunningOnBot;
+}

--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -10,60 +10,9 @@ import 'package:meta/meta.dart';
 
 import '../convert.dart';
 import '../globals.dart' as globals;
-import 'context.dart';
 import 'file_system.dart';
 import 'io.dart' as io;
 import 'terminal.dart';
-
-const BotDetector _kBotDetector = BotDetector();
-
-class BotDetector {
-  const BotDetector();
-
-  bool get isRunningOnBot {
-    if (
-        // Explicitly stated to not be a bot.
-        globals.platform.environment['BOT'] == 'false'
-
-        // Set by the IDEs to the IDE name, so a strong signal that this is not a bot.
-        || globals.platform.environment.containsKey('FLUTTER_HOST')
-        // When set, GA logs to a local file (normally for tests) so we don't need to filter.
-        || globals.platform.environment.containsKey('FLUTTER_ANALYTICS_LOG_FILE')
-    ) {
-      return false;
-    }
-
-    return globals.platform.environment['BOT'] == 'true'
-
-        // https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
-        || globals.platform.environment['TRAVIS'] == 'true'
-        || globals.platform.environment['CONTINUOUS_INTEGRATION'] == 'true'
-        || globals.platform.environment.containsKey('CI') // Travis and AppVeyor
-
-        // https://www.appveyor.com/docs/environment-variables/
-        || globals.platform.environment.containsKey('APPVEYOR')
-
-        // https://cirrus-ci.org/guide/writing-tasks/#environment-variables
-        || globals.platform.environment.containsKey('CIRRUS_CI')
-
-        // https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
-        || (globals.platform.environment.containsKey('AWS_REGION') &&
-            globals.platform.environment.containsKey('CODEBUILD_INITIATOR'))
-
-        // https://wiki.jenkins.io/display/JENKINS/Building+a+software+project#Buildingasoftwareproject-belowJenkinsSetEnvironmentVariables
-        || globals.platform.environment.containsKey('JENKINS_URL')
-
-        // Properties on Flutter's Chrome Infra bots.
-        || globals.platform.environment['CHROME_HEADLESS'] == '1'
-        || globals.platform.environment.containsKey('BUILDBOT_BUILDERNAME')
-        || globals.platform.environment.containsKey('SWARMING_TASK_ID');
-  }
-}
-
-bool get isRunningOnBot {
-  final BotDetector botDetector = context.get<BotDetector>() ?? _kBotDetector;
-  return botDetector.isRunningOnBot;
-}
 
 /// Convert `foo_bar` to `fooBar`.
 String camelCase(String str) {

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -22,7 +22,6 @@ import 'base/signals.dart';
 import 'base/terminal.dart';
 import 'base/time.dart';
 import 'base/user_messages.dart';
-import 'base/utils.dart';
 import 'build_system/build_system.dart';
 import 'cache.dart';
 import 'compile.dart';
@@ -75,7 +74,6 @@ Future<T> runInContext<T>(
       ApplicationPackageFactory: () => ApplicationPackageFactory(),
       Artifacts: () => CachedArtifacts(),
       AssetBundleFactory: () => AssetBundleFactory.defaultInstance,
-      BotDetector: () => const BotDetector(),
       BuildSystem: () => const BuildSystem(),
       Cache: () => Cache(),
       ChromeLauncher: () => const ChromeLauncher(),

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -6,13 +6,13 @@ import 'dart:async';
 
 import 'package:meta/meta.dart';
 
+import '../base/bot_detector.dart';
 import '../base/common.dart';
 import '../base/context.dart';
 import '../base/file_system.dart';
 import '../base/io.dart' as io;
 import '../base/logger.dart';
 import '../base/process.dart';
-import '../base/utils.dart';
 import '../cache.dart';
 import '../globals.dart' as globals;
 import '../reporting/reporting.dart';
@@ -232,7 +232,7 @@ class _DefaultPub implements Pub {
     @required bool retry,
     bool showTraceForErrors,
   }) async {
-    showTraceForErrors ??= isRunningOnBot;
+    showTraceForErrors ??= isRunningOnBot(globals.platform);
 
     String lastPubMessage = 'no message';
     bool versionSolvingFailed = false;
@@ -368,7 +368,7 @@ String _getPubEnvironmentValue(PubContext pubContext) {
   final String existing = globals.platform.environment[_pubEnvironmentKey];
   final List<String> values = <String>[
     if (existing != null && existing.isNotEmpty) existing,
-    if (isRunningOnBot) 'flutter_bot',
+    if (isRunningOnBot(globals.platform)) 'flutter_bot',
     'flutter_cli',
     ...pubContext._values,
   ];

--- a/packages/flutter_tools/lib/src/reporting/reporting.dart
+++ b/packages/flutter_tools/lib/src/reporting/reporting.dart
@@ -10,12 +10,12 @@ import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 import 'package:usage/usage_io.dart';
 
+import '../base/bot_detector.dart';
 import '../base/context.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/os.dart';
 import '../base/time.dart';
-import '../base/utils.dart';
 import '../doctor.dart';
 import '../features.dart';
 import '../globals.dart' as globals;

--- a/packages/flutter_tools/lib/src/reporting/usage.dart
+++ b/packages/flutter_tools/lib/src/reporting/usage.dart
@@ -176,7 +176,7 @@ class _DefaultUsage implements Usage {
         // Many CI systems don't do a full git checkout.
         version.endsWith('/unknown') ||
         // Ignore bots.
-        isRunningOnBot ||
+        isRunningOnBot(globals.platform) ||
         // Ignore when suppressed by FLUTTER_SUPPRESS_ANALYTICS.
         suppressEnvFlag
       )) {

--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -5,9 +5,9 @@
 import 'dart:async';
 
 import 'package:args/command_runner.dart';
+import 'package:flutter_tools/src/base/bot_detector.dart';
 import 'package:flutter_tools/src/base/file_system.dart' hide IOSink;
 import 'package:flutter_tools/src/base/io.dart';
-import 'package:flutter_tools/src/base/utils.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/packages.dart';
 import 'package:flutter_tools/src/dart/pub.dart';

--- a/packages/flutter_tools/test/general.shard/base/bot_detector_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/bot_detector_test.dart
@@ -2,13 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter_tools/src/base/io.dart';
-
-import 'package:flutter_tools/src/base/utils.dart';
+import 'package:flutter_tools/src/base/bot_detector.dart';
 import 'package:platform/platform.dart';
 
 import '../../src/common.dart';
-import '../../src/context.dart';
 import '../../src/mocks.dart';
 
 void main() {
@@ -20,45 +17,33 @@ void main() {
     setUp(() {
       fakePlatform = FakePlatform()..environment = <String, String>{};
       mockStdio = MockStdio();
-      botDetector = const BotDetector();
+      botDetector = BotDetector(platform: fakePlatform);
     });
 
     group('isRunningOnBot', () {
-      testUsingContext('returns false unconditionally if BOT=false is set', () async {
+      testWithoutContext('returns false unconditionally if BOT=false is set', () async {
         fakePlatform.environment['BOT'] = 'false';
         fakePlatform.environment['TRAVIS'] = 'true';
         expect(botDetector.isRunningOnBot, isFalse);
-      }, overrides: <Type, Generator>{
-        Stdio: () => mockStdio,
-        Platform: () => fakePlatform,
       });
 
-      testUsingContext('returns false unconditionally if FLUTTER_HOST is set', () async {
+      testWithoutContext('returns false unconditionally if FLUTTER_HOST is set', () async {
         fakePlatform.environment['FLUTTER_HOST'] = 'foo';
         fakePlatform.environment['TRAVIS'] = 'true';
         expect(botDetector.isRunningOnBot, isFalse);
-      }, overrides: <Type, Generator>{
-        Stdio: () => mockStdio,
-        Platform: () => fakePlatform,
       });
 
-      testUsingContext('returns false with and without a terminal attached', () async {
+      testWithoutContext('returns false with and without a terminal attached', () async {
         mockStdio.stdout.hasTerminal = true;
         expect(botDetector.isRunningOnBot, isFalse);
         mockStdio.stdout.hasTerminal = false;
         expect(botDetector.isRunningOnBot, isFalse);
-      }, overrides: <Type, Generator>{
-        Stdio: () => mockStdio,
-        Platform: () => fakePlatform,
       });
 
-      testUsingContext('can test analytics outputs on bots when outputting to a file', () async {
+      testWithoutContext('can test analytics outputs on bots when outputting to a file', () async {
         fakePlatform.environment['TRAVIS'] = 'true';
         fakePlatform.environment['FLUTTER_ANALYTICS_LOG_FILE'] = '/some/file';
         expect(botDetector.isRunningOnBot, isFalse);
-      }, overrides: <Type, Generator>{
-        Stdio: () => mockStdio,
-        Platform: () => fakePlatform,
       });
     });
   });

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -7,11 +7,11 @@ import 'dart:collection';
 
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/bot_detector.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
-import 'package:flutter_tools/src/base/utils.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';


### PR DESCRIPTION
## Description

Remove references to the context from the bot detector. Also move the bot detector out of `utils.dart`.

## Tests

I added the following tests:

Fixed up `bot_detector_test.dart`

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
