### PR TITLE
[bugfix] SliverGeometry is not valid: The "layoutExtent" is negative

### DIFF
--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -1445,7 +1445,7 @@ class RenderSliverOverlapAbsorber extends RenderSliver with RenderObjectWithChil
       scrollExtent: childLayoutGeometry.scrollExtent - childLayoutGeometry.maxScrollObstructionExtent,
       paintExtent: childLayoutGeometry.paintExtent,
       paintOrigin: childLayoutGeometry.paintOrigin,
-      layoutExtent: childLayoutGeometry.paintExtent - childLayoutGeometry.maxScrollObstructionExtent,
+      layoutExtent: math.max(0, childLayoutGeometry.paintExtent - childLayoutGeometry.maxScrollObstructionExtent),
       maxPaintExtent: childLayoutGeometry.maxPaintExtent,
       maxScrollObstructionExtent: childLayoutGeometry.maxScrollObstructionExtent,
       hitTestExtent: childLayoutGeometry.hitTestExtent,

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -676,6 +676,13 @@ void main() {
     await gesture.up();
     debugDefaultTargetPlatformOverride = null;
   });
+
+
+  testWidgets('NestedScrollView and SliverOverlapAbsorber for PR #48947', (WidgetTester tester) async {
+    await tester.pumpWidget(_TestLayoutExtentIsNegative(1));
+    await tester.pumpWidget(_TestLayoutExtentIsNegative(10));
+  });
+
 }
 
 class TestHeader extends SliverPersistentHeaderDelegate {
@@ -691,4 +698,53 @@ class TestHeader extends SliverPersistentHeaderDelegate {
   }
   @override
   bool shouldRebuild(TestHeader oldDelegate) => false;
+}
+
+class _TestLayoutExtentIsNegative extends StatelessWidget {
+  final int widgetCountBeforeSliverOverlapAbsorber;
+
+  _TestLayoutExtentIsNegative(this.widgetCountBeforeSliverOverlapAbsorber);
+
+  @override
+  Widget build(BuildContext context) {
+    return NestedScrollView(
+      headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
+        return <Widget>[
+          ...List<Widget>.generate(widgetCountBeforeSliverOverlapAbsorber, (_) => SliverToBoxAdapter(
+            child: Container(
+              color: Colors.red,
+              height: 200,
+              margin:const EdgeInsets.all(20),
+            ),
+          ),
+          ),
+          SliverOverlapAbsorber(
+            handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
+            sliver: SliverAppBar(
+              pinned: true,
+              forceElevated: innerBoxIsScrolled,
+              backgroundColor: Colors.blue[300],
+              title: Container(
+                height: 50,
+                child: const Center(
+                  child: Text('Sticky Header'),
+                ),
+              ),
+            ),
+          )
+        ];
+      },
+      body: Container(
+        height: 2000,
+        margin: const EdgeInsets.only(top: 50),
+        child: ListView(
+          children: List<Widget>.generate(3, (_) => Container(
+            color: Colors.green[200],
+            height: 200,
+            margin: const EdgeInsets.all(20),
+          ),),
+        ),
+      ),
+    );
+  }
 }

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -677,12 +677,10 @@ void main() {
     debugDefaultTargetPlatformOverride = null;
   });
 
