### PR TITLE
[flutter_tool] Make base/net.dart context free

### DIFF
--- a/packages/flutter_tools/lib/src/base/net.dart
+++ b/packages/flutter_tools/lib/src/base/net.dart
@@ -4,12 +4,14 @@
 
 import 'dart:async';
 
-import '../base/context.dart';
+import 'package:meta/meta.dart';
+import 'package:platform/platform.dart';
+
 import '../convert.dart';
-import '../globals.dart' as globals;
 import 'common.dart';
 import 'file_system.dart';
 import 'io.dart';
+import 'logger.dart';
 
 const int kNetworkProblemExitCode = 50;
 
@@ -17,138 +19,159 @@ typedef HttpClientFactory = HttpClient Function();
 
 typedef UrlTunneller = Future<String> Function(String url);
 
-/// Download a file from the given URL.
-///
-/// If a destination file is not provided, returns the bytes.
-///
-/// If a destination file is provided, streams the bytes to that file and
-/// returns an empty list.
-///
-/// If [maxAttempts] is exceeded, returns null.
-Future<List<int>> fetchUrl(Uri url, {
-  int maxAttempts,
-  File destFile,
-}) async {
-  int attempts = 0;
-  int durationSeconds = 1;
-  while (true) {
-    attempts += 1;
-    _MemoryIOSink memorySink;
-    IOSink sink;
-    if (destFile == null) {
-      memorySink = _MemoryIOSink();
-      sink = memorySink;
+class Net {
+  Net({
+    HttpClientFactory httpClientFactory,
+    @required Logger logger,
+    @required Platform platform,
+  }) :
+    _httpClientFactory = httpClientFactory,
+    _logger = logger,
+    _platform = platform;
+
+  final HttpClientFactory _httpClientFactory;
+
+  final Logger _logger;
+
+  final Platform _platform;
+
+  /// Download a file from the given URL.
+  ///
+  /// If a destination file is not provided, returns the bytes.
+  ///
+  /// If a destination file is provided, streams the bytes to that file and
+  /// returns an empty list.
+  ///
+  /// If [maxAttempts] is exceeded, returns null.
+  Future<List<int>> fetchUrl(Uri url, {
+    int maxAttempts,
+    File destFile,
+  }) async {
+    int attempts = 0;
+    int durationSeconds = 1;
+    while (true) {
+      attempts += 1;
+      _MemoryIOSink memorySink;
+      IOSink sink;
+      if (destFile == null) {
+        memorySink = _MemoryIOSink();
+        sink = memorySink;
+      } else {
+        sink = destFile.openWrite();
+      }
+
+      final bool result = await _attempt(
+        url,
+        destSink: sink,
+      );
+      if (result) {
+        return memorySink?.writes?.takeBytes() ?? <int>[];
+      }
+
+      if (maxAttempts != null && attempts >= maxAttempts) {
+        _logger.printStatus('Download failed -- retry $attempts');
+        return null;
+      }
+      _logger.printStatus(
+        'Download failed -- attempting retry $attempts in '
+        '$durationSeconds second${ durationSeconds == 1 ? "" : "s"}...',
+      );
+      await Future<void>.delayed(Duration(seconds: durationSeconds));
+      if (durationSeconds < 64) {
+        durationSeconds *= 2;
+      }
+    }
+  }
+
+  /// Check if the given URL points to a valid endpoint.
+  Future<bool> doesRemoteFileExist(Uri url) => _attempt(url, onlyHeaders: true);
+
+  // Returns true on success and false on failure.
+  Future<bool> _attempt(Uri url, {
+    IOSink destSink,
+    bool onlyHeaders = false,
+  }) async {
+    assert(onlyHeaders || destSink != null);
+    _logger.printTrace('Downloading: $url');
+    HttpClient httpClient;
+    if (_httpClientFactory != null) {
+      httpClient = _httpClientFactory();
     } else {
-      sink = destFile.openWrite();
+      httpClient = HttpClient();
     }
-
-    final bool result = await _attempt(
-      url,
-      destSink: sink,
-    );
-    if (result) {
-      return memorySink?.writes?.takeBytes() ?? <int>[];
-    }
-
-    if (maxAttempts != null && attempts >= maxAttempts) {
-      globals.printStatus('Download failed -- retry $attempts');
-      return null;
-    }
-    globals.printStatus('Download failed -- attempting retry $attempts in '
-        '$durationSeconds second${ durationSeconds == 1 ? "" : "s"}...');
-    await Future<void>.delayed(Duration(seconds: durationSeconds));
-    if (durationSeconds < 64) {
-      durationSeconds *= 2;
-    }
-  }
-}
-
-/// Check if the given URL points to a valid endpoint.
-Future<bool> doesRemoteFileExist(Uri url) async => await _attempt(url, onlyHeaders: true);
-
-// Returns true on success and false on failure.
-Future<bool> _attempt(Uri url, {
-  IOSink destSink,
-  bool onlyHeaders = false,
-}) async {
-  assert(onlyHeaders || destSink != null);
-  globals.printTrace('Downloading: $url');
-  HttpClient httpClient;
-  if (context.get<HttpClientFactory>() != null) {
-    httpClient = context.get<HttpClientFactory>()();
-  } else {
-    httpClient = HttpClient();
-  }
-  HttpClientRequest request;
-  HttpClientResponse response;
-  try {
-    if (onlyHeaders) {
-      request = await httpClient.headUrl(url);
-    } else {
-      request = await httpClient.getUrl(url);
-    }
-    response = await request.close();
-  } on ArgumentError catch (error) {
-    final String overrideUrl = globals.platform.environment['FLUTTER_STORAGE_BASE_URL'];
-    if (overrideUrl != null && url.toString().contains(overrideUrl)) {
-      globals.printError(error.toString());
+    HttpClientRequest request;
+    HttpClientResponse response;
+    try {
+      if (onlyHeaders) {
+        request = await httpClient.headUrl(url);
+      } else {
+        request = await httpClient.getUrl(url);
+      }
+      response = await request.close();
+    } on ArgumentError catch (error) {
+      final String overrideUrl = _platform.environment['FLUTTER_STORAGE_BASE_URL'];
+      if (overrideUrl != null && url.toString().contains(overrideUrl)) {
+        _logger.printError(error.toString());
+        throwToolExit(
+          'The value of FLUTTER_STORAGE_BASE_URL ($overrideUrl) could not be '
+          'parsed as a valid url. Please see https://flutter.dev/community/china '
+          'for an example of how to use it.\n'
+          'Full URL: $url',
+          exitCode: kNetworkProblemExitCode,);
+      }
+      _logger.printError(error.toString());
+      rethrow;
+    } on HandshakeException catch (error) {
+      _logger.printTrace(error.toString());
       throwToolExit(
-        'The value of FLUTTER_STORAGE_BASE_URL ($overrideUrl) could not be '
-        'parsed as a valid url. Please see https://flutter.dev/community/china '
-        'for an example of how to use it.\n'
-        'Full URL: $url',
-        exitCode: kNetworkProblemExitCode,);
-    }
-    globals.printError(error.toString());
-    rethrow;
-  } on HandshakeException catch (error) {
-    globals.printTrace(error.toString());
-    throwToolExit(
-      'Could not authenticate download server. You may be experiencing a man-in-the-middle attack,\n'
-      'your network may be compromised, or you may have malware installed on your computer.\n'
-      'URL: $url',
-      exitCode: kNetworkProblemExitCode,
-    );
-  } on SocketException catch (error) {
-    globals.printTrace('Download error: $error');
-    return false;
-  } on HttpException catch (error) {
-    globals.printTrace('Download error: $error');
-    return false;
-  }
-  assert(response != null);
-
-  // If we're making a HEAD request, we're only checking to see if the URL is
-  // valid.
-  if (onlyHeaders) {
-    return response.statusCode == HttpStatus.ok;
-  }
-  if (response.statusCode != HttpStatus.ok) {
-    if (response.statusCode > 0 && response.statusCode < 500) {
-      throwToolExit(
-        'Download failed.\n'
-        'URL: $url\n'
-        'Error: ${response.statusCode} ${response.reasonPhrase}',
+        'Could not authenticate download server. You may be experiencing a man-in-the-middle attack,\n'
+        'your network may be compromised, or you may have malware installed on your computer.\n'
+        'URL: $url',
         exitCode: kNetworkProblemExitCode,
       );
+    } on SocketException catch (error) {
+      _logger.printTrace('Download error: $error');
+      return false;
+    } on HttpException catch (error) {
+      _logger.printTrace('Download error: $error');
+      return false;
     }
-    // 5xx errors are server errors and we can try again
-    globals.printTrace('Download error: ${response.statusCode} ${response.reasonPhrase}');
-    return false;
-  }
-  globals.printTrace('Received response from server, collecting bytes...');
-  try {
-    assert(destSink != null);
-    await response.forEach(destSink.add);
-    return true;
-  } on IOException catch (error) {
-    globals.printTrace('Download error: $error');
-    return false;
-  } finally {
-    await destSink?.flush();
-    await destSink?.close();
+    assert(response != null);
+
+    // If we're making a HEAD request, we're only checking to see if the URL is
+    // valid.
+    if (onlyHeaders) {
+      return response.statusCode == HttpStatus.ok;
+    }
+    if (response.statusCode != HttpStatus.ok) {
+      if (response.statusCode > 0 && response.statusCode < 500) {
+        throwToolExit(
+          'Download failed.\n'
+          'URL: $url\n'
+          'Error: ${response.statusCode} ${response.reasonPhrase}',
+          exitCode: kNetworkProblemExitCode,
+        );
+      }
+      // 5xx errors are server errors and we can try again
+      _logger.printTrace('Download error: ${response.statusCode} ${response.reasonPhrase}');
+      return false;
+    }
+    _logger.printTrace('Received response from server, collecting bytes...');
+    try {
+      assert(destSink != null);
+      await response.forEach(destSink.add);
+      return true;
+    } on IOException catch (error) {
+      _logger.printTrace('Download error: $error');
+      return false;
+    } finally {
+      await destSink?.flush();
+      await destSink?.close();
+    }
   }
 }
+
+
 
 /// An IOSink that collects whatever is written to it.
 class _MemoryIOSink implements IOSink {

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -11,7 +11,9 @@ import '../android/android.dart' as android;
 import '../android/android_sdk.dart' as android_sdk;
 import '../android/gradle_utils.dart' as gradle;
 import '../base/common.dart';
+import '../base/context.dart';
 import '../base/file_system.dart';
+import '../base/io.dart';
 import '../base/net.dart';
 import '../base/os.dart';
 import '../base/utils.dart';
@@ -166,6 +168,14 @@ class CreateCommand extends FlutterCommand {
     };
   }
 
+  // Lazy-initialize the net utilities with values from the context.
+  Net _cachedNet;
+  Net get _net => _cachedNet ??= Net(
+    httpClientFactory: context.get<HttpClientFactory>() ?? () => HttpClient(),
+    logger: globals.logger,
+    platform: globals.platform,
+  );
+
   // If it has a .metadata file with the project_type in it, use that.
   // If it has an android dir and an android/app dir, it's a legacy app
   // If it has an ios dir and an ios/Flutter dir, it's a legacy app
@@ -230,13 +240,14 @@ class CreateCommand extends FlutterCommand {
         'documentation and try again.');
     }
 
-    return utf8.decode(await fetchUrl(Uri.https(_snippetsHost, 'snippets/$sampleId.dart')));
+    final Uri snippetsUri = Uri.https(_snippetsHost, 'snippets/$sampleId.dart');
+    return utf8.decode(await _net.fetchUrl(snippetsUri));
   }
 
   /// Fetches the samples index file from the Flutter docs website.
   Future<String> _fetchSamplesIndexFromServer() async {
-    return utf8.decode(
-      await fetchUrl(Uri.https(_snippetsHost, 'snippets/index.json'), maxAttempts: 2));
+    final Uri snippetsUri = Uri.https(_snippetsHost, 'snippets/index.json');
+    return utf8.decode(await _net.fetchUrl(snippetsUri, maxAttempts: 2));
   }
 
   /// Fetches the samples index file from the server and writes it to

--- a/packages/flutter_tools/test/src/testbed.dart
+++ b/packages/flutter_tools/test/src/testbed.dart
@@ -918,4 +918,13 @@ class FakeCache implements Cache {
   @override
   Future<void> updateAll(Set<DevelopmentArtifact> requiredArtifacts) async {
   }
+
+  @override
+  Future<void> downloadFile(Uri url, File location) async {
+  }
+
+  @override
+  Future<bool> doesRemoteExist(String message, Uri url) async {
+    return true;
+  }
 }


### PR DESCRIPTION
## Description

Removes references to globals from `base/net.dart`. Updates tests to `testWithoutContext()`.

## Related Issues

https://github.com/flutter/flutter/issues/47161

## Tests

I added the following tests:

Updated tests in `net_test.dart`.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
