### PR TITLE
Fix StrutStyle docs to remove references to leading property.

### DIFF
--- a/packages/flutter/lib/src/painting/strut_style.dart
+++ b/packages/flutter/lib/src/painting/strut_style.dart
@@ -28,10 +28,10 @@ import 'text_style.dart';
 ///
 /// The vertical components of strut are as follows:
 ///
-///  * `leading * fontSize / 2` or half the font leading if `leading` is undefined (half leading)
+///  * Half the font-defined leading
 ///  * `ascent * height`
 ///  * `descent * height`
-///  * `leading * fontSize / 2` or half the font leading if `leading` is undefined (half leading)
+///  * Half the font-defined leading
 ///
 /// The sum of these four values is the total height of the line.
 ///
@@ -40,7 +40,8 @@ import 'text_style.dart';
 /// split evenly between the top and bottom. The values for `ascent` and
 /// `descent` are provided by the font named by [fontFamily]. If no
 /// [fontFamily] or [fontFamilyFallback] is provided, then the platform's
-/// default family will be used.
+/// default family will be used. Many fonts will have leading values of
+/// zero, so in practice, the leading component is often irrelevant.
 ///
 /// When [height] is omitted or null, then the font defined ascent and descent
 /// will be used. The font's combined ascent and descent may be taller or


### PR DESCRIPTION
Docs-only change

The `leading` property was removed, so these references to it are outdated.

Also added a note to help reduce confusion when people see that most fonts have zero leading.