### PR TITLE
Inject platform into build ios-framework command

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -4,10 +4,12 @@
 
 import 'dart:async';
 
+import '../aot.dart';
+import '../bundle.dart';
 import '../commands/build_linux.dart';
 import '../commands/build_macos.dart';
 import '../commands/build_windows.dart';
-
+import '../globals.dart' as globals;
 import '../runner/flutter_command.dart';
 import 'build_aar.dart';
 import 'build_aot.dart';
@@ -26,7 +28,12 @@ class BuildCommand extends FlutterCommand {
     addSubcommand(BuildAppBundleCommand(verboseHelp: verboseHelp));
     addSubcommand(BuildAotCommand(verboseHelp: verboseHelp));
     addSubcommand(BuildIOSCommand());
-    addSubcommand(BuildIOSFrameworkCommand());
+    addSubcommand(BuildIOSFrameworkCommand(
+      aotBuilder: AotBuilder(),
+      bundleBuilder: BundleBuilder(),
+      cache: globals.cache,
+      platform: globals.platform,
+    ));
     addSubcommand(BuildBundleCommand(verboseHelp: verboseHelp));
     addSubcommand(BuildWebCommand());
     addSubcommand(BuildMacosCommand());

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
@@ -5,41 +5,54 @@
 import 'dart:io';
 
 import 'package:file/memory.dart';
+import 'package:flutter_tools/src/aot.dart';
 import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/bundle.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build_ios_framework.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/version.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:mockito/mockito.dart';
+import 'package:platform/platform.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
 
 void main() {
   group('build ios-framework', () {
+    MemoryFileSystem memoryFileSystem;
+    MockFlutterVersion mockFlutterVersion;
+    MockGitTagVersion mockGitTagVersion;
+    MockCache mockCache;
+    Directory outputDirectory;
+    FakePlatform fakePlatform;
+
+    setUpAll(() {
+      Cache.disableLocking();
+    });
+
+    setUp(() {
+      memoryFileSystem = MemoryFileSystem();
+      mockFlutterVersion = MockFlutterVersion();
+      mockGitTagVersion = MockGitTagVersion();
+      mockCache = MockCache();
+      fakePlatform = FakePlatform()..operatingSystem = 'macos';
+
+      when(mockFlutterVersion.gitTagVersion).thenReturn(mockGitTagVersion);
+      outputDirectory = globals.fs.systemTempDirectory
+          .createTempSync('flutter_build_ios_framework_test_output.')
+          .childDirectory('Debug')
+        ..createSync();
+    });
+
     group('podspec', () {
-      MemoryFileSystem memoryFileSystem;
-      MockFlutterVersion mockFlutterVersion;
-      MockGitTagVersion mockGitTagVersion;
-      MockCache mockCache;
-      Directory outputDirectory;
       const String storageBaseUrl = 'https://fake.googleapis.com';
       const String engineRevision = '0123456789abcdef';
       File licenseFile;
 
       setUp(() {
-        memoryFileSystem = MemoryFileSystem();
-        mockFlutterVersion = MockFlutterVersion();
-        mockGitTagVersion = MockGitTagVersion();
-        mockCache = MockCache();
-
         when(mockFlutterVersion.gitTagVersion).thenReturn(mockGitTagVersion);
-        outputDirectory = globals.fs.systemTempDirectory
-            .createTempSync('flutter_build_ios_framework_test_output.')
-            .childDirectory('Debug')
-          ..createSync();
-
         when(mockCache.storageBaseUrl).thenReturn(storageBaseUrl);
         when(mockCache.engineRevision).thenReturn(engineRevision);
         licenseFile = memoryFileSystem.file('LICENSE');
@@ -51,6 +64,9 @@ void main() {
         when(mockFlutterVersion.frameworkVersion).thenReturn(frameworkVersion);
 
         final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
+          aotBuilder: MockAotBuilder(),
+          bundleBuilder: MockBundleBuilder(),
+          platform: fakePlatform,
           flutterVersion: mockFlutterVersion,
           cache: mockCache
         );
@@ -73,6 +89,9 @@ void main() {
         when(mockGitTagVersion.commits).thenReturn(2);
 
         final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
+          aotBuilder: MockAotBuilder(),
+          bundleBuilder: MockBundleBuilder(),
+          platform: fakePlatform,
           flutterVersion: mockFlutterVersion,
           cache: mockCache
         );
@@ -92,6 +111,9 @@ void main() {
         when(mockGitTagVersion.commits).thenReturn(0);
 
         final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
+          aotBuilder: MockAotBuilder(),
+          bundleBuilder: MockBundleBuilder(),
+          platform: fakePlatform,
           flutterVersion: mockFlutterVersion,
           cache: mockCache
         );
@@ -123,8 +145,11 @@ void main() {
 
         testUsingContext('contains license and version', () async {
           final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
-              flutterVersion: mockFlutterVersion,
-              cache: mockCache
+            aotBuilder: MockAotBuilder(),
+            bundleBuilder: MockBundleBuilder(),
+            platform: fakePlatform,
+            flutterVersion: mockFlutterVersion,
+            cache: mockCache
           );
           command.produceFlutterPodspec(BuildMode.debug, outputDirectory);
 
@@ -140,8 +165,11 @@ void main() {
 
         testUsingContext('debug URL', () async {
           final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
-              flutterVersion: mockFlutterVersion,
-              cache: mockCache
+            aotBuilder: MockAotBuilder(),
+            bundleBuilder: MockBundleBuilder(),
+            platform: fakePlatform,
+            flutterVersion: mockFlutterVersion,
+            cache: mockCache
           );
           command.produceFlutterPodspec(BuildMode.debug, outputDirectory);
 
@@ -155,8 +183,11 @@ void main() {
 
         testUsingContext('profile URL', () async {
           final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
-              flutterVersion: mockFlutterVersion,
-              cache: mockCache
+            aotBuilder: MockAotBuilder(),
+            bundleBuilder: MockBundleBuilder(),
+            platform: fakePlatform,
+            flutterVersion: mockFlutterVersion,
+            cache: mockCache
           );
           command.produceFlutterPodspec(BuildMode.profile, outputDirectory);
 
@@ -170,8 +201,11 @@ void main() {
 
         testUsingContext('release URL', () async {
           final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
-              flutterVersion: mockFlutterVersion,
-              cache: mockCache
+            aotBuilder: MockAotBuilder(),
+            bundleBuilder: MockBundleBuilder(),
+            platform: fakePlatform,
+            flutterVersion: mockFlutterVersion,
+            cache: mockCache
           );
           command.produceFlutterPodspec(BuildMode.release, outputDirectory);
 
@@ -190,3 +224,5 @@ void main() {
 class MockFlutterVersion extends Mock implements FlutterVersion {}
 class MockGitTagVersion extends Mock implements GitTagVersion {}
 class MockCache extends Mock implements Cache {}
+class MockAotBuilder extends Mock implements AotBuilder {}
+class MockBundleBuilder extends Mock implements BundleBuilder {}


### PR DESCRIPTION
## Description

Inject platform into "build ios-framework" command instead of using global, light refactoring to make the non-test code explicit what's being injected instead of lazily instantiating.

## Tests

Updated build_ios_framework_test.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*