### PR TITLE
[Gallery] Fix text contrast ratio on homepage and contacts demo

### DIFF
--- a/examples/flutter_gallery/lib/demo/contacts_demo.dart
+++ b/examples/flutter_gallery/lib/demo/contacts_demo.dart
@@ -169,9 +169,9 @@ class ContactsDemoState extends State<ContactsDemo> {
                     const DecoratedBox(
                       decoration: BoxDecoration(
                         gradient: LinearGradient(
-                          begin: Alignment(0.0, -1.0),
-                          end: Alignment(0.0, -0.4),
-                          colors: <Color>[Color(0x60000000), Color(0x00000000)],
+                          begin: Alignment.topCenter,
+                          end: Alignment(0, .35),
+                          colors: <Color>[Color(0xC0000000), Color(0x00000000)],
                         ),
                       ),
                     ),

--- a/examples/flutter_gallery/lib/gallery/options.dart
+++ b/examples/flutter_gallery/lib/gallery/options.dart
@@ -194,9 +194,10 @@ class _Heading extends StatelessWidget {
     final ThemeData theme = Theme.of(context);
     return _OptionsItem(
       child: DefaultTextStyle(
-        style: theme.textTheme.body1.copyWith(
+        style: theme.textTheme.title.copyWith(
           fontFamily: 'GoogleSans',
-          color: theme.accentColor,
+          color: theme.colorScheme.onPrimary,
+          fontWeight: FontWeight.w700,
         ),
         child: Semantics(
           child: Text(text),
@@ -525,7 +526,7 @@ class GalleryOptionsPage extends StatelessWidget {
           _TextDirectionItem(options, onOptionsChanged),
           _TimeDilationItem(options, onOptionsChanged),
           const Divider(),
-          const _Heading('Platform mechanics'),
+          const ExcludeSemantics(child: _Heading('Platform mechanics')),
           _PlatformItem(options, onOptionsChanged),
           ..._enabledDiagnosticItems(),
           const Divider(),

--- a/examples/flutter_gallery/test/accessibility_test.dart
+++ b/examples/flutter_gallery/test/accessibility_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:flutter_gallery/gallery/app.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_gallery/demo/all.dart';
 import 'package:flutter_gallery/gallery/themes.dart';
@@ -755,5 +756,14 @@ void main() {
         handle.dispose();
       });
     }
+  });
+
+  group('Gallery home page meets text contrast guidelines', () {
+    testWidgets('options menu', (WidgetTester tester) async {
+      await tester.pumpWidget(const GalleryApp(testMode: true));
+      await tester.tap(find.byTooltip('Toggle options page'));
+      await tester.pumpAndSettle();
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+    });
   });
 }

--- a/examples/flutter_gallery/test/accessibility_test.dart
+++ b/examples/flutter_gallery/test/accessibility_test.dart
@@ -765,5 +765,27 @@ void main() {
       await tester.pumpAndSettle();
       await expectLater(tester, meetsGuideline(textContrastGuideline));
     });
+
+    testWidgets('options menu - dark theme', (WidgetTester tester) async {
+      await tester.pumpWidget(const GalleryApp(testMode: true));
+      await tester.tap(find.byTooltip('Toggle options page'));
+      await tester.pumpAndSettle();
+
+      // Toggle dark mode.
+      final Finder themeToggleContainer = find.ancestor(
+        of: find.text('Theme'),
+        matching: find.byType(Container),
+      );
+      final Finder themeMenuButton = find.descendant(
+        of: themeToggleContainer,
+        matching: find.byIcon(Icons.arrow_drop_down),
+      );
+      await tester.tap(themeMenuButton);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Dark'));
+      await tester.pumpAndSettle();
+
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+    });
   });
 }


### PR DESCRIPTION
## Description

* Updated the options menu on the homepage of the flutter gallery to have larger, bold headings, rather than light blue headings so that the text contrast ratio is more readable. 
* Made gradient darker on the image in the contacts demo to improve the contrast ratio with the app bar buttons.
* Wrapped "Platform Mechanics" header in an `ExcludeSemantics` widget to remove redundant repetition on screen readers.

|| Before      | After |
|--| ----------- | ----------- |
Homepage| ![1gC1UcC11Ns](https://user-images.githubusercontent.com/4229329/72296057-c7628080-3626-11ea-8212-245708ad0bd5.png) | ![ATPp6d3rnHN](https://user-images.githubusercontent.com/4229329/72296096-d812f680-3626-11ea-8ab0-27a18eb5101f.png)|
Contacts Demo|![ue2PTdc2tX7](https://user-images.githubusercontent.com/4229329/72296108-e103c800-3626-11ea-8473-95d0e5c69825.png)|![E5WDFi8HymJ](https://user-images.githubusercontent.com/4229329/72296131-ed882080-3626-11ea-8f27-abc12a3f97b5.png)|

## Related Issues

* closes https://github.com/flutter/flutter/issues/14474.

## Tests

I added the following tests:

* Contrast ratio test for the options menu on the home page of the gallery.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
