### PR TITLE
Add missing type arguments to fix implicit dynamic.

### DIFF
--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -874,8 +874,8 @@ void main() {
             builder: (BuildContext context) {
               return RaisedButton(
                 onPressed: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute<dynamic>(
+                  Navigator.of(context).push<void>(
+                    MaterialPageRoute<void>(
                       builder: (BuildContext innerContext) {
                         return Container(
                           key: containerKey,
@@ -924,8 +924,8 @@ void main() {
             builder: (BuildContext context) {
               return RaisedButton(
                 onPressed: () {
-                  Navigator.of(context).push(
-                    ModifiedReverseTransitionDurationRoute<dynamic>(
+                  Navigator.of(context).push<void>(
+                    ModifiedReverseTransitionDurationRoute<void>(
                       builder: (BuildContext innerContext) {
                         return Container(
                           key: containerKey,
@@ -983,8 +983,8 @@ void main() {
             builder: (BuildContext context) {
               return RaisedButton(
                 onPressed: () {
-                  Navigator.of(context).push(
-                    ModifiedReverseTransitionDurationRoute<dynamic>(
+                  Navigator.of(context).push<void>(
+                    ModifiedReverseTransitionDurationRoute<void>(
                       builder: (BuildContext innerContext) {
                         return Container(
                           key: containerKey,


### PR DESCRIPTION
Analyzer removed reporting of `IMPLICIT_DYNAMIC_*`, because it was considered DDC only feature. It was a mistake, and we are reverting this change in https://dart-review.googlesource.com/c/sdk/+/131723 But Flutter has to be fixed before we can land.

https://github.com/dart-lang/sdk/issues/40129