### PR TITLE
Set highContrast value from AccessibilityFeatures into MediaQueryData

### DIFF
--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -124,7 +124,7 @@ class MediaQueryData {
       invertColors = window.accessibilityFeatures.invertColors,
       disableAnimations = window.accessibilityFeatures.disableAnimations,
       boldText = window.accessibilityFeatures.boldText,
-      highContrast = false,
+      highContrast = window.accessibilityFeatures.highContrast,
       alwaysUse24HourFormat = window.alwaysUse24HourFormat;
 
   /// The size of the media in logical pixels (e.g, the size of the screen).

--- a/packages/flutter/test/widgets/media_query_test.dart
+++ b/packages/flutter/test/widgets/media_query_test.dart
@@ -67,6 +67,7 @@ void main() {
     expect(data.invertColors, false);
     expect(data.disableAnimations, false);
     expect(data.boldText, false);
+    expect(data.highContrast, false);
     expect(data.platformBrightness, Brightness.light);
     expect(data.physicalDepth, equals(WidgetsBinding.instance.window.physicalDepth));
   });
@@ -87,6 +88,7 @@ void main() {
     expect(copied.invertColors, data.invertColors);
     expect(copied.disableAnimations, data.disableAnimations);
     expect(copied.boldText, data.boldText);
+    expect(copied.highContrast, data.highContrast);
     expect(copied.platformBrightness, data.platformBrightness);
   });
 
@@ -117,6 +119,7 @@ void main() {
       invertColors: true,
       disableAnimations: true,
       boldText: true,
+      highContrast: true,
       platformBrightness: Brightness.dark,
     );
     expect(copied.size, customSize);
@@ -132,6 +135,7 @@ void main() {
     expect(copied.invertColors, true);
     expect(copied.disableAnimations, true);
     expect(copied.boldText, true);
+    expect(copied.highContrast, true);
     expect(copied.platformBrightness, Brightness.dark);
   });
 
@@ -158,6 +162,7 @@ void main() {
           invertColors: true,
           disableAnimations: true,
           boldText: true,
+          highContrast: true,
         ),
         child: Builder(
           builder: (BuildContext context) {
@@ -190,6 +195,7 @@ void main() {
     expect(unpadded.invertColors, true);
     expect(unpadded.disableAnimations, true);
     expect(unpadded.boldText, true);
+    expect(unpadded.highContrast, true);
   });
 
   testWidgets('MediaQuery.removePadding only removes specified padding', (WidgetTester tester) async {
@@ -215,6 +221,7 @@ void main() {
           invertColors: true,
           disableAnimations: true,
           boldText: true,
+          highContrast: true,
         ),
         child: Builder(
           builder: (BuildContext context) {
@@ -244,6 +251,7 @@ void main() {
     expect(unpadded.invertColors, true);
     expect(unpadded.disableAnimations, true);
     expect(unpadded.boldText, true);
+    expect(unpadded.highContrast, true);
   });
 
   testWidgets('MediaQuery.removeViewInsets removes specified viewInsets', (WidgetTester tester) async {
@@ -269,6 +277,7 @@ void main() {
           invertColors: true,
           disableAnimations: true,
           boldText: true,
+          highContrast: true,
         ),
         child: Builder(
           builder: (BuildContext context) {
@@ -301,6 +310,7 @@ void main() {
     expect(unpadded.invertColors, true);
     expect(unpadded.disableAnimations, true);
     expect(unpadded.boldText, true);
+    expect(unpadded.highContrast, true);
   });
 
   testWidgets('MediaQuery.removeViewInsets removes only specified viewInsets', (WidgetTester tester) async {
@@ -326,6 +336,7 @@ void main() {
           invertColors: true,
           disableAnimations: true,
           boldText: true,
+          highContrast: true,
         ),
         child: Builder(
           builder: (BuildContext context) {
@@ -355,6 +366,7 @@ void main() {
     expect(unpadded.invertColors, true);
     expect(unpadded.disableAnimations, true);
     expect(unpadded.boldText, true);
+    expect(unpadded.highContrast, true);
   });
 
   testWidgets('MediaQuery.removeViewPadding removes specified viewPadding', (WidgetTester tester) async {
@@ -380,6 +392,7 @@ void main() {
           invertColors: true,
           disableAnimations: true,
           boldText: true,
+          highContrast: true,
         ),
         child: Builder(
           builder: (BuildContext context) {
@@ -412,6 +425,7 @@ void main() {
     expect(unpadded.invertColors, true);
     expect(unpadded.disableAnimations, true);
     expect(unpadded.boldText, true);
+    expect(unpadded.highContrast, true);
   });
 
   testWidgets('MediaQuery.removeViewPadding removes only specified viewPadding', (WidgetTester tester) async {
@@ -437,6 +451,7 @@ void main() {
           invertColors: true,
           disableAnimations: true,
           boldText: true,
+          highContrast: true,
         ),
         child: Builder(
           builder: (BuildContext context) {
@@ -466,6 +481,7 @@ void main() {
     expect(unpadded.invertColors, true);
     expect(unpadded.disableAnimations, true);
     expect(unpadded.boldText, true);
+    expect(unpadded.highContrast, true);
   });
 
   testWidgets('MediaQuery.textScaleFactorOf', (WidgetTester tester) async {

--- a/packages/flutter_test/test/window_test.dart
+++ b/packages/flutter_test/test/window_test.dart
@@ -256,6 +256,7 @@ class FakeAccessibilityFeatures implements AccessibilityFeatures {
     this.disableAnimations = false,
     this.boldText = false,
     this.reduceMotion = false,
+    this.highContrast = false,
   });
 
   @override
@@ -272,6 +273,9 @@ class FakeAccessibilityFeatures implements AccessibilityFeatures {
 
   @override
   final bool reduceMotion;
+
+  @override
+  final bool highContrast;
 
   /// This gives us some grace time when the dart:ui side adds something to
   /// [AccessibilityFeatures], and makes things easier when we do rolls to


### PR DESCRIPTION
## Description

Part of the efforts to fix the issue #48418 split in a new PR as suggested by @Piinks in #48486

The `highContrast` property is going to be added to the class `AccessibilityFeatures` in the PR: flutter/engine#15343

Here, I set it to the `MediaQueryData` class so it can be used by Flutter developers by querying: `MediaQuery.of(context).highContrast`

Design document: https://flutter.dev/go/cupertino-increase-contrast

## Related Issues

Blocked by: https://github.com/flutter/engine/pull/15343

Fixes: #48418

Related to: https://github.com/flutter/flutter/pull/48486

## Tests

Tests are covered in https://github.com/flutter/flutter/pull/48486

## Checklist

Checklist covered in https://github.com/flutter/flutter/pull/48486

## Breaking Change

Change info covered in https://github.com/flutter/flutter/pull/48486