### PR TITLE
[flutter_tools] handle plugins for entrypoints outside of lib

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -83,7 +83,8 @@ class WebEntrypointTarget extends Target {
         .childDirectory('lib')
         .childFile('generated_plugin_registrant.dart')
         .absolute.path;
-      final Uri generatedImport = packageUriMapper.map(generatedPath);
+      final String generatedImport = packageUriMapper.map(generatedPath)?.toString()
+        ?? globals.fs.file(generatedPath).absolute.uri.toString();
       contents = '''
 import 'dart:ui' as ui;
 

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -117,6 +117,18 @@ void main() {
     expect(generated, contains("import 'file:///other/lib/main.dart' as entrypoint;"));
   }));
 
+  test('WebEntrypointTarget generates a plugin registrant for a file outside of main', () => testbed.run(() async {
+    environment.defines[kTargetFile] = globals.fs.path.join('other', 'lib', 'main.dart');
+    environment.defines[kHasWebPlugins] = 'true';
+    await const WebEntrypointTarget().build(environment);
+
+    final String generated = environment.buildDir.childFile('main.dart').readAsStringSync();
+
+    // Import.
+    expect(generated, contains("import 'file:///other/lib/main.dart' as entrypoint;"));
+    expect(generated, contains("import 'file:///foo/lib/generated_plugin_registrant.dart';"));
+  }));
+
 
   test('WebEntrypointTarget generates an entrypoint with plugins and init platform on windows', () => testbed.run(() async {
     environment.defines[kHasWebPlugins] = 'true';


### PR DESCRIPTION
## Description

If the target file was not under lib, the packagemapper couldn't find it, resulting in a null import. Fall back to absolute path with file URI.

Fixes https://github.com/flutter/flutter/issues/49254