### PR TITLE
Reduced code duplication in ink_splash.dart, ink_ripple.dart

### DIFF
--- a/packages/flutter/lib/src/material/ink_ripple.dart
+++ b/packages/flutter/lib/src/material/ink_ripple.dart
@@ -237,28 +237,6 @@ class InkRipple extends InteractiveInkFeature {
       referenceBox.size.center(Offset.zero),
       Curves.ease.transform(_radiusController.value),
     );
-    final Offset originOffset = MatrixUtils.getAsTranslation(transform);
-    canvas.save();
-    if (originOffset == null) {
-      canvas.transform(transform.storage);
-    } else {
-      canvas.translate(originOffset.dx, originOffset.dy);
-    }
-    if (_clipCallback != null) {
-      final Rect rect = _clipCallback();
-      if (_customBorder != null) {
-        canvas.clipPath(_customBorder.getOuterPath(rect, textDirection: _textDirection));
-      } else if (_borderRadius != BorderRadius.zero) {
-        canvas.clipRRect(RRect.fromRectAndCorners(
-          rect,
-          topLeft: _borderRadius.topLeft, topRight: _borderRadius.topRight,
-          bottomLeft: _borderRadius.bottomLeft, bottomRight: _borderRadius.bottomRight,
-        ));
-      } else {
-        canvas.clipRect(rect);
-      }
-    }
-    canvas.drawCircle(center, _radius.value, paint);
-    canvas.restore();
+    paintInkCircle(canvas, transform, paint, center, _textDirection, _radius, _customBorder, _borderRadius, _clipCallback);
   }
 }

--- a/packages/flutter/lib/src/material/ink_ripple.dart
+++ b/packages/flutter/lib/src/material/ink_ripple.dart
@@ -237,6 +237,16 @@ class InkRipple extends InteractiveInkFeature {
       referenceBox.size.center(Offset.zero),
       Curves.ease.transform(_radiusController.value),
     );
-    paintInkCircle(canvas, transform, paint, center, _textDirection, _radius, _customBorder, _borderRadius, _clipCallback);
+    paintInkCircle(
+      canvas: canvas,
+      transform: transform,
+      paint: paint,
+      center: center,
+      textDirection: _textDirection,
+      radius: _radius.value,
+      customBorder: _customBorder,
+      borderRadius: _borderRadius,
+      clipCallback: _clipCallback,
+    );
   }
 }

--- a/packages/flutter/lib/src/material/ink_splash.dart
+++ b/packages/flutter/lib/src/material/ink_splash.dart
@@ -202,6 +202,16 @@ class InkSplash extends InteractiveInkFeature {
     Offset center = _position;
     if (_repositionToReferenceBox)
       center = Offset.lerp(center, referenceBox.size.center(Offset.zero), _radiusController.value);
-    paintInkCircle(canvas, transform, paint, center, _textDirection, _radius, _customBorder, _borderRadius, _clipCallback);
+    paintInkCircle(
+      canvas: canvas,
+      transform: transform,
+      paint: paint,
+      center: center,
+      textDirection: _textDirection,
+      radius: _radius.value,
+      customBorder: _customBorder,
+      borderRadius: _borderRadius,
+      clipCallback: _clipCallback,
+    );
   }
 }

