### PR TITLE
Fix "boolean expression must not be null" when returning from the background

### DIFF
--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -228,7 +228,7 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
     try {
       final ui.SceneBuilder builder = ui.SceneBuilder();
       final ui.Scene scene = layer.buildScene(builder);
-      if (automaticSystemUiAdjustment)
+      if (automaticSystemUiAdjustment == true)
         _updateSystemChrome();
       _window.render(scene);
       scene.dispose();


### PR DESCRIPTION
## Description

Fixes an assertion when returning to the flutter app from another app, called with a custom scheme url:
```
The following assertion was thrown during a scheduler callback: 
Failed assertion: boolean expression must not be null
```

## Related Issues

#29838, #36778, #43373, maybe #48676

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.


Edit: Added reference to #48676