### PR TITLE
Android Project: Opt into splash behavior by default.

### DIFF
--- a/packages/flutter_tools/templates/app/android.tmpl/app/src/main/AndroidManifest.xml.tmpl
+++ b/packages/flutter_tools/templates/app/android.tmpl/app/src/main/AndroidManifest.xml.tmpl
@@ -25,6 +25,25 @@
                 android:name="io.flutter.app.android.SplashScreenUntilFirstFrame"
                 android:value="true" />
             {{/useAndroidEmbeddingV2}}
+            {{#useAndroidEmbeddingV2}}
+            <!-- Specifies an Android theme to apply to this Activity as soon as
+                 the Android process has started. This theme is visible to the user
+                 while the Flutter UI initializes. After that, this theme continues
+                 to determine the Window background behind the Flutter UI. -->
+            <meta-data
+              android:name="io.flutter.embedding.android.NormalTheme"
+              android:resource="@style/NormalTheme"
+              />
+            <!-- Displays an Android View that continues showing the launch screen
+                 Drawable until Flutter paints its first frame, then this splash
+                 screen fades out. A splash screen is useful to avoid any visual
+                 gap between the end of Android's launch screen and the painting of
+                 Flutter's first frame. -->
+            <meta-data
+              android:name="io.flutter.embedding.android.SplashScreenDrawable"
+              android:resource="@drawable/launch_background"
+              />
+            {{/useAndroidEmbeddingV2}}
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/packages/flutter_tools/templates/app/android.tmpl/app/src/main/res/values/styles.xml
+++ b/packages/flutter_tools/templates/app/android.tmpl/app/src/main/res/values/styles.xml
@@ -1,8 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Theme applied to the Android Window while the process is starting -->
     <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">
         <!-- Show a splash screen on the activity. Automatically removed when
              Flutter draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
+    </style>
+    <!-- Theme applied to the Android Window as soon as the process has started.
+         This theme determines the color of the Android Window while your
+         Flutter UI initializes, as well as behind your Flutter UI while its
+         running.
+         
+         This Theme is only used starting with V2 of Flutter's Android embedding. -->
+    <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
+        <item name="android:windowBackground">@android:color/white</item>
     </style>
 </resources>


### PR DESCRIPTION
The existing new project template for Android does not include launch screen and splash screen behavior by default. Requiring developers to follow instructions to set up this behavior themselves seems to be creating confusion. I also found out that new iOS projects come with splash support automatically.

This PR configures new Android projects to use a launch screen and splash screen by default. This default selection is just a white screen, so it won't necessarily look like a splash screen to users, but by simply specifying an image within `launch_drawable.xml`, the white screen will behave like any other splash screen.

**Testing**
I believe that existing tests will ensure that these changes do not interfere with project creation, nor do they break anything with regard to app launch and execution. @blasten can you confirm that?

I don't think that any visual verification of splash screen appearance is logistically feasible as it would require a careful coordination of Espresso screenshots in conjunction with Flutter driver screenshots, and both of those screenshots would be highly timing/processor sensitive, leading to very flaky tests.