### PR TITLE
Allow for cupertino modal popups to be dismissed with semantics

### DIFF
--- a/examples/flutter_gallery/lib/demo/cupertino/cupertino_picker_demo.dart
+++ b/examples/flutter_gallery/lib/demo/cupertino/cupertino_picker_demo.dart
@@ -108,6 +108,7 @@ class _CupertinoPickerDemoState extends State<CupertinoPickerDemo> {
       onTap: () async {
         await showCupertinoModalPopup<void>(
           context: context,
+          semanticsDismissible: true,
           builder: (BuildContext context) {
             return _BottomPicker(
               child: CupertinoPicker(
@@ -144,6 +145,7 @@ class _CupertinoPickerDemoState extends State<CupertinoPickerDemo> {
       onTap: () {
         showCupertinoModalPopup<void>(
           context: context,
+          semanticsDismissible: true,
           builder: (BuildContext context) {
             return _BottomPicker(
               child: CupertinoTimerPicker(
@@ -176,6 +178,7 @@ class _CupertinoPickerDemoState extends State<CupertinoPickerDemo> {
       onTap: () {
         showCupertinoModalPopup<void>(
           context: context,
+          semanticsDismissible: true,
           builder: (BuildContext context) {
             return _BottomPicker(
               child: CupertinoDatePicker(
@@ -207,6 +210,7 @@ class _CupertinoPickerDemoState extends State<CupertinoPickerDemo> {
       onTap: () {
         showCupertinoModalPopup<void>(
           context: context,
+          semanticsDismissible: true,
           builder: (BuildContext context) {
             return _BottomPicker(
               child: CupertinoDatePicker(
@@ -238,6 +242,7 @@ class _CupertinoPickerDemoState extends State<CupertinoPickerDemo> {
       onTap: () {
         showCupertinoModalPopup<void>(
           context: context,
+          semanticsDismissible: true,
           builder: (BuildContext context) {
             return _BottomPicker(
               child: CupertinoDatePicker(

--- a/packages/flutter/lib/src/cupertino/picker.dart
+++ b/packages/flutter/lib/src/cupertino/picker.dart
@@ -35,7 +35,8 @@ const double _kOverAndUnderCenterOpacity = 0.447;
 /// that child the initially selected child.
 ///
 /// Can be used with [showCupertinoModalPopup] to display the picker modally at the
-/// bottom of the screen.
+/// bottom of the screen. When calling [showCupertinoModalPopup], be sure to set
+/// `semanticsDismissible` to true to enable dismissing the modal via semantics.
 ///
 /// Sizes itself to its parent. All children are sized to the same size based
 /// on [itemExtent].

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -811,7 +811,7 @@ class _CupertinoModalPopupRoute<T> extends PopupRoute<T> {
   bool get barrierDismissible => true;
 
   @override
-  bool get semanticsDismissible => false;
+  bool get semanticsDismissible => true;
 
   @override
   Duration get transitionDuration => _kModalPopupTransitionDuration;

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -792,14 +792,18 @@ class _CupertinoModalPopupRoute<T> extends PopupRoute<T> {
     this.barrierColor,
     this.barrierLabel,
     this.builder,
+    bool semanticsDismissible,
     ImageFilter filter,
     RouteSettings settings,
   }) : super(
          filter: filter,
          settings: settings,
-       );
+       ) {
+    _semanticsDismissible = semanticsDismissible;
+  }
 
   final WidgetBuilder builder;
+  bool _semanticsDismissible;
 
   @override
   final String barrierLabel;
@@ -811,7 +815,7 @@ class _CupertinoModalPopupRoute<T> extends PopupRoute<T> {
   bool get barrierDismissible => true;
 
   @override
-  bool get semanticsDismissible => true;
+  bool get semanticsDismissible => _semanticsDismissible ?? false;
 
   @override
   Duration get transitionDuration => _kModalPopupTransitionDuration;
@@ -871,6 +875,9 @@ class _CupertinoModalPopupRoute<T> extends PopupRoute<T> {
 /// popup to the [Navigator] furthest from or nearest to the given `context`. It
 /// is `false` by default.
 ///
+/// The `semanticsDismissble` argument is used to determine whether the
+/// semantics of the modal barrier are included in the semantics tree.
+///
 /// The `builder` argument typically builds a [CupertinoActionSheet] widget.
 /// Content below the widget is dimmed with a [ModalBarrier]. The widget built
 /// by the `builder` does not share a context with the location that
@@ -891,6 +898,7 @@ Future<T> showCupertinoModalPopup<T>({
   @required WidgetBuilder builder,
   ImageFilter filter,
   bool useRootNavigator = true,
+  bool semanticsDismissible,
 }) {
   assert(useRootNavigator != null);
   return Navigator.of(context, rootNavigator: useRootNavigator).push(
@@ -899,6 +907,7 @@ Future<T> showCupertinoModalPopup<T>({
       barrierLabel: 'Dismiss',
       builder: builder,
       filter: filter,
+      semanticsDismissible: semanticsDismissible,
     ),
   );
 }

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -1083,8 +1083,7 @@ void main() {
     await tester.tap(find.text('tap'));
     await tester.pumpAndSettle();
 
-    expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.tap]));
-    expect(semantics, includesNodeWith(label: 'Dismiss'));
+    expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.tap], label: 'Dismiss'));
     debugDefaultTargetPlatformOverride = null;
   });
 }

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -1056,7 +1056,7 @@ void main() {
     expect(nestedObserver.dialogCount, 1);
   });
 
-  testWidgets('showCupertinoModalPopup allows for semantics dismiss on iOS', (WidgetTester tester) async {
+  testWidgets('showCupertinoModalPopup does not allow for semantics dismiss by default', (WidgetTester tester) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
     final SemanticsTester semantics = SemanticsTester(tester);
     await tester.pumpWidget(CupertinoApp(
@@ -1083,7 +1083,45 @@ void main() {
     await tester.tap(find.text('tap'));
     await tester.pumpAndSettle();
 
-    expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.tap], label: 'Dismiss'));
+    expect(semantics, isNot(includesNodeWith(
+      actions: <SemanticsAction>[SemanticsAction.tap],
+      label: 'Dismiss',
+    )));
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets('showCupertinoModalPopup allows for semantics dismiss when set', (WidgetTester tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    final SemanticsTester semantics = SemanticsTester(tester);
+    await tester.pumpWidget(CupertinoApp(
+      home: Navigator(
+        onGenerateRoute: (RouteSettings settings) {
+          return PageRouteBuilder<dynamic>(
+            pageBuilder: (BuildContext context, Animation<double> _, Animation<double> __) {
+              return GestureDetector(
+                onTap: () async {
+                  await showCupertinoModalPopup<void>(
+                    context: context,
+                    semanticsDismissible: true,
+                    builder: (BuildContext context) => const SizedBox(),
+                  );
+                },
+                child: const Text('tap'),
+              );
+            },
+          );
+        },
+      ),
+    ));
+
+    // Push the route.
+    await tester.tap(find.text('tap'));
+    await tester.pumpAndSettle();
+
+    expect(semantics, includesNodeWith(
+      actions: <SemanticsAction>[SemanticsAction.tap],
+      label: 'Dismiss',
+    ));
     debugDefaultTargetPlatformOverride = null;
   });
 }

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -3,10 +3,13 @@
 // found in the LICENSE file.
 
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:mockito/mockito.dart';
+
+import '../widgets/semantics_tester.dart';
 
 void main() {
   MockNavigatorObserver navigatorObserver;
@@ -1051,6 +1054,38 @@ void main() {
 
     expect(rootObserver.dialogCount, 0);
     expect(nestedObserver.dialogCount, 1);
+  });
+
+  testWidgets('showCupertinoModalPopup allows for semantics dismiss on iOS', (WidgetTester tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    final SemanticsTester semantics = SemanticsTester(tester);
+    await tester.pumpWidget(CupertinoApp(
+      home: Navigator(
+        onGenerateRoute: (RouteSettings settings) {
+          return PageRouteBuilder<dynamic>(
+            pageBuilder: (BuildContext context, Animation<double> _, Animation<double> __) {
+              return GestureDetector(
+                onTap: () async {
+                  await showCupertinoModalPopup<void>(
+                    context: context,
+                    builder: (BuildContext context) => const SizedBox(),
+                  );
+                },
+                child: const Text('tap'),
+              );
+            },
+          );
+        },
+      ),
+    ));
+
+    // Push the route.
+    await tester.tap(find.text('tap'));
+    await tester.pumpAndSettle();
+
+    expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.tap]));
+    expect(semantics, includesNodeWith(label: 'Dismiss'));
+    debugDefaultTargetPlatformOverride = null;
   });
 }
 


### PR DESCRIPTION
## Description

Currently, if you use `showCupertinoModalPopup`, the popup is not able to be dismissed with semantics. This becomes especially obvious in the date/time picker demo in the gallery. The user becomes stuck and not able to dismiss the picker.

This change enables semantic dismissing for the modal popup as an opt-in parameter. Additionally this updates the cupertino picker demo to use this new parameter.

## Related Issues

Closes #48026

## Tests

I added the following tests:

* check that `showCupertinoModalPopup` has dismiss semantics

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
