### PR TITLE
[flutter_tools] rollback to dwds 0.8.5, fix versioning

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -525,8 +525,11 @@ class _ExperimentalResidentWebRunner extends ResidentWebRunner {
     if (device.device is ChromeDevice) {
       final Chrome chrome = await ChromeLauncher.connectedInstance;
       final ChromeTab chromeTab = await chrome.chromeConnection.getTab((ChromeTab chromeTab) {
-        return chromeTab.url.contains(debuggingOptions.hostname);
+        return !chromeTab.url.startsWith('chrome-extension');
       });
+      if (chromeTab == null) {
+        throwToolExit('Failed to connect to Chrome instance.');
+      }
       _wipConnection = await chromeTab.connect();
     }
     appStartedCompleter?.complete();

--- a/packages/flutter_tools/lib/src/build_runner/web_fs.dart
+++ b/packages/flutter_tools/lib/src/build_runner/web_fs.dart
@@ -342,8 +342,8 @@ class WebFs {
       dwds,
       // Format ipv6 hosts according to RFC 5952.
       internetAddress.type == InternetAddressType.IPv4
-        ? '${internetAddress.address}:$hostPort'
-        : '[${internetAddress.address}]:$hostPort',
+        ? 'http://${internetAddress.address}:$hostPort'
+        : 'http://[${internetAddress.address}]:$hostPort',
       assetServer,
       buildInfo.isDebug,
       flutterProject,

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -23,6 +23,7 @@ const Map<String, String> _kManuallyPinnedDependencies = <String, String>{
   'flutter_gallery_assets': '0.1.9+2', // See //examples/flutter_gallery/pubspec.yaml
   'mockito': '^4.1.0',  // Prevent mockito from downgrading to 4.0.0
   'vm_service_client': '0.2.6+2', // Final version before being marked deprecated.
+  'dwds': '0.8.5', // Requires updates to web_fs due to breaking changes.
 };
 
 class UpdatePackagesCommand extends FlutterCommand {

--- a/packages/flutter_tools/lib/src/web/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/web/devfs_web.dart
@@ -280,8 +280,8 @@ class WebDevFS implements DevFS {
     // Format ipv6 hosts according to RFC 5952.
     return Uri.parse(
       internetAddress.type == InternetAddressType.IPv4
-        ? '${internetAddress.address}:$port'
-        : '[${internetAddress.address}]:$port'
+        ? 'http://${internetAddress.address}:$port'
+        : 'http://[${internetAddress.address}]:$port'
     );
   }
 

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   # To update these, use "flutter update-packages --force-upgrade".
   archive: 2.0.11
   args: 1.5.2
-  dwds: 0.9.0
+  dwds: 0.8.5
   completion: 0.2.1+1
   coverage: 0.13.3+3
   crypto: 2.1.3
@@ -19,7 +19,6 @@ dependencies:
   http: 0.12.0+4
   intl: 0.16.1
   json_rpc_2: 2.1.0
-  linter: 0.1.109
   meta: 1.1.8
   multicast_dns: 0.2.2
   mustache: 1.1.1
@@ -129,4 +128,4 @@ dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
 
-# PUBSPEC CHECKSUM: 8f2f
+# PUBSPEC CHECKSUM: 7cef


### PR DESCRIPTION
## Description

We need to deal with the slight breaking change in 0.9.0 before upgrading, also fixes some minor issues when resolving hosts.

Fixes https://github.com/flutter/flutter/issues/49297