### PR TITLE
[flutter_tool] Don't crash on a failure to write to std{out,err}

### DIFF
--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -112,12 +112,12 @@ Future<int> _handleToolError(
     }
   } else {
     // We've crashed; emit a log report.
-    stderr.writeln();
+    safeStdioWrite(stderr, '\n');
 
     if (!reportCrashes) {
       // Print the stack trace on the bots - don't write a crash report.
-      stderr.writeln('$error');
-      stderr.writeln(stackTrace.toString());
+      safeStdioWrite(stderr, '$error\n');
+      safeStdioWrite(stderr, '$stackTrace\n');
       return _exit(1);
     }
 
@@ -138,9 +138,10 @@ Future<int> _handleToolError(
 
       return _exit(1);
     } catch (error) {
-      stderr.writeln(
+      safeStdioWrite(
+        stderr,
         'Unable to generate crash report due to secondary error: $error\n'
-            'please let us know at https://github.com/flutter/flutter/issues.',
+        'please let us know at https://github.com/flutter/flutter/issues.\n',
       );
       // Any exception throw here (including one thrown by `_exit()`) will
       // get caught by our zone's `onError` handler. In order to avoid an

--- a/packages/flutter_tools/lib/src/base/io.dart
+++ b/packages/flutter_tools/lib/src/base/io.dart
@@ -253,6 +253,22 @@ Stream<List<int>> get stdin => globals.stdio.stdin;
 io.IOSink get stderr => globals.stdio.stderr;
 bool get stdinHasTerminal => globals.stdio.stdinHasTerminal;
 
+/// Writes [message] to [sink], falling back on [fallback] if the write
+/// throws any exception. The default fallback calls [print] on [message].
+void safeStdioWrite(io.IOSink sink, String message, {
+  void Function(String, dynamic, StackTrace) fallback,
+}) {
+  try {
+    sink.write(message);
+  } catch (err, stack) {
+    if (fallback == null) {
+      print(message);
+    } else {
+      fallback(message, err, stack);
+    }
+  }
+}
+
 // TODO(zra): Move pid and writePidFile into `ProcessInfo`.
 void writePidFile(String pidFile) {
   if (pidFile != null) {

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -143,7 +143,7 @@ class Daemon {
     final dynamic id = request['id'];
 
     if (id == null) {
-      stderr.writeln('no id for request: $request');
+      safeStdioWrite(stderr, 'no id for request: $request\n');
       return;
     }
 
@@ -323,9 +323,9 @@ class DaemonDomain extends Domain {
           // capture the print output for testing.
           print(message.message);
         } else if (message.level == 'error') {
-          stderr.writeln(message.message);
+          safeStdioWrite(stderr, '${message.message}\n');
           if (message.stackTrace != null) {
-            stderr.writeln(message.stackTrace.toString().trimRight());
+            safeStdioWrite(stderr, '${message.stackTrace.toString().trimRight()}\n');
           }
         }
       } else {
@@ -872,7 +872,13 @@ Stream<Map<String, dynamic>> get stdinCommandStream => stdin
   });
 
 void stdoutCommandResponse(Map<String, dynamic> command) {
-  stdout.writeln('[${jsonEncodeObject(command)}]');
+  safeStdioWrite(
+    stdout,
+    '[${jsonEncodeObject(command)}]\n',
+    fallback: (String message, dynamic error, StackTrace stack) {
+      throwToolExit('Failed to write daemon command response to stdout: $error');
+    },
+  );
 }
 
 String jsonEncodeObject(dynamic object) {

--- a/packages/flutter_tools/lib/src/commands/shell_completion.dart
+++ b/packages/flutter_tools/lib/src/commands/shell_completion.dart
@@ -49,7 +49,8 @@ class ShellCompletionCommand extends FlutterCommand {
     }
 
     if (argResults.rest.isEmpty || argResults.rest.first == '-') {
-      stdout.write(generateCompletionScript(<String>['flutter']));
+      final String script = generateCompletionScript(<String>['flutter']);
+      safeStdioWrite(stdout, script);
       return FlutterCommandResult.warning();
     }
 


### PR DESCRIPTION
## Description

When stdout and stderr are pipes, writing to them can throw an exception when the other side of the pipes are closed. This can happen e.g. when the tool is spawned as a subprocess of gradle or an IDE.

This PR wraps stdio writes in a `try {} catch {}` with the callsite able to provide a fallback, which defaults to `print()`.

## Related Issues

Frequent crasher on recent dev channel builds.

## Tests

I added the following tests:

Added a test to logger_test.dart.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
