### PR TITLE
Be clearer about when and why we override HttpClient in tests

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -466,6 +466,30 @@ Future<void> _runFrameworkTests() async {
         'FLUTTER_EXPERIMENTAL_BUILD': 'true',
       },
     );
+    const String httpClientWarning =
+      'Warning: At least one test in this suite creates an HttpClient. When\n'
+      'running a test suite that uses TestWidgetsFlutterBinding, all HTTP\n'
+      'requests will return status code 400, and no network request will\n'
+      'actually be made. Any test expecting an real network connection and\n'
+      'status code will fail.\n'
+      'To test code that needs an HttpClient, provide your own HttpClient\n'
+      'implementation to the code under test, so that your test can\n'
+      'consistently provide a testable response to the code under test.';
+    await _runFlutterTest(
+      path.join(flutterRoot, 'packages', 'flutter_test'),
+      script: path.join('test', 'bindings_test_failure.dart'),
+      expectFailure: true,
+      printOutput: false,
+      outputChecker: (CapturedOutput output) {
+        final Iterable<Match> matches = httpClientWarning.allMatches(output.stdout);
+        if (matches == null || matches.isEmpty || matches.length > 1) {
+          return 'Failed to print warning about HttpClientUsage, or printed it too many times.\n'
+                 'stdout:\n${output.stdout}';
+        }
+        return null;
+      },
+      tableData: bigqueryApi?.tabledata,
+    );
   }
 
   await selectSubshard(<String, ShardRunner>{

--- a/packages/flutter_test/lib/src/_binding_io.dart
+++ b/packages/flutter_test/lib/src/_binding_io.dart
@@ -11,6 +11,9 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
+// ignore: deprecated_member_use
+import 'package:test_api/test_api.dart' as test_package;
+
 
 import 'binding.dart';
 
@@ -77,14 +80,14 @@ class _MockHttpOverrides extends HttpOverrides {
   @override
   HttpClient createHttpClient(SecurityContext _) {
     if (!warningPrinted) {
-      debugPrint(
-        'Warning: At least one test in this suite creates an HttpClient. When '
-        'running a test suite that uses TestWidgetsFlutterBinding, all HTTP '
-        'requests will return status code 400, and no network request will '
-        'actually be made. Any test expecting an real network connection and '
+      test_package.printOnFailure(
+        'Warning: At least one test in this suite creates an HttpClient. When\n'
+        'running a test suite that uses TestWidgetsFlutterBinding, all HTTP\n'
+        'requests will return status code 400, and no network request will\n'
+        'actually be made. Any test expecting an real network connection and\n'
         'status code will fail.\n'
-        'To test code that needs an HttpClient, provide your own HttpClient '
-        'implementation to the code under test, so that your test can '
+        'To test code that needs an HttpClient, provide your own HttpClient\n'
+        'implementation to the code under test, so that your test can\n'
         'consistently provide a testable response to the code under test.');
       warningPrinted = true;
     }

--- a/packages/flutter_test/lib/src/_binding_io.dart
+++ b/packages/flutter_test/lib/src/_binding_io.dart
@@ -73,8 +73,21 @@ void mockFlutterAssets() {
 /// If another [HttpClient] is provided using [HttpOverrides.runZoned], that will
 /// take precedence over this provider.
 class _MockHttpOverrides extends HttpOverrides {
+  bool warningPrinted = false;
   @override
   HttpClient createHttpClient(SecurityContext _) {
+    if (!warningPrinted) {
+      debugPrint(
+        'Warning: At least one test in this suite creates an HttpClient. When '
+        'running a test suite that uses TestWidgetsFlutterBinding, all HTTP '
+        'requests will return status code 400, and no network request will '
+        'actually be made. Any test expecting an real network connection and '
+        'status code will fail.\n'
+        'To test code that needs an HttpClient, provide your own HttpClient '
+        'implementation to the code under test, so that your test can '
+        'consistently provide a testable response to the code under test.');
+      warningPrinted = true;
+    }
     return _MockHttpClient();
   }
 }

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -147,6 +147,13 @@ class TestDefaultBinaryMessenger extends BinaryMessenger {
 ///
 /// When using these bindings, certain features are disabled. For
 /// example, [timeDilation] is reset to 1.0 on initialization.
+///
+/// In non-browser tests, the binding overrides `HttpClient` creation with a
+/// fake client that always returns a status code of 400. This is to prevent
+/// tests from making network calls, which could introduce flakiness. A test
+/// that actually needs to make a network call should provide its own
+/// `HttpClient` to the code making the call, so that it can appropriately mock
+/// or fake responses.
 abstract class TestWidgetsFlutterBinding extends BindingBase
   with ServicesBinding,
        SchedulerBinding,

--- a/packages/flutter_test/test/bindings_test.dart
+++ b/packages/flutter_test/test/bindings_test.dart
@@ -32,8 +32,10 @@ void main() {
     TestWidgetsFlutterBinding.ensureInitialized();
     final DebugPrintCallback oldDebugPrint = debugPrint;
     String printedMessage;
+    int calls = 0;
     debugPrint = (String message, {int wrapWidth}) {
       printedMessage = message;
+      calls += 1;
     };
     HttpClient();
     debugPrint = oldDebugPrint;
@@ -48,5 +50,8 @@ void main() {
       'implementation to the code under test, so that your test can '
       'consistently provide a testable response to the code under test.',
     );
+    expect(calls, 1);
+    HttpClient();
+    expect(calls, 1);
   }, skip: isBrowser); // We don't override this in the browser.
 }

--- a/packages/flutter_test/test/bindings_test.dart
+++ b/packages/flutter_test/test/bindings_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -27,31 +24,4 @@ void main() {
       expect(binding.defaultTestTimeout.duration, const Duration(minutes: 5));
     });
   });
-
-  test('Http Warning Message',  () {
-    TestWidgetsFlutterBinding.ensureInitialized();
-    final DebugPrintCallback oldDebugPrint = debugPrint;
-    String printedMessage;
-    int calls = 0;
-    debugPrint = (String message, {int wrapWidth}) {
-      printedMessage = message;
-      calls += 1;
-    };
-    HttpClient();
-    debugPrint = oldDebugPrint;
-    expect(
-      printedMessage,
-      'Warning: At least one test in this suite creates an HttpClient. When '
-      'running a test suite that uses TestWidgetsFlutterBinding, all HTTP '
-      'requests will return status code 400, and no network request will '
-      'actually be made. Any test expecting an real network connection and '
-      'status code will fail.\n'
-      'To test code that needs an HttpClient, provide your own HttpClient '
-      'implementation to the code under test, so that your test can '
-      'consistently provide a testable response to the code under test.',
-    );
-    expect(calls, 1);
-    HttpClient();
-    expect(calls, 1);
-  }, skip: isBrowser); // We don't override this in the browser.
 }

--- a/packages/flutter_test/test/bindings_test.dart
+++ b/packages/flutter_test/test/bindings_test.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -24,4 +27,26 @@ void main() {
       expect(binding.defaultTestTimeout.duration, const Duration(minutes: 5));
     });
   });
