### PR TITLE
[flutter_tools] Enable fast start by default

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -188,8 +188,7 @@ class RunCommand extends RunCommandBase {
       )
       ..addFlag('fast-start',
         negatable: true,
-        defaultsTo: false,
-        hide: true,
+        defaultsTo: true,
         help: 'Whether to quickly bootstrap applications with a minimal app. '
               'Currently this is only supported on Android devices. This option '
               'cannot be paired with --use-application-binary.'
@@ -318,10 +317,6 @@ class RunCommand extends RunCommandBase {
       await super.validateCommand();
     }
 
-    if (boolArg('fast-start') && runningWithPrebuiltApplication) {
-      throwToolExit('--fast-start is not supported with --use-application-binary');
-    }
-
     devices = await findAllTargetDevices();
     if (devices == null) {
       throwToolExit(null);
@@ -364,7 +359,9 @@ class RunCommand extends RunCommandBase {
         vmserviceOutFile: stringArg('vmservice-out-file'),
         // Allow forcing fast-start to off to prevent doing more work on devices that
         // don't support it.
-        fastStart: boolArg('fast-start') && devices.every((Device device) => device.supportsFastStart),
+        fastStart: boolArg('fast-start')
+          && !runningWithPrebuiltApplication
+          && devices.every((Device device) => device.supportsFastStart),
       );
     }
   }
@@ -427,12 +424,6 @@ class RunCommand extends RunCommandBase {
     }
 
     for (final Device device in devices) {
-      if (!device.supportsFastStart && boolArg('fast-start')) {
-        globals.printStatus(
-          'Using --fast-start option with device ${device.name}, but this device '
-          'does not support it. Overriding the setting to false.'
-        );
-      }
       if (await device.isLocalEmulator) {
         if (await device.supportsHardwareRendering) {
           final bool enableSoftwareRendering = boolArg('enable-software-rendering') == true;

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -77,7 +77,7 @@ void main() {
         ]);
         fail('Expect exception');
       } catch (e) {
-        expect(e.toString(), contains('--fast-start is not supported with --use-application-binary'));
+        expect(e.toString(), isNot(contains('--fast-start is not supported with --use-application-binary')));
       }
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
@@ -115,10 +115,10 @@ void main() {
       }
 
       final BufferLogger bufferLogger = globals.logger as BufferLogger;
-      expect(bufferLogger.statusText, contains(
+      expect(bufferLogger.statusText, isNot(contains(
         'Using --fast-start option with device mockdevice, but this device '
         'does not support it. Overriding the setting to false.'
-      ));
+      )));
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
       ProcessManager: () => FakeProcessManager.any(),


### PR DESCRIPTION
## Description

Enables fast start by default, with a silent fallback if the device or configuration does not support it. This means iOS and google3 should continue to work as is.