### PR TITLE
Avoid runtimeType.toString in toString overrides/debugLabels

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -44,6 +44,9 @@ Future<void> run(List<String> arguments) async {
     exitWithError(<String>['The analyze.dart script must be run with --enable-asserts.']);
   }
 
+  print('$clock runtimeType in toString...');
+  await verifyNoRuntimeTypeInToString(flutterRoot);
+
   print('$clock Unexpected binaries...');
   await verifyNoBinaries(flutterRoot);
 
@@ -539,6 +542,54 @@ Future<void> verifyInternationalizations() async {
       'Did you forget to run gen_localizations.dart after updating a .arb file?',
     ]);
   }
+}
+
+Future<void> verifyNoRuntimeTypeInToString(String workingDirectory) async {
+  final List<File> files = _allFiles(path.join(workingDirectory, 'packages', 'flutter', 'lib'), 'dart', minimumMatches: 400)
+      .where((File file) => !file.path.endsWith(path.join('lib', 'src', 'foundation', 'object.dart')))
+      .toList();
+  final RegExp toStringRegExp = RegExp(r'^\s+String\s+to(.+?)?String(.+?)?\(\)\s+(\{|=>)');
+  final List<String> problems = <String>[];
+  for (final File file in files) {
+    final List<String> lines = file.readAsLinesSync();
+    for (int index = 0; index < lines.length; index++) {
+      if (toStringRegExp.hasMatch(lines[index])) {
+        final int sourceLine = index;
+        bool _checkForRuntimeType(String line) {
+          if (line.contains(r'$runtimeType') || line.contains('runtimeType.toString()')) {
+            problems.add('${file.path}:$sourceLine}: toString calls runtimeType.toString');
+            return true;
+          }
+          return false;
+        }
+        if (_checkForRuntimeType(lines[index])) {
+          continue;
+        }
+        if (lines[index].contains('=>')) {
+          while (!lines[index].contains(';')) {
+            index++;
+            assert(index < lines.length, 'Source file $file has unterminated toString method.');
+            if (_checkForRuntimeType(lines[index])) {
+              break;
+            }
+          }
+        } else {
+          int openBraceCount = '{'.allMatches(lines[index]).length - '}'.allMatches(lines[index]).length;
+          while (!lines[index].contains('}') && openBraceCount > 0) {
+            index++;
+            assert(index < lines.length, 'Source file $file has unbalanced braces in a toString method.');
+            if (_checkForRuntimeType(lines[index])) {
+              break;
+            }
+            openBraceCount += '{'.allMatches(lines[index]).length;
+            openBraceCount -= '}'.allMatches(lines[index]).length;
+          }
+        }
+      }
+    }
+  }
+  if (problems.isNotEmpty)
+    exitWithError(problems);
 }
 
 Future<void> verifyNoTrailingSpaces(String workingDirectory, { int minimumMatches = 4000 }) async {

--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -545,8 +545,12 @@ Future<void> verifyInternationalizations() async {
 }
 
 Future<void> verifyNoRuntimeTypeInToString(String workingDirectory) async {
-  final List<File> files = _allFiles(path.join(workingDirectory, 'packages', 'flutter', 'lib'), 'dart', minimumMatches: 400)
-      .where((File file) => !file.path.endsWith(path.join('lib', 'src', 'foundation', 'object.dart')))
+  final String flutterLib = path.join(workingDirectory, 'packages', 'flutter', 'lib');
+  final Set<String> excludedFiles = <String>{
+    path.join(flutterLib, 'src', 'foundation', 'object.dart'), // Calls this from within an assert.
+  };
+  final List<File> files = _allFiles(flutterLib, 'dart', minimumMatches: 400)
+      .where((File file) => !excludedFiles.contains(file.path))
       .toList();
   final RegExp toStringRegExp = RegExp(r'^\s+String\s+to(.+?)?String(.+?)?\(\)\s+(\{|=>)');
   final List<String> problems = <String>[];

--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -558,7 +558,7 @@ Future<void> verifyNoRuntimeTypeInToString(String workingDirectory) async {
     final List<String> lines = file.readAsLinesSync();
     for (int index = 0; index < lines.length; index++) {
       if (toStringRegExp.hasMatch(lines[index])) {
-        final int sourceLine = index;
+        final int sourceLine = index + 1;
         bool _checkForRuntimeType(String line) {
           if (line.contains(r'$runtimeType') || line.contains('runtimeType.toString()')) {
             problems.add('${file.path}:$sourceLine}: toString calls runtimeType.toString');

--- a/packages/flutter/lib/foundation.dart
+++ b/packages/flutter/lib/foundation.dart
@@ -47,6 +47,7 @@ export 'src/foundation/isolates.dart';
 export 'src/foundation/key.dart';
 export 'src/foundation/licenses.dart';
 export 'src/foundation/node.dart';
+export 'src/foundation/object.dart';
 export 'src/foundation/observer_list.dart';
 export 'src/foundation/platform.dart';
 export 'src/foundation/print.dart';

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -233,8 +233,8 @@ class ProxyAnimation extends Animation<double>
   @override
   String toString() {
     if (parent == null)
-      return '$runtimeType(null; ${super.toStringDetails()} ${value.toStringAsFixed(3)})';
-    return '$parent\u27A9$runtimeType';
+      return '${objectRuntimeType(this, 'ProxyAnimation')}(null; ${super.toStringDetails()} ${value.toStringAsFixed(3)})';
+    return '$parent\u27A9${objectRuntimeType(this, 'ProxyAnimation')}';
   }
 }
 
@@ -310,7 +310,7 @@ class ReverseAnimation extends Animation<double>
 
   @override
   String toString() {
-    return '$parent\u27AA$runtimeType';
+    return '$parent\u27AA${objectRuntimeType(this, 'ReverseAnimation')}';
   }
 }
 
@@ -594,8 +594,8 @@ class TrainHoppingAnimation extends Animation<double>
   @override
   String toString() {
     if (_nextTrain != null)
-      return '$currentTrain\u27A9$runtimeType(next: $_nextTrain)';
-    return '$currentTrain\u27A9$runtimeType(no next)';
+      return '$currentTrain\u27A9${objectRuntimeType(this, 'TrainHoppingAnimation')}(next: $_nextTrain)';
+    return '$currentTrain\u27A9${objectRuntimeType(this, 'TrainHoppingAnimation')}(no next)';
   }
 }
 
@@ -655,7 +655,7 @@ abstract class CompoundAnimation<T> extends Animation<T>
 
   @override
   String toString() {
-    return '$runtimeType($first, $next)';
+    return '${objectRuntimeType(this, 'CompoundAnimation')}($first, $next)';
   }
 
   AnimationStatus _lastStatus;

--- a/packages/flutter/lib/src/animation/curves.dart
+++ b/packages/flutter/lib/src/animation/curves.dart
@@ -46,7 +46,7 @@ abstract class ParametricCurve<T> {
   }
 
   @override
-  String toString() => '$runtimeType';
+  String toString() => '${objectRuntimeType(this, 'ParametricCurve')}';
 }
 
 /// An parametric animation easing curve, i.e. a mapping of the unit interval to
@@ -139,7 +139,7 @@ class SawTooth extends Curve {
 
   @override
   String toString() {
-    return '$runtimeType($count)';
+    return '${objectRuntimeType(this, 'SawTooth')}($count)';
   }
 }
 
@@ -190,8 +190,8 @@ class Interval extends Curve {
   @override
   String toString() {
     if (curve is! _Linear)
-      return '$runtimeType($begin\u22EF$end)\u27A9$curve';
-    return '$runtimeType($begin\u22EF$end)';
+      return '${objectRuntimeType(this, 'Interval')}($begin\u22EF$end)\u27A9$curve';
+    return '${objectRuntimeType(this, 'Interval')}($begin\u22EF$end)';
   }
 }
 
@@ -300,7 +300,7 @@ class Cubic extends Curve {
 
   @override
   String toString() {
-    return '$runtimeType(${a.toStringAsFixed(2)}, ${b.toStringAsFixed(2)}, ${c.toStringAsFixed(2)}, ${d.toStringAsFixed(2)})';
+    return '${objectRuntimeType(this, 'Cubic')}(${a.toStringAsFixed(2)}, ${b.toStringAsFixed(2)}, ${c.toStringAsFixed(2)}, ${d.toStringAsFixed(2)})';
   }
 }
 
@@ -1087,7 +1087,7 @@ class FlippedCurve extends Curve {
 
   @override
   String toString() {
-    return '$runtimeType($curve)';
+    return '${objectRuntimeType(this, 'FlippedCurve')}($curve)';
   }
 }
 
@@ -1193,7 +1193,7 @@ class ElasticInCurve extends Curve {
 
   @override
   String toString() {
-    return '$runtimeType($period)';
+    return '${objectRuntimeType(this, 'ElasticInCurve')}($period)';
   }
 }
 
@@ -1220,7 +1220,7 @@ class ElasticOutCurve extends Curve {
 
   @override
   String toString() {
-    return '$runtimeType($period)';
+    return '${objectRuntimeType(this, 'ElasticOutCurve')}($period)';
   }
 }
 
@@ -1252,7 +1252,7 @@ class ElasticInOutCurve extends Curve {
 
   @override
   String toString() {
-    return '$runtimeType($period)';
+    return '${objectRuntimeType(this, 'ElasticInOutCurve')}($period)';
   }
 }
 

--- a/packages/flutter/lib/src/animation/tween.dart
+++ b/packages/flutter/lib/src/animation/tween.dart
@@ -261,7 +261,7 @@ class Tween<T extends dynamic> extends Animatable<T> {
   }
 
   @override
-  String toString() => '$runtimeType($begin \u2192 $end)';
+  String toString() => '${objectRuntimeType(this, 'Animatable')}($begin \u2192 $end)';
 }
 
 /// A [Tween] that evaluates its [parent] in reverse.
@@ -401,7 +401,7 @@ class ConstantTween<T> extends Tween<T> {
   T lerp(double t) => begin;
 
   @override
-  String toString() => '$runtimeType(value: $begin)';
+  String toString() => '${objectRuntimeType(this, 'ReverseTween')}(value: $begin)';
 }
 
 /// Transforms the value of the given animation by the given curve.
@@ -450,5 +450,5 @@ class CurveTween extends Animatable<double> {
   }
 
   @override
-  String toString() => '$runtimeType(curve: $curve)';
+  String toString() => '${objectRuntimeType(this, 'CurveTween')}(curve: $curve)';
 }

--- a/packages/flutter/lib/src/foundation/binding.dart
+++ b/packages/flutter/lib/src/foundation/binding.dart
@@ -15,6 +15,7 @@ import 'assertions.dart';
 import 'basic_types.dart';
 import 'constants.dart';
 import 'debug.dart';
+import 'object.dart';
 import 'platform.dart';
 import 'print.dart';
 
@@ -546,7 +547,7 @@ abstract class BindingBase {
   }
 
   @override
-  String toString() => '<$runtimeType>';
+  String toString() => '<${objectRuntimeType(this, 'BindingBase')}>';
 }
 
 /// Terminate the Flutter application.

