### PR TITLE
Remove App.framework copy during build ios-framework

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -326,17 +326,17 @@ end
   Future<void> _produceAppFramework(BuildMode mode, Directory iPhoneBuildOutput, Directory simulatorBuildOutput, Directory modeDirectory) async {
     const String appFrameworkName = 'App.framework';
     final Directory destinationAppFrameworkDirectory = modeDirectory.childDirectory(appFrameworkName);
-    destinationAppFrameworkDirectory.createSync(recursive: true);
 
     if (mode == BuildMode.debug) {
       final Status status = globals.logger.startProgress(' ├─Adding placeholder App.framework for debug...', timeout: timeoutConfiguration.fastOperation);
       try {
+        destinationAppFrameworkDirectory.createSync(recursive: true);
         await _produceStubAppFrameworkIfNeeded(mode, iPhoneBuildOutput, simulatorBuildOutput, destinationAppFrameworkDirectory);
       } finally {
         status.stop();
       }
     } else {
-      await _produceAotAppFrameworkIfNeeded(mode, iPhoneBuildOutput, destinationAppFrameworkDirectory);
+      await _produceAotAppFrameworkIfNeeded(mode, modeDirectory);
     }
 
     final File sourceInfoPlist = _project.ios.hostAppRoot.childDirectory('Flutter').childFile('AppFrameworkInfo.plist');
@@ -398,8 +398,7 @@ end
 
   Future<void> _produceAotAppFrameworkIfNeeded(
     BuildMode mode,
-    Directory iPhoneBuildOutput,
-    Directory destinationAppFrameworkDirectory,
+    Directory destinationDirectory,
   ) async {
     if (mode == BuildMode.debug) {
       return;
@@ -411,7 +410,7 @@ end
     try {
       await aotBuilder.build(
         platform: TargetPlatform.ios,
-        outputPath: iPhoneBuildOutput.path,
+        outputPath: destinationDirectory.path,
         buildMode: mode,
         // Relative paths show noise in the compiler https://github.com/dart-lang/sdk/issues/37978.
         mainDartFile: globals.fs.path.absolute(targetFile),
@@ -422,11 +421,11 @@ end
         dartDefines: dartDefines,
       );
 
-      const String appFrameworkName = 'App.framework';
-      fsUtils.copyDirectorySync(
-        iPhoneBuildOutput.childDirectory(appFrameworkName),
-        destinationAppFrameworkDirectory,
-      );
+//      const String appFrameworkName = 'App.framework';
+//      fsUtils.copyDirectorySync(
+//        iPhoneBuildOutput.childDirectory(appFrameworkName),
+//        destinationAppFrameworkDirectory,
+//      );
     } finally {
       status.stop();
     }

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -398,7 +398,7 @@ end
 
   Future<void> _produceAotAppFrameworkIfNeeded(
     BuildMode mode,
-    Directory destinationDirectory,
+    Directory destinationAppFrameworkDirectory,
   ) async {
     if (mode == BuildMode.debug) {
       return;
@@ -410,7 +410,7 @@ end
     try {
       await aotBuilder.build(
         platform: TargetPlatform.ios,
-        outputPath: destinationDirectory.path,
+        outputPath: destinationAppFrameworkDirectory.path,
         buildMode: mode,
         // Relative paths show noise in the compiler https://github.com/dart-lang/sdk/issues/37978.
         mainDartFile: globals.fs.path.absolute(targetFile),

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -398,7 +398,7 @@ end
 
   Future<void> _produceAotAppFrameworkIfNeeded(
     BuildMode mode,
-    Directory destinationAppFrameworkDirectory,
+    Directory destinationDirectory,
   ) async {
     if (mode == BuildMode.debug) {
       return;
@@ -410,7 +410,7 @@ end
     try {
       await aotBuilder.build(
         platform: TargetPlatform.ios,
-        outputPath: destinationAppFrameworkDirectory.path,
+        outputPath: destinationDirectory.path,
         buildMode: mode,
         // Relative paths show noise in the compiler https://github.com/dart-lang/sdk/issues/37978.
         mainDartFile: globals.fs.path.absolute(targetFile),

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -420,12 +420,6 @@ end
         iosBuildArchs: <DarwinArch>[DarwinArch.armv7, DarwinArch.arm64],
         dartDefines: dartDefines,
       );
-
-//      const String appFrameworkName = 'App.framework';
-//      fsUtils.copyDirectorySync(
-//        iPhoneBuildOutput.childDirectory(appFrameworkName),
-//        destinationAppFrameworkDirectory,
-//      );
     } finally {
       status.stop();
     }


### PR DESCRIPTION
## Description

Remove extra framework copy and just produce the fat framework to its final destination.

## Tests

build_ios_framework_module_test is already testing and validating the final copy location.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*