### PR TITLE
Selection menu not showing when selection is 0,0

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -409,8 +409,14 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ) {
     // Changes made by the keyboard can sometimes be "out of band" for listening
     // components, so always send those events, even if we didn't think it
-    // changed.
-    if (nextSelection == selection && cause != SelectionChangedCause.keyboard) {
+    // changed. Also, focusing an empty field is sent as a selection change even
+    // if the selection offset didn't change.
+    final bool focusingEmpty = nextSelection.baseOffset == 0
+      && nextSelection.extentOffset == 0
+      && !hasFocus;
+    if (nextSelection == selection
+        && cause != SelectionChangedCause.keyboard
+        && !focusingEmpty) {
       return;
     }
     if (onSelectionChanged != null) {

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -870,6 +870,27 @@ void main() {
     expect(handle.opacity.value, equals(1.0));
   });
 
+
+  testWidgets('Long pressing a field with selection 0,0 shows the selection menu', (WidgetTester tester) async {
+    await tester.pumpWidget(overlay(
+      child: TextField(
+        controller: TextEditingController.fromValue(
+          const TextEditingValue(
+            selection: TextSelection(baseOffset: 0, extentOffset: 0),
+          ),
+        ),
+      ),
+    ));
+
+    expect(find.text('PASTE'), findsNothing);
+
+    final Offset emptyPos = textOffsetToPosition(tester, 0);
+    await tester.longPressAt(emptyPos, pointer: 7);
+    await tester.pumpAndSettle();
+
+    expect(find.text('PASTE'), findsOneWidget);
+  });
+
   testWidgets('Entering text hides selection handle caret', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController();
 


### PR DESCRIPTION
## Description

Before this PR, if you set a TextField's controller with a selection of 0,0, then the TextField wouldn't show the selection menu before any text was entered.

```dart
TextField(
  controller: TextEditingController.fromValue(
    TextEditingValue(
      selection: TextEditingSelection(baseOffset: 0, extentOffset: 0),
    ),
  ),
),
```

The problem is that when the user focuses the field, RenderEditable tries to set the selection to 0,0, but it sees that it already is 0,0 and thinks nothing has changed.  EditableText is not informed that anything happened, and the selection menu is not created.  Usually, selection would be -1,-1 and this would work fine.

This PR considers this situation to be a selection change, so the field will be focused and the selection menu can be shown.

## Related Issues

Closes https://github.com/flutter/flutter/issues/37798

## Tests

  * Test that a long press in a 0,0 field successfully shows the selection menu.