--- a/packages/flutter/lib/src/material/ink_splash.dart
+++ b/packages/flutter/lib/src/material/ink_splash.dart
@@ -202,28 +202,6 @@ class InkSplash extends InteractiveInkFeature {
     Offset center = _position;
     if (_repositionToReferenceBox)
       center = Offset.lerp(center, referenceBox.size.center(Offset.zero), _radiusController.value);
-    final Offset originOffset = MatrixUtils.getAsTranslation(transform);
-    canvas.save();
-    if (originOffset == null) {
-      canvas.transform(transform.storage);
-    } else {
-      canvas.translate(originOffset.dx, originOffset.dy);
-    }
-    if (_clipCallback != null) {
-      final Rect rect = _clipCallback();
-      if (_customBorder != null) {
-        canvas.clipPath(_customBorder.getOuterPath(rect, textDirection: _textDirection));
-      } else if (_borderRadius != BorderRadius.zero) {
-        canvas.clipRRect(RRect.fromRectAndCorners(
-          rect,
-          topLeft: _borderRadius.topLeft, topRight: _borderRadius.topRight,
-          bottomLeft: _borderRadius.bottomLeft, bottomRight: _borderRadius.bottomRight,
-        ));
-      } else {
-        canvas.clipRect(rect);
-      }
-    }
-    canvas.drawCircle(center, _radius.value, paint);
-    canvas.restore();
+    paintInkCircle(canvas, transform, paint, center, _textDirection, _radius, _customBorder, _borderRadius, _clipCallback);
   }
 }

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -67,21 +67,32 @@ abstract class InteractiveInkFeature extends InkFeature {
 
   /// Draws an ink splash or ink ripple on the passed in [Canvas].
   ///
-  /// The [transform] argument gives the coordinate conversion from the coordinate
-  /// system of the canvas to the coordinate system of the [referenceBox].
+  /// The [transform] argument is the [Matrix4] transform that typically
+  /// shifts the coordinate space of the canvas to the space in which
+  /// the ink circle is to be painted.
   ///
-  /// [Center], [Paint] and [radius] are used to paint the cirle with desired origin,
-  /// paint and radius
+  /// [center] is the [Offset] from origin of the canvas where center
+  /// of the circle is drawn
   ///
-  /// [TextDirection] is used for calculating path to clip if [customBorder] is not null.
+  /// Using [paint] you can specify properties like color, strokewidth, colorFiler, etc
+  /// for painting the circle
   ///
-  /// If [customBorder] is not null, the canvas is clipped by the [ShapeBorder] provided. If
-  /// [customBorder] is null and [borderRadius] is provided (i.e not [BorderRadius.zero]),
-  /// the canvas is clipped by the [BorderRadius] provided.
+  /// [radius] is the radius of circle to be drawn on canvas
   ///
-  /// If [clipCallBack] is null, no clipping is performed and only the ink circle is painted
+  /// [clipCallback] is required by ink effects to obtain the rectangle for the effect,
+  /// if [clipCallback] is null, no clipping is performed and only the ink circle is painted
   ///
-  /// The [InkSplash] and [InkRipple] widgets draw their ink circles using this function.
+  /// [customBorder] is a [ShapeBorder] which can be used if you want to clip
+  /// something other than a simply a [Rect] or [RRect]
+  ///
+  /// If [customBorder] is provided, the canvas is clipped by it. If
+  /// [customBorder] is null, canvas is clipped by the [RRect]
+  /// formed by [borderRadius] and [clipCallBack]
+  ///
+  /// [textDirection] is used if [customBorder] is provided (as [customBorder] can have
+  /// a [textDirection] dependency), it is required for calculation of path to clip
+  ///
+  /// Used by [InkSplash] and [InkRipple], for example.
   @protected
   void paintInkCircle({
     @required Canvas canvas,

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -72,35 +72,37 @@ abstract class InteractiveInkFeature extends InkFeature {
   /// the ink circle is to be painted.
   ///
   /// [center] is the [Offset] from origin of the canvas where center
-  /// of the circle is drawn
+  /// of the circle is drawn.
   ///
-  /// Using [paint] you can specify properties like color, strokewidth, colorFiler, etc
-  /// for painting the circle
+  /// [paint] takes a [Paint] object that describes the styles used to draw the ink circle.
+  /// For example, [paint] can specify properties like color, strokewidth, colorFiler.
   ///
-  /// [radius] is the radius of circle to be drawn on canvas
+  /// [radius] is the radius of ink circle to be drawn on canvas.
   ///
-  /// [clipCallback] is required by ink effects to obtain the rectangle for the effect,
-  /// if [clipCallback] is null, no clipping is performed and only the ink circle is painted
+  /// [clipCallback] is the callback used to obtain the [Rect] used for clipping the ink effect.
+  /// If [clipCallback] is null, no clipping is performed on the ink circle.
   ///
-  /// [customBorder] is a [ShapeBorder] which can be used if you want to clip
-  /// something other than a simply a [Rect] or [RRect]
+  /// Clipping can happen in 3 different ways -
+  ///  1. If [customBorder] is provided, it is used to determine the path
+  ///     for clipping.
+  ///  2. If [customBorder] is null, and [borderRadius] is provided, canvas
+  ///     is clipped by a [RRect] created from [clipCallback] and [borderRadius].
+  ///  3. if [borderRadius] is the default [BorderRadius.zero]. The [Rect] provided
+  ///      by [clipCallback] is used for clipping.
   ///
-  /// If [customBorder] is provided, the canvas is clipped by it. If
-  /// [customBorder] is null, canvas is clipped by the [RRect]
-  /// formed by [borderRadius] and [clipCallBack]
+  /// [textDirection] is used by [customBorder] if it is non-null. This allows the [customBorder]'s path
+  /// to be properly defined if it was the path was expressed in terms of "start" and "end" instead of
+  /// "left" and "right".
   ///
-  /// [textDirection] is used if [customBorder] is provided (as [customBorder] can have
-  /// a [textDirection] dependency), it is required for calculation of path to clip
-  ///
-  /// Used by [InkSplash] and [InkRipple], for example.
+  /// For examples on how the function is used, see [InkSplash] and [InkRipple].
   @protected
   void paintInkCircle({
     @required Canvas canvas,
     @required Matrix4 transform,
     @required Paint paint,
     @required Offset center,
-    @required TextDirection textDirection,
     @required double radius,
+    TextDirection textDirection,
     ShapeBorder customBorder,
     BorderRadius borderRadius = BorderRadius.zero,
     RectCallback clipCallback,
@@ -109,7 +111,7 @@ abstract class InteractiveInkFeature extends InkFeature {
     assert(transform != null);
     assert(paint != null);
     assert(center != null);
-    assert(textDirection != null);
+    assert(customBorder == null || textDirection != null, 'Must provide textDirection if customBorder is not null');
     assert(radius != null);
     assert(borderRadius != null);
 

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -64,6 +64,43 @@ abstract class InteractiveInkFeature extends InkFeature {
     _color = value;
     controller.markNeedsPaint();
   }
+
+  /// paints a ripple/splash Ink Circle
+  @protected
+  void paintInkCircle(
+    Canvas canvas,
+    Matrix4 transform,
+    Paint paint,
+    Offset center,
+    TextDirection textDirection,
+    Animation<double> radius,
+    ShapeBorder customBorder,
+    BorderRadius borderRadius,
+    RectCallback clipCallback) {
+    final Offset originOffset = MatrixUtils.getAsTranslation(transform);
+    canvas.save();
+    if (originOffset == null) {
+      canvas.transform(transform.storage);
+    } else {
+      canvas.translate(originOffset.dx, originOffset.dy);
+    }
+    if (clipCallback != null) {
+      final Rect rect = clipCallback();
+      if (customBorder != null) {
+        canvas.clipPath(customBorder.getOuterPath(rect, textDirection: textDirection));
+      } else if (borderRadius != BorderRadius.zero) {
+        canvas.clipRRect(RRect.fromRectAndCorners(
+          rect,
+          topLeft: borderRadius.topLeft, topRight: borderRadius.topRight,
+          bottomLeft: borderRadius.bottomLeft, bottomRight: borderRadius.bottomRight,
+        ));
+      } else {
+        canvas.clipRect(rect);
+      }
+    }
+    canvas.drawCircle(center, radius.value, paint);
+    canvas.restore();
+  }
 }
 
 /// An encapsulation of an [InteractiveInkFeature] constructor used by

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -65,18 +65,29 @@ abstract class InteractiveInkFeature extends InkFeature {
     controller.markNeedsPaint();
   }
 
-  /// paints a ripple/splash Ink Circle
+  /// Called during [paintFeature] in [InkSplash] and [InkRipple] widgets
+  ///
+  /// Combines the common parts of painting a ripple and splash ink circle
   @protected
-  void paintInkCircle(
-    Canvas canvas,
-    Matrix4 transform,
-    Paint paint,
-    Offset center,
-    TextDirection textDirection,
-    Animation<double> radius,
+  void paintInkCircle({
+    @required Canvas canvas,
+    @required Matrix4 transform,
+    @required Paint paint,
+    @required Offset center,
+    @required TextDirection textDirection,
+    @required double radius,
     ShapeBorder customBorder,
-    BorderRadius borderRadius,
-    RectCallback clipCallback) {
+    BorderRadius borderRadius = BorderRadius.zero,
+    RectCallback clipCallback,
+    }) {
+    assert(canvas != null);
+    assert(transform != null);
+    assert(paint != null);
+    assert(center != null);
+    assert(textDirection != null);
+    assert(radius != null);
+    assert(borderRadius != null);
+
     final Offset originOffset = MatrixUtils.getAsTranslation(transform);
     canvas.save();
     if (originOffset == null) {
@@ -98,7 +109,7 @@ abstract class InteractiveInkFeature extends InkFeature {
         canvas.clipRect(rect);
       }
     }
-    canvas.drawCircle(center, radius.value, paint);
+    canvas.drawCircle(center, radius, paint);
     canvas.restore();
   }
 }

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -67,6 +67,14 @@ abstract class InteractiveInkFeature extends InkFeature {
 
   /// Draws an ink splash or ink ripple on the passed in [Canvas].
   ///
+  /// The [transform] argument gives the coordinate conversion from the coordinate
+  /// system of the canvas to the coordinate system of the [referenceBox].
+  ///
+  /// [Center], [Paint] and [radius] are used to paint the cirle with desired origin,
+  /// paint and radius
+  ///
+  /// [TextDirection] is used for calculating path to clip if [customBorder] is not null.
+  ///
   /// If [customBorder] is not null, the canvas is clipped by the [ShapeBorder] provided. If
   /// [customBorder] is null and [borderRadius] is provided (i.e not [BorderRadius.zero]),
   /// the canvas is clipped by the [BorderRadius] provided.

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -65,9 +65,15 @@ abstract class InteractiveInkFeature extends InkFeature {
     controller.markNeedsPaint();
   }
 
-  /// Called during [paintFeature] in [InkSplash] and [InkRipple] widgets
+  /// Draws an ink splash or ink ripple on the passed in [Canvas].
   ///
-  /// Combines the common parts of painting a ripple and splash ink circle
+  /// If [customBorder] is not null, the canvas is clipped by the [ShapeBorder] provided. If
+  /// [customBorder] is null and [borderRadius] is provided (i.e not [BorderRadius.zero]),
+  /// the canvas is clipped by the [BorderRadius] provided.
+  ///
+  /// If [clipCallBack] is null, no clipping is performed and only the ink circle is painted
+  ///
+  /// The [InkSplash] and [InkRipple] widgets draw their ink circles using this function.
   @protected
   void paintInkCircle({
     @required Canvas canvas,

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -71,11 +71,11 @@ abstract class InteractiveInkFeature extends InkFeature {
   /// shifts the coordinate space of the canvas to the space in which
   /// the ink circle is to be painted.
   ///
-  /// [center] is the [Offset] from origin of the canvas where center
+  /// [center] is the [Offset] from origin of the canvas where the center
   /// of the circle is drawn.
   ///
   /// [paint] takes a [Paint] object that describes the styles used to draw the ink circle.
-  /// For example, [paint] can specify properties like color, strokewidth, colorFiler.
+  /// For example, [paint] can specify properties like color, strokewidth, colorFilter.
   ///
   /// [radius] is the radius of ink circle to be drawn on canvas.
   ///
@@ -85,9 +85,9 @@ abstract class InteractiveInkFeature extends InkFeature {
   /// Clipping can happen in 3 different ways -
   ///  1. If [customBorder] is provided, it is used to determine the path
   ///     for clipping.
-  ///  2. If [customBorder] is null, and [borderRadius] is provided, canvas
-  ///     is clipped by a [RRect] created from [clipCallback] and [borderRadius].
-  ///  3. if [borderRadius] is the default [BorderRadius.zero]. The [Rect] provided
+  ///  2. If [customBorder] is null, and [borderRadius] is provided, the canvas
+  ///     is clipped by an [RRect] created from [clipCallback] and [borderRadius].
+  ///  3. If [borderRadius] is the default [BorderRadius.zero], then the [Rect] provided
   ///      by [clipCallback] is used for clipping.
   ///
   /// [textDirection] is used by [customBorder] if it is non-null. This allows the [customBorder]'s path
@@ -111,7 +111,6 @@ abstract class InteractiveInkFeature extends InkFeature {
     assert(transform != null);
     assert(paint != null);
     assert(center != null);
-    assert(customBorder == null || textDirection != null, 'Must provide textDirection if customBorder is not null');
     assert(radius != null);
     assert(borderRadius != null);
 


### PR DESCRIPTION
## Description
Reduced code duplication in ink_splash and ink_ripple material widgets

## Related Issues
Fixes #21014

## Tests
Golden tests material.bottom_navigation_bar.shifting_transition.[0-7]

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
