### PR TITLE
Track lastKnownRemoteTextEditingValue separately from received data

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1205,6 +1205,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   // TextInputClient implementation:
 
   TextEditingValue _lastKnownRemoteTextEditingValue;
+  TextEditingValue _receivedRemoteTextEditingValue;
 
   @override
   TextEditingValue get currentTextEditingValue => _value;
@@ -1224,9 +1225,10 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         _obscureLatestCharIndex = _value.selection.baseOffset;
       }
     }
-    _lastKnownRemoteTextEditingValue = value;
+    print('Updating-remoteValue: ${value.text}');
+    _receivedRemoteTextEditingValue = value;
     _formatAndSetValue(value);
-
+    _lastKnownRemoteTextEditingValue = value;
     // To keep the cursor from blinking while typing, we want to restart the
     // cursor timer every time a new character is typed.
     _stopCursorTimer(resetCharTicks: false);
@@ -1351,8 +1353,9 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     if (!_hasInputConnection)
       return;
     final TextEditingValue localValue = _value;
-    if (localValue == _lastKnownRemoteTextEditingValue)
+    if (localValue == _receivedRemoteTextEditingValue)
       return;
+    print('Setting IMM: ${localValue.text}');
     _lastKnownRemoteTextEditingValue = localValue;
     _textInputConnection.setEditingState(localValue);
   }