-
-  testWidgets('NestedScrollView and SliverOverlapAbsorber for PR #48947', (WidgetTester tester) async {
-    await tester.pumpWidget(_TestLayoutExtentIsNegative(1));
-    await tester.pumpWidget(_TestLayoutExtentIsNegative(10));
+  testWidgets('NestedScrollView with SliverOverlapAbsorber in or out of the first screen', (WidgetTester tester) async {
+    await tester.pumpWidget(const _TestLayoutExtentIsNegative(1));
+    await tester.pumpWidget(const _TestLayoutExtentIsNegative(10));
   });
-
 }
 
 class TestHeader extends SliverPersistentHeaderDelegate {
@@ -701,9 +699,10 @@ class TestHeader extends SliverPersistentHeaderDelegate {
 }
 
 class _TestLayoutExtentIsNegative extends StatelessWidget {
-  final int widgetCountBeforeSliverOverlapAbsorber;
 
-  _TestLayoutExtentIsNegative(this.widgetCountBeforeSliverOverlapAbsorber);
+  const _TestLayoutExtentIsNegative(this.widgetCountBeforeSliverOverlapAbsorber);
+
+  final int widgetCountBeforeSliverOverlapAbsorber;
 
   @override
   Widget build(BuildContext context) {

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -677,6 +677,7 @@ void main() {
     debugDefaultTargetPlatformOverride = null;
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/39963.
   testWidgets('NestedScrollView with SliverOverlapAbsorber in or out of the first screen', (WidgetTester tester) async {
     await tester.pumpWidget(const _TestLayoutExtentIsNegative(1));
     await tester.pumpWidget(const _TestLayoutExtentIsNegative(10));
@@ -699,11 +700,8 @@ class TestHeader extends SliverPersistentHeaderDelegate {
 }
 
 class _TestLayoutExtentIsNegative extends StatelessWidget {
-
   const _TestLayoutExtentIsNegative(this.widgetCountBeforeSliverOverlapAbsorber);
-
   final int widgetCountBeforeSliverOverlapAbsorber;
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -714,14 +712,15 @@ class _TestLayoutExtentIsNegative extends StatelessWidget {
         body: NestedScrollView(
           headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
             return <Widget>[
-              ...List<Widget>.generate(widgetCountBeforeSliverOverlapAbsorber, (_) => SliverToBoxAdapter(
-                child: Container(
-                  color: Colors.red,
-                  height: 200,
-                  margin:const EdgeInsets.all(20),
-                ),
-              ),
-              ),
+              ...List<Widget>.generate(widgetCountBeforeSliverOverlapAbsorber, (_) {
+                return SliverToBoxAdapter(
+                  child: Container(
+                    color: Colors.red,
+                    height: 200,
+                    margin:const EdgeInsets.all(20),
+                  ),
+                );
+              },),
               SliverOverlapAbsorber(
                 handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
                 sliver: SliverAppBar(
@@ -742,11 +741,13 @@ class _TestLayoutExtentIsNegative extends StatelessWidget {
             height: 2000,
             margin: const EdgeInsets.only(top: 50),
             child: ListView(
-              children: List<Widget>.generate(3, (_) => Container(
-                color: Colors.green[200],
-                height: 200,
-                margin: const EdgeInsets.all(20),
-              ),),
+              children: List<Widget>.generate(3, (_) {
+                return Container(
+                  color: Colors.green[200],
+                  height: 200,
+                  margin: const EdgeInsets.all(20),
+                );
+              },),
             ),
           ),
         ),

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -706,42 +706,49 @@ class _TestLayoutExtentIsNegative extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return NestedScrollView(
-      headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
-        return <Widget>[
-          ...List<Widget>.generate(widgetCountBeforeSliverOverlapAbsorber, (_) => SliverToBoxAdapter(
-            child: Container(
-              color: Colors.red,
-              height: 200,
-              margin:const EdgeInsets.all(20),
-            ),
-          ),
-          ),
-          SliverOverlapAbsorber(
-            handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
-            sliver: SliverAppBar(
-              pinned: true,
-              forceElevated: innerBoxIsScrolled,
-              backgroundColor: Colors.blue[300],
-              title: Container(
-                height: 50,
-                child: const Center(
-                  child: Text('Sticky Header'),
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('Test'),
+        ),
+        body: NestedScrollView(
+          headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
+            return <Widget>[
+              ...List<Widget>.generate(widgetCountBeforeSliverOverlapAbsorber, (_) => SliverToBoxAdapter(
+                child: Container(
+                  color: Colors.red,
+                  height: 200,
+                  margin:const EdgeInsets.all(20),
                 ),
               ),
+              ),
+              SliverOverlapAbsorber(
+                handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
+                sliver: SliverAppBar(
+                  pinned: true,
+                  forceElevated: innerBoxIsScrolled,
+                  backgroundColor: Colors.blue[300],
+                  title: Container(
+                    height: 50,
+                    child: const Center(
+                      child: Text('Sticky Header'),
+                    ),
+                  ),
+                ),
+              )
+            ];
+          },
+          body: Container(
+            height: 2000,
+            margin: const EdgeInsets.only(top: 50),
+            child: ListView(
+              children: List<Widget>.generate(3, (_) => Container(
+                color: Colors.green[200],
+                height: 200,
+                margin: const EdgeInsets.all(20),
+              ),),
             ),
-          )
-        ];
-      },
-      body: Container(
-        height: 2000,
-        margin: const EdgeInsets.only(top: 50),
-        child: ListView(
-          children: List<Widget>.generate(3, (_) => Container(
-            color: Colors.green[200],
-            height: 200,
-            margin: const EdgeInsets.all(20),
-          ),),
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Description

related widgets:
- NestedScrollView
- SliverOverlapAbsorber

To reproduce the bug of issue,  please click this url: https://dartpad.dev/2630a061cf2632a1ffd6fb6c13c94e4c

try to change the value of `widgetCountBeforeSliverOverlapAbsorber` form `1` to `10`.
- 1: it works fine
- 10: got error message: `SliverGeometry is not valid: The "layoutExtent" is negative.`

## Related Issues

Fixes #39963

