### PR TITLE
Disable flaky LineMetrics test

### DIFF
--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -806,5 +806,5 @@ void main() {
   // does not have a clear cause. This may or may not be a dart compiler
   // issue or similar. See https://github.com/flutter/flutter/issues/43763
   // for more info.
-  }, skip: true); 
+  }, skip: true);
 }

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -801,5 +801,10 @@ void main() {
     expect(lines[1].lineNumber, 1);
     expect(lines[2].lineNumber, 2);
     expect(lines[3].lineNumber, 3);
-  }, skip: !isLinux);
+
+  // Disable this test, this is causing a large amount of flaking and
+  // does not have a clear cause. This may or may not be a dart compiler
+  // issue or similar. See https://github.com/flutter/flutter/issues/43763
+  // for more info.
+  }, skip: true); 
 }


### PR DESCRIPTION
## Description

This test is flaky, and we have been unable to discern what is causing it. The code looks sound, and this does not reproduce locally. The values in this test are still tested in LibTxt unittests. @dnfield has suggested that this may be related to a dart compiler issue.

Disabling for now to stop blocking things.

## Related Issues

https://github.com/flutter/flutter/issues/43763

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
