### PR TITLE
Removed copyWith attribute in SearchDelegate #32180

### DIFF
--- a/examples/flutter_gallery/lib/demo/material/search_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/search_demo.dart
@@ -60,7 +60,7 @@ class _SearchDemoState extends State<SearchDemo> {
                   ? Icons.more_horiz
                   : Icons.more_vert,
             ),
-            onPressed: () {},
+            onPressed: () { },
           ),
         ],
       ),
@@ -86,13 +86,12 @@ class _SearchDemoState extends State<SearchDemo> {
                       Text(' icon in the AppBar'),
                     ],
                   ),
-                  const Text(
-                      'and search for an integer between 0 and 100,000.'),
+                  const Text('and search for an integer between 0 and 100,000.'),
                 ],
               ),
             ),
             const SizedBox(height: 64.0),
-            Text('Last selected integer: ${_lastIntegerSelected ?? 'NONE'}.'),
+            Text('Last selected integer: ${_lastIntegerSelected ?? 'NONE' }.'),
           ],
         ),
       ),
@@ -135,8 +134,7 @@ class _SearchDemoState extends State<SearchDemo> {
 }
 
 class _SearchDemoSearchDelegate extends SearchDelegate<int> {
-  final List<int> _data =
-      List<int>.generate(100001, (int i) => i).reversed.toList();
+  final List<int> _data = List<int>.generate(100001, (int i) => i).reversed.toList();
   final List<int> _history = <int>[42607, 85604, 66374, 44, 174];
 
   @override
@@ -277,8 +275,7 @@ class _SuggestionList extends StatelessWidget {
           title: RichText(
             text: TextSpan(
               text: suggestion.substring(0, query.length),
-              style:
-                  theme.textTheme.subhead.copyWith(fontWeight: FontWeight.bold),
+              style: theme.textTheme.subhead.copyWith(fontWeight: FontWeight.bold),
               children: <TextSpan>[
                 TextSpan(
                   text: suggestion.substring(query.length),

--- a/examples/flutter_gallery/lib/demo/material/search_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/search_demo.dart
@@ -60,7 +60,7 @@ class _SearchDemoState extends State<SearchDemo> {
                   ? Icons.more_horiz
                   : Icons.more_vert,
             ),
-            onPressed: () { },
+            onPressed: () {},
           ),
         ],
       ),
@@ -86,12 +86,13 @@ class _SearchDemoState extends State<SearchDemo> {
                       Text(' icon in the AppBar'),
                     ],
                   ),
-                  const Text('and search for an integer between 0 and 100,000.'),
+                  const Text(
+                      'and search for an integer between 0 and 100,000.'),
                 ],
               ),
             ),
             const SizedBox(height: 64.0),
-            Text('Last selected integer: ${_lastIntegerSelected ?? 'NONE' }.'),
+            Text('Last selected integer: ${_lastIntegerSelected ?? 'NONE'}.'),
           ],
         ),
       ),
