### PR TITLE
Scoped image cache

### DIFF
--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -16,6 +16,7 @@ import 'binding.dart';
 import 'framework.dart';
 import 'localizations.dart';
 import 'media_query.dart';
+import 'scoped_image_cache.dart';
 import 'ticker_provider.dart';
 
 export 'package:flutter/painting.dart' show
@@ -82,7 +83,7 @@ Future<void> precacheImage(
 }) {
   final ImageConfiguration config = createLocalImageConfiguration(context, size: size);
   final Completer<void> completer = Completer<void>();
-  final ImageStream stream = provider.resolve(config);
+  final ImageStream stream = provider.resolve(config, imageCache: ScopedImageCache.of(context));
   ImageStreamListener listener;
   listener = ImageStreamListener(
     (ImageInfo image, bool sync) {
@@ -1007,10 +1008,13 @@ class _ImageState extends State<Image> with WidgetsBindingObserver {
 
   void _resolveImage() {
     final ImageStream newStream =
-      widget.image.resolve(createLocalImageConfiguration(
-        context,
-        size: widget.width != null && widget.height != null ? Size(widget.width, widget.height) : null,
-      ));
+      widget.image.resolve(
+        createLocalImageConfiguration(
+          context,
+          size: widget.width != null && widget.height != null ? Size(widget.width, widget.height) : null,
+        ),
+        imageCache: ScopedImageCache.of(context),
+      );
     assert(newStream != null);
     _updateSourceStream(newStream);
   }

--- a/packages/flutter/lib/src/widgets/scoped_image_cache.dart
+++ b/packages/flutter/lib/src/widgets/scoped_image_cache.dart
@@ -1,0 +1,92 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/painting.dart';
+
+import 'framework.dart';
+
+/// Scopes access to an [ImageCache] for a specific subtree of widgets.
+///
+/// Framework widgets avoid directly using [PaintingBinding.imageCache],
+/// and instead look for the nearest [ImageCache] available via this widget's
+/// static members [dependOn] and [of]. These methods can return the global
+/// image cache if no [ScopedImageCache] is available in the tree. The
+/// [dependOn] method will throw by default if there is no [ScopedImageCache],
+/// since it is intended to introduce a dependency on a [ScopedImageCache], and
+/// callers would not be notified if the cache were somehow changed on the
+/// [PaintingBinding].
+///
+/// The [of] method will not throw by default since it is not intended
+/// to introduce any such dependency.
+@immutable
+class ScopedImageCache extends InheritedWidget {
+  /// Creates a new [ScopedImageCache], which is used to introduce an
+  /// [ImageCache] for a specific part of a widget subtree.
+  const ScopedImageCache({
+    @required Widget child,
+    @required ImageCache imageCache,
+    Key key,
+  }) : assert(child != null),
+       assert(imageCache != null),
+       _imageCache = imageCache,
+       super(key: key, child: child);
+
+  final ImageCache _imageCache;
+
+  static FlutterError _getError(BuildContext context) {
+    return FlutterError.fromParts(<DiagnosticsNode>[
+      ErrorSummary('ScopedImageCache.of() called on a context that does not contain a ScopedImageCache.'),
+      ErrorDescription(
+        'No ScopedImageCache ancestor could be found starting from the '
+        'context that was passed to ScopedImageCache.of(). This can happen '
+        'because you did not introduce a ScopedImageCache widget into the '
+        'tree, or the context you are using comes from a widget above the '
+        'widget you introduced.\n'
+      ),
+      context.describeElement('The context used was'),
+    ]);
+  }
+
+  /// Finds the nearest [ImageCache] from a [ScopedImageCache] enclosing the
+  /// build context. If there is no [ImageCache] widget, it will return the
+  /// [ImageCache] on the [PaintingBinding.instance].
+  ///
+  /// This method will throw if [paintingBindingOk] is set to false and there is
+  /// no [ScopedImageCache] in the tree above the caller's [context].
+  ///
+  /// Calling this method does not cause the caller to depend on this widget. If
+  /// a caller wants to be notified when the [ImageCache] instance is changed,
+  /// the [ImageCache.dependOn] method should be used instead.
+  static ImageCache of(BuildContext context, { bool paintingBindingOk = true }) {
+    final ScopedImageCache widget = context.findAncestorWidgetOfExactType<ScopedImageCache>();
+    if (widget == null) {
+      if (!paintingBindingOk) {
+        throw _getError(context);
+      }
+      return PaintingBinding.instance.imageCache;
+    }
+    return widget._imageCache;
+  }
+
+  /// Finds the nearest [ImageCache] from a [ScopedImageCache] enclosing the
+  /// build context and introduces a dependency on the [ScopedImageCache].
+  ///
+  /// If the widget tree is rebuilt and the [ScopedImageCache] parent gets a new
+  /// [ImageCache] to refer to, subscribers will receive a call to
+  /// [didUpdateDependencies]. Callers that use such methods to resolve images
+  /// should not use this method, but instead use [of].
+  static ImageCache dependOn(BuildContext context, { bool paintingBindingOk = false }) {
+    final ScopedImageCache widget = context.dependOnInheritedWidgetOfExactType<ScopedImageCache>();
+    if (widget == null) {
+      if (!paintingBindingOk) {
+        throw _getError(context);
+      }
+      return PaintingBinding.instance.imageCache;
+    }
+    return widget._imageCache;
+  }
+
+  @override
+  bool updateShouldNotify(ScopedImageCache oldWidget) => _imageCache != oldWidget._imageCache;
+}

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -77,6 +77,7 @@ export 'src/widgets/primary_scroll_controller.dart';
 export 'src/widgets/raw_keyboard_listener.dart';
 export 'src/widgets/routes.dart';
 export 'src/widgets/safe_area.dart';
+export 'src/widgets/scoped_image_cache.dart';
 export 'src/widgets/scroll_activity.dart';
 export 'src/widgets/scroll_configuration.dart';
 export 'src/widgets/scroll_context.dart';

--- a/packages/flutter/test/painting/image_test_utils.dart
+++ b/packages/flutter/test/painting/image_test_utils.dart
@@ -25,9 +25,9 @@ class TestImageProvider extends ImageProvider<TestImageProvider> {
   }
 
   @override
-  ImageStream resolve(ImageConfiguration config) {
+  ImageStream resolve(ImageConfiguration config, { ImageCache imageCache }) {
     configuration = config;
-    return super.resolve(configuration);
+    return super.resolve(configuration, imageCache: imageCache);
   }
 
   @override

--- a/packages/flutter/test/widgets/scoped_image_cache_test.dart
+++ b/packages/flutter/test/widgets/scoped_image_cache_test.dart
@@ -1,0 +1,212 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'image_data.dart';
+
+void main() {
+  testWidgets('ScopedImageCache.of finds the right cache', (WidgetTester tester) async {
+    final GlobalKey<_TestStatefulWidgetState> key = GlobalKey<_TestStatefulWidgetState>();
+    final TestImageCache imageCache = TestImageCache();
+    await tester.pumpWidget(ScopedImageCache(
+      child: TestStatefulWidget(key),
+      imageCache: imageCache,
+    ));
+
+    expect(find.byKey(key), findsOneWidget);
+    expect(key.currentState.didChangeDependenciesCount, 1);
+    expect(ScopedImageCache.of(key.currentContext), imageCache);
+    expect(key.currentState.didChangeDependenciesCount, 1);
+
+    await tester.pumpWidget(ScopedImageCache(
+      child: TestStatefulWidget(key),
+      imageCache: PaintingBinding.instance.imageCache,
+    ));
+
+    expect(find.byKey(key), findsOneWidget);
+    expect(key.currentState.didChangeDependenciesCount, 1);
+    expect(ScopedImageCache.of(key.currentContext), PaintingBinding.instance.imageCache);
+    expect(key.currentState.didChangeDependenciesCount, 1);
+
+    await tester.pumpWidget(TestStatefulWidget(key));
+
+    expect(find.byKey(key), findsOneWidget);
+    expect(key.currentState.didChangeDependenciesCount, 1);
+    expect(ScopedImageCache.of(key.currentContext), PaintingBinding.instance.imageCache);
+    expect(key.currentState.didChangeDependenciesCount, 1);
+  });
+
+  testWidgets('ScopedImageCache.dependOn finds the right cache', (WidgetTester tester) async {
+    final GlobalKey<_TestStatefulWidgetState> key = GlobalKey<_TestStatefulWidgetState>();
+    final TestImageCache imageCache = TestImageCache();
+    await tester.pumpWidget(ScopedImageCache(
+      child: TestStatefulWidget(key),
+      imageCache: imageCache,
+    ));
+
+    expect(find.byKey(key), findsOneWidget);
+    expect(key.currentState.didChangeDependenciesCount, 1);
+    expect(ScopedImageCache.dependOn(key.currentContext), imageCache);
+    expect(key.currentState.didChangeDependenciesCount, 1);
+
+    await tester.pumpWidget(ScopedImageCache(
+      child: TestStatefulWidget(key),
+      imageCache: PaintingBinding.instance.imageCache,
+    ));
+
+    expect(find.byKey(key), findsOneWidget);
+    expect(key.currentState.didChangeDependenciesCount, 2);
+    expect(ScopedImageCache.dependOn(key.currentContext), PaintingBinding.instance.imageCache);
+    expect(key.currentState.didChangeDependenciesCount, 2);
+
+    await tester.pumpWidget(TestStatefulWidget(key));
+
+    expect(find.byKey(key), findsOneWidget);
+    expect(key.currentState.didChangeDependenciesCount, 3);
+    expect(ScopedImageCache.dependOn(key.currentContext, paintingBindingOk: true), PaintingBinding.instance.imageCache);
+    expect(key.currentState.didChangeDependenciesCount, 3);
+  });
+
+  testWidgets('ScopedImageCache works to catch the image stream', (WidgetTester tester) async {
+    final TestImageCache imageCache = TestImageCache();
+    final Completer<void> completer = Completer<void>();
+    final Uint8List bytes = Uint8List.fromList(kTransparentImage);
+
+    final ExpensiveImageProvider provider = ExpensiveImageProvider('asdf', completer, bytes);
+    final Image image = Image(image: provider);
+
+    // Build a widget that acts like a custom wrapper around an Image widget
+    // and uses the widget's image provider to resolve the image.
+    await tester.pumpWidget(Builder(
+      builder: (BuildContext context) {
+        // Trigger an early resolve call. A real client would rather do whatever
+        // work with the stream they need via the custom image cache, but this
+        // is enough to satisfy the test.
+        image.image.resolve(
+          createLocalImageConfiguration(context),
+          imageCache: imageCache
+        );
+        return ScopedImageCache(
+          imageCache: imageCache,
+          child: image,
+        );
+      }
+    ));
+
+    expect(provider.loadAsyncCalls, 1);
+    expect(provider.decodeCalls, 0);
+    completer.complete();
+    await tester.idle();
+
+    // If the `image` failed to use our `imageCache`, these will be > 1.
+    expect(provider.loadAsyncCalls, 1);
+    expect(provider.decodeCalls, 1);
+  });
+}
+
+class SpecialWrapperImage extends StatelessWidget {
+  const SpecialWrapperImage(this.image, { Key key }) : super(key: key);
+
+  final Image image;
+
+  @override
+  Widget build(BuildContext context) {
+    return image;
+  }
+}
+
+class ExpensiveImageProvider extends ImageProvider<String> {
+  ExpensiveImageProvider(this.key, this.completer, this.bytes);
+
+  final String key;
+
+  final Completer<void> completer;
+  final Uint8List bytes;
+
+  int loadAsyncCalls = 0;
+  int decodeCalls = 0;
+
+  Future<ui.Codec> _loadAsync(String key, DecoderCallback decode) async {
+    assert(key == this.key);
+
+    loadAsyncCalls += 1;
+    await completer.future;
+    decodeCalls += 1;
+    return decode(bytes);
+  }
+
+  @override
+  ImageStreamCompleter load(String key, DecoderCallback decode) {
+    return MultiFrameImageStreamCompleter(
+      codec: _loadAsync(key, decode),
+      scale: 1.0,
+    );
+  }
+
+  @override
+  Future<String> obtainKey(ImageConfiguration configuration) {
+    return Future<String>.value(key);
+  }
+
+
+}
+
+class TestImageCache implements ImageCache {
+  final Map<Object, ImageStreamCompleter> cache = <Object, ImageStreamCompleter>{};
+
+  @override
+  int maximumSize;
+
+  @override
+  int maximumSizeBytes;
+
+  @override
+  void clear() {
+    cache.clear();
+  }
+
+  @override
+  int get currentSize => throw UnimplementedError();
+
+  @override
+  int get currentSizeBytes => throw UnimplementedError();
+
+  @override
+  bool evict(Object key) {
+    return cache.remove(key) != null;
+  }
+
+  @override
+  ImageStreamCompleter putIfAbsent(Object key, ImageStreamCompleter Function() loader, { ImageErrorListener onError }) {
+    if (!cache.containsKey(key)) {
+      cache[key] = loader();
+    }
+    return cache[key];
+  }
+}
+
+class TestStatefulWidget extends StatefulWidget {
+  const TestStatefulWidget(Key key) : super (key: key);
+  @override
+  State<StatefulWidget> createState() => _TestStatefulWidgetState();
+}
+
+class _TestStatefulWidgetState extends State<TestStatefulWidget>{
+  int didChangeDependenciesCount = 0;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    didChangeDependenciesCount += 1;
+  }
+
+  @override
+  Widget build(BuildContext context) => const  SizedBox(height: 10, width: 10);
+}


### PR DESCRIPTION
## Description

Allows the introduction of a custom image caching implementation in the widget tree.

This is intended to allow customers who want to wrap subtrees of widget (or even a single Image widget) with special caching rules.  For example, someone might want to create a `SpecialImage` widget that takes an `Image` widget as its child, and is able to do things with the `ImageStream` that `Image` will resolve.  This would allow other widgets to compose `Image` widgets and get access to the `ImageStream` without messing up the global cache. For example, a wrapper widget could listen to the stream of a `NetworkImage` this way without running the risk of calling resolve multiple times due to the image being too large for the cache.

/cc @ignatz

## Related Issues

https://github.com/flutter/flutter/issues/47378
https://github.com/flutter/flutter/issues/47380

#48305

## Tests

I added the following tests:

Test for new classes/code, test for the case of creating a wrapper widget.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [x] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [x] I wrote a migration guide: *Replace with a link to your migration guide*

I will write a migration guide for this - the break is adding a new optional parameter to resolve, and it breaks our tests but no internal or customer tests.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
