### PR TITLE
Add support for `--tags` for flutter test command line flags #32836

### DIFF
--- a/dev/automated_tests/flutter_test/filtering_tag_test.dart
+++ b/dev/automated_tests/flutter_test/filtering_tag_test.dart
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
+
+void main() {
+  test('included', () {
+    expect(2 + 2, 4);
+  }, tags: 'good-tag');
+  test('excluded', () {
+    throw 'this test should have been filtered out';
+  }, tags: 'bad-tag');
+}

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -44,12 +44,10 @@ class TestCommand extends FastFlutterCommand {
       )
       ..addOption('tags',
         abbr: 't',
-        defaultsTo: '',
         help: 'Run only tests associated with tags',
       )
       ..addOption('exclude-tags',
         abbr: 'x',
-        defaultsTo: '',
         help: 'Run only tests WITHOUT given tags',
       )
       ..addFlag('start-paused',

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -44,10 +44,12 @@ class TestCommand extends FastFlutterCommand {
       )
       ..addOption('tags',
         abbr: 't',
+        defaultsTo: '',
         help: 'Run only tests associated with tags',
       )
       ..addOption('exclude-tags',
         abbr: 'x',
+        defaultsTo: '',
         help: 'Run only tests WITHOUT given tags',
       )
       ..addFlag('start-paused',

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -42,6 +42,14 @@ class TestCommand extends FastFlutterCommand {
         valueHelp: 'substring',
         splitCommas: false,
       )
+      ..addOption('tags',
+        abbr: 't',
+        help: 'Run only tests associated with tags',
+      )
+      ..addOption('exclude-tags',
+        abbr: 'x',
+        help: 'Run only tests WITHOUT given tags',
+      )
       ..addFlag('start-paused',
         defaultsTo: false,
         negatable: false,
@@ -161,6 +169,8 @@ class TestCommand extends FastFlutterCommand {
     final bool buildTestAssets = boolArg('test-assets');
     final List<String> names = stringsArg('name');
     final List<String> plainNames = stringsArg('plain-name');
+    final String tags = stringArg('tags');
+    final String excludeTags = stringArg('exclude-tags');
     final FlutterProject flutterProject = FlutterProject.current();
 
     if (buildTestAssets && flutterProject.manifest.assets.isNotEmpty) {
@@ -254,6 +264,8 @@ class TestCommand extends FastFlutterCommand {
       workDir: workDir,
       names: names,
       plainNames: plainNames,
+      tags: tags,
+      excludeTags: excludeTags,
       watcher: watcher,
       enableObservatory: collector != null || startPaused || boolArg('enable-vmservice'),
       startPaused: startPaused,

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -31,8 +31,8 @@ abstract class FlutterTestRunner {
     Directory workDir,
     List<String> names = const <String>[],
     List<String> plainNames = const <String>[],
-    String tags = '',
-    String excludeTags = '',
+    String tags,
+    String excludeTags,
     bool enableObservatory = false,
     bool startPaused = false,
     bool disableServiceAuthCodes = false,
@@ -64,6 +64,8 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
     Directory workDir,
     List<String> names = const <String>[],
     List<String> plainNames = const <String>[],
+    String tags,
+    String excludeTags,
     bool enableObservatory = false,
     bool startPaused = false,
     bool disableServiceAuthCodes = false,
@@ -104,9 +106,9 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
         ...<String>['--name', name],
       for (final String plainName in plainNames)
         ...<String>['--plain-name', plainName],
-      if (tags.isNotEmpty)
+      if (tags != null && tags.isNotEmpty)
         ...<String>['--tags', tags],
-      if (excludeTags.isNotEmpty)
+      if (excludeTags != null && excludeTags.isNotEmpty)
         ...<String>['--exclude-tags', excludeTags],
       '--test-randomize-ordering-seed=$randomSeed',
     ];

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -91,6 +91,14 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
       throwToolExit('Cannot execute Flutter tester at $shellPath');
     }
 
+    if(tags != null && tags.isEmpty){
+      throwToolExit('`tags` parameter cannot be empty');
+    }
+
+    if(excludeTags != null && excludeTags.isEmpty){
+      throwToolExit('`exclude-tags` parameter cannot be empty');
+    }
+
     // Compute the command-line arguments for package:test.
     final List<String> testArgs = <String>[
       if (!globals.terminal.supportsColor)

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -31,6 +31,8 @@ abstract class FlutterTestRunner {
     Directory workDir,
     List<String> names = const <String>[],
     List<String> plainNames = const <String>[],
+    String tags = '',
+    String excludeTags = '',
     bool enableObservatory = false,
     bool startPaused = false,
     bool disableServiceAuthCodes = false,
@@ -102,6 +104,10 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
         ...<String>['--name', name],
       for (final String plainName in plainNames)
         ...<String>['--plain-name', plainName],
+      if (tags.isNotEmpty)
+        ...<String>['--tags', tags],
+      if (excludeTags.isNotEmpty)
+        ...<String>['--exclude-tags', excludeTags],
       '--test-randomize-ordering-seed=$randomSeed',
     ];
     if (web) {

--- a/packages/flutter_tools/test/commands.shard/permeable/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/test_test.dart
@@ -96,6 +96,27 @@ void main() {
     expect(result.exitCode, 0);
   });
 
+
+  testUsingContext('flutter test should run a test with given tag', () async {
+    Cache.flutterRoot = '../..';
+    final ProcessResult result = await _runFlutterTest('filtering_tag', automatedTestsDirectory, flutterTestDirectory,
+        extraArguments: const <String>['--tags', 'good-tag']);
+    if (!(result.stdout as String).contains('+1: All tests passed')) {
+      fail('unexpected output from test:\n\n${result.stdout}\n-- end stdout --\n\n');
+    }
+    expect(result.exitCode, 0);
+  });
+
+  testUsingContext('flutter test should run a test when its name contains a string', () async {
+    Cache.flutterRoot = '../..';
+    final ProcessResult result = await _runFlutterTest('filtering_tag', automatedTestsDirectory, flutterTestDirectory,
+        extraArguments: const <String>['--exclude-tags', 'bad-tag']);
+    if (!(result.stdout as String).contains('+1: All tests passed')) {
+      fail('unexpected output from test:\n\n${result.stdout}\n-- end stdout --\n\n');
+    }
+    expect(result.exitCode, 0);
+  });
+
   testUsingContext('flutter test should test runs to completion', () async {
     Cache.flutterRoot = '../..';
     final ProcessResult result = await _runFlutterTest('trivial', automatedTestsDirectory, flutterTestDirectory,

--- a/packages/flutter_tools/test/commands.shard/permeable/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/test_test.dart
@@ -117,6 +117,26 @@ void main() {
     expect(result.exitCode, 0);
   });
 
+  testUsingContext('flutter test should fail a test when tags argument is empty', () async {
+    Cache.flutterRoot = '../..';
+    final ProcessResult result = await _runFlutterTest('filtering_tag', automatedTestsDirectory, flutterTestDirectory,
+        extraArguments: const <String>['--tags']);
+    if (!(result.stdout as String).contains('-1: `tags` parameter cannot be empty')) {
+      fail('unexpected output from test:\n\n${result.stdout}\n-- end stdout --\n\n');
+    }
+    expect(result.exitCode, 0);
+  });
+
+  testUsingContext('flutter test should fail a test when exclude-tags argument is empty', () async {
+    Cache.flutterRoot = '../..';
+    final ProcessResult result = await _runFlutterTest('filtering_tag', automatedTestsDirectory, flutterTestDirectory,
+        extraArguments: const <String>['--exclude-tags']);
+    if (!(result.stdout as String).contains('-1: `exclude-tags` parameter cannot be empty')) {
+      fail('unexpected output from test:\n\n${result.stdout}\n-- end stdout --\n\n');
+    }
+    expect(result.exitCode, 0);
+  });
+
   testUsingContext('flutter test should test runs to completion', () async {
     Cache.flutterRoot = '../..';
     final ProcessResult result = await _runFlutterTest('trivial', automatedTestsDirectory, flutterTestDirectory,


### PR DESCRIPTION
## Description

This PR adds support for `--tags` and `--exclude-tags` for flutter test tool.

## Related Issues

#32836

## Tests

I added the following tests:

`flutter test should run a test with given tag`
`flutter test should run a test when its name contains a string`

in `test_test.dart` file.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