@@ -134,7 +135,8 @@ class _SearchDemoState extends State<SearchDemo> {
 }
 
 class _SearchDemoSearchDelegate extends SearchDelegate<int> {
-  final List<int> _data = List<int>.generate(100001, (int i) => i).reversed.toList();
+  final List<int> _data =
+      List<int>.generate(100001, (int i) => i).reversed.toList();
   final List<int> _history = <int>[42607, 85604, 66374, 44, 174];
 
   @override
@@ -153,7 +155,6 @@ class _SearchDemoSearchDelegate extends SearchDelegate<int> {
 
   @override
   Widget buildSuggestions(BuildContext context) {
-
     final Iterable<int> suggestions = query.isEmpty
         ? _history
         : _data.where((int i) => '$i'.startsWith(query));
@@ -276,7 +277,8 @@ class _SuggestionList extends StatelessWidget {
           title: RichText(
             text: TextSpan(
               text: suggestion.substring(0, query.length),
-              style: theme.textTheme.subhead.copyWith(fontWeight: FontWeight.bold),
+              style:
+                  theme.textTheme.subhead.copyWith(fontWeight: FontWeight.bold),
               children: <TextSpan>[
                 TextSpan(
                   text: suggestion.substring(query.length),

--- a/examples/flutter_gallery/lib/demo/material/search_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/search_demo.dart
@@ -153,6 +153,7 @@ class _SearchDemoSearchDelegate extends SearchDelegate<int> {
 
   @override
   Widget buildSuggestions(BuildContext context) {
+
     final Iterable<int> suggestions = query.isEmpty
         ? _history
         : _data.where((int i) => '$i'.startsWith(query));

--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -8,7 +8,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import 'app_bar.dart';
-import 'colors.dart';
 import 'debug.dart';
 import 'input_border.dart';
 import 'input_decorator.dart';

--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -15,6 +15,7 @@ import 'material_localizations.dart';
 import 'scaffold.dart';
 import 'text_field.dart';
 import 'theme.dart';
+import 'colors.dart';
 
 /// Shows a full screen search page and returns the search result selected by
 /// the user when the page is closed.

--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -15,7 +15,6 @@ import 'material_localizations.dart';
 import 'scaffold.dart';
 import 'text_field.dart';
 import 'theme.dart';
-import 'colors.dart';
 
 /// Shows a full screen search page and returns the search result selected by
 /// the user when the page is closed.

--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -193,12 +193,7 @@ abstract class SearchDelegate<T> {
     assert(context != null);
     final ThemeData theme = Theme.of(context);
     assert(theme != null);
-    return theme.copyWith(
-      primaryColor: Colors.white,
-      primaryIconTheme: theme.primaryIconTheme.copyWith(color: Colors.grey),
-      primaryColorBrightness: Brightness.light,
-      primaryTextTheme: theme.textTheme,
-    );
+    return theme;
   }
 
   /// The current query string shown in the [AppBar].

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -46,8 +46,7 @@ void main() {
     expect(selectedResults, <String>['Result']);
   });
 
-  testWidgets('Can close search with system back button to return null',
-      (WidgetTester tester) async {
+  testWidgets('Can close search with system back button to return null', (WidgetTester tester) async {
     // regression test for https://github.com/flutter/flutter/issues/18145
 
     final _TestSearchDelegate delegate = _TestSearchDelegate();
@@ -72,10 +71,8 @@ void main() {
     expect(find.text('Suggestions'), findsOneWidget);
 
     // Simulate system back button
-    final ByteData message =
-        const JSONMethodCodec().encodeMethodCall(const MethodCall('popRoute'));
-    await ServicesBinding.instance.defaultBinaryMessenger
-        .handlePlatformMessage('flutter/navigation', message, (_) {});
+    final ByteData message = const JSONMethodCodec().encodeMethodCall(const MethodCall('popRoute'));
+    await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage('flutter/navigation', message, (_) { });
     await tester.pumpAndSettle();
 
     expect(selectedResults, <void>[null]);
@@ -103,8 +100,8 @@ void main() {
     await tester.tap(find.byTooltip('Search'));
     await tester.pumpAndSettle();
 
-    final TextField textField =
-        tester.widget<TextField>(find.byType(TextField));
+    final TextField textField = tester.widget<TextField>(find.byType(TextField));
+
     final Color hintColor = textField.decoration.hintStyle.color;
     expect(hintColor, delegate.hintTextColor);
   });
@@ -189,8 +186,7 @@ void main() {
     expect(selectedResults, <String>['Result']);
   });
 
-  testWidgets('Can switch between results and suggestions',
-      (WidgetTester tester) async {
+  testWidgets('Can switch between results and suggestions', (WidgetTester tester) async {
     final _TestSearchDelegate delegate = _TestSearchDelegate();
 
     await tester.pumpWidget(TestHomePage(
@@ -260,8 +256,7 @@ void main() {
     expect(textField.focusNode.hasFocus, isFalse);
   });
 
-  testWidgets('Fresh search allways starts with empty query',
-      (WidgetTester tester) async {
+  testWidgets('Fresh search allways starts with empty query', (WidgetTester tester) async {
     final _TestSearchDelegate delegate = _TestSearchDelegate();
 
     await tester.pumpWidget(TestHomePage(
@@ -297,8 +292,7 @@ void main() {
     expect(delegate.query, 'Foo');
   });
 
-  testWidgets('Initial query null re-used previous query',
-      (WidgetTester tester) async {
+  testWidgets('Initial query null re-used previous query', (WidgetTester tester) async {
     final _TestSearchDelegate delegate = _TestSearchDelegate();
 
     delegate.query = 'Foo';
@@ -314,8 +308,7 @@ void main() {
     expect(delegate.query, 'Foo');
   });
 
-  testWidgets('Changing query shows up in search field',
-      (WidgetTester tester) async {
+  testWidgets('Changing query shows up in search field', (WidgetTester tester) async {
     final _TestSearchDelegate delegate = _TestSearchDelegate();
 
     await tester.pumpWidget(TestHomePage(
@@ -337,8 +330,7 @@ void main() {
     expect(find.text('Bar'), findsOneWidget);
   });
 
-  testWidgets('transitionAnimation runs while search fades in/out',
-      (WidgetTester tester) async {
+  testWidgets('transitionAnimation runs while search fades in/out', (WidgetTester tester) async {
     final _TestSearchDelegate delegate = _TestSearchDelegate();
 
     await tester.pumpWidget(TestHomePage(
@@ -367,8 +359,7 @@ void main() {
     expect(delegate.transitionAnimation.status, AnimationStatus.dismissed);
   });
 
-  testWidgets('Closing nested search returns to search',
-      (WidgetTester tester) async {
+  testWidgets('Closing nested search returns to search', (WidgetTester tester) async {
     final List<String> nestedSearchResults = <String>[];
     final _TestSearchDelegate nestedSearchDelegate = _TestSearchDelegate(
       suggestions: 'Nested Suggestions',
@@ -432,9 +423,7 @@ void main() {
     expect(selectedResults, <String>['Result']);
   });
 
-  testWidgets(
-      'Closing search with nested search shown goes back to underlying route',
-      (WidgetTester tester) async {
+  testWidgets('Closing search with nested search shown goes back to underlying route', (WidgetTester tester) async {
     _TestSearchDelegate delegate;
     final List<String> nestedSearchResults = <String>[];
     final _TestSearchDelegate nestedSearchDelegate = _TestSearchDelegate(
@@ -508,11 +497,9 @@ void main() {
 
   testWidgets('Custom searchFieldLabel value', (WidgetTester tester) async {
     const String searchHint = 'custom search hint';
-    final String defaultSearchHint =
-        const DefaultMaterialLocalizations().searchFieldLabel;
+    final String defaultSearchHint = const DefaultMaterialLocalizations().searchFieldLabel;
 
-    final _TestSearchDelegate delegate =
-        _TestSearchDelegate(searchHint: searchHint);
+    final _TestSearchDelegate delegate = _TestSearchDelegate(searchHint: searchHint);
 
     await tester.pumpWidget(TestHomePage(
       delegate: delegate,
@@ -524,10 +511,8 @@ void main() {
     expect(find.text(defaultSearchHint), findsNothing);
   });
 
-  testWidgets('Default searchFieldLabel is used when it is set to null',
-      (WidgetTester tester) async {
-    final String searchHint =
-        const DefaultMaterialLocalizations().searchFieldLabel;
+  testWidgets('Default searchFieldLabel is used when it is set to null', (WidgetTester tester) async {
+    final String searchHint = const DefaultMaterialLocalizations().searchFieldLabel;
 
     final _TestSearchDelegate delegate = _TestSearchDelegate();
 
@@ -540,8 +525,7 @@ void main() {
     expect(find.text(searchHint), findsOneWidget);
   });
 
-  testWidgets('keyboard show search button by default',
-      (WidgetTester tester) async {
+  testWidgets('keyboard show search button by default', (WidgetTester tester) async {
     final _TestSearchDelegate delegate = _TestSearchDelegate();
 
     await tester.pumpWidget(TestHomePage(
@@ -552,15 +536,11 @@ void main() {
 
     await tester.showKeyboard(find.byType(TextField));
 
-    expect(tester.testTextInput.setClientArgs['inputAction'],
-        TextInputAction.search.toString());
+    expect(tester.testTextInput.setClientArgs['inputAction'], TextInputAction.search.toString());
   });
 
-  testWidgets(
-      'Custom textInputAction results in keyboard with corresponding button',
-      (WidgetTester tester) async {
-    final _TestSearchDelegate delegate =
-        _TestSearchDelegate(textInputAction: TextInputAction.done);
+  testWidgets('Custom textInputAction results in keyboard with corresponding button', (WidgetTester tester) async {
+    final _TestSearchDelegate delegate = _TestSearchDelegate(textInputAction: TextInputAction.done);
 
     await tester.pumpWidget(TestHomePage(
       delegate: delegate,
@@ -568,12 +548,11 @@ void main() {
     await tester.tap(find.byTooltip('Search'));
     await tester.pumpAndSettle();
     await tester.showKeyboard(find.byType(TextField));
-    expect(tester.testTextInput.setClientArgs['inputAction'],
-        TextInputAction.done.toString());
+    expect(tester.testTextInput.setClientArgs['inputAction'], TextInputAction.done.toString());
   });
 
   group('contributes semantics', () {
-    TestSemantics buildExpected({String routeName}) {
+    TestSemantics buildExpected({ String routeName }) {
       return TestSemantics.root(
         children: <TestSemantics>[
           TestSemantics(
@@ -610,9 +589,7 @@ void main() {
                           SemanticsFlag.isTextField,
                           SemanticsFlag.isFocused,
                           SemanticsFlag.isHeader,
-                          if (debugDefaultTargetPlatformOverride !=
-                              TargetPlatform.iOS)
-                            SemanticsFlag.namesRoute,
+                          if (debugDefaultTargetPlatformOverride != TargetPlatform.iOS) SemanticsFlag.namesRoute,
                         ],
                         actions: <SemanticsAction>[
                           SemanticsAction.tap,
@@ -621,8 +598,7 @@ void main() {
                         ],
                         label: 'Search',
                         textDirection: TextDirection.ltr,
-                        textSelection:
-                            const TextSelection(baseOffset: 0, extentOffset: 0),
+                        textSelection: const TextSelection(baseOffset: 0, extentOffset: 0),
                       ),
                     ],
                   ),
@@ -656,16 +632,12 @@ void main() {
       await tester.tap(find.byTooltip('Search'));
       await tester.pumpAndSettle();
 
-      expect(
-          semantics,
-          hasSemantics(buildExpected(routeName: 'Search'),
-              ignoreId: true, ignoreRect: true, ignoreTransform: true));
-
+      expect(semantics, hasSemantics(buildExpected(routeName: 'Search'),
+          ignoreId: true, ignoreRect: true, ignoreTransform: true));
       semantics.dispose();
     });
 
-    testWidgets('does not include routeName on iOS',
-        (WidgetTester tester) async {
+    testWidgets('does not include routeName on iOS', (WidgetTester tester) async {
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
       final SemanticsTester semantics = SemanticsTester(tester);
       final _TestSearchDelegate delegate = _TestSearchDelegate();
@@ -676,11 +648,8 @@ void main() {
       await tester.tap(find.byTooltip('Search'));
       await tester.pumpAndSettle();
 
-      expect(
-          semantics,
-          hasSemantics(buildExpected(routeName: ''),
-              ignoreId: true, ignoreRect: true, ignoreTransform: true));
-
+      expect(semantics, hasSemantics(buildExpected(routeName: ''),
+          ignoreId: true, ignoreRect: true, ignoreTransform: true));
       debugDefaultTargetPlatformOverride = null;
       semantics.dispose();
     });
@@ -758,8 +727,7 @@ class _TestSearchDelegate extends SearchDelegate<String> {
     final ThemeData theme = Theme.of(context);
     return theme.copyWith(
       primaryColor: primaryColor,
-      inputDecorationTheme:
-          InputDecorationTheme(hintStyle: TextStyle(color: hintTextColor)),
+      inputDecorationTheme: InputDecorationTheme(hintStyle: TextStyle(color: hintTextColor)),
     );
   }
 

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -46,7 +46,8 @@ void main() {
     expect(selectedResults, <String>['Result']);
   });
 
-  testWidgets('Can close search with system back button to return null', (WidgetTester tester) async {
+  testWidgets('Can close search with system back button to return null',
+      (WidgetTester tester) async {
     // regression test for https://github.com/flutter/flutter/issues/18145
 
     final _TestSearchDelegate delegate = _TestSearchDelegate();
@@ -71,8 +72,10 @@ void main() {
     expect(find.text('Suggestions'), findsOneWidget);
 
     // Simulate system back button
-    final ByteData message = const JSONMethodCodec().encodeMethodCall(const MethodCall('popRoute'));
-    await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage('flutter/navigation', message, (_) { });
+    final ByteData message =
+        const JSONMethodCodec().encodeMethodCall(const MethodCall('popRoute'));
+    await ServicesBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage('flutter/navigation', message, (_) {});
     await tester.pumpAndSettle();
 
     expect(selectedResults, <void>[null]);
@@ -100,9 +103,25 @@ void main() {
     await tester.tap(find.byTooltip('Search'));
     await tester.pumpAndSettle();
 
-    final TextField textField = tester.widget<TextField>(find.byType(TextField));
+    final TextField textField =
+        tester.widget<TextField>(find.byType(TextField));
     final Color hintColor = textField.decoration.hintStyle.color;
     expect(hintColor, delegate.hintTextColor);
+  });
+
+  testWidgets('SearchBar color overridden', (WidgetTester tester) async {
+    final _TestSearchDelegate delegate = _TestSearchDelegate();
+
+    await tester.pumpWidget(TestHomePage(
+      delegate: delegate,
+    ));
+    await tester.tap(find.byTooltip('Search'));
+    await tester.pumpAndSettle();
+
+    final AppBar appBar = tester.widget<AppBar>(find.byType(AppBar));
+    final Color primaryColor = appBar.backgroundColor;
+
+    expect(primaryColor, delegate.primaryColor);
   });
 
   testWidgets('Requests suggestions', (WidgetTester tester) async {
@@ -170,7 +189,8 @@ void main() {
     expect(selectedResults, <String>['Result']);
   });
 
-  testWidgets('Can switch between results and suggestions', (WidgetTester tester) async {
+  testWidgets('Can switch between results and suggestions',
+      (WidgetTester tester) async {
     final _TestSearchDelegate delegate = _TestSearchDelegate();
 
     await tester.pumpWidget(TestHomePage(
@@ -240,7 +260,8 @@ void main() {
     expect(textField.focusNode.hasFocus, isFalse);
   });
 
-  testWidgets('Fresh search allways starts with empty query', (WidgetTester tester) async {
+  testWidgets('Fresh search allways starts with empty query',
+      (WidgetTester tester) async {
     final _TestSearchDelegate delegate = _TestSearchDelegate();
 
     await tester.pumpWidget(TestHomePage(
@@ -276,7 +297,8 @@ void main() {
     expect(delegate.query, 'Foo');
   });
 
-  testWidgets('Initial query null re-used previous query', (WidgetTester tester) async {
+  testWidgets('Initial query null re-used previous query',
+      (WidgetTester tester) async {
     final _TestSearchDelegate delegate = _TestSearchDelegate();
 
     delegate.query = 'Foo';
@@ -292,7 +314,8 @@ void main() {
     expect(delegate.query, 'Foo');
   });
 
-  testWidgets('Changing query shows up in search field', (WidgetTester tester) async {
+  testWidgets('Changing query shows up in search field',
+      (WidgetTester tester) async {
     final _TestSearchDelegate delegate = _TestSearchDelegate();
 
     await tester.pumpWidget(TestHomePage(
@@ -314,7 +337,8 @@ void main() {
     expect(find.text('Bar'), findsOneWidget);
   });
 
-  testWidgets('transitionAnimation runs while search fades in/out', (WidgetTester tester) async {
+  testWidgets('transitionAnimation runs while search fades in/out',
+      (WidgetTester tester) async {
     final _TestSearchDelegate delegate = _TestSearchDelegate();
 
     await tester.pumpWidget(TestHomePage(
@@ -343,7 +367,8 @@ void main() {
     expect(delegate.transitionAnimation.status, AnimationStatus.dismissed);
   });
 
-  testWidgets('Closing nested search returns to search', (WidgetTester tester) async {
+  testWidgets('Closing nested search returns to search',
+      (WidgetTester tester) async {
     final List<String> nestedSearchResults = <String>[];
     final _TestSearchDelegate nestedSearchDelegate = _TestSearchDelegate(
       suggestions: 'Nested Suggestions',
@@ -407,7 +432,9 @@ void main() {
     expect(selectedResults, <String>['Result']);
   });
 
-  testWidgets('Closing search with nested search shown goes back to underlying route', (WidgetTester tester) async {
+  testWidgets(
+      'Closing search with nested search shown goes back to underlying route',
+      (WidgetTester tester) async {
     _TestSearchDelegate delegate;
     final List<String> nestedSearchResults = <String>[];
     final _TestSearchDelegate nestedSearchDelegate = _TestSearchDelegate(
@@ -481,9 +508,11 @@ void main() {
 
   testWidgets('Custom searchFieldLabel value', (WidgetTester tester) async {
     const String searchHint = 'custom search hint';
-    final String defaultSearchHint = const DefaultMaterialLocalizations().searchFieldLabel;
+    final String defaultSearchHint =
+        const DefaultMaterialLocalizations().searchFieldLabel;
 
-    final _TestSearchDelegate delegate = _TestSearchDelegate(searchHint: searchHint);
+    final _TestSearchDelegate delegate =
+        _TestSearchDelegate(searchHint: searchHint);
 
     await tester.pumpWidget(TestHomePage(
       delegate: delegate,
@@ -495,8 +524,10 @@ void main() {
     expect(find.text(defaultSearchHint), findsNothing);
   });
 
-  testWidgets('Default searchFieldLabel is used when it is set to null', (WidgetTester tester) async {
-    final String searchHint = const DefaultMaterialLocalizations().searchFieldLabel;
+  testWidgets('Default searchFieldLabel is used when it is set to null',
+      (WidgetTester tester) async {
+    final String searchHint =
+        const DefaultMaterialLocalizations().searchFieldLabel;
 
     final _TestSearchDelegate delegate = _TestSearchDelegate();
 
@@ -509,7 +540,8 @@ void main() {
     expect(find.text(searchHint), findsOneWidget);
   });
 
-  testWidgets('keyboard show search button by default', (WidgetTester tester) async {
+  testWidgets('keyboard show search button by default',
+      (WidgetTester tester) async {
     final _TestSearchDelegate delegate = _TestSearchDelegate();
 
     await tester.pumpWidget(TestHomePage(
@@ -520,11 +552,15 @@ void main() {
 
     await tester.showKeyboard(find.byType(TextField));
 
-    expect(tester.testTextInput.setClientArgs['inputAction'], TextInputAction.search.toString());
+    expect(tester.testTextInput.setClientArgs['inputAction'],
+        TextInputAction.search.toString());
   });
 
-  testWidgets('Custom textInputAction results in keyboard with corresponding button', (WidgetTester tester) async {
-    final _TestSearchDelegate delegate = _TestSearchDelegate(textInputAction: TextInputAction.done);
+  testWidgets(
+      'Custom textInputAction results in keyboard with corresponding button',
+      (WidgetTester tester) async {
+    final _TestSearchDelegate delegate =
+        _TestSearchDelegate(textInputAction: TextInputAction.done);
 
     await tester.pumpWidget(TestHomePage(
       delegate: delegate,
@@ -532,11 +568,12 @@ void main() {
     await tester.tap(find.byTooltip('Search'));
     await tester.pumpAndSettle();
     await tester.showKeyboard(find.byType(TextField));
-    expect(tester.testTextInput.setClientArgs['inputAction'], TextInputAction.done.toString());
+    expect(tester.testTextInput.setClientArgs['inputAction'],
+        TextInputAction.done.toString());
   });
 
   group('contributes semantics', () {
-    TestSemantics buildExpected({ String routeName }) {
+    TestSemantics buildExpected({String routeName}) {
       return TestSemantics.root(
         children: <TestSemantics>[
           TestSemantics(
@@ -573,7 +610,9 @@ void main() {
                           SemanticsFlag.isTextField,
                           SemanticsFlag.isFocused,
                           SemanticsFlag.isHeader,
-                          if (debugDefaultTargetPlatformOverride != TargetPlatform.iOS) SemanticsFlag.namesRoute,
+                          if (debugDefaultTargetPlatformOverride !=
+                              TargetPlatform.iOS)
+                            SemanticsFlag.namesRoute,
                         ],
                         actions: <SemanticsAction>[
                           SemanticsAction.tap,
@@ -582,7 +621,8 @@ void main() {
                         ],
                         label: 'Search',
                         textDirection: TextDirection.ltr,
-                        textSelection: const TextSelection(baseOffset: 0, extentOffset: 0),
+                        textSelection:
+                            const TextSelection(baseOffset: 0, extentOffset: 0),
                       ),
                     ],
                   ),
@@ -616,13 +656,16 @@ void main() {
       await tester.tap(find.byTooltip('Search'));
       await tester.pumpAndSettle();
 
-      expect(semantics, hasSemantics(buildExpected(routeName: 'Search'),
-          ignoreId: true, ignoreRect: true, ignoreTransform: true));
+      expect(
+          semantics,
+          hasSemantics(buildExpected(routeName: 'Search'),
+              ignoreId: true, ignoreRect: true, ignoreTransform: true));
 
       semantics.dispose();
     });
 
-    testWidgets('does not include routeName on iOS', (WidgetTester tester) async {
+    testWidgets('does not include routeName on iOS',
+        (WidgetTester tester) async {
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
       final SemanticsTester semantics = SemanticsTester(tester);
       final _TestSearchDelegate delegate = _TestSearchDelegate();
@@ -633,8 +676,10 @@ void main() {
       await tester.tap(find.byTooltip('Search'));
       await tester.pumpAndSettle();
 
-      expect(semantics, hasSemantics(buildExpected(routeName: ''),
-          ignoreId: true, ignoreRect: true, ignoreTransform: true));
+      expect(
+          semantics,
+          hasSemantics(buildExpected(routeName: ''),
+              ignoreId: true, ignoreRect: true, ignoreTransform: true));
 
       debugDefaultTargetPlatformOverride = null;
       semantics.dispose();
@@ -706,12 +751,15 @@ class _TestSearchDelegate extends SearchDelegate<String> {
   final String result;
   final List<Widget> actions;
   final Color hintTextColor = Colors.green;
+  final Color primaryColor = Colors.pink;
 
   @override
   ThemeData appBarTheme(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     return theme.copyWith(
-      inputDecorationTheme: InputDecorationTheme(hintStyle: TextStyle(color: hintTextColor)),
+      primaryColor: primaryColor,
+      inputDecorationTheme:
+          InputDecorationTheme(hintStyle: TextStyle(color: hintTextColor)),
     );
   }
 

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -117,7 +117,7 @@ void main() {
     final AppBar appBar = tester.widget<AppBar>(find.byType(AppBar));
     final Color primaryColor = appBar.backgroundColor;
 
-    expect(primaryColor, delegate.primaryColor);
+    expect(primaryColor, Colors.pink);
   });
 
   testWidgets('Requests suggestions', (WidgetTester tester) async {
@@ -772,8 +772,6 @@ class _TestSearchDelegate extends SearchDelegate<String> {
 
 class _TestSearchDelegatePrimaryColor extends SearchDelegate<String> {
   _TestSearchDelegatePrimaryColor();
-
-  final Color primaryColor = Colors.pink;
 
   @override
   Widget buildLeading(BuildContext context) {

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -793,4 +793,3 @@ class _TestSearchDelegatePrimaryColor extends SearchDelegate<String> {
     return <Widget>[];
   }
 }
-

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -101,13 +101,12 @@ void main() {
     await tester.pumpAndSettle();
 
     final TextField textField = tester.widget<TextField>(find.byType(TextField));
-
     final Color hintColor = textField.decoration.hintStyle.color;
     expect(hintColor, delegate.hintTextColor);
   });
 
   testWidgets('SearchBar color overridden', (WidgetTester tester) async {
-    final _TestSearchDelegate2 delegate = _TestSearchDelegate2();
+    final _TestSearchDelegatePrimaryColor delegate = _TestSearchDelegatePrimaryColor();
 
     await tester.pumpWidget(TestHomePage(
       delegate: delegate,
@@ -634,6 +633,7 @@ void main() {
 
       expect(semantics, hasSemantics(buildExpected(routeName: 'Search'),
           ignoreId: true, ignoreRect: true, ignoreTransform: true));
+
       semantics.dispose();
     });
 
@@ -650,6 +650,7 @@ void main() {
 
       expect(semantics, hasSemantics(buildExpected(routeName: ''),
           ignoreId: true, ignoreRect: true, ignoreTransform: true));
+
       debugDefaultTargetPlatformOverride = null;
       semantics.dispose();
     });
@@ -769,55 +770,29 @@ class _TestSearchDelegate extends SearchDelegate<String> {
   }
 }
 
-class _TestSearchDelegate2 extends SearchDelegate<String> {
-  _TestSearchDelegate2({
-    this.suggestions = 'Suggestions',
-    this.result = 'Result',
-    this.actions = const <Widget>[],
-    String searchHint,
-    TextInputAction textInputAction = TextInputAction.search,
-  }) : super(searchFieldLabel: searchHint, textInputAction: textInputAction);
+class _TestSearchDelegatePrimaryColor extends SearchDelegate<String> {
+  _TestSearchDelegatePrimaryColor();
 
-  final String suggestions;
-  final String result;
-  final List<Widget> actions;
   final Color primaryColor = Colors.pink;
-
 
   @override
   Widget buildLeading(BuildContext context) {
-    return IconButton(
-      tooltip: 'Back',
-      icon: const Icon(Icons.arrow_back),
-      onPressed: () {
-        close(context, result);
-      },
-    );
+    return const Text('Leading');
   }
-
-  final List<String> queriesForSuggestions = <String>[];
-  final List<String> queriesForResults = <String>[];
 
   @override
   Widget buildSuggestions(BuildContext context) {
-    queriesForSuggestions.add(query);
-    return MaterialButton(
-      onPressed: () {
-        showResults(context);
-      },
-      child: Text(suggestions),
-    );
+    return const Text('Suggestions');
   }
 
   @override
   Widget buildResults(BuildContext context) {
-    queriesForResults.add(query);
     return const Text('Results');
   }
 
   @override
   List<Widget> buildActions(BuildContext context) {
-    return actions;
+    return <Widget>[];
   }
 }
 

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -107,7 +107,7 @@ void main() {
   });
 
   testWidgets('SearchBar color overridden', (WidgetTester tester) async {
-    final _TestSearchDelegate delegate = _TestSearchDelegate();
+    final _TestSearchDelegate2 delegate = _TestSearchDelegate2();
 
     await tester.pumpWidget(TestHomePage(
       delegate: delegate,
@@ -673,6 +673,9 @@ class TestHomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      theme: ThemeData(
+        primaryColor: Colors.pink,
+      ),
       home: Builder(builder: (BuildContext context) {
         return Scaffold(
           appBar: AppBar(
@@ -720,13 +723,11 @@ class _TestSearchDelegate extends SearchDelegate<String> {
   final String result;
   final List<Widget> actions;
   final Color hintTextColor = Colors.green;
-  final Color primaryColor = Colors.pink;
 
   @override
   ThemeData appBarTheme(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     return theme.copyWith(
-      primaryColor: primaryColor,
       inputDecorationTheme: InputDecorationTheme(hintStyle: TextStyle(color: hintTextColor)),
     );
   }
@@ -767,3 +768,56 @@ class _TestSearchDelegate extends SearchDelegate<String> {
     return actions;
   }
 }
+
+class _TestSearchDelegate2 extends SearchDelegate<String> {
+  _TestSearchDelegate2({
+    this.suggestions = 'Suggestions',
+    this.result = 'Result',
+    this.actions = const <Widget>[],
+    String searchHint,
+    TextInputAction textInputAction = TextInputAction.search,
+  }) : super(searchFieldLabel: searchHint, textInputAction: textInputAction);
+
+  final String suggestions;
+  final String result;
+  final List<Widget> actions;
+  final Color primaryColor = Colors.pink;
+
+
+  @override
+  Widget buildLeading(BuildContext context) {
+    return IconButton(
+      tooltip: 'Back',
+      icon: const Icon(Icons.arrow_back),
+      onPressed: () {
+        close(context, result);
+      },
+    );
+  }
+
+  final List<String> queriesForSuggestions = <String>[];
+  final List<String> queriesForResults = <String>[];
+
+  @override
+  Widget buildSuggestions(BuildContext context) {
+    queriesForSuggestions.add(query);
+    return MaterialButton(
+      onPressed: () {
+        showResults(context);
+      },
+      child: Text(suggestions),
+    );
+  }
+
+  @override
+  Widget buildResults(BuildContext context) {
+    queriesForResults.add(query);
+    return const Text('Results');
+  }
+
+  @override
+  List<Widget> buildActions(BuildContext context) {
+    return actions;
+  }
+}
+


### PR DESCRIPTION
## Description

Removed copyWith attribute in SearchDelegate because it was forcing users to use those attributes. This would cause problems when users wanted to create a custom dark search delegate.

## Related Issues

Closes #32180 

## Tests

I added the following tests:

Added test to search_test.dart to see if you can change the colour of the search bar.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
