### PR TITLE
Allow Dismissible to have a null direction

### DIFF
--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -62,6 +62,8 @@ enum DismissDirection {
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=iEMgjrfuc58}
 ///
+/// If [direction] is null, then the widget will not be dismissible.
+///
 /// Backgrounds can be used to implement the "leave-behind" idiom. If a background
 /// is specified it is stacked behind the Dismissible's child and is exposed when
 /// the child moves.
@@ -97,6 +99,10 @@ class Dismissible extends StatefulWidget {
   }) : assert(key != null),
        assert(secondaryBackground == null || background != null),
        assert(dragStartBehavior != null),
+       assert(
+         child != null || direction != null,
+         'If direction is null, then child must not be null.',
+       ),
        super(key: key);
 
   /// The widget below this widget in the tree.
@@ -130,6 +136,10 @@ class Dismissible extends StatefulWidget {
   final DismissDirectionCallback onDismissed;
 
   /// The direction in which the widget can be dismissed.
+  ///
+  /// If null, the widget will not be dismissible.
+  ///
+  /// The widget's [child] should not be null if [direction] is null.
   final DismissDirection direction;
 
   /// The amount of time the widget will spend contracting before [onDismissed] is called.
@@ -377,7 +387,6 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
   }
 
   _FlingGestureKind _describeFlingGesture(Velocity velocity) {
-    assert(widget.direction != null);
     if (_dragExtent == 0.0) {
       // If it was a fling, then it was a fling that was let loose at the exact
       // middle of the range (i.e. when there's no displacement). In that case,
@@ -512,6 +521,10 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
   @override
   Widget build(BuildContext context) {
     super.build(context); // See AutomaticKeepAliveClientMixin.
+
+    if (widget.direction == null) {
+      return widget.child;
+    }
 
     assert(!_directionIsXAxis || debugCheckHasDirectionality(context));
 

--- a/packages/flutter/test/widgets/dismissible_test.dart
+++ b/packages/flutter/test/widgets/dismissible_test.dart
@@ -755,7 +755,6 @@ void main() {
       throwsAssertionError,
     );
   });
-  
   testWidgets('setState that does not remove the Dismissible from tree should throws Error', (WidgetTester tester) async {
     scrollDirection = Axis.vertical;
     dismissDirection = DismissDirection.horizontal;

--- a/packages/flutter/test/widgets/dismissible_test.dart
+++ b/packages/flutter/test/widgets/dismissible_test.dart
@@ -733,6 +733,29 @@ void main() {
     expect(confirmDismissDirection, DismissDirection.endToStart);
   });
 
+  testWidgets('Dismissible with a null direction does not get dismissed', (WidgetTester tester) async {
+    dismissDirection = null;
+
+    await tester.pumpWidget(buildTest());
+    expect(dismissedItems, isEmpty);
+    expect(find.text('0'), findsOneWidget);
+
+    await dismissItem(tester, 0, gestureDirection: AxisDirection.right);
+    expect(dismissedItems, isEmpty);
+    expect(find.text('0'), findsOneWidget);
+  });
+
+  testWidgets('Dismissible cannot have a null child and direction', (WidgetTester tester) async {
+    expect(
+      () => Dismissible(
+        key: const ObjectKey(0),
+        child: null,
+        direction: null,
+      ),
+      throwsAssertionError,
+    );
+  });
+  
   testWidgets('setState that does not remove the Dismissible from tree should throws Error', (WidgetTester tester) async {
     scrollDirection = Axis.vertical;
     dismissDirection = DismissDirection.horizontal;


### PR DESCRIPTION
This is re-staged from an old PR that did not land (#36613):

## Description

This pull request allows `Dismissible.direction` to be `null`, which will help simplify user code when attempting to completely disable the dismiss gesture on a Dismissible:

Previous code:

```dart
Listview.builder(...
  itemBuilder:
    return isDisabled ?
      CardWidgetAndCode(
        ...
      )
    : Dismissible(
      child: CardWidgetAndCode( //  <-- duplicate code and/or function call
        ...
      )
    )
)
```

New simplified code:

```dart
Listview.builder(...
  itemBuilder:
    Dismissible(
      direction: isDisabled ? null : DismissDirection.horizontal,
      child: CardWidgetAndCode(
        ...
      )
    )
)
```

## Related Issues

Fixes #24713

## Tests

I added a test to ensure that attempting to dismiss a Dismissible with a null direction does not dismiss it.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
