### PR TITLE
Print more layer debug info

### DIFF
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -537,6 +537,10 @@ class PictureLayer extends Layer {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<Rect>('paint bounds', canvasBounds));
     properties.add(DiagnosticsProperty<String>('picture', describeIdentity(_picture)));
+    properties.add(DiagnosticsProperty<String>(
+      'raster cache hints',
+      'isComplex = $isComplexHint, willChange = $willChangeHint'),
+    );
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -460,6 +460,7 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<Object>('owner', owner, level: parent != null ? DiagnosticLevel.hidden : DiagnosticLevel.info, defaultValue: null));
     properties.add(DiagnosticsProperty<dynamic>('creator', debugCreator, defaultValue: null, level: DiagnosticLevel.debug));
+    properties.add(DiagnosticsProperty<String>('engine layer', describeIdentity(_engineLayer)));
   }
 }
 
@@ -535,6 +536,7 @@ class PictureLayer extends Layer {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<Rect>('paint bounds', canvasBounds));
+    properties.add(DiagnosticsProperty<String>('picture', describeIdentity(_picture)));
   }
 
   @override

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -270,7 +270,7 @@ void main() {
         r'TransformLayer#[0-9a-f]{5}\n'
         r'   owner: RenderView#[0-9a-f]{5}\n'
         r'   creator: RenderView\n'
-        r'   engine layer: TransformEngineLayer#[0-9a-f]{5}\n'
+        r'   engine layer: (TransformEngineLayer|PersistedTransform)#[0-9a-f]{5}\n'
         r'   offset: Offset\(0\.0, 0\.0\)\n'
         r'   transform:\n'
         r'     \[0] 3\.0,0\.0,0\.0,0\.0\n'

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -270,6 +270,7 @@ void main() {
         r'TransformLayer#[0-9a-f]{5}\n'
         r'   owner: RenderView#[0-9a-f]{5}\n'
         r'   creator: RenderView\n'
+        r'   engine layer: TransformEngineLayer#[0-9a-f]{5}\n'
         r'   offset: Offset\(0\.0, 0\.0\)\n'
         r'   transform:\n'
         r'     \[0] 3\.0,0\.0,0\.0,0\.0\n'

--- a/packages/flutter/test/rendering/layers_test.dart
+++ b/packages/flutter/test/rendering/layers_test.dart
@@ -256,16 +256,19 @@ void main() {
     );
   });
 
-  test('PictureLayer prints picture and engine layer in debug info', () {
+  test('PictureLayer prints picture, engine layer, and raster cache hints in debug info', () {
     final PictureRecorder recorder = PictureRecorder();
     final Canvas canvas = Canvas(recorder);
     canvas.drawPaint(Paint());
     final Picture picture = recorder.endRecording();
     final PictureLayer layer = PictureLayer(const Rect.fromLTRB(0, 0, 1, 1));
     layer.picture = picture;
+    layer.isComplexHint = true;
+    layer.willChangeHint = false;
     final List<String> info = _getDebugInfo(layer);
     expect(info, contains('picture: ${describeIdentity(picture)}'));
     expect(info, contains('engine layer: ${describeIdentity(null)}'));
+    expect(info, contains('raster cache hints: isComplex = true, willChange = false'));
   });
 
   test('mutating PictureLayer fields triggers needsAddToScene', () {

--- a/packages/flutter/test/rendering/layers_test.dart
+++ b/packages/flutter/test/rendering/layers_test.dart
@@ -256,6 +256,18 @@ void main() {
     );
   });
 
+  test('PictureLayer prints picture and engine layer in debug info', () {
+    final PictureRecorder recorder = PictureRecorder();
+    final Canvas canvas = Canvas(recorder);
+    canvas.drawPaint(Paint());
+    final Picture picture = recorder.endRecording();
+    final PictureLayer layer = PictureLayer(const Rect.fromLTRB(0, 0, 1, 1));
+    layer.picture = picture;
+    final List<String> info = _getDebugInfo(layer);
+    expect(info, contains('picture: ${describeIdentity(picture)}'));
+    expect(info, contains('engine layer: ${describeIdentity(null)}'));
+  });
+
   test('mutating PictureLayer fields triggers needsAddToScene', () {
     final PictureLayer pictureLayer = PictureLayer(Rect.zero);
     checkNeedsAddToScene(pictureLayer, () {


### PR DESCRIPTION
1. Picture identity is added to debug picture raster cache.
2. Engine layer identity is added to debug layer raster cache.
3. Raster cache hints such as isComplex and willChange are also added.

Our clients may need them to debug some performance issues related to the raster cache.

Tests added: PictureLayer prints picture, engine layer, and raster cache hints in debug info