--- a/packages/flutter/lib/src/foundation/object.dart
+++ b/packages/flutter/lib/src/foundation/object.dart
@@ -1,0 +1,18 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// Framework code should use this method in favor of calling `toString` on
+/// [Object.runtimeType].
+///
+/// Calling `toString` on a runtime type is a non-trivial operation that can
+/// negatively impact performance. If asserts are enabled, this method will
+/// return `object.runtimeType.toString()`; otherwise, it will return the
+/// [optimizedValue], which must be a simple constant string.
+String objectRuntimeType(Object object, String optimizedValue) {
+  assert(() {
+    optimizedValue = object.runtimeType.toString();
+    return true;
+  }());
+  return optimizedValue;
+}

--- a/packages/flutter/lib/src/foundation/stack_frame.dart
+++ b/packages/flutter/lib/src/foundation/stack_frame.dart
@@ -6,6 +6,8 @@ import 'dart:ui' show hashValues;
 
 import 'package:meta/meta.dart';
 
+import 'object.dart';
+
 /// A object representation of a frame from a stack trace.
 ///
 /// {@tool snippet}
@@ -226,5 +228,5 @@ class StackFrame {
   }
 
   @override
-  String toString() => '$runtimeType(#$number, $packageScheme:$package/$packagePath:$line:$column, className: $className, method: $method)';
+  String toString() => '${objectRuntimeType(this, 'StackFrame')}(#$number, $packageScheme:$package/$packagePath:$line:$column, className: $className, method: $method)';
 }

--- a/packages/flutter/lib/src/gestures/drag_details.dart
+++ b/packages/flutter/lib/src/gestures/drag_details.dart
@@ -43,7 +43,7 @@ class DragDownDetails {
   final Offset localPosition;
 
   @override
-  String toString() => '$runtimeType($globalPosition)';
+  String toString() => '${objectRuntimeType(this, 'DragDownDetails')}($globalPosition)';
 }
 
 /// Signature for when a pointer has contacted the screen and might begin to
@@ -100,7 +100,7 @@ class DragStartDetails {
   // instead).
 
   @override
-  String toString() => '$runtimeType($globalPosition)';
+  String toString() => '${objectRuntimeType(this, 'DragStartDetails')}($globalPosition)';
 }
 
 /// Signature for when a pointer has contacted the screen and has begun to move.
@@ -184,7 +184,7 @@ class DragUpdateDetails {
   final Offset localPosition;
 
   @override
-  String toString() => '$runtimeType($delta)';
+  String toString() => '${objectRuntimeType(this, 'DragUpdateDetails')}($delta)';
 }
 
 /// Signature for when a pointer that is in contact with the screen and moving
@@ -234,5 +234,5 @@ class DragEndDetails {
   final double primaryVelocity;
 
   @override
-  String toString() => '$runtimeType($velocity)';
+  String toString() => '${objectRuntimeType(this, 'DragEndDetails')}($velocity)';
 }

--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -595,5 +595,5 @@ class OffsetPair {
   }
 
   @override
-  String toString() => '${objectRuntimeType(this, 'GestureRecognizer')}(local: $local, global: $global)';
+  String toString() => '${objectRuntimeType(this, 'OffsetPair')}(local: $local, global: $global)';
 }

--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -595,5 +595,5 @@ class OffsetPair {
   }
 
   @override
-  String toString() => '$runtimeType(local: $local, global: $global)';
+  String toString() => '${objectRuntimeType(this, 'GestureRecognizer')}(local: $local, global: $global)';
 }

--- a/packages/flutter/lib/src/material/arc.dart
+++ b/packages/flutter/lib/src/material/arc.dart
@@ -325,7 +325,7 @@ class MaterialRectArcTween extends RectTween {
 
   @override
   String toString() {
-    return '${objectRuntimeType(this, '_Diagonal')}($begin \u2192 $end; beginArc=$beginArc, endArc=$endArc)';
+    return '${objectRuntimeType(this, 'MaterialRectArcTween')}($begin \u2192 $end; beginArc=$beginArc, endArc=$endArc)';
   }
 }
 

--- a/packages/flutter/lib/src/material/arc.dart
+++ b/packages/flutter/lib/src/material/arc.dart
@@ -6,6 +6,7 @@ import 'dart:math' as math;
 import 'dart:ui' show lerpDouble;
 
 import 'package:flutter/animation.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 
 // How close the begin and end points must be to an axis to be considered
@@ -169,7 +170,7 @@ class MaterialPointArcTween extends Tween<Offset> {
 
   @override
   String toString() {
-    return '$runtimeType($begin \u2192 $end; center=$center, radius=$radius, beginAngle=$beginAngle, endAngle=$endAngle)';
+    return '${objectRuntimeType(this, 'MaterialPointArcTween')}($begin \u2192 $end; center=$center, radius=$radius, beginAngle=$beginAngle, endAngle=$endAngle)';
   }
 }
 
@@ -324,7 +325,7 @@ class MaterialRectArcTween extends RectTween {
 
   @override
   String toString() {
-    return '$runtimeType($begin \u2192 $end; beginArc=$beginArc, endArc=$endArc)';
+    return '${objectRuntimeType(this, '_Diagonal')}($begin \u2192 $end; beginArc=$beginArc, endArc=$endArc)';
   }
 }
 
@@ -410,6 +411,6 @@ class MaterialRectCenterArcTween extends RectTween {
 
   @override
   String toString() {
-    return '$runtimeType($begin \u2192 $end; centerArc=$centerArc)';
+    return '${objectRuntimeType(this, 'MaterialRectCenterArcTween')}($begin \u2192 $end; centerArc=$centerArc)';
   }
 }

