### PR TITLE
Revert "Always use new plugin schema for plugin template (#48258)"

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -642,6 +642,10 @@ To edit platform code in an IDE see https://flutter.dev/developing-packages/#edi
       'web': web,
       'macos': macos,
       'year': DateTime.now().year,
+      // For now, the new plugin schema is only used when a desktop plugin is
+      // enabled. Once the new schema is supported on stable, this should be
+      // removed, and the new schema should always be used.
+      'useNewPluginSchema': macos,
       // If a desktop platform is included, add a workaround for #31366.
       // When Linux and Windows are added, we will need this workaround again.
       'includeTargetPlatformWorkaround': false,

--- a/packages/flutter_tools/templates/plugin/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/plugin/pubspec.yaml.tmpl
@@ -21,9 +21,23 @@ dev_dependencies:
 # The following section is specific to Flutter.
 flutter:
   # This section identifies this Flutter project as a plugin project.
+{{^useNewPluginSchema}}
+  # The androidPackage and pluginClass identifiers should not ordinarily
+  # be modified. They are used by the tooling to maintain consistency when
+  # adding or updating assets for this project.
+  plugin:
+    androidPackage: {{androidIdentifier}}
+    pluginClass: {{pluginClass}}
+{{/useNewPluginSchema}}
+{{#useNewPluginSchema}}
   # The 'pluginClass' and Android 'package' identifiers should not ordinarily
   # be modified. They are used by the tooling to maintain consistency when
   # adding or updating assets for this project.
+  #
+  # NOTE: This new plugin description format is not supported on Flutter's
+  # stable channel as of 1.9.1. A plugin published using this format will not
+  # work for most clients until the next major stable release.
+  # However, it is required in order to declare macOS support.
   plugin:
     platforms:
       android:
@@ -31,10 +45,9 @@ flutter:
         pluginClass: {{pluginClass}}
       ios:
         pluginClass: {{pluginClass}}
-{{#macos}}
       macos:
         pluginClass: {{pluginClass}}
-{{/macos}}
+{{/useNewPluginSchema}}
 
   # To add assets to your plugin package, add an assets section, like this:
   # assets:


### PR DESCRIPTION
This reverts commit 9d4a35ba8b822862e52b320120527aab313db855 because it appears to break

[the gradle_non_android_plugin_test](https://cirrus-ci.com/task/5257262881046528).