### PR TITLE
Copy the local engine repo in the output directory

### DIFF
--- a/packages/flutter_tools/gradle/aar_init_script.gradle
+++ b/packages/flutter_tools/gradle/aar_init_script.gradle
@@ -33,7 +33,7 @@ void configureProject(Project project, String outputDir) {
     project.android.libraryVariants.all { variant ->
         addAarTask(project, variant)
     }
-    
+
     project.uploadArchives {
         repositories {
             mavenDeployer {

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -546,6 +546,19 @@ Future<void> buildGradleAar({
     command.add('-Plocal-engine-repo=${localEngineRepo.path}');
     command.add('-Plocal-engine-build-mode=${androidBuildInfo.buildInfo.modeName}');
     command.add('-Plocal-engine-out=${localEngineArtifacts.engineOutPath}');
+
+    // Copy the local engine repo in the output directory.
+    try {
+      fsUtils.copyDirectorySync(
+        localEngineRepo,
+        getRepoDirectory(outputDirectory),
+      );
+    } on FileSystemException catch(_) {
+      throwToolExit(
+        'Failed to copy the local engine ${localEngineRepo.path} repo '
+        'in ${outputDirectory.path}'
+      );
+    }
   }
 
   command.add(aarTask);

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -1055,10 +1055,12 @@ plugin1=${plugin1.path}
     MockProcessManager mockProcessManager;
     FakePlatform android;
     FileSystem fileSystem;
+    FileSystemUtils fileSystemUtils;
     Cache cache;
 
     setUp(() {
       fileSystem = MemoryFileSystem();
+      fileSystemUtils = MockFileSystemUtils();
       mockAndroidSdk = MockAndroidSdk();
       mockAndroidStudio = MockAndroidStudio();
       mockArtifacts = MockLocalEngineArtifacts();
@@ -1773,6 +1775,12 @@ plugin1=${plugin1.path}
         '''
       );
 
+      fileSystem.directory('.android/gradle')
+        .createSync(recursive: true);
+
+      fileSystem.directory('.android/gradle/wrapper')
+        .createSync(recursive: true);
+
       fileSystem.file('.android/gradlew').createSync(recursive: true);
 
       fileSystem.file('.android/gradle.properties')
@@ -1789,6 +1797,8 @@ plugin1=${plugin1.path}
       )).thenAnswer((_) async => ProcessResult(1, 0, '', ''));
 
       fileSystem.directory('build/outputs/repo').createSync(recursive: true);
+
+      when(fileSystemUtils.copyDirectorySync(any, any)).thenReturn(null);
 
       await buildGradleAar(
         androidBuildInfo: const AndroidBuildInfo(BuildInfo(BuildMode.release, null)),
@@ -1812,6 +1822,15 @@ plugin1=${plugin1.path}
       expect(actualGradlewCall, contains('-Plocal-engine-build-mode=release'));
       expect(actualGradlewCall, contains('-PbuildNumber=2.0'));
 
+      // Verify the local engine repo is copied into the generated Maven repo.
+      final List<dynamic> copyDirectoryArguments = verify(
+        fileSystemUtils.copyDirectorySync(captureAny, captureAny)
+      ).captured;
+
+      expect(copyDirectoryArguments.length, 2);
+      expect((copyDirectoryArguments.first as Directory).path, '/.tmp_rand0/flutter_tool_local_engine_repo.rand0');
+      expect((copyDirectoryArguments.last as Directory).path, 'build/outputs/repo');
+
     }, overrides: <Type, Generator>{
       AndroidSdk: () => mockAndroidSdk,
       AndroidStudio: () => mockAndroidStudio,
@@ -1819,6 +1838,7 @@ plugin1=${plugin1.path}
       Cache: () => cache,
       Platform: () => android,
       FileSystem: () => fileSystem,
+      FileSystemUtils: () => fileSystemUtils,
       ProcessManager: () => mockProcessManager,
     });
   });
@@ -2047,6 +2067,7 @@ class MockAndroidProject extends Mock implements AndroidProject {}
 class MockAndroidStudio extends Mock implements AndroidStudio {}
 class MockDirectory extends Mock implements Directory {}
 class MockFile extends Mock implements File {}
+class MockFileSystemUtils extends Mock implements FileSystemUtils {}
 class MockFlutterProject extends Mock implements FlutterProject {}
 class MockLocalEngineArtifacts extends Mock implements LocalEngineArtifacts {}
 class MockProcessManager extends Mock implements ProcessManager {}


### PR DESCRIPTION
## Description

Copy the local engine repo in the output Maven repo, so a local engine can be used when building AARs. After this change, the local engine is in the output repo:
```
build
└── host
    └── outputs
        └── repo
            ├── com
            │   └── example
            │       └── module
            │           └── flutter_debug
            │               ├── 1.0
            │               │   ├── flutter_debug-1.0.aar
            │               │   ├── flutter_debug-1.0.aar.md5
            │               │   ├── flutter_debug-1.0.aar.sha1
            │               │   ├── flutter_debug-1.0.pom
            │               │   ├── flutter_debug-1.0.pom.md5
            │               │   └── flutter_debug-1.0.pom.sha1
            │               ├── maven-metadata.xml
            │               ├── maven-metadata.xml.md5
            │               └── maven-metadata.xml.sha1
            └── io
                └── flutter
                    ├── arm64_v8a_debug
                    │   └── 1.0.0-bca8ac1e61f8482a191328e6790b6ad7a8c577a2
                    │       ├── arm64_v8a_debug-1.0.0-bca8ac1e61f8482a191328e6790b6ad7a8c577a2.jar
                    │       └── arm64_v8a_debug-1.0.0-bca8ac1e61f8482a191328e6790b6ad7a8c577a2.pom
                    ├── flutter_embedding_debug
                    │   └── 1.0.0-bca8ac1e61f8482a191328e6790b6ad7a8c577a2
                    │       ├── flutter_embedding_debug-1.0.0-bca8ac1e61f8482a191328e6790b6ad7a8c577a2.jar
                    │       └── flutter_embedding_debug-1.0.0-bca8ac1e61f8482a191328e6790b6ad7a8c577a2.pom
                    └── plugins
                        └── imagepicker
                            └── image_picker_debug
                                ├── 1.0
                                │   ├── image_picker_debug-1.0.aar
                                │   ├── image_picker_debug-1.0.aar.md5
                                │   ├── image_picker_debug-1.0.aar.sha1
                                │   ├── image_picker_debug-1.0.pom
                                │   ├── image_picker_debug-1.0.pom.md5
                                │   └── image_picker_debug-1.0.pom.sha1
                                ├── maven-metadata.xml
                                ├── maven-metadata.xml.md5
                                └── maven-metadata.xml.sha1
```

In the host app, you only need to add:

```
repositories {
  maven {
    url '<path-to-module>/build/host/outputs/repo'
  }
}
```

## Tests

I added the following tests: unit test.


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