--- a/packages/flutter/lib/src/material/floating_action_button_location.dart
+++ b/packages/flutter/lib/src/material/floating_action_button_location.dart
@@ -4,6 +4,7 @@
 
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import 'scaffold.dart';
@@ -121,7 +122,7 @@ abstract class FloatingActionButtonLocation {
   Offset getOffset(ScaffoldPrelayoutGeometry scaffoldGeometry);
 
   @override
-  String toString() => '$runtimeType';
+  String toString() => '${objectRuntimeType(this, 'FloatingActionButtonLocation')}';
 }
 
 double _leftOffset(ScaffoldPrelayoutGeometry scaffoldGeometry, { double offset = 0.0 }) {
@@ -406,7 +407,7 @@ abstract class FloatingActionButtonAnimator {
   double getAnimationRestart(double previousValue) => 0.0;
 
   @override
-  String toString() => '$runtimeType';
+  String toString() => '${objectRuntimeType(this, '_CenterFloatFloatingActionButtonLocation')}';
 }
 
 class _ScalingFabMotionAnimator extends FloatingActionButtonAnimator {

--- a/packages/flutter/lib/src/material/floating_action_button_location.dart
+++ b/packages/flutter/lib/src/material/floating_action_button_location.dart
@@ -407,7 +407,7 @@ abstract class FloatingActionButtonAnimator {
   double getAnimationRestart(double previousValue) => 0.0;
 
   @override
-  String toString() => '${objectRuntimeType(this, '_CenterFloatFloatingActionButtonLocation')}';
+  String toString() => '${objectRuntimeType(this, 'FloatingActionButtonAnimator')}';
 }
 
 class _ScalingFabMotionAnimator extends FloatingActionButtonAnimator {

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -178,7 +178,7 @@ class _TransitionSnapshotFabLocation extends FloatingActionButtonLocation {
 
   @override
   String toString() {
-    return '${objectRuntimeType(this, 'ScaffoldPrelayoutGeometry')}(begin: $begin, end: $end, progress: $progress)';
+    return '${objectRuntimeType(this, '_TransitionSnapshotFabLocation')}(begin: $begin, end: $end, progress: $progress)';
   }
 }
 

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -178,7 +178,7 @@ class _TransitionSnapshotFabLocation extends FloatingActionButtonLocation {
 
   @override
   String toString() {
-    return '$runtimeType(begin: $begin, end: $end, progress: $progress)';
+    return '${objectRuntimeType(this, 'ScaffoldPrelayoutGeometry')}(begin: $begin, end: $end, progress: $progress)';
   }
 }
 

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -2896,7 +2896,7 @@ class RangeValues {
 
   @override
   String toString() {
-    return '$runtimeType($start, $end)';
+    return '${objectRuntimeType(this, 'SliderTheme')}($start, $end)';
   }
 }
 
@@ -2935,6 +2935,6 @@ class RangeLabels {
 
   @override
   String toString() {
-    return '$runtimeType($start, $end)';
+    return '${objectRuntimeType(this, 'RangeLabels')}($start, $end)';
   }
 }

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -2896,7 +2896,7 @@ class RangeValues {
 
   @override
   String toString() {
-    return '${objectRuntimeType(this, 'SliderTheme')}($start, $end)';
+    return '${objectRuntimeType(this, 'RangeValues')}($start, $end)';
   }
 }
 

--- a/packages/flutter/lib/src/painting/_network_image_io.dart
+++ b/packages/flutter/lib/src/painting/_network_image_io.dart
@@ -120,5 +120,5 @@ class NetworkImage extends image_provider.ImageProvider<image_provider.NetworkIm
   int get hashCode => ui.hashValues(url, scale);
 
   @override
-  String toString() => '$runtimeType("$url", scale: $scale)';
+  String toString() => '${objectRuntimeType(this, 'NetworkImage')}("$url", scale: $scale)';
 }

--- a/packages/flutter/lib/src/painting/_network_image_web.dart
+++ b/packages/flutter/lib/src/painting/_network_image_web.dart
@@ -78,5 +78,5 @@ class NetworkImage extends image_provider.ImageProvider<image_provider.NetworkIm
   int get hashCode => ui.hashValues(url, scale);
 
   @override
-  String toString() => '$runtimeType("$url", scale: $scale)';
+  String toString() => '${objectRuntimeType(this, 'NetworkImage')}("$url", scale: $scale)';
 }

--- a/packages/flutter/lib/src/painting/alignment.dart
+++ b/packages/flutter/lib/src/painting/alignment.dart
@@ -669,6 +669,6 @@ class TextAlignVertical {
 
   @override
   String toString() {
-    return '$runtimeType(y: $y)';
+    return '${objectRuntimeType(this, 'AlignmentGeometry')}(y: $y)';
   }
 }

--- a/packages/flutter/lib/src/painting/alignment.dart
+++ b/packages/flutter/lib/src/painting/alignment.dart
@@ -669,6 +669,6 @@ class TextAlignVertical {
 
   @override
   String toString() {
-    return '${objectRuntimeType(this, 'AlignmentGeometry')}(y: $y)';
+    return '${objectRuntimeType(this, 'TextAlignVertical')}(y: $y)';
   }
 }

--- a/packages/flutter/lib/src/painting/beveled_rectangle_border.dart
+++ b/packages/flutter/lib/src/painting/beveled_rectangle_border.dart
@@ -4,6 +4,8 @@
 
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart';
+
 import 'basic_types.dart';
 import 'border_radius.dart';
 import 'borders.dart';
@@ -146,6 +148,6 @@ class BeveledRectangleBorder extends ShapeBorder {
 
   @override
   String toString() {
-    return '$runtimeType($side, $borderRadius)';
+    return '${objectRuntimeType(this, 'BeveledRectangleBorder')}($side, $borderRadius)';
   }
 }

--- a/packages/flutter/lib/src/painting/borders.dart
+++ b/packages/flutter/lib/src/painting/borders.dart
@@ -267,7 +267,7 @@ class BorderSide {
   int get hashCode => hashValues(color, width, style);
 
   @override
-  String toString() => '$runtimeType($color, ${width.toStringAsFixed(1)}, $style)';
+  String toString() => '${objectRuntimeType(this, 'BorderSide')}($color, ${width.toStringAsFixed(1)}, $style)';
 }
 
 /// Base class for shape outlines.
@@ -488,7 +488,7 @@ abstract class ShapeBorder {
 
   @override
   String toString() {
-    return '$runtimeType()';
+    return '${objectRuntimeType(this, 'ShapeBorder')}()';
   }
 }
 

--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -545,14 +545,14 @@ class Border extends BoxBorder {
   @override
   String toString() {
     if (isUniform)
-      return '$runtimeType.all($top)';
+      return '${objectRuntimeType(this, 'Border')}.all($top)';
     final List<String> arguments = <String>[
       if (top != BorderSide.none) 'top: $top',
       if (right != BorderSide.none) 'right: $right',
       if (bottom != BorderSide.none) 'bottom: $bottom',
       if (left != BorderSide.none) 'left: $left',
     ];
-    return '$runtimeType(${arguments.join(", ")})';
+    return '${objectRuntimeType(this, 'Border')}(${arguments.join(", ")})';
   }
 }
 
@@ -854,6 +854,6 @@ class BorderDirectional extends BoxBorder {
       if (end != BorderSide.none) 'end: $end',
       if (bottom != BorderSide.none) 'bottom: $bottom',
     ];
-    return '$runtimeType(${arguments.join(", ")})';
+    return '${objectRuntimeType(this, 'BorderDirectional')}(${arguments.join(", ")})';
   }
 }

--- a/packages/flutter/lib/src/painting/circle_border.dart
+++ b/packages/flutter/lib/src/painting/circle_border.dart
@@ -4,6 +4,8 @@
 
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart';
+
 import 'basic_types.dart';
 import 'borders.dart';
 import 'edge_insets.dart';
@@ -93,6 +95,6 @@ class CircleBorder extends ShapeBorder {
 
   @override
   String toString() {
-    return '$runtimeType($side)';
+    return '${objectRuntimeType(this, 'CircleBorder')}($side)';
   }
 }

--- a/packages/flutter/lib/src/painting/colors.dart
+++ b/packages/flutter/lib/src/painting/colors.dart
@@ -228,7 +228,7 @@ class HSVColor {
   int get hashCode => hashValues(alpha, hue, saturation, value);
 
   @override
-  String toString() => '$runtimeType($alpha, $hue, $saturation, $value)';
+  String toString() => '${objectRuntimeType(this, 'HSVColor')}($alpha, $hue, $saturation, $value)';
 }
 
 /// A color represented using [alpha], [hue], [saturation], and [lightness].
@@ -412,7 +412,7 @@ class HSLColor {
   int get hashCode => hashValues(alpha, hue, saturation, lightness);
 
   @override
-  String toString() => '$runtimeType($alpha, $hue, $saturation, $lightness)';
+  String toString() => '${objectRuntimeType(this, 'HSLColor')}($alpha, $hue, $saturation, $lightness)';
 }
 
 /// A color that has a small table of related colors called a "swatch".
@@ -455,7 +455,7 @@ class ColorSwatch<T> extends Color {
   int get hashCode => hashValues(runtimeType, value, _swatch);
 
   @override
-  String toString() => '$runtimeType(primary value: ${super.toString()})';
+  String toString() => '${objectRuntimeType(this, 'ColorSwatch')}(primary value: ${super.toString()})';
 }
 
 /// [DiagnosticsProperty] that has an [Color] as value.

--- a/packages/flutter/lib/src/painting/continuous_rectangle_border.dart
+++ b/packages/flutter/lib/src/painting/continuous_rectangle_border.dart
@@ -4,6 +4,8 @@
 
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart';
+
 import 'basic_types.dart';
 import 'border_radius.dart';
 import 'borders.dart';
@@ -161,6 +163,6 @@ class ContinuousRectangleBorder extends ShapeBorder {
 
   @override
   String toString() {
-    return '$runtimeType($side, $borderRadius)';
+    return '${objectRuntimeType(this, 'ContinuousRectangleBorder')}($side, $borderRadius)';
   }
 }

--- a/packages/flutter/lib/src/painting/decoration.dart
+++ b/packages/flutter/lib/src/painting/decoration.dart
@@ -26,7 +26,7 @@ abstract class Decoration extends Diagnosticable {
   const Decoration();
 
   @override
-  String toStringShort() => '$runtimeType';
+  String toStringShort() => '${objectRuntimeType(this, 'Decoration')}';
 
   /// In checked mode, throws an exception if the object is not in a
   /// valid configuration. Otherwise, returns true.

--- a/packages/flutter/lib/src/painting/decoration_image.dart
+++ b/packages/flutter/lib/src/painting/decoration_image.dart
@@ -172,7 +172,7 @@ class DecorationImage {
       if (matchTextDirection)
         'match text direction',
     ];
-    return '$runtimeType(${properties.join(", ")})';
+    return '${objectRuntimeType(this, 'DecorationImage')}(${properties.join(", ")})';
   }
 }
 
@@ -291,7 +291,7 @@ class DecorationImagePainter {
 
   @override
   String toString() {
-    return '$runtimeType(stream: $_imageStream, image: $_image) for $_details';
+    return '${objectRuntimeType(this, 'DecorationImagePainter')}(stream: $_imageStream, image: $_image) for $_details';
   }
 }
 

