### PR TITLE
Guard against a null navigator on popping a route.

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -136,7 +136,7 @@ abstract class Route<T> {
   @mustCallSuper
   TickerFuture didPush() {
     return TickerFuture.complete()..then<void>((void _) {
-      navigator.focusScopeNode.requestFocus();
+      navigator?.focusScopeNode?.requestFocus();
     });
   }
 


### PR DESCRIPTION
## Description
When a route pop occurs right after a push (i.e. in the same function), the pop tries to re-focus the previously focused item, but if the push happened synchronously in the same function, then there isn't a navigator set yet on the newly pushed route, so it's null.

This can be the result of a programming error, but (I think) it can also legitimately happen if an operation that was posting a "loading" dialog, for instance, happened so fast that the dialog was immediately popped.

It's OK to not do the focus in that case, since the focus won't have time to change either, and there's no way to know what focus scope to use anyhow without a navigator.

## Related Issues

- Fixes https://github.com/flutter/flutter/issues/45539

## Tests

- Added a test to make sure that popping right after a push doesn't crash.

## Breaking Change

- [X] No, this is *not* a breaking change.