### PR TITLE
[flutter_tools] Support linux release build

### DIFF
--- a/packages/flutter_tools/bin/tool_backend.dart
+++ b/packages/flutter_tools/bin/tool_backend.dart
@@ -47,10 +47,15 @@ or
           if (localEngine != null) '--local-engine=$localEngine',
           'assemble',
           '-dTargetPlatform=$targetPlatform',
-          '-dBuildMode=debug',
+          '-dBuildMode=$buildMode',
           '-dTargetFile=$flutterTarget',
           '--output=build',
-          'debug_bundle_linux_assets',
+          if (buildMode == 'debug')
+            'debug_bundle_linux_assets'
+          else if (buildMode == 'release')
+            'release_bundle_linux_assets'
+          else if (buildMode == 'profile')
+            'profile_bundle_linux_assets'
         ]);
     if (unpackResult.exitCode != 0) {
       stderr.write(unpackResult.stderr);

--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -345,6 +345,7 @@ class AOTSnapshotter {
       TargetPlatform.android_x64,
       TargetPlatform.ios,
       TargetPlatform.darwin_x64,
+      TargetPlatform.linux_x64,
     ].contains(platform);
   }
 

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -35,7 +35,6 @@ const List<Target> _kDefaultTargets = <Target>[
   DebugMacOSBundleFlutterAssets(),
   ProfileMacOSBundleFlutterAssets(),
   ReleaseMacOSBundleFlutterAssets(),
-  DebugBundleLinuxAssets(),
   WebServiceWorker(),
   DebugAndroidApplication(),
   FastStartAndroidApplication(),
@@ -52,6 +51,10 @@ const List<Target> _kDefaultTargets = <Target>[
   androidArmReleaseBundle,
   androidArm64ReleaseBundle,
   androidx64ReleaseBundle,
+  // Linux specific targets
+  DebugBundleLinuxAssets(),
+  ProfileBundleLinuxAssets(),
+  ReleaseBundleLinuxAssets(),
 ];
 
 /// Assemble provides a low level API to interact with the flutter tool build

--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
+++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
@@ -39,15 +39,6 @@ export PROJECT_DIR=${linuxProject.project.directory.path}
     ..createSync(recursive: true)
     ..writeAsStringSync(buffer.toString());
 
-  if (!buildInfo.isDebug) {
-    const String warning = '🚧 ';
-    globals.printStatus(warning * 20);
-    globals.printStatus('Warning: Only debug is currently implemented for Linux. This is effectively a debug build.');
-    globals.printStatus('See https://github.com/flutter/flutter/issues/38478 for details and updates.');
-    globals.printStatus(warning * 20);
-    globals.printStatus('');
-  }
-
   // Invoke make.
   final String buildFlag = getNameForBuildMode(buildInfo.mode ?? BuildMode.release);
   final Stopwatch sw = Stopwatch()..start();

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
@@ -225,24 +225,6 @@ BINARY_NAME=fizz_bar
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: false),
   });
 
-  testUsingContext('Release build prints an under-construction warning', () async {
-    final BuildCommand command = BuildCommand();
-    applyMocksToCommand(command);
-    setUpMockProjectFilesForBuild();
-    expectMakeInvocationWithMode('release');
-
-    await createTestCommandRunner(command).run(
-      const <String>['build', 'linux']
-    );
-
-    expect(testLogger.statusText, contains('🚧'));
-  }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(),
-    ProcessManager: () => mockProcessManager,
-    Platform: () => linuxPlatform,
-    FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
-  });
-
   testUsingContext('hidden when not enabled on Linux host', () {
     when(globals.platform.isLinux).thenReturn(true);
 


### PR DESCRIPTION
## Description

All of the necessary tool changes for linux release/profile builds for local-engine. If we want to wait for cached artifacts support, then this will also need to wait for recipe changes.

Fixes https://github.com/flutter/flutter/issues/39665
Fixes https://github.com/flutter/flutter/issues/38478

No changes needed to linux template