### PR TITLE
Move Xcode context fetch to global.dart

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -244,12 +244,12 @@ class AOTSnapshotter {
     final String assemblyO = globals.fs.path.join(outputPath, 'snapshot_assembly.o');
     List<String> isysrootArgs;
     if (isIOS) {
-      final String iPhoneSDKLocation = await xcode.sdkLocation(SdkType.iPhone);
+      final String iPhoneSDKLocation = await globals.xcode.sdkLocation(SdkType.iPhone);
       if (iPhoneSDKLocation != null) {
         isysrootArgs = <String>['-isysroot', iPhoneSDKLocation];
       }
     }
-    final RunResult compileResult = await xcode.cc(<String>[
+    final RunResult compileResult = await globals.xcode.cc(<String>[
       '-arch', targetArch,
       if (isysrootArgs != null) ...isysrootArgs,
       if (bitcode) embedBitcodeArg,
@@ -277,7 +277,7 @@ class AOTSnapshotter {
       '-o', appLib,
       assemblyO,
     ];
-    final RunResult linkResult = await xcode.clang(linkArgs);
+    final RunResult linkResult = await globals.xcode.clang(linkArgs);
     if (linkResult.exitCode != 0) {
       globals.printError('Failed to link AOT snapshot. Linker terminated with exit code ${compileResult.exitCode}');
     }

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -179,7 +179,7 @@ Future<RunResult> createStubAppFramework(File outputFile, SdkType sdk) async {
       ];
     }
 
-    return await xcode.clang(<String>[
+    return await globals.xcode.clang(<String>[
       '-x',
       'c',
       ...archFlags,
@@ -189,7 +189,7 @@ Future<RunResult> createStubAppFramework(File outputFile, SdkType sdk) async {
       '-Xlinker', '-rpath', '-Xlinker', '@executable_path/Frameworks',
       '-Xlinker', '-rpath', '-Xlinker', '@loader_path/Frameworks',
       '-install_name', '@rpath/App.framework/App',
-      '-isysroot', await xcode.sdkLocation(sdk),
+      '-isysroot', await globals.xcode.sdkLocation(sdk),
       '-o', outputFile.path,
     ]);
   } finally {

--- a/packages/flutter_tools/lib/src/build_system/targets/macos.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/macos.dart
@@ -9,7 +9,6 @@ import '../../base/io.dart';
 import '../../base/process.dart';
 import '../../build_info.dart';
 import '../../globals.dart' as globals;
-import '../../macos/xcode.dart';
 import '../build_system.dart';
 import '../depfile.dart';
 import '../exceptions.dart';
@@ -155,7 +154,7 @@ class DebugMacOSFramework extends Target {
         ..writeAsStringSync(r'''
 static const int Moo = 88;
 ''');
-    final RunResult result = await xcode.clang(<String>[
+    final RunResult result = await globals.xcode.clang(<String>[
       '-x',
       'c',
       debugApp.path,

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -127,7 +127,7 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
     if (!boolArg('universal') && !boolArg('xcframework')) {
       throwToolExit('--universal or --xcframework is required.');
     }
-    if (boolArg('xcframework') && xcode.majorVersion < 11) {
+    if (boolArg('xcframework') && globals.xcode.majorVersion < 11) {
       throwToolExit('--xcframework requires Xcode 11.');
     }
     if (buildModes.isEmpty) {

--- a/packages/flutter_tools/lib/src/commands/clean.dart
+++ b/packages/flutter_tools/lib/src/commands/clean.dart
@@ -11,7 +11,6 @@ import '../base/logger.dart';
 import '../build_info.dart';
 import '../globals.dart' as globals;
 import '../ios/xcodeproj.dart';
-import '../macos/xcode.dart';
 import '../project.dart';
 import '../runner/flutter_command.dart';
 
@@ -34,7 +33,7 @@ class CleanCommand extends FlutterCommand {
     // Clean Xcode to remove intermediate DerivedData artifacts.
     // Do this before removing ephemeral directory, which would delete the xcworkspace.
     final FlutterProject flutterProject = FlutterProject.current();
-    if (xcode.isInstalledAndMeetsVersionCheck) {
+    if (globals.xcode.isInstalledAndMeetsVersionCheck) {
       await _cleanXcode(flutterProject.ios);
       await _cleanXcode(flutterProject.macos);
     }

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -14,6 +14,7 @@ import 'base/io.dart';
 import 'base/logger.dart';
 import 'base/terminal.dart';
 import 'cache.dart';
+import 'macos/xcode.dart';
 
 Logger get logger => context.get<Logger>();
 Cache get cache => context.get<Cache>();
@@ -40,6 +41,7 @@ const Platform _kLocalPlatform = LocalPlatform();
 
 Platform get platform => context.get<Platform>() ?? _kLocalPlatform;
 
+Xcode get xcode => context.get<Xcode>();
 
 /// Display an error level message to the user. Commands should use this if they
 /// fail in some way.

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -8,7 +8,6 @@ import '../base/process.dart';
 import '../device.dart';
 import '../emulator.dart';
 import '../globals.dart' as globals;
-import '../macos/xcode.dart';
 import 'ios_workflow.dart';
 import 'simulators.dart';
 
@@ -45,7 +44,7 @@ class IOSEmulator extends Emulator {
         'open',
         ...additionalArgs,
         '-a',
-        xcode.getSimulatorPath(),
+        globals.xcode.getSimulatorPath(),
       ];
 
       final RunResult launchResult = await processUtils.run(args);
@@ -69,7 +68,7 @@ class IOSEmulator extends Emulator {
 
 /// Return the list of iOS Simulators (there can only be zero or one).
 List<IOSEmulator> getEmulators() {
-  final String simulatorPath = xcode.getSimulatorPath();
+  final String simulatorPath = globals.xcode.getSimulatorPath();
   if (simulatorPath == null) {
     return <IOSEmulator>[];
   }

--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -5,7 +5,6 @@
 import '../base/context.dart';
 import '../doctor.dart';
 import '../globals.dart' as globals;
-import '../macos/xcode.dart';
 
 IOSWorkflow get iosWorkflow => context.get<IOSWorkflow>();
 
@@ -17,12 +16,12 @@ class IOSWorkflow implements Workflow {
 
   // We need xcode (+simctl) to list simulator devices, and libimobiledevice to list real devices.
   @override
-  bool get canListDevices => xcode.isInstalledAndMeetsVersionCheck && xcode.isSimctlInstalled;
+  bool get canListDevices => globals.xcode.isInstalledAndMeetsVersionCheck && globals.xcode.isSimctlInstalled;
 
   // We need xcode to launch simulator devices, and ideviceinstaller and ios-deploy
   // for real devices.
   @override
-  bool get canLaunchDevices => xcode.isInstalledAndMeetsVersionCheck;
+  bool get canLaunchDevices => globals.xcode.isInstalledAndMeetsVersionCheck;
 
   @override
   bool get canListEmulators => false;

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -717,7 +717,7 @@ bool _checkXcodeVersion() {
     globals.printError('Cannot find "xcodebuild". $_xcodeRequirement');
     return false;
   }
-  if (!xcode.isVersionSatisfactory) {
+  if (!globals.xcode.isVersionSatisfactory) {
     globals.printError('Found "${xcodeProjectInterpreter.versionText}". $_xcodeRequirement');
     return false;
   }

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -19,7 +19,6 @@ import '../bundle.dart';
 import '../convert.dart';
 import '../device.dart';
 import '../globals.dart' as globals;
-import '../macos/xcode.dart';
 import '../project.dart';
 import '../protocol_discovery.dart';
 import 'ios_workflow.dart';
@@ -47,7 +46,7 @@ class IOSSimulatorUtils {
   static IOSSimulatorUtils get instance => context.get<IOSSimulatorUtils>();
 
   Future<List<IOSSimulator>> getAttachedDevices() async {
-    if (!xcode.isInstalledAndMeetsVersionCheck) {
+    if (!globals.xcode.isInstalledAndMeetsVersionCheck) {
       return <IOSSimulator>[];
     }
 
@@ -519,7 +518,7 @@ class IOSSimulator extends Device {
   }
 
   bool get _xcodeVersionSupportsScreenshot {
-    return xcode.majorVersion > 8 || (xcode.majorVersion == 8 && xcode.minorVersion >= 2);
+    return globals.xcode.majorVersion > 8 || (globals.xcode.majorVersion == 8 && globals.xcode.minorVersion >= 2);
   }
 
   @override

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -9,7 +9,6 @@ import 'package:platform/platform.dart';
 import 'package:process/process.dart';
 
 import '../base/common.dart';
-import '../base/context.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
@@ -18,8 +17,6 @@ import '../ios/xcodeproj.dart';
 
 const int kXcodeRequiredVersionMajor = 10;
 const int kXcodeRequiredVersionMinor = 2;
-
-Xcode get xcode => context.get<Xcode>();
 
 enum SdkType {
   iPhone,

--- a/packages/flutter_tools/lib/src/macos/xcode_validator.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode_validator.dart
@@ -5,6 +5,7 @@
 import '../base/context.dart';
 import '../base/user_messages.dart';
 import '../doctor.dart';
+import '../globals.dart' as globals;
 import 'xcode.dart';
 
 XcodeValidator get xcodeValidator => context.get<XcodeValidator>();
@@ -18,36 +19,36 @@ class XcodeValidator extends DoctorValidator {
     ValidationType xcodeStatus = ValidationType.missing;
     String xcodeVersionInfo;
 
-    if (xcode.isInstalled) {
+    if (globals.xcode.isInstalled) {
       xcodeStatus = ValidationType.installed;
 
-      messages.add(ValidationMessage(userMessages.xcodeLocation(xcode.xcodeSelectPath)));
+      messages.add(ValidationMessage(userMessages.xcodeLocation(globals.xcode.xcodeSelectPath)));
 
-      xcodeVersionInfo = xcode.versionText;
+      xcodeVersionInfo = globals.xcode.versionText;
       if (xcodeVersionInfo.contains(',')) {
         xcodeVersionInfo = xcodeVersionInfo.substring(0, xcodeVersionInfo.indexOf(','));
       }
-      messages.add(ValidationMessage(xcode.versionText));
+      messages.add(ValidationMessage(globals.xcode.versionText));
 
-      if (!xcode.isInstalledAndMeetsVersionCheck) {
+      if (!globals.xcode.isInstalledAndMeetsVersionCheck) {
         xcodeStatus = ValidationType.partial;
         messages.add(ValidationMessage.error(
             userMessages.xcodeOutdated(kXcodeRequiredVersionMajor, kXcodeRequiredVersionMinor)
         ));
       }
 
-      if (!xcode.eulaSigned) {
+      if (!globals.xcode.eulaSigned) {
         xcodeStatus = ValidationType.partial;
         messages.add(ValidationMessage.error(userMessages.xcodeEula));
       }
-      if (!xcode.isSimctlInstalled) {
+      if (!globals.xcode.isSimctlInstalled) {
         xcodeStatus = ValidationType.partial;
         messages.add(ValidationMessage.error(userMessages.xcodeMissingSimct));
       }
 
     } else {
       xcodeStatus = ValidationType.missing;
-      if (xcode.xcodeSelectPath == null || xcode.xcodeSelectPath.isEmpty) {
+      if (globals.xcode.xcodeSelectPath == null || globals.xcode.xcodeSelectPath.isEmpty) {
         messages.add(ValidationMessage.error(userMessages.xcodeMissing));
       } else {
         messages.add(ValidationMessage.error(userMessages.xcodeIncomplete));

--- a/packages/flutter_tools/test/general.shard/base/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/build_test.dart
@@ -308,8 +308,8 @@ void main() {
       };
 
       final RunResult successResult = RunResult(ProcessResult(1, 0, '', ''), <String>['command name', 'arguments...']);
-      when(xcode.cc(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
-      when(xcode.clang(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
+      when(mockXcode.cc(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
+      when(mockXcode.clang(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
 
       final int genSnapshotExitCode = await snapshotter.build(
         platform: TargetPlatform.ios,
@@ -334,14 +334,14 @@ void main() {
         'main.dill',
       ]);
 
-      final VerificationResult toVerifyCC = verify(xcode.cc(captureAny));
+      final VerificationResult toVerifyCC = verify(mockXcode.cc(captureAny));
       expect(toVerifyCC.callCount, 1);
       final dynamic ccArgs = toVerifyCC.captured.first;
       expect(ccArgs, contains('-fembed-bitcode'));
       expect(ccArgs, contains('-isysroot'));
       expect(ccArgs, contains(kSDKPath));
 
-      final VerificationResult toVerifyClang = verify(xcode.clang(captureAny));
+      final VerificationResult toVerifyClang = verify(mockXcode.clang(captureAny));
       expect(toVerifyClang.callCount, 1);
       final dynamic clangArgs = toVerifyClang.captured.first;
       expect(clangArgs, contains('-fembed-bitcode'));
@@ -365,8 +365,8 @@ void main() {
       };
 
       final RunResult successResult = RunResult(ProcessResult(1, 0, '', ''), <String>['command name', 'arguments...']);
-      when(xcode.cc(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
-      when(xcode.clang(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
+      when(mockXcode.cc(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
+      when(mockXcode.clang(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
 
       final int genSnapshotExitCode = await snapshotter.build(
         platform: TargetPlatform.ios,
@@ -391,14 +391,14 @@ void main() {
         'main.dill',
       ]);
 
-      final VerificationResult toVerifyCC = verify(xcode.cc(captureAny));
+      final VerificationResult toVerifyCC = verify(mockXcode.cc(captureAny));
       expect(toVerifyCC.callCount, 1);
       final dynamic ccArgs = toVerifyCC.captured.first;
       expect(ccArgs, contains('-fembed-bitcode'));
       expect(ccArgs, contains('-isysroot'));
       expect(ccArgs, contains(kSDKPath));
 
-      final VerificationResult toVerifyClang = verify(xcode.clang(captureAny));
+      final VerificationResult toVerifyClang = verify(mockXcode.clang(captureAny));
       expect(toVerifyClang.callCount, 1);
       final dynamic clangArgs = toVerifyClang.captured.first;
       expect(clangArgs, contains('-fembed-bitcode'));
@@ -425,8 +425,8 @@ void main() {
       };
 
       final RunResult successResult = RunResult(ProcessResult(1, 0, '', ''), <String>['command name', 'arguments...']);
-      when(xcode.cc(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
-      when(xcode.clang(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
+      when(mockXcode.cc(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
+      when(mockXcode.clang(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
 
       final int genSnapshotExitCode = await snapshotter.build(
         platform: TargetPlatform.ios,
@@ -450,11 +450,11 @@ void main() {
         '--no-use-integer-division',
         'main.dill',
       ]);
-      verifyNever(xcode.cc(argThat(contains('-fembed-bitcode'))));
-      verifyNever(xcode.clang(argThat(contains('-fembed-bitcode'))));
+      verifyNever(mockXcode.cc(argThat(contains('-fembed-bitcode'))));
+      verifyNever(mockXcode.clang(argThat(contains('-fembed-bitcode'))));
 
-      verify(xcode.cc(argThat(contains('-isysroot')))).called(1);
-      verify(xcode.clang(argThat(contains('-isysroot')))).called(1);
+      verify(mockXcode.cc(argThat(contains('-isysroot')))).called(1);
+      verify(mockXcode.clang(argThat(contains('-isysroot')))).called(1);
 
       final File assemblyFile = globals.fs.file(assembly);
       expect(assemblyFile.existsSync(), true);
@@ -472,8 +472,8 @@ void main() {
       };
 
       final RunResult successResult = RunResult(ProcessResult(1, 0, '', ''), <String>['command name', 'arguments...']);
-      when(xcode.cc(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
-      when(xcode.clang(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
+      when(mockXcode.cc(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
+      when(mockXcode.clang(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
 
       final int genSnapshotExitCode = await snapshotter.build(
         platform: TargetPlatform.ios,
@@ -508,8 +508,8 @@ void main() {
       };
 
       final RunResult successResult = RunResult(ProcessResult(1, 0, '', ''), <String>['command name', 'arguments...']);
-      when(xcode.cc(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
-      when(xcode.clang(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
+      when(mockXcode.cc(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
+      when(mockXcode.clang(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
 
       final int genSnapshotExitCode = await snapshotter.build(
         platform: TargetPlatform.ios,
@@ -546,8 +546,8 @@ void main() {
       };
 
       final RunResult successResult = RunResult(ProcessResult(1, 0, '', ''), <String>['command name', 'arguments...']);
-      when(xcode.cc(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
-      when(xcode.clang(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
+      when(mockXcode.cc(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
+      when(mockXcode.clang(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
 
       final int genSnapshotExitCode = await snapshotter.build(
         platform: TargetPlatform.ios,
@@ -640,8 +640,8 @@ void main() {
       };
 
       final RunResult successResult = RunResult(ProcessResult(1, 0, '', ''), <String>['command name', 'arguments...']);
-      when(xcode.cc(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
-      when(xcode.clang(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
+      when(mockXcode.cc(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
+      when(mockXcode.clang(any)).thenAnswer((_) => Future<RunResult>.value(successResult));
 
       final int genSnapshotExitCode = await snapshotterWithTimings.build(
         platform: TargetPlatform.android_arm,

--- a/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
@@ -49,6 +49,7 @@ void main() {
   Testbed testbed;
   Environment environment;
   MockPlatform mockPlatform;
+  MockXcode mockXcode;
 
   setUpAll(() {
     Cache.disableLocking();
@@ -56,6 +57,7 @@ void main() {
   });
 
   setUp(() {
+    mockXcode = MockXcode();
     mockPlatform = MockPlatform();
     when(mockPlatform.isWindows).thenReturn(false);
     when(mockPlatform.isMacOS).thenReturn(true);
@@ -202,10 +204,10 @@ void main() {
       environment.buildDir.childFile('snapshot_assembly.S').createSync();
       return Future<int>.value(0);
     });
-    when(xcode.cc(any)).thenAnswer((Invocation invocation) {
+    when(mockXcode.cc(any)).thenAnswer((Invocation invocation) {
       return Future<RunResult>.value(RunResult(FakeProcessResult()..exitCode = 0, <String>['test']));
     });
-    when(xcode.clang(any)).thenAnswer((Invocation invocation) {
+    when(mockXcode.clang(any)).thenAnswer((Invocation invocation) {
       return Future<RunResult>.value(RunResult(FakeProcessResult()..exitCode = 0, <String>['test']));
     });
     environment.buildDir.childFile('app.dill').createSync(recursive: true);
@@ -218,7 +220,7 @@ flutter_tools:lib/''');
     await const CompileMacOSFramework().build(environment..defines[kBuildMode] = 'release');
   }, overrides: <Type, Generator>{
     GenSnapshot: () => MockGenSnapshot(),
-    Xcode: () => MockXCode(),
+    Xcode: () => mockXcode,
   }));
 }
 
@@ -226,7 +228,7 @@ class MockPlatform extends Mock implements Platform {}
 class MockCocoaPods extends Mock implements CocoaPods {}
 class MockProcessManager extends Mock implements ProcessManager {}
 class MockGenSnapshot extends Mock implements GenSnapshot {}
-class MockXCode extends Mock implements Xcode {}
+class MockXcode extends Mock implements Xcode {}
 class FakeProcessResult implements ProcessResult {
   @override
   int exitCode;


### PR DESCRIPTION
## Description

Move `Xcode get xcode => context.get<Xcode>();` into globals.dart to force `global.` prefix on usages and include in the tool technical debt counts.

## Related Issues

Continuation of https://github.com/flutter/flutter/pull/47398.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*