### PR TITLE
get runtime of each step of setup_script for mac & linux

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -50,13 +50,13 @@ task:
     fingerprint_script: echo $OS; cat bin/internal/*.version
   setup_script:
     - date
-    - git clean -xffd
-    - git fetch origin
-    - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
-    - flutter config --no-analytics
-    - flutter doctor -v
-    - flutter update-packages
-    - ./dev/bots/accept_android_sdk_licenses.sh
+    - time git clean -xffd
+    - time git fetch origin
+    - time git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
+    - time flutter config --no-analytics
+    - time flutter doctor -v
+    - time flutter update-packages
+    - time ./dev/bots/accept_android_sdk_licenses.sh
     - date
   on_failure:
     failure_script:
@@ -509,15 +509,15 @@ task:
     MEMORY: 8G
   setup_script:
     - date
-    - which flutter
-    - bundle --version
-    - sudo bundle install --system --gemfile=dev/ci/mac/Gemfile
-    - git clean -xffd
-    - git fetch origin
-    - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
-    - flutter config --no-analytics
-    - flutter doctor -v
-    - flutter update-packages
+    - time which flutter
+    - time bundle --version
+    - time sudo bundle install --system --gemfile=dev/ci/mac/Gemfile
+    - time git clean -xffd
+    - time git fetch origin
+    - time git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
+    - time flutter config --no-analytics
+    - time flutter doctor -v
+    - time flutter update-packages
     - date
     - which flutter
   on_failure:


### PR DESCRIPTION
## Description

[Sometimes](https://cirrus-ci.com/task/4519782837911552?command=setup#L262) the cirrus setup step times out after an hour. It would be helpful to know exactly what was done during that hour (i.e. was it mostly spent on the last step, or was there an intermediary step that took unexpectedly long).

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*
