### PR TITLE
Add additional expects to check if flake is a race

### DIFF
--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -741,6 +741,9 @@ void main() {
 
     painter.layout(maxWidth: 300);
 
+    expect(painter.text, const TextSpan(text: text));
+    expect(painter.preferredLineHeight, 14);
+
     final List<ui.LineMetrics> lines = painter.computeLineMetrics();
 
     expect(lines.length, 4);


### PR DESCRIPTION
This minor change adds 2 additional asserts/expects between layout and computeLineMetrics to check if the flakiness is caused by an unexpected race between the two calls.

The preferredLineHeight call should be expensive enough to cover any race.

If this fixes it, then a race is confirmed.

See https://github.com/flutter/flutter/issues/43763