### PR TITLE
Unmark tests as flaky because they are no longer flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -357,7 +357,6 @@ tasks:
       Run flutter web on the devicelab and hot restart.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
-    flaky: true
 
   web_size__compile_test:
     description: >
@@ -595,7 +594,6 @@ tasks:
       Checks the functionality and performance of hot reload on a macOS target platform
     stage: devicelab
     required_agent_capabilities: ["mac/ios"]
-    flaky: true
 
   # Tests running on Windows host
 


### PR DESCRIPTION
Unmarking these two tests as flaky since they have not flaked at all (and have been first time successful) for a long time.