### PR TITLE
AppBar can now have custom titleHeight

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -197,7 +197,6 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
     this.centerTitle,
     this.titleSpacing = NavigationToolbar.kMiddleSpacing,
     this.titleHeight = kToolbarHeight,
-    this.centerIcons = true,
     this.toolbarOpacity = 1.0,
     this.bottomOpacity = 1.0,
   }) : assert(automaticallyImplyLeading != null),
@@ -205,7 +204,6 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
        assert(primary != null),
        assert(titleSpacing != null),
        assert(titleHeight != null),
-       assert(centerIcons != null),
        assert(toolbarOpacity != null),
        assert(bottomOpacity != null),
        preferredSize = Size.fromHeight(titleHeight + (bottom?.preferredSize?.height ?? 0.0)),
@@ -369,15 +367,6 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///
   /// This value must not be null, and defaults to [kToolbarHeight].
   final double titleHeight;
-
-  /// Whether [leading] and [actions] should always be placed vertically center.
-  /// If [titleHeight] is not modified, this option has NO effect.
-  ///
-  /// If true, [leading] and [actions] are always placed vertically center.
-  /// If false, icons will be placed on top.
-  ///
-  /// Defaults to true.
-  final bool centerIcons;
 
   /// How opaque the toolbar part of the app bar is.
   ///
@@ -548,8 +537,6 @@ class _AppBarState extends State<AppBar> {
       trailing: actions,
       centerMiddle: widget._getEffectiveCenterTitle(theme),
       middleSpacing: widget.titleSpacing,
-      defaultToolbarHeight: kToolbarHeight,
-      centerIcons: widget.centerIcons,
     );
 
     // If the toolbar is allocated less than titleHeight make it
@@ -709,7 +696,6 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
     @required this.centerTitle,
     @required this.titleSpacing,
     @required this.titleHeight,
-    @required this.centerIcons,
     @required this.expandedHeight,
     @required this.collapsedHeight,
     @required this.topPadding,
@@ -720,7 +706,6 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
     @required this.shape,
   }) : assert(primary || topPadding == 0.0),
        assert(titleHeight != null),
-       assert(centerIcons != null),
        _bottomHeight = bottom?.preferredSize?.height ?? 0.0;
 
   final Widget leading;
@@ -740,7 +725,6 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
   final bool centerTitle;
   final double titleSpacing;
   final double titleHeight;
-  final bool centerIcons;
   final double expandedHeight;
   final double collapsedHeight;
   final double topPadding;
@@ -805,7 +789,6 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
         centerTitle: centerTitle,
         titleSpacing: titleSpacing,
         titleHeight: titleHeight,
-        centerIcons: centerIcons,
         shape: shape,
         toolbarOpacity: toolbarOpacity,
         bottomOpacity: pinned ? 1.0 : ((visibleMainHeight / _bottomHeight).clamp(0.0, 1.0) as double),
@@ -833,7 +816,6 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
         || centerTitle != oldDelegate.centerTitle
         || titleSpacing != oldDelegate.titleSpacing
         || titleHeight != oldDelegate.titleHeight
-        || centerIcons != oldDelegate.centerIcons
         || expandedHeight != oldDelegate.expandedHeight
         || topPadding != oldDelegate.topPadding
         || pinned != oldDelegate.pinned
