### PR TITLE
Prevent crash when autofocus:true in EditableText

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1140,8 +1140,12 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   void didChangeDependencies() {
     super.didChangeDependencies();
     if (!_didAutoFocus && widget.autofocus) {
-      FocusScope.of(context).autofocus(widget.focusNode);
       _didAutoFocus = true;
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          FocusScope.of(context).autofocus(widget.focusNode);
+        }
+      });
     }
   }
 

--- a/packages/flutter/test/cupertino/tab_scaffold_test.dart
+++ b/packages/flutter/test/cupertino/tab_scaffold_test.dart
@@ -116,24 +116,31 @@ void main() {
       ),
     );
 
-    expect(tabsBuilt, const <int>[0]);
+    // Tab#0 is built twice, initiated in the following places:
+    //
+    // 1. `WidgetsBinding.attachRootWidget()`.
+    // 2. `WidgetsBinding.drawFrame()`.
+    expect(tabsBuilt, const <int>[0, 0]);
     expect(find.text('Page 1'), findsOneWidget);
     expect(find.text('Page 2'), findsNothing);
+    tabsBuilt.clear();
 
     await tester.tap(find.text('Tab 2'));
     await tester.pump();
 
     // Both tabs are built but only one is onstage.
-    expect(tabsBuilt, const <int>[0, 0, 1]);
+    expect(tabsBuilt, const <int>[0, 1]);
     expect(find.text('Page 1', skipOffstage: false), isOffstage);
     expect(find.text('Page 2'), findsOneWidget);
+    tabsBuilt.clear();
 
     await tester.tap(find.text('Tab 1'));
     await tester.pump();
 
-    expect(tabsBuilt, const <int>[0, 0, 1, 0, 1]);
+    expect(tabsBuilt, const <int>[0, 1]);
     expect(find.text('Page 1'), findsOneWidget);
     expect(find.text('Page 2', skipOffstage: false), isOffstage);
+    tabsBuilt.clear();
   });
 
   testWidgets('Last tab gets focus', (WidgetTester tester) async {
@@ -555,7 +562,11 @@ void main() {
       ),
     );
 
-    expect(tabsBuilt, const <int>[0]);
+    // Tab#0 is built twice, initiated in the following places:
+    //
+    // 1. `WidgetsBinding.attachRootWidget()`.
+    // 2. `WidgetsBinding.drawFrame()`.
+    expect(tabsBuilt, const <int>[0, 0]);
     // selectedTabs list is appended to on onTap callbacks. We didn't tap
     // any tabs yet.
     expect(selectedTabs, const <int>[]);

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -3821,6 +3821,7 @@ void main() {
         return null;
       });
 
