### PR TITLE
Increase iteration counts to help improve noise in benchmark results.

### DIFF
--- a/dev/benchmarks/microbenchmarks/lib/geometry/matrix_utils_transform_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/geometry/matrix_utils_transform_bench.dart
@@ -10,8 +10,8 @@ import 'package:vector_math/vector_math_64.dart';
 
 import '../common.dart';
 
-const int _kNumIterations = 1000000;
-const int _kNumWarmUp = 10000;
+const int _kNumIterations = 10000000;
+const int _kNumWarmUp = 100000;
 
 void main() {
   assert(false, "Don't run benchmarks in checked mode! Use 'flutter run --release'.");


### PR DESCRIPTION
These benchmarks have been showing quite a bit of run-to-run noise recently on iOS and they execute very quickly (less than .5s per benchmark) so I am increasing the number of iterations by a factor of 10 to get more consistent numbers to avoid having to move the baseline level.