### PR TITLE
Update assert message for AnimatedContainer

### DIFF
--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -649,7 +649,7 @@ class AnimatedContainer extends ImplicitlyAnimatedWidget {
        assert(constraints == null || constraints.debugAssertIsValid()),
        assert(color == null || decoration == null,
          'Cannot provide both a color and a decoration\n'
-         'The color argument is just a shorthand for "decoration: new BoxDecoration(backgroundColor: color)".'
+         'The color argument is just a shorthand for "decoration: BoxDecoration(color: color)".'
        ),
        decoration = decoration ?? (color != null ? BoxDecoration(color: color) : null),
        constraints =


### PR DESCRIPTION
## Description

The error message was misleading because BoxDecoration does not have a `backgroundColor` parameter. Instead it has a `color` parameter, which sets the background color. I also removed the optional `new` keyword.