### PR TITLE
ButtonBar.verticalDirection and AlertDialog.actionsVerticalDirection

### DIFF
--- a/packages/flutter/lib/src/material/button_bar.dart
+++ b/packages/flutter/lib/src/material/button_bar.dart
@@ -64,7 +64,7 @@ class ButtonBar extends StatelessWidget {
     this.buttonPadding,
     this.buttonAlignedDropdown,
     this.layoutBehavior,
-    this.verticalDirection,
+    this.overflowDirection,
     this.children = const <Widget>[],
   }) : assert(buttonMinWidth == null || buttonMinWidth >= 0.0),
        assert(buttonHeight == null || buttonHeight >= 0.0),
@@ -130,10 +130,18 @@ class ButtonBar extends StatelessWidget {
   /// Defines the vertical direction of a [ButtonBar]'s children if it
   /// overflows.
   ///
+  /// If [children] do not fit into a single row, then they
+  /// are arranged in a column. The first action is at the top of the
+  /// column if this property is set to [VerticalDirection.down], since it
+  /// "starts" at the top and "ends" at the bottom. On the other hand,
+  /// the first action will be at the bottom of the column if this
+  /// property is set to [VerticalDirection.up], since it "starts" at the
+  /// bottom and "ends" at the top.
+  ///
   /// If null then it will use the surrounding
   /// [ButtonBarTheme.verticalDirection]. If that is null, it will
   /// default to [VerticalDirection.down].
-  final VerticalDirection verticalDirection;
+  final VerticalDirection overflowDirection;
 
   /// The buttons to arrange horizontally.
   ///
@@ -161,7 +169,7 @@ class ButtonBar extends StatelessWidget {
       child: _ButtonBarRow(
         mainAxisAlignment: alignment ?? barTheme.alignment ?? MainAxisAlignment.end,
         mainAxisSize: mainAxisSize ?? barTheme.mainAxisSize ?? MainAxisSize.max,
-        verticalDirection: verticalDirection ?? barTheme.verticalDirection ?? VerticalDirection.down,
+        overflowDirection: overflowDirection ?? barTheme.overflowDirection ?? VerticalDirection.down,
         children: children.map<Widget>((Widget child) {
           return Padding(
             padding: EdgeInsets.symmetric(horizontal: paddingUnit),
@@ -216,7 +224,7 @@ class _ButtonBarRow extends Flex {
     MainAxisAlignment mainAxisAlignment = MainAxisAlignment.start,
     CrossAxisAlignment crossAxisAlignment = CrossAxisAlignment.center,
     TextDirection textDirection,
-    VerticalDirection verticalDirection = VerticalDirection.down,
+    VerticalDirection overflowDirection = VerticalDirection.down,
     TextBaseline textBaseline,
   }) : super(
     children: children,
@@ -225,7 +233,7 @@ class _ButtonBarRow extends Flex {
     mainAxisAlignment: mainAxisAlignment,
     crossAxisAlignment: crossAxisAlignment,
     textDirection: textDirection,
-    verticalDirection: verticalDirection,
+    verticalDirection: overflowDirection,
     textBaseline: textBaseline,
   );
 

--- a/packages/flutter/lib/src/material/button_bar.dart
+++ b/packages/flutter/lib/src/material/button_bar.dart
@@ -139,7 +139,7 @@ class ButtonBar extends StatelessWidget {
   /// bottom and "ends" at the top.
   ///
   /// If null then it will use the surrounding
-  /// [ButtonBarTheme.verticalDirection]. If that is null, it will
+  /// [ButtonBarTheme.overflowDirection]. If that is null, it will
   /// default to [VerticalDirection.down].
   final VerticalDirection overflowDirection;
 

--- a/packages/flutter/lib/src/material/button_bar.dart
+++ b/packages/flutter/lib/src/material/button_bar.dart
@@ -312,8 +312,16 @@ class _RenderButtonBarRow extends RenderFlex {
       super.performLayout();
     } else {
       final BoxConstraints childConstraints = constraints.copyWith(minWidth: 0.0);
-      RenderBox child = firstChild;
+      RenderBox child;
       double currentHeight = 0.0;
+      switch (verticalDirection) {
+        case VerticalDirection.down:
+          child = firstChild;
+          break;
+        case VerticalDirection.up:
+          child = lastChild;
+          break;
+      }
 
       while (child != null) {
         final FlexParentData childParentData = child.parentData as FlexParentData;
@@ -357,7 +365,14 @@ class _RenderButtonBarRow extends RenderFlex {
             break;
         }
         currentHeight += child.size.height;
-        child = childParentData.nextSibling;
+        switch (verticalDirection) {
+          case VerticalDirection.down:
+            child = childParentData.nextSibling;
+            break;
+          case VerticalDirection.up:
+            child = childParentData.previousSibling;
+            break;
+        }
       }
       size = constraints.constrain(Size(constraints.maxWidth, currentHeight));
     }

--- a/packages/flutter/lib/src/material/button_bar.dart
+++ b/packages/flutter/lib/src/material/button_bar.dart
@@ -64,6 +64,7 @@ class ButtonBar extends StatelessWidget {
     this.buttonPadding,
     this.buttonAlignedDropdown,
     this.layoutBehavior,
+    this.verticalDirection,
     this.children = const <Widget>[],
   }) : assert(buttonMinWidth == null || buttonMinWidth >= 0.0),
        assert(buttonHeight == null || buttonHeight >= 0.0),
@@ -126,6 +127,14 @@ class ButtonBar extends StatelessWidget {
   /// If that is null, it will default [ButtonBarLayoutBehavior.padded].
   final ButtonBarLayoutBehavior layoutBehavior;
 
+  /// Defines the vertical direction of a [ButtonBar]'s children if it
+  /// overflows.
+  ///
+  /// If null then it will use the surrounding
+  /// [ButtonBarTheme.verticalDirection]. If that is null, it will
+  /// default to [VerticalDirection.down].
+  final VerticalDirection verticalDirection;
+
   /// The buttons to arrange horizontally.
   ///
   /// Typically [RaisedButton] or [FlatButton] widgets.
@@ -152,6 +161,7 @@ class ButtonBar extends StatelessWidget {
       child: _ButtonBarRow(
         mainAxisAlignment: alignment ?? barTheme.alignment ?? MainAxisAlignment.end,
         mainAxisSize: mainAxisSize ?? barTheme.mainAxisSize ?? MainAxisSize.max,
+        verticalDirection: verticalDirection ?? barTheme.verticalDirection ?? VerticalDirection.down,
         children: children.map<Widget>((Widget child) {
           return Padding(
             padding: EdgeInsets.symmetric(horizontal: paddingUnit),

--- a/packages/flutter/lib/src/material/button_bar_theme.dart
+++ b/packages/flutter/lib/src/material/button_bar_theme.dart
@@ -38,7 +38,7 @@ class ButtonBarThemeData extends Diagnosticable {
     this.buttonPadding,
     this.buttonAlignedDropdown,
     this.layoutBehavior,
-    this.verticalDirection,
+    this.overflowDirection,
   }) : assert(buttonMinWidth == null || buttonMinWidth >= 0.0),
        assert(buttonHeight == null || buttonHeight >= 0.0);
 
@@ -100,7 +100,15 @@ class ButtonBarThemeData extends Diagnosticable {
 
   /// Defines the vertical direction of a [ButtonBar]'s children if it
   /// overflows.
-  final VerticalDirection verticalDirection;
+  ///
+  /// If the [ButtonBar]'s children do not fit into a single row, then they
+  /// are arranged in a column. The first action is at the top of the
+  /// column if this property is set to [VerticalDirection.down], since it
+  /// "starts" at the top and "ends" at the bottom. On the other hand,
+  /// the first action will be at the bottom of the column if this
+  /// property is set to [VerticalDirection.up], since it "starts" at the
+  /// bottom and "ends" at the top.
+  final VerticalDirection overflowDirection;
 
   /// Creates a copy of this object but with the given fields replaced with the
   /// new values.
@@ -113,7 +121,7 @@ class ButtonBarThemeData extends Diagnosticable {
     EdgeInsetsGeometry buttonPadding,
     bool buttonAlignedDropdown,
     ButtonBarLayoutBehavior layoutBehavior,
-    VerticalDirection verticalDirection,
+    VerticalDirection overflowDirection,
   }) {
     return ButtonBarThemeData(
       alignment: alignment ?? this.alignment,
@@ -124,7 +132,7 @@ class ButtonBarThemeData extends Diagnosticable {
       buttonPadding: buttonPadding ?? this.buttonPadding,
       buttonAlignedDropdown: buttonAlignedDropdown ?? this.buttonAlignedDropdown,
       layoutBehavior: layoutBehavior ?? this.layoutBehavior,
-      verticalDirection: verticalDirection ?? this.verticalDirection,
+      overflowDirection: overflowDirection ?? this.overflowDirection,
     );
   }
 
@@ -146,7 +154,7 @@ class ButtonBarThemeData extends Diagnosticable {
       buttonPadding: EdgeInsetsGeometry.lerp(a?.buttonPadding, b?.buttonPadding, t),
       buttonAlignedDropdown: t < 0.5 ? a.buttonAlignedDropdown : b.buttonAlignedDropdown,
       layoutBehavior: t < 0.5 ? a.layoutBehavior : b.layoutBehavior,
-      verticalDirection: t < 0.5 ? a.verticalDirection : b.verticalDirection,
+      overflowDirection: t < 0.5 ? a.overflowDirection : b.overflowDirection,
     );
   }
 
@@ -161,7 +169,7 @@ class ButtonBarThemeData extends Diagnosticable {
       buttonPadding,
       buttonAlignedDropdown,
       layoutBehavior,
-      verticalDirection,
+      overflowDirection,
     );
   }
 
@@ -180,7 +188,7 @@ class ButtonBarThemeData extends Diagnosticable {
         && other.buttonPadding == buttonPadding
         && other.buttonAlignedDropdown == buttonAlignedDropdown
         && other.layoutBehavior == layoutBehavior
-        && other.verticalDirection == verticalDirection;
+        && other.overflowDirection == overflowDirection;
   }
 
   @override
@@ -198,7 +206,7 @@ class ButtonBarThemeData extends Diagnosticable {
         ifTrue: 'dropdown width matches button',
         defaultValue: null));
     properties.add(DiagnosticsProperty<ButtonBarLayoutBehavior>('layoutBehavior', layoutBehavior, defaultValue: null));
-    properties.add(DiagnosticsProperty<VerticalDirection>('verticalDirection', verticalDirection, defaultValue: null));
+    properties.add(DiagnosticsProperty<VerticalDirection>('overflowDirection', overflowDirection, defaultValue: null));
   }
 }
 

--- a/packages/flutter/lib/src/material/button_bar_theme.dart
+++ b/packages/flutter/lib/src/material/button_bar_theme.dart
@@ -38,6 +38,7 @@ class ButtonBarThemeData extends Diagnosticable {
     this.buttonPadding,
     this.buttonAlignedDropdown,
     this.layoutBehavior,
+    this.verticalDirection,
   }) : assert(buttonMinWidth == null || buttonMinWidth >= 0.0),
        assert(buttonHeight == null || buttonHeight >= 0.0);
 
@@ -97,6 +98,10 @@ class ButtonBarThemeData extends Diagnosticable {
   /// constraint or with padding.
   final ButtonBarLayoutBehavior layoutBehavior;
 
+  /// Defines the vertical direction of a [ButtonBar]'s children if it
+  /// overflows.
+  final VerticalDirection verticalDirection;
+
   /// Creates a copy of this object but with the given fields replaced with the
   /// new values.
   ButtonBarThemeData copyWith({
@@ -108,6 +113,7 @@ class ButtonBarThemeData extends Diagnosticable {
     EdgeInsetsGeometry buttonPadding,
     bool buttonAlignedDropdown,
     ButtonBarLayoutBehavior layoutBehavior,
+    VerticalDirection verticalDirection,
   }) {
     return ButtonBarThemeData(
       alignment: alignment ?? this.alignment,
@@ -118,6 +124,7 @@ class ButtonBarThemeData extends Diagnosticable {
       buttonPadding: buttonPadding ?? this.buttonPadding,
       buttonAlignedDropdown: buttonAlignedDropdown ?? this.buttonAlignedDropdown,
       layoutBehavior: layoutBehavior ?? this.layoutBehavior,
+      verticalDirection: verticalDirection ?? this.verticalDirection,
     );
   }
 
@@ -139,6 +146,7 @@ class ButtonBarThemeData extends Diagnosticable {
       buttonPadding: EdgeInsetsGeometry.lerp(a?.buttonPadding, b?.buttonPadding, t),
       buttonAlignedDropdown: t < 0.5 ? a.buttonAlignedDropdown : b.buttonAlignedDropdown,
       layoutBehavior: t < 0.5 ? a.layoutBehavior : b.layoutBehavior,
+      verticalDirection: t < 0.5 ? a.verticalDirection : b.verticalDirection,
     );
   }
 
@@ -153,6 +161,7 @@ class ButtonBarThemeData extends Diagnosticable {
       buttonPadding,
       buttonAlignedDropdown,
       layoutBehavior,
+      verticalDirection,
     );
   }
 
@@ -170,7 +179,8 @@ class ButtonBarThemeData extends Diagnosticable {
         && other.buttonHeight == buttonHeight
         && other.buttonPadding == buttonPadding
         && other.buttonAlignedDropdown == buttonAlignedDropdown
-        && other.layoutBehavior == layoutBehavior;
+        && other.layoutBehavior == layoutBehavior
+        && other.verticalDirection == verticalDirection;
   }
 
   @override
@@ -188,6 +198,7 @@ class ButtonBarThemeData extends Diagnosticable {
         ifTrue: 'dropdown width matches button',
         defaultValue: null));
     properties.add(DiagnosticsProperty<ButtonBarLayoutBehavior>('layoutBehavior', layoutBehavior, defaultValue: null));
+    properties.add(DiagnosticsProperty<VerticalDirection>('verticalDirection', verticalDirection, defaultValue: null));
   }
 }
 

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -334,7 +334,7 @@ class AlertDialog extends StatelessWidget {
   /// bottom and "ends" at the top.
   ///
   /// If null then it will use the surrounding
-  /// [ButtonBarTheme.buttonBarOverflowDirection]. If that is null, it will
+  /// [ButtonBarTheme.overflowDirection]. If that is null, it will
   /// default to [VerticalDirection.down].
   ///
   /// See also:

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -222,6 +222,7 @@ class AlertDialog extends StatelessWidget {
     this.contentTextStyle,
     this.actions,
     this.actionsPadding = EdgeInsets.zero,
+    this.actionsVerticalDirection,
     this.buttonPadding,
     this.backgroundColor,
     this.elevation,
@@ -315,7 +316,23 @@ class AlertDialog extends StatelessWidget {
   /// )
   /// ```
   /// {@end-tool}
+  ///
+  /// See also:
+  ///
+  /// * [ButtonBar], which [actions] configures to lay itself out.
   final EdgeInsetsGeometry actionsPadding;
+
+  /// The vertical direction of [actions] if the children overflow
+  /// horizontally.
+  ///
+  /// If null then it will use the surrounding
+  /// [ButtonBarTheme.verticalDirection]. If that is null, it will
+  /// default to [VerticalDirection.down].
+  ///
+  /// See also:
+  ///
+  /// * [ButtonBar], which [actions] configures to lay itself out.
+  final VerticalDirection actionsVerticalDirection;
 
   /// The padding that surrounds each button in [actions].
   ///
@@ -325,6 +342,10 @@ class AlertDialog extends StatelessWidget {
   /// If this property is null, then it will use the surrounding
   /// [ButtonBarTheme.buttonPadding]. If that is null, it will default to
   /// 8.0 logical pixels on the left and right.
+  ///
+  /// See also:
+  ///
+  /// * [ButtonBar], which [actions] configures to lay itself out.
   final EdgeInsetsGeometry buttonPadding;
 
   /// {@macro flutter.material.dialog.backgroundColor}
@@ -415,6 +436,7 @@ class AlertDialog extends StatelessWidget {
         padding: actionsPadding,
         child: ButtonBar(
           buttonPadding: buttonPadding,
+          verticalDirection: actionsVerticalDirection,
           children: actions,
         ),
       );

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -222,7 +222,7 @@ class AlertDialog extends StatelessWidget {
     this.contentTextStyle,
     this.actions,
     this.actionsPadding = EdgeInsets.zero,
-    this.actionsVerticalDirection,
+    this.actionsOverflowDirection,
     this.buttonPadding,
     this.backgroundColor,
     this.elevation,
@@ -325,14 +325,22 @@ class AlertDialog extends StatelessWidget {
   /// The vertical direction of [actions] if the children overflow
   /// horizontally.
   ///
+  /// If the dialog's [actions] do not fit into a single row, then they
+  /// are arranged in a column. The first action is at the top of the
+  /// column if this property is set to [VerticalDirection.down], since it
+  /// "starts" at the top and "ends" at the bottom. On the other hand,
+  /// the first action will be at the bottom of the column if this
+  /// property is set to [VerticalDirection.up], since it "starts" at the
+  /// bottom and "ends" at the top.
+  ///
   /// If null then it will use the surrounding
-  /// [ButtonBarTheme.verticalDirection]. If that is null, it will
+  /// [ButtonBarTheme.buttonBarOverflowDirection]. If that is null, it will
   /// default to [VerticalDirection.down].
   ///
   /// See also:
   ///
   /// * [ButtonBar], which [actions] configures to lay itself out.
-  final VerticalDirection actionsVerticalDirection;
+  final VerticalDirection actionsOverflowDirection;
 
   /// The padding that surrounds each button in [actions].
   ///
@@ -436,7 +444,7 @@ class AlertDialog extends StatelessWidget {
         padding: actionsPadding,
         child: ButtonBar(
           buttonPadding: buttonPadding,
-          verticalDirection: actionsVerticalDirection,
+          overflowDirection: actionsOverflowDirection,
           children: actions,
         ),
       );

--- a/packages/flutter/test/material/button_bar_test.dart
+++ b/packages/flutter/test/material/button_bar_test.dart
@@ -544,5 +544,34 @@ void main() {
         expect(containerOneRect.left, buttonBarRect.left);
       },
     );
+
+    testWidgets(
+      "ButtonBar's children respects verticalDirection when overflowing",
+      (WidgetTester tester) async {
+        final Key keyOne = UniqueKey();
+        final Key keyTwo = UniqueKey();
+        await tester.pumpWidget(
+          MaterialApp(
+            home: ButtonBar(
+              alignment: MainAxisAlignment.center,
+              // Set padding to zero to align buttons with edge of button bar.
+              buttonPadding: EdgeInsets.zero,
+              // Set the vertical direction to start from the bottom and lay
+              // out upwards.
+              verticalDirection: VerticalDirection.up,
+              children: <Widget>[
+                Container(key: keyOne, height: 50.0, width: 500.0),
+                Container(key: keyTwo, height: 50.0, width: 500.0),
+              ],
+            ),
+          ),
+        );
+
+        final Rect containerOneRect = tester.getRect(find.byKey(keyOne));
+        final Rect containerTwoRect = tester.getRect(find.byKey(keyTwo));
+        // Second [Container] should appear above first container.
+        expect(containerTwoRect.bottom, containerOneRect.top);
+      },
+    );
   });
 }

--- a/packages/flutter/test/material/button_bar_test.dart
+++ b/packages/flutter/test/material/button_bar_test.dart
@@ -558,7 +558,7 @@ void main() {
               buttonPadding: EdgeInsets.zero,
               // Set the vertical direction to start from the bottom and lay
               // out upwards.
-              verticalDirection: VerticalDirection.up,
+              overflowDirection: VerticalDirection.up,
               children: <Widget>[
                 Container(key: keyOne, height: 50.0, width: 500.0),
                 Container(key: keyTwo, height: 50.0, width: 500.0),

--- a/packages/flutter/test/material/button_bar_theme_test.dart
+++ b/packages/flutter/test/material/button_bar_theme_test.dart
@@ -18,7 +18,7 @@ void main() {
     expect(buttonBarTheme.buttonPadding, null);
     expect(buttonBarTheme.buttonAlignedDropdown, null);
     expect(buttonBarTheme.layoutBehavior, null);
-    expect(buttonBarTheme.verticalDirection, null);
+    expect(buttonBarTheme.overflowDirection, null);
   });
 
   test('ThemeData uses default ButtonBarThemeData', () {
@@ -40,7 +40,7 @@ void main() {
       buttonPadding: EdgeInsets.symmetric(vertical: 5.0),
       buttonAlignedDropdown: false,
       layoutBehavior: ButtonBarLayoutBehavior.padded,
-      verticalDirection: VerticalDirection.down,
+      overflowDirection: VerticalDirection.down,
     );
     const ButtonBarThemeData barThemeAccent = ButtonBarThemeData(
       alignment: MainAxisAlignment.center,
@@ -51,7 +51,7 @@ void main() {
       buttonPadding: EdgeInsets.symmetric(horizontal: 10.0),
       buttonAlignedDropdown: true,
       layoutBehavior: ButtonBarLayoutBehavior.constrained,
-      verticalDirection: VerticalDirection.up,
+      overflowDirection: VerticalDirection.up,
     );
 
     final ButtonBarThemeData lerp = ButtonBarThemeData.lerp(barThemePrimary, barThemeAccent, 0.5);
@@ -63,7 +63,7 @@ void main() {
     expect(lerp.buttonPadding, equals(const EdgeInsets.fromLTRB(5.0, 2.5, 5.0, 2.5)));
     expect(lerp.buttonAlignedDropdown, isTrue);
     expect(lerp.layoutBehavior, equals(ButtonBarLayoutBehavior.constrained));
-    expect(lerp.verticalDirection, equals(VerticalDirection.up));
+    expect(lerp.overflowDirection, equals(VerticalDirection.up));
   });
 
   testWidgets('Default ButtonBarThemeData debugFillProperties', (WidgetTester tester) async {
@@ -89,7 +89,7 @@ void main() {
       buttonPadding: EdgeInsets.symmetric(horizontal: 7.3),
       buttonAlignedDropdown: true,
       layoutBehavior: ButtonBarLayoutBehavior.constrained,
-      verticalDirection: VerticalDirection.up,
+      overflowDirection: VerticalDirection.up,
     ).debugFillProperties(builder);
 
     final List<String> description = builder.properties
@@ -106,7 +106,7 @@ void main() {
       'padding: EdgeInsets(7.3, 0.0, 7.3, 0.0)',
       'dropdown width matches button',
       'layoutBehavior: ButtonBarLayoutBehavior.constrained',
-      'verticalDirection: VerticalDirection.up',
+      'overflowDirection: VerticalDirection.up',
     ]);
   });
 

--- a/packages/flutter/test/material/button_bar_theme_test.dart
+++ b/packages/flutter/test/material/button_bar_theme_test.dart
@@ -18,6 +18,7 @@ void main() {
     expect(buttonBarTheme.buttonPadding, null);
     expect(buttonBarTheme.buttonAlignedDropdown, null);
     expect(buttonBarTheme.layoutBehavior, null);
+    expect(buttonBarTheme.verticalDirection, null);
   });
 
   test('ThemeData uses default ButtonBarThemeData', () {
@@ -39,6 +40,7 @@ void main() {
       buttonPadding: EdgeInsets.symmetric(vertical: 5.0),
       buttonAlignedDropdown: false,
       layoutBehavior: ButtonBarLayoutBehavior.padded,
+      verticalDirection: VerticalDirection.down,
     );
     const ButtonBarThemeData barThemeAccent = ButtonBarThemeData(
       alignment: MainAxisAlignment.center,
@@ -49,6 +51,7 @@ void main() {
       buttonPadding: EdgeInsets.symmetric(horizontal: 10.0),
       buttonAlignedDropdown: true,
       layoutBehavior: ButtonBarLayoutBehavior.constrained,
+      verticalDirection: VerticalDirection.up,
     );
 
     final ButtonBarThemeData lerp = ButtonBarThemeData.lerp(barThemePrimary, barThemeAccent, 0.5);
@@ -60,6 +63,7 @@ void main() {
     expect(lerp.buttonPadding, equals(const EdgeInsets.fromLTRB(5.0, 2.5, 5.0, 2.5)));
     expect(lerp.buttonAlignedDropdown, isTrue);
     expect(lerp.layoutBehavior, equals(ButtonBarLayoutBehavior.constrained));
+    expect(lerp.verticalDirection, equals(VerticalDirection.up));
   });
 
   testWidgets('Default ButtonBarThemeData debugFillProperties', (WidgetTester tester) async {
@@ -85,6 +89,7 @@ void main() {
       buttonPadding: EdgeInsets.symmetric(horizontal: 7.3),
       buttonAlignedDropdown: true,
       layoutBehavior: ButtonBarLayoutBehavior.constrained,
+      verticalDirection: VerticalDirection.up,
     ).debugFillProperties(builder);
 
     final List<String> description = builder.properties
@@ -101,6 +106,7 @@ void main() {
       'padding: EdgeInsets(7.3, 0.0, 7.3, 0.0)',
       'dropdown width matches button',
       'layoutBehavior: ButtonBarLayoutBehavior.constrained',
+      'verticalDirection: VerticalDirection.up',
     ]);
   });
 

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -550,7 +550,7 @@ void main() {
           child: const Text('Looooooooooooooong button 2'),
         ),
       ],
-      actionsVerticalDirection: VerticalDirection.up,
+      actionsOverflowDirection: VerticalDirection.up,
     );
 
     await tester.pumpWidget(

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -560,10 +560,10 @@ void main() {
     await tester.tap(find.text('X'));
     await tester.pumpAndSettle();
 
-    final Rect containerOneRect = tester.getRect(find.byKey(key1));
-    final Rect containerTwoRect = tester.getRect(find.byKey(key2));
-    // Second [Container] should appear above first container.
-    expect(containerTwoRect.bottom, containerOneRect.top);
+    final Rect buttonOneRect = tester.getRect(find.byKey(key1));
+    final Rect buttonTwoRect = tester.getRect(find.byKey(key2));
+    // Second [RaisedButton] should appear above the first.
+    expect(buttonTwoRect.bottom, buttonOneRect.top);
   });
 
   testWidgets('Dialogs removes MediaQuery padding and view insets', (WidgetTester tester) async {

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -531,6 +531,41 @@ void main() {
     ); // right
   });
 
+  testWidgets('Dialogs can set the vertical direction of actions', (WidgetTester tester) async {
+    final GlobalKey key1 = GlobalKey();
+    final GlobalKey key2 = GlobalKey();
+
+    final AlertDialog dialog = AlertDialog(
+      title: const Text('title'),
+      content: const Text('content'),
+      actions: <Widget>[
+        RaisedButton(
+          key: key1,
+          onPressed: () {},
+          child: const Text('Looooooooooooooong button 1'),
+        ),
+        RaisedButton(
+          key: key2,
+          onPressed: () {},
+          child: const Text('Looooooooooooooong button 2'),
+        ),
+      ],
+      actionsVerticalDirection: VerticalDirection.up,
+    );
+
+    await tester.pumpWidget(
+      _appWithAlertDialog(tester, dialog),
+    );
+
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
+
+    final Rect containerOneRect = tester.getRect(find.byKey(key1));
+    final Rect containerTwoRect = tester.getRect(find.byKey(key2));
+    // Second [Container] should appear above first container.
+    expect(containerTwoRect.bottom, containerOneRect.top);
+  });
+
   testWidgets('Dialogs removes MediaQuery padding and view insets', (WidgetTester tester) async {
     BuildContext outerContext;
     BuildContext routeContext;


### PR DESCRIPTION
## Description

According to [the Material specification](https://material.io/components/dialogs/#anatomy), it should be possible to set "confirming actions [to] appear above dismissive actions".

![image](https://user-images.githubusercontent.com/27032613/72278104-28b72f00-35e8-11ea-8c3a-1a7b09dded33.png)

The current ButtonBar does not respect vertical direction and does not take in a custom value as a parameter. Hence, it is impossible to get the achieved effect by default, since this is what happens:

### Non-overflow case
![non-overflow](https://user-images.githubusercontent.com/27032613/72278308-96635b00-35e8-11ea-86fd-874e562abebc.png)

### Overflow case
![overflow](https://user-images.githubusercontent.com/27032613/72278309-96fbf180-35e8-11ea-9f14-66b8d7552c1d.png)

This PR fixes that by introducing an optional verticalDirection parameter to achieve that effect. For example, here is the code and the resulting widget:
```dart
AlertDialog(
  title: const Text('title'),
  content: const Text('content'),
  actionsVerticalDirection: VerticalDirection.up,
  actions: <Widget>[
    RaisedButton(
      onPressed: () {},
      child: const Text('Looooong Cancel'),
    ),
    RaisedButton(
      onPressed: () {},
      child: const Text('Looooong Looooong Accept'),
    ),
  ],
),
```

### Achievable after the fix:
![alert-dialog-fix](https://user-images.githubusercontent.com/27032613/72278661-551f7b00-35e9-11ea-932e-1edd0c481c4c.png)

## Related Issues

Fixes https://github.com/flutter/flutter/issues/48727

## Tests

I added the following tests:

- A test for ButtonBarTheme.verticalPadding, updated all other tests to accommodate the new parameter
- A test for ButtonBar.verticalPadding
- A test for AlertDialog.verticalPadding

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