--- a/packages/flutter/lib/src/painting/gradient.dart
+++ b/packages/flutter/lib/src/painting/gradient.dart
@@ -511,7 +511,7 @@ class LinearGradient extends Gradient {
 
   @override
   String toString() {
-    return '${objectRuntimeType(this, '_ColorsAndStops')}($begin, $end, $colors, $stops, $tileMode)';
+    return '${objectRuntimeType(this, 'LinearGradient')}($begin, $end, $colors, $stops, $tileMode)';
   }
 }
 

--- a/packages/flutter/lib/src/painting/gradient.dart
+++ b/packages/flutter/lib/src/painting/gradient.dart
@@ -511,7 +511,7 @@ class LinearGradient extends Gradient {
 
   @override
   String toString() {
-    return '$runtimeType($begin, $end, $colors, $stops, $tileMode)';
+    return '${objectRuntimeType(this, '_ColorsAndStops')}($begin, $end, $colors, $stops, $tileMode)';
   }
 }
 
@@ -773,7 +773,7 @@ class RadialGradient extends Gradient {
 
   @override
   String toString() {
-    return '$runtimeType($center, $radius, $colors, $stops, $tileMode, $focal, $focalRadius)';
+    return '${objectRuntimeType(this, 'RadialGradient')}($center, $radius, $colors, $stops, $tileMode, $focal, $focalRadius)';
   }
 }
 
@@ -1018,6 +1018,6 @@ class SweepGradient extends Gradient {
 
   @override
   String toString() {
-    return '$runtimeType($center, $startAngle, $endAngle, $colors, $stops, $tileMode)';
+    return '${objectRuntimeType(this, 'SweepGradient')}($center, $startAngle, $endAngle, $colors, $stops, $tileMode)';
   }
 }

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -403,7 +403,7 @@ abstract class ImageProvider<T> {
   ImageStreamCompleter load(T key, DecoderCallback decode);
 
   @override
-  String toString() => '$runtimeType()';
+  String toString() => '${objectRuntimeType(this, 'ImageConfiguration')}()';
 }
 
 /// Key for the image obtained by an [AssetImage] or [ExactAssetImage].
@@ -449,7 +449,7 @@ class AssetBundleImageKey {
   int get hashCode => hashValues(bundle, name, scale);
 
   @override
-  String toString() => '$runtimeType(bundle: $bundle, name: "$name", scale: $scale)';
+  String toString() => '${objectRuntimeType(this, 'AssetBundleImageKey')}(bundle: $bundle, name: "$name", scale: $scale)';
 }
 
 /// A subclass of [ImageProvider] that knows about [AssetBundle]s.
@@ -666,7 +666,7 @@ class FileImage extends ImageProvider<FileImage> {
   int get hashCode => hashValues(file?.path, scale);
 
   @override
-  String toString() => '$runtimeType("${file?.path}", scale: $scale)';
+  String toString() => '${objectRuntimeType(this, 'AssetBundleImageProvider')}("${file?.path}", scale: $scale)';
 }
 
 /// Decodes the given [Uint8List] buffer as an image, associating it with the
@@ -727,7 +727,7 @@ class MemoryImage extends ImageProvider<MemoryImage> {
   int get hashCode => hashValues(bytes.hashCode, scale);
 
   @override
-  String toString() => '$runtimeType(${describeIdentity(bytes)}, scale: $scale)';
+  String toString() => '${objectRuntimeType(this, 'MemoryImage')}(${describeIdentity(bytes)}, scale: $scale)';
 }
 
 /// Fetches an image from an [AssetBundle], associating it with the given scale.
@@ -865,7 +865,7 @@ class ExactAssetImage extends AssetBundleImageProvider {
   int get hashCode => hashValues(keyName, scale, bundle);
 
   @override
-  String toString() => '$runtimeType(name: "$keyName", scale: $scale, bundle: $bundle)';
+  String toString() => '${objectRuntimeType(this, 'ExactAssetImage')}(name: "$keyName", scale: $scale, bundle: $bundle)';
 }
 
 // A completer used when resolving an image fails sync.

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -666,7 +666,7 @@ class FileImage extends ImageProvider<FileImage> {
   int get hashCode => hashValues(file?.path, scale);
 
   @override
-  String toString() => '${objectRuntimeType(this, 'AssetBundleImageProvider')}("${file?.path}", scale: $scale)';
+  String toString() => '${objectRuntimeType(this, 'FileImage')}("${file?.path}", scale: $scale)';
 }
 
 /// Decodes the given [Uint8List] buffer as an image, associating it with the

--- a/packages/flutter/lib/src/painting/image_resolution.dart
+++ b/packages/flutter/lib/src/painting/image_resolution.dart
@@ -289,5 +289,5 @@ class AssetImage extends AssetBundleImageProvider {
   int get hashCode => hashValues(keyName, bundle);
 
   @override
-  String toString() => '$runtimeType(bundle: $bundle, name: "$keyName")';
+  String toString() => '${objectRuntimeType(this, 'AssetImage')}(bundle: $bundle, name: "$keyName")';
 }

--- a/packages/flutter/lib/src/painting/inline_span.dart
+++ b/packages/flutter/lib/src/painting/inline_span.dart
@@ -96,7 +96,7 @@ class InlineSpanSemanticsInformation {
   int get hashCode => hashValues(text, semanticsLabel, recognizer, isPlaceholder);
 
   @override
-  String toString() => '$runtimeType{text: $text, semanticsLabel: $semanticsLabel, recognizer: $recognizer}';
+  String toString() => '${objectRuntimeType(this, 'Accumulator')}{text: $text, semanticsLabel: $semanticsLabel, recognizer: $recognizer}';
 }
 
 /// An immutable span of inline content which forms part of a paragraph.

--- a/packages/flutter/lib/src/painting/inline_span.dart
+++ b/packages/flutter/lib/src/painting/inline_span.dart
@@ -96,7 +96,7 @@ class InlineSpanSemanticsInformation {
   int get hashCode => hashValues(text, semanticsLabel, recognizer, isPlaceholder);
 
   @override
-  String toString() => '${objectRuntimeType(this, 'Accumulator')}{text: $text, semanticsLabel: $semanticsLabel, recognizer: $recognizer}';
+  String toString() => '${objectRuntimeType(this, 'InlineSpanSemanticsInformation')}{text: $text, semanticsLabel: $semanticsLabel, recognizer: $recognizer}';
 }
 
 /// An immutable span of inline content which forms part of a paragraph.

--- a/packages/flutter/lib/src/painting/rounded_rectangle_border.dart
+++ b/packages/flutter/lib/src/painting/rounded_rectangle_border.dart
@@ -136,7 +136,7 @@ class RoundedRectangleBorder extends ShapeBorder {
 
   @override
   String toString() {
-    return '$runtimeType($side, $borderRadius)';
+    return '${objectRuntimeType(this, 'RoundedRectangleBorder')}($side, $borderRadius)';
   }
 }
 

--- a/packages/flutter/lib/src/painting/stadium_border.dart
+++ b/packages/flutter/lib/src/painting/stadium_border.dart
@@ -4,6 +4,8 @@
 
 import 'dart:ui' as ui show lerpDouble;
 
+import 'package:flutter/foundation.dart';
+
 import 'basic_types.dart';
 import 'border_radius.dart';
 import 'borders.dart';
@@ -122,7 +124,7 @@ class StadiumBorder extends ShapeBorder {
 
   @override
   String toString() {
-    return '$runtimeType($side)';
+    return '${objectRuntimeType(this, 'StadiumBorder')}($side)';
   }
 }
 

--- a/packages/flutter/lib/src/painting/strut_style.dart
+++ b/packages/flutter/lib/src/painting/strut_style.dart
@@ -570,7 +570,7 @@ class StrutStyle extends Diagnosticable {
   }
 
   @override
-  String toStringShort() => '$runtimeType';
+  String toStringShort() => '${objectRuntimeType(this, 'StrutStyle')}';
 
   /// Adds all properties prefixing property names with the optional `prefix`.
   @override

--- a/packages/flutter/lib/src/painting/text_span.dart
+++ b/packages/flutter/lib/src/painting/text_span.dart
@@ -440,7 +440,7 @@ class TextSpan extends InlineSpan {
   );
 
   @override
-  String toStringShort() => '$runtimeType';
+  String toStringShort() => '${objectRuntimeType(this, 'TextSpan')}';
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -1195,7 +1195,7 @@ class TextStyle extends Diagnosticable {
   }
 
   @override
-  String toStringShort() => '$runtimeType';
+  String toStringShort() => '${objectRuntimeType(this, 'TextStyle')}';
 
   /// Adds all properties prefixing property names with the optional `prefix`.
   @override

--- a/packages/flutter/lib/src/physics/simulation.dart
+++ b/packages/flutter/lib/src/physics/simulation.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
+
 import 'tolerance.dart';
 
 /// The base class for all simulations.
@@ -52,5 +54,5 @@ abstract class Simulation {
   Tolerance tolerance;
 
   @override
-  String toString() => '$runtimeType';
+  String toString() => '${objectRuntimeType(this, 'Simulation')}';
 }

--- a/packages/flutter/lib/src/physics/spring_simulation.dart
+++ b/packages/flutter/lib/src/physics/spring_simulation.dart
@@ -4,6 +4,8 @@
 
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart';
+
 import 'simulation.dart';
 import 'tolerance.dart';
 import 'utils.dart';
