### PR TITLE
download font-subset

### DIFF
--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -62,17 +62,19 @@ enum Artifact {
   // Fuchsia artifacts from the engine prebuilts.
   fuchsiaKernelCompiler,
   fuchsiaFlutterRunner,
+
+  /// Tools related to subsetting or icon font files.
+  fontSubset,
+  constFinder,
 }
 
 String _artifactToFileName(Artifact artifact, [ TargetPlatform platform, BuildMode mode ]) {
+  final String exe = platform == TargetPlatform.windows_x64 ? '.exe' : '';
   switch (artifact) {
     case Artifact.genSnapshot:
       return 'gen_snapshot';
     case Artifact.flutterTester:
-      if (platform == TargetPlatform.windows_x64) {
-        return 'flutter_tester.exe';
-      }
-      return 'flutter_tester';
+      return 'flutter_tester$exe';
     case Artifact.snapshotDart:
       return 'snapshot.dart';
     case Artifact.flutterFramework:
@@ -98,10 +100,7 @@ String _artifactToFileName(Artifact artifact, [ TargetPlatform platform, BuildMo
     case Artifact.frontendServerSnapshotForEngineDartSdk:
       return 'frontend_server.dart.snapshot';
     case Artifact.engineDartBinary:
-      if (platform == TargetPlatform.windows_x64) {
-        return 'dart.exe';
-      }
-      return 'dart';
+      return 'dart$exe';
     case Artifact.dart2jsSnapshot:
       return 'dart2js.dart.snapshot';
     case Artifact.dartdevcSnapshot:
@@ -140,6 +139,10 @@ String _artifactToFileName(Artifact artifact, [ TargetPlatform platform, BuildMo
       final String jitOrAot = mode.isJit ? '_jit' : '_aot';
       final String productOrNo = mode.isRelease ? '_product' : '';
       return 'flutter$jitOrAot${productOrNo}_runner-0.far';
+    case Artifact.fontSubset:
+      return 'font-subset$exe';
+    case Artifact.constFinder:
+      return 'const_finder.dart.snapshot';
   }
   assert(false, 'Invalid artifact $artifact.');
   return null;
@@ -366,6 +369,9 @@ class CachedArtifacts extends Artifacts {
       case Artifact.skyEnginePath:
         final Directory dartPackageDirectory = _cache.getCacheDir('pkg');
         return _fileSystem.path.join(dartPackageDirectory.path,  _artifactToFileName(artifact));
+      case Artifact.fontSubset:
+      case Artifact.constFinder:
+        return _cache.getArtifactDirectory('font-subset').childFile(_artifactToFileName(artifact, platform, mode)).path;
       default:
         assert(false, 'Artifact $artifact not available for platform $platform.');
         return null;
@@ -538,6 +544,10 @@ class LocalEngineArtifacts extends Artifacts {
         final String jitOrAot = mode.isJit ? '_jit' : '_aot';
         final String productOrNo = mode.isRelease ? '_product' : '';
         return _fileSystem.path.join(engineOutPath, 'flutter$jitOrAot${productOrNo}_runner-0.far');
+      case Artifact.fontSubset:
+        return _fileSystem.path.join(_hostEngineOutPath, artifactFileName);
+      case Artifact.constFinder:
+        return _fileSystem.path.join(_hostEngineOutPath, 'gen', artifactFileName);
     }
     assert(false, 'Invalid artifact $artifact.');
     return null;

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -710,7 +710,10 @@ abstract class EngineCachedArtifact extends CachedArtifact {
       final String cacheDir = toolsDir[0];
       final String urlPath = toolsDir[1];
       final Directory dir = globals.fs.directory(globals.fs.path.join(location.path, cacheDir));
-      await _downloadZipArchive('Downloading $cacheDir ($urlPath) tools...', Uri.parse(url + urlPath), dir);
+
+      // Avoid printing things like 'Downloading linux-x64 tools...' multiple times.
+      final String friendlyName = urlPath.replaceAll('/artifacts.zip', '').replaceAll('.zip', '');
+      await _downloadZipArchive('Downloading $friendlyName tools...', Uri.parse(url + urlPath), dir);
 
       _makeFilesExecutable(dir);
 

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -124,6 +124,7 @@ class Cache {
       for (final String artifactName in IosUsbArtifacts.artifactNames) {
         _artifacts.add(IosUsbArtifacts(artifactName, this));
       }
+      _artifacts.add(FontSubsetArtifacts(this));
     } else {
       _artifacts.addAll(artifacts);
     }
@@ -709,7 +710,7 @@ abstract class EngineCachedArtifact extends CachedArtifact {
       final String cacheDir = toolsDir[0];
       final String urlPath = toolsDir[1];
       final Directory dir = globals.fs.directory(globals.fs.path.join(location.path, cacheDir));
-      await _downloadZipArchive('Downloading $cacheDir tools...', Uri.parse(url + urlPath), dir);
+      await _downloadZipArchive('Downloading $cacheDir ($urlPath) tools...', Uri.parse(url + urlPath), dir);
 
       _makeFilesExecutable(dir);
 
@@ -1174,6 +1175,33 @@ class MacOSFuchsiaSDKArtifacts extends _FuchsiaSDKArtifacts {
     }
     return _doUpdate();
   }
+}
+
+/// Cached artifacts for font subsetting.
+class FontSubsetArtifacts extends EngineCachedArtifact {
+  FontSubsetArtifacts(Cache cache) : super(artifactName, cache, DevelopmentArtifact.universal);
+
+  static const String artifactName = 'font-subset';
+
+  @override
+  List<List<String>> getBinaryDirs() {
+    const Map<String, List<String>> artifacts = <String, List<String>> {
+      'macos': <String>['darwin-x64', 'darwin-x64/$artifactName.zip'],
+      'linux': <String>['linux-x64', 'linux-x64/$artifactName.zip'],
+      'windows': <String>['windows-x64', 'windows-x64/$artifactName.zip'],
+    };
+    final List<String> binaryDirs = artifacts[globals.platform.operatingSystem];
+    if (binaryDirs == null) {
+      throwToolExit('Unsupported operating system: ${globals.platform.operatingSystem}');
+    }
+    return <List<String>>[binaryDirs];
+  }
+
+  @override
+  List<String> getLicenseDirs() => const <String>[];
+
+  @override
+  List<String> getPackageDirs() => const <String>[];
 }
 
 /// Cached iOS/USB binary artifacts.

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -278,17 +278,19 @@ void main() {
     MemoryFileSystem memoryFileSystem;
     MockCache mockCache;
     MockOperatingSystemUtils mockOperatingSystemUtils;
+    MockHttpClient mockHttpClient;
 
     setUp(() {
       fakeHttpClient = FakeHttpClient();
+      mockHttpClient = MockHttpClient();
       fakePlatform = FakePlatform()..environment = const <String, String>{};
       memoryFileSystem = MemoryFileSystem();
       mockCache = MockCache();
       mockOperatingSystemUtils = MockOperatingSystemUtils();
-      when(mockOperatingSystemUtils.verifyZip(any)).thenReturn(true);
     });
 
     testUsingContext('makes binary dirs readable and executable by all', () async {
+      when(mockOperatingSystemUtils.verifyZip(any)).thenReturn(true);
       final Directory artifactDir = globals.fs.systemTempDirectory.createTempSync('flutter_cache_test_artifact.');
       final Directory downloadDir = globals.fs.systemTempDirectory.createTempSync('flutter_cache_test_download.');
       when(mockCache.getArtifactDirectory(any)).thenReturn(artifactDir);
@@ -313,6 +315,47 @@ void main() {
       FileSystem: () => memoryFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
       HttpClientFactory: () => () => fakeHttpClient,
+      OperatingSystemUtils: () => mockOperatingSystemUtils,
+      Platform: () => fakePlatform,
+    });
+
+    testUsingContext('prints a friendly name when downloading', () async {
+      when(mockOperatingSystemUtils.verifyZip(any)).thenReturn(false);
+      final MockHttpClientRequest httpClientRequest = MockHttpClientRequest();
+      final MockHttpClientResponse httpClientResponse = MockHttpClientResponse();
+      when(httpClientResponse.statusCode).thenReturn(200);
+
+      when(httpClientRequest.close()).thenAnswer((_) async => httpClientResponse);
+      when(mockHttpClient.getUrl(any)).thenAnswer((_) async => httpClientRequest);
+
+      final Directory artifactDir = globals.fs.systemTempDirectory.createTempSync('flutter_cache_test_artifact.');
+      final Directory downloadDir = globals.fs.systemTempDirectory.createTempSync('flutter_cache_test_download.');
+      when(mockCache.getArtifactDirectory(any)).thenReturn(artifactDir);
+      when(mockCache.getDownloadDir()).thenReturn(downloadDir);
+      final FakeCachedArtifact artifact = FakeCachedArtifact(
+        cache: mockCache,
+        binaryDirs: <List<String>>[
+          <String>['bin_dir', 'darwin-x64/artifacts.zip'],
+          <String>['font-subset', 'darwin-x64/font-subset.zip'],
+        ],
+        requiredArtifacts: DevelopmentArtifact.universal,
+      );
+      await artifact.updateInner();
+      expect(testLogger.statusText, isNotNull);
+      expect(testLogger.statusText, isNotEmpty);
+      expect(
+        testLogger.statusText.split('\n'),
+        <String>[
+          'Downloading darwin-x64 tools...',
+          'Downloading darwin-x64/font-subset tools...',
+          '',
+        ],
+      );
+    }, overrides: <Type, Generator>{
+      Cache: () => mockCache,
+      FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
+      HttpClientFactory: () => () => mockHttpClient,
       OperatingSystemUtils: () => mockOperatingSystemUtils,
       Platform: () => fakePlatform,
     });
@@ -552,3 +595,6 @@ class MockCache extends Mock implements Cache {}
 class MockOperatingSystemUtils extends Mock implements OperatingSystemUtils {}
 class MockPlatform extends Mock implements Platform {}
 class MockVersionedPackageResolver extends Mock implements VersionedPackageResolver {}
+
+class MockHttpClientRequest extends Mock implements HttpClientRequest {}
+class MockHttpClientResponse extends Mock implements HttpClientResponse {}

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -446,6 +446,45 @@ void main() {
       ]);
     });
   }, skip: !globals.platform.isLinux);
+
+
+  testUsingContext('FontSubset in univeral artifacts', () {
+    final MockCache mockCache = MockCache();
+    final FontSubsetArtifacts artifacts = FontSubsetArtifacts(mockCache);
+    expect(artifacts.developmentArtifact, DevelopmentArtifact.universal);
+  });
+
+  testUsingContext('FontSubset artifacts on linux', () {
+    final MockCache mockCache = MockCache();
+    final FontSubsetArtifacts artifacts = FontSubsetArtifacts(mockCache);
+    expect(artifacts.getBinaryDirs(), <List<String>>[<String>['linux-x64', 'linux-x64/font-subset.zip']]);
+  }, overrides: <Type, Generator> {
+    Platform: () => FakePlatform()..operatingSystem = 'linux',
+  });
+
+  testUsingContext('FontSubset artifacts on windows', () {
+    final MockCache mockCache = MockCache();
+    final FontSubsetArtifacts artifacts = FontSubsetArtifacts(mockCache);
+    expect(artifacts.getBinaryDirs(), <List<String>>[<String>['windows-x64', 'windows-x64/font-subset.zip']]);
+  }, overrides: <Type, Generator> {
+    Platform: () => FakePlatform()..operatingSystem = 'windows',
+  });
+
+  testUsingContext('FontSubset artifacts on macos', () {
+    final MockCache mockCache = MockCache();
+    final FontSubsetArtifacts artifacts = FontSubsetArtifacts(mockCache);
+    expect(artifacts.getBinaryDirs(), <List<String>>[<String>['darwin-x64', 'darwin-x64/font-subset.zip']]);
+  }, overrides: <Type, Generator> {
+    Platform: () => FakePlatform()..operatingSystem = 'macos',
+  });
+
+  testUsingContext('FontSubset artifacts on fuchsia', () {
+    final MockCache mockCache = MockCache();
+    final FontSubsetArtifacts artifacts = FontSubsetArtifacts(mockCache);
+    expect(() => artifacts.getBinaryDirs(), throwsToolExit(message: 'Unsupported operating system: ${globals.platform.operatingSystem}'));
+  }, overrides: <Type, Generator> {
+    Platform: () => FakePlatform()..operatingSystem = 'fuchsia',
+  });
 }
 
 class FakeCachedArtifact extends EngineCachedArtifact {


### PR DESCRIPTION
## Description

consume font subsetting tools when caching artifacts.

This adds roughtly 2.5 mb of download, and about 6mb of additional cache overhead (font-subset executable is just over half a meg, const_finder snapshot is about 5.5 megs).

This also prints out a more friendly name for repeated tool artifacts, e.g. instead of repeatedly printing out `darwin-x64 tools`, it will print things like `darwin-x64/font-subset` (unless it's for the `artifacts.zip` archive, in which case it will print the old string).

## Related Issues

#43642 
#43644 

## Tests

I added the following tests:

Test that the new artifact does the expected things on various platforms: provide right paths on Windows/Mac/Linux, throw on other OS.

Test for friendly string logging.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
