### PR TITLE
Expose a color property to CloseButton

### DIFF
--- a/packages/flutter/lib/src/material/back_button.dart
+++ b/packages/flutter/lib/src/material/back_button.dart
@@ -128,13 +128,20 @@ class BackButton extends StatelessWidget {
 ///  * [IconButton], to create other material design icon buttons.
 class CloseButton extends StatelessWidget {
   /// Creates a Material Design close button.
-  const CloseButton({ Key key }) : super(key: key);
+  const CloseButton({ Key key, this.color }) : super(key: key);
+
+  /// The color to use for the icon.
+  ///
+  /// Defaults to the [IconThemeData.color] specified in the ambient [IconTheme],
+  /// which usually matches the ambient [Theme]'s [ThemeData.iconTheme].
+  final Color color;
 
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterialLocalizations(context));
     return IconButton(
       icon: const Icon(Icons.close),
+      color: color,
       tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
       onPressed: () {
         Navigator.maybePop(context);

--- a/packages/flutter/test/material/back_button_test.dart
+++ b/packages/flutter/test/material/back_button_test.dart
@@ -69,7 +69,6 @@ void main() {
     final Key iOSKey = UniqueKey();
     final Key androidKey = UniqueKey();
 
-
     await tester.pumpWidget(
       MaterialApp(
         home: Column(
@@ -90,6 +89,24 @@ void main() {
     final Icon iOSIcon = tester.widget(find.descendant(of: find.byKey(iOSKey), matching: find.byType(Icon)));
     final Icon androidIcon = tester.widget(find.descendant(of: find.byKey(androidKey), matching: find.byType(Icon)));
     expect(iOSIcon == androidIcon, false);
+  });
+
+  testWidgets('BackButton color', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(
+          child: BackButton(
+            color: Colors.blue,
+          ),
+        ),
+      ),
+    );
+
+    final RichText iconText = tester.firstWidget(find.descendant(
+        of: find.byType(BackButton),
+        matching: find.byType(RichText)
+    ));
+    expect(iconText.text.style.color, Colors.blue);
   });
 
   testWidgets('BackButton semantics', (WidgetTester tester) async {
@@ -122,5 +139,23 @@ void main() {
       isFocusable: true,
     ));
     handle.dispose();
+  });
+
+  testWidgets('CloseButton color', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(
+          child: CloseButton(
+            color: Colors.red,
+          ),
+        ),
+      ),
+    );
+
+    final RichText iconText = tester.firstWidget(find.descendant(
+        of: find.byType(CloseButton),
+        matching: find.byType(RichText)
+    ));
+    expect(iconText.text.style.color, Colors.red);
   });
 }


### PR DESCRIPTION
NOTE: this is from @Zazo032, but we were having issues with his PR (https://github.com/flutter/flutter/pull/45618) merging into master, so I have recreated it here.

## Description

This PR adds the `color` parameter to the `CloseButton` widget (similar to how `BackButton` is defined).

## Related Issues

Fixes https://github.com/flutter/flutter/issues/45612

## Tests

I added the following tests:

- CloseButton color test

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
