### PR TITLE
Require Visual Studio 2019 for Windows

### DIFF
--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -196,7 +196,11 @@ class UserMessages {
   String visualStudioMissing(String workload, List<String> components) =>
       'Visual Studio not installed; this is necessary for Windows development.\n'
       'Download at https://visualstudio.microsoft.com/downloads/.\n'
-      'Please install the "$workload" workload, including following components:\n  ${components.join('\n  ')}';
+      'Please install the "$workload" workload, including the following components:\n  ${components.join('\n  ')}';
+  String visualStudioTooOld(String minimumVersion, String workload, List<String> components) =>
+      'Visual Studio $minimumVersion or later is required.\n'
+      'Download at https://visualstudio.microsoft.com/downloads/.\n'
+      'Please install the "$workload" workload, including the following components:\n  ${components.join('\n  ')}';
   String get visualStudioIsPrerelease => 'The current Visual Studio installation is a pre-release version. It may not be '
       'supported by Flutter yet.';
   String get visualStudioNotLaunchable =>

--- a/packages/flutter_tools/lib/src/windows/visual_studio_validator.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio_validator.dart
@@ -12,10 +12,6 @@ VisualStudioValidator get visualStudioValidator => context.get<VisualStudioValid
 class VisualStudioValidator extends DoctorValidator {
   const VisualStudioValidator() : super('Visual Studio - develop for Windows');
 
-  int get majorVersion => visualStudio.fullVersion != null
-      ? int.tryParse(visualStudio.fullVersion.split('.')[0])
-      : null;
-
   @override
   Future<ValidationResult> validate() async {
     final List<ValidationMessage> messages = <ValidationMessage>[];
@@ -39,7 +35,16 @@ class VisualStudioValidator extends DoctorValidator {
       }
 
       // Messages for faulty installations.
-      if (visualStudio.isRebootRequired) {
+      if (!visualStudio.isAtLeastMinimumVersion) {
+        status = ValidationType.partial;
+        messages.add(ValidationMessage.error(
+            userMessages.visualStudioTooOld(
+                visualStudio.minimumVersionDescription,
+                visualStudio.workloadDescription,
+                visualStudio.necessaryComponentDescriptions(),
+            ),
+        ));
+      } else if (visualStudio.isRebootRequired) {
         status = ValidationType.partial;
         messages.add(ValidationMessage.error(userMessages.visualStudioRebootRequired));
       } else if (!visualStudio.isComplete) {
@@ -48,12 +53,12 @@ class VisualStudioValidator extends DoctorValidator {
       } else if (!visualStudio.isLaunchable) {
         status = ValidationType.partial;
         messages.add(ValidationMessage.error(userMessages.visualStudioNotLaunchable));
-      } else  if (!visualStudio.hasNecessaryComponents) {
+      } else if (!visualStudio.hasNecessaryComponents) {
         status = ValidationType.partial;
         messages.add(ValidationMessage.error(
             userMessages.visualStudioMissingComponents(
                 visualStudio.workloadDescription,
-                visualStudio.necessaryComponentDescriptions(majorVersion),
+                visualStudio.necessaryComponentDescriptions(),
             ),
         ));
       }
@@ -63,7 +68,7 @@ class VisualStudioValidator extends DoctorValidator {
       messages.add(ValidationMessage.error(
         userMessages.visualStudioMissing(
           visualStudio.workloadDescription,
-          visualStudio.necessaryComponentDescriptions(majorVersion),
+          visualStudio.necessaryComponentDescriptions(),
         ),
       ));
     }

--- a/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
@@ -48,14 +48,28 @@ void main() {
     },
   };
 
-  // A version of a response that doesn't include certain installation status
-  // information that might be missing in older Visual Studio versions.
-  const Map<String, dynamic> _missingStatusResponse = <String, dynamic>{
+  // A response for a VS installation that's too old.
+  const Map<String, dynamic> _tooOldResponse = <String, dynamic>{
     'installationPath': visualStudioPath,
     'displayName': 'Visual Studio Community 2017',
     'installationVersion': '15.9.28307.665',
+    'isRebootRequired': false,
+    'isComplete': true,
+    'isLaunchable': true,
+    'isPrerelease': false,
     'catalog': <String, dynamic>{
       'productDisplayVersion': '15.9.12',
+    },
+  };
+
+  // A version of a response that doesn't include certain installation status
+  // information that might be missing in older vswhere.
+  const Map<String, dynamic> _missingStatusResponse = <String, dynamic>{
+    'installationPath': visualStudioPath,
+    'displayName': 'Visual Studio Community 2017',
+    'installationVersion': '16.4.29609.76',
+    'catalog': <String, dynamic>{
+      'productDisplayVersion': '16.4.1',
     },
   };
 
@@ -108,13 +122,13 @@ void main() {
   // Sets whether or not a vswhere query with the required components will
   // return an installation.
   void setMockCompatibleVisualStudioInstallation(Map<String, dynamic>response) {
-    setMockVswhereResponse(_requiredComponents, null, response);
+    setMockVswhereResponse(_requiredComponents, <String>['-version', '16'], response);
   }
 
   // Sets whether or not a vswhere query with the required components will
   // return a pre-release installation.
   void setMockPrereleaseVisualStudioInstallation(Map<String, dynamic>response) {
-    setMockVswhereResponse(_requiredComponents, <String>['-prerelease'], response);
+    setMockVswhereResponse(_requiredComponents, <String>['-version', '16', '-prerelease'], response);
   }
 
   // Sets whether or not a vswhere query searching for 'all' and 'prerelease'
@@ -200,6 +214,7 @@ void main() {
 
       visualStudio = VisualStudio();
       expect(visualStudio.isInstalled, false);
+      expect(visualStudio.isAtLeastMinimumVersion, false);
       expect(visualStudio.hasNecessaryComponents, false);
       expect(visualStudio.isComplete, false);
       expect(visualStudio.isRebootRequired, false);
@@ -214,21 +229,25 @@ void main() {
       Platform: () => windowsPlatform,
     });
 
-    testUsingContext('necessaryComponentDescriptions suggest the right VS tools on major version 15', () {
+    testUsingContext('necessaryComponentDescriptions suggest the right VS tools on major version 16', () {
+      setMockCompatibleVisualStudioInstallation(_defaultResponse);
 
       visualStudio = VisualStudio();
-      final String toolsString = visualStudio.necessaryComponentDescriptions(15)[1];
-      expect(toolsString.contains('v141'), true);
+      final String toolsString = visualStudio.necessaryComponentDescriptions()[1];
+      expect(toolsString.contains('v142'), true);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFilesystem,
       ProcessManager: () => mockProcessManager,
       Platform: () => windowsPlatform,
     });
 
-    testUsingContext('necessaryComponentDescriptions suggest the right VS tools on major version != 15', () {
+    testUsingContext('necessaryComponentDescriptions suggest the right VS tools on an old version', () {
+      setMockCompatibleVisualStudioInstallation(null);
+      setMockPrereleaseVisualStudioInstallation(null);
+      setMockAnyVisualStudioInstallation(_tooOldResponse);
 
       visualStudio = VisualStudio();
-      final String toolsString = visualStudio.necessaryComponentDescriptions(16)[1];
+      final String toolsString = visualStudio.necessaryComponentDescriptions()[1];
       expect(toolsString.contains('v142'), true);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFilesystem,
@@ -262,6 +281,19 @@ void main() {
       Platform: () => windowsPlatform,
     });
 
+    testUsingContext('isInstalled returns true when VS is present but too old', () {
+      setMockCompatibleVisualStudioInstallation(null);
+      setMockPrereleaseVisualStudioInstallation(null);
+      setMockAnyVisualStudioInstallation(_tooOldResponse);
+
+      visualStudio = VisualStudio();
+      expect(visualStudio.isInstalled, true);
+    }, overrides: <Type, Generator>{
+      FileSystem: () => memoryFilesystem,
+      ProcessManager: () => mockProcessManager,
+      Platform: () => windowsPlatform,
+    });
+
     testUsingContext('isInstalled returns true when a prerelease version of VS is present', () {
       setMockCompatibleVisualStudioInstallation(null);
       setMockAnyVisualStudioInstallation(null);
@@ -273,6 +305,20 @@ void main() {
       visualStudio = VisualStudio();
       expect(visualStudio.isInstalled, true);
       expect(visualStudio.isPrerelease, true);
+    }, overrides: <Type, Generator>{
+      FileSystem: () => memoryFilesystem,
+      ProcessManager: () => mockProcessManager,
+      Platform: () => windowsPlatform,
+    });
+
+    testUsingContext('isAtLeastMinimumVersion returns false when the version found is too old', () {
+      setMockCompatibleVisualStudioInstallation(null);
+      setMockPrereleaseVisualStudioInstallation(null);
+      setMockAnyVisualStudioInstallation(_tooOldResponse);
+
+      visualStudio = VisualStudio();
+      expect(visualStudio.isInstalled, true);
+      expect(visualStudio.isAtLeastMinimumVersion, false);
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFilesystem,
       ProcessManager: () => mockProcessManager,
@@ -421,6 +467,7 @@ void main() {
 
       visualStudio = VisualStudio();
       expect(visualStudio.isInstalled, true);
+      expect(visualStudio.isAtLeastMinimumVersion, true);
       expect(visualStudio.hasNecessaryComponents, true);
       expect(visualStudio.vcvarsPath, equals(vcvarsPath));
     }, overrides: <Type, Generator>{


### PR DESCRIPTION
## Description

Up the minimum requirement for targetting Windows from VS 2017 to VS
2019. This will allow using newer toolchain features, such as less
strict SDK versioning.

## Related Issues

Fixes #48782

## Tests

I added the following tests: Ensures that version detection behaves as expected. Updated existing tests to use 2019 for "good" cases.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

This is technically a breaking change since builds that worked with 2017 previously will now require installing 2019, but Windows is explicitly unstable at this point, and not subject to the breaking change policy.