### PR TITLE
Precache iOS artifacts before platform_view_ios__start_up

### DIFF
--- a/dev/devicelab/bin/tasks/platform_view_ios__start_up.dart
+++ b/dev/devicelab/bin/tasks/platform_view_ios__start_up.dart
@@ -19,7 +19,20 @@ Future<void> main() async {
     );
     await inDirectory(platformViewDirectory, () async {
       await flutter('pub', options: <String>['get']);
+      // Pre-cache the iOS artifacts; this may be the first test run on this machine.
+      await flutter(
+        'precache',
+        options: <String>[
+          '--no-android',
+          '--no-fuchsia',
+          '--no-linux',
+          '--no-macos',
+          '--no-web',
+          '--no-windows',
+        ],
+      );
     });
+
     final Directory iosDirectory = dir(
       '$platformViewDirectoryPath/ios',
     );


### PR DESCRIPTION
## Description

When platform_view_ios__start_up was the first test run on a newly minted devicelab machine, it would fail until `flutter build ios` or some other command would cache the iOS engine artifacts.

Pre-cache before the benchmark starts.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/44228

## Tests

The following fails on master and passes on this PR:
```
$ rm -rf bin/cache/artifacts/engine/ios* 
$ rm -rf examples/platform_view/ios/Flutter/Flutter.framework/
$ cd dev/devicelab && dart bin/run.dart -t platform_view_ios__start_up
```

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*