### PR TITLE
[flutter_tools] add a dart command in flutter cli

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -4,6 +4,8 @@
 
 import 'dart:async';
 
+import 'package:flutter_tools/src/commands/dart.dart';
+
 import 'runner.dart' as runner;
 import 'src/base/context.dart';
 // The build_runner code generation is provided here to make it easier to
@@ -72,6 +74,7 @@ Future<void> main(List<String> args) async {
     ConfigCommand(verboseHelp: verboseHelp),
     CreateCommand(),
     DaemonCommand(hidden: !verboseHelp),
+    DartCommand(),
     DevicesCommand(),
     DoctorCommand(verbose: verbose),
     DriveCommand(),

--- a/packages/flutter_tools/lib/src/commands/dart.dart
+++ b/packages/flutter_tools/lib/src/commands/dart.dart
@@ -4,21 +4,21 @@
 
 import 'dart:async';
 
+import '../artifacts.dart' show Artifact;
+import '../base/process.dart' show RunResult, processUtils;
 import '../globals.dart';
 import '../runner/flutter_command.dart';
-import '../base/process.dart' show RunResult, processUtils;
-import '../artifacts.dart' show Artifact;
 
 class DartCommand extends FlutterCommand {
   @override
   String get description => 'Run the Flutter Dart SDK for use.';
 
   @override
-  String get name => 'dart';
-
-  @override
   String get invocation =>
       '${runner.executableName} $name <dart file or snapshot dart file> [args]';
+
+  @override
+  String get name => 'dart';
 
   @override
   Future<FlutterCommandResult> runCommand() async {

--- a/packages/flutter_tools/lib/src/commands/dart.dart
+++ b/packages/flutter_tools/lib/src/commands/dart.dart
@@ -1,0 +1,40 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import '../globals.dart';
+import '../runner/flutter_command.dart';
+import '../base/process.dart' show RunResult, processUtils;
+import '../artifacts.dart' show Artifact;
+
+class DartCommand extends FlutterCommand {
+  @override
+  String get description => 'Run the Flutter Dart SDK for use.';
+
+  @override
+  String get name => 'dart';
+
+  @override
+  String get invocation =>
+      '${runner.executableName} $name <dart file or snapshot dart file> [args]';
+
+  @override
+  Future<FlutterCommandResult> runCommand() async {
+    final String engineDartPath =
+        artifacts.getArtifactPath(Artifact.engineDartBinary);
+    final List<String> runList = <String>[engineDartPath];
+    if (argResults.arguments.isNotEmpty) {
+      final List<String> args = <String>[...argResults.arguments];
+      final String dartFileToRun = args[0];
+      args.remove(dartFileToRun);
+      runList.add(dartFileToRun);
+      runList.addAll(args);
+    }
+    final RunResult run = processUtils.runSync(runList);
+    print(run);
+
+    return const FlutterCommandResult(ExitStatus.success);
+  }
+}


### PR DESCRIPTION
## Description

As a member of the flutterando, Brazilian community, we created a dart cli called slidy, for some advances in it we would like to have easy access to the flutter dart, so I request the PR so that we can run it through the command `flutter dart <dart-file or snapshot-file> `

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
