### PR TITLE
Add very large text scale support for time picker

### DIFF
--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -263,7 +263,11 @@ class _DayPeriodControl extends StatelessWidget {
               heightFactor: 1,
               child: Semantics(
                 selected: amSelected,
-                child: Text(materialLocalizations.anteMeridiemAbbreviation, style: amStyle, textScaleFactor: buttonTextScaleFactor),
+                child: Text(
+                    materialLocalizations.anteMeridiemAbbreviation,
+                    style: amStyle,
+                    textScaleFactor: buttonTextScaleFactor,
+                ),
               ),
             ),
           ),
@@ -286,7 +290,11 @@ class _DayPeriodControl extends StatelessWidget {
               heightFactor: 1,
               child: Semantics(
                 selected: !amSelected,
-                child: Text(materialLocalizations.postMeridiemAbbreviation, style: pmStyle, textScaleFactor: buttonTextScaleFactor),
+                child: Text(
+                    materialLocalizations.postMeridiemAbbreviation,
+                    style: pmStyle,
+                    textScaleFactor: buttonTextScaleFactor,
+                ),
               ),
             ),
           ),
@@ -385,7 +393,12 @@ class _HourControl extends StatelessWidget {
           type: MaterialType.transparency,
           child: InkWell(
             onTap: Feedback.wrapForTap(() => fragmentContext.onModeChange(_TimePickerMode.hour), context),
-            child: Text(formattedHour, style: hourStyle, textAlign: TextAlign.end, textScaleFactor: 1.0,),
+            child: Text(
+              formattedHour,
+              style: hourStyle,
+              textAlign: TextAlign.end,
+              textScaleFactor: 1.0,
+            ),
           ),
         ),
       ),

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -1328,7 +1328,7 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
 
   _TappableLabel _buildTappableLabel(TextTheme textTheme, int value, String label, VoidCallback onTap) {
     final TextStyle style = textTheme.subhead;
-    final labelScaleFactor = math.min(MediaQuery.of(context).textScaleFactor, 2.0);
+    final double labelScaleFactor = math.min(MediaQuery.of(context).textScaleFactor, 2.0);
     return _TappableLabel(
       value: value,
       painter: TextPainter(

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -1328,13 +1328,13 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
 
   _TappableLabel _buildTappableLabel(TextTheme textTheme, int value, String label, VoidCallback onTap) {
     final TextStyle style = textTheme.subhead;
-    // TODO(abarth): Handle textScaleFactor.
-    // https://github.com/flutter/flutter/issues/5939
+    final labelScaleFactor = math.min(MediaQuery.of(context).textScaleFactor, 2.0);
     return _TappableLabel(
       value: value,
       painter: TextPainter(
         text: TextSpan(style: style, text: label),
         textDirection: TextDirection.ltr,
+        textScaleFactor: labelScaleFactor,
       )..layout(),
       onTap: onTap,
     );

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -247,6 +247,8 @@ class _DayPeriodControl extends StatelessWidget {
     );
     final bool layoutPortrait = orientation == Orientation.portrait;
 
+    final double buttonTextScaleFactor = math.min(MediaQuery.of(context).textScaleFactor, 2.0);
+
     final Widget amButton = ConstrainedBox(
       constraints: _kMinTappableRegion,
       child: Material(
@@ -261,7 +263,7 @@ class _DayPeriodControl extends StatelessWidget {
               heightFactor: 1,
               child: Semantics(
                 selected: amSelected,
-                child: Text(materialLocalizations.anteMeridiemAbbreviation, style: amStyle),
+                child: Text(materialLocalizations.anteMeridiemAbbreviation, style: amStyle, textScaleFactor: buttonTextScaleFactor),
               ),
             ),
           ),
@@ -284,7 +286,7 @@ class _DayPeriodControl extends StatelessWidget {
               heightFactor: 1,
               child: Semantics(
                 selected: !amSelected,
-                child: Text(materialLocalizations.postMeridiemAbbreviation, style: pmStyle),
+                child: Text(materialLocalizations.postMeridiemAbbreviation, style: pmStyle, textScaleFactor: buttonTextScaleFactor),
               ),
             ),
           ),
@@ -383,7 +385,7 @@ class _HourControl extends StatelessWidget {
           type: MaterialType.transparency,
           child: InkWell(
             onTap: Feedback.wrapForTap(() => fragmentContext.onModeChange(_TimePickerMode.hour), context),
-            child: Text(formattedHour, style: hourStyle, textAlign: TextAlign.end),
+            child: Text(formattedHour, style: hourStyle, textAlign: TextAlign.end, textScaleFactor: 1.0,),
           ),
         ),
       ),
@@ -404,7 +406,7 @@ class _StringFragment extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ExcludeSemantics(
-      child: Text(value, style: fragmentContext.inactiveStyle),
+      child: Text(value, style: fragmentContext.inactiveStyle, textScaleFactor: 1.0),
     );
   }
 }
@@ -453,7 +455,7 @@ class _MinuteControl extends StatelessWidget {
           type: MaterialType.transparency,
           child: InkWell(
             onTap: Feedback.wrapForTap(() => fragmentContext.onModeChange(_TimePickerMode.minute), context),
-            child: Text(formattedMinute, style: minuteStyle, textAlign: TextAlign.start),
+            child: Text(formattedMinute, style: minuteStyle, textAlign: TextAlign.start, textScaleFactor: 1.0),
           ),
         ),
       ),

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -261,6 +261,7 @@ void _tests() {
     WidgetTester tester,
     bool alwaysUse24HourFormat, {
     TimeOfDay initialTime = const TimeOfDay(hour: 7, minute: 0),
+    double textScaleFactor = 1.0,
   }) async {
     await tester.pumpWidget(
       Localizations(
@@ -270,7 +271,10 @@ void _tests() {
           DefaultWidgetsLocalizations.delegate,
         ],
         child: MediaQuery(
-          data: MediaQueryData(alwaysUse24HourFormat: alwaysUse24HourFormat),
+          data: MediaQueryData(
+            alwaysUse24HourFormat: alwaysUse24HourFormat,
+            textScaleFactor: textScaleFactor,
+          ),
           child: Material(
             child: Directionality(
               textDirection: TextDirection.ltr,
@@ -688,6 +692,54 @@ void _tests() {
 
     expect(rootObserver.pickerCount, 0);
     expect(nestedObserver.pickerCount, 1);
+  });
+
+  testWidgets('no overflow with largest text scale',
+      (WidgetTester tester) async {
+    Widget buildFrame(double textScaleFactor) {
+      return MaterialApp(
+        home: Material(
+          child: MediaQuery(
+            data: MediaQueryData(textScaleFactor: textScaleFactor),
+            child: Center(
+              child: Builder(
+                builder: (BuildContext context) {
+                  return RaisedButton(
+                    child: const Text('X'),
+                    onPressed: () {
+                      showTimePicker(
+                        context: context,
+                        initialTime: const TimeOfDay(hour: 7, minute: 0),
+                        builder: (BuildContext context, Widget child) {
+                          return child;
+                        },
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    await mediaQueryBoilerplate(tester, false,
+        textScaleFactor: 1.0,
+        initialTime: const TimeOfDay(hour: 7, minute: 41));
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
+    expect(tester.getSize(find.text('41')).height, equals(50));
+
+    await tester.tap(find.text('OK')); // dismiss the dialog
+    await tester.pumpAndSettle();
+
+    await mediaQueryBoilerplate(tester, false,
+        textScaleFactor: 2.0,
+        initialTime: const TimeOfDay(hour: 7, minute: 41));
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
+    expect(tester.getSize(find.text('41')).height, equals(100));
   });
 }
 

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -696,8 +696,12 @@ void _tests() {
 
   testWidgets('text scale affects certain elements and not others',
       (WidgetTester tester) async {
-    await mediaQueryBoilerplate(tester, false, textScaleFactor: 1.0,
-        initialTime: const TimeOfDay(hour: 7, minute: 41));
+    await mediaQueryBoilerplate(
+        tester,
+        false,
+        textScaleFactor: 1.0,
+        initialTime: const TimeOfDay(hour: 7, minute: 41),
+    );
     await tester.tap(find.text('X'));
     await tester.pumpAndSettle();
 
@@ -708,8 +712,12 @@ void _tests() {
     await tester.pumpAndSettle();
 
     // Verify that the time display is not affected by text scale.
-    await mediaQueryBoilerplate(tester, false, textScaleFactor: 2.0,
-        initialTime: const TimeOfDay(hour: 7, minute: 41));
+    await mediaQueryBoilerplate(
+        tester,
+        false,
+        textScaleFactor: 2.0,
+        initialTime: const TimeOfDay(hour: 7, minute: 41),
+    );
     await tester.tap(find.text('X'));
     await tester.pumpAndSettle();
 
@@ -720,8 +728,12 @@ void _tests() {
     await tester.pumpAndSettle();
 
     // Verify that text scale for AM/PM is at most 2x.
-    await mediaQueryBoilerplate(tester, false, textScaleFactor: 3.0,
-        initialTime: const TimeOfDay(hour: 7, minute: 41));
+    await mediaQueryBoilerplate(
+        tester,
+        false,
+        textScaleFactor: 3.0,
+        initialTime: const TimeOfDay(hour: 7, minute: 41),
+    );
     await tester.tap(find.text('X'));
     await tester.pumpAndSettle();
 


### PR DESCRIPTION
## Description

This PR adds support for very large text scales (called "Larger Accessibility Sizes" on iOS). 

### Before

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-01-14 at 16 26 09](https://user-images.githubusercontent.com/6655696/72384022-a95e5400-36ea-11ea-8701-cb2d625fcdfa.png)
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-01-14 at 16 26 05](https://user-images.githubusercontent.com/6655696/72384163-dc084c80-36ea-11ea-98fa-481b54eb78c7.png)


### After

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-01-14 at 16 24 33](https://user-images.githubusercontent.com/6655696/72384051-b67b4300-36ea-11ea-9d2b-8a00a8914718.png)
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-01-14 at 16 24 37](https://user-images.githubusercontent.com/6655696/72384131-cc890380-36ea-11ea-9aea-bb7683804dca.png)


## Related Issues

Closes #5939 

## Tests

I added a test which ensures that certain elements are not affected by text scale (i.e. they are already large, like the time display), while others grow to a reasonable size.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
