### PR TITLE
Return the correct number of semantic children for the ListView.separated constructor

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -1051,7 +1051,7 @@ class ListView extends BoxScrollView {
            }
            return widget;
          },
-         childCount: _computeSemanticChildCount(itemCount),
+         childCount: _computeActualChildCount(itemCount),
          addAutomaticKeepAlives: addAutomaticKeepAlives,
          addRepaintBoundaries: addRepaintBoundaries,
          addSemanticIndexes: addSemanticIndexes,
@@ -1069,7 +1069,7 @@ class ListView extends BoxScrollView {
          shrinkWrap: shrinkWrap,
          padding: padding,
          cacheExtent: cacheExtent,
-         semanticChildCount: _computeSemanticChildCount(itemCount),
+         semanticChildCount: itemCount,
        );
 
   /// Creates a scrollable, linear array of widgets with a custom child model.
@@ -1215,8 +1215,8 @@ class ListView extends BoxScrollView {
     properties.add(DoubleProperty('itemExtent', itemExtent, defaultValue: null));
   }
 
-  // Helper method to compute the semantic child count for the separated constructor.
-  static int _computeSemanticChildCount(int itemCount) {
+  // Helper method to compute the actual child count for the separated constructor.
+  static int _computeActualChildCount(int itemCount) {
     return math.max(0, itemCount * 2 - 1);
   }
 }

--- a/packages/flutter/test/widgets/list_view_builder_test.dart
+++ b/packages/flutter/test/widgets/list_view_builder_test.dart
@@ -304,6 +304,54 @@ void main() {
     expect(find.text('s5'), findsNothing);
     expect(find.text('i6'), findsNothing);
   });
+
+
+  testWidgets('ListView.separated uses correct semanticChildCount', (WidgetTester tester) async {
+    Widget buildFrame({int itemCount}) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: ListView.separated(
+          itemCount: itemCount,
+          itemBuilder: (BuildContext context, int index) {
+            return SizedBox(
+              height: 100.0,
+              child: Text('i$index'),
+            );
+          },
+          separatorBuilder: (BuildContext context, int index) {
+            return SizedBox(
+              height: 10.0,
+              child: Text('s$index'),
+            );
+          },
+        ),
+      );
+    }
+
+    Scrollable scrollable() {
+      return tester.widget<Scrollable>(
+        find.descendant(
+          of: find.byType(ListView),
+          matching: find.byType(Scrollable),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame(itemCount: 0));
+    expect(scrollable().semanticChildCount, 0);
+
+    await tester.pumpWidget(buildFrame(itemCount: 1));
+    expect(scrollable().semanticChildCount, 1);
+
+    await tester.pumpWidget(buildFrame(itemCount: 2));
+    expect(scrollable().semanticChildCount, 2);
+
+    await tester.pumpWidget(buildFrame(itemCount: 3));
+    expect(scrollable().semanticChildCount, 3);
+
+    await tester.pumpWidget(buildFrame(itemCount: 4));
+    expect(scrollable().semanticChildCount, 4);
+  });
 }
 
 void check({ List<int> visible = const <int>[], List<int> hidden = const <int>[] }) {


### PR DESCRIPTION
## Description

This change ensures that the `ListView.separated` constructor uses the item count for the `semanticChildCount` instead of also including the separators in that count.

## Related Issues

Closes #31781

## Tests

I added the following tests:

* A test to make sure the `semanticChildCount` of the inner `Scrollable` is correct.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
