### PR TITLE
Updated flutter/examples to further conform to new embedding: removed…

### DIFF
--- a/examples/platform_channel_swift/android/app/src/main/java/com/example/platformchannel/MainActivity.java
+++ b/examples/platform_channel_swift/android/app/src/main/java/com/example/platformchannel/MainActivity.java
@@ -12,18 +12,18 @@ import android.content.IntentFilter;
 import android.os.BatteryManager;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
-import android.os.Bundle;
+
 import androidx.annotation.NonNull;
+
 import io.flutter.embedding.android.FlutterActivity;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.EventChannel.EventSink;
 import io.flutter.plugin.common.EventChannel.StreamHandler;
+import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.MethodCall;
-import io.flutter.plugins.GeneratedPluginRegistrant;
 
 public class MainActivity extends FlutterActivity {
   private static final String BATTERY_CHANNEL = "samples.flutter.io/battery";
@@ -31,8 +31,6 @@ public class MainActivity extends FlutterActivity {
 
   @Override
   public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
-    GeneratedPluginRegistrant.registerWith(flutterEngine);
-
     new EventChannel(flutterEngine.getDartExecutor(), CHARGING_CHANNEL).setStreamHandler(
       new StreamHandler() {
         private BroadcastReceiver chargingStateChangeReceiver;


### PR DESCRIPTION

## Description
When I am checking the platform_channel_swift example project, I see that MainActivity is not Migrated to Android embedding v2. Also, I want to remove the unused imports in the MainActivity class.

## Related Issues
https://github.com/flutter/flutter/issues/48659
