### PR TITLE
[tools] Rename dev_finder to device-finder.

### DIFF
--- a/dev/bots/run_fuchsia_tests.sh
+++ b/dev/bots/run_fuchsia_tests.sh
@@ -13,7 +13,7 @@
 # The first and only parameter should be the path to the Fuchsia system image
 # tarball, e.g. `./run_fuchsia_tests.sh generic-x64.tgz`.
 #
-# This script expects `pm`, `dev_finder`, and `fuchsia_ctl` to all be in the
+# This script expects `pm`, `device-finder`, and `fuchsia_ctl` to all be in the
 # same directory as the script.
 
 set -Ee

--- a/dev/devicelab/lib/framework/adb.dart
+++ b/dev/devicelab/lib/framework/adb.dart
@@ -223,9 +223,9 @@ class FuchsiaDeviceDiscovery implements DeviceDiscovery {
  FuchsiaDevice _workingDevice;
 
  String get _devFinder {
-    final String devFinder = path.join(getArtifactPath(), 'fuchsia', 'tools', 'dev_finder');
+    final String devFinder = path.join(getArtifactPath(), 'fuchsia', 'tools', 'device-finder');
     if (!File(devFinder).existsSync()) {
-      throw FileSystemException('Couldn\'t find dev_finder at location $devFinder');
+      throw FileSystemException('Couldn\'t find device-finder at location $devFinder');
     }
     return devFinder;
  }

--- a/packages/flutter_tools/bin/fuchsia_attach.dart
+++ b/packages/flutter_tools/bin/fuchsia_attach.dart
@@ -27,7 +27,7 @@ final ArgParser parser = ArgParser()
   ..addOption('target', help: 'The GN target to attach to')
   ..addOption('entrypoint', defaultsTo: 'main.dart', help: 'The filename of the main method. Defaults to main.dart')
   ..addOption('device', help: 'The device id to attach to')
-  ..addOption('dev-finder', help: 'The location of the dev_finder binary')
+  ..addOption('dev-finder', help: 'The location of the device-finder binary')
   ..addFlag('verbose', negatable: true);
 
 // Track the original working directory so that the tool can find the
@@ -57,7 +57,7 @@ Future<void> main(List<String> args) async {
   globals.fs.currentDirectory = path;
 
   if (!devFinder.existsSync()) {
-    print('Error: dev_finder not found at ${devFinder.path}.');
+    print('Error: device-finder not found at ${devFinder.path}.');
     return 1;
   }
   if (!frontendServer.existsSync()) {

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_dev_finder.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_dev_finder.dart
@@ -7,7 +7,7 @@ import '../base/process.dart';
 import '../globals.dart' as globals;
 import 'fuchsia_sdk.dart';
 
-// Usage: dev_finder <flags> <subcommand> <subcommand args>
+// Usage: device-finder <flags> <subcommand> <subcommand args>
 //
 // Subcommands:
 //   commands         list all command names
@@ -17,7 +17,7 @@ import 'fuchsia_sdk.dart';
 //   resolve          attempts to resolve all passed Fuchsia domain names on the
 //                    network
 
-/// A simple wrapper for the Fuchsia SDK's 'dev_finder' tool.
+/// A simple wrapper for the Fuchsia SDK's 'device-finder' tool.
 class FuchsiaDevFinder {
   /// Returns a list of attached devices as a list of strings with entries
   /// formatted as follows:
@@ -25,7 +25,7 @@ class FuchsiaDevFinder {
   Future<List<String>> list() async {
     if (fuchsiaArtifacts.devFinder == null ||
         !fuchsiaArtifacts.devFinder.existsSync()) {
-      throwToolExit('Fuchsia dev_finder tool not found.');
+      throwToolExit('Fuchsia device-finder tool not found.');
     }
     final List<String> command = <String>[
       fuchsiaArtifacts.devFinder.path,
@@ -34,7 +34,7 @@ class FuchsiaDevFinder {
     ];
     final RunResult result = await processUtils.run(command);
     if (result.exitCode != 0) {
-      globals.printError('dev_finder failed: ${result.stderr}');
+      globals.printError('device-finder failed: ${result.stderr}');
       return null;
     }
     return result.stdout.split('\n');
@@ -50,7 +50,7 @@ class FuchsiaDevFinder {
   Future<String> resolve(String deviceName, {bool local = false}) async {
     if (fuchsiaArtifacts.devFinder == null ||
         !fuchsiaArtifacts.devFinder.existsSync()) {
-      throwToolExit('Fuchsia dev_finder tool not found.');
+      throwToolExit('Fuchsia device-finder tool not found.');
     }
     final List<String> command = <String>[
       fuchsiaArtifacts.devFinder.path,
@@ -61,7 +61,7 @@ class FuchsiaDevFinder {
     ];
     final RunResult result = await processUtils.run(command);
     if (result.exitCode != 0) {
-      globals.printError('dev_finder failed: ${result.stderr}');
+      globals.printError('device-finder failed: ${result.stderr}');
       return null;
     }
     return result.stdout.trim();

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
@@ -29,7 +29,7 @@ class FuchsiaSdk {
   FuchsiaPM get fuchsiaPM => _fuchsiaPM ??= FuchsiaPM();
   FuchsiaPM _fuchsiaPM;
 
-  /// Interface to the 'dev_finder' tool.
+  /// Interface to the 'device-finder' tool.
   FuchsiaDevFinder _fuchsiaDevFinder;
   FuchsiaDevFinder get fuchsiaDevFinder =>
       _fuchsiaDevFinder ??= FuchsiaDevFinder();
@@ -40,7 +40,7 @@ class FuchsiaSdk {
       _fuchsiaKernelCompiler ??= FuchsiaKernelCompiler();
 
   /// Example output:
-  ///    $ dev_finder list -full
+  ///    $ device-finder list -full
   ///    > 192.168.42.56 paper-pulp-bush-angel
   Future<String> listDevices() async {
     if (fuchsiaArtifacts.devFinder == null ||
@@ -127,7 +127,7 @@ class FuchsiaArtifacts {
 
     final String fuchsia = globals.cache.getArtifactDirectory('fuchsia').path;
     final String tools = globals.fs.path.join(fuchsia, 'tools');
-    final File devFinder = globals.fs.file(globals.fs.path.join(tools, 'dev_finder'));
+    final File devFinder = globals.fs.file(globals.fs.path.join(tools, 'device-finder'));
     final File pm = globals.fs.file(globals.fs.path.join(tools, 'pm'));
 
     return FuchsiaArtifacts(

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
@@ -55,7 +55,7 @@ void main() {
       expect(device.name, name);
     });
 
-    testUsingContext('parse dev_finder output', () async {
+    testUsingContext('parse device-finder output', () async {
       const String example = '2001:0db8:85a3:0000:0000:8a2e:0370:7334 paper-pulp-bush-angel';
       final List<FuchsiaDevice> names = await parseListDevices(example);
 
@@ -66,7 +66,7 @@ void main() {
       FuchsiaSdk: () => MockFuchsiaSdk(),
     });
 
-    testUsingContext('parse junk dev_finder output', () async {
+    testUsingContext('parse junk device-finder output', () async {
       const String example = 'junk';
       final List<FuchsiaDevice> names = await parseListDevices(example);
 
@@ -591,7 +591,7 @@ void main() {
       OperatingSystemUtils: () => osUtils,
     });
 
-    testUsingContext('fail with correct LaunchResult when dev_finder fails', () async {
+    testUsingContext('fail with correct LaunchResult when device-finder fails', () async {
       final LaunchResult launchResult =
           await setupAndStartApp(prebuilt: true, mode: BuildMode.release);
       expect(launchResult.started, isFalse);


### PR DESCRIPTION
## Description

dev_finder name is deprecated. device-finder is preferred.
Functionality remains identical, this is an aesthetic change.

This change was generated via:
$ find . -not -path '*/\.*' -type f -exec sed -i 's/(^import.*)!dev_finder/device-finder/g' {} \\;

## Related Issues

None

## Tests

No tests affected.
