### PR TITLE
contains

### DIFF
--- a/packages/flutter/test/foundation/assertions_test.dart
+++ b/packages/flutter/test/foundation/assertions_test.dart
@@ -379,7 +379,7 @@ void main() {
 
     expect(builder.properties.length, 4);
     expect(builder.properties[0].toString(), 'The following assertion was thrown:');
-    expect(builder.properties[1].toString(), 'Assertion failed');
+    expect(builder.properties[1].toString(), contains('Assertion failed'));
     expect(builder.properties[2] is ErrorSpacer, true);
     final DiagnosticsStackTrace trace = builder.properties[3] as DiagnosticsStackTrace;
     expect(trace, isNotNull);
@@ -413,7 +413,7 @@ void main() {
     details.debugFillProperties(builder);
     expect(builder.properties.length, 6);
     expect(builder.properties[0].toString(), 'The following assertion was thrown:');
-    expect(builder.properties[1].toString(), 'Assertion failed');
+    expect(builder.properties[1].toString(), contains('Assertion failed'));
     expect(builder.properties[2] is ErrorSpacer, true);
     expect(
       builder.properties[3].toString(),


### PR DESCRIPTION
https://github.com/dart-lang/sdk/commit/98bafeeb3a86df902baa32b32d3c17b84335adb5 is changing `AssertionError.toString` to include the message.

This makes these tests a bit more flexible so that change can roll in without breaking.

Since this is an error-message only change, I'm considering this to not violate the breaking change policy.  /cc @goderbauer @Hixie 