@@ -55,7 +57,7 @@ class SpringDescription {
   final double damping;
 
   @override
-  String toString() => '$runtimeType(mass: ${mass.toStringAsFixed(1)}, stiffness: ${stiffness.toStringAsFixed(1)}, damping: ${damping.toStringAsFixed(1)})';
+  String toString() => '${objectRuntimeType(this, 'SpringDescription')}(mass: ${mass.toStringAsFixed(1)}, stiffness: ${stiffness.toStringAsFixed(1)}, damping: ${damping.toStringAsFixed(1)})';
 }
 
 /// The kind of spring solution that the [SpringSimulation] is using to simulate the spring.
@@ -119,7 +121,7 @@ class SpringSimulation extends Simulation {
   }
 
   @override
-  String toString() => '$runtimeType(end: $_endPosition, $type)';
+  String toString() => '${objectRuntimeType(this, 'SpringSimulation')}(end: $_endPosition, $type)';
 }
 
 /// A [SpringSimulation] where the value of [x] is guaranteed to have exactly the

--- a/packages/flutter/lib/src/rendering/custom_layout.dart
+++ b/packages/flutter/lib/src/rendering/custom_layout.dart
@@ -294,7 +294,7 @@ abstract class MultiChildLayoutDelegate {
   ///
   /// By default, returns the [runtimeType] of the class.
   @override
-  String toString() => '${objectRuntimeType(this, 'MultiChildLayoutParentData')}';
+  String toString() => '${objectRuntimeType(this, 'MultiChildLayoutDelegate')}';
 }
 
 /// Defers the layout of multiple children to a delegate.

--- a/packages/flutter/lib/src/rendering/custom_layout.dart
+++ b/packages/flutter/lib/src/rendering/custom_layout.dart
@@ -294,7 +294,7 @@ abstract class MultiChildLayoutDelegate {
   ///
   /// By default, returns the [runtimeType] of the class.
   @override
-  String toString() => '$runtimeType';
+  String toString() => '${objectRuntimeType(this, 'MultiChildLayoutParentData')}';
 }
 
 /// Defers the layout of multiple children to a delegate.

--- a/packages/flutter/lib/src/rendering/flow.dart
+++ b/packages/flutter/lib/src/rendering/flow.dart
@@ -132,7 +132,7 @@ abstract class FlowDelegate {
   ///
   /// By default, returns the [runtimeType] of the class.
   @override
-  String toString() => '$runtimeType';
+  String toString() => '${objectRuntimeType(this, 'FlowPaintingContext')}';
 }
 
 /// Parent data for use with [RenderFlow].

--- a/packages/flutter/lib/src/rendering/flow.dart
+++ b/packages/flutter/lib/src/rendering/flow.dart
@@ -132,7 +132,7 @@ abstract class FlowDelegate {
   ///
   /// By default, returns the [runtimeType] of the class.
   @override
-  String toString() => '${objectRuntimeType(this, 'FlowPaintingContext')}';
+  String toString() => '${objectRuntimeType(this, 'FlowDelegate')}';
 }
 
 /// Parent data for use with [RenderFlow].

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -36,7 +36,7 @@ class AnnotationEntry<T> {
 
   @override
   String toString() {
-    return '$runtimeType(annotation: $annotation, localPostion: $localPosition)';
+    return '${objectRuntimeType(this, 'AnnotationEntry')}(annotation: $annotation, localPostion: $localPosition)';
   }
 }
 

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -615,7 +615,7 @@ class PaintingContext extends ClipContext {
   }
 
   @override
-  String toString() => '${objectRuntimeType(this, 'ParentData')}#$hashCode(layer: $_containerLayer, canvas bounds: $estimatedBounds)';
+  String toString() => '${objectRuntimeType(this, 'PaintingContext')}#$hashCode(layer: $_containerLayer, canvas bounds: $estimatedBounds)';
 }
 
 /// An abstract set of layout constraints.

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -615,7 +615,7 @@ class PaintingContext extends ClipContext {
   }
 
   @override
-  String toString() => '$runtimeType#$hashCode(layer: $_containerLayer, canvas bounds: $estimatedBounds)';
+  String toString() => '${objectRuntimeType(this, 'ParentData')}#$hashCode(layer: $_containerLayer, canvas bounds: $estimatedBounds)';
 }
 
 /// An abstract set of layout constraints.

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -1138,7 +1138,7 @@ abstract class CustomClipper<T> {
   bool shouldReclip(covariant CustomClipper<T> oldClipper);
 
   @override
-  String toString() => '${objectRuntimeType(this, 'RenderIntrinsicWidth')}';
+  String toString() => '${objectRuntimeType(this, 'CustomClipper')}';
 }
 
 /// A [CustomClipper] that clips to the outer path of a [ShapeBorder].

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -1138,7 +1138,7 @@ abstract class CustomClipper<T> {
   bool shouldReclip(covariant CustomClipper<T> oldClipper);
 
   @override
-  String toString() => '$runtimeType';
+  String toString() => '${objectRuntimeType(this, 'RenderIntrinsicWidth')}';
 }
 
 /// A [CustomClipper] that clips to the outer path of a [ShapeBorder].

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -715,7 +715,7 @@ class SliverGeometry extends Diagnosticable {
         if (check)
           return;
         throw FlutterError.fromParts(<DiagnosticsNode>[
-          ErrorSummary('$runtimeType is not valid: $summary'),
+          ErrorSummary('${objectRuntimeType(this, 'SliverGeometry')} is not valid: $summary'),
           ...?details,
           if (informationCollector != null)
             ...informationCollector(),
@@ -758,7 +758,7 @@ class SliverGeometry extends Diagnosticable {
   }
 
   @override
-  String toStringShort() => '$runtimeType';
+  String toStringShort() => '${objectRuntimeType(this, 'SliverConstraints')}';
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -1394,7 +1394,7 @@ abstract class RenderSliver extends RenderObject {
   @protected
   double childMainAxisPosition(covariant RenderObject child) {
     assert(() {
-      throw FlutterError('$runtimeType does not implement childPosition.');
+      throw FlutterError('${objectRuntimeType(this, 'SliverHitTestResult')} does not implement childPosition.');
     }());
     return 0.0;
   }
@@ -1431,7 +1431,7 @@ abstract class RenderSliver extends RenderObject {
   @override
   void applyPaintTransform(RenderObject child, Matrix4 transform) {
     assert(() {
-      throw FlutterError('$runtimeType does not implement applyPaintTransform.');
+      throw FlutterError('${objectRuntimeType(this, 'SliverHitTestResult')} does not implement applyPaintTransform.');
     }());
   }
 

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -758,7 +758,7 @@ class SliverGeometry extends Diagnosticable {
   }
 
   @override
-  String toStringShort() => '${objectRuntimeType(this, 'SliverConstraints')}';
+  String toStringShort() => '${objectRuntimeType(this, 'SliverGeometry')}';
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -1394,7 +1394,7 @@ abstract class RenderSliver extends RenderObject {
   @protected
   double childMainAxisPosition(covariant RenderObject child) {
     assert(() {
-      throw FlutterError('${objectRuntimeType(this, 'SliverHitTestResult')} does not implement childPosition.');
+      throw FlutterError('${objectRuntimeType(this, 'RenderSliver')} does not implement childPosition.');
     }());
     return 0.0;
   }
@@ -1431,7 +1431,7 @@ abstract class RenderSliver extends RenderObject {
   @override
   void applyPaintTransform(RenderObject child, Matrix4 transform) {
     assert(() {
-      throw FlutterError('${objectRuntimeType(this, 'SliverHitTestResult')} does not implement applyPaintTransform.');
+      throw FlutterError('${objectRuntimeType(this, 'RenderSliver')} does not implement applyPaintTransform.');
     }());
   }
 

--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -76,7 +76,7 @@ abstract class TableColumnWidth {
   double flex(Iterable<RenderBox> cells) => null;
 
   @override
-  String toString() => '$runtimeType';
+  String toString() => '${objectRuntimeType(this, 'TableCellParentData')}';
 }
 
 /// Sizes the column according to the intrinsic dimensions of all the
@@ -115,7 +115,7 @@ class IntrinsicColumnWidth extends TableColumnWidth {
   double flex(Iterable<RenderBox> cells) => _flex;
 
   @override
-  String toString() => '$runtimeType(flex: ${_flex?.toStringAsFixed(1)})';
+  String toString() => '${objectRuntimeType(this, 'IntrinsicColumnWidth')}(flex: ${_flex?.toStringAsFixed(1)})';
 }
 
 /// Sizes the column to a specific number of pixels.
@@ -141,7 +141,7 @@ class FixedColumnWidth extends TableColumnWidth {
   }
 
   @override
-  String toString() => '$runtimeType(${debugFormatDouble(value)})';
+  String toString() => '${objectRuntimeType(this, 'FixedColumnWidth')}(${debugFormatDouble(value)})';
 }
 
 /// Sizes the column to a fraction of the table's constraints' maxWidth.
@@ -173,7 +173,7 @@ class FractionColumnWidth extends TableColumnWidth {
   }
 
   @override
-  String toString() => '$runtimeType($value)';
+  String toString() => '${objectRuntimeType(this, 'FractionColumnWidth')}($value)';
 }
 
 /// Sizes the column by taking a part of the remaining space once all
@@ -210,7 +210,7 @@ class FlexColumnWidth extends TableColumnWidth {
   }
 
   @override
-  String toString() => '$runtimeType(${debugFormatDouble(value)})';
+  String toString() => '${objectRuntimeType(this, 'FlexColumnWidth')}(${debugFormatDouble(value)})';
 }
 
 /// Sizes the column such that it is the size that is the maximum of
@@ -261,7 +261,7 @@ class MaxColumnWidth extends TableColumnWidth {
   }
 
   @override
-  String toString() => '$runtimeType($a, $b)';
+  String toString() => '${objectRuntimeType(this, 'MaxColumnWidth')}($a, $b)';
 }
 
 /// Sizes the column such that it is the size that is the minimum of
@@ -312,7 +312,7 @@ class MinColumnWidth extends TableColumnWidth {
   }
 
   @override
-  String toString() => '$runtimeType($a, $b)';
+  String toString() => '${objectRuntimeType(this, 'MinColumnWidth')}($a, $b)';
 }
 
 /// Vertical alignment options for cells in [RenderTable] objects.

--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -76,7 +76,7 @@ abstract class TableColumnWidth {
   double flex(Iterable<RenderBox> cells) => null;
 
   @override
-  String toString() => '${objectRuntimeType(this, 'TableCellParentData')}';
+  String toString() => '${objectRuntimeType(this, 'TableColumnWidth')}';
 }
 
 /// Sizes the column according to the intrinsic dimensions of all the

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -138,7 +138,7 @@ class RevealedOffset {
 
   @override
   String toString() {
-    return '${objectRuntimeType(this, 'RenderAbstractViewport')}(offset: $offset, rect: $rect)';
+    return '${objectRuntimeType(this, 'RevealedOffset')}(offset: $offset, rect: $rect)';
   }
 }
 

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -138,7 +138,7 @@ class RevealedOffset {
 
   @override
   String toString() {
-    return '$runtimeType(offset: $offset, rect: $rect)';
+    return '${objectRuntimeType(this, 'RenderAbstractViewport')}(offset: $offset, rect: $rect)';
   }
 }
 

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -376,7 +376,7 @@ class SemanticsData extends Diagnosticable {
   bool hasAction(SemanticsAction action) => (actions & action.index) != 0;
 
   @override
-  String toStringShort() => '${objectRuntimeType(this, 'CustomSemanticsAction')}';
+  String toStringShort() => '${objectRuntimeType(this, 'SemanticsData')}';
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -1150,7 +1150,7 @@ class SemanticsProperties extends DiagnosticableTree {
   }
 
   @override
-  String toStringShort() => '${objectRuntimeType(this, '_SemanticsDiagnosticableNode')}'; // the hashCode isn't important since we're immutable
+  String toStringShort() => '${objectRuntimeType(this, 'SemanticsProperties')}'; // the hashCode isn't important since we're immutable
 }
 
 /// In tests use this function to reset the counter used to generate

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -67,7 +67,7 @@ class SemanticsTag {
   final String name;
 
   @override
-  String toString() => '$runtimeType($name)';
+  String toString() => '${objectRuntimeType(this, 'SemanticsTag')}($name)';
 }
 
 /// An identifier of a custom semantics action.
@@ -376,7 +376,7 @@ class SemanticsData extends Diagnosticable {
   bool hasAction(SemanticsAction action) => (actions & action.index) != 0;
 
   @override
-  String toStringShort() => '$runtimeType';
+  String toStringShort() => '${objectRuntimeType(this, 'CustomSemanticsAction')}';
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -1150,7 +1150,7 @@ class SemanticsProperties extends DiagnosticableTree {
   }
 
   @override
-  String toStringShort() => '$runtimeType'; // the hashCode isn't important since we're immutable
+  String toStringShort() => '${objectRuntimeType(this, '_SemanticsDiagnosticableNode')}'; // the hashCode isn't important since we're immutable
 }
 
 /// In tests use this function to reset the counter used to generate
@@ -2168,7 +2168,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
   }
 
   @override
-  String toStringShort() => '$runtimeType#$id';
+  String toStringShort() => '${objectRuntimeType(this, 'SemanticsNode')}#$id';
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/semantics/semantics_event.dart
+++ b/packages/flutter/lib/src/semantics/semantics_event.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 
 /// An event sent by the application to notify interested listeners that
@@ -48,7 +49,7 @@ abstract class SemanticsEvent {
     final List<String> sortedKeys = dataMap.keys.toList()..sort();
     for (final String key in sortedKeys)
       pairs.add('$key: ${dataMap[key]}');
-    return '$runtimeType(${pairs.join(', ')})';
+    return '${objectRuntimeType(this, 'SemanticsEvent')}(${pairs.join(', ')})';
   }
 }
 

