### PR TITLE
Exclude modal barrier Semantics in Drawer on Android

### DIFF
--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -542,18 +542,20 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
           child: Stack(
             children: <Widget>[
               BlockSemantics(
-                child: GestureDetector(
+                child: ExcludeSemantics(
                   // On Android, the back button is used to dismiss a modal.
-                  excludeFromSemantics: platformHasBackButton,
-                  onTap: close,
-                  child: Semantics(
-                    label: MaterialLocalizations.of(context)?.modalBarrierDismissLabel,
-                    child: MouseRegion(
-                      opaque: true,
-                      child: Container( // The drawer's "scrim"
-                        color: _scrimColorTween.evaluate(_controller),
+                  excluding: platformHasBackButton,
+                  child: GestureDetector(
+                    onTap: close,
+                    child: Semantics(
+                      label: MaterialLocalizations.of(context)?.modalBarrierDismissLabel,
+                      child: MouseRegion(
+                        opaque: true,
+                        child: Container( // The drawer's "scrim"
+                          color: _scrimColorTween.evaluate(_controller),
+                        ),
                       ),
-                    )
+                    ),
                   ),
                 ),
               ),

--- a/packages/flutter/test/widgets/drawer_test.dart
+++ b/packages/flutter/test/widgets/drawer_test.dart
@@ -328,6 +328,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 100));
 
     expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.tap]));
+    expect(semantics, includesNodeWith(label: 'Dismiss'));
 
     semantics.dispose();
 
@@ -357,6 +358,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 100));
 
     expect(semantics, isNot(includesNodeWith(actions: <SemanticsAction>[SemanticsAction.tap])));
+    expect(semantics, isNot(includesNodeWith(label: 'Dismiss')));
 
     semantics.dispose();
   });


### PR DESCRIPTION
## Description

Right now the semantics of the modal barrier for Drawer is visible and accessible for Android even though that is not intended behavior. The way to close the Drawer is via the back button. This change makes sure the dismiss semantics barrier does not show up on Android.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/39896

## Tests

I added the following tests:

"Dismissible ModalBarrier includes button in semantic tree on iOS" test/widgets/drawer_test.dart

"Dismissible ModalBarrier is hidden on Android (back button is used to dismiss)" test/widgets/drawer_test.dart

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
