### PR TITLE
fix focus traversal after pages popped

### DIFF
--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -668,10 +668,15 @@ class _ModalScopeState<T> extends State<_ModalScope<T>> {
     super.dispose();
   }
 
+  bool get _shouldIgnoreFocusRequest {
+    return widget.route.animation?.status == AnimationStatus.reverse ||
+      (widget.route.navigator?.userGestureInProgress ?? false);
+  }
+
   // This should be called to wrap any changes to route.isCurrent, route.canPop,
   // and route.offstage.
   void _routeSetState(VoidCallback fn) {
-    if (widget.route.isCurrent) {
+    if (widget.route.isCurrent && !_shouldIgnoreFocusRequest) {
       widget.route.navigator.focusScopeNode.setFirstFocus(focusScopeNode);
     }
     setState(fn);
@@ -704,8 +709,7 @@ class _ModalScopeState<T> extends State<_ModalScope<T>> {
                     AnimatedBuilder(
                       animation: widget.route.navigator?.userGestureInProgressNotifier ?? ValueNotifier<bool>(false),
                       builder: (BuildContext context, Widget child) {
-                        final bool ignoreEvents = widget.route.animation?.status == AnimationStatus.reverse ||
-                            (widget.route.navigator?.userGestureInProgress ?? false);
+                        final bool ignoreEvents = _shouldIgnoreFocusRequest;
                         focusScopeNode.canRequestFocus = !ignoreEvents;
                         return IgnorePointer(
                           ignoring: ignoreEvents,

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -1160,6 +1160,52 @@ void main() {
       modalBarrierAnimation = tester.widget<AnimatedModalBarrier>(animatedModalBarrier).color;
       expect(modalBarrierAnimation.value, Colors.black);
     });
+
+    testWidgets('focus traverse correct when pop mutiple page simultaneously', (WidgetTester tester) async {
+      // Regression test: https://github.com/flutter/flutter/issues/48903
+      final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+      await tester.pumpWidget(MaterialApp(
+        navigatorKey: navigatorKey,
+        home: const Text('dummy1'),
+      ));
+      final Element textOnPageOne = tester.element(find.text('dummy1'));
+      final FocusScopeNode focusNodeOnPageOne = FocusScope.of(textOnPageOne);
+      expect(focusNodeOnPageOne.hasFocus, isTrue);
+
+      // Pushes one page.
+      navigatorKey.currentState.push<void>(
+        MaterialPageRoute<void>(
+          builder: (BuildContext context) => const Text('dummy2'),
+        )
+      );
+      await tester.pumpAndSettle();
+
+      final Element textOnPageTwo = tester.element(find.text('dummy2'));
+      final FocusScopeNode focusNodeOnPageTwo = FocusScope.of(textOnPageTwo);
+      // The focus should be on second page.
+      expect(focusNodeOnPageOne.hasFocus, isFalse);
+      expect(focusNodeOnPageTwo.hasFocus, isTrue);
+
+      // Pushes another page.
+      navigatorKey.currentState.push<void>(
+        MaterialPageRoute<void>(
+          builder: (BuildContext context) => const Text('dummy3'),
+        )
+      );
+      await tester.pumpAndSettle();
+      final Element textOnPageThree = tester.element(find.text('dummy3'));
+      final FocusScopeNode focusNodeOnPageThree = FocusScope.of(textOnPageThree);
+      // The focus should be on third page.
+      expect(focusNodeOnPageOne.hasFocus, isFalse);
+      expect(focusNodeOnPageTwo.hasFocus, isFalse);
+      expect(focusNodeOnPageThree.hasFocus, isTrue);
+
+      // Pops two pages simultaneously.
+      navigatorKey.currentState.popUntil((Route<void> route) => route.isFirst);
+      await tester.pumpAndSettle();
+      // It should refocus page one after pops.
+      expect(focusNodeOnPageOne.hasFocus, isTrue);
+    });
   });
 }
 


### PR DESCRIPTION
## Description

There are two mechanism that traverse the focus in ModalRoute when a page pop, and they are not in sync and conflict with each other
https://github.com/flutter/flutter/blob/22fc21526094268b73ac81a3cb1c60f03724b4ba/packages/flutter/lib/src/widgets/routes.dart#L674
and
https://github.com/flutter/flutter/blob/22fc21526094268b73ac81a3cb1c60f03724b4ba/packages/flutter/lib/src/widgets/routes.dart#L704

The first one request focus regardless the state of animation controller, while the second one enable focus based on the state of animation controller. This makes focus node traverse to a weird place when pops more than two pages.

for example, we have three pages in routes history
page1
page2
page3   <--- current focus

we pop page2 and page3 at the same time, as soon as the animation controller is reverse we trigger
https://github.com/flutter/flutter/blob/22fc21526094268b73ac81a3cb1c60f03724b4ba/packages/flutter/lib/src/widgets/routes.dart#L674
page3 will trigger first and then page2, the bring the focus to page2 before the animation has even starting the build the first frame.

https://github.com/flutter/flutter/blob/22fc21526094268b73ac81a3cb1c60f03724b4ba/packages/flutter/lib/src/widgets/routes.dart#L704
will try to bring the focus from page3 to page2, and then page2 to page1. However, the focus is already on page2, and there are series of FocusNode marked dirty with nextnode = null which brings the focus to be on root focus node and cause this error.

## Related Issues

fixes https://github.com/flutter/flutter/issues/48903
## Tests

I added the following tests:

"focus traverse correct when pop mutiple page simultaneously"

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
