### PR TITLE
Exposed optional scrollController property in ReorderableListView

### DIFF
--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -62,6 +62,7 @@ class ReorderableListView extends StatefulWidget {
     this.header,
     @required this.children,
     @required this.onReorder,
+    this.scrollController,
     this.scrollDirection = Axis.vertical,
     this.padding,
     this.reverse = false,
@@ -86,6 +87,9 @@ class ReorderableListView extends StatefulWidget {
   ///
   /// List [children] can only drag along this [Axis].
   final Axis scrollDirection;
+
+  /// Controls scrolls and measures scroll progress.
+  final ScrollController scrollController;
 
   /// The amount of space by which to inset the [children].
   final EdgeInsets padding;
@@ -140,6 +144,7 @@ class _ReorderableListViewState extends State<ReorderableListView> {
         return _ReorderableListContent(
           header: widget.header,
           children: widget.children,
+          scrollController: widget.scrollController,
           scrollDirection: widget.scrollDirection,
           onReorder: widget.onReorder,
           padding: widget.padding,
@@ -165,6 +170,7 @@ class _ReorderableListContent extends StatefulWidget {
   const _ReorderableListContent({
     @required this.header,
     @required this.children,
+    @required this.scrollController,
     @required this.scrollDirection,
     @required this.padding,
     @required this.onReorder,
@@ -173,6 +179,7 @@ class _ReorderableListContent extends StatefulWidget {
 
   final Widget header;
   final List<Widget> children;
+  final ScrollController scrollController;
   final Axis scrollDirection;
   final EdgeInsets padding;
   final ReorderCallback onReorder;
@@ -262,7 +269,7 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
 
   @override
   void didChangeDependencies() {
-    _scrollController = PrimaryScrollController.of(context) ?? ScrollController();
+    _scrollController = widget.scrollController ?? (PrimaryScrollController.of(context) ?? ScrollController());
     super.didChangeDependencies();
   }
 

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -91,9 +91,9 @@ class ReorderableListView extends StatefulWidget {
   /// Creates a [ScrollPosition] to manage and determine which portion
   /// of the content is visible in the scroll view.
   ///
-  /// This can be used in many ways, such as setting an initial scroll offset, 
-  /// (via [ScrollController.initialScrollOffset]), reading the current scroll position 
-  /// (via [ScrollController.offset]), or changing it (via [ScrollController.jumpTo] or 
+  /// This can be used in many ways, such as setting an initial scroll offset,
+  /// (via [ScrollController.initialScrollOffset]), reading the current scroll position
+  /// (via [ScrollController.offset]), or changing it (via [ScrollController.jumpTo] or
   /// [ScrollController.animateTo]).
   final ScrollController scrollController;
 

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -269,7 +269,7 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
 
   @override
   void didChangeDependencies() {
-    _scrollController = widget.scrollController ?? (PrimaryScrollController.of(context) ?? ScrollController());
+    _scrollController = widget.scrollController ?? PrimaryScrollController.of(context) ?? ScrollController();
     super.didChangeDependencies();
   }
 

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -88,8 +88,13 @@ class ReorderableListView extends StatefulWidget {
   /// List [children] can only drag along this [Axis].
   final Axis scrollDirection;
 
-  /// Creates a ScrollPosition to manage and determine which portion
-  /// of the content is visible in a scroll view.
+  /// Creates a [ScrollPosition] to manage and determine which portion
+  /// of the content is visible in the scroll view.
+  ///
+  /// This can be used in many ways, such as setting an initial scroll offset, 
+  /// (via [ScrollController.initialScrollOffset]), reading the current scroll position 
+  /// (via [ScrollController.offset]), or changing it (via [ScrollController.jumpTo] or 
+  /// [ScrollController.animateTo]).
   final ScrollController scrollController;
 
   /// The amount of space by which to inset the [children].

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -88,7 +88,8 @@ class ReorderableListView extends StatefulWidget {
   /// List [children] can only drag along this [Axis].
   final Axis scrollDirection;
 
-  /// Controls scrolls and measures scroll progress.
+  /// Creates a ScrollPosition to manage and determine which portion
+  /// of the content is visible in a scroll view.
   final ScrollController scrollController;
 
   /// The amount of space by which to inset the [children].

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -263,29 +263,72 @@ void main() {
         expect(scrollView.controller, primary2);
       });
 
-      testWidgets('Use custom ScrollController when scrollController is set', (WidgetTester tester) async {
-        final ScrollController customController = ScrollController(initialScrollOffset: 10);
+      testWidgets('Test custom ScrollController behavior when set', (WidgetTester tester) async {
+        const Key firstBox = Key('C');
+        const Key secondBox = Key('B');
+        const Key thirdBox = Key('A');
+        
+        final ScrollController customController = ScrollController();
+
         await tester.pumpWidget(
           MaterialApp(
-            home: ReorderableListView(
-              scrollController: customController,
-              children: const <Widget>[
-                SizedBox(width: 100.0, height: 100.0, child: Text('C'), key: Key('C')),
-                SizedBox(width: 100.0, height: 100.0, child: Text('B'), key: Key('B')),
-                SizedBox(width: 100.0, height: 100.0, child: Text('A'), key: Key('A')),
-              ],
-              onReorder: (int oldIndex, int newIndex) { },
+            home: Scaffold(
+              body: SizedBox(
+                height: 200,
+                child: ReorderableListView(
+                  scrollController: customController,
+                  children: const <Widget>[
+                    SizedBox(width: 100.0, height: 100.0, child: Text('C'), key: firstBox),
+                    SizedBox(width: 100.0, height: 100.0, child: Text('B'), key: secondBox),
+                    SizedBox(width: 100.0, height: 100.0, child: Text('A'), key: thirdBox),
+                  ],
+                  onReorder: (int oldIndex, int newIndex) { },
+                ),
+              ),
             ),
-          )
+          ),
         );
 
-        final ReorderableListView listView = tester.widget(
+        // Check initial scroll offset of first list item relative to
+        // the offset of the list view.
+        customController.animateTo(
+          40.0, 
+          duration: const Duration(milliseconds: 200), 
+          curve: Curves.linear
+        );
+
+        await tester.pumpAndSettle();
+
+        Offset listViewTopLeft = tester.getTopLeft(
           find.byType(ReorderableListView),
         );
 
-        listView.scrollController.jumpTo(20);
+        Offset firstBoxTopLeft = tester.getTopLeft(
+          find.byKey(firstBox)
+        );
 
-        expect(customController.offset, 20);
+        expect(firstBoxTopLeft.dy, listViewTopLeft.dy - 40.0);
+
+        // Drag the UI to see if the scroll controller updates accordingly
+        await tester.drag(
+          find.text('B'), 
+          const Offset(0.0, -100.0),
+        );
+
+        listViewTopLeft = tester.getTopLeft(
+          find.byType(ReorderableListView),
+        );
+
+        firstBoxTopLeft = tester.getTopLeft(
+          find.byKey(firstBox),
+        );
+        
+        // Initial scroll controller offset: 40.0
+        // Drag UI by 100.0 upwards vertically
+        // First 20.0 px always ignored, so scroll offset is only
+        // shifted by 80.0.
+        // Final offset: 40.0 + 80.0 = 120.0
+        expect(customController.offset, 120.0);
       });
 
       testWidgets('Still builds when no PrimaryScrollController is available', (WidgetTester tester) async {

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -267,9 +267,7 @@ void main() {
         const Key firstBox = Key('C');
         const Key secondBox = Key('B');
         const Key thirdBox = Key('A');
-        
         final ScrollController customController = ScrollController();
-
         await tester.pumpWidget(
           MaterialApp(
             home: Scaffold(
@@ -277,12 +275,12 @@ void main() {
                 height: 200,
                 child: ReorderableListView(
                   scrollController: customController,
+                  onReorder: (int oldIndex, int newIndex) { },
                   children: const <Widget>[
                     SizedBox(width: 100.0, height: 100.0, child: Text('C'), key: firstBox),
                     SizedBox(width: 100.0, height: 100.0, child: Text('B'), key: secondBox),
                     SizedBox(width: 100.0, height: 100.0, child: Text('A'), key: thirdBox),
                   ],
-                  onReorder: (int oldIndex, int newIndex) { },
                 ),
               ),
             ),
@@ -296,17 +294,13 @@ void main() {
           duration: const Duration(milliseconds: 200), 
           curve: Curves.linear
         );
-
         await tester.pumpAndSettle();
-
         Offset listViewTopLeft = tester.getTopLeft(
           find.byType(ReorderableListView),
         );
-
         Offset firstBoxTopLeft = tester.getTopLeft(
           find.byKey(firstBox)
         );
-
         expect(firstBoxTopLeft.dy, listViewTopLeft.dy - 40.0);
 
         // Drag the UI to see if the scroll controller updates accordingly
@@ -314,15 +308,12 @@ void main() {
           find.text('B'), 
           const Offset(0.0, -100.0),
         );
-
         listViewTopLeft = tester.getTopLeft(
           find.byType(ReorderableListView),
         );
-
         firstBoxTopLeft = tester.getTopLeft(
           find.byKey(firstBox),
         );
-        
         // Initial scroll controller offset: 40.0
         // Drag UI by 100.0 upwards vertically
         // First 20.0 px always ignored, so scroll offset is only

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -263,6 +263,26 @@ void main() {
         expect(scrollView.controller, primary2);
       });
 
+      testWidgets('Use custom ScrollController when scrollController is set', (WidgetTester tester) async {
+        final ScrollController customController = ScrollController();
+        final Widget reorderableList = ReorderableListView(
+          scrollController: customController,
+          children: const <Widget>[
+            SizedBox(width: 100.0, height: 100.0, child: Text('C'), key: Key('C')),
+            SizedBox(width: 100.0, height: 100.0, child: Text('B'), key: Key('B')),
+            SizedBox(width: 100.0, height: 100.0, child: Text('A'), key: Key('A')),
+          ],
+          onReorder: (int oldIndex, int newIndex) { },
+        );
+
+        await tester.pumpWidget(MaterialApp(home: reorderableList));
+        final ReorderableListView listView = tester.widget(
+          find.byType(ReorderableListView),
+        );
+
+        expect(listView.scrollController, customController);
+      });
+
       testWidgets('Still builds when no PrimaryScrollController is available', (WidgetTester tester) async {
         final Widget reorderableList = ReorderableListView(
           children: const <Widget>[

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -264,7 +264,7 @@ void main() {
       });
 
       testWidgets('Use custom ScrollController when scrollController is set', (WidgetTester tester) async {
-        final ScrollController customController = ScrollController();
+        final ScrollController customController = ScrollController(initialScrollOffset: 10);
         await tester.pumpWidget(
           MaterialApp(
             home: ReorderableListView(
@@ -283,7 +283,9 @@ void main() {
           find.byType(ReorderableListView),
         );
 
-        expect(listView.scrollController, customController);
+        listView.scrollController.jumpTo(20);
+
+        expect(customController.offset, 20);
       });
 
       testWidgets('Still builds when no PrimaryScrollController is available', (WidgetTester tester) async {

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -265,17 +265,20 @@ void main() {
 
       testWidgets('Use custom ScrollController when scrollController is set', (WidgetTester tester) async {
         final ScrollController customController = ScrollController();
-        final Widget reorderableList = ReorderableListView(
-          scrollController: customController,
-          children: const <Widget>[
-            SizedBox(width: 100.0, height: 100.0, child: Text('C'), key: Key('C')),
-            SizedBox(width: 100.0, height: 100.0, child: Text('B'), key: Key('B')),
-            SizedBox(width: 100.0, height: 100.0, child: Text('A'), key: Key('A')),
-          ],
-          onReorder: (int oldIndex, int newIndex) { },
+        await tester.pumpWidget(
+          MaterialApp(
+            home: ReorderableListView(
+              scrollController: customController,
+              children: const <Widget>[
+                SizedBox(width: 100.0, height: 100.0, child: Text('C'), key: Key('C')),
+                SizedBox(width: 100.0, height: 100.0, child: Text('B'), key: Key('B')),
+                SizedBox(width: 100.0, height: 100.0, child: Text('A'), key: Key('A')),
+              ],
+              onReorder: (int oldIndex, int newIndex) { },
+            ),
+          )
         );
 
-        await tester.pumpWidget(MaterialApp(home: reorderableList));
         final ReorderableListView listView = tester.widget(
           find.byType(ReorderableListView),
         );

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -290,8 +290,8 @@ void main() {
         // Check initial scroll offset of first list item relative to
         // the offset of the list view.
         customController.animateTo(
-          40.0, 
-          duration: const Duration(milliseconds: 200), 
+          40.0,
+          duration: const Duration(milliseconds: 200),
           curve: Curves.linear
         );
         await tester.pumpAndSettle();
@@ -305,7 +305,7 @@ void main() {
 
         // Drag the UI to see if the scroll controller updates accordingly
         await tester.drag(
-          find.text('B'), 
+          find.text('B'),
           const Offset(0.0, -100.0),
         );
         listViewTopLeft = tester.getTopLeft(


### PR DESCRIPTION
## Description

This exposes `scrollController` to the developer, allowing you to directly add a custom `ScrollController` without wrapping it with (or relying on) a PrimaryScrollController.

## Related Issues

#48219

## Tests

I added the following tests:

- Added check to see if custom widget was being set in `test\material\reorderable_list_test.dart`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
