### PR TITLE
make spring effect sensitive to scroll direction (#42540)

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_simulation.dart
+++ b/packages/flutter/lib/src/widgets/scroll_simulation.dart
@@ -42,10 +42,10 @@ class BouncingScrollSimulation extends Simulation {
        assert(leadingExtent <= trailingExtent),
        assert(spring != null),
        super(tolerance: tolerance) {
-    if (position < leadingExtent) {
+    if (velocity <= 0.0 && position < leadingExtent) {
       _springSimulation = _underscrollSimulation(position, velocity);
       _springTime = double.negativeInfinity;
-    } else if (position > trailingExtent) {
+    } else if (velocity >= 0.0 && position > trailingExtent) {
       _springSimulation = _overscrollSimulation(position, velocity);
       _springTime = double.negativeInfinity;
     } else {
@@ -76,12 +76,14 @@ class BouncingScrollSimulation extends Simulation {
   /// scroll into overscroll.
   static const double maxSpringTransferVelocity = 5000.0;
 
-  /// When [x] falls below this value the simulation switches from an internal friction
-  /// model to a spring model which causes [x] to "spring" back to [leadingExtent].
+  /// When [x] falls below this value and the [velocity] is smaller than 0.0 the 
+  /// simulation switches from an internal friction model to a spring model which 
+  /// causes [x] to "spring" back to [leadingExtent].
   final double leadingExtent;
 
-  /// When [x] exceeds this value the simulation switches from an internal friction
-  /// model to a spring model which causes [x] to "spring" back to [trailingExtent].
+  /// When [x] exceeds this value and the [velocity] is bigger than 0.0 the
+  /// simulation switches from an internal friction model to a spring model which
+  /// causes [x] to "spring" back to [trailingExtent].
   final double trailingExtent;
 
   /// The spring used used to return [x] to either [leadingExtent] or [trailingExtent].


### PR DESCRIPTION
## Description

Whenever using BouncingScrollPhysics() and scrolling to the leading/trailing extent such that the page bounces and then, while the page is still bouncing, scrolling into the opposite direction, the page seems to lock-in, meaning it bounces in the opposite direction instead of normally scrolling. After that the page's scroll position is again the leading/trailing extent.

**On a technical level:** Currently, in the constructor of the BouncingScrollSimulation class the `_springSimulation` is set as the `_underscrollSimulation()` or `_overscrollSimulation()` function, whenever the scroll position is smaller or bigger than the leading or trailing extent respectively, however, not taking into account the sign of the velocity. Therefore, whenever the scroll position is outside the bounds of the leading or trailing extent, every 'fling-action' will trigger a `ScrollSpringSimulation()`, regardless of the fling-direction.

I simply added a condition, checking the sign of the velocity, when assigning the `_springSimulation`.

## Related Issues

Fixes #42540

## Tests

I tested this locally on an Adroid device.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

The command `flutter analyze` returns: No issues found!

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.
  - [ ] I wrote a design doc: https://flutter.dev/go/template Replace this with a link to your design doc's short link
  - [ ] I got input from the developer relations team, specifically from: Replace with the names of who gave advice
  - [ ] I wrote a migration guide: Replace with a link to your migration guide

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
