### PR TITLE
[infra] reduce cirrus task dependencies

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -305,18 +305,6 @@ task:
     - name: deploy_gallery-linux # linux- and macos- only
       depends_on:
         - analyze-linux
-        - framework_tests-widgets-linux
-        - framework_tests-libraries-linux
-        - framework_tests-misc-linux
-        - tool_tests-general-linux
-        - tool_tests-commands-linux
-        - tool_tests-integration-linux
-        - build_tests-linux
-        - hostonly_devicelab_tests-0-linux
-        - hostonly_devicelab_tests-1-linux
-        - hostonly_devicelab_tests-2-linux
-        - hostonly_devicelab_tests-3_last-linux
-        - firebase_test_lab_tests-linux
       environment:
         # As of October 2019, 1 CPU and 4G of RAM let deploy_gallery-linux finish in about 15
         # minutes, once it got started.
@@ -627,18 +615,6 @@ task:
     - name: deploy_gallery-macos # linux- and macos- only
       depends_on:
         - analyze-linux
-        - framework_tests-widgets-macos
-        - framework_tests-libraries-macos
-        - framework_tests-misc-macos
-        - tool_tests-general-macos
-        - tool_tests-commands-macos
-        - tool_tests-integration-macos
-        - build_tests-macos
-        - hostonly_devicelab_tests-0-macos
-        - hostonly_devicelab_tests-1-macos
-        - hostonly_devicelab_tests-2-macos
-        - hostonly_devicelab_tests-3_last-macos
-        - firebase_test_lab_tests-linux
       environment:
         # Apple Fastlane password.
         FASTLANE_PASSWORD: ENCRYPTED[4b1f0b8d52874e9de965acd46c79743f3b81f3a513614179b9be7cf53dc8258753e257bdadb11a298ee455259df21865]
@@ -663,18 +639,6 @@ docker_builder:
   depends_on:
     - docs-linux
     - analyze-linux
-    - framework_tests-widgets-linux
-    - framework_tests-libraries-linux
-    - framework_tests-misc-linux
-    - tool_tests-general-linux
-    - tool_tests-commands-linux
-    - tool_tests-integration-linux
-    - build_tests-linux
-    - hostonly_devicelab_tests-0-linux
-    - hostonly_devicelab_tests-1-linux
-    - hostonly_devicelab_tests-2-linux
-    - hostonly_devicelab_tests-3_last-linux
-    - firebase_test_lab_tests-linux
   build_script:
     - cd "$CIRRUS_WORKING_DIR/dev/ci/docker_linux"
     - ./docker_build.sh

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -303,6 +303,9 @@ task:
         - ./dev/bots/firebase_testlab.sh
 
     - name: deploy_gallery-linux # linux- and macos- only
+      # Do not add more tasks here. Nothing is currently deployed from master branch, so it is safe to run
+      # even if a test has failed. The behavior of failing dependencies is non-ideal for infra health.
+      # See also: https://github.com/flutter/flutter/pull/49454
       depends_on:
         - analyze-linux
       environment:
@@ -613,6 +616,9 @@ task:
         - dart --enable-asserts dev/customer_testing/run_tests.dart --skip-on-fetch-failure --skip-template bin/cache/pkg/tests/registry/*.test
 
     - name: deploy_gallery-macos # linux- and macos- only
+      # Do not add more tasks here. Nothing is currently deployed from master branch, so it is safe to run
+      # even if a test has failed. The behavior of failing dependencies is non-ideal for infra health.
+      # See also: https://github.com/flutter/flutter/pull/49454
       depends_on:
         - analyze-linux
       environment:
@@ -636,6 +642,8 @@ docker_builder:
   only_if: $CIRRUS_TAG != ''
   environment:
     GCLOUD_CREDENTIALS: ENCRYPTED[f7c098d4dd7f5ee1bfee0bb7e944cce72efbe10e97ad6440ae72de4de6a1c24d23f421a2619c668e94377fb64b0bb3e6]
+  # Do not add more tasks here. The behavior of failing dependencies is non-ideal for infra health.
+  # See also: https://github.com/flutter/flutter/pull/49454
   depends_on:
     - docs-linux
     - analyze-linux


### PR DESCRIPTION
## Description

Currently the deploy_gallery-* tasks depend on a large number of other cirrus tasks. The intention, I believe, is to avoid running these deployments on obviously failing builds.

Unfortunately cirrus infra is unstable, failing due to agents being killed or other issues that are not diagnosable via logs. When a parent task fails due to an infra issue, it also causes the child tasks to be cancelled. When the failed parent task is rerun, naturally the child task cannot be rerun until complete.

Since we have moved to a model where the build is considered red until 100% of previously failing tasks have passed, this behavior roughly doubles the outage time from a flaked test. If you conservatively assume each cirrus task takes 30 minutes to schedule and run, then a failure of one of the `depends_on` tasks would lead to approximately an hour of outage.

To reduce the outage to "only" half an hour, I propose removing all "depends_on" clauses except for `analyze_linux/docs`, which is faster than average and fairly stable.