### PR TITLE
[Flutter Driver] Extend getText to support more widgets

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -50,3 +50,4 @@ Jefferson Quesado <jeff.quesado@gmail.com>
 Mark Diener <rpzrpzrpz@gmail.com>
 Alek Åström <alek.astrom@gmail.com>
 Efthymios Sarpmpanis <e.sarbanis@gmail.com>
+Cédric Wyss <cedi.wyss@gmail.com>

--- a/packages/flutter_driver/lib/src/extension/extension.dart
+++ b/packages/flutter_driver/lib/src/extension/extension.dart
@@ -545,28 +545,29 @@ class FlutterDriverExtension {
   Future<GetTextResult> _getText(Command command) async {
     final GetText getTextCommand = command as GetText;
     final Finder target = await _waitForElement(_createFinder(getTextCommand.finder));
-    // TODO(yjbanov): support more ways to read text
+
     final Widget widget = target.evaluate().single.widget;
-    switch (widget.runtimeType) {
-      case RichText:
-        final RichText richText = widget as RichText;
-        if (richText.text.runtimeType == TextSpan)
-          return GetTextResult((richText.text as TextSpan).text);
-        break;
-      case EditableText:
-        return GetTextResult((widget as EditableText).controller.text);
-      case TextField:
-        return GetTextResult((widget as TextField).controller.text);
-      case TextFormField:
-        return GetTextResult((widget as TextFormField).controller.text);
-      case Text:
-        return GetTextResult((widget as Text).data);
-      default:
-        break;
+    String text;
+
+    if (widget.runtimeType == Text) {
+      text = (widget as Text).data;
+    } else if (widget.runtimeType == RichText) {
+      final RichText richText = widget as RichText;
+      if (richText.text.runtimeType == TextSpan)
+        text = (richText.text as TextSpan).text;
+    } else if (widget.runtimeType == TextField) {
+      text = (widget as TextField).controller.text;
+    } else if (widget.runtimeType == TextFormField) {
+      text = (widget as TextFormField).controller.text;
+    } else if (widget.runtimeType == EditableText) {
+      text = (widget as EditableText).controller.text;
     }
 
-    throw UnsupportedError(
-        'Type '+widget.runtimeType.toString()+' is currently not supported by getText');
+    if (text == null) {
+      throw UnsupportedError('Type ${widget.runtimeType.toString()} is currently not supported by getText');
+    }
+
+    return GetTextResult(text);
   }
 
   Future<SetTextEntryEmulationResult> _setTextEntryEmulation(Command command) async {

--- a/packages/flutter_driver/lib/src/extension/extension.dart
+++ b/packages/flutter_driver/lib/src/extension/extension.dart
@@ -553,8 +553,9 @@ class FlutterDriverExtension {
       text = (widget as Text).data;
     } else if (widget.runtimeType == RichText) {
       final RichText richText = widget as RichText;
-      if (richText.text.runtimeType == TextSpan)
+      if (richText.text.runtimeType == TextSpan) {
         text = (richText.text as TextSpan).text;
+      }
     } else if (widget.runtimeType == TextField) {
       text = (widget as TextField).controller.text;
     } else if (widget.runtimeType == TextFormField) {

--- a/packages/flutter_driver/lib/src/extension/extension.dart
+++ b/packages/flutter_driver/lib/src/extension/extension.dart
@@ -546,8 +546,27 @@ class FlutterDriverExtension {
     final GetText getTextCommand = command as GetText;
     final Finder target = await _waitForElement(_createFinder(getTextCommand.finder));
     // TODO(yjbanov): support more ways to read text
-    final Text text = target.evaluate().single.widget as Text;
-    return GetTextResult(text.data);
+    final Widget widget = target.evaluate().single.widget;
+    switch (widget.runtimeType) {
+      case RichText:
+        final RichText richText = widget as RichText;
+        if (richText.text.runtimeType == TextSpan)
+          return GetTextResult((richText.text as TextSpan).text);
+        break;
+      case EditableText:
+        return GetTextResult((widget as EditableText).controller.text);
+      case TextField:
+        return GetTextResult((widget as TextField).controller.text);
+      case TextFormField:
+        return GetTextResult((widget as TextFormField).controller.text);
+      case Text:
+        return GetTextResult((widget as Text).data);
+      default:
+        break;
+    }
+
+    throw UnsupportedError(
+        'Type '+widget.runtimeType.toString()+' is currently not supported by getText');
   }
 
   Future<SetTextEntryEmulationResult> _setTextEntryEmulation(Command command) async {

--- a/packages/flutter_driver/test/src/real_tests/extension_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/extension_test.dart
@@ -543,6 +543,66 @@ void main() {
     expect(await getOffset(OffsetType.center), const Offset(40 + (100 / 2), 30 + (120 / 2)));
   });
 
+  testWidgets('getText', (WidgetTester tester) async {
+    await silenceDriverLogger(() async {
+      final FlutterDriverExtension extension = FlutterDriverExtension((String arg) async => '', true);
+
+      Future<String> getTextInternal(SerializableFinder search) async {
+        final Map<String, String> arguments = GetText(search, timeout: const Duration(seconds: 1)).serialize();
+        final Map<String, dynamic> result = await extension.call(arguments);
+        if (result['isError'] as bool) {
+          return null;
+        }
+        return GetTextResult.fromJson(result['response'] as Map<String, dynamic>).text;
+      }
+
+      await tester.pumpWidget(
+          MaterialApp(
+              home: Scaffold(body:Column(
+                key: const ValueKey<String>('column'),
+                children: <Widget>[
+                  Text('Hello1', key: ValueKey<String>('text1')),
+                  Container(
+                      height:25.0,
+                      child: RichText(
+                          key: ValueKey<String>('text2'),
+                          text: TextSpan(text: 'Hello2'))
+                  ),
+                  Container(
+                      height:25.0,
+                      child: EditableText(
+                          key: ValueKey<String>('text3'),
+                          controller: TextEditingController(text: 'Hello3'),
+                          focusNode: FocusNode(),
+                          style: TextStyle(),
+                          cursorColor: Colors.red,
+                          backgroundCursorColor: Colors.black)
+                  ),
+                  Container(
+                      height:25.0,
+                      child: TextField(
+                          key: ValueKey<String>('text4'),
+                          controller: TextEditingController(text: 'Hello4'))
+                  ),
+                  Container(
+                      height:25.0,
+                      child: TextFormField(
+                          key: ValueKey<String>('text5'),
+                          controller: TextEditingController(text: 'Hello5'))
+                  ),
+                ],
+              ))
+          )
+      );
+
+      expect(await getTextInternal(ByValueKey('text1')), 'Hello1');
+      expect(await getTextInternal(ByValueKey('text2')), 'Hello2');
+      expect(await getTextInternal(ByValueKey('text3')), 'Hello3');
+      expect(await getTextInternal(ByValueKey('text4')), 'Hello4');
+      expect(await getTextInternal(ByValueKey('text5')), 'Hello5');
+    });
+  });
+
   testWidgets('descendant finder', (WidgetTester tester) async {
     await silenceDriverLogger(() async {
       final FlutterDriverExtension extension = FlutterDriverExtension((String arg) async => '', true);

--- a/packages/flutter_driver/test/src/real_tests/extension_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/extension_test.dart
@@ -561,35 +561,36 @@ void main() {
               home: Scaffold(body:Column(
                 key: const ValueKey<String>('column'),
                 children: <Widget>[
-                  Text('Hello1', key: ValueKey<String>('text1')),
+                  const Text('Hello1', key: const ValueKey<String>('text1')),
                   Container(
                       height:25.0,
                       child: RichText(
-                          key: ValueKey<String>('text2'),
-                          text: TextSpan(text: 'Hello2'))
+                          key: const ValueKey<String>('text2'),
+                          text: const TextSpan(text: 'Hello2'))
                   ),
                   Container(
                       height:25.0,
                       child: EditableText(
-                          key: ValueKey<String>('text3'),
+                          key: const ValueKey<String>('text3'),
                           controller: TextEditingController(text: 'Hello3'),
                           focusNode: FocusNode(),
-                          style: TextStyle(),
+                          style: const TextStyle(),
                           cursorColor: Colors.red,
                           backgroundCursorColor: Colors.black)
                   ),
                   Container(
                       height:25.0,
                       child: TextField(
-                          key: ValueKey<String>('text4'),
+                          key: const ValueKey<String>('text4'),
                           controller: TextEditingController(text: 'Hello4'))
                   ),
                   Container(
                       height:25.0,
                       child: TextFormField(
-                          key: ValueKey<String>('text5'),
+                          key: const ValueKey<String>('text5'),
                           controller: TextEditingController(text: 'Hello5'))
                   ),
+
                 ],
               ))
           )

--- a/packages/flutter_driver/test/src/real_tests/extension_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/extension_test.dart
@@ -600,6 +600,12 @@ void main() {
       expect(await getTextInternal(ByValueKey('text3')), 'Hello3');
       expect(await getTextInternal(ByValueKey('text4')), 'Hello4');
       expect(await getTextInternal(ByValueKey('text5')), 'Hello5');
+
+      //Check if error thrown for other types
+      final Map<String, String> arguments = GetText(ByValueKey('column'), timeout: const Duration(seconds: 1)).serialize();
+      final Map<String, dynamic> response = await extension.call(arguments);
+      expect(response['isError'], true);
+      expect(response['response'], contains('is currently not supported by getText'));
     });
   });
 

--- a/packages/flutter_driver/test/src/real_tests/extension_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/extension_test.dart
@@ -561,15 +561,16 @@ void main() {
               home: Scaffold(body:Column(
                 key: const ValueKey<String>('column'),
                 children: <Widget>[
-                  const Text('Hello1', key: const ValueKey<String>('text1')),
+                  const Text('Hello1', key: ValueKey<String>('text1')),
                   Container(
-                      height:25.0,
+                      height: 25.0,
                       child: RichText(
                           key: const ValueKey<String>('text2'),
-                          text: const TextSpan(text: 'Hello2'))
+                          text: const TextSpan(text: 'Hello2')
+                      )
                   ),
                   Container(
-                      height:25.0,
+                      height: 25.0,
                       child: EditableText(
                           key: const ValueKey<String>('text3'),
                           controller: TextEditingController(text: 'Hello3'),
@@ -579,18 +580,19 @@ void main() {
                           backgroundCursorColor: Colors.black)
                   ),
                   Container(
-                      height:25.0,
+                      height: 25.0,
                       child: TextField(
                           key: const ValueKey<String>('text4'),
-                          controller: TextEditingController(text: 'Hello4'))
+                          controller: TextEditingController(text: 'Hello4')
+                      )
                   ),
                   Container(
-                      height:25.0,
+                      height: 25.0,
                       child: TextFormField(
                           key: const ValueKey<String>('text5'),
-                          controller: TextEditingController(text: 'Hello5'))
+                          controller: TextEditingController(text: 'Hello5')
+                      )
                   ),
-
                 ],
               ))
           )
@@ -602,7 +604,7 @@ void main() {
       expect(await getTextInternal(ByValueKey('text4')), 'Hello4');
       expect(await getTextInternal(ByValueKey('text5')), 'Hello5');
 
-      //Check if error thrown for other types
+      // Check if error thrown for other types
       final Map<String, String> arguments = GetText(ByValueKey('column'), timeout: const Duration(seconds: 1)).serialize();
       final Map<String, dynamic> response = await extension.call(arguments);
       expect(response['isError'], true);


### PR DESCRIPTION
## Description

As driver.getText is currently limited to Text Widgets only, I added the most common Widgets where this would be handy to receive too.

As so, in addition to Text, now these will work too:
RichText
EditableText
TextField
TextFormField

I am aware of the fact, that this list may still be incomplete and there would probably be a better way of implementing this, but all alternatives would require a lot of rebuilds to be made.

## Related Issues

#16013
#48797

## Tests

Added unit test for the existing (Text) as well as all newly added Widgets and the case with an invalid type.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
