### PR TITLE
[flutter_tool] Don't crash on failed stamp file update

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -511,7 +511,16 @@ abstract class CachedArtifact extends ArtifactSet {
       }
     }
     await updateInner();
-    cache.setStampFor(stampName, version);
+    try {
+      cache.setStampFor(stampName, version);
+    } on FileSystemException catch (err) {
+      globals.printError(
+        'The new artifact "$name" was downloaded, but Flutter failed to update '
+        'its stamp file, receiving the error "$err". '
+        'Flutter can continue, but the artifact may be re-downloaded on '
+        'subsequent invocations until the problem is resolved.',
+      );
+    }
     _removeDownloadedFiles();
   }
 

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -114,6 +114,23 @@ void main() {
       ProcessManager: () => FakeProcessManager.any(),
     });
 
+    testUsingContext('Continues on failed stamp file update', () async {
+      final Directory artifactDir = globals.fs.systemTempDirectory.createTempSync('flutter_cache_test_artifact.');
+      final Directory downloadDir = globals.fs.systemTempDirectory.createTempSync('flutter_cache_test_download.');
+      when(mockCache.getArtifactDirectory(any)).thenReturn(artifactDir);
+      when(mockCache.getDownloadDir()).thenReturn(downloadDir);
+      when(mockCache.setStampFor(any, any)).thenAnswer((_) {
+        throw const FileSystemException('stamp write failed');
+      });
+      final FakeSimpleArtifact artifact = FakeSimpleArtifact(mockCache);
+      await artifact.update();
+      expect(testLogger.errorText, contains('stamp write failed'));
+    }, overrides: <Type, Generator>{
+      Cache: () => mockCache,
+      FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
+    });
+
     testUsingContext('Gradle wrapper should not be up to date, if some cached artifact is not available', () {
       final GradleWrapper gradleWrapper = GradleWrapper(mockCache);
       final Directory directory = globals.fs.directory('/Applications/flutter/bin/cache');
@@ -452,6 +469,19 @@ class FakeCachedArtifact extends EngineCachedArtifact {
 
   @override
   List<String> getPackageDirs() => packageDirs;
+}
+
+class FakeSimpleArtifact extends CachedArtifact {
+  FakeSimpleArtifact(Cache cache) : super(
+    'fake',
+    cache,
+    DevelopmentArtifact.universal,
+  );
+
+  @override
+  Future<void> updateInner() async {
+    // nop.
+  }
 }
 
 class FakeDownloadedArtifact extends CachedArtifact {


### PR DESCRIPTION
## Description

It can happen that a user's permissions are in a state such that downloading and extracting a cached artifact can succeed, but the stamp file update can fail. Rather than crash in this situation, this PR emits error messages and continues. The file may be redownloaded on the next run, but that is probably better than crashing and sending a report to crash logging that we probably can't take action on.

## Related Issues

Third highest crasher in crash logging on stable.

## Tests

I added the following tests:

Added a test to cache_test.dart

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
