### PR TITLE
Add channel-specific dartpad URL to snippet generation

### DIFF
--- a/dev/snippets/config/skeletons/dartpad-sample.html
+++ b/dev/snippets/config/skeletons/dartpad-sample.html
@@ -22,7 +22,7 @@
 </div>
 <div class="snippet-container">
     <div class="snippet" id="longSnippet{{serial}}">
-        <iframe class="snippet-dartpad" src="https://dartpad.dev/embed-flutter.html?split=60&run=true&sample_id={{id}}"></iframe>
+        <iframe class="snippet-dartpad" src="https://dartpad.dev/embed-flutter.html?split=60&run=true&sample_id={{id}}&sample_channel={{channel}}"></iframe>
     </div>
     <div class="snippet" id="shortSnippet{{serial}}" hidden>
         {{description}}

--- a/dev/snippets/lib/main.dart
+++ b/dev/snippets/lib/main.dart
@@ -22,6 +22,16 @@ const String _kTemplateOption = 'template';
 const String _kTypeOption = 'type';
 const String _kShowDartPad = 'dartpad';
 
+String getChannelName() {
+  final RegExp gitBranchRegexp = RegExp(r'^## (.*)');
+  final ProcessResult gitResult = Process.runSync('git', <String>['status', '-b', '--porcelain']);
+  if (gitResult.exitCode != 0)
+    throw 'git status exit with non-zero exit code: ${gitResult.exitCode}';
+  final Match gitBranchMatch = gitBranchRegexp.firstMatch(
+      (gitResult.stdout as String).trim().split('\n').first);
+  return gitBranchMatch == null ? '<unknown>' : gitBranchMatch.group(1).split('...').first;
+}
+
 /// Generates snippet dartdoc output for a given input, and creates any sample
 /// applications needed by the snippet.
 void main(List<String> argList) {
@@ -176,6 +186,7 @@ void main(List<String> argList) {
           ? int.tryParse(environment['SOURCE_LINE'])
           : null,
       'id': id.join('.'),
+      'channel': getChannelName(),
       'serial': serial,
       'package': packageName,
       'library': libraryName,

--- a/dev/snippets/lib/snippets.dart
+++ b/dev/snippets/lib/snippets.dart
@@ -124,12 +124,19 @@ class SnippetGenerator {
     description = description.trim().isNotEmpty
         ? '<div class="snippet-description">{@end-inject-html}$description{@inject-html}</div>'
         : '';
+
+    // DartPad only supports stable or master as valid channels. Use master
+    // if not on stable so that local runs will work (although they will
+    // still take their sample code from the master docs server).
+    final String channel = metadata['channel'] == 'stable' ? 'stable' : 'master';
+
     final Map<String, String> substitutions = <String, String>{
       'description': description,
       'code': htmlEscape.convert(result.join('\n')),
       'language': language ?? 'dart',
       'serial': '',
       'id': metadata['id'] as String,
+      'channel': channel,
       'element': metadata['element'] as String ?? '',
       'app': '',
     };
@@ -226,8 +233,7 @@ class SnippetGenerator {
     assert(template != null || type != SnippetType.sample);
     assert(metadata != null && metadata['id'] != null);
     assert(input != null);
-    assert(!showDartPad || type == SnippetType.sample,
-        'Only application snippets work with dartpad.');
+    assert(!showDartPad || type == SnippetType.sample, 'Only application samples work with dartpad.');
     final List<_ComponentTuple> snippetData = parseInput(_loadFileAsUtf8(input));
     switch (type) {
       case SnippetType.sample:
@@ -264,9 +270,7 @@ class SnippetGenerator {
           (_ComponentTuple data) => data.name == 'description',
           orElse: () => null,
         );
-        metadata ??= <String, Object>{};
         metadata.addAll(<String, Object>{
-          'id': metadata['id'],
           'file': path.basename(outputFile.path),
           'description': description?.mergedContent,
         });

--- a/dev/snippets/test/snippets_test.dart
+++ b/dev/snippets/test/snippets_test.dart
@@ -52,7 +52,7 @@ main() {
 ''');
       configuration.getHtmlSkeletonFile(SnippetType.sample, showDartPad: true).writeAsStringSync('''
 <div>HTML Bits (DartPad-style)</div>
-<iframe class="snippet-dartpad" src="https://dartpad.dev/embed-flutter.html?split=60&run=true&sample_id={{id}}"></iframe>
+<iframe class="snippet-dartpad" src="https://dartpad.dev/embed-flutter.html?split=60&run=true&sample_id={{id}}&sample_channel={{channel}}"></iframe>
 <div>More HTML Bits</div>
 ''');
       generator = SnippetGenerator(configuration: configuration);
@@ -61,7 +61,7 @@ main() {
       tmpDir.deleteSync(recursive: true);
     });
 
-    test('generates application snippets', () async {
+    test('generates samples', () async {
       final File inputFile = File(path.join(tmpDir.absolute.path, 'snippet_in.txt'))
         ..createSync(recursive: true)
         ..writeAsStringSync('''
@@ -87,6 +87,7 @@ void main() {
         template: 'template',
         metadata: <String, Object>{
           'id': 'id',
+          'channel': 'stable',
           'element': 'MyElement',
         },
         output: outputFile,
@@ -95,6 +96,7 @@ void main() {
       expect(html, contains('<div>More HTML Bits</div>'));
       expect(html, contains('print(&#39;The actual \$name.&#39;);'));
       expect(html, contains('A description of the snippet.\n'));
+      expect(html, isNot(contains('sample_channel=stable')));
       expect(
           html,
           contains('&#47;&#47; A description of the snippet.\n'
@@ -109,7 +111,7 @@ void main() {
       expect(outputContents, contains("const String name = 'snippet';"));
     });
 
-    test('generates sample snippets', () async {
+    test('generates snippets', () async {
       final File inputFile = File(path.join(tmpDir.absolute.path, 'snippet_in.txt'))
         ..createSync(recursive: true)
         ..writeAsStringSync('''
@@ -137,7 +139,7 @@ void main() {
       expect(html, contains('main() {'));
     });
 
-    test('generates dartpad snippets', () async {
+    test('generates dartpad samples', () async {
       final File inputFile = File(path.join(tmpDir.absolute.path, 'snippet_in.txt'))
         ..createSync(recursive: true)
         ..writeAsStringSync('''
@@ -157,14 +159,14 @@ void main() {
         SnippetType.sample,
         showDartPad: true,
         template: 'template',
-        metadata: <String, Object>{'id': 'id'},
+        metadata: <String, Object>{'id': 'id', 'channel': 'stable'},
       );
       expect(html, contains('<div>HTML Bits (DartPad-style)</div>'));
       expect(html, contains('<div>More HTML Bits</div>'));
-      expect(html, contains('<iframe class="snippet-dartpad" src="https://dartpad.dev/embed-flutter.html?split=60&run=true&sample_id=id"></iframe>'));
+      expect(html, contains('<iframe class="snippet-dartpad" src="https://dartpad.dev/embed-flutter.html?split=60&run=true&sample_id=id&sample_channel=stable"></iframe>'));
     });
 
-    test('generates snippet application metadata', () async {
+    test('generates sample metadata', () async {
       final File inputFile = File(path.join(tmpDir.absolute.path, 'snippet_in.txt'))
         ..createSync(recursive: true)
         ..writeAsStringSync('''
@@ -187,11 +189,12 @@ void main() {
         SnippetType.sample,
         template: 'template',
         output: outputFile,
-        metadata: <String, Object>{'sourcePath': 'some/path.dart', 'id': 'id'},
+        metadata: <String, Object>{'sourcePath': 'some/path.dart', 'id': 'id', 'channel': 'stable'},
       );
       expect(expectedMetadataFile.existsSync(), isTrue);
       final Map<String, dynamic> json = jsonDecode(expectedMetadataFile.readAsStringSync()) as Map<String, dynamic>;
       expect(json['id'], equals('id'));
+      expect(json['channel'], equals('stable'));
       expect(json['file'], equals('snippet_out.dart'));
       expect(json['description'], equals('A description of the snippet.\n\nOn several lines.'));
       // Ensure any passed metadata is included in the output JSON too.


### PR DESCRIPTION
## Description

Adds the channel to docs generation for dartpad samples, since the new query parameter was added in https://github.com/dart-lang/dart-pad/pull/1462

## Breaking Change

- [X] No, this is *not* a breaking change.