### PR TITLE
Replace FlutterVersion.instance with FlutterVersion context fetch in global.dart

### DIFF
--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -24,7 +24,6 @@ import 'src/reporting/github_template.dart';
 import 'src/reporting/reporting.dart';
 import 'src/runner/flutter_command.dart';
 import 'src/runner/flutter_command_runner.dart';
-import 'src/version.dart';
 
 /// Runs the Flutter tool with support for the specified list of [commands].
 Future<int> run(
@@ -57,7 +56,7 @@ Future<int> run(
       onFailure: (String _) => 'en_US',
     );
 
-    String getVersion() => flutterVersion ?? FlutterVersion.instance.getVersionString(redactUnknownBranches: true);
+    String getVersion() => flutterVersion ?? globals.flutterVersion.getVersionString(redactUnknownBranches: true);
     Object firstError;
     StackTrace firstStackTrace;
     return await runZoned<Future<int>>(() async {

--- a/packages/flutter_tools/lib/src/base/fingerprint.dart
+++ b/packages/flutter_tools/lib/src/base/fingerprint.dart
@@ -8,7 +8,6 @@ import 'package:quiver/core.dart' show hash2;
 
 import '../convert.dart' show json;
 import '../globals.dart' as globals;
-import '../version.dart';
 import 'file_system.dart';
 import 'utils.dart';
 
@@ -123,7 +122,7 @@ class Fingerprint {
     final Map<String, dynamic> content = castStringKeyedMap(json.decode(jsonData));
 
     final String version = content['version'] as String;
-    if (version != FlutterVersion.instance.frameworkRevision) {
+    if (version != globals.flutterVersion.frameworkRevision) {
       throw ArgumentError('Incompatible fingerprint version: $version');
     }
     _checksums = castStringKeyedMap(content['files'])?.cast<String,String>() ?? <String, String>{};
@@ -134,7 +133,7 @@ class Fingerprint {
   Map<String, String> _properties;
 
   String toJson() => json.encode(<String, dynamic>{
-    'version': FlutterVersion.instance.frameworkRevision,
+    'version': globals.flutterVersion.frameworkRevision,
     'properties': _properties,
     'files': _checksums,
   });

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -180,7 +180,7 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
 
       if (boolArg('cocoapods')) {
         // FlutterVersion.instance kicks off git processing which can sometimes fail, so don't try it until needed.
-        _flutterVersion ??= FlutterVersion.instance;
+        _flutterVersion ??= globals.flutterVersion;
         produceFlutterPodspec(mode, modeDirectory);
       } else {
         // Copy Flutter.framework.

--- a/packages/flutter_tools/lib/src/commands/channel.dart
+++ b/packages/flutter_tools/lib/src/commands/channel.dart
@@ -53,8 +53,8 @@ class ChannelCommand extends FlutterCommand {
 
   Future<void> _listChannels({ bool showAll, bool verbose }) async {
     // Beware: currentBranch could contain PII. See getBranchName().
-    final String currentChannel = FlutterVersion.instance.channel;
-    final String currentBranch = FlutterVersion.instance.getBranchName();
+    final String currentChannel = globals.flutterVersion.channel;
+    final String currentBranch = globals.flutterVersion.getBranchName();
     final Set<String> seenUnofficialChannels = <String>{};
     final List<String> rawOutput = <String>[];
 
@@ -128,7 +128,7 @@ class ChannelCommand extends FlutterCommand {
   }
 
   static Future<void> upgradeChannel() async {
-    final String channel = FlutterVersion.instance.channel;
+    final String channel = globals.flutterVersion.channel;
     if (FlutterVersion.obsoleteBranches.containsKey(channel)) {
       final String alternative = FlutterVersion.obsoleteBranches[channel];
       globals.printStatus("Transitioning from '$channel' to '$alternative'...");

--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -12,7 +12,6 @@ import '../features.dart';
 import '../globals.dart' as globals;
 import '../reporting/reporting.dart';
 import '../runner/flutter_command.dart';
-import '../version.dart';
 
 class ConfigCommand extends FlutterCommand {
   ConfigCommand({ bool verboseHelp = false }) {
@@ -68,7 +67,7 @@ class ConfigCommand extends FlutterCommand {
     // List all config settings. for feature flags, include whether they
     // are available.
     final Map<String, Feature> featuresByName = <String, Feature>{};
-    final String channel = FlutterVersion.instance.channel;
+    final String channel = globals.flutterVersion.channel;
     for (final Feature feature in allFeatures) {
       if (feature.configSetting != null) {
         featuresByName[feature.configSetting] = feature;

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -25,7 +25,6 @@ import '../project.dart';
 import '../reporting/reporting.dart';
 import '../runner/flutter_command.dart';
 import '../template.dart';
-import '../version.dart';
 
 enum _ProjectType {
   /// This is the default project with the user-managed host code.
@@ -219,7 +218,7 @@ class CreateCommand extends FlutterCommand {
   }
 
   /// The hostname for the Flutter docs for the current channel.
-  String get _snippetsHost => FlutterVersion.instance.channel == 'stable'
+  String get _snippetsHost => globals.flutterVersion.channel == 'stable'
         ? 'docs.flutter.io'
         : 'master-docs.flutter.io';
 
@@ -628,8 +627,8 @@ To edit platform code in an IDE see https://flutter.dev/developing-packages/#edi
       'withPluginHook': withPluginHook,
       'androidLanguage': androidLanguage,
       'iosLanguage': iosLanguage,
-      'flutterRevision': FlutterVersion.instance.frameworkRevision,
-      'flutterChannel': FlutterVersion.instance.channel,
+      'flutterRevision': globals.flutterVersion.frameworkRevision,
+      'flutterChannel': globals.flutterVersion.channel,
       'web': web,
       'macos': macos,
       'year': DateTime.now().year,

--- a/packages/flutter_tools/lib/src/commands/precache.dart
+++ b/packages/flutter_tools/lib/src/commands/precache.dart
@@ -9,7 +9,6 @@ import '../cache.dart';
 import '../features.dart';
 import '../globals.dart' as globals;
 import '../runner/flutter_command.dart';
-import '../version.dart';
 
 class PrecacheCommand extends FlutterCommand {
   PrecacheCommand({bool verboseHelp = false}) {
@@ -94,7 +93,7 @@ class PrecacheCommand extends FlutterCommand {
     final Set<DevelopmentArtifact> requiredArtifacts = <DevelopmentArtifact>{};
     for (final DevelopmentArtifact artifact in DevelopmentArtifact.values) {
       // Don't include unstable artifacts on stable branches.
-      if (!FlutterVersion.instance.isMaster && artifact.unstable) {
+      if (!globals.flutterVersion.isMaster && artifact.unstable) {
         continue;
       }
       if (artifact.feature != null && !featureFlags.isEnabled(artifact.feature)) {

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -23,7 +23,6 @@ import '../run_cold.dart';
 import '../run_hot.dart';
 import '../runner/flutter_command.dart';
 import '../tracing.dart';
-import '../version.dart';
 import '../web/web_runner.dart';
 import 'daemon.dart';
 
@@ -419,7 +418,7 @@ class RunCommand extends RunCommandBase {
     }
     globals.terminal.usesTerminalUi = true;
 
-    if (argResults['dart-flags'] != null && !FlutterVersion.instance.isMaster) {
+    if (argResults['dart-flags'] != null && !globals.flutterVersion.isMaster) {
       throw UsageException('--dart-flags is not available on the stable '
                            'channel.', null);
     }

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -55,7 +55,7 @@ class UpgradeCommand extends FlutterCommand {
       boolArg('force'),
       boolArg('continue'),
       GitTagVersion.determine(),
-      FlutterVersion.instance,
+      globals.flutterVersion,
     );
   }
 }

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -603,7 +603,7 @@ class FlutterValidator extends DoctorValidator {
     String frameworkVersion;
 
     try {
-      final FlutterVersion version = FlutterVersion.instance;
+      final FlutterVersion version = globals.flutterVersion;
       versionChannel = version.channel;
       frameworkVersion = version.frameworkVersion;
       messages.add(ValidationMessage(userMessages.flutterVersion(

--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -6,7 +6,6 @@ import 'package:meta/meta.dart';
 
 import 'base/context.dart';
 import 'globals.dart' as globals;
-import 'version.dart';
 
 /// The current [FeatureFlags] implementation.
 ///
@@ -45,7 +44,7 @@ class FeatureFlags {
   ///
   /// Prefer using one of the specific getters above instead of this API.
   bool isEnabled(Feature feature) {
-    final String currentChannel = FlutterVersion.instance.channel;
+    final String currentChannel = globals.flutterVersion.channel;
     final FeatureChannelSetting featureSetting = feature.getSettingForChannel(currentChannel);
     if (!featureSetting.available) {
       return false;

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -15,6 +15,7 @@ import 'base/logger.dart';
 import 'base/terminal.dart';
 import 'cache.dart';
 import 'macos/xcode.dart';
+import 'version.dart';
 
 Logger get logger => context.get<Logger>();
 Cache get cache => context.get<Cache>();
@@ -42,6 +43,7 @@ const Platform _kLocalPlatform = LocalPlatform();
 Platform get platform => context.get<Platform>() ?? _kLocalPlatform;
 
 Xcode get xcode => context.get<Xcode>();
+FlutterVersion get flutterVersion => context.get<FlutterVersion>();
 
 /// Display an error level message to the user. Commands should use this if they
 /// fail in some way.

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -19,7 +19,6 @@ import 'globals.dart' as globals;
 import 'macos/cocoapods.dart';
 import 'platform_plugins.dart';
 import 'project.dart';
-import 'version.dart';
 
 void _renderTemplateToFile(String template, dynamic context, String filePath) {
   final String renderedTemplate =
@@ -418,7 +417,7 @@ bool _writeFlutterPluginsList(FlutterProject project, List<Plugin> plugins) {
   /// https://github.com/flutter/flutter/issues/48918
   result['dependencyGraph'] = _createPluginLegacyDependencyGraph(plugins);
   result['date_created'] = systemClock.now().toString();
-  result['version'] = flutterVersion.frameworkVersion;
+  result['version'] = globals.flutterVersion.frameworkVersion;
 
   // Only notify if the plugins list has changed. [date_created] will always be different,
   // [version] is not relevant for this check.

--- a/packages/flutter_tools/lib/src/reporting/usage.dart
+++ b/packages/flutter_tools/lib/src/reporting/usage.dart
@@ -162,7 +162,7 @@ class _DefaultUsage implements Usage {
     String configDirOverride,
     String logFile,
   }) {
-    final FlutterVersion flutterVersion = FlutterVersion.instance;
+    final FlutterVersion flutterVersion = globals.flutterVersion;
     final String version = versionOverride ?? flutterVersion.getVersionString(redactUnknownBranches: true);
     final bool suppressEnvFlag = globals.platform.environment['FLUTTER_SUPPRESS_ANALYTICS'] == 'true';
     final String logFilePath = logFile ?? globals.platform.environment['FLUTTER_ANALYTICS_LOG_FILE'];
@@ -367,7 +367,7 @@ class _DefaultUsage implements Usage {
         isFirstRun ||
         // Display the welcome message if we are not on master, and if the
         // persistent tool state instructs that we should.
-        (!FlutterVersion.instance.isMaster &&
+        (!globals.flutterVersion.isMaster &&
         (persistentToolState.redisplayWelcomeMessage ?? true))) {
       _printWelcome();
       _printedWelcome = true;

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -24,7 +24,6 @@ import '../device.dart';
 import '../globals.dart' as globals;
 import '../reporting/reporting.dart';
 import '../tester/flutter_tester.dart';
-import '../version.dart';
 
 const String kFlutterRootEnvironmentVariableName = 'FLUTTER_ROOT'; // should point to //flutter/ (root of flutter/flutter repo)
 const String kFlutterEngineEnvironmentVariableName = 'FLUTTER_ENGINE'; // should point to //engine/src/ (root of flutter/engine repo)
@@ -303,7 +302,7 @@ class FlutterCommandRunner extends CommandRunner<void> {
 
         _checkFlutterCopy();
         try {
-          await FlutterVersion.instance.ensureVersionFile();
+          await globals.flutterVersion.ensureVersionFile();
         } on FileSystemException catch (e) {
           globals.printError('Failed to write the version file to the artifact cache: "$e".');
           globals.printError('Please ensure you have permissions in the artifact cache directory.');
@@ -311,7 +310,7 @@ class FlutterCommandRunner extends CommandRunner<void> {
         }
         final bool machineFlag = topLevelResults['machine'] as bool;
         if (topLevelResults.command?.name != 'upgrade' && topLevelResults['version-check'] as bool && !machineFlag) {
-          await FlutterVersion.instance.checkFlutterVersionFreshness();
+          await globals.flutterVersion.checkFlutterVersionFreshness();
         }
 
         if (topLevelResults.wasParsed('packages')) {
@@ -325,9 +324,9 @@ class FlutterCommandRunner extends CommandRunner<void> {
           flutterUsage.sendCommand('version');
           String status;
           if (machineFlag) {
-            status = const JsonEncoder.withIndent('  ').convert(FlutterVersion.instance.toJson());
+            status = const JsonEncoder.withIndent('  ').convert(globals.flutterVersion.toJson());
           } else {
-            status = FlutterVersion.instance.toString();
+            status = globals.flutterVersion.toString();
           }
           globals.printStatus(status);
           return;

--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -65,7 +65,7 @@ class FlutterTesterDevice extends Device {
 
   @override
   Future<String> get sdkNameAndVersion async {
-    final FlutterVersion flutterVersion = FlutterVersion.instance;
+    final FlutterVersion flutterVersion = globals.flutterVersion;
     return 'Flutter ${flutterVersion.frameworkRevisionShort}';
   }
 

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -7,7 +7,6 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 
 import 'base/common.dart';
-import 'base/context.dart';
 import 'base/file_system.dart';
 import 'base/io.dart';
 import 'base/process.dart';
@@ -15,8 +14,6 @@ import 'base/time.dart';
 import 'cache.dart';
 import 'convert.dart';
 import 'globals.dart' as globals;
-
-FlutterVersion get flutterVersion => context.get<FlutterVersion>();
 
 class FlutterVersion {
   FlutterVersion([this._clock = const SystemClock()]) {
@@ -214,8 +211,6 @@ class FlutterVersion {
       await _run(<String>['git', 'remote', 'remove', _versionCheckRemote]);
     }
   }
-
-  static FlutterVersion get instance => context.get<FlutterVersion>();
 
   /// Return a short string for the version (e.g. `master/0.0.59-pre.92`, `scroll_refactor/a76bc8e22b`).
   String getVersionString({ bool redactUnknownBranches = false }) {

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'package:flutter_tools/src/runner/flutter_command_runner.dart';
 import 'package:flutter_tools/src/version.dart';
@@ -57,7 +58,7 @@ void main() {
 
     group('run', () {
       testUsingContext('checks that Flutter installation is up-to-date', () async {
-        final MockFlutterVersion version = FlutterVersion.instance as MockFlutterVersion;
+        final MockFlutterVersion version = globals.flutterVersion as MockFlutterVersion;
         bool versionChecked = false;
         when(version.checkFlutterVersionFreshness()).thenAnswer((_) async {
           versionChecked = true;
@@ -73,7 +74,7 @@ void main() {
       }, initializeFlutterRoot: false);
 
       testUsingContext('does not check that Flutter installation is up-to-date with --machine flag', () async {
-        final MockFlutterVersion version = FlutterVersion.instance as MockFlutterVersion;
+        final MockFlutterVersion version = globals.flutterVersion as MockFlutterVersion;
         bool versionChecked = false;
         when(version.checkFlutterVersionFreshness()).thenAnswer((_) async {
           versionChecked = true;
@@ -89,7 +90,7 @@ void main() {
       }, initializeFlutterRoot: false);
 
       testUsingContext('throw tool exit if the version file cannot be written', () async {
-        final MockFlutterVersion version = FlutterVersion.instance as MockFlutterVersion;
+        final MockFlutterVersion version = globals.flutterVersion as MockFlutterVersion;
         when(version.ensureVersionFile()).thenThrow(const FileSystemException());
 
         expect(() async => await runner.run(<String>['dummy']), throwsA(isA<ToolExit>()));

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/time.dart';
 import 'package:flutter_tools/src/base/utils.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/version.dart';
 import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
@@ -56,7 +57,7 @@ void main() {
           expectSetStamp: true,
           channel: channel,
         );
-        await FlutterVersion.instance.checkFlutterVersionFreshness();
+        await globals.flutterVersion.checkFlutterVersionFreshness();
         _expectVersionMessage('');
       }, overrides: <Type, Generator>{
         FlutterVersion: () => FlutterVersion(_testClock),
@@ -78,7 +79,7 @@ void main() {
           expectServerPing: true,
           channel: channel,
         );
-        final FlutterVersion version = FlutterVersion.instance;
+        final FlutterVersion version = globals.flutterVersion;
 
         await version.checkFlutterVersionFreshness();
         _expectVersionMessage('');
@@ -101,7 +102,7 @@ void main() {
           channel: channel,
         );
 
-        final FlutterVersion version = FlutterVersion.instance;
+        final FlutterVersion version = globals.flutterVersion;
         await version.checkFlutterVersionFreshness();
         _expectVersionMessage(FlutterVersion.newVersionAvailableMessage());
       }, overrides: <Type, Generator>{
@@ -123,7 +124,7 @@ void main() {
           channel: channel,
         );
 
-        final FlutterVersion version = FlutterVersion.instance;
+        final FlutterVersion version = globals.flutterVersion;
         await version.checkFlutterVersionFreshness();
         _expectVersionMessage(FlutterVersion.newVersionAvailableMessage());
         expect((await VersionCheckStamp.load()).lastTimeWarningWasPrinted, _testClock.now());
@@ -146,7 +147,7 @@ void main() {
           expectServerPing: true,
           channel: channel,
         );
-        final FlutterVersion version = FlutterVersion.instance;
+        final FlutterVersion version = globals.flutterVersion;
 
         await version.checkFlutterVersionFreshness();
         _expectVersionMessage(FlutterVersion.newVersionAvailableMessage());
@@ -181,7 +182,7 @@ void main() {
           expectServerPing: true,
           channel: channel,
         );
-        final FlutterVersion version = FlutterVersion.instance;
+        final FlutterVersion version = globals.flutterVersion;
 
         await version.checkFlutterVersionFreshness();
         _expectVersionMessage(FlutterVersion.newVersionAvailableMessage());
@@ -201,7 +202,7 @@ void main() {
           expectSetStamp: true,
           channel: channel,
         );
-        final FlutterVersion version = FlutterVersion.instance;
+        final FlutterVersion version = globals.flutterVersion;
 
         await version.checkFlutterVersionFreshness();
         _expectVersionMessage('');
@@ -221,7 +222,7 @@ void main() {
           expectSetStamp: true,
           channel: channel,
         );
-        final FlutterVersion version = FlutterVersion.instance;
+        final FlutterVersion version = globals.flutterVersion;
 
         await version.checkFlutterVersionFreshness();
         _expectVersionMessage(FlutterVersion.versionOutOfDateMessage(_testClock.now().difference(getChannelOutOfDateVersion())));
@@ -241,7 +242,7 @@ void main() {
           expectSetStamp: true,
           channel: channel,
         );
-        final FlutterVersion version = FlutterVersion.instance;
+        final FlutterVersion version = globals.flutterVersion;
 
         when(mockProcessManager.runSync(
           <String>['git', 'merge-base', '--is-ancestor', 'abcdef', '123456'],


### PR DESCRIPTION
## Description

Move `FlutterVersion get flutterVersion => context.get<FlutterVersion>();` into globals.dart to force `global.` prefix on usages and include in the tool technical debt counts.

Replace `FlutterVersion.instance` with `globals.flutterVersion`.  
Looks like the static `FlutterVersion.instance` predates the context: https://github.com/flutter/flutter/pull/8801

## Related Issues

Continuation of https://github.com/flutter/flutter/pull/47398.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*