### PR TITLE
[flutter_tools] hide assembly warning

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -65,7 +65,8 @@ class GenSnapshot {
       // Filter out gen_snapshot's warning message about stripping debug symbols
       // from ELF library snapshots.
       const String kStripWarning = 'Warning: Generating ELF library without DWARF debugging information.';
-      outputFilter = (String line) => line != kStripWarning ? line : null;
+      const String kAssemblyStripWarning = 'Warning: Generating assembly code without DWARF debugging information';
+      outputFilter = (String line) => line != kStripWarning && line != kAssemblyStripWarning ? line : null;
     }
 
     return processUtils.stream(


### PR DESCRIPTION
## Description
Fixes https://github.com/flutter/flutter/issues/49661