### PR TITLE
[flutter_tool] Hide unsafe std{out,err} operations

### DIFF
--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -112,12 +112,12 @@ Future<int> _handleToolError(
     }
   } else {
     // We've crashed; emit a log report.
-    safeStdioWrite(stderr, '\n');
+    globals.stdio.stderrWrite('\n');
 
     if (!reportCrashes) {
       // Print the stack trace on the bots - don't write a crash report.
-      safeStdioWrite(stderr, '$error\n');
-      safeStdioWrite(stderr, '$stackTrace\n');
+      globals.stdio.stderrWrite('$error\n');
+      globals.stdio.stderrWrite('$stackTrace\n');
       return _exit(1);
     }
 
@@ -138,8 +138,7 @@ Future<int> _handleToolError(
 
       return _exit(1);
     } catch (error) {
-      safeStdioWrite(
-        stderr,
+      globals.stdio.stderrWrite(
         'Unable to generate crash report due to secondary error: $error\n'
         'please let us know at https://github.com/flutter/flutter/issues.\n',
       );

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -9,7 +9,7 @@ import 'package:platform/platform.dart';
 
 import '../base/context.dart';
 import '../globals.dart' as globals;
-import 'io.dart' hide stderr, stdin, stdout;
+import 'io.dart';
 import 'terminal.dart' show AnsiTerminal, TerminalColor, OutputPreferences;
 import 'utils.dart';
 
@@ -268,14 +268,10 @@ class StdoutLogger extends Logger {
   }
 
   @protected
-  void writeToStdOut(String message) {
-    safeStdioWrite(_stdio.stdout, message);
-  }
+  void writeToStdOut(String message) => _stdio.stdoutWrite(message);
 
   @protected
-  void writeToStdErr(String message) {
-    safeStdioWrite(_stdio.stderr, message);
-  }
+  void writeToStdErr(String message) => _stdio.stderrWrite(message);
 
   @override
   void printTrace(String message) { }
@@ -363,7 +359,7 @@ class WindowsStdoutLogger extends StdoutLogger {
     final String windowsMessage = message
       .replaceAll('✗', 'X')
       .replaceAll('✓', '√');
-    safeStdioWrite(_stdio.stdout, windowsMessage);
+    _stdio.stdoutWrite(windowsMessage);
   }
 }
 
@@ -794,9 +790,7 @@ class SummaryStatus extends Status {
     super.start();
   }
 
-  void _writeToStdOut(String message) {
-    safeStdioWrite(_stdio.stdout, message);
-  }
+  void _writeToStdOut(String message) => _stdio.stdoutWrite(message);
 
   void _printMessage() {
     assert(!_messageShowingOnCurrentLine);
@@ -903,9 +897,7 @@ class AnsiSpinner extends Status {
     _startSpinner();
   }
 
-  void _writeToStdOut(String message) {
-    safeStdioWrite(_stdio.stdout, message);
-  }
+  void _writeToStdOut(String message) => _stdio.stdoutWrite(message);
 
   void _startSpinner() {
     _writeToStdOut(_clear); // for _callback to backspace over

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -143,7 +143,7 @@ class Daemon {
     final dynamic id = request['id'];
 
     if (id == null) {
-      safeStdioWrite(stderr, 'no id for request: $request\n');
+      globals.stdio.stderrWrite('no id for request: $request\n');
       return;
     }
 
@@ -323,9 +323,11 @@ class DaemonDomain extends Domain {
           // capture the print output for testing.
           print(message.message);
         } else if (message.level == 'error') {
-          safeStdioWrite(stderr, '${message.message}\n');
+          globals.stdio.stderrWrite('${message.message}\n');
           if (message.stackTrace != null) {
-            safeStdioWrite(stderr, '${message.stackTrace.toString().trimRight()}\n');
+            globals.stdio.stderrWrite(
+              '${message.stackTrace.toString().trimRight()}\n',
+            );
           }
         }
       } else {
@@ -862,7 +864,7 @@ class DeviceDomain extends Domain {
   }
 }
 
-Stream<Map<String, dynamic>> get stdinCommandStream => stdin
+Stream<Map<String, dynamic>> get stdinCommandStream => globals.stdio.stdin
   .transform<String>(utf8.decoder)
   .transform<String>(const LineSplitter())
   .where((String line) => line.startsWith('[{') && line.endsWith('}]'))
@@ -872,8 +874,7 @@ Stream<Map<String, dynamic>> get stdinCommandStream => stdin
   });
 
 void stdoutCommandResponse(Map<String, dynamic> command) {
-  safeStdioWrite(
-    stdout,
+  globals.stdio.stdoutWrite(
     '[${jsonEncodeObject(command)}]\n',
     fallback: (String message, dynamic error, StackTrace stack) {
       throwToolExit('Failed to write daemon command response to stdout: $error');

--- a/packages/flutter_tools/lib/src/commands/shell_completion.dart
+++ b/packages/flutter_tools/lib/src/commands/shell_completion.dart
@@ -8,7 +8,6 @@ import 'package:completion/completion.dart';
 
 import '../base/common.dart';
 import '../base/file_system.dart';
-import '../base/io.dart';
 import '../globals.dart' as globals;
 import '../runner/flutter_command.dart';
 
@@ -50,7 +49,7 @@ class ShellCompletionCommand extends FlutterCommand {
 
     if (argResults.rest.isEmpty || argResults.rest.first == '-') {
       final String script = generateCompletionScript(<String>['flutter']);
-      safeStdioWrite(stdout, script);
+      globals.stdio.stdoutWrite(script);
       return FlutterCommandResult.warning();
     }
 

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -308,7 +308,7 @@ class _DefaultPub implements Pub {
     );
 
     // Pipe the Flutter tool stdin to the pub stdin.
-    unawaited(process.stdin.addStream(io.stdin)
+    unawaited(process.stdin.addStream(globals.stdio.stdin)
       // If pub exits unexpectedly with an error, that will be reported below
       // by the tool exit after the exit code check.
       .catchError((dynamic err, StackTrace stack) {
@@ -320,8 +320,8 @@ class _DefaultPub implements Pub {
     // Pipe the pub stdout and stderr to the tool stdout and stderr.
     try {
       await Future.wait<dynamic>(<Future<dynamic>>[
-        io.stdout.addStream(process.stdout),
-        io.stderr.addStream(process.stderr),
+        globals.stdio.addStdoutStream(process.stdout),
+        globals.stdio.addStderrStream(process.stderr),
       ]);
     } catch (err, stack) {
       globals.printTrace('Echoing stdout or stderr from the pub subprocess failed:');

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -629,7 +629,8 @@ abstract class FlutterCommand extends Command<void> {
       final Map<CustomDimensions, String> additionalUsageValues =
         <CustomDimensions, String>{
           ...?await usageValues,
-          CustomDimensions.commandHasTerminal: io.stdout.hasTerminal ? 'true' : 'false',
+          CustomDimensions.commandHasTerminal:
+            globals.stdio.hasTerminal ? 'true' : 'false',
         };
       Usage.command(commandPath, parameters: additionalUsageValues);
     }

--- a/packages/flutter_tools/lib/src/test/event_printer.dart
+++ b/packages/flutter_tools/lib/src/test/event_printer.dart
@@ -2,13 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import '../base/io.dart' show stdout;
 import '../convert.dart';
+import '../globals.dart' as globals;
 import 'watcher.dart';
 
 /// Prints JSON events when running a test in --machine mode.
 class EventPrinter extends TestWatcher {
-  EventPrinter({StringSink out}) : _out = out ?? stdout;
+  EventPrinter({StringSink out}) : _out = out ?? globals.stdio.stdout;
 
   final StringSink _out;
 

--- a/packages/flutter_tools/test/general.shard/base/logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/logger_test.dart
@@ -20,8 +20,17 @@ final String bold = RegExp.escape(AnsiTerminal.bold);
 final String resetBold = RegExp.escape(AnsiTerminal.resetBold);
 final String resetColor = RegExp.escape(AnsiTerminal.resetColor);
 
-class MockStdio extends Mock implements Stdio {}
 class MockStdout extends Mock implements Stdout {}
+
+class ThrowingStdio extends Stdio {
+  ThrowingStdio(this.stdout, this.stderr);
+
+  @override
+  final Stdout stdout;
+
+  @override
+  final IOSink stderr;
+}
 
 void main() {
   group('AppContext', () {
@@ -82,13 +91,11 @@ void main() {
   });
 
   testWithoutContext('Logger does not throw when stdio write throws', () async {
-    final MockStdio stdio = MockStdio();
     final MockStdout stdout = MockStdout();
     final MockStdout stderr = MockStdout();
+    final ThrowingStdio stdio = ThrowingStdio(stdout, stderr);
     bool stdoutThrew = false;
     bool stderrThrew = false;
-    when(stdio.stdout).thenReturn(stdout);
-    when(stdio.stderr).thenReturn(stderr);
     when(stdout.write(any)).thenAnswer((_) {
       stdoutThrew = true;
       throw 'Error';


### PR DESCRIPTION
## Description

This is a cleanup for https://github.com/flutter/flutter/pull/49380. In particular, it hides `stdout` and `stderr` in `Stdio` in `io.dart`, and exposes only the functionality that we use.

## Tests

I added the following tests:

There was no change in functionality. Things we weren't using are now invisible/hidden by `io.dart`.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
