### PR TITLE
[flutter_tools] open chrome with unresolved hostname

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/web_fs.dart
+++ b/packages/flutter_tools/lib/src/build_runner/web_fs.dart
@@ -340,10 +340,7 @@ class WebFs {
       client,
       server,
       dwds,
-      // Format ipv6 hosts according to RFC 5952.
-      internetAddress.type == InternetAddressType.IPv4
-        ? 'http://${internetAddress.address}:$hostPort'
-        : 'http://[${internetAddress.address}]:$hostPort',
+      'http://$effectiveHostname:$hostPort',
       assetServer,
       buildInfo.isDebug,
       flutterProject,

--- a/packages/flutter_tools/lib/src/web/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/web/devfs_web.dart
@@ -276,13 +276,7 @@ class WebDevFS implements DevFS {
   @override
   Future<Uri> create() async {
     _webAssetServer = await WebAssetServer.start(hostname, port);
-    final InternetAddress internetAddress = _webAssetServer.internetAddress;
-    // Format ipv6 hosts according to RFC 5952.
-    return Uri.parse(
-      internetAddress.type == InternetAddressType.IPv4
-        ? 'http://${internetAddress.address}:$port'
-        : 'http://[${internetAddress.address}]:$port'
-    );
+    return Uri.parse('http://$hostname:$port');
   }
 
   @override

--- a/packages/flutter_tools/test/general.shard/web/web_fs_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/web_fs_test.dart
@@ -181,10 +181,7 @@ void main() {
       dartDefines: const <String>[],
     );
 
-    // Might be either ipv4 or ipv6 for localhost.
-    final bool hasExpectedUri = webFs.uri.toString().contains('[::1]:1234') ||
-                                webFs.uri.toString().contains('127.0.0.1:1234');
-    expect(hasExpectedUri, true);
+    expect(webFs.uri.toString(), contains('localhost'));
     expect(lastPort, 1234);
   }));
 


### PR DESCRIPTION
## Description

Still serve to resolved host address, but open chrome with unresolved host name so firebase auth can work. 

Fixes https://github.com/flutter/flutter/issues/49614