### PR TITLE
Sort Element.dependencies during toString

### DIFF
--- a/dev/integration_tests/codegen/lib/main.dart
+++ b/dev/integration_tests/codegen/lib/main.dart
@@ -45,6 +45,6 @@ class _ExampleWidgetState extends State<ExampleWidget> {
 class GeneratedWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Text(generated.message);
+    return Text(generated.message as String);
   }
 }

--- a/dev/integration_tests/codegen/lib/main.dart
+++ b/dev/integration_tests/codegen/lib/main.dart
@@ -45,6 +45,6 @@ class _ExampleWidgetState extends State<ExampleWidget> {
 class GeneratedWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Text(generated.message as String);
+    return Text(generated.message);
   }
 }

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3920,7 +3920,11 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
     }
     properties.add(FlagProperty('dirty', value: dirty, ifTrue: 'dirty'));
     if (_dependencies != null && _dependencies.isNotEmpty) {
-      final List<DiagnosticsNode> diagnosticsDependencies = _dependencies
+      final List<InheritedElement> sortedDependencies = _dependencies
+        .toList()
+        ..sort((InheritedElement a, InheritedElement b) =>
+          a.widget.runtimeType.toString().compareTo(b.widget.runtimeType.toString()));
+      final List<DiagnosticsNode> diagnosticsDependencies = sortedDependencies
         .map((InheritedElement element) => element.widget.toDiagnosticsNode(style: DiagnosticsTreeStyle.sparse))
         .toList();
       properties.add(DiagnosticsProperty<List<DiagnosticsNode>>('dependencies', diagnosticsDependencies));

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -658,6 +658,60 @@ void main() {
     test.includeChild = false;
   });
 
+  testWidgets('Element diagnostics with multiple dependencies', (WidgetTester tester) async {
+    GlobalKey key0;
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: DefaultFocusTraversal(
+          child: Container(
+            key: key0 = GlobalKey(),
+          ),
+        ),
+      ),
+    );
+    final StatelessElement element1 = key0.currentContext as StatelessElement;
+    element1.dependOnInheritedWidgetOfExactType<Directionality>();
+    element1.dependOnInheritedWidgetOfExactType<DefaultFocusTraversal>();
+
+    expect(element1, hasAGoodToStringDeep);
+    expect(
+      element1.toStringDeep(),
+      equalsIgnoringHashCodes(
+        'Container-[GlobalKey#00000](dependencies: [DefaultFocusTraversal, Directionality])\n'
+        '└LimitedBox(maxWidth: 0.0, maxHeight: 0.0, renderObject: RenderLimitedBox#00000)\n'
+        ' └ConstrainedBox(BoxConstraints(biggest), renderObject: RenderConstrainedBox#00000)\n'
+        ''
+      ),
+    );
+
+    // Do again with reversed order
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: DefaultFocusTraversal(
+          child: Container(
+            key: key0 = GlobalKey(),
+          ),
+        ),
+      ),
+    );
+    final StatelessElement element2 = key0.currentContext as StatelessElement;
+    element2.dependOnInheritedWidgetOfExactType<DefaultFocusTraversal>();
+    element2.dependOnInheritedWidgetOfExactType<Directionality>();
+
+    expect(element2, hasAGoodToStringDeep);
+    expect(
+      element2.toStringDeep(),
+      equalsIgnoringHashCodes(
+        'Container-[GlobalKey#00000](dependencies: [DefaultFocusTraversal, Directionality])\n'
+        '└LimitedBox(maxWidth: 0.0, maxHeight: 0.0, renderObject: RenderLimitedBox#00000)\n'
+        ' └ConstrainedBox(BoxConstraints(biggest), renderObject: RenderConstrainedBox#00000)\n'
+        ''
+      ),
+    );
+  });
+
   testWidgets('scheduleBuild while debugBuildingDirtyElements is true', (WidgetTester tester) async {
     /// ignore here is required for testing purpose because changing the flag properly is hard
     // ignore: invalid_use_of_protected_member


### PR DESCRIPTION
## Description

Since `Element.dependencies` is a `HashSet`, its order is not guaranteed, which can cause problem if someone relies on its exact string value. This is actually observed in https://github.com/flutter/flutter/pull/48453, where `stepper_test.dart` compares the exact value of an error that includes the string of `Stepper`, and the order isn't even consistent between desktop and web.

This PR fixes this issue by sorting `dependencies` by the widget name. I assume this should be sufficient in most cases, since the most common way of adding a dependency is `dependOnInheritedWidgetOfExactType`, in which case there should be no conflicted widget types.

## Related Issues

- Blocks https://github.com/flutter/flutter/pull/48453

## Tests

I added the following tests:

- Element diagnostics with multiple dependencies

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
