### PR TITLE
Make build_aar_*_tests actually use release builds.

### DIFF
--- a/dev/devicelab/bin/tasks/build_aar_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_aar_module_test.dart
@@ -57,7 +57,7 @@ Future<void> main() async {
       await inDirectory(projectDir, () async {
         await flutter(
           'build',
-          options: <String>['aar', '--verbose'],
+          options: <String>['aar', '--release', '--verbose'],
         );
       });
 

--- a/dev/devicelab/bin/tasks/build_aar_plugin_test.dart
+++ b/dev/devicelab/bin/tasks/build_aar_plugin_test.dart
@@ -44,7 +44,7 @@ Future<void> main() async {
       await inDirectory(projectDir, () async {
         await flutter(
           'build',
-          options: <String>['aar', '--verbose'],
+          options: <String>['aar', '--verbose', '--release'],
         );
       });
 


### PR DESCRIPTION
This test claims intends to be creating release builds, but actually it is creating profile builds.

I've updated the test to use release builds. This is important because we run this test on the 3xH configuration, which only compiles release builds. 

See https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket.appspot.com/8891214368988307984/+/steps/flutter_test_hostonly_devicelab_tests/0/stdout for a resulting error.