### PR TITLE
switching channel prompts to run flutter upgrade

### DIFF
--- a/packages/flutter_tools/lib/src/commands/channel.dart
+++ b/packages/flutter_tools/lib/src/commands/channel.dart
@@ -126,7 +126,7 @@ class ChannelCommand extends FlutterCommand {
     }
     await _checkout(branchName);
     globals.printStatus("Successfully switched to flutter channel '$branchName'.");
-    globals.printStatus("Now run \"flutter upgrade\" to ensure that you're on the latest build from this channel.");
+    globals.printStatus("To ensure that you're on the latest build from this channel, run 'flutter upgrade'");
   }
 
   static Future<void> upgradeChannel() async {

--- a/packages/flutter_tools/lib/src/commands/channel.dart
+++ b/packages/flutter_tools/lib/src/commands/channel.dart
@@ -116,7 +116,7 @@ class ChannelCommand extends FlutterCommand {
     }
   }
 
-  Future<void> _switchChannel(String branchName) {
+  Future<void> _switchChannel(String branchName) async {
     globals.printStatus("Switching to flutter channel '$branchName'...");
     if (FlutterVersion.obsoleteBranches.containsKey(branchName)) {
       final String alternative = FlutterVersion.obsoleteBranches[branchName];
@@ -124,7 +124,9 @@ class ChannelCommand extends FlutterCommand {
     } else if (!FlutterVersion.officialChannels.contains(branchName)) {
       globals.printStatus('This is not an official channel. For a list of available channels, try "flutter channel".');
     }
-    return _checkout(branchName);
+    await _checkout(branchName);
+    globals.printStatus("Successfully switched to flutter channel '$branchName'.");
+    globals.printStatus("Now run \"flutter upgrade\" to ensure that you're on the latest build from this channel.");
   }
 
   static Future<void> upgradeChannel() async {

--- a/packages/flutter_tools/test/general.shard/channel_test.dart
+++ b/packages/flutter_tools/test/general.shard/channel_test.dart
@@ -274,6 +274,7 @@ void main() {
       final CommandRunner<void> runner = createTestCommandRunner(command);
       await runner.run(<String>['channel', 'beta']);
 
+      expect(testLogger.statusText, contains("Successfully switched to flutter channel 'beta'."));
       expect(testLogger.statusText, contains("To ensure that you're on the latest build from this channel, run 'flutter upgrade'"));
       expect(testLogger.errorText, hasLength(0));
     }, overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/general.shard/channel_test.dart
+++ b/packages/flutter_tools/test/general.shard/channel_test.dart
@@ -274,6 +274,22 @@ void main() {
       final CommandRunner<void> runner = createTestCommandRunner(command);
       await runner.run(<String>['channel', 'beta']);
 
+      verify(mockProcessManager.start(
+        <String>['git', 'fetch'],
+        workingDirectory: anyNamed('workingDirectory'),
+        environment: anyNamed('environment'),
+      )).called(1);
+      verify(mockProcessManager.start(
+        <String>['git', 'show-ref', '--verify', '--quiet', 'refs/heads/beta'],
+        workingDirectory: anyNamed('workingDirectory'),
+        environment: anyNamed('environment'),
+      )).called(1);
+      verify(mockProcessManager.start(
+        <String>['git', 'checkout', 'beta', '--'],
+        workingDirectory: anyNamed('workingDirectory'),
+        environment: anyNamed('environment'),
+      )).called(1);
+
       expect(testLogger.statusText, contains("Successfully switched to flutter channel 'beta'."));
       expect(testLogger.statusText, contains("To ensure that you're on the latest build from this channel, run 'flutter upgrade'"));
       expect(testLogger.errorText, hasLength(0));


### PR DESCRIPTION
## Description

Added print statements to prompt user to run `flutter upgrade` after running `flutter channel foo`

## Related Issues

resolves #16030

## Tests
None... simply added print statements

Here's an output from my system:
```
Switching to flutter channel 'beta'...
git: Switched to branch 'beta'
git: Your branch is up-to-date with 'origin/beta'.
Successfully switched to flutter channel 'beta'.
Now run "flutter upgrade" to ensure that you're on the latest build from this channel.
```
## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