@@ -950,7 +932,6 @@ class SliverAppBar extends StatefulWidget {
     this.centerTitle,
     this.titleSpacing = NavigationToolbar.kMiddleSpacing,
     this.titleHeight = kToolbarHeight,
-    this.centerIcons = true,
     this.expandedHeight,
     this.floating = false,
     this.pinned = false,
@@ -964,7 +945,6 @@ class SliverAppBar extends StatefulWidget {
        assert(primary != null),
        assert(titleSpacing != null),
        assert(titleHeight != null),
-       assert(centerIcons != null),
        assert(floating != null),
        assert(pinned != null),
        assert(snap != null),
@@ -1127,15 +1107,6 @@ class SliverAppBar extends StatefulWidget {
   ///
   /// This value must not be null, and defaults to [kToolbarHeight].
   final double titleHeight;
-
-  /// Whether [leading] and [actions] should always be placed vertically center.
-  /// If [titleHeight] is not modified, this option has NO effect.
-  ///
-  /// If true, [leading] and [actions] are always placed vertically center.
-  /// If false, icons will be placed on top.
-  ///
-  /// Defaults to true.
-  final bool centerIcons;
 
   /// The size of the app bar when it is fully expanded.
   ///
@@ -1321,7 +1292,6 @@ class _SliverAppBarState extends State<SliverAppBar> with TickerProviderStateMix
           centerTitle: widget.centerTitle,
           titleSpacing: widget.titleSpacing,
           titleHeight: widget.titleHeight,
-          centerIcons: widget.centerIcons,
           expandedHeight: widget.expandedHeight,
           collapsedHeight: collapsedHeight,
           topPadding: topPadding,

--- a/packages/flutter/lib/src/widgets/navigation_toolbar.dart
+++ b/packages/flutter/lib/src/widgets/navigation_toolbar.dart
@@ -32,11 +32,8 @@ class NavigationToolbar extends StatelessWidget {
     this.trailing,
     this.centerMiddle = true,
     this.middleSpacing = kMiddleSpacing,
-    this.defaultToolbarHeight,
-    this.centerIcons = true,
   }) : assert(centerMiddle != null),
        assert(middleSpacing != null),
-       assert(centerIcons != null),
        super(key: key);
 
   /// The default spacing around the [middle] widget in dp.
@@ -61,24 +58,6 @@ class NavigationToolbar extends StatelessWidget {
   /// Defaults to [kMiddleSpacing].
   final double middleSpacing;
 
-  /// The default height used for the [middle].
-  /// This value is only used when [AppBar.titleHeight] is used exclusively.
-  /// and [centerIcons] is false.
-  /// Used to get [kToolbarHeight] when using custom AppBar titleHeight.
-  /// If null, fallbacks to widget's size.
-  ///
-  /// Note: Kept nullable because [_PersistentNavigationBar] from cupertino also uses this.
-  final double defaultToolbarHeight;
-
-  /// Whether [leading] and [trailing] should always be placed vertically center.
-  /// If [AppBar.titleHeight] is not modified, this option has NO effect.
-  ///
-  /// If true, [leading] and [trailing] are always placed vertically center.
-  /// If false, icons will be placed on top.
-  ///
-  /// Defaults to true.
-  final bool centerIcons;
-
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasDirectionality(context));
@@ -88,8 +67,6 @@ class NavigationToolbar extends StatelessWidget {
         centerMiddle: centerMiddle,
         middleSpacing: middleSpacing,
         textDirection: textDirection,
-        defaultToolbarHeight: defaultToolbarHeight,
-        centerIcons: centerIcons,
       ),
       children: <Widget>[
         if (leading != null) LayoutId(id: _ToolbarSlot.leading, child: leading),
@@ -111,11 +88,8 @@ class _ToolbarLayout extends MultiChildLayoutDelegate {
     this.centerMiddle,
     @required this.middleSpacing,
     @required this.textDirection,
-    @required this.defaultToolbarHeight,
-    @required this.centerIcons,
   }) : assert(middleSpacing != null),
-       assert(textDirection != null),
-       assert(centerIcons != null);
+       assert(textDirection != null);
 
   // If false the middle widget should be start-justified within the space
   // between the leading and trailing widgets.
@@ -128,10 +102,6 @@ class _ToolbarLayout extends MultiChildLayoutDelegate {
 
   final TextDirection textDirection;
 
-  final double defaultToolbarHeight;
-
-  final bool centerIcons;
-
   @override
   void performLayout(Size size) {
     double leadingWidth = 0.0;
@@ -141,11 +111,8 @@ class _ToolbarLayout extends MultiChildLayoutDelegate {
       final BoxConstraints constraints = BoxConstraints(
         minWidth: 0.0,
         maxWidth: size.width / 3.0, // The leading widget shouldn't take up more than 1/3 of the space.
-        minHeight: centerIcons ? size.height : math.min(size.height, defaultToolbarHeight ?? size.height),
-        // If icons to be centered, the height should be exactly the height of the bar,
-        // otherwise use minimum of widget height and [defaultToolbarHeight].
-        // If [defaultToolbarHeight] is null, fallback to widget height.
-        maxHeight: centerIcons ? size.height : math.min(size.height, defaultToolbarHeight ?? size.height),
+        minHeight: size.height, // The height should be exactly the height of the bar.
+        maxHeight: size.height,
       );
       leadingWidth = layoutChild(_ToolbarSlot.leading, constraints).width;
       double leadingX;
@@ -161,12 +128,7 @@ class _ToolbarLayout extends MultiChildLayoutDelegate {
     }
 
     if (hasChild(_ToolbarSlot.trailing)) {
-      final BoxConstraints constraints = BoxConstraints(
-          minWidth: 0.0,
-          maxWidth: size.width,
-          minHeight: 0.0,
-          maxHeight: centerIcons ? size.height : math.min(size.height, defaultToolbarHeight ?? size.height),
-      );
+      final BoxConstraints constraints = BoxConstraints.loose(size);
       final Size trailingSize = layoutChild(_ToolbarSlot.trailing, constraints);
       double trailingX;
       switch (textDirection) {
@@ -177,8 +139,7 @@ class _ToolbarLayout extends MultiChildLayoutDelegate {
           trailingX = size.width - trailingSize.width;
           break;
       }
-      final double height = centerIcons ? size.height : math.min(size.height, defaultToolbarHeight ?? size.height);
-      final double trailingY = (height - trailingSize.height) / 2.0;
+      final double trailingY = (size.height - trailingSize.height) / 2.0;
       trailingWidth = trailingSize.width;
       positionChild(_ToolbarSlot.trailing, Offset(trailingX, trailingY));
     }
@@ -219,8 +180,6 @@ class _ToolbarLayout extends MultiChildLayoutDelegate {
   bool shouldRelayout(_ToolbarLayout oldDelegate) {
     return oldDelegate.centerMiddle != centerMiddle
         || oldDelegate.middleSpacing != middleSpacing
-        || oldDelegate.defaultToolbarHeight != defaultToolbarHeight
-        || oldDelegate.centerIcons != centerIcons
         || oldDelegate.textDirection != textDirection;
   }
 }

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -994,6 +994,29 @@ void main() {
     expect(find.byIcon(Icons.menu), findsNothing);
   });
 
+  testWidgets('AppBar sizes according to titleHeight', (WidgetTester tester) async {
+    final GlobalKey key = GlobalKey();
+    const double customTitleHeight = 128.0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: AppBar(
+            leading: Placeholder(key: key),
+            title: const Text('Abc'),
+            titleHeight: customTitleHeight,
+            actions: const <Widget>[
+              Placeholder(fallbackWidth: 10.0),
+              Placeholder(fallbackWidth: 10.0),
+              Placeholder(fallbackWidth: 10.0),
+            ],
+          ),
+        ),
+      ),
+    );
+    expect(tester.renderObject<RenderBox>(find.byKey(key)).localToGlobal(Offset.zero), const Offset(0.0, 0.0));
+    expect(tester.renderObject<RenderBox>(find.byKey(key)).size, const Size(56.0, customTitleHeight));
+  });
+
   testWidgets('AppBar handles loose children 0', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
     await tester.pumpWidget(

--- a/packages/flutter/test/material/floating_action_button_location_test.dart
+++ b/packages/flutter/test/material/floating_action_button_location_test.dart
@@ -316,6 +316,28 @@ void main() {
     expect(tester.getCenter(find.byType(FloatingActionButton)).dy, kToolbarHeight);
   }, skip: isBrowser);
 
+  testWidgets('Mini-start-top floating action button location, with custom titleHeight', (WidgetTester tester) async {
+    const double customTitleHeight = 128.0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(titleHeight: customTitleHeight),
+          floatingActionButton: FloatingActionButton(onPressed: () { }, mini: true),
+          floatingActionButtonLocation: FloatingActionButtonLocation.miniStartTop,
+          body: Column(
+            children: const <Widget>[
+              ListTile(
+                leading: CircleAvatar(),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    expect(tester.getCenter(find.byType(FloatingActionButton)).dx, tester.getCenter(find.byType(CircleAvatar)).dx);
+    expect(tester.getCenter(find.byType(FloatingActionButton)).dy, customTitleHeight);
+  }, skip: isBrowser);
+
   testWidgets('Start-top floating action button location LTR', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
#### NOTE: This PR is same as #48557, but fixes identified changes. That was closed. Still, any suggestions are welcome.

Allows `AppBar` (and `SliverAppBar`) to have any height we specify.

## Description


- Previously, `AppBar`'s height was limited to 56.0 using a constant `kToolbarHeight`. This allows us to change AppBar's height using `titleHeight` parameter. If we omit this parameter, it fallbacks to `kToolbarHeight` (the default behavior), otherwise acts accordingly.

- When we specify `titleHeight`, the icons (`leading` and `actions`) are also centered vertically. (the default behavior). So, I also introduced a boolean `centerIcons` parameter, which when set to `false`, the icons stay on top (see below screenshots for more clarity).

### <a href="//imgur.com/a/TqmuR4x">SCREENSHOTS</a>

## Related Issues

#### using `titleHeight` parameter:
#23373 solved
#40134 solved
#7330 looks related

#### using `centerIcons` parameter:
- No issue is related with this parameter

## Tests

I added the following tests:

- Added test in `app_bar_test.dart` so that we can check custom title height provided.
- Added test in `floating_action_button_location_test.dart` so that we can check mini-start top FAB location.
- Added test in `scrollable_semantics_test.dart` so that showOnScreen works with pinned app bar.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.
   
<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
