### PR TITLE
Generate bitcode for plugin frameworks for flutter build ios-framework

### DIFF
--- a/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
@@ -123,6 +123,7 @@ Future<void> main() async {
         );
 
         await _checkFrameworkArchs(appFrameworkPath, mode);
+        await _checkBitcode(appFrameworkPath, mode);
 
         final String aotSymbols = await dylibSymbols(appFrameworkPath);
 
@@ -168,6 +169,7 @@ Future<void> main() async {
         );
 
         await _checkFrameworkArchs(engineFrameworkPath, mode);
+        await _checkBitcode(engineFrameworkPath, mode);
 
         checkFileExists(path.join(
           outputPath,
@@ -211,6 +213,7 @@ Future<void> main() async {
           'device_info',
         );
         await _checkFrameworkArchs(pluginFrameworkPath, mode);
+        await _checkBitcode(pluginFrameworkPath, mode);
 
         checkFileExists(path.join(
           outputPath,
@@ -235,7 +238,7 @@ Future<void> main() async {
         }
       }
 
-      section("Check all modes' have generated plugin registrant");
+      section('Check all modes have generated plugin registrant');
 
       for (final String mode in <String>['Debug', 'Profile', 'Release']) {
         final String registrantFrameworkPath = path.join(
@@ -246,6 +249,7 @@ Future<void> main() async {
         );
 
         await _checkFrameworkArchs(registrantFrameworkPath, mode);
+        await _checkBitcode(registrantFrameworkPath, mode);
 
         checkFileExists(path.join(
           outputPath,
@@ -308,5 +312,14 @@ Future<void> _checkFrameworkArchs(String frameworkPath, String mode) async {
   // Release and Profile should not.
   if (containsSimulator != isDebug) {
     throw TaskResult.failure('$mode $frameworkPath x86_64 architecture ${isDebug ? 'missing' : 'present'}');
+  }
+}
+
+Future<void> _checkBitcode(String frameworkPath, String mode) async {
+  checkFileExists(frameworkPath);
+
+  // Bitcode only needed in Release mode for archiving.
+  if (mode == 'Release' && !await containsBitcode(frameworkPath)) {
+    throw TaskResult.failure('$frameworkPath does not contain bitcode');
   }
 }

--- a/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
@@ -42,6 +42,21 @@ Future<void> main() async {
         );
       });
 
+      // First, build the module in Debug to copy the debug version of Flutter.framework.
+      // This proves "flutter build ios-framework" re-copies the relevant Flutter.framework,
+      // otherwise building plugins with bitcode will fail linking because the debug version
+      // of Flutter.framework does not contain bitcode.
+      await inDirectory(projectDir, () async {
+        await flutter(
+          'build',
+          options: <String>[
+            'ios',
+            '--debug',
+            '--no-codesign',
+          ],
+        );
+      });
+
       // This builds all build modes' frameworks by default
       section('Build frameworks');
 

--- a/dev/devicelab/lib/framework/ios.dart
+++ b/dev/devicelab/lib/framework/ios.dart
@@ -54,6 +54,48 @@ Future<String> dylibSymbols(String pathToDylib) {
   return eval('nm', <String>['-g', pathToDylib]);
 }
 
-Future<String> fileType(String pathToDylib) {
-  return eval('file', <String>[pathToDylib]);
+Future<String> fileType(String pathToBinary) {
+  return eval('file', <String>[pathToBinary]);
+}
+
+Future<bool> containsBitcode(String pathToBinary) async {
+  // See: https://stackoverflow.com/questions/32755775/how-to-check-a-static-library-is-built-contain-bitcode
+  final String loadCommands = await eval('otool', <String>[
+    '-l',
+    pathToBinary,
+  ]);
+  if (!loadCommands.contains('__LLVM')) {
+    return false;
+  }
+  // Presence of the section may mean a bitcode marker was embedded (size=1), but there is no content.
+  if (!loadCommands.contains('size 0x0000000000000001')) {
+    return true;
+  }
+  // Check the false positives: size=1 wasn't referencing the __LLVM section.
+
+  bool emptyBitcodeMarkerFound = false;
+  //  Section
+  //  sectname __bundle
+  //  segname __LLVM
+  //  addr 0x003c4000
+  //  size 0x0042b633
+  //  offset 3932160
+  //  ...
+  final List<String> lines = LineSplitter.split(loadCommands).toList();
+  lines.asMap().forEach((int index, String line) {
+    if (line.contains('segname __LLVM') && lines.length - index - 1 > 3) {
+      final String emptyBitcodeMarker = lines
+        .skip(index - 1)
+        .take(3)
+        .firstWhere(
+          (String line) => line.contains(' size 0x0000000000000001'),
+          orElse: () => null,
+      );
+      if (emptyBitcodeMarker != null) {
+        emptyBitcodeMarkerFound = true;
+        return;
+      }
+    }
+  });
+  return !emptyBitcodeMarkerFound;
 }

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -490,10 +490,6 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
       return;
     }
 
-    final Directory engineDest = ephemeralDirectory
-      .childDirectory('Flutter')
-      .childDirectory('engine');
-
     _deleteIfExistsSync(ephemeralDirectory);
     _overwriteFromTemplate(
       globals.fs.path.join('module', 'ios', 'library'),
@@ -511,23 +507,30 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
           ephemeralDirectory,
         );
       }
-      // Copy podspec and framework from engine cache. The actual build mode
-      // doesn't actually matter as it will be overwritten by xcode_backend.sh.
-      // However, cocoapods will run before that script and requires something
-      // to be in this location.
-      final Directory framework = globals.fs.directory(
+      copyEngineArtifactToProject(BuildMode.debug);
+    }
+  }
+
+  void copyEngineArtifactToProject(BuildMode mode) {
+    // Copy podspec and framework from engine cache. The actual build mode
+    // doesn't actually matter as it will be overwritten by xcode_backend.sh.
+    // However, cocoapods will run before that script and requires something
+    // to be in this location.
+    final Directory framework = globals.fs.directory(
         globals.artifacts.getArtifactPath(Artifact.flutterFramework,
-        platform: TargetPlatform.ios,
-        mode: BuildMode.debug,
-      ));
-      if (framework.existsSync()) {
-        final File podspec = framework.parent.childFile('Flutter.podspec');
-        fsUtils.copyDirectorySync(
-          framework,
-          engineDest.childDirectory('Flutter.framework'),
-        );
-        podspec.copySync(engineDest.childFile('Flutter.podspec').path);
-      }
+          platform: TargetPlatform.ios,
+          mode: mode,
+        ));
+    if (framework.existsSync()) {
+      final Directory engineDest = ephemeralDirectory
+          .childDirectory('Flutter')
+          .childDirectory('engine');
+      final File podspec = framework.parent.childFile('Flutter.podspec');
+      fsUtils.copyDirectorySync(
+        framework,
+        engineDest.childDirectory('Flutter.framework'),
+      );
+      podspec.copySync(engineDest.childFile('Flutter.podspec').path);
     }
   }
 

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -517,10 +517,12 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
     // However, cocoapods will run before that script and requires something
     // to be in this location.
     final Directory framework = globals.fs.directory(
-      globals.artifacts.getArtifactPath(Artifact.flutterFramework,
-      platform: TargetPlatform.ios,
-      mode: mode,
-    ));
+      globals.artifacts.getArtifactPath(
+        Artifact.flutterFramework,
+        platform: TargetPlatform.ios,
+        mode: mode,
+      )
+    );
     if (framework.existsSync()) {
       final Directory engineDest = ephemeralDirectory
           .childDirectory('Flutter')

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -517,10 +517,10 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
     // However, cocoapods will run before that script and requires something
     // to be in this location.
     final Directory framework = globals.fs.directory(
-        globals.artifacts.getArtifactPath(Artifact.flutterFramework,
-          platform: TargetPlatform.ios,
-          mode: mode,
-        ));
+      globals.artifacts.getArtifactPath(Artifact.flutterFramework,
+      platform: TargetPlatform.ios,
+      mode: mode,
+    ));
     if (framework.existsSync()) {
       final Directory engineDest = ephemeralDirectory
           .childDirectory('Flutter')


### PR DESCRIPTION
## Description

1. The plugin frameworks didn't have bitcode embedded because they were being built, not archived.  Add `BITCODE_GENERATION_MODE` when building to force marker or actual bitcode, depending on configuration.

2. While building the Flutter plugins, they were linking on the last version of Flutter.framework copied from `flutter build`/`run`.  So if you ran `flutter build ios --debug` then `flutter build ios-framework`, the Release plugins would not compile with bitcode since they were linking on the debug version of Flutter.framework, which does not contain bitcode.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/48092

## Tests

- Added bitcode checks to build_ios_framework_module_test integration test.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*