### PR TITLE
[web] Wire the "--start-paused" flag correctly for web

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -83,12 +83,13 @@ class FlutterWebPlatform extends PlatformPlugin {
     FlutterProject flutterProject,
     String shellPath,
     bool updateGoldens = false,
+    bool pauseAfterLoad = false,
   }) async {
     final shelf_io.IOServer server =
         shelf_io.IOServer(await HttpMultiServer.loopback(0));
     return FlutterWebPlatform._(
       server,
-      Configuration.current,
+      Configuration.current.change(pauseAfterLoad: pauseAfterLoad),
       root,
       flutterProject: flutterProject,
       shellPath: shellPath,
@@ -339,6 +340,7 @@ class FlutterWebPlatform extends PlatformPlugin {
       browser,
       hostUrl,
       completer.future,
+      headless: !_config.pauseAfterLoad,
     );
 
     // Store null values for browsers that error out so we know not to load them
@@ -587,6 +589,8 @@ class BrowserManager {
   /// [future]. If [debug] is true, starts the browser in debug mode, with its
   /// debugger interfaces on and detected.
   ///
+  /// The browser will start in headless mode if [headless] is true.
+  ///
   /// The [settings] indicate how to invoke this browser's executable.
   ///
   /// Returns the browser manager, or throws an [ApplicationException] if a
@@ -596,9 +600,10 @@ class BrowserManager {
     Uri url,
     Future<WebSocketChannel> future, {
     bool debug = false,
+    bool headless = true,
   }) async {
     final Chrome chrome =
-        await chromeLauncher.launch(url.toString(), headless: true);
+        await chromeLauncher.launch(url.toString(), headless: headless);
 
     final Completer<BrowserManager> completer = Completer<BrowserManager>();
 

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -56,6 +56,8 @@ Future<int> runTests(
   final List<String> testArgs = <String>[
     if (!globals.terminal.supportsColor)
       '--no-color',
+    if (startPaused)
+      '--pause-after-load',
     if (machine)
       ...<String>['-r', 'json']
     else
@@ -96,6 +98,7 @@ Future<int> runTests(
           updateGoldens: updateGoldens,
           shellPath: shellPath,
           flutterProject: flutterProject,
+          pauseAfterLoad: startPaused,
         );
       },
     );

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -48,6 +48,31 @@ void main() {
     ProcessManager: () => FakeProcessManager.any(),
     Cache: () => FakeCache(),
   });
+
+  testUsingContext('Pipes start-paused to package:test',
+      () async {
+    final FakePackageTest fakePackageTest = FakePackageTest();
+
+    final TestCommand testCommand = TestCommand(testWrapper: fakePackageTest);
+    final CommandRunner<void> commandRunner =
+        createTestCommandRunner(testCommand);
+
+    await commandRunner.run(const <String>[
+      'test',
+      '--no-pub',
+      '--start-paused',
+      '--',
+      'test/fake_test.dart',
+    ]);
+    expect(
+      fakePackageTest.lastArgs,
+      contains('--pause-after-load'),
+    );
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fs,
+    ProcessManager: () => FakeProcessManager.any(),
+    Cache: () => FakeCache(),
+  });
 }
 
 class FakePackageTest implements TestWrapper {


### PR DESCRIPTION
## Description

Setting the `--start-paused` flag when running `flutter test` will do three things:
1. Make Chrome launch in headful mode (instead of headless).
2. Set `debug=true` in the url being loaded in Chrome.
3. Pass `--pause-after-load` to `package:test`.

## Tests

I added the following tests:
* `flutter_tools/test/commands.shard/hermetic/test_test.dart`