### PR TITLE
Don't pre-cache Android artifacts with --no-android flag

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/precache_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/precache_test.dart
@@ -44,8 +44,6 @@ void main() {
     expect(artifacts, unorderedEquals(<DevelopmentArtifact>{
       DevelopmentArtifact.universal,
       DevelopmentArtifact.web,
-      DevelopmentArtifact.androidGenSnapshot,
-      DevelopmentArtifact.androidMaven,
     }));
   }, overrides: <Type, Generator>{
     Cache: () => cache,
@@ -59,9 +57,20 @@ void main() {
 
     expect(artifacts, unorderedEquals(<DevelopmentArtifact>{
       DevelopmentArtifact.universal,
-      DevelopmentArtifact.androidGenSnapshot,
-      DevelopmentArtifact.androidMaven,
     }));
+  }, overrides: <Type, Generator>{
+    Cache: () => cache,
+    FeatureFlags: () => TestFeatureFlags(isWebEnabled: false),
+  });
+
+  testUsingContext('precache exits if requesting mismatched artifacts.', () async {
+    final PrecacheCommand command = PrecacheCommand();
+    applyMocksToCommand(command);
+
+    expect(createTestCommandRunner(command).run(const <String>['precache',
+      '--no-android',
+      '--android_gen_snapshot',
+    ]), throwsToolExit(message: '--android_gen_snapshot requires --android'));
   }, overrides: <Type, Generator>{
     Cache: () => cache,
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: false),


### PR DESCRIPTION
## Description

Do not pre-cache Android maven artifacts with `--no-android` flag.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/49006.
See https://github.com/flutter/flutter/pull/39157

## Tests

Updated precache_test.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [x] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*