### PR TITLE
Fix semantic sort name

### DIFF
--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -3981,30 +3981,18 @@ String _concatStrings({
   return '$thisString\n$nestedLabel';
 }
 
-/// Base class for all sort keys for [Semantics] accessibility traversal order
-/// sorting.
+/// Base class for all sort keys for [SemanticsProperties.sortKey] accessibility
+/// traversal order sorting.
 ///
-/// Only keys of the same type and having matching [name]s are compared. If a
-/// list of sibling [SemanticsNode]s contains keys that are not comparable with
-/// each other the list is first sorted using the default sorting algorithm.
-/// Then the nodes are broken down into groups by moving comparable nodes
-/// towards the _earliest_ node in the group. Finally each group is sorted by
-/// sort key and the resulting list is made by concatenating the sorted groups
-/// back.
+/// Sort keys are sorted by [name], then by the comparison that the subclass
+/// implements. If [SemanticsProperties.sortKey] is specified, sort keys within
+/// the same semantic group must all be of the same type.
 ///
-/// For example, let's take nodes (C, D, B, E, A, F). Let's assign node A key 1,
-/// node B key 2, node C key 3. Let's also assume that the default sort order
-/// leaves the original list intact. Because nodes A, B, and C, have comparable
-/// sort key, they will form a group by pulling all nodes towards the earliest
-/// node, which is C. The result is group (C, B, A). The remaining nodes D, E,
-/// F, form a second group with sort key being `null`. The first group is sorted
-/// using their sort keys becoming (A, B, C). The second group is left as is
-/// because it does not specify sort keys. Then we concatenate the two groups -
-/// (A, B, C) and (D, E, F) - into the final (A, B, C, D, E, F).
+/// Keys with no [name] are compared to to other keys with no [name], and will
+/// be traversed before those with a [name].
 ///
-/// Because of the complexity introduced by incomparable sort keys among sibling
-/// nodes, it is recommended to either use comparable keys for all nodes, or
-/// use null for all of them, leaving the sort order to the default algorithm.
+/// If no sort key is applied to a semantics node, then it will be ordered using
+/// a platform dependent default algorithm.
 ///
 /// See also:
 ///
@@ -4012,39 +4000,37 @@ String _concatStrings({
 abstract class SemanticsSortKey extends Diagnosticable implements Comparable<SemanticsSortKey> {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
-  ///
-  /// The [name] argument is optional.
   const SemanticsSortKey({this.name});
 
-  /// An optional name that will make this sort key only order itself
-  /// with respect to other sort keys of the same [name], as long as
-  /// they are of the same [runtimeType].
+  /// An optional name that will group this sort key with other sort keys of the
+  /// same [name].
   ///
-  /// Sort keys that have different types are sorted only by name.  If they have
-  /// different types and identical names, then they are sorted arbitrarily, but
-  /// consistently. The arbitrary ordering could change if the app is
-  /// recompiled, so if consistent ordering is required, then apply a name or
-  /// other sort criteria.
+  /// Sort keys must have the same `runtimeType` when compared.
+  ///
+  /// Keys with no [name] are compared to to other keys with no [name], and will
+  /// be traversed before those with a [name].
   final String name;
 
   @override
   int compareTo(SemanticsSortKey other) {
-    // The sorting algorithm must not compare incomparable keys. If the name and
-    // the type are identical, then defer to the subclass implementation for
-    // ordering.
+    // Sort by name first and then subclass ordering.
+    assert(runtimeType == other.runtimeType, 'Semantics sort keys can only be compared to other sort keys of the same type.');
+
+    // Defer to the subclass implementation for ordering only if the names are
+    // identical (or both null).
     if (name == other.name) {
-      if (other.runtimeType == runtimeType) {
-        return doCompare(other);
-      } else {
-        // If the names are the same, but the types are different, then sort by
-        // type hash code to provide a consistent (but arbitrary) ordering.
-        return runtimeType.hashCode.compareTo(other.runtimeType.hashCode);
-      }
+      return doCompare(other);
     }
 
-    // Keys that don't share the same type and/or name are sorted only by name.
-    final int nameComparison = (name ?? '').compareTo(other.name ?? '');
-    return nameComparison;
+    // Keys that don't have a name are sorted together and come before those with
+    // a name.
+    if (name == null && other.name != null) {
+      return -1;
+    } else if (name != null && other.name == null) {
+      return 1;
+    }
+
+    return name.compareTo(other.name);
   }
 
   /// The implementation of [compareTo].
@@ -4072,14 +4058,22 @@ abstract class SemanticsSortKey extends Diagnosticable implements Comparable<Sem
 /// The [OrdinalSortKey] compares itself with other [OrdinalSortKey]s
 /// to sort based on the order it is given.
 ///
-/// The ordinal value `order` is typically a whole number, though it can be
+/// [OrdinalSortKey]s are sorted by the optional [name], then by their [order].
+/// If [SemanticsProperties.sortKey] is a [OrdinalSortKey], then all the other
+/// speficied sort keys in the same semantics group must also be
+/// [OrdinalSortKey]s.
+///
+/// Keys with no [name] are compared to to other keys with no [name], and will
+/// be traversed before those with a [name].
+///
+/// The ordinal value [order] is typically a whole number, though it can be
 /// fractional, e.g. in order to fit between two other consecutive whole
 /// numbers. The value must be finite (it cannot be [double.nan],
 /// [double.infinity], or [double.negativeInfinity]).
 class OrdinalSortKey extends SemanticsSortKey {
-  /// Creates a semantics sort key that uses a [double] as its key value.
+  /// Creates a const semantics sort key that uses a [double] as its key value.
   ///
-  /// The [order] must be a finite number.
+  /// The [order] must be a finite number, and must not be null.
   const OrdinalSortKey(
     this.order, {
     String name,
@@ -4093,7 +4087,8 @@ class OrdinalSortKey extends SemanticsSortKey {
   /// the order in which this node is traversed by the platform's accessibility
   /// services.
   ///
-  /// Lower values will be traversed first.
+  /// Lower values will be traversed first. Keys with the same [name] will be
+  /// grouped together and sorted by name first, and then sorted by [order].
   final double order;
 
   @override

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -3988,7 +3988,7 @@ String _concatStrings({
 /// implements. If [SemanticsProperties.sortKey] is specified, sort keys within
 /// the same semantic group must all be of the same type.
 ///
-/// Keys with no [name] are compared to to other keys with no [name], and will
+/// Keys with no [name] are compared to other keys with no [name], and will
 /// be traversed before those with a [name].
 ///
 /// If no sort key is applied to a semantics node, then it will be ordered using
@@ -4007,7 +4007,7 @@ abstract class SemanticsSortKey extends Diagnosticable implements Comparable<Sem
   ///
   /// Sort keys must have the same `runtimeType` when compared.
   ///
-  /// Keys with no [name] are compared to to other keys with no [name], and will
+  /// Keys with no [name] are compared to other keys with no [name], and will
   /// be traversed before those with a [name].
   final String name;
 
@@ -4063,7 +4063,7 @@ abstract class SemanticsSortKey extends Diagnosticable implements Comparable<Sem
 /// speficied sort keys in the same semantics group must also be
 /// [OrdinalSortKey]s.
 ///
-/// Keys with no [name] are compared to to other keys with no [name], and will
+/// Keys with no [name] are compared to other keys with no [name], and will
 /// be traversed before those with a [name].
 ///
 /// The ordinal value [order] is typically a whole number, though it can be

--- a/packages/flutter/test/semantics/semantics_test.dart
+++ b/packages/flutter/test/semantics/semantics_test.dart
@@ -242,25 +242,25 @@ void main() {
     );
   });
 
-  test('Incompatible OrdinalSortKeys sort properly when compared', () {
-    // Different types, but null names.
-    expect(const OrdinalSortKey(0.0).compareTo(const CustomSortKey(0.0)), equals(-1));
-
-    // Different types, but same names.
-    expect(const OrdinalSortKey(0.0, name: 'a').compareTo(const CustomSortKey(0.0, name: 'a')), equals(-1));
-
-    // Same types, different names.
-    expect(const OrdinalSortKey(0.0, name: 'a').compareTo(const OrdinalSortKey(0.0, name: 'b')), equals(-1));
+  test('Incompatible OrdinalSortKey throw AssertionError when compared', () {
+    // Different types.
+    expect(() {
+      const OrdinalSortKey(0.0).compareTo(const CustomSortKey(0.0));
+    }, throwsAssertionError);
   });
 
-  test('OrdinalSortKey compares correctly', () {
+  test('OrdinalSortKey compares correctly when names are the same', () {
     const List<List<SemanticsSortKey>> tests = <List<SemanticsSortKey>>[
       <SemanticsSortKey>[OrdinalSortKey(0.0), OrdinalSortKey(0.0)],
       <SemanticsSortKey>[OrdinalSortKey(0.0), OrdinalSortKey(1.0)],
       <SemanticsSortKey>[OrdinalSortKey(1.0), OrdinalSortKey(0.0)],
       <SemanticsSortKey>[OrdinalSortKey(1.0), OrdinalSortKey(1.0)],
+      <SemanticsSortKey>[OrdinalSortKey(0.0, name: 'a'), OrdinalSortKey(0.0, name: 'a')],
+      <SemanticsSortKey>[OrdinalSortKey(0.0, name: 'a'), OrdinalSortKey(1.0, name: 'a')],
+      <SemanticsSortKey>[OrdinalSortKey(1.0, name: 'a'), OrdinalSortKey(0.0, name: 'a')],
+      <SemanticsSortKey>[OrdinalSortKey(1.0, name: 'a'), OrdinalSortKey(1.0, name: 'a')],
     ];
-    final List<int> expectedResults = <int>[0, -1, 1, 0];
+    final List<int> expectedResults = <int>[0, -1, 1, 0, 0, -1, 1, 0];
     assert(tests.length == expectedResults.length);
     final List<int> results = <int>[
       for (final List<SemanticsSortKey> tuple in tests) tuple[0].compareTo(tuple[1]),
@@ -270,27 +270,24 @@ void main() {
 
   test('OrdinalSortKey compares correctly when the names are different', () {
     const List<List<SemanticsSortKey>> tests = <List<SemanticsSortKey>>[
+      <SemanticsSortKey>[OrdinalSortKey(0.0), OrdinalSortKey(0.0, name: 'bar')],
+      <SemanticsSortKey>[OrdinalSortKey(0.0), OrdinalSortKey(1.0, name: 'bar')],
+      <SemanticsSortKey>[OrdinalSortKey(1.0), OrdinalSortKey(0.0, name: 'bar')],
+      <SemanticsSortKey>[OrdinalSortKey(1.0), OrdinalSortKey(1.0, name: 'bar')],
+      <SemanticsSortKey>[OrdinalSortKey(0.0, name: 'foo'), OrdinalSortKey(0.0)],
+      <SemanticsSortKey>[OrdinalSortKey(0.0, name: 'foo'), OrdinalSortKey(1.0)],
+      <SemanticsSortKey>[OrdinalSortKey(1.0, name: 'foo'), OrdinalSortKey(0.0)],
+      <SemanticsSortKey>[OrdinalSortKey(1.0, name: 'foo'), OrdinalSortKey(1.0)],
       <SemanticsSortKey>[OrdinalSortKey(0.0, name: 'foo'), OrdinalSortKey(0.0, name: 'bar')],
       <SemanticsSortKey>[OrdinalSortKey(0.0, name: 'foo'), OrdinalSortKey(1.0, name: 'bar')],
       <SemanticsSortKey>[OrdinalSortKey(1.0, name: 'foo'), OrdinalSortKey(0.0, name: 'bar')],
       <SemanticsSortKey>[OrdinalSortKey(1.0, name: 'foo'), OrdinalSortKey(1.0, name: 'bar')],
+      <SemanticsSortKey>[OrdinalSortKey(0.0, name: 'bar'), OrdinalSortKey(0.0, name: 'foo')],
+      <SemanticsSortKey>[OrdinalSortKey(0.0, name: 'bar'), OrdinalSortKey(1.0, name: 'foo')],
+      <SemanticsSortKey>[OrdinalSortKey(1.0, name: 'bar'), OrdinalSortKey(0.0, name: 'foo')],
+      <SemanticsSortKey>[OrdinalSortKey(1.0, name: 'bar'), OrdinalSortKey(1.0, name: 'foo')],
     ];
-    final List<int> expectedResults = <int>[1, 1, 1, 1];
-    assert(tests.length == expectedResults.length);
-    final List<int> results = <int>[
-      for (final List<SemanticsSortKey> tuple in tests) tuple[0].compareTo(tuple[1]),
-    ];
-    expect(results, orderedEquals(expectedResults));
-  });
-
-  test('OrdinalSortKey compares correctly when the types are different', () {
-    const List<List<SemanticsSortKey>> tests = <List<SemanticsSortKey>>[
-      <SemanticsSortKey>[OrdinalSortKey(0.0, name: 'foo'), CustomSortKey(0.0, name: 'foo')],
-      <SemanticsSortKey>[OrdinalSortKey(0.0, name: 'foo'), CustomSortKey(1.0, name: 'foo')],
-      <SemanticsSortKey>[OrdinalSortKey(1.0, name: 'foo'), CustomSortKey(0.0, name: 'foo')],
-      <SemanticsSortKey>[OrdinalSortKey(1.0, name: 'foo'), CustomSortKey(1.0, name: 'foo')],
-    ];
-    final List<int> expectedResults = <int>[-1, -1, -1, -1];
+    final List<int> expectedResults = <int>[ -1, -1, -1, -1, 1, 1, 1, 1, 1, 1, 1, 1, -1, -1, -1, -1];
     assert(tests.length == expectedResults.length);
     final List<int> results = <int>[
       for (final List<SemanticsSortKey> tuple in tests) tuple[0].compareTo(tuple[1]),

--- a/packages/flutter/test/semantics/semantics_test.dart
+++ b/packages/flutter/test/semantics/semantics_test.dart
@@ -266,6 +266,9 @@ void main() {
       for (final List<SemanticsSortKey> tuple in tests) tuple[0].compareTo(tuple[1]),
     ];
     expect(results, orderedEquals(expectedResults));
+
+    // Differing types should throw an assertion.
+    expect(() => const OrdinalSortKey(0.0).compareTo(const CustomSortKey(0.0)), throwsAssertionError);
   });
 
   test('OrdinalSortKey compares correctly when the names are different', () {

--- a/packages/flutter/test/semantics/semantics_test.dart
+++ b/packages/flutter/test/semantics/semantics_test.dart
@@ -242,16 +242,15 @@ void main() {
     );
   });
 
-  test('Incompatible OrdinalSortKey throw AssertionError when compared', () {
-    // Different types.
-    expect(() {
-      const OrdinalSortKey(0.0).compareTo(const CustomSortKey(0.0));
-    }, throwsAssertionError);
+  test('Incompatible OrdinalSortKeys sort properly when compared', () {
+    // Different types, but null names.
+    expect(const OrdinalSortKey(0.0).compareTo(const CustomSortKey(0.0)), equals(-1));
 
-    // Different names.
-    expect(() {
-      const OrdinalSortKey(0.0, name: 'a').compareTo(const OrdinalSortKey(0.0, name: 'b'));
-    }, throwsAssertionError);
+    // Different types, but same names.
+    expect(const OrdinalSortKey(0.0, name: 'a').compareTo(const CustomSortKey(0.0, name: 'a')), equals(-1));
+
+    // Same types, different names.
+    expect(const OrdinalSortKey(0.0, name: 'a').compareTo(const OrdinalSortKey(0.0, name: 'b')), equals(-1));
   });
 
   test('OrdinalSortKey compares correctly', () {
@@ -269,14 +268,29 @@ void main() {
     expect(results, orderedEquals(expectedResults));
   });
 
-  test('OrdinalSortKey compares correctly', () {
+  test('OrdinalSortKey compares correctly when the names are different', () {
     const List<List<SemanticsSortKey>> tests = <List<SemanticsSortKey>>[
-      <SemanticsSortKey>[OrdinalSortKey(0.0), OrdinalSortKey(0.0)],
-      <SemanticsSortKey>[OrdinalSortKey(0.0), OrdinalSortKey(1.0)],
-      <SemanticsSortKey>[OrdinalSortKey(1.0), OrdinalSortKey(0.0)],
-      <SemanticsSortKey>[OrdinalSortKey(1.0), OrdinalSortKey(1.0)],
+      <SemanticsSortKey>[OrdinalSortKey(0.0, name: 'foo'), OrdinalSortKey(0.0, name: 'bar')],
+      <SemanticsSortKey>[OrdinalSortKey(0.0, name: 'foo'), OrdinalSortKey(1.0, name: 'bar')],
+      <SemanticsSortKey>[OrdinalSortKey(1.0, name: 'foo'), OrdinalSortKey(0.0, name: 'bar')],
+      <SemanticsSortKey>[OrdinalSortKey(1.0, name: 'foo'), OrdinalSortKey(1.0, name: 'bar')],
     ];
-    final List<int> expectedResults = <int>[0, -1, 1, 0];
+    final List<int> expectedResults = <int>[1, 1, 1, 1];
+    assert(tests.length == expectedResults.length);
+    final List<int> results = <int>[
+      for (final List<SemanticsSortKey> tuple in tests) tuple[0].compareTo(tuple[1]),
+    ];
+    expect(results, orderedEquals(expectedResults));
+  });
+
+  test('OrdinalSortKey compares correctly when the types are different', () {
+    const List<List<SemanticsSortKey>> tests = <List<SemanticsSortKey>>[
+      <SemanticsSortKey>[OrdinalSortKey(0.0, name: 'foo'), CustomSortKey(0.0, name: 'foo')],
+      <SemanticsSortKey>[OrdinalSortKey(0.0, name: 'foo'), CustomSortKey(1.0, name: 'foo')],
+      <SemanticsSortKey>[OrdinalSortKey(1.0, name: 'foo'), CustomSortKey(0.0, name: 'foo')],
+      <SemanticsSortKey>[OrdinalSortKey(1.0, name: 'foo'), CustomSortKey(1.0, name: 'foo')],
+    ];
+    final List<int> expectedResults = <int>[-1, -1, -1, -1];
     assert(tests.length == expectedResults.length);
     final List<int> results = <int>[
       for (final List<SemanticsSortKey> tuple in tests) tuple[0].compareTo(tuple[1]),


### PR DESCRIPTION
## Description

Before this change, the `SemanticSortKey` and `OrdinalSortKey` could take an optional name that was supposed to group keys with the same name together. Unfortunately, that isn't what happens.  What happens is: if you specify a name, then you have to specify a name for all sort keys and it has to be the _same_ name, because if tries to compare keys that have different names (or one that is null or one that isn't), it will assert. This makes the grouping feature useless.

This change makes it so that if you specify a name, then nodes are first sorted by the name, and then by the sorting algorithm of the sort key (the `order` if it's an `OrdinalSortKey`).  That way the name property works as advertised.

This change isn't a breaking change, because prior to this, keys with different names weren't actually allowed, even though the docs said they were.

Also, I removed a very convoluted description of an example of how keys work, since it was pretty much impossible to follow, and I made the docs clearer (I hope).

## Tests

- Added tests for keys with different names.

## Breaking Change

- [X] No, this is *not* a breaking change.