+    // ignore: deprecated_member_use
     await tester.pumpWidgetLegacy(
       MaterialApp(
         home: Material(
@@ -3893,6 +3894,7 @@ void main() {
         return null;
       });
 
+    // ignore: deprecated_member_use
     await tester.pumpWidgetLegacy(
       MaterialApp(
         home: Material(
@@ -4008,6 +4010,7 @@ void main() {
         maxLines: 3,
       );
 
+    // ignore: deprecated_member_use
     await tester.pumpWidgetLegacy(
       MaterialApp(
         home: Material(

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -3821,7 +3821,7 @@ void main() {
         return null;
       });
 
-    await tester.pumpWidget(
+    await tester.pumpWidgetLegacy(
       MaterialApp(
         home: Material(
           child: RawKeyboardListener(
@@ -3893,7 +3893,7 @@ void main() {
         return null;
       });
 
-    await tester.pumpWidget(
+    await tester.pumpWidgetLegacy(
       MaterialApp(
         home: Material(
           child: RawKeyboardListener(
@@ -4008,7 +4008,7 @@ void main() {
         maxLines: 3,
       );
 
-    await tester.pumpWidget(
+    await tester.pumpWidgetLegacy(
       MaterialApp(
         home: Material(
           child: RawKeyboardListener(

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4137,6 +4137,39 @@ void main() {
     }
     expect(tester.testTextInput.editingState['text'], 'flutter is the best!...');
   });
+
+  testWidgets('autofocus:true on first frame does not throw', (WidgetTester tester) async {
+    final TextEditingController controller = TextEditingController(text: testText);
+    controller.selection = const TextSelection(
+      baseOffset: 0,
+      extentOffset: 0,
+      affinity: TextAffinity.upstream,
+    );
+
+    await tester.pumpWidget(MaterialApp(
+      home: EditableText(
+        maxLines: 10,
+        controller: controller,
+        showSelectionHandles: true,
+        autofocus: true,
+        focusNode: FocusNode(),
+        style: Typography(platform: TargetPlatform.android).black.subhead,
+        cursorColor: Colors.blue,
+        backgroundCursorColor: Colors.grey,
+        selectionControls: materialTextSelectionControls,
+        keyboardType: TextInputType.text,
+        textAlign: TextAlign.right,
+        onSelectionChanged: (TextSelection newSelection, SelectionChangedCause newCause) {
+        },
+      ),
+    ));
+
+
+    await tester.pumpAndSettle(); // Wait for autofocus to take effect.
+
+    final dynamic exception = tester.takeException();
+    expect(exception, isNull);
+  });
 }
 
 class MockTextSelectionControls extends Mock implements TextSelectionControls {

--- a/packages/flutter/test/widgets/tween_animation_builder_test.dart
+++ b/packages/flutter/test/widgets/tween_animation_builder_test.dart
@@ -23,18 +23,26 @@ void main() {
       ),
     );
     expect(endCount, 0);
-    expect(values, <int>[10]);
+    // TweenAnimationBuilder is built twice, initiated in the following places:
+    //
+    // 1. `WidgetsBinding.attachRootWidget()`.
+    // 2. `WidgetsBinding.drawFrame()`.
+    expect(values, <int>[10, 10]);
+    values.clear();
 
     await tester.pump(const Duration(milliseconds: 500));
-    expect(values, <int>[10, 60]);
+    expect(values, <int>[60]);
+    values.clear();
 
     await tester.pump(const Duration(milliseconds: 501));
     expect(endCount, 1);
-    expect(values, <int>[10, 60, 110]);
+    expect(values, <int>[110]);
+    values.clear();
 
     await tester.pump(const Duration(milliseconds: 500));
     expect(endCount, 1);
-    expect(values, <int>[10, 60, 110]);
+    expect(values, <int>[]);
+    values.clear();
   });
 
   testWidgets('No initial animation when begin=null', (WidgetTester tester) async {
@@ -98,18 +106,27 @@ void main() {
     }
 
     await tester.pumpWidget(buildWidget(tween: IntTween(begin: 0, end: 100)));
-    expect(values, <int>[0]);
+    // TweenAnimationBuilder is built twice, initiated in the following places:
+    //
+    // 1. `WidgetsBinding.attachRootWidget()`.
+    // 2. `WidgetsBinding.drawFrame()`.
+    expect(values, <int>[0, 0]);
+    values.clear();
     await tester.pump(const Duration(seconds: 2)); // finish first animation.
-    expect(values, <int>[0, 100]);
+    expect(values, <int>[100]);
+    values.clear();
 
     await tester.pumpWidget(buildWidget(tween: IntTween(begin: 100, end: 200)));
-    expect(values, <int>[0, 100, 100]);
+    expect(values, <int>[100]);
+    values.clear();
 
     await tester.pump(const Duration(milliseconds: 500));
-    expect(values, <int>[0, 100, 100, 150]);
+    expect(values, <int>[150]);
+    values.clear();
 
     await tester.pump(const Duration(milliseconds: 500));
-    expect(values, <int>[0, 100, 100, 150, 200]);
+    expect(values, <int>[200]);
+    values.clear();
   });
 
   testWidgets('Curve is respected', (WidgetTester tester) async {
@@ -127,7 +144,11 @@ void main() {
     }
 
     await tester.pumpWidget(buildWidget(tween: IntTween(begin: 0, end: 100), curve: Curves.easeInExpo));
-    expect(values, <int>[0]);
+    // TweenAnimationBuilder is built twice, initiated in the following places:
+    //
+    // 1. `WidgetsBinding.attachRootWidget()`.
+    // 2. `WidgetsBinding.drawFrame()`.
+    expect(values, <int>[0, 0]);
     await tester.pump(const Duration(milliseconds: 500));
     expect(values.last, lessThan(50));
     expect(values.last, greaterThan(0));
@@ -156,18 +177,27 @@ void main() {
     }
 
     await tester.pumpWidget(buildWidget(tween: IntTween(begin: 0, end: 100), duration: const Duration(seconds: 1)));
-    expect(values, <int>[0]);
+    // In the first pump, TweenAnimationBuilder is built twice, initiated in the following places:
+    //
+    // 1. `WidgetsBinding.attachRootWidget()`.
+    // 2. `WidgetsBinding.drawFrame()`.
+    expect(values, <int>[0, 0]);
+    values.clear();
     await tester.pump(const Duration(milliseconds: 500));
-    expect(values, <int>[0, 50]);
+    expect(values, <int>[50]);
+    values.clear();
 
     await tester.pump(const Duration(seconds: 2)); // finish animation.
-
+    expect(values, <int>[100]);
     values.clear();
+
     // Update duration (and tween to re-trigger animation).
     await tester.pumpWidget(buildWidget(tween: IntTween(begin: 100, end: 200), duration: const Duration(seconds: 2)));
     expect(values, <int>[100]);
+    values.clear();
     await tester.pump(const Duration(milliseconds: 500));
-    expect(values, <int>[100, 125]);
+    expect(values, <int>[125]);
+    values.clear();
   });
 
   testWidgets('Child is integrated into tree', (WidgetTester tester) async {
@@ -205,22 +235,30 @@ void main() {
       await tester.pumpWidget(buildWidget(
         tween: IntTween(begin: 0, end: 100),
       ));
-      expect(values, <int>[0]);
+      // TweenAnimationBuilder is built twice, initiated in the following places:
+      //
+      // 1. `WidgetsBinding.attachRootWidget()`.
+      // 2. `WidgetsBinding.drawFrame()`.
+      expect(values, <int>[0, 0]);
+      values.clear();
       await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[0, 50]);
+      expect(values, <int>[50]);
+      values.clear();
 
       // Change tween
       await tester.pumpWidget(buildWidget(
         tween: IntTween(begin: 200, end: 300),
       ));
-      expect(values, <int>[0, 50, 50]); // gapless: animation continues where it left off.
+      expect(values, <int>[50]); // gapless: animation continues where it left off.
+      values.clear();
 
       await tester.pump(const Duration(milliseconds: 500));
-      expect(values, <int>[0, 50, 50, 175]); // 175 = halfway between 50 and new target 300.
+      expect(values, <int>[175]); // 175 = halfway between 50 and new target 300.
+      values.clear();
 
       // Run animation to end
       await tester.pump(const Duration(seconds: 2));
-      expect(values, <int>[0, 50, 50, 175, 300]);
+      expect(values, <int>[300]);
       values.clear();
     });
 
@@ -249,7 +287,11 @@ void main() {
       ));
       await tester.pump(const Duration(milliseconds: 500));
       await tester.pump(const Duration(seconds: 2));
-      expect(values, <int>[0, 50, 50, 175, 300]);
+      // In the first pump, TweenAnimationBuilder is built twice, initiated in the following places:
+      //
+      // 1. `WidgetsBinding.attachRootWidget()`.
+      // 2. `WidgetsBinding.drawFrame()`.
+      expect(values, <int>[0, 0, 50, 50, 175, 300]);
       values.clear();
     });
   });
@@ -275,7 +317,11 @@ void main() {
       tween: tween1,
     ));
     await tester.pump(const Duration(milliseconds: 500));
-    expect(values, <int>[0, 50]);
+    // In the first pump, TweenAnimationBuilder is built twice, initiated in the following places:
+    //
+    // 1. `WidgetsBinding.attachRootWidget()`.
+    // 2. `WidgetsBinding.drawFrame()`.
+    expect(values, <int>[0, 0, 50]);
     values.clear();
 
     // Change tween
@@ -312,7 +358,11 @@ void main() {
       curve: Curves.linear,
     ));
     await tester.pump(const Duration(seconds: 2));
-    expect(values, <int>[0, 100]);
+    // In the first pump, TweenAnimationBuilder is built twice, initiated in the following places:
+    //
+    // 1. `WidgetsBinding.attachRootWidget()`.
+    // 2. `WidgetsBinding.drawFrame()`.
+    expect(values, <int>[0, 0, 100]);
     values.clear();
 
     await tester.pumpWidget(buildWidget(
@@ -341,7 +391,11 @@ void main() {
     ));
     await tester.pump(const Duration(milliseconds: 500));
     await tester.pump(const Duration(milliseconds: 500));
-    expect(values, <int>[0, 50, 100]);
+    // In the first pump, TweenAnimationBuilder is built twice, initiated in the following places:
+    //
+    // 1. `WidgetsBinding.attachRootWidget()`.
+    // 2. `WidgetsBinding.drawFrame()`.
+    expect(values, <int>[0, 0, 50, 100]);
     values.clear();
 
     await tester.pumpWidget(buildWidget(
@@ -369,22 +423,32 @@ void main() {
       tween: IntTween(begin: 0, end: 100),
     ));
     await tester.pump(const Duration(milliseconds: 500));
-    expect(values, <int>[0, 50]);
-    await tester.pumpWidget(buildWidget(
-      tween: IntTween(begin: 200, end: 300),
-    ));
-    await tester.pump(const Duration(milliseconds: 500));
-    expect(values, <int>[0, 50, 50, 175]);
-
-    await tester.pumpWidget(buildWidget(
-      tween: IntTween(begin: 200, end: 300),
-    ));
-    expect(values, <int>[0, 50, 50, 175, 175]);
-    await tester.pump(const Duration(milliseconds: 500));
-    expect(values, <int>[0, 50, 50, 175, 175, 300]);
-
+    // In the first pump, TweenAnimationBuilder is built twice, initiated in the following places:
+    //
+    // 1. `WidgetsBinding.attachRootWidget()`.
+    // 2. `WidgetsBinding.drawFrame()`.
+    expect(values, <int>[0, 0, 50]);
     values.clear();
+    await tester.pumpWidget(buildWidget(
+      tween: IntTween(begin: 200, end: 300),
+    ));
+    expect(values, <int>[50]);
+    values.clear();
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(values, <int>[175]);
+    values.clear();
+
+    await tester.pumpWidget(buildWidget(
+      tween: IntTween(begin: 200, end: 300),
+    ));
+    expect(values, <int>[175]);
+    values.clear();
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(values, <int>[300]);
+    values.clear();
+
     await tester.pump(const Duration(seconds: 2));
-    expect(values, everyElement(300));
+    expect(values, <int>[300]);
+    values.clear();
   });
 }

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -450,7 +450,10 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
     });
   }
 
-  @Deprecated('Use WidgetTester.pumpWidget() instead.')
+  @Deprecated(
+    'Use WidgetTester.pumpWidget() instead. '
+    'This feature was deprecated after v1.14.1'
+  )
   Future<void> pumpWidgetLegacy(Widget widget) {
     return TestAsyncUtils.guard<void>(() {
       binding.attachRootWidget(widget);

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -452,7 +452,7 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
 
   @Deprecated(
     'Use WidgetTester.pumpWidget() instead. '
-    'This feature was deprecated after v1.14.1'
+    'This feature was deprecated after v1.14.1.'
   )
   Future<void> pumpWidgetLegacy(Widget widget) {
     return TestAsyncUtils.guard<void>(() {

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -404,6 +404,8 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
   @override
   TestWidgetsFlutterBinding get binding => super.binding as TestWidgetsFlutterBinding;
 
+  bool _firstPumpWidget = true;
+
   /// Renders the UI from the given [widget].
   ///
   /// Calls [runApp] with the given widget, then triggers a frame and flushes
@@ -438,7 +440,22 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
     return TestAsyncUtils.guard<void>(() {
       binding.attachRootWidget(widget);
       binding.scheduleFrame();
+      if (_firstPumpWidget) {
+        _firstPumpWidget = false;
+        // Emulate what `RenderObjectToWidgetAdapter.attachToRenderTree` does
+        // when it builds a new tree from scratch.
+        binding.buildOwner.buildScope(binding.renderViewElement);
+      }
       return binding.pump(duration, phase);
+    });
+  }
+
+  @Deprecated('Use WidgetTester.pumpWidget() instead.')
+  Future<void> pumpWidgetLegacy(Widget widget) {
+    return TestAsyncUtils.guard<void>(() {
+      binding.attachRootWidget(widget);
+      binding.scheduleFrame();
+      return binding.pump();
     });
   }
 

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -450,6 +450,14 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
     });
   }
 
+  /// This is the old implementation of [pumpWidget] that was replaced in
+  /// https://github.com/flutter/flutter/pull/48922.
+  ///
+  /// Differences are explained in the tests in `test/widget_tester_test.dart`.
+  ///
+  /// The only reason we still have this is because a few material text field
+  /// tests are failing with the new implementation of [pumpWidget]. See
+  /// https://github.com/flutter/flutter/issues/49077.
   @Deprecated(
     'Use WidgetTester.pumpWidget() instead. '
     'This feature was deprecated after v1.14.1.'

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -626,6 +626,7 @@ void main() {
       void log(String message) {
         logs.add(message);
       }
+      // ignore: deprecated_member_use_from_same_package
       await tester.pumpWidgetLegacy(Container(child: LogWidget(log, key: UniqueKey())));
 
       // Microtasks from `didChangeDependencies` and `build` should execute
@@ -640,6 +641,7 @@ void main() {
       ]);
       logs.clear();
 
+      // ignore: deprecated_member_use_from_same_package
       await tester.pumpWidgetLegacy(Container(child: LogWidget(log, key: UniqueKey())));
       expect(logs, <String>[
         'didChangeDependencies',


### PR DESCRIPTION
## Description

When `autofocus:true` in an `EditableText` widget, the logic that handles the focus is triggered too early (before the `RenderEditable` object is laid out) which causes a crash because it relies on layout information. As it turns out, this only happens when the `EditableText` is part of the initial frame when the app starts.

This revealed a discrepancy between `WidgetTester.pumpWidget()` and `runApp()`. The `autofocus:true` crash only occurs with `runApp()` but not with `WidgetTester.pumpWidget()`. That's because `WidgetTester.pumpWidget()` behaves as if there was a frame prior to this. And that doesn't match `runApp()` which renders the first frame with no frames prior. In this PR, I added a fix that @yjbanov and I think is right, but we are looking for other people's feedback.

Of course, this change caused several tests to fail because they were relying on the `WidgetTester.pumpWidget()` behavior.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/47235

## Tests

I added the following tests:
* `test/widgets/editable_text_test.dart`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
