### PR TITLE
Step 3 of 4: Make AlertDialog scrollable by default

### DIFF
--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -228,7 +228,7 @@ class AlertDialog extends StatelessWidget {
     this.elevation,
     this.semanticLabel,
     this.shape,
-    this.scrollable = false,
+    this.scrollable = true,
   }) : assert(contentPadding != null),
        super(key: key);
 

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -952,7 +952,6 @@ void main() {
           color: Colors.green,
           height: 1000,
         ),
-        scrollable: true,
       );
       await tester.pumpWidget(_appWithAlertDialog(tester, dialog));
       await tester.tap(find.text('X'));
@@ -972,7 +971,6 @@ void main() {
           color: Colors.orange,
           height: 1000,
         ),
-        scrollable: true,
       );
       await tester.pumpWidget(_appWithAlertDialog(tester, dialog));
       await tester.tap(find.text('X'));
@@ -998,7 +996,6 @@ void main() {
           color: Colors.orange,
           height: 400,
         ),
-        scrollable: true,
       );
       await tester.pumpWidget(_appWithAlertDialog(tester, dialog));
       await tester.tap(find.text('X'));


### PR DESCRIPTION
## Migration Description

This is a temporary change that aims, in the future, to make the `AlertDialog` widget scrollable by default. The long-term goal is to make dialogs scrollable by default and remove the `scrollable` parameter altogether. This intermediate step is necessary because of our [new breaking change policy](https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes) requiring that our breaking changes be soft breaking changes. Making the new change opt-in allows developers the opportunity to experience the changes ahead of time so that they can fix any issues with the app resulting from the change or fix any broken tests that do not expect details in the new implementation.

### Example migration steps
1. Set all `AlertDialog` instances in app to have `scrollable` be true. 
```dart
AlertDialog(
  scrollable: true, // add this line
  // ...
)
```
2. Examine all screens with AlertDialogs to ensure that layout looks good, make sure existing unit tests are not breaking. If something is broken, fix it. An example of a test that might fail is if a unit test was using `find.byType(SingleChildScrollView).first`, the introduction of an additional `SingleChildScrollView` by default may not be expected by the test. If the issue cannot be fixed, it may not be an intended change, so file an issue to `flutter/flutter` on GitHub. 
3. A new PR will be introduced to set `AlertDialog.scrollable` to `true` by default. This will default everybody's AlertDialog to the latest design by default. If developers have properly migrated in step 2, this shouldn't cause any issues to your app. This would be the opportunity to remove the `scrollable` parameter from your application since it is true by default now and it will be removed in a subsequent PR.
```dart
AlertDialog(
  // scrollable: true, // remove this line, since it should be true by default at this point.
  // ...
)
```
4. Finally, a final PR will remove the `scrollable` parameter altogether. If you removed the `scrollable` parameter from your `AlertDialog instances in step 3, this should not affect your application.

## Change Description
When the title and content are too tall in an AlertDialog, the title can end up overflowing while the content will be clipped. An example of this occurring is when the text scale factor is increased, causing parts of the alert dialog to be obscured.

This PR sets AlertDialog.scrollable to `true` by default.

### Normal size behavior: 
<img width="366" alt="Screen Shot 2019-10-21 at 4 56 01 PM" src="https://user-images.githubusercontent.com/27032613/67251441-fdc3a180-f423-11e9-97bb-1326f7baca20.png">

### Original implementation causing overflow:
<img width="361" alt="Screen Shot 2019-10-21 at 4 57 49 PM" src="https://user-images.githubusercontent.com/27032613/67251423-f0a6b280-f423-11e9-8a49-2b789e1ed9ba.png">

### Overflow Fix:
<img width="356" alt="Screen Shot 2019-10-21 at 4 59 22 PM" src="https://user-images.githubusercontent.com/27032613/67251482-25b30500-f424-11e9-9d36-a5333c04f618.png">

![scroll_alert_dialog](https://user-images.githubusercontent.com/27032613/67251559-64e15600-f424-11e9-96ca-b1a3efb322e4.gif)

## Related Issues

Fixes part of https://github.com/flutter/flutter/issues/42696

## Tests

- Updated the pre-existing AlertDialog scrollable tests to verify that it is scrollable by default.

## Glossary

Scrollable AlertDialog design document: https://flutter.dev/go/scrollable-alert-dialog
Breaking change notice on Flutter website: https://flutter.dev/docs/release/breaking-changes/scrollable_alert_dialog#context

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
