### PR TITLE
Fix CupertinoDatePicker range validation

### DIFF
--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -935,6 +935,39 @@ void main() {
       );
     });
 
+    testWidgets(
+      'date picker should only take into account the date part of minimumDate and maximumDate',
+      (WidgetTester tester) async {
+        // Regression test for https://github.com/flutter/flutter/issues/49606.
+        DateTime date;
+        final DateTime minDate = DateTime(2020, 1, 1, 12);
+        await tester.pumpWidget(
+          CupertinoApp(
+            home: Center(
+              child: SizedBox(
+                height: 400.0,
+                width: 400.0,
+                child: CupertinoDatePicker(
+                  mode: CupertinoDatePickerMode.date,
+                  minimumDate: minDate,
+                  onDateTimeChanged: (DateTime newDate) { date = newDate; },
+                  initialDateTime: DateTime(2020, 1, 12),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        // Scroll to 2019.
+        await tester.drag(find.text('2020'), const Offset(0.0, 32.0), touchSlopY: 0.0);
+        await tester.pump();
+        await tester.pumpAndSettle();
+        expect(date.year, minDate.year);
+        expect(date.month, minDate.month);
+        expect(date.day, minDate.day);
+    });
+
+
     group('Picker handles initial noon/midnight times', () {
       testWidgets('midnight', (WidgetTester tester) async {
         DateTime date;


### PR DESCRIPTION
## Description

When in date mode, `CupertinoDatePicker`'s selected date represents all `DateTime`s in the currently selected day, not the start time of the selected day.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/49606

## Tests

I added the following tests:

- date picker should only take into account the date part of minimumDate and maximumDate

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
