### PR TITLE
[Devicelab] microbenchmarks is broken.

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -507,8 +507,6 @@ tasks:
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
     timeout_in_minutes: 30
-    # TODO(wutong): Timeout on iOS 13. https://github.com/flutter/flutter/issues/49635
-    flaky: true
 
   flutter_view_ios__start_up:
     description: >


### PR DESCRIPTION
The test consistently hangs on iOS 13 device, therefore it's not a flaky test, see https://github.com/flutter/flutter/issues/49635.