@@ -1616,7 +1619,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   }
 
   void _formatAndSetValue(TextEditingValue value) {
-    final bool textChanged = _value?.text != value?.text;
+    final bool textChanged = _value?.text != value?.text && value?.text != _lastKnownRemoteTextEditingValue?.text;
     if (textChanged && widget.inputFormatters != null && widget.inputFormatters.isNotEmpty) {
       for (final TextInputFormatter formatter in widget.inputFormatters)
         value = formatter.formatEditUpdate(_value, value);
@@ -1627,6 +1630,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     }
     if (textChanged && widget.onChanged != null)
       widget.onChanged(value.text);
+    print('Finish Format: ${_value.text}');
   }
 
   void _onCursorColorTick() {

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1633,7 +1633,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         value = formatter.formatEditUpdate(_value, value);
       _value = value;
       _updateRemoteEditingValueIfNeeded();
-    } else {
+    } else if (!isRepeat) {
       _value = value;
     }
     if (textChanged && widget.onChanged != null)

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1626,8 +1626,9 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   void _formatAndSetValue(TextEditingValue value) {
     // Check if the new value is the same as the current local value, or is the same
     // as the post-formatting value of the previous pass.
-    final bool textChanged = _value?.text != value?.text && value?.text != _lastFormattedUnmodifiedTextEditingValue?.text;
-    if (textChanged && widget.inputFormatters != null && widget.inputFormatters.isNotEmpty) {
+    final bool textChanged = _value?.text != value?.text;
+    final bool isRepeat = value?.text == _lastFormattedUnmodifiedTextEditingValue?.text;
+    if (textChanged && !isRepeat && widget.inputFormatters != null && widget.inputFormatters.isNotEmpty) {
       for (final TextInputFormatter formatter in widget.inputFormatters)
         value = formatter.formatEditUpdate(_value, value);
       _value = value;

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1204,10 +1204,9 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
 
   // TextInputClient implementation:
 
-  // _lastKnownRemoteTextEditingValue tracks the value of the input method,
-  // and is updated to the formatted version when the local value is sent
-  // to the input method.
-  TextEditingValue _lastKnownRemoteTextEditingValue;
+  // _lastFormattedUnmodifiedTextEditingValue tracks the last value
+  // that the formatter ran on and is used to prevent double-formatting.
+  TextEditingValue _lastFormattedUnmodifiedTextEditingValue;
   // _receivedRemoteTextEditingValue is the direct value last passed in
   // updateEditingValue. This value does not get updated with the formatted
   // version.
@@ -1361,7 +1360,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     final TextEditingValue localValue = _value;
     if (localValue == _receivedRemoteTextEditingValue)
       return;
-    _lastKnownRemoteTextEditingValue = localValue;
     _textInputConnection.setEditingState(localValue);
   }
 
@@ -1422,7 +1420,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     }
     if (!_hasInputConnection) {
       final TextEditingValue localValue = _value;
-      _lastKnownRemoteTextEditingValue = localValue;
+      _lastFormattedUnmodifiedTextEditingValue = localValue;
       _textInputConnection = TextInput.attach(
         this,
         TextInputConfiguration(
@@ -1462,7 +1460,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     if (_hasInputConnection) {
       _textInputConnection.close();
       _textInputConnection = null;
-      _lastKnownRemoteTextEditingValue = null;
+      _lastFormattedUnmodifiedTextEditingValue = null;
       _receivedRemoteTextEditingValue = null;
     }
   }
@@ -1481,7 +1479,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     if (_hasInputConnection) {
       _textInputConnection.connectionClosedReceived();
       _textInputConnection = null;
-      _lastKnownRemoteTextEditingValue = null;
+      _lastFormattedUnmodifiedTextEditingValue = null;
       _receivedRemoteTextEditingValue = null;
       _finalizeEditing(true);
     }
@@ -1628,7 +1626,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   void _formatAndSetValue(TextEditingValue value) {
     // Check if the new value is the same as the current local value, or is the same
     // as the post-formatting value of the previous pass.
-    final bool textChanged = _value?.text != value?.text && value?.text != _lastKnownRemoteTextEditingValue?.text;
+    final bool textChanged = _value?.text != value?.text && value?.text != _lastFormattedUnmodifiedTextEditingValue?.text;
     if (textChanged && widget.inputFormatters != null && widget.inputFormatters.isNotEmpty) {
       for (final TextInputFormatter formatter in widget.inputFormatters)
         value = formatter.formatEditUpdate(_value, value);
@@ -1639,7 +1637,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     }
     if (textChanged && widget.onChanged != null)
       widget.onChanged(value.text);
-    _lastKnownRemoteTextEditingValue = _receivedRemoteTextEditingValue;
+    _lastFormattedUnmodifiedTextEditingValue = _receivedRemoteTextEditingValue;
   }
 
   void _onCursorColorTick() {

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1626,13 +1626,14 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   }
 
   void _formatAndSetValue(TextEditingValue value) {
+    // Check if the new value is the same as the current local value, or is the same
+    // as the post-formatting value of the previous pass.
     final bool textChanged = _value?.text != value?.text && value?.text != _lastKnownRemoteTextEditingValue?.text;
     if (textChanged && widget.inputFormatters != null && widget.inputFormatters.isNotEmpty) {
       for (final TextInputFormatter formatter in widget.inputFormatters)
         value = formatter.formatEditUpdate(_value, value);
       _value = value;
-      // _updateRemoteEditingValueIfNeeded();
-      _updateRemoteEditingValueIfNeeded()
+      _updateRemoteEditingValueIfNeeded();
     } else {
       _value = value;
     }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1258,7 +1258,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         break;
       default:
         // Finalize editing, but don't give up focus because this keyboard
-        //  action does not imply the user is done inputting information.
+        // action does not imply the user is done inputting information.
         _finalizeEditing(false);
         break;
     }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1633,7 +1633,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         value = formatter.formatEditUpdate(_value, value);
       _value = value;
       _updateRemoteEditingValueIfNeeded();
-    } else if (!isRepeat) {
+    } else if (!isRepeat || !textChanged) {
       _value = value;
     }
     if (textChanged && widget.onChanged != null)

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4180,7 +4180,7 @@ void main() {
   });
 
   testWidgets('updateEditingValue filters multiple calls from formatter', (WidgetTester tester) async {
-    MockTextFormatter formatter = MockTextFormatter();
+    final MockTextFormatter formatter = MockTextFormatter();
     await tester.pumpWidget(
       MediaQuery(
         data: const MediaQueryData(devicePixelRatio: 1.0),
@@ -4213,20 +4213,20 @@ void main() {
     expect(tester.testTextInput.editingState['text'], equals('test'));
     expect(state.wantKeepAlive, true);
 
-    state.updateEditingValue(TextEditingValue(text: ''));
-    state.updateEditingValue(TextEditingValue(text: 'a'));
-    state.updateEditingValue(TextEditingValue(text: 'aa'));
-    state.updateEditingValue(TextEditingValue(text: 'aaa'));
-    state.updateEditingValue(TextEditingValue(text: 'aa'));
-    state.updateEditingValue(TextEditingValue(text: 'aaa'));
-    state.updateEditingValue(TextEditingValue(text: 'aaaa'));
-    state.updateEditingValue(TextEditingValue(text: 'aa'));
-    state.updateEditingValue(TextEditingValue(text: 'aaaaaaa'));
-    state.updateEditingValue(TextEditingValue(text: 'aa'));
-    state.updateEditingValue(TextEditingValue(text: 'aaaaaaaaa'));
-    state.updateEditingValue(TextEditingValue(text: 'aaaaaaaaa')); // Skipped
+    state.updateEditingValue(const TextEditingValue(text: ''));
+    state.updateEditingValue(const TextEditingValue(text: 'a'));
+    state.updateEditingValue(const TextEditingValue(text: 'aa'));
+    state.updateEditingValue(const TextEditingValue(text: 'aaa'));
+    state.updateEditingValue(const TextEditingValue(text: 'aa'));
+    state.updateEditingValue(const TextEditingValue(text: 'aaa'));
+    state.updateEditingValue(const TextEditingValue(text: 'aaaa'));
+    state.updateEditingValue(const TextEditingValue(text: 'aa'));
+    state.updateEditingValue(const TextEditingValue(text: 'aaaaaaa'));
+    state.updateEditingValue(const TextEditingValue(text: 'aa'));
+    state.updateEditingValue(const TextEditingValue(text: 'aaaaaaaaa'));
+    state.updateEditingValue(const TextEditingValue(text: 'aaaaaaaaa')); // Skipped
 
-    List<String> referenceLog = [];
+    final List<String> referenceLog = [];
     referenceLog.add('[1]: , a');
     referenceLog.add('[1]: normal aa');
     referenceLog.add('[2]: aa, aaa');

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4226,25 +4226,26 @@ void main() {
     state.updateEditingValue(const TextEditingValue(text: 'aaaaaaaaa'));
     state.updateEditingValue(const TextEditingValue(text: 'aaaaaaaaa')); // Skipped
 
-    final List<String> referenceLog = <String>[];
-    referenceLog.add('[1]: , a');
-    referenceLog.add('[1]: normal aa');
-    referenceLog.add('[2]: aa, aaa');
-    referenceLog.add('[2]: normal aaaa');
-    referenceLog.add('[3]: aaaa, aa');
-    referenceLog.add('[3]: deleting a');
-    referenceLog.add('[4]: a, aaa');
-    referenceLog.add('[4]: normal aaaaaaaa');
-    referenceLog.add('[5]: aaaaaaaa, aaaa');
-    referenceLog.add('[5]: deleting aaa');
-    referenceLog.add('[6]: aaa, aa');
-    referenceLog.add('[6]: deleting aaaa');
-    referenceLog.add('[7]: aaaa, aaaaaaa');
-    referenceLog.add('[7]: normal aaaaaaaaaaaaaa');
-    referenceLog.add('[8]: aaaaaaaaaaaaaa, aa');
-    referenceLog.add('[8]: deleting aaaaaa');
-    referenceLog.add('[9]: aaaaaa, aaaaaaaaa');
-    referenceLog.add('[9]: normal aaaaaaaaaaaaaaaaaa');
+    const List<String> referenceLog = <String>[
+      '[1]: , a',
+      '[1]: normal aa',
+      '[2]: aa, aaa',
+      '[2]: normal aaaa',
+      '[3]: aaaa, aa',
+      '[3]: deleting a',
+      '[4]: a, aaa',
+      '[4]: normal aaaaaaaa',
+      '[5]: aaaaaaaa, aaaa',
+      '[5]: deleting aaa',
+      '[6]: aaa, aa',
+      '[6]: deleting aaaa',
+      '[7]: aaaa, aaaaaaa',
+      '[7]: normal aaaaaaaaaaaaaa',
+      '[8]: aaaaaaaaaaaaaa, aa',
+      '[8]: deleting aaaaaa',
+      '[9]: aaaaaa, aaaaaaaaa',
+      '[9]: normal aaaaaaaaaaaaaaaaaa',
+    ];
 
     expect(formatter.log, referenceLog);
   });

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4226,7 +4226,7 @@ void main() {
     state.updateEditingValue(const TextEditingValue(text: 'aaaaaaaaa'));
     state.updateEditingValue(const TextEditingValue(text: 'aaaaaaaaa')); // Skipped
 
-    final List<String> referenceLog = [];
+    final List<String> referenceLog = <String>[];
     referenceLog.add('[1]: , a');
     referenceLog.add('[1]: normal aa');
     referenceLog.add('[2]: aa, aaa');
@@ -4250,9 +4250,8 @@ void main() {
   });
 }
 
-@immutable
 class MockTextFormatter extends TextInputFormatter {
-  MockTextFormatter() : _counter = 0, log = [];
+  MockTextFormatter() : _counter = 0, log = <String>[];
 
   int _counter;
   List<String> log;
@@ -4276,13 +4275,13 @@ class MockTextFormatter extends TextInputFormatter {
 
   TextEditingValue _handleTextDeletion(
       TextEditingValue oldValue, TextEditingValue newValue) {
-    String result = 'a' * (_counter - 2);
+    final String result = 'a' * (_counter - 2);
     log.add('[$_counter]: deleting $result');
     return TextEditingValue(text: result);
   }
 
   TextEditingValue _formatText(TextEditingValue value) {
-    String result = 'a' * _counter * 2;
+    final String result = 'a' * _counter * 2;
     log.add('[$_counter]: normal $result');
     return TextEditingValue(text: result);
   }

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4228,25 +4228,23 @@ void main() {
 
     List<String> referenceLog = [];
     referenceLog.add('[1]: , a');
-    referenceLog.add('[1]: normal a');
-    referenceLog.add('[2]: a, aa');
-    referenceLog.add('[2]: normal aa');
-    referenceLog.add('[3]: aa, aaa');
-    referenceLog.add('[3]: normal aaa');
-    referenceLog.add('[4]: aaa, aa');
-    referenceLog.add('[4]: deleting aa');
-    referenceLog.add('[5]: aa, aaa');
-    referenceLog.add('[5]: normal aaaaa');
-    referenceLog.add('[6]: aaaaa, aaaa');
+    referenceLog.add('[1]: normal aa');
+    referenceLog.add('[2]: aa, aaa');
+    referenceLog.add('[2]: normal aaaa');
+    referenceLog.add('[3]: aaaa, aa');
+    referenceLog.add('[3]: deleting a');
+    referenceLog.add('[4]: a, aaa');
+    referenceLog.add('[4]: normal aaaaaaaa');
+    referenceLog.add('[5]: aaaaaaaa, aaaa');
+    referenceLog.add('[5]: deleting aaa');
+    referenceLog.add('[6]: aaa, aa');
     referenceLog.add('[6]: deleting aaaa');
-    referenceLog.add('[7]: aaaa, aa');
-    referenceLog.add('[7]: deleting aaaaa');
-    referenceLog.add('[8]: aaaaa, aaaaaaa');
-    referenceLog.add('[8]: normal aaaaaaaa');
-    referenceLog.add('[9]: aaaaaaaa, aa');
-    referenceLog.add('[9]: deleting aaaaaaa');
-    referenceLog.add('[10]: aaaaaaa, aaaaaaaaa');
-    referenceLog.add('[10]: normal aaaaaaaaaa');
+    referenceLog.add('[7]: aaaa, aaaaaaa');
+    referenceLog.add('[7]: normal aaaaaaaaaaaaaa');
+    referenceLog.add('[8]: aaaaaaaaaaaaaa, aa');
+    referenceLog.add('[8]: deleting aaaaaa');
+    referenceLog.add('[9]: aaaaaa, aaaaaaaaa');
+    referenceLog.add('[9]: normal aaaaaaaaaaaaaaaaaa');
 
     expect(formatter.log, referenceLog);
   });
@@ -4284,7 +4282,7 @@ class MockTextFormatter extends TextInputFormatter {
   }
 
   TextEditingValue _formatText(TextEditingValue value) {
-    String result = 'a' * _counter;
+    String result = 'a' * _counter * 2;
     log.add('[$_counter]: normal $result');
     return TextEditingValue(text: result);
   }

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4205,12 +4205,12 @@ void main() {
 
     await tester.tap(find.byType(EditableText));
     await tester.showKeyboard(find.byType(EditableText));
-    controller.text = 'test';
+    controller.text = '';
     await tester.idle();
 
     final EditableTextState state =
         tester.state<EditableTextState>(find.byType(EditableText));
-    expect(tester.testTextInput.editingState['text'], equals('test'));
+    expect(tester.testTextInput.editingState['text'], equals(''));
     expect(state.wantKeepAlive, true);
 
     state.updateEditingValue(const TextEditingValue(text: ''));


### PR DESCRIPTION
# Description

Here, we track the last formatted value separately from the last passed-in update value to avoid double-formatting the update value.

Double formatting, depending on the implementation of the formatter, can produce unpredictable and incorrect behavior. 

## Related Issues

Fixes https://github.com/flutter/flutter/issues/48608 and
https://b.corp.google.com/issues/144323703
