### PR TITLE
WIP Turn back on macOS shard Cirrus caching

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -508,15 +508,24 @@ task:
   pub_cache:
     folder: $HOME/.pub-cache
     fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"; echo 1
-    populate_script: flutter update-packages
+    populate_script:
+      - git fetch origin
+      - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
+      - flutter update-packages
   flutter_pkg_cache:
     folder: bin/cache/pkg
     fingerprint_script: echo $OS; cat bin/internal/*.version; echo 1
-    populate_script: flutter precache --no-android --no-ios
+    populate_script:
+      - git fetch origin
+      - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
+      - flutter precache --no-android --no-ios
   artifacts_cache:
     folder: bin/cache/artifacts
     fingerprint_script: echo $OS; cat bin/internal/engine.version; echo 1
-    populate_script: flutter precache
+    populate_script:
+      - git fetch origin
+      - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
+      - flutter precache
   setup_script:
     - date
     - which flutter

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -511,7 +511,7 @@ task:
     populate_script:
       - git fetch origin
       - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
-      - flutter precache --no-android
+      - flutter precache
   flutter_pkg_cache:
     folder: bin/cache/pkg
     fingerprint_script: echo $OS; cat bin/internal/*.version; echo 1
@@ -536,6 +536,7 @@ task:
     - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
     - flutter config --no-analytics
     - flutter doctor -v
+    - flutter update-packages
     - date
     - which flutter
   on_failure:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -531,7 +531,7 @@ task:
     - which flutter
     - bundle --version
     - sudo bundle install --system --gemfile=dev/ci/mac/Gemfile
-    - git clean -xffd
+    - git clean -xffd --exclude=bin/cache/
     - git fetch origin
     - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
     - flutter config --no-analytics

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -508,17 +508,24 @@ task:
   pub_cache:
     folder: $HOME/.pub-cache
     fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"
+    populate_script:
+      - flutter update-packages
   flutter_pkg_cache:
     folder: bin/cache/pkg
     fingerprint_script: echo $OS; cat bin/internal/*.version
+    populate_script:
+      - flutter precache --no-android --no-ios
   artifacts_cache:
     folder: bin/cache/artifacts
     fingerprint_script: echo $OS; cat bin/internal/engine.version
+    populate_script:
+      - flutter precache
   setup_script:
     - date
     - which flutter
     - bundle --version
     - sudo bundle install --system --gemfile=dev/ci/mac/Gemfile
+    - bundle info xcpretty
     - git clean -xffd
     - git fetch origin
     - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -50,7 +50,7 @@ task:
     fingerprint_script: echo $OS; cat bin/internal/*.version
   setup_script:
     - date
-    - git clean -xffd
+    - git clean -xffd --exclude=bin/cache/
     - git fetch origin
     - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
     - flutter config --no-analytics
@@ -339,7 +339,7 @@ task:
     folder: bin\cache\artifacts
     fingerprint_script: echo %OS% & type bin\internal\*.version
   setup_script:
-    - git clean -xffd
+    - git clean -xffd --exclude=bin/cache/
     - git fetch origin
     - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
     - flutter config --no-analytics

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -508,30 +508,26 @@ task:
   pub_cache:
     folder: $HOME/.pub-cache
     fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"
-    populate_script:
-      - flutter update-packages
+    populate_script: flutter update-packages
   flutter_pkg_cache:
     folder: bin/cache/pkg
     fingerprint_script: echo $OS; cat bin/internal/*.version
-    populate_script:
-      - flutter precache --no-android --no-ios
+    populate_script: flutter precache --no-android --no-ios
   artifacts_cache:
     folder: bin/cache/artifacts
     fingerprint_script: echo $OS; cat bin/internal/engine.version
-    populate_script:
-      - flutter precache
+    populate_script: flutter precache
   setup_script:
     - date
     - which flutter
     - bundle --version
     - sudo bundle install --system --gemfile=dev/ci/mac/Gemfile
-    - bundle info xcpretty
+    - sudo bundle info xcpretty
     - git clean -xffd
     - git fetch origin
     - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
     - flutter config --no-analytics
     - flutter doctor -v
-    - flutter update-packages
     - date
     - which flutter
   on_failure:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -493,8 +493,6 @@ task:
         - dart --enable-asserts dev\customer_testing\run_tests.dart --skip-on-fetch-failure --skip-template bin/cache/pkg/tests/registry/*.test
 
 # MACOS SHARDS
-# Mac doesn't use caches because they apparently take longer to populate and save
-# than just fetching the data in the first place.
 task:
   osx_instance:
     image: mojave-flutter # see https://cirrus-ci.org/guide/macOS/ for list of images (we should update regularly)
@@ -507,6 +505,15 @@ task:
     COCOAPODS_DISABLE_STATS: true
     CPU: 2
     MEMORY: 8G
+  pub_cache:  
+    folder: $HOME/.pub-cache  
+    fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR" 
+  flutter_pkg_cache:  
+    folder: bin/cache/pkg 
+    fingerprint_script: echo $OS; cat bin/internal/*.version  
+  artifacts_cache:  
+    folder: bin/cache/artifacts 
+    fingerprint_script: echo $OS; cat bin/internal/engine.version
   setup_script:
     - date
     - which flutter

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -505,20 +505,6 @@ task:
     COCOAPODS_DISABLE_STATS: true
     CPU: 2
     MEMORY: 8G
-  pub_cache:
-    folder: $HOME/.pub-cache
-    fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"; echo 1
-    populate_script:
-      - git fetch origin
-      - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
-      - flutter update-packages
-  flutter_pkg_cache:
-    folder: bin/cache/pkg
-    fingerprint_script: echo $OS; cat bin/internal/*.version; echo 1
-    populate_script:
-      - git fetch origin
-      - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
-      - flutter precache --no-android --no-ios
   artifacts_cache:
     folder: bin/cache/artifacts
     fingerprint_script: echo $OS; cat bin/internal/engine.version; echo 1
@@ -526,12 +512,26 @@ task:
       - git fetch origin
       - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
       - flutter precache
+  flutter_pkg_cache:
+    folder: bin/cache/pkg
+    fingerprint_script: echo $OS; cat bin/internal/*.version; echo 1
+    populate_script:
+      - git fetch origin
+      - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
+      - flutter precache --no-android --no-ios
+  pub_cache:
+    folder: $HOME/.pub-cache
+    fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"; echo 1
+    populate_script:
+      - git fetch origin
+      - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
+      - flutter update-packages
   setup_script:
     - date
     - which flutter
     - bundle --version
     - sudo bundle install --system --gemfile=dev/ci/mac/Gemfile
-    - sudo bundle info xcpretty
+    - sudo bundle info xcpretty --system --gemfile=dev/ci/mac/Gemfile
     - git clean -xffd
     - git fetch origin
     - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -507,15 +507,15 @@ task:
     MEMORY: 8G
   pub_cache:
     folder: $HOME/.pub-cache
-    fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"
+    fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"; echo 1
     populate_script: flutter update-packages
   flutter_pkg_cache:
     folder: bin/cache/pkg
-    fingerprint_script: echo $OS; cat bin/internal/*.version
+    fingerprint_script: echo $OS; cat bin/internal/*.version; echo 1
     populate_script: flutter precache --no-android --no-ios
   artifacts_cache:
     folder: bin/cache/artifacts
-    fingerprint_script: echo $OS; cat bin/internal/engine.version
+    fingerprint_script: echo $OS; cat bin/internal/engine.version; echo 1
     populate_script: flutter precache
   setup_script:
     - date

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -39,18 +39,30 @@ task:
     CIRRUS_DOCKER_CONTEXT: "dev/"
     PATH: "$CIRRUS_WORKING_DIR/bin:$CIRRUS_WORKING_DIR/bin/cache/dart-sdk/bin:$PATH"
     ANDROID_SDK_ROOT: "/opt/android_sdk"
-  pub_cache:
-    folder: $HOME/.pub-cache
-    fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"
-  flutter_pkg_cache:
-    folder: bin/cache/pkg
-    fingerprint_script: echo $OS; cat bin/internal/*.version
   artifacts_cache:
     folder: bin/cache/artifacts
-    fingerprint_script: echo $OS; cat bin/internal/*.version
+    fingerprint_script: echo $OS; cat bin/internal/*.version; echo 1
+    populate_script:
+      - git fetch origin
+      - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
+      - flutter precache
+  flutter_pkg_cache:
+    folder: bin/cache/pkg
+    fingerprint_script: echo $OS; cat bin/internal/*.version; echo 1
+    populate_script:
+      - git fetch origin
+      - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
+      - flutter precache --no-android --no-ios
+  pub_cache:
+    folder: $HOME/.pub-cache
+    fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"; echo 1
+    populate_script:
+      - git fetch origin
+      - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
+      - flutter update-packages
   setup_script:
     - date
-    - git clean -xffd --exclude=bin/cache/
+    - git clean -xffd --exclude=bin/
     - git fetch origin
     - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
     - flutter config --no-analytics
@@ -339,7 +351,7 @@ task:
     folder: bin\cache\artifacts
     fingerprint_script: echo %OS% & type bin\internal\*.version
   setup_script:
-    - git clean -xffd --exclude=bin\cache\
+    - git clean -xffd --exclude=bin\
     - git fetch origin
     - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
     - flutter config --no-analytics
@@ -531,7 +543,7 @@ task:
     - which flutter
     - bundle --version
     - sudo bundle install --system --gemfile=dev/ci/mac/Gemfile
-    - git clean -xffd --exclude=bin/cache/
+    - git clean -xffd --exclude=bin/
     - git fetch origin
     - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
     - flutter config --no-analytics

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -511,7 +511,7 @@ task:
     populate_script:
       - git fetch origin
       - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
-      - flutter precache
+      - flutter precache --no-android
   flutter_pkg_cache:
     folder: bin/cache/pkg
     fingerprint_script: echo $OS; cat bin/internal/*.version; echo 1
@@ -531,7 +531,6 @@ task:
     - which flutter
     - bundle --version
     - sudo bundle install --system --gemfile=dev/ci/mac/Gemfile
-    - sudo bundle info xcpretty --system --gemfile=dev/ci/mac/Gemfile
     - git clean -xffd
     - git fetch origin
     - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -339,7 +339,7 @@ task:
     folder: bin\cache\artifacts
     fingerprint_script: echo %OS% & type bin\internal\*.version
   setup_script:
-    - git clean -xffd --exclude=bin/cache/
+    - git clean -xffd --exclude=bin\cache\
     - git fetch origin
     - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
     - flutter config --no-analytics

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -505,14 +505,14 @@ task:
     COCOAPODS_DISABLE_STATS: true
     CPU: 2
     MEMORY: 8G
-  pub_cache:  
-    folder: $HOME/.pub-cache  
-    fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR" 
-  flutter_pkg_cache:  
-    folder: bin/cache/pkg 
-    fingerprint_script: echo $OS; cat bin/internal/*.version  
-  artifacts_cache:  
-    folder: bin/cache/artifacts 
+  pub_cache:
+    folder: $HOME/.pub-cache
+    fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"
+  flutter_pkg_cache:
+    folder: bin/cache/pkg
+    fingerprint_script: echo $OS; cat bin/internal/*.version
+  artifacts_cache:
+    folder: bin/cache/artifacts
     fingerprint_script: echo $OS; cat bin/internal/engine.version
   setup_script:
     - date


### PR DESCRIPTION
## Description

At one point it was faster to directly [re-download assets needed for macOS shards than to use the cache](https://github.com/flutter/flutter/pull/37880#issuecomment-519653694).  Try turning the caches back on now that the Cirrus Macs have been upgraded to Catalina.

## Related Issues

Reverts part of https://github.com/flutter/flutter/pull/37880.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*