### PR TITLE
Exclude cleaning the bin/cache right after its fetched from the Cirrus cache

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -50,7 +50,7 @@ task:
     fingerprint_script: echo $OS; cat bin/internal/*.version
   setup_script:
     - date
-    - git clean -xffd
+    - git clean -xffd --exclude=bin/cache/
     - git fetch origin
     - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
     - flutter config --no-analytics
@@ -339,7 +339,7 @@ task:
     folder: bin\cache\artifacts
     fingerprint_script: echo %OS% & type bin\internal\*.version
   setup_script:
-    - git clean -xffd
+    - git clean -xffd --exclude=bin\cache\
     - git fetch origin
     - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
     - flutter config --no-analytics
@@ -512,7 +512,7 @@ task:
     - which flutter
     - bundle --version
     - sudo bundle install --system --gemfile=dev/ci/mac/Gemfile
-    - git clean -xffd
+    - git clean -xffd --exclude=bin/cache/
     - git fetch origin
     - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
     - flutter config --no-analytics


### PR DESCRIPTION
## Description
The Cirrus setup scripts are removing the `bin/cache` directory during setup immediately after downloading them from the Cirrus cache, which causes the artifacts to be re-downloaded.  Exclude that directory from the `git clean` step.

Previous behavior:
```
Downloaded 53Mb.
Cache hit for artifacts-39db3c9a9d11270e41e03e4d8852f567c7a9ed656343acfcabab56bac9c9f6d0!
```
https://cirrus-ci.com/task/6032092437938176?command=artifacts#L16

```
git clean -xffd
Removing bin/cache/
```
https://cirrus-ci.com/task/6032092437938176?command=setup#L3
```
flutter doctor -v
Downloading Material fonts...                                       0.8s
Downloading Gradle Wrapper...                                       0.0s
Downloading package sky_engine...                                   0.3s
Downloading flutter_patched_sdk tools...                            0.9s
Downloading flutter_patched_sdk_product tools...                    0.7s
Downloading linux-x64 tools...                                      1.4s
Downloading linux-x64/font-subset tools...                          0.2s
Downloading android-arm-profile/linux-x64 tools...                  0.2s
Downloading android-arm-release/linux-x64 tools...                  0.1s
Downloading android-arm64-profile/linux-x64 tools...                0.2s
Downloading android-arm64-release/linux-x64 tools...                0.1s
Downloading android-x64-profile/linux-x64 tools...                  0.1s
Downloading android-x64-release/linux-x64 tools...                  0.1s
```
https://cirrus-ci.com/task/6032092437938176?command=setup#L372

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*