+
+  test('Http Warning Message',  () {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    final DebugPrintCallback oldDebugPrint = debugPrint;
+    String printedMessage;
+    debugPrint = (String message, {int wrapWidth}) {
+      printedMessage = message;
+    };
+    HttpClient();
+    debugPrint = oldDebugPrint;
+    expect(
+      printedMessage,
+      'Warning: At least one test in this suite creates an HttpClient. When '
+      'running a test suite that uses TestWidgetsFlutterBinding, all HTTP '
+      'requests will return status code 400, and no network request will '
+      'actually be made. Any test expecting an real network connection and '
+      'status code will fail.\n'
+      'To test code that needs an HttpClient, provide your own HttpClient '
+      'implementation to the code under test, so that your test can '
+      'consistently provide a testable response to the code under test.',
+    );
+  }, skip: isBrowser); // We don't override this in the browser.
 }

--- a/packages/flutter_test/test/bindings_test_failure.dart
+++ b/packages/flutter_test/test/bindings_test_failure.dart
@@ -1,0 +1,23 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+// This test checks that we output something on test failure.
+// It should not be run as part of a normal test suite, as it is expected to
+// fail.  See dev/bots/test.dart, which runs this test and checks that it fails
+// and prints the expected warning about HttpClient usage in a failing test.
+
+void main() {
+  test('Http Warning Message', () {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    HttpClient();
+    // Make sure we only add the message once.
+    HttpClient();
+    HttpClient();
+    fail('Intentional');
+  }); // We don't override this in the browser.
+}

--- a/packages/flutter_test/test/bindings_test_failure.dart
+++ b/packages/flutter_test/test/bindings_test_failure.dart
@@ -6,10 +6,13 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-// This test checks that we output something on test failure.
+// This test checks that we output something on test failure where the test
+// creates an HttpClient.
 // It should not be run as part of a normal test suite, as it is expected to
-// fail.  See dev/bots/test.dart, which runs this test and checks that it fails
-// and prints the expected warning about HttpClient usage in a failing test.
+// fail. See dev/bots/test.dart, which runs this test, checks that it fails,
+// and prints the expected warning about HttpClient usage.
+// We don't run this for browser tests, since we don't override the behavior
+// in browser tests.
 
 void main() {
   test('Http Warning Message', () {
@@ -19,5 +22,5 @@ void main() {
     HttpClient();
     HttpClient();
     fail('Intentional');
-  }); // We don't override this in the browser.
+  });
 }


### PR DESCRIPTION
## Description

Outside of browser contexts, we override the HttpClient implementation to one that always returns 400 - this helps make tests more hermetic and prevent users from making mistakes in tests by introduce real life network calls into a unit test.

This can be confusing for users, particularly if they're mixing both `testWidgets` and `test` tests in the same suite, and it's unclear that the binding has taken over the whole suite.  This adds new functionality to print out a warning message if a failing test has created our special HttpClient, and updates docs on the TestFlutterWidgetsBinding class.

## Related Issues

fixes #35318

## Tests

I added the following tests:

Test that checks that we print out the message, and that we only do it once per suite.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
