### PR TITLE
Run "build ios-framework" processes async

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -314,7 +314,7 @@ end
           '-output',
           fatFlutterFrameworkBinary.path
         ];
-        final RunResult lipoResult = processUtils.runSync(
+        final RunResult lipoResult = await processUtils.run(
           lipoCommand,
           allowReentrantFlutter: false,
         );
@@ -395,7 +395,7 @@ end
       destinationAppFrameworkDirectory.childFile(binaryName).path
     ];
 
-    final RunResult lipoResult = processUtils.runSync(
+    final RunResult lipoResult = await processUtils.run(
       lipoCommand,
       allowReentrantFlutter: false,
     );
@@ -467,7 +467,7 @@ end
         'ONLY_ACTIVE_ARCH=NO' // No device targeted, so build all valid architectures.
       ];
 
-      RunResult buildPluginsResult = processUtils.runSync(
+      RunResult buildPluginsResult = await processUtils.run(
         pluginsBuildCommand,
         workingDirectory: _project.ios.hostAppRoot.childDirectory('Pods').path,
         allowReentrantFlutter: false,
@@ -492,7 +492,7 @@ end
           // No device targeted, so build all valid architectures.
         ];
 
-        buildPluginsResult = processUtils.runSync(
+        buildPluginsResult = await processUtils.run(
           pluginsBuildCommand,
           workingDirectory: _project.ios.hostAppRoot
             .childDirectory('Pods')
@@ -544,7 +544,7 @@ end
               modeDirectory.childDirectory(podFrameworkName).childFile(binaryName).path
             ];
 
-            final RunResult pluginsLipoResult = processUtils.runSync(
+            final RunResult pluginsLipoResult = await processUtils.run(
               lipoCommand,
               workingDirectory: outputDirectory.path,
               allowReentrantFlutter: false,
@@ -575,7 +575,7 @@ end
               modeDirectory.childFile('$binaryName.xcframework').path
             ];
 
-            final RunResult xcframeworkResult = processUtils.runSync(
+            final RunResult xcframeworkResult = await processUtils.run(
               xcframeworkCommand,
               workingDirectory: outputDirectory.path,
               allowReentrantFlutter: false,
@@ -619,7 +619,7 @@ end
     }
   }
 
-  void _produceDebugXCFramework(Directory fatFramework, String frameworkBinaryName) {
+  Future<void> _produceDebugXCFramework(Directory fatFramework, String frameworkBinaryName) async {
     final String frameworkFileName = fatFramework.basename;
     final File fatFlutterFrameworkBinary = fatFramework.childFile(
       frameworkBinaryName,
@@ -652,7 +652,7 @@ end
         armFlutterFrameworkBinary.path
       ];
 
-      RunResult lipoResult = processUtils.runSync(
+      RunResult lipoResult = await processUtils.run(
         lipoCommand,
         allowReentrantFlutter: false,
       );
@@ -678,7 +678,7 @@ end
         simulatorFlutterFrameworkBinary.path
       ];
 
-      lipoResult = processUtils.runSync(
+      lipoResult = await processUtils.run(
         lipoCommand,
         allowReentrantFlutter: false,
       );
@@ -700,7 +700,7 @@ end
             .path
       ];
 
-      final RunResult xcframeworkResult = processUtils.runSync(
+      final RunResult xcframeworkResult = await processUtils.run(
         xcframeworkCommand,
         allowReentrantFlutter: false,
       );
@@ -715,11 +715,11 @@ end
     }
   }
 
-  void _produceNonDebugXCFramework(
+  Future<void> _produceNonDebugXCFramework(
     BuildMode mode,
     Directory fatFramework,
     String frameworkBinaryName,
-  ) {
+  ) async {
     // Simulator is only supported in Debug mode.
     // "Fat" framework here must only contain arm.
     final List<String> xcframeworkCommand = <String>[
@@ -732,7 +732,7 @@ end
           .path
     ];
 
-    final RunResult xcframeworkResult = processUtils.runSync(
+    final RunResult xcframeworkResult = await processUtils.run(
       xcframeworkCommand,
       allowReentrantFlutter: false,
     );

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -329,7 +329,7 @@ end
       status.stop();
     }
 
-    _produceXCFramework(mode, fatFlutterFrameworkCopy);
+    await _produceXCFramework(mode, fatFlutterFrameworkCopy);
   }
 
   Future<void> _produceAppFramework(BuildMode mode, Directory iPhoneBuildOutput, Directory simulatorBuildOutput, Directory modeDirectory) async {
@@ -367,7 +367,7 @@ end
     } finally {
       status.stop();
     }
-    _produceXCFramework(mode, destinationAppFrameworkDirectory);
+    await _produceXCFramework(mode, destinationAppFrameworkDirectory);
   }
 
   Future<void> _produceStubAppFrameworkIfNeeded(BuildMode mode, Directory iPhoneBuildOutput, Directory simulatorBuildOutput, Directory destinationAppFrameworkDirectory) async {
@@ -594,7 +594,7 @@ end
     }
   }
 
-  void _produceXCFramework(BuildMode mode, Directory fatFramework) {
+  Future<void> _produceXCFramework(BuildMode mode, Directory fatFramework) async {
     if (boolArg('xcframework')) {
       final String frameworkBinaryName = globals.fs.path.basenameWithoutExtension(
           fatFramework.basename);
@@ -605,9 +605,9 @@ end
       );
       try {
         if (mode == BuildMode.debug) {
-          _produceDebugXCFramework(fatFramework, frameworkBinaryName);
+          await _produceDebugXCFramework(fatFramework, frameworkBinaryName);
         } else {
-          _produceNonDebugXCFramework(mode, fatFramework, frameworkBinaryName);
+          await _produceNonDebugXCFramework(mode, fatFramework, frameworkBinaryName);
         }
       } finally {
         status.stop();


### PR DESCRIPTION
## Description

Run `lipo` and `xcodebuild` processes async since they can take a few seconds and were causing status waiting indicator stutter.

## Tests

Already exercised in build_ios_framework_module_test.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*