### PR TITLE
Copy support on web

### DIFF
--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -495,6 +495,9 @@ class _SelectableTextState extends State<SelectableText> with AutomaticKeepAlive
     if (!_selectionGestureDetectorBuilder.shouldShowSelectionToolbar)
       return false;
 
+    if (cause == SelectionChangedCause.drag)
+      return true;
+
     if (_controller.selection.isCollapsed)
       return false;
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1789,13 +1789,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   /// Returns `false` if a toolbar couldn't be shown, such as when the toolbar
   /// is already shown, or when no text selection currently exists.
   bool showToolbar() {
-    // Web is using native dom elements to enable clipboard functionality of the
-    // toolbar: copy, paste, select, cut. It might also provide additional
-    // functionality depending on the browser (such as translate). Due to this
-    // we should not show a Flutter toolbar for the editable text elements.
-    if (kIsWeb) {
-      return false;
-    }
 
     if (_selectionOverlay == null || _selectionOverlay.toolbarIsVisible) {
       return false;

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -904,6 +904,7 @@ class TextSelectionGestureDetectorBuilder {
     final PointerDeviceKind kind = details.kind;
     _shouldShowSelectionToolbar = kind == null
                               || kind == PointerDeviceKind.touch
+                              || kind == PointerDeviceKind.mouse
                               || kind == PointerDeviceKind.stylus;
   }
 

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -2578,7 +2578,7 @@ void main() {
   );
 
   testWidgets(
-    'Mouse double tap does not show handles nor toolbar',
+    'Mouse double tap does not show handles only toolbar',
     (WidgetTester tester) async {
       final TextEditingController controller = TextEditingController(
         text: 'abc def ghi',
@@ -2609,7 +2609,7 @@ void main() {
       await gesture.up();
       await tester.pump();
 
-      expect(editableText.selectionOverlay.toolbarIsVisible, isFalse);
+      expect(editableText.selectionOverlay.toolbarIsVisible, isTrue);
       expect(editableText.selectionOverlay.handlesAreVisible, isFalse);
 
       final Offset hPos = textOffsetToPosition(tester, 9); // Position of 'h'.
@@ -2624,8 +2624,8 @@ void main() {
       await gesture.up();
       await tester.pump();
 
-      expect(editableText.selectionOverlay.handlesAreVisible, isFalse);
-      expect(editableText.selectionOverlay.toolbarIsVisible, isFalse);
+      expect(editableText.selectionOverlay.handlesAreVisible, isTrue);
+      expect(editableText.selectionOverlay.toolbarIsVisible, isTrue);
     },
   );
 

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -7095,7 +7095,7 @@ void main() {
   );
 
   testWidgets(
-    'Mouse tap does not show handles nor toolbar',
+    'Mouse tap does not show toolbar, only handles',
     (WidgetTester tester) async {
       final TextEditingController controller = TextEditingController(
         text: 'abc def ghi',
@@ -7123,7 +7123,7 @@ void main() {
 
       final EditableTextState editableText = tester.state(find.byType(EditableText));
       expect(editableText.selectionOverlay.toolbarIsVisible, isFalse);
-      expect(editableText.selectionOverlay.handlesAreVisible, isFalse);
+      expect(editableText.selectionOverlay.handlesAreVisible, isTrue);
     },
   );
 
@@ -7156,7 +7156,7 @@ void main() {
 
       final EditableTextState editableText = tester.state(find.byType(EditableText));
       expect(editableText.selectionOverlay.toolbarIsVisible, isFalse);
-      expect(editableText.selectionOverlay.handlesAreVisible, isFalse);
+      expect(editableText.selectionOverlay.handlesAreVisible, isTrue);
     },
   );
 
@@ -7192,8 +7192,8 @@ void main() {
       await tester.pump();
 
       final EditableTextState editableText = tester.state(find.byType(EditableText));
-      expect(editableText.selectionOverlay.toolbarIsVisible, isFalse);
-      expect(editableText.selectionOverlay.handlesAreVisible, isFalse);
+      expect(editableText.selectionOverlay.toolbarIsVisible, isTrue);
+      expect(editableText.selectionOverlay.handlesAreVisible, isTrue);
     },
   );
 

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -3696,7 +3696,7 @@ void main() {
   );
 
   testWidgets(
-    'Mouse double tap does not show handles nor toolbar',
+    'Mouse double tap does not toolbar, only handles',
     (WidgetTester tester) async {
       await tester.pumpWidget(
         const MaterialApp(
@@ -3723,7 +3723,7 @@ void main() {
       await tester.pump();
 
       final EditableTextState editableText = tester.state(find.byType(EditableText));
-      expect(editableText.selectionOverlay.toolbarIsVisible, isFalse);
+      expect(editableText.selectionOverlay.toolbarIsVisible, isTrue);
       expect(editableText.selectionOverlay.handlesAreVisible, isFalse);
     },
   );


### PR DESCRIPTION
## Description

This PR adds support for copying text on Web. It modifies `selectable_text.dart` to support drag behaviour, registers `PointerDeviceKind.mouse` as a supported device type and removes the web platform check from `showToolbar` in `editable_text.dart`. The `kIsWeb` check was removed since the framework is not using native dom elements at the current time. Instead, the text is drawn directly to `Canvas` leaving users without the ability to copy text on the website. 

## Related Issues
 - https://github.com/flutter/flutter/issues/47234
  - https://github.com/flutter/flutter/issues/32246

## Tests
Modified the following tests:
   - text_field_test.dart 
   - selectable_text_test.dart 
  -  text_field_test.dart

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x ] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? No

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
