### PR TITLE
Add Semantics link in the SemanticsDebugger

### DIFF
--- a/packages/flutter/lib/src/widgets/semantics_debugger.dart
+++ b/packages/flutter/lib/src/widgets/semantics_debugger.dart
@@ -259,6 +259,10 @@ class _SemanticsDebuggerPainter extends CustomPainter {
       annotations.add('textfield');
       wantsTap = true;
     }
+    if (data.hasFlag(SemanticsFlag.isLink)) {
+      annotations.add('link');
+      wantsTap = true;
+    }
 
     if (data.hasAction(SemanticsAction.tap)) {
       if (!wantsTap)

--- a/packages/flutter/test/widgets/semantics_debugger_test.dart
+++ b/packages/flutter/test/widgets/semantics_debugger_test.dart
@@ -461,6 +461,34 @@ void main() {
     );
   });
 
+  testWidgets('SemanticsDebugger link', (WidgetTester tester) async {
+    final UniqueKey widgetKey = UniqueKey();
+    final UniqueKey debugger = UniqueKey();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SemanticsDebugger(
+          key: debugger,
+          child: Material(
+            child: Semantics(
+              key: widgetKey,
+              label: 'summarized text',
+              link: true,
+              excludeSemantics: true,
+              child: const Text('detailed text'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      _getMessageShownInSemanticsDebugger(
+          widgetKey: widgetKey, debuggerKey: debugger, tester: tester),
+      'summarized text (link; disabled)',
+    );
+  });
+
   testWidgets('SemanticsDebugger label style is used in the painter.', (WidgetTester tester) async {
     final UniqueKey debugger = UniqueKey();
     const TextStyle labelStyle = TextStyle(color: Colors.amber);


### PR DESCRIPTION
## Description

Fixed SemanticsDebugger that does not show Semantics link
Note that lots of diffs are due to dartfmt

## Related Issues

#44543

## Tests

I added the following tests:

Added tests to semantics_debugger_test.dart

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
