### PR TITLE
PaginatedDataTable to use localization on availableRowsPerPage

### DIFF
--- a/packages/flutter/lib/src/material/paginated_data_table.dart
+++ b/packages/flutter/lib/src/material/paginated_data_table.dart
@@ -374,7 +374,7 @@ class PaginatedDataTableState extends State<PaginatedDataTable> {
         .map<DropdownMenuItem<int>>((int value) {
           return DropdownMenuItem<int>(
             value: value,
-            child: Text('$value'),
+            child: Text(localizations.formatDecimal(value)),
           );
         })
         .toList();


### PR DESCRIPTION
PaginatedDataTable currently uses the default number formatting in its footer. Certain languages, including Persian, use a different set of Unicode characters to display numbers.

As an example:

```
۰, ۱, ۲, ۳, ۴, ۵, ۶, ۷, ۸, ۹

are equivalents of

0, 1, 2, 3, 4, 5, 6, 7, 8, 9
```