### PR TITLE
Provide a non-null default value for the compute debug label in release mode

### DIFF
--- a/packages/flutter/lib/src/foundation/_isolates_io.dart
+++ b/packages/flutter/lib/src/foundation/_isolates_io.dart
@@ -12,9 +12,7 @@ import 'isolates.dart' as isolates;
 
 /// The dart:io implementation of [isolate.compute].
 Future<R> compute<Q, R>(isolates.ComputeCallback<Q, R> callback, Q message, { String debugLabel }) async {
-  if (!kReleaseMode) {
-    debugLabel ??= callback.toString();
-  }
+  debugLabel ??= kReleaseMode ? 'compute' : callback.toString();
   final Flow flow = Flow.begin();
   Timeline.startSync('$debugLabel: start', flow: flow);
   final ReceivePort resultPort = ReceivePort();
@@ -80,7 +78,7 @@ class _IsolateConfiguration<Q, R> {
 Future<void> _spawn<Q, R>(_IsolateConfiguration<Q, FutureOr<R>> configuration) async {
   R result;
   await Timeline.timeSync(
-    '${configuration.debugLabel}',
+    configuration.debugLabel,
     () async {
       final FutureOr<R> applicationResult = await configuration.apply();
       result = await applicationResult;


### PR DESCRIPTION
Timeline APIs require non-null operation labels.