--- a/packages/flutter/lib/src/services/message_codec.dart
+++ b/packages/flutter/lib/src/services/message_codec.dart
@@ -48,7 +48,7 @@ class MethodCall {
   final dynamic arguments;
 
   @override
-  String toString() => '${objectRuntimeType(this, 'MessageCodec')}($method, $arguments)';
+  String toString() => '${objectRuntimeType(this, 'MethodCall')}($method, $arguments)';
 }
 
 /// A codec for method calls and enveloped results.

--- a/packages/flutter/lib/src/services/message_codec.dart
+++ b/packages/flutter/lib/src/services/message_codec.dart
@@ -48,7 +48,7 @@ class MethodCall {
   final dynamic arguments;
 
   @override
-  String toString() => '$runtimeType($method, $arguments)';
+  String toString() => '${objectRuntimeType(this, 'MessageCodec')}($method, $arguments)';
 }
 
 /// A codec for method calls and enveloped results.

--- a/packages/flutter/lib/src/services/raw_keyboard_android.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_android.dart
@@ -442,7 +442,7 @@ class RawKeyEventDataAndroid extends RawKeyEventData {
 
   @override
   String toString() {
-    return '$runtimeType(keyLabel: $keyLabel flags: $flags, codePoint: $codePoint, '
+    return '${objectRuntimeType(this, 'RawKeyEventDataAndroid')}(keyLabel: $keyLabel flags: $flags, codePoint: $codePoint, '
       'keyCode: $keyCode, scanCode: $scanCode, metaState: $metaState, '
       'modifiers down: $modifiersPressed)';
   }

--- a/packages/flutter/lib/src/services/raw_keyboard_fuchsia.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_fuchsia.dart
@@ -287,7 +287,7 @@ class RawKeyEventDataFuchsia extends RawKeyEventData {
 
   @override
   String toString() {
-    return '$runtimeType(hidUsage: $hidUsage, codePoint: $codePoint, modifiers: $modifiers, '
+    return '${objectRuntimeType(this, 'RawKeyEventDataFuchsia')}(hidUsage: $hidUsage, codePoint: $codePoint, modifiers: $modifiers, '
         'modifiers down: $modifiersPressed)';
   }
 }

--- a/packages/flutter/lib/src/services/raw_keyboard_linux.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_linux.dart
@@ -127,7 +127,7 @@ class RawKeyEventDataLinux extends RawKeyEventData {
 
   @override
   String toString() {
-    return '$runtimeType(keyLabel: $keyLabel, keyCode: $keyCode, scanCode: $scanCode,'
+    return '${objectRuntimeType(this, 'RawKeyEventDataLinux')}(keyLabel: $keyLabel, keyCode: $keyCode, scanCode: $scanCode,'
         ' unicodeScalarValues: $unicodeScalarValues, modifiers: $modifiers, '
         'modifiers down: $modifiersPressed)';
   }

--- a/packages/flutter/lib/src/services/raw_keyboard_macos.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_macos.dart
@@ -349,7 +349,7 @@ class RawKeyEventDataMacOs extends RawKeyEventData {
 
   @override
   String toString() {
-    return '$runtimeType(keyLabel: $keyLabel, keyCode: $keyCode, characters: $characters,'
+    return '${objectRuntimeType(this, 'RawKeyEventDataMacOs')}(keyLabel: $keyLabel, keyCode: $keyCode, characters: $characters,'
         ' unmodifiedCharacters: $charactersIgnoringModifiers, modifiers: $modifiers, '
         'modifiers down: $modifiersPressed)';
   }

--- a/packages/flutter/lib/src/services/raw_keyboard_web.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_web.dart
@@ -192,7 +192,7 @@ class RawKeyEventDataWeb extends RawKeyEventData {
 
   @override
   String toString() {
-    return '$runtimeType(keyLabel: $keyLabel, code: $code, '
+    return '${objectRuntimeType(this, 'RawKeyEventDataWeb')}(keyLabel: $keyLabel, code: $code, '
         'metaState: $metaState, modifiers down: $modifiersPressed)';
   }
 }

--- a/packages/flutter/lib/src/services/text_editing.dart
+++ b/packages/flutter/lib/src/services/text_editing.dart
@@ -94,7 +94,7 @@ class TextSelection extends TextRange {
 
   @override
   String toString() {
-    return '$runtimeType(baseOffset: $baseOffset, extentOffset: $extentOffset, affinity: $affinity, isDirectional: $isDirectional)';
+    return '${objectRuntimeType(this, 'TextSelection')}(baseOffset: $baseOffset, extentOffset: $extentOffset, affinity: $affinity, isDirectional: $isDirectional)';
   }
 
   @override

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -182,7 +182,7 @@ class TextInputType {
 
   @override
   String toString() {
-    return '$runtimeType('
+    return '${objectRuntimeType(this, 'TextInputType')}('
         'name: $_name, '
         'signed: $signed, '
         'decimal: $decimal)';
@@ -685,7 +685,7 @@ class TextEditingValue {
   }
 
   @override
-  String toString() => '$runtimeType(text: \u2524$text\u251C, selection: $selection, composing: $composing)';
+  String toString() => '${objectRuntimeType(this, 'TextInputConfiguration')}(text: \u2524$text\u251C, selection: $selection, composing: $composing)';
 
   @override
   bool operator ==(Object other) {

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -685,7 +685,7 @@ class TextEditingValue {
   }
 
   @override
-  String toString() => '${objectRuntimeType(this, 'TextInputConfiguration')}(text: \u2524$text\u251C, selection: $selection, composing: $composing)';
+  String toString() => '${objectRuntimeType(this, 'TextEditingValue')}(text: \u2524$text\u251C, selection: $selection, composing: $composing)';
 
   @override
   bool operator ==(Object other) {

--- a/packages/flutter/lib/src/widgets/async.dart
+++ b/packages/flutter/lib/src/widgets/async.dart
@@ -264,7 +264,7 @@ class AsyncSnapshot<T> {
   bool get hasError => error != null;
 
   @override
-  String toString() => '${objectRuntimeType(this, 'StreamBuilderBase')}($connectionState, $data, $error)';
+  String toString() => '${objectRuntimeType(this, 'AsyncSnapshot')}($connectionState, $data, $error)';
 
   @override
   bool operator ==(Object other) {

--- a/packages/flutter/lib/src/widgets/async.dart
+++ b/packages/flutter/lib/src/widgets/async.dart
@@ -8,6 +8,8 @@
 
 import 'dart:async' show Future, Stream, StreamSubscription;
 
+import 'package:flutter/foundation.dart';
+
 import 'framework.dart';
 
 // Examples can assume:
@@ -262,7 +264,7 @@ class AsyncSnapshot<T> {
   bool get hasError => error != null;
 
   @override
-  String toString() => '$runtimeType($connectionState, $data, $error)';
+  String toString() => '${objectRuntimeType(this, 'StreamBuilderBase')}($connectionState, $data, $error)';
 
   @override
   bool operator ==(Object other) {

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2092,11 +2092,11 @@ class SizedBox extends SingleChildRenderObjectWidget {
   String toStringShort() {
     String type;
     if (width == double.infinity && height == double.infinity) {
-      type = '$runtimeType.expand';
+      type = '${objectRuntimeType(this, 'TestWidget')}.expand';
     } else if (width == 0.0 && height == 0.0) {
-      type = '$runtimeType.shrink';
+      type = '${objectRuntimeType(this, 'TestWidget')}.shrink';
     } else {
-      type = '$runtimeType';
+      type = '${objectRuntimeType(this, 'TestWidget')}';
     }
     return key == null ? '$type' : '$type-$key';
   }

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2092,11 +2092,11 @@ class SizedBox extends SingleChildRenderObjectWidget {
   String toStringShort() {
     String type;
     if (width == double.infinity && height == double.infinity) {
-      type = '${objectRuntimeType(this, 'TestWidget')}.expand';
+      type = '${objectRuntimeType(this, 'SizedBox')}.expand';
     } else if (width == 0.0 && height == 0.0) {
-      type = '${objectRuntimeType(this, 'TestWidget')}.shrink';
+      type = '${objectRuntimeType(this, 'SizedBox')}.shrink';
     } else {
-      type = '${objectRuntimeType(this, 'TestWidget')}';
+      type = '${objectRuntimeType(this, 'SizedBox')}';
     }
     return key == null ? '$type' : '$type-$key';
   }

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -476,7 +476,7 @@ class _DraggableScrollableSheetScrollPosition
     );
 
     final AnimationController ballisticController = AnimationController.unbounded(
-      debugLabel: '${objectRuntimeType(this, 'HomePage')}',
+      debugLabel: '${objectRuntimeType(this, '_DraggableScrollableSheetPosition')}',
       vsync: context.vsync,
     );
     double lastDelta = 0;

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 
 import 'basic.dart';
@@ -475,7 +476,7 @@ class _DraggableScrollableSheetScrollPosition
     );
 
     final AnimationController ballisticController = AnimationController.unbounded(
-      debugLabel: '$runtimeType',
+      debugLabel: '${objectRuntimeType(this, 'HomePage')}',
       vsync: context.vsync,
     );
     double lastDelta = 0;

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3870,7 +3870,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   /// A short, textual description of this element.
   @override
   String toStringShort() {
-    return widget != null ? '${widget.toStringShort()}' : '[${objectRuntimeType(this, '_InactiveElements')}]';
+    return widget != null ? '${widget.toStringShort()}' : '[${objectRuntimeType(this, 'Element')}]';
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -87,7 +87,7 @@ class ObjectKey extends LocalKey {
   String toString() {
     if (runtimeType == ObjectKey)
       return '[${describeIdentity(value)}]';
-    return '[$runtimeType ${describeIdentity(value)}]';
+    return '[${objectRuntimeType(this, 'RenderFrogJar')} ${describeIdentity(value)}]';
   }
 }
 
@@ -337,7 +337,7 @@ class GlobalObjectKey<T extends State<StatefulWidget>> extends GlobalKey<T> {
 
   @override
   String toString() {
-    String selfType = runtimeType.toString();
+    String selfType = objectRuntimeType(this, 'GlobalObjectKey');
     // const GlobalObjectKey().runtimeType.toString() returns 'GlobalObjectKey<State<StatefulWidget>>'
     // because GlobalObjectKey is instantiated to its bounds. To avoid cluttering the output
     // we remove the suffix.
@@ -442,7 +442,7 @@ abstract class Widget extends DiagnosticableTree {
   /// A short, textual description of this widget.
   @override
   String toStringShort() {
-    return key == null ? '$runtimeType' : '$runtimeType-$key';
+    return key == null ? '${objectRuntimeType(this, 'GlobalKey')}' : '${objectRuntimeType(this, 'RenderFrogJar')}-$key';
   }
 
   @override
@@ -3870,7 +3870,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   /// A short, textual description of this element.
   @override
   String toStringShort() {
-    return widget != null ? '${widget.toStringShort()}' : '[$runtimeType]';
+    return widget != null ? '${widget.toStringShort()}' : '[${objectRuntimeType(this, '_InactiveElements')}]';
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -87,7 +87,7 @@ class ObjectKey extends LocalKey {
   String toString() {
     if (runtimeType == ObjectKey)
       return '[${describeIdentity(value)}]';
-    return '[${objectRuntimeType(this, 'RenderFrogJar')} ${describeIdentity(value)}]';
+    return '[${objectRuntimeType(this, 'ObjectKey')} ${describeIdentity(value)}]';
   }
 }
 
@@ -442,7 +442,7 @@ abstract class Widget extends DiagnosticableTree {
   /// A short, textual description of this widget.
   @override
   String toStringShort() {
-    return key == null ? '${objectRuntimeType(this, 'GlobalKey')}' : '${objectRuntimeType(this, 'RenderFrogJar')}-$key';
+    return key == null ? '${objectRuntimeType(this, 'Widget')}' : '${objectRuntimeType(this, 'Widget')}-$key';
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -338,7 +338,7 @@ class GlobalObjectKey<T extends State<StatefulWidget>> extends GlobalKey<T> {
   @override
   String toString() {
     String selfType = objectRuntimeType(this, 'GlobalObjectKey');
-    // const GlobalObjectKey().runtimeType.toString() returns 'GlobalObjectKey<State<StatefulWidget>>'
+    // The runtimeType string of a GlobalObjectKey() returns 'GlobalObjectKey<State<StatefulWidget>>'
     // because GlobalObjectKey is instantiated to its bounds. To avoid cluttering the output
     // we remove the suffix.
     const String suffix = '<State<StatefulWidget>>';

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -1104,7 +1104,7 @@ abstract class SemanticsGestureDelegate {
   void assignSemantics(RenderSemanticsGestureHandler renderObject);
 
   @override
-  String toString() => '$runtimeType()';
+  String toString() => '${objectRuntimeType(this, 'GestureRecognizerFactory')}()';
 }
 
 // The default semantics delegate of [RawGestureDetector]. Its behavior is

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -1104,7 +1104,7 @@ abstract class SemanticsGestureDelegate {
   void assignSemantics(RenderSemanticsGestureHandler renderObject);
 
   @override
-  String toString() => '${objectRuntimeType(this, 'GestureRecognizerFactory')}()';
+  String toString() => '${objectRuntimeType(this, 'SemanticsGestureDelegate')}()';
 }
 
 // The default semantics delegate of [RawGestureDetector]. Its behavior is

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -135,7 +135,7 @@ abstract class LocalizationsDelegate<T> {
   Type get type => T;
 
   @override
-  String toString() => '$runtimeType[$type]';
+  String toString() => '${objectRuntimeType(this, 'Intl')}[$type]';
 }
 
 /// Interface for localized resource values for the lowest levels of the Flutter

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -135,7 +135,7 @@ abstract class LocalizationsDelegate<T> {
   Type get type => T;
 
   @override
-  String toString() => '${objectRuntimeType(this, 'Intl')}[$type]';
+  String toString() => '${objectRuntimeType(this, 'LocalizationsDelegate')}[$type]';
 }
 
 /// Interface for localized resource values for the lowest levels of the Flutter

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -574,7 +574,7 @@ class MediaQueryData {
 
   @override
   String toString() {
-    return '$runtimeType('
+    return '${objectRuntimeType(this, 'MediaQueryData')}('
              'size: $size, '
              'devicePixelRatio: ${devicePixelRatio.toStringAsFixed(1)}, '
              'textScaleFactor: ${textScaleFactor.toStringAsFixed(1)}, '

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -344,7 +344,7 @@ class RouteSettings {
   final Object arguments;
 
   @override
-  String toString() => '$runtimeType("$name", $arguments)';
+  String toString() => '${objectRuntimeType(this, 'RouteSettings')}("$name", $arguments)';
 }
 
 /// An interface for observing the behavior of a [Navigator].

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -843,7 +843,7 @@ class _NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldCont
   }
 
   @override
-  String toString() => '${objectRuntimeType(this, 'NestedScrollView')}(outer=$_outerController; inner=$_innerController)';
+  String toString() => '${objectRuntimeType(this, '_NestedScrollCoordinator')}(outer=$_outerController; inner=$_innerController)';
 }
 
 class _NestedScrollController extends ScrollController {
@@ -1226,7 +1226,7 @@ class _NestedOuterBallisticScrollActivity extends BallisticScrollActivity {
 
   @override
   String toString() {
-    return '${objectRuntimeType(this, '_NestedScrollController')}(${metrics.minRange} .. ${metrics.maxRange}; correcting by ${metrics.correctionOffset})';
+    return '${objectRuntimeType(this, '_NestedOuterBallisticScrollActivity')}(${metrics.minRange} .. ${metrics.maxRange}; correcting by ${metrics.correctionOffset})';
   }
 }
 

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter/physics.dart';
@@ -842,7 +843,7 @@ class _NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldCont
   }
 
   @override
-  String toString() => '$runtimeType(outer=$_outerController; inner=$_innerController)';
+  String toString() => '${objectRuntimeType(this, 'NestedScrollView')}(outer=$_outerController; inner=$_innerController)';
 }
 
 class _NestedScrollController extends ScrollController {
@@ -1225,7 +1226,7 @@ class _NestedOuterBallisticScrollActivity extends BallisticScrollActivity {
 
   @override
   String toString() {
-    return '$runtimeType(${metrics.minRange} .. ${metrics.maxRange}; correcting by ${metrics.correctionOffset})';
+    return '${objectRuntimeType(this, '_NestedScrollController')}(${metrics.minRange} .. ${metrics.maxRange}; correcting by ${metrics.correctionOffset})';
   }
 }
 
@@ -1310,7 +1311,7 @@ class SliverOverlapAbsorberHandle extends ChangeNotifier {
         extra = ', $_writers WRITERS ASSIGNED';
         break;
     }
-    return '$runtimeType($layoutExtent$extra)';
+    return '${objectRuntimeType(this, 'SliverOverlapAbsorberHandle')}($layoutExtent$extra)';
   }
 }
 

--- a/packages/flutter/lib/src/widgets/notification_listener.dart
+++ b/packages/flutter/lib/src/widgets/notification_listener.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
+
 import 'framework.dart';
 
 /// Signature for [Notification] listeners.
@@ -65,7 +67,7 @@ abstract class Notification {
   String toString() {
     final List<String> description = <String>[];
     debugFillDescription(description);
-    return '$runtimeType(${description.join(", ")})';
+    return '${objectRuntimeType(this, 'Notification')}(${description.join(", ")})';
   }
 
   /// Add additional information to the given description for use by [toString].

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -354,10 +354,10 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
   }
 
   /// A short description of this route useful for debugging.
-  String get debugLabel => '${objectRuntimeType(this, 'OverlayRoute')}';
+  String get debugLabel => '${objectRuntimeType(this, 'TransitionRoute')}';
 
   @override
-  String toString() => '${objectRuntimeType(this, 'OverlayRoute')}(animation: $_controller)';
+  String toString() => '${objectRuntimeType(this, 'TransitionRoute')}(animation: $_controller)';
 }
 
 /// An entry in the history of a [LocalHistoryRoute].
@@ -1366,7 +1366,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   }
 
   @override
-  String toString() => '${objectRuntimeType(this, 'LocalHistoryEntry')}($settings, animation: $_animation)';
+  String toString() => '${objectRuntimeType(this, 'ModalRoute')}($settings, animation: $_animation)';
 }
 
 /// A modal route that overlays a widget over the current route.

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -354,10 +354,10 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
   }
 
   /// A short description of this route useful for debugging.
-  String get debugLabel => '$runtimeType';
+  String get debugLabel => '${objectRuntimeType(this, 'OverlayRoute')}';
 
   @override
-  String toString() => '$runtimeType(animation: $_controller)';
+  String toString() => '${objectRuntimeType(this, 'OverlayRoute')}(animation: $_controller)';
 }
 
 /// An entry in the history of a [LocalHistoryRoute].
@@ -1366,7 +1366,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   }
 
   @override
-  String toString() => '$runtimeType($settings, animation: $_animation)';
+  String toString() => '${objectRuntimeType(this, 'LocalHistoryEntry')}($settings, animation: $_animation)';
 }
 
 /// A modal route that overlays a widget over the current route.

--- a/packages/flutter/lib/src/widgets/scroll_activity.dart
+++ b/packages/flutter/lib/src/widgets/scroll_activity.dart
@@ -507,7 +507,7 @@ class BallisticScrollActivity extends ScrollActivity {
     TickerProvider vsync,
   ) : super(delegate) {
     _controller = AnimationController.unbounded(
-      debugLabel: kDebugMode ? '$runtimeType' : null,
+      debugLabel: kDebugMode ? '${objectRuntimeType(this, 'ScrollActivityDelegate')}' : null,
       vsync: vsync,
     )
       ..addListener(_tick)
@@ -604,7 +604,7 @@ class DrivenScrollActivity extends ScrollActivity {
     _completer = Completer<void>();
     _controller = AnimationController.unbounded(
       value: from,
-      debugLabel: '$runtimeType',
+      debugLabel: '${objectRuntimeType(this, 'DrivenScrollActivity')}',
       vsync: vsync,
     )
       ..addListener(_tick)

--- a/packages/flutter/lib/src/widgets/scroll_activity.dart
+++ b/packages/flutter/lib/src/widgets/scroll_activity.dart
@@ -507,7 +507,7 @@ class BallisticScrollActivity extends ScrollActivity {
     TickerProvider vsync,
   ) : super(delegate) {
     _controller = AnimationController.unbounded(
-      debugLabel: kDebugMode ? '${objectRuntimeType(this, 'ScrollActivityDelegate')}' : null,
+      debugLabel: kDebugMode ? '${objectRuntimeType(this, 'BallisticScrollActivity')}' : null,
       vsync: vsync,
     )
       ..addListener(_tick)

--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -77,7 +77,7 @@ class ScrollBehavior {
   bool shouldNotify(covariant ScrollBehavior oldDelegate) => false;
 
   @override
-  String toString() => '$runtimeType';
+  String toString() => '${objectRuntimeType(this, 'ScrollBehavior')}';
 }
 
 /// Controls how [Scrollable] widgets behave in a subtree.

--- a/packages/flutter/lib/src/widgets/scroll_metrics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_metrics.dart
@@ -147,6 +147,6 @@ class FixedScrollMetrics extends ScrollMetrics {
 
   @override
   String toString() {
-    return '$runtimeType(${extentBefore.toStringAsFixed(1)}..[${extentInside.toStringAsFixed(1)}]..${extentAfter.toStringAsFixed(1)})';
+    return '${objectRuntimeType(this, 'ScrollMetrics')}(${extentBefore.toStringAsFixed(1)}..[${extentInside.toStringAsFixed(1)}]..${extentAfter.toStringAsFixed(1)})';
   }
 }

--- a/packages/flutter/lib/src/widgets/scroll_metrics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_metrics.dart
@@ -147,6 +147,6 @@ class FixedScrollMetrics extends ScrollMetrics {
 
   @override
   String toString() {
-    return '${objectRuntimeType(this, 'ScrollMetrics')}(${extentBefore.toStringAsFixed(1)}..[${extentInside.toStringAsFixed(1)}]..${extentAfter.toStringAsFixed(1)})';
+    return '${objectRuntimeType(this, 'FixedScrollMetrics')}(${extentBefore.toStringAsFixed(1)}..[${extentInside.toStringAsFixed(1)}]..${extentAfter.toStringAsFixed(1)})';
   }
 }

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -270,8 +270,8 @@ class ScrollPhysics {
   @override
   String toString() {
     if (parent == null)
-      return runtimeType.toString();
-    return '$runtimeType -> $parent';
+      return objectRuntimeType(this, 'ScrollPhsyics');
+    return '${objectRuntimeType(this, 'ScrollPhysics')} -> $parent';
   }
 }
 

--- a/packages/flutter/lib/src/widgets/scroll_simulation.dart
+++ b/packages/flutter/lib/src/widgets/scroll_simulation.dart
@@ -123,7 +123,7 @@ class BouncingScrollSimulation extends Simulation {
 
   @override
   String toString() {
-    return '$runtimeType(leadingExtent: $leadingExtent, trailingExtent: $trailingExtent)';
+    return '${objectRuntimeType(this, 'BouncingScrollSimulation')}(leadingExtent: $leadingExtent, trailingExtent: $trailingExtent)';
   }
 }
 


### PR DESCRIPTION
Refactoring: avoid calling `runtimeType.toString()` outside of asserts or error conditions.

~~I'll see if I can find a way to add a presubmit for this.~~ added something to the analyze.dart to check that we don't use `$runtimeType` in `toString` methods.

@a14n @zanderso @jonahwilliams 

Fixes https://github.com/flutter/flutter/issues/31695