### PR TITLE
Disallow empty platforms and specific platforms when parsing manifest for plugins

### DIFF
--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -202,6 +202,9 @@ class Plugin {
 
   static List<String> _validateMultiPlatformYaml(YamlMap yaml) {
     bool isInvalid(String key, bool Function(YamlMap) validate) {
+      if (!yaml.containsKey(key)) {
+        return false;
+      }
       final dynamic value = yaml[key];
       if (value is! YamlMap) {
         return true;

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -204,13 +204,17 @@ class Plugin {
     bool isInvalid(String key, bool Function(YamlMap) validate) {
       final dynamic value = yaml[key];
       if (value is! YamlMap) {
-        return false;
+        return true;
       }
       final YamlMap yamlValue = value as YamlMap;
       if (yamlValue.containsKey('default_package')) {
         return false;
       }
       return !validate(yamlValue);
+    }
+
+    if (yaml == null) {
+      return <String>['Invalid "platforms" specification.'];
     }
     final List<String> errors = <String>[];
     if (isInvalid(AndroidPlugin.kConfigKey, AndroidPlugin.validate)) {

--- a/packages/flutter_tools/test/general.shard/plugin_parsing_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugin_parsing_test.dart
@@ -157,5 +157,27 @@ void main() {
 
       expect(plugin.platforms, <String, PluginPlatform> {});
     });
+
+    test('error on empty platforms', () {
+      const String pluginYamlRaw = 'platforms:\n';
+
+      final YamlMap pluginYaml = loadYaml(pluginYamlRaw) as YamlMap;
+      expect(
+            () => Plugin.fromYaml(_kTestPluginName, _kTestPluginPath, pluginYaml, const <String>[]),
+        throwsToolExit(message: 'Invalid "platforms" specification.'),
+      );
+    });
+
+    test('error on empty platform', () {
+      const String pluginYamlRaw =
+          'platforms:\n'
+          ' android:\n';
+
+      final YamlMap pluginYaml = loadYaml(pluginYamlRaw) as YamlMap;
+      expect(
+            () => Plugin.fromYaml(_kTestPluginName, _kTestPluginPath, pluginYaml, const <String>[]),
+        throwsToolExit(message: 'Invalid "android" plugin specification.'),
+      );
+    });
   });
 }


### PR DESCRIPTION
## Description

Error when parsing manifests with empty "platform", error when a specific platform's value isn't a map or is null.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/49251
Fixes https://github.com/flutter/flutter/issues/49249


## Tests

"error on empty platforms" fails on master:
```
   Which: threw NoSuchMethodError:<NoSuchMethodError: The method '[]' was called on null.
                Receiver: null
                Tried calling: []("android")>
          stack dart:core                                           Object.noSuchMethod
                package:flutter_tools/src/plugins.dart 205:33       Plugin._validateMultiPlatformYaml.isInvalid
                package:flutter_tools/src/plugins.dart 216:18       Plugin._validateMultiPlatformYaml
                package:flutter_tools/src/plugins.dart 197:14       Plugin.validatePluginYaml
                package:flutter_tools/src/plugins.dart 77:33        new Plugin.fromYaml
                test/general.shard/plugin_parsing_test.dart 166:26  main.<fn>.<fn>.<fn>
                package:test_api                                    expect
                test/general.shard/plugin_parsing_test.dart 165:7   main.<fn>.<fn>
```
"error on empty platform'" fails on master:
```
   Which: threw NoSuchMethodError:<NoSuchMethodError: The method 'containsKey' was called on null.
                Receiver: null
                Tried calling: containsKey("default_package")>
          stack dart:core                                           Object.noSuchMethod
                package:flutter_tools/src/plugins.dart 252:49       Plugin._providesImplementationForPlatform
                package:flutter_tools/src/plugins.dart 102:9        new Plugin._fromMultiPlatformYaml
                package:flutter_tools/src/plugins.dart 82:21        new Plugin.fromYaml
                test/general.shard/plugin_parsing_test.dart 178:26  main.<fn>.<fn>.<fn>
                package:test_api                                    expect
                test/general.shard/plugin_parsing_test.dart 177:7   main.<fn>.<fn>
```

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*