### PR TITLE
Replace ideviceinfo and idevice_id with xcdevice

### DIFF
--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -166,6 +166,11 @@ Future<T> runInContext<T>(
         fileSystem: globals.fs,
         xcodeProjectInterpreter: xcodeProjectInterpreter,
       ),
+      XCDevice: () => XCDevice(
+        processManager: globals.processManager,
+        logger: globals.logger,
+        xcode: globals.xcode,
+      ),
       XcodeProjectInterpreter: () => XcodeProjectInterpreter(
         logger: globals.logger,
         processManager: globals.processManager,

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -57,6 +57,8 @@ Xcode get xcode => context.get<Xcode>();
 FlutterVersion get flutterVersion => context.get<FlutterVersion>();
 IMobileDevice get iMobileDevice => context.get<IMobileDevice>();
 
+XCDevice get xcdevice => context.get<XCDevice>();
+
 /// Display an error level message to the user. Commands should use this if they
 /// fail in some way.
 ///

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -216,6 +216,7 @@ class XCDevice {
             '--find',
             'xcdevice'
           ],
+          throwOnError: true,
         ).stdout.trim();
       } on ProcessException catch (exception) {
         _logger.printTrace('Process exception finding xcdevice:\n$exception');
@@ -244,6 +245,7 @@ class XCDevice {
           '--timeout',
           '1',
         ],
+        throwOnError: true,
       );
       if (result.exitCode == 0) {
         final List<dynamic> listResults = json.decode(result.stdout) as List<dynamic>;

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -296,6 +296,8 @@ class XCDevice {
     //  },
     // ...
 
+    final RegExp operatingSystemRegex = RegExp(r'(.*) \(.*\)$');
+
     final List<IOSDevice> devices = <IOSDevice>[];
     for (final dynamic device in allAvailableDevices) {
       if (device is! Map) {
@@ -335,7 +337,6 @@ class XCDevice {
 
       String sdkVersion;
       if (deviceProperties.containsKey('operatingSystemVersion')) {
-        final RegExp operatingSystemRegex = RegExp(r'(.*) \(.*\)$');
         final String operatingSystemVersion = deviceProperties['operatingSystemVersion'] as String;
         sdkVersion = operatingSystemRegex.firstMatch(operatingSystemVersion.trim())?.group(1);
       }
@@ -418,22 +419,18 @@ class XCDevice {
 
     final Map<String, dynamic> error = deviceProperties['error'] as Map<String, dynamic>;
 
-    final StringBuffer errorMessage = StringBuffer();
-    if (deviceProperties.containsKey('name')) {
-      errorMessage.write('"${deviceProperties['name']}" error: ');
-    }
+    final StringBuffer errorMessage = StringBuffer('Error: ');
 
     if (error.containsKey('description')) {
       final String description = error['description'] as String;
       errorMessage.write(description);
+    } else {
+      errorMessage.write('Xcode pairing error.');
     }
 
     if (error.containsKey('recoverySuggestion')) {
       final String recoverySuggestion = error['recoverySuggestion'] as String;
       errorMessage.write(' $recoverySuggestion');
-    }
-    if (errorMessage.isEmpty) {
-      errorMessage.write('Xcode pairing error');
     }
 
     if (error.containsKey('code') && error['code'] is int) {

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -424,6 +424,9 @@ class XCDevice {
     if (error.containsKey('description')) {
       final String description = error['description'] as String;
       errorMessage.write(description);
+      if (!description.endsWith('.')) {
+        errorMessage.write('.');
+      }
     } else {
       errorMessage.write('Xcode pairing error.');
     }

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -257,6 +257,9 @@ class XCDevice {
       _logger.printTrace('Process exception running xcdevice list:\n$exception');
     } on ArgumentError catch (exception) {
       _logger.printTrace('Argument exception running xcdevice list:\n$exception');
+    } on FormatException catch (exception) {
+      // Failed to parse the xcdevice output, or it returned junk.
+      _logger.printError('xcdevice returned non-JSON response:\n$exception');
     }
 
     return null;

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -257,9 +257,6 @@ class XCDevice {
       _logger.printTrace('Process exception running xcdevice list:\n$exception');
     } on ArgumentError catch (exception) {
       _logger.printTrace('Argument exception running xcdevice list:\n$exception');
-    } on FormatException catch (exception) {
-      // Failed to parse the xcdevice output, or it returned junk.
-      _logger.printError('xcdevice returned non-JSON response:\n$exception');
     }
 
     return null;

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -234,7 +234,8 @@ class XCDevice {
       // USB-tethered devices should be found quickly. 1 second timeout is faster than the default.
       final RunResult result = await _processUtils.run(
         <String>[
-          xcdevicePath,
+          'xcrun',
+          'xcdevice',
           'list',
           '--timeout',
           '1',

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -52,6 +52,7 @@ class MockXcode extends Mock implements Xcode {}
 class MockFile extends Mock implements File {}
 class MockPortForwarder extends Mock implements DevicePortForwarder {}
 class MockUsage extends Mock implements Usage {}
+class MockXcdevice extends Mock implements XCDevice {}
 
 void main() {
   final FakePlatform macPlatform = FakePlatform.fromPlatform(const LocalPlatform());
@@ -65,17 +66,17 @@ void main() {
     final List<Platform> unsupportedPlatforms = <Platform>[linuxPlatform, windowsPlatform];
 
     testUsingContext('successfully instantiates on Mac OS', () {
-      IOSDevice('device-123');
+      IOSDevice('device-123', name: 'iPhone 1', sdkVersion: '13.3', cpuArchitecture: DarwinArch.arm64);
     }, overrides: <Type, Generator>{
       Platform: () => macPlatform,
     });
 
     testUsingContext('parses major version', () {
-      expect(IOSDevice('device-123', sdkVersion: '1.0.0').majorSdkVersion, 1);
-      expect(IOSDevice('device-123', sdkVersion: '13.1.1').majorSdkVersion, 13);
-      expect(IOSDevice('device-123', sdkVersion: '10').majorSdkVersion, 10);
-      expect(IOSDevice('device-123', sdkVersion: '0').majorSdkVersion, 0);
-      expect(IOSDevice('device-123', sdkVersion: 'bogus').majorSdkVersion, 0);
+      expect(IOSDevice('device-123', name: 'iPhone 1', cpuArchitecture: DarwinArch.arm64, sdkVersion: '1.0.0').majorSdkVersion, 1);
+      expect(IOSDevice('device-123', name: 'iPhone 1', cpuArchitecture: DarwinArch.arm64, sdkVersion: '13.1.1').majorSdkVersion, 13);
+      expect(IOSDevice('device-123', name: 'iPhone 1', cpuArchitecture: DarwinArch.arm64, sdkVersion: '10').majorSdkVersion, 10);
+      expect(IOSDevice('device-123', name: 'iPhone 1', cpuArchitecture: DarwinArch.arm64, sdkVersion: '0').majorSdkVersion, 0);
+      expect(IOSDevice('device-123', name: 'iPhone 1', cpuArchitecture: DarwinArch.arm64, sdkVersion: 'bogus').majorSdkVersion, 0);
     }, overrides: <Type, Generator>{
       Platform: () => macPlatform,
     });
@@ -83,7 +84,7 @@ void main() {
     for (final Platform platform in unsupportedPlatforms) {
       testUsingContext('throws UnsupportedError exception if instantiated on ${platform.operatingSystem}', () {
         expect(
-          () { IOSDevice('device-123'); },
+          () { IOSDevice('device-123', name: 'iPhone 1', sdkVersion: '13.3', cpuArchitecture: DarwinArch.arm64); },
           throwsAssertionError,
         );
       }, overrides: <Type, Generator>{
@@ -132,7 +133,7 @@ void main() {
       });
 
       testUsingContext(' kills all log readers & port forwarders', () async {
-        device = IOSDevice('123');
+        device = IOSDevice('123', name: 'iPhone 1', sdkVersion: '13.3', cpuArchitecture: DarwinArch.arm64);
         logReader1 = createLogReader(device, appPackage1, mockProcess1);
         logReader2 = createLogReader(device, appPackage2, mockProcess2);
         portForwarder = createPortForwarder(forwardedPort, device);
@@ -239,9 +240,6 @@ void main() {
         )).thenAnswer(
           (_) => Future<ProcessResult>.value(ProcessResult(1, 0, '', ''))
         );
-
-        when(mockIMobileDevice.getInfoForDevice(any, 'CPUArchitecture'))
-            .thenAnswer((_) => Future<String>.value('arm64'));
       });
 
       tearDown(() {
@@ -252,7 +250,7 @@ void main() {
       });
 
       testUsingContext('disposing device disposes the portForwarder', () async {
-        final IOSDevice device = IOSDevice('123');
+        final IOSDevice device = IOSDevice('123', name: 'iPhone 1', sdkVersion: '13.3', cpuArchitecture: DarwinArch.arm64);
         device.portForwarder = mockPortForwarder;
         device.setLogReader(mockApp, mockLogReader);
         await device.dispose();
@@ -261,24 +259,8 @@ void main() {
         Platform: () => macPlatform,
       });
 
-      testUsingContext('returns failed if the IOSDevice is not found', () async {
-        final IOSDevice device = IOSDevice('123');
-        when(mockIMobileDevice.getInfoForDevice(any, 'CPUArchitecture')).thenThrow(
-          const IOSDeviceNotFoundError(
-            'ideviceinfo could not find device:\n'
-            'No device found with udid 123, is it plugged in?\n'
-            'Try unlocking attached devices.'
-          )
-        );
-        final LaunchResult result = await device.startApp(mockApp);
-        expect(result.started, false);
-      }, overrides: <Type, Generator>{
-        IMobileDevice: () => mockIMobileDevice,
-        Platform: () => macPlatform,
-      });
-
       testUsingContext(' succeeds in debug mode via mDNS', () async {
-        final IOSDevice device = IOSDevice('123');
+        final IOSDevice device = IOSDevice('123', name: 'iPhone 1', sdkVersion: '13.3', cpuArchitecture: DarwinArch.arm64);
         device.portForwarder = mockPortForwarder;
         device.setLogReader(mockApp, mockLogReader);
         final Uri uri = Uri(
@@ -315,7 +297,7 @@ void main() {
       testUsingContext(' .forward() will kill iproxy processes before invoking a second', () async {
         const String deviceId = '123';
         const int devicePort = 456;
-        final IOSDevice device = IOSDevice(deviceId);
+        final IOSDevice device = IOSDevice(deviceId, name: 'iPhone 1', sdkVersion: '13.3', cpuArchitecture: DarwinArch.arm64);
         final IOSDevicePortForwarder portForwarder = IOSDevicePortForwarder(device);
         bool firstRun = true;
         final MockProcess successProcess = MockProcess(
@@ -349,7 +331,7 @@ void main() {
       });
 
       testUsingContext(' succeeds in debug mode when mDNS fails by falling back to manual protocol discovery', () async {
-        final IOSDevice device = IOSDevice('123');
+        final IOSDevice device = IOSDevice('123', name: 'iPhone 1', sdkVersion: '13.3', cpuArchitecture: DarwinArch.arm64);
         device.portForwarder = mockPortForwarder;
         device.setLogReader(mockApp, mockLogReader);
         // Now that the reader is used, start writing messages to it.
@@ -381,7 +363,7 @@ void main() {
       });
 
       testUsingContext(' fails in debug mode when mDNS fails and when Observatory URI is malformed', () async {
-        final IOSDevice device = IOSDevice('123');
+        final IOSDevice device = IOSDevice('123', name: 'iPhone 1', sdkVersion: '13.3', cpuArchitecture: DarwinArch.arm64);
         device.portForwarder = mockPortForwarder;
         device.setLogReader(mockApp, mockLogReader);
 
@@ -413,7 +395,7 @@ void main() {
       });
 
       testUsingContext('succeeds in release mode', () async {
-        final IOSDevice device = IOSDevice('123');
+        final IOSDevice device = IOSDevice('123', name: 'iPhone 1', sdkVersion: '13.3', cpuArchitecture: DarwinArch.arm64);
         final LaunchResult launchResult = await device.startApp(mockApp,
           prebuiltApplication: true,
           debuggingOptions: DebuggingOptions.disabled(const BuildInfo(BuildMode.release, null, treeShakeIcons: false)),
@@ -431,7 +413,7 @@ void main() {
       });
 
       testUsingContext('succeeds with --cache-sksl', () async {
-        final IOSDevice device = IOSDevice('123');
+        final IOSDevice device = IOSDevice('123', name: 'iPhone 1', sdkVersion: '13.3', cpuArchitecture: DarwinArch.arm64);
         device.setLogReader(mockApp, mockLogReader);
         final Uri uri = Uri(
           scheme: 'http',
@@ -475,7 +457,7 @@ void main() {
       });
 
       testUsingContext('succeeds with --device-vmservice-port', () async {
-        final IOSDevice device = IOSDevice('123');
+        final IOSDevice device = IOSDevice('123', name: 'iPhone 1', sdkVersion: '13.3', cpuArchitecture: DarwinArch.arm64);
         device.setLogReader(mockApp, mockLogReader);
         final Uri uri = Uri(
           scheme: 'http',
@@ -589,7 +571,7 @@ void main() {
 
           final IOSApp app = await AbsoluteBuildableIOSApp.fromProject(
             FlutterProject.fromDirectory(projectDir).ios);
-          final IOSDevice device = IOSDevice('123');
+          final IOSDevice device = IOSDevice('123', name: 'iPhone 1', sdkVersion: '13.3', cpuArchitecture: DarwinArch.arm64);
 
           // Pre-create the expected build products.
           targetBuildDir.createSync(recursive: true);
@@ -697,7 +679,7 @@ void main() {
       });
 
       testUsingContext('installApp() invokes process with correct environment', () async {
-        final IOSDevice device = IOSDevice('123');
+        final IOSDevice device = IOSDevice('123', name: 'iPhone 1', sdkVersion: '13.3', cpuArchitecture: DarwinArch.arm64);
         const String bundlePath = '/path/to/bundle';
         final List<String> args = <String>[installerPath, '-i', bundlePath];
         when(mockApp.deviceBundlePath).thenReturn(bundlePath);
@@ -719,7 +701,7 @@ void main() {
       });
 
       testUsingContext('isAppInstalled() invokes process with correct environment', () async {
-        final IOSDevice device = IOSDevice('123');
+        final IOSDevice device = IOSDevice('123', name: 'iPhone 1', sdkVersion: '13.3', cpuArchitecture: DarwinArch.arm64);
         final List<String> args = <String>[installerPath, '--list-apps'];
         when(mockProcessManager.run(args, environment: env))
             .thenAnswer(
@@ -736,7 +718,7 @@ void main() {
       });
 
       testUsingContext('uninstallApp() invokes process with correct environment', () async {
-        final IOSDevice device = IOSDevice('123');
+        final IOSDevice device = IOSDevice('123', name: 'iPhone 1', sdkVersion: '13.3', cpuArchitecture: DarwinArch.arm64);
         final List<String> args = <String>[installerPath, '-U', appId];
         when(mockApp.id).thenReturn(appId);
         when(mockProcessManager.run(args, environment: env))
@@ -755,90 +737,61 @@ void main() {
   });
 
   group('getAttachedDevices', () {
-    MockIMobileDevice mockIMobileDevice;
+    MockXcdevice mockXcdevice;
 
     setUp(() {
-      mockIMobileDevice = MockIMobileDevice();
-    });
-
-    testUsingContext('return no devices if Xcode is not installed', () async {
-      when(mockIMobileDevice.isInstalled).thenReturn(false);
-      expect(await IOSDevice.getAttachedDevices(), isEmpty);
-    }, overrides: <Type, Generator>{
-      IMobileDevice: () => mockIMobileDevice,
-      Platform: () => macPlatform,
-    });
-
-    testUsingContext('returns no devices if none are attached', () async {
-      when(globals.iMobileDevice.isInstalled).thenReturn(true);
-      when(globals.iMobileDevice.getAvailableDeviceIDs())
-          .thenAnswer((Invocation invocation) => Future<String>.value(''));
-      final List<IOSDevice> devices = await IOSDevice.getAttachedDevices();
-      expect(devices, isEmpty);
-    }, overrides: <Type, Generator>{
-      IMobileDevice: () => mockIMobileDevice,
-      Platform: () => macPlatform,
+      mockXcdevice = MockXcdevice();
     });
 
     final List<Platform> unsupportedPlatforms = <Platform>[linuxPlatform, windowsPlatform];
-    for (final Platform platform in unsupportedPlatforms) {
-      testUsingContext('throws Unsupported Operation exception on ${platform.operatingSystem}', () async {
-        when(globals.iMobileDevice.isInstalled).thenReturn(false);
-        when(globals.iMobileDevice.getAvailableDeviceIDs())
-            .thenAnswer((Invocation invocation) => Future<String>.value(''));
+    for (final Platform unsupportedPlatform in unsupportedPlatforms) {
+      testWithoutContext('throws Unsupported Operation exception on ${unsupportedPlatform.operatingSystem}', () async {
+        when(mockXcdevice.isInstalled).thenReturn(false);
         expect(
-            () async { await IOSDevice.getAttachedDevices(); },
+            () async { await IOSDevice.getAttachedDevices(unsupportedPlatform, mockXcdevice); },
             throwsA(isA<UnsupportedError>()),
         );
-      }, overrides: <Type, Generator>{
-        IMobileDevice: () => mockIMobileDevice,
-        Platform: () => platform,
       });
     }
 
     testUsingContext('returns attached devices', () async {
-      when(globals.iMobileDevice.isInstalled).thenReturn(true);
-      when(globals.iMobileDevice.getAvailableDeviceIDs())
-          .thenAnswer((Invocation invocation) => Future<String>.value('''
-98206e7a4afd4aedaff06e687594e089dede3c44
-f577a7903cc54959be2e34bc4f7f80b7009efcf4
-'''));
-      when(globals.iMobileDevice.getInfoForDevice('98206e7a4afd4aedaff06e687594e089dede3c44', 'DeviceName'))
-          .thenAnswer((_) => Future<String>.value('La tele me regarde'));
-      when(globals.iMobileDevice.getInfoForDevice('98206e7a4afd4aedaff06e687594e089dede3c44', 'ProductVersion'))
-          .thenAnswer((_) => Future<String>.value('10.3.2'));
-      when(globals.iMobileDevice.getInfoForDevice('f577a7903cc54959be2e34bc4f7f80b7009efcf4', 'DeviceName'))
-          .thenAnswer((_) => Future<String>.value('Puits sans fond'));
-      when(globals.iMobileDevice.getInfoForDevice('f577a7903cc54959be2e34bc4f7f80b7009efcf4', 'ProductVersion'))
-          .thenAnswer((_) => Future<String>.value('11.0'));
-      final List<IOSDevice> devices = await IOSDevice.getAttachedDevices();
-      expect(devices, hasLength(2));
-      expect(devices[0].id, '98206e7a4afd4aedaff06e687594e089dede3c44');
-      expect(devices[0].name, 'La tele me regarde');
-      expect(devices[1].id, 'f577a7903cc54959be2e34bc4f7f80b7009efcf4');
-      expect(devices[1].name, 'Puits sans fond');
+      when(mockXcdevice.isInstalled).thenReturn(true);
+      final IOSDevice device = IOSDevice('d83d5bc53967baa0ee18626ba87b6254b2ab5418', name: 'Paired iPhone', sdkVersion: '13.3', cpuArchitecture: DarwinArch.arm64);
+      when(mockXcdevice.getAvailableTetheredIOSDevices())
+          .thenAnswer((Invocation invocation) => Future<List<IOSDevice>>.value(<IOSDevice>[device]));
+
+      final List<IOSDevice> devices = await IOSDevice.getAttachedDevices(macPlatform, mockXcdevice);
+      expect(devices, hasLength(1));
+      expect(identical(devices.first, device), isTrue);
     }, overrides: <Type, Generator>{
-      IMobileDevice: () => mockIMobileDevice,
       Platform: () => macPlatform,
     });
+  });
 
-    testUsingContext('returns attached devices and ignores devices that cannot be found by ideviceinfo', () async {
-      when(globals.iMobileDevice.isInstalled).thenReturn(true);
-      when(globals.iMobileDevice.getAvailableDeviceIDs())
-          .thenAnswer((Invocation invocation) => Future<String>.value('''
-98206e7a4afd4aedaff06e687594e089dede3c44
-f577a7903cc54959be2e34bc4f7f80b7009efcf4
-'''));
-      when(globals.iMobileDevice.getInfoForDevice('98206e7a4afd4aedaff06e687594e089dede3c44', 'DeviceName'))
-          .thenAnswer((_) => Future<String>.value('La tele me regarde'));
-      when(globals.iMobileDevice.getInfoForDevice('f577a7903cc54959be2e34bc4f7f80b7009efcf4', 'DeviceName'))
-          .thenThrow(const IOSDeviceNotFoundError('Device not found'));
-      final List<IOSDevice> devices = await IOSDevice.getAttachedDevices();
-      expect(devices, hasLength(1));
-      expect(devices[0].id, '98206e7a4afd4aedaff06e687594e089dede3c44');
-      expect(devices[0].name, 'La tele me regarde');
+  group('getDiagnostics', () {
+    MockXcdevice mockXcdevice;
+
+    setUp(() {
+      mockXcdevice = MockXcdevice();
+    });
+
+    final List<Platform> unsupportedPlatforms = <Platform>[linuxPlatform, windowsPlatform];
+    for (final Platform unsupportedPlatform in unsupportedPlatforms) {
+      testWithoutContext('throws returns platform diagnostic exception on ${unsupportedPlatform.operatingSystem}', () async {
+        when(mockXcdevice.isInstalled).thenReturn(false);
+        expect((await IOSDevice.getDiagnostics(unsupportedPlatform, mockXcdevice)).first, 'Control of iOS devices or simulators only supported on macOS.');
+      });
+    }
+
+    testUsingContext('returns diagnostics', () async {
+      when(mockXcdevice.isInstalled).thenReturn(true);
+      when(mockXcdevice.getDiagnostics())
+          .thenAnswer((Invocation invocation) => Future<List<String>>.value(<String>['Generic pairing error']));
+
+      final List<String> diagnostics = await IOSDevice.getDiagnostics(macPlatform, mockXcdevice);
+      expect(diagnostics, hasLength(1));
+      expect(diagnostics.first, 'Generic pairing error');
     }, overrides: <Type, Generator>{
-      IMobileDevice: () => mockIMobileDevice,
       Platform: () => macPlatform,
     });
   });
@@ -877,7 +830,7 @@ Runner(UIKit)[297] <Notice>: E is for enpitsu"
         return Future<Process>.value(mockProcess);
       });
 
-      final IOSDevice device = IOSDevice('123456');
+      final IOSDevice device = IOSDevice('123456', name: 'iPhone 1', sdkVersion: '10.3', cpuArchitecture: DarwinArch.arm64);
       final DeviceLogReader logReader = device.getLogReader(
         app: await BuildableIOSApp.fromProject(mockIosProject),
       );
@@ -888,6 +841,7 @@ Runner(UIKit)[297] <Notice>: E is for enpitsu"
       IMobileDevice: () => mockIMobileDevice,
       Platform: () => macPlatform,
     });
+
     testUsingContext('includes multi-line Flutter logs in the output', () async {
       when(mockIMobileDevice.startLogger('123456')).thenAnswer((Invocation invocation) {
         final Process mockProcess = MockProcess(
@@ -902,7 +856,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
         return Future<Process>.value(mockProcess);
       });
 
-      final IOSDevice device = IOSDevice('123456');
+      final IOSDevice device = IOSDevice('123456', name: 'iPhone 1', sdkVersion: '10.3', cpuArchitecture: DarwinArch.arm64);
       final DeviceLogReader logReader = device.getLogReader(
         app: await BuildableIOSApp.fromProject(mockIosProject),
       );
@@ -932,7 +886,7 @@ flutter:
     globals.fs.file('.packages').createSync();
     final FlutterProject flutterProject = FlutterProject.current();
 
-    expect(IOSDevice('test').isSupportedForProject(flutterProject), true);
+    expect(IOSDevice('test', name: 'iPhone 1', sdkVersion: '13.3', cpuArchitecture: DarwinArch.arm64).isSupportedForProject(flutterProject), true);
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(),
     ProcessManager: () => FakeProcessManager.any(),
@@ -944,7 +898,7 @@ flutter:
     globals.fs.directory('ios').createSync();
     final FlutterProject flutterProject = FlutterProject.current();
 
-    expect(IOSDevice('test').isSupportedForProject(flutterProject), true);
+    expect(IOSDevice('test', name: 'iPhone 1', sdkVersion: '13.3', cpuArchitecture: DarwinArch.arm64).isSupportedForProject(flutterProject), true);
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(),
     ProcessManager: () => FakeProcessManager.any(),
@@ -956,7 +910,7 @@ flutter:
     globals.fs.file('.packages').createSync();
     final FlutterProject flutterProject = FlutterProject.current();
 
-    expect(IOSDevice('test').isSupportedForProject(flutterProject), false);
+    expect(IOSDevice('test', name: 'iPhone 1', sdkVersion: '13.3', cpuArchitecture: DarwinArch.arm64).isSupportedForProject(flutterProject), false);
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(),
     ProcessManager: () => FakeProcessManager.any(),

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -235,12 +235,11 @@ void main() {
       testWithoutContext('xcdevice fails', () async {
         when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
 
-        const String xcdevicePath = '/path/to/xcdevice';
         when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
-            .thenReturn(ProcessResult(1, 0, xcdevicePath, ''));
+            .thenReturn(ProcessResult(1, 0, '/path/to/xcdevice', ''));
 
-        when(processManager.run(<String>[xcdevicePath, 'list', '--timeout', '1']))
-            .thenThrow(const ProcessException(xcdevicePath, <String>['list', '--timeout', '1']));
+        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '1']))
+            .thenThrow(const ProcessException('xcrun', <String>['xcdevice', 'list', '--timeout', '1']));
 
         expect(await xcdevice.getAvailableTetheredIOSDevices(), isEmpty);
       });
@@ -248,9 +247,8 @@ void main() {
       testUsingContext('returns devices', () async {
         when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
 
-        const String xcdevicePath = '/path/to/xcdevice';
         when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
-            .thenReturn(ProcessResult(1, 0, xcdevicePath, ''));
+            .thenReturn(ProcessResult(1, 0, '/path/to/xcdevice', ''));
 
         const String devicesOutput = '''
 [
@@ -345,7 +343,7 @@ void main() {
 ]
 ''';
 
-        when(processManager.run(<String>[xcdevicePath, 'list', '--timeout', '1']))
+        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '1']))
             .thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 0, devicesOutput, '')));
         final List<IOSDevice> devices = await xcdevice.getAvailableTetheredIOSDevices();
         expect(devices, hasLength(3));
@@ -380,12 +378,11 @@ void main() {
       testWithoutContext('xcdevice fails', () async {
         when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
 
-        const String xcdevicePath = '/path/to/xcdevice';
         when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
-            .thenReturn(ProcessResult(1, 0, xcdevicePath, ''));
+            .thenReturn(ProcessResult(1, 0, '/path/to/xcdevice', ''));
 
-        when(processManager.run(<String>[xcdevicePath, 'list', '--timeout', '1']))
-            .thenThrow(const ProcessException(xcdevicePath, <String>['list', '--timeout', '1']));
+        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '1']))
+            .thenThrow(const ProcessException('xcrun', <String>['xcdevice', 'list', '--timeout', '1']));
 
         expect(await xcdevice.getDiagnostics(), isEmpty);
       });
@@ -393,9 +390,8 @@ void main() {
       testUsingContext('returns error message', () async {
         when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
 
-        const String xcdevicePath = '/path/to/xcdevice';
         when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
-            .thenReturn(ProcessResult(1, 0, xcdevicePath, ''));
+            .thenReturn(ProcessResult(1, 0, '/path/to/xcdevice', ''));
 
         const String devicesOutput = '''
 [
@@ -464,7 +460,7 @@ void main() {
 ]
 ''';
 
-        when(processManager.run(<String>[xcdevicePath, 'list', '--timeout', '1']))
+        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '1']))
             .thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 0, devicesOutput, '')));
         final List<String> errors = await xcdevice.getDiagnostics();
         expect(errors, hasLength(3));

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -390,7 +390,7 @@ void main() {
         expect(await xcdevice.getDiagnostics(), isEmpty);
       });
 
-      testUsingContext('returns error message with name', () async {
+      testUsingContext('returns error message', () async {
         when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
 
         const String xcdevicePath = '/path/to/xcdevice';
@@ -441,7 +441,7 @@ void main() {
     "error" : {
       "code" : -9,
       "failureReason" : "",
-      "description" : "iPhone is not paired with your computer.",
+      "description" : "iPhone is not paired with your computer",
       "domain" : "com.apple.platform.iphoneos"
     }
   },
@@ -468,9 +468,9 @@ void main() {
             .thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 0, devicesOutput, '')));
         final List<String> errors = await xcdevice.getDiagnostics();
         expect(errors, hasLength(3));
-        expect(errors[0], '"An iPhone (Space Gray)" error: iPhone is not paired with your computer. To use iPhone with Xcode, unlock it and choose to trust this computer when prompted. (code -9)');
-        expect(errors[1], '"iPhone" error: iPhone is not paired with your computer. (code -9)');
-        expect(errors[2], 'Xcode pairing error (code -13)');
+        expect(errors[0], 'Error: iPhone is not paired with your computer. To use iPhone with Xcode, unlock it and choose to trust this computer when prompted. (code -9)');
+        expect(errors[1], 'Error: iPhone is not paired with your computer. (code -9)');
+        expect(errors[2], 'Error: Xcode pairing error. (code -13)');
       }, overrides: <Type, Generator>{
         Platform: () => macPlatform,
       });

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -416,7 +416,7 @@ void main() {
       "underlyingErrors" : [
         {
           "code" : 5,
-          "failureReason" : "allowsSecureServices: 1. isConnected: 0. Platform: <DVTPlatform:0x7f804ce32880:'com.apple.platform.iphoneos':<DVTFilePath:0x7f804ce32800:'\/Users\/magder\/Applications\/Xcode_11-3-1.app\/Contents\/Developer\/Platforms\/iPhoneOS.platform'>>. DTDKDeviceIdentifierIsIDID: 0",
+          "failureReason" : "allowsSecureServices: 1. isConnected: 0. Platform: <DVTPlatform:0x7f804ce32880:'com.apple.platform.iphoneos':<DVTFilePath:0x7f804ce32800:'\/Users\/Applications\/Xcode.app\/Contents\/Developer\/Platforms\/iPhoneOS.platform'>>. DTDKDeviceIdentifierIsIDID: 0",
           "description" : "📱<DVTiOSDevice (0x7f801f190450), iPhone, iPhone, 13.3 (17C54), d83d5bc53967baa0ee18626ba87b6254b2ab5418> -- Failed _shouldMakeReadyForDevelopment check even though device is not locked by passcode.",
           "recoverySuggestion" : "",
           "domain" : "com.apple.platform.iphoneos"

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -387,6 +387,44 @@ void main() {
         expect(await xcdevice.getDiagnostics(), isEmpty);
       });
 
+      testUsingContext('uses cache', () async {
+        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
+
+        when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
+            .thenReturn(ProcessResult(1, 0, '/path/to/xcdevice', ''));
+
+        const String devicesOutput = '''
+[
+  {
+    "simulator" : false,
+    "operatingSystemVersion" : "13.3 (17C54)",
+    "interface" : "network",
+    "available" : false,
+    "platform" : "com.apple.platform.iphoneos",
+    "modelCode" : "iPhone8,1",
+    "identifier" : "d83d5bc53967baa0ee18626ba87b6254b2ab5418",
+    "architecture" : "arm64",
+    "modelName" : "iPhone 6s",
+    "error" : {
+      "code" : -13,
+      "failureReason" : "",
+      "domain" : "com.apple.platform.iphoneos"
+    }
+  }
+]
+''';
+
+        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '1']))
+            .thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 0, devicesOutput, '')));
+        await xcdevice.getAvailableTetheredIOSDevices();
+        final List<String> errors = await xcdevice.getDiagnostics();
+        expect(errors, hasLength(1));
+
+        verify(processManager.run(any)).called(1);
+      }, overrides: <Type, Generator>{
+        Platform: () => macPlatform,
+      });
+
       testUsingContext('returns error message', () async {
         when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
 

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -6,6 +6,8 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart' show ProcessException, ProcessResult;
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/ios/devices.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
 import 'package:mockito/mockito.dart';
@@ -21,160 +23,460 @@ class MockPlatform extends Mock implements Platform {}
 
 void main() {
   ProcessManager processManager;
-  Xcode xcode;
-  MockXcodeProjectInterpreter mockXcodeProjectInterpreter;
-  MockPlatform platform;
   Logger logger;
-  FileSystem fileSystem;
 
   setUp(() {
     logger = MockLogger();
-    fileSystem = MemoryFileSystem();
     processManager = MockProcessManager();
-    mockXcodeProjectInterpreter = MockXcodeProjectInterpreter();
-    platform = MockPlatform();
-    xcode = Xcode(
-      logger: logger,
-      platform: platform,
-      fileSystem: fileSystem,
-      processManager: processManager,
-      xcodeProjectInterpreter: mockXcodeProjectInterpreter,
-    );
   });
 
-  testWithoutContext('xcodeSelectPath returns null when xcode-select is not installed', () {
-    when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
-        .thenThrow(const ProcessException('/usr/bin/xcode-select', <String>['--print-path']));
-    expect(xcode.xcodeSelectPath, isNull);
-    when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
-        .thenThrow(ArgumentError('Invalid argument(s): Cannot find executable for /usr/bin/xcode-select'));
+  group('Xcode', () {
+    Xcode xcode;
+    MockXcodeProjectInterpreter mockXcodeProjectInterpreter;
+    MockPlatform platform;
+    FileSystem fileSystem;
 
-    expect(xcode.xcodeSelectPath, isNull);
-  });
+    setUp(() {
+      fileSystem = MemoryFileSystem();
+      mockXcodeProjectInterpreter = MockXcodeProjectInterpreter();
+      platform = MockPlatform();
+      xcode = Xcode(
+        logger: logger,
+        platform: platform,
+        fileSystem: fileSystem,
+        processManager: processManager,
+        xcodeProjectInterpreter: mockXcodeProjectInterpreter,
+      );
+    });
 
-  testWithoutContext('xcodeSelectPath returns path when xcode-select is installed', () {
-    const String xcodePath = '/Applications/Xcode8.0.app/Contents/Developer';
-    when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
+    testWithoutContext('xcodeSelectPath returns null when xcode-select is not installed', () {
+      when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
+          .thenThrow(const ProcessException('/usr/bin/xcode-select', <String>['--print-path']));
+      expect(xcode.xcodeSelectPath, isNull);
+      when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
+          .thenThrow(ArgumentError('Invalid argument(s): Cannot find executable for /usr/bin/xcode-select'));
+
+      expect(xcode.xcodeSelectPath, isNull);
+    });
+
+    testWithoutContext('xcodeSelectPath returns path when xcode-select is installed', () {
+      const String xcodePath = '/Applications/Xcode8.0.app/Contents/Developer';
+      when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
+          .thenReturn(ProcessResult(1, 0, xcodePath, ''));
+
+      expect(xcode.xcodeSelectPath, xcodePath);
+    });
+
+    testWithoutContext('xcodeVersionSatisfactory is false when version is less than minimum', () {
+      when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
+      when(mockXcodeProjectInterpreter.majorVersion).thenReturn(9);
+      when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
+
+      expect(xcode.isVersionSatisfactory, isFalse);
+    });
+
+    testWithoutContext('xcodeVersionSatisfactory is false when xcodebuild tools are not installed', () {
+      when(mockXcodeProjectInterpreter.isInstalled).thenReturn(false);
+
+      expect(xcode.isVersionSatisfactory, isFalse);
+    });
+
+    testWithoutContext('xcodeVersionSatisfactory is true when version meets minimum', () {
+      when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
+      when(mockXcodeProjectInterpreter.majorVersion).thenReturn(10);
+      when(mockXcodeProjectInterpreter.minorVersion).thenReturn(2);
+
+      expect(xcode.isVersionSatisfactory, isTrue);
+    });
+
+    testWithoutContext('xcodeVersionSatisfactory is true when major version exceeds minimum', () {
+      when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
+      when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
+      when(mockXcodeProjectInterpreter.minorVersion).thenReturn(2);
+
+      expect(xcode.isVersionSatisfactory, isTrue);
+    });
+
+    testWithoutContext('xcodeVersionSatisfactory is true when minor version exceeds minimum', () {
+      when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
+      when(mockXcodeProjectInterpreter.majorVersion).thenReturn(10);
+      when(mockXcodeProjectInterpreter.minorVersion).thenReturn(3);
+
+      expect(xcode.isVersionSatisfactory, isTrue);
+    });
+
+    testWithoutContext('isInstalledAndMeetsVersionCheck is false when not macOS', () {
+      when(platform.isMacOS).thenReturn(false);
+
+      expect(xcode.isInstalledAndMeetsVersionCheck, isFalse);
+    });
+
+    testWithoutContext('isInstalledAndMeetsVersionCheck is false when not installed', () {
+      when(platform.isMacOS).thenReturn(true);
+      const String xcodePath = '/Applications/Xcode8.0.app/Contents/Developer';
+      when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
         .thenReturn(ProcessResult(1, 0, xcodePath, ''));
+      when(mockXcodeProjectInterpreter.isInstalled).thenReturn(false);
 
-    expect(xcode.xcodeSelectPath, xcodePath);
+      expect(xcode.isInstalledAndMeetsVersionCheck, isFalse);
+    });
+
+    testWithoutContext('isInstalledAndMeetsVersionCheck is false when no xcode-select', () {
+      when(platform.isMacOS).thenReturn(true);
+      when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
+        .thenReturn(ProcessResult(1, 127, '', 'ERROR'));
+      when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
+      when(mockXcodeProjectInterpreter.majorVersion).thenReturn(10);
+      when(mockXcodeProjectInterpreter.minorVersion).thenReturn(2);
+
+      expect(xcode.isInstalledAndMeetsVersionCheck, isFalse);
+    });
+
+    testWithoutContext('isInstalledAndMeetsVersionCheck is false when version not satisfied', () {
+      when(platform.isMacOS).thenReturn(true);
+      const String xcodePath = '/Applications/Xcode8.0.app/Contents/Developer';
+      when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
+        .thenReturn(ProcessResult(1, 0, xcodePath, ''));
+      when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
+      when(mockXcodeProjectInterpreter.majorVersion).thenReturn(9);
+      when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
+
+      expect(xcode.isInstalledAndMeetsVersionCheck, isFalse);
+    });
+
+    testWithoutContext('isInstalledAndMeetsVersionCheck is true when macOS and installed and version is satisfied', () {
+      when(platform.isMacOS).thenReturn(true);
+      const String xcodePath = '/Applications/Xcode8.0.app/Contents/Developer';
+      when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
+        .thenReturn(ProcessResult(1, 0, xcodePath, ''));
+      when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
+      when(mockXcodeProjectInterpreter.majorVersion).thenReturn(10);
+      when(mockXcodeProjectInterpreter.minorVersion).thenReturn(2);
+
+      expect(xcode.isInstalledAndMeetsVersionCheck, isTrue);
+    });
+
+    testWithoutContext('eulaSigned is false when clang is not installed', () {
+      when(processManager.runSync(<String>['/usr/bin/xcrun', 'clang']))
+          .thenThrow(const ProcessException('/usr/bin/xcrun', <String>['clang']));
+
+      expect(xcode.eulaSigned, isFalse);
+    });
+
+    testWithoutContext('eulaSigned is false when clang output indicates EULA not yet accepted', () {
+      when(processManager.runSync(<String>['/usr/bin/xcrun', 'clang']))
+          .thenReturn(ProcessResult(1, 1, '', 'Xcode EULA has not been accepted.\nLaunch Xcode and accept the license.'));
+
+      expect(xcode.eulaSigned, isFalse);
+    });
+
+    testWithoutContext('eulaSigned is true when clang output indicates EULA has been accepted', () {
+      when(processManager.runSync(<String>['/usr/bin/xcrun', 'clang']))
+          .thenReturn(ProcessResult(1, 1, '', 'clang: error: no input files'));
+
+      expect(xcode.eulaSigned, isTrue);
+    });
+
+    testWithoutContext('SDK name', () {
+      expect(getNameForSdk(SdkType.iPhone), 'iphoneos');
+      expect(getNameForSdk(SdkType.iPhoneSimulator), 'iphonesimulator');
+      expect(getNameForSdk(SdkType.macOS), 'macosx');
+    });
   });
 
-  testWithoutContext('xcodeVersionSatisfactory is false when version is less than minimum', () {
-    when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-    when(mockXcodeProjectInterpreter.majorVersion).thenReturn(9);
-    when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
+  group('xcdevice', () {
+    XCDevice xcdevice;
+    MockXcode mockXcode;
 
-    expect(xcode.isVersionSatisfactory, isFalse);
-  });
+    setUp(() {
+      mockXcode = MockXcode();
+      xcdevice = XCDevice(
+        processManager: processManager,
+        logger: logger,
+        xcode: mockXcode,
+      );
+    });
 
-  testWithoutContext('xcodeVersionSatisfactory is false when xcodebuild tools are not installed', () {
-    when(mockXcodeProjectInterpreter.isInstalled).thenReturn(false);
+    group('installed', () {
+      testWithoutContext('Xcode not installed', () {
+        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(false);
+        expect(xcdevice.isInstalled, false);
+      });
 
-    expect(xcode.isVersionSatisfactory, isFalse);
-  });
+      testWithoutContext("xcrun can't find xcdevice", () {
+        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
 
-  testWithoutContext('xcodeVersionSatisfactory is true when version meets minimum', () {
-    when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-    when(mockXcodeProjectInterpreter.majorVersion).thenReturn(10);
-    when(mockXcodeProjectInterpreter.minorVersion).thenReturn(2);
+        when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
+            .thenThrow(const ProcessException('xcrun', <String>['--find', 'xcdevice']));
+        expect(xcdevice.isInstalled, false);
+        verify(processManager.runSync(any)).called(1);
+      });
 
-    expect(xcode.isVersionSatisfactory, isTrue);
-  });
+      testWithoutContext('is installed', () {
+        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
 
-  testWithoutContext('xcodeVersionSatisfactory is true when major version exceeds minimum', () {
-    when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-    when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
-    when(mockXcodeProjectInterpreter.minorVersion).thenReturn(2);
+        when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
+            .thenReturn(ProcessResult(1, 0, '/path/to/xcdevice', ''));
+        expect(xcdevice.isInstalled, true);
+      });
+    });
 
-    expect(xcode.isVersionSatisfactory, isTrue);
-  });
+    group('available devices', () {
+      final FakePlatform macPlatform = FakePlatform.fromPlatform(const LocalPlatform());
+      macPlatform.operatingSystem = 'macos';
 
-  testWithoutContext('xcodeVersionSatisfactory is true when minor version exceeds minimum', () {
-    when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-    when(mockXcodeProjectInterpreter.majorVersion).thenReturn(10);
-    when(mockXcodeProjectInterpreter.minorVersion).thenReturn(3);
+      testWithoutContext('Xcode not installed', () async {
+        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(false);
 
-    expect(xcode.isVersionSatisfactory, isTrue);
-  });
+        expect(await xcdevice.getAvailableTetheredIOSDevices(), isEmpty);
+        verifyNever(processManager.run(any));
+      });
 
-  testWithoutContext('isInstalledAndMeetsVersionCheck is false when not macOS', () {
-    when(platform.isMacOS).thenReturn(false);
+      testWithoutContext('xcdevice fails', () async {
+        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
 
-    expect(xcode.isInstalledAndMeetsVersionCheck, isFalse);
-  });
+        const String xcdevicePath = '/path/to/xcdevice';
+        when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
+            .thenReturn(ProcessResult(1, 0, xcdevicePath, ''));
 
-  testWithoutContext('isInstalledAndMeetsVersionCheck is false when not installed', () {
-    when(platform.isMacOS).thenReturn(true);
-    const String xcodePath = '/Applications/Xcode8.0.app/Contents/Developer';
-    when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
-      .thenReturn(ProcessResult(1, 0, xcodePath, ''));
-    when(mockXcodeProjectInterpreter.isInstalled).thenReturn(false);
+        when(processManager.run(<String>[xcdevicePath, 'list', '--timeout', '1']))
+            .thenThrow(const ProcessException(xcdevicePath, <String>['list', '--timeout', '1']));
 
-    expect(xcode.isInstalledAndMeetsVersionCheck, isFalse);
-  });
+        expect(await xcdevice.getAvailableTetheredIOSDevices(), isEmpty);
+      });
 
-  testWithoutContext('isInstalledAndMeetsVersionCheck is false when no xcode-select', () {
-    when(platform.isMacOS).thenReturn(true);
-    when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
-      .thenReturn(ProcessResult(1, 127, '', 'ERROR'));
-    when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-    when(mockXcodeProjectInterpreter.majorVersion).thenReturn(10);
-    when(mockXcodeProjectInterpreter.minorVersion).thenReturn(2);
+      testUsingContext('returns devices', () async {
+        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
 
-    expect(xcode.isInstalledAndMeetsVersionCheck, isFalse);
-  });
+        const String xcdevicePath = '/path/to/xcdevice';
+        when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
+            .thenReturn(ProcessResult(1, 0, xcdevicePath, ''));
 
-  testWithoutContext('isInstalledAndMeetsVersionCheck is false when version not satisfied', () {
-    when(platform.isMacOS).thenReturn(true);
-    const String xcodePath = '/Applications/Xcode8.0.app/Contents/Developer';
-    when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
-      .thenReturn(ProcessResult(1, 0, xcodePath, ''));
-    when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-    when(mockXcodeProjectInterpreter.majorVersion).thenReturn(9);
-    when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
+        const String devicesOutput = '''
+[
+  {
+    "simulator" : true,
+    "operatingSystemVersion" : "13.3 (17K446)",
+    "available" : true,
+    "platform" : "com.apple.platform.appletvsimulator",
+    "modelCode" : "AppleTV5,3",
+    "identifier" : "CBB5E1ED-2172-446E-B4E7-F2B5823DBBA6",
+    "architecture" : "x86_64",
+    "modelName" : "Apple TV",
+    "name" : "Apple TV"
+  },
+  {
+    "simulator" : false,
+    "operatingSystemVersion" : "13.3 (17C54)",
+    "interface" : "usb",
+    "available" : true,
+    "platform" : "com.apple.platform.iphoneos",
+    "modelCode" : "iPhone8,1",
+    "identifier" : "d83d5bc53967baa0ee18626ba87b6254b2ab5418",
+    "architecture" : "arm64",
+    "modelName" : "iPhone 6s",
+    "name" : "An iPhone (Space Gray)"
+  },
+  {
+    "simulator" : false,
+    "operatingSystemVersion" : "10.1 (14C54)",
+    "interface" : "usb",
+    "available" : true,
+    "platform" : "com.apple.platform.iphoneos",
+    "modelCode" : "iPad11,4",
+    "identifier" : "98206e7a4afd4aedaff06e687594e089dede3c44",
+    "architecture" : "armv7",
+    "modelName" : "iPad Air 3rd Gen",
+    "name" : "iPad 1"
+  },
+  {
+    "simulator" : false,
+    "operatingSystemVersion" : "10.1 (14C54)",
+    "interface" : "network",
+    "available" : true,
+    "platform" : "com.apple.platform.iphoneos",
+    "modelCode" : "iPad11,4",
+    "identifier" : "234234234234234234345445687594e089dede3c44",
+    "architecture" : "arm64",
+    "modelName" : "iPad Air 3rd Gen",
+    "name" : "A networked iPad"
+  },
+  {
+    "simulator" : false,
+    "operatingSystemVersion" : "10.1 (14C54)",
+    "interface" : "usb",
+    "available" : true,
+    "platform" : "com.apple.platform.iphoneos",
+    "modelCode" : "iPad11,4",
+    "identifier" : "f577a7903cc54959be2e34bc4f7f80b7009efcf4",
+    "architecture" : "BOGUS",
+    "modelName" : "iPad Air 3rd Gen",
+    "name" : "iPad 2"
+  },
+  {
+    "simulator" : true,
+    "operatingSystemVersion" : "6.1.1 (17S445)",
+    "available" : true,
+    "platform" : "com.apple.platform.watchsimulator",
+    "modelCode" : "Watch5,4",
+    "identifier" : "2D74FB11-88A0-44D0-B81E-C0C142B1C94A",
+    "architecture" : "i386",
+    "modelName" : "Apple Watch Series 5 - 44mm",
+    "name" : "Apple Watch Series 5 - 44mm"
+  },
+  {
+    "simulator" : false,
+    "operatingSystemVersion" : "13.3 (17C54)",
+    "interface" : "usb",
+    "available" : false,
+    "platform" : "com.apple.platform.iphoneos",
+    "modelCode" : "iPhone8,1",
+    "identifier" : "c4ca6f7a53027d1b7e4972e28478e7a28e2faee2",
+    "architecture" : "arm64",
+    "modelName" : "iPhone 6s",
+    "name" : "iPhone",
+    "error" : {
+      "code" : -9,
+      "failureReason" : "",
+      "description" : "iPhone is not paired with your computer.",
+      "domain" : "com.apple.platform.iphoneos"
+    }
+  }
+]
+''';
 
-    expect(xcode.isInstalledAndMeetsVersionCheck, isFalse);
-  });
+        when(processManager.run(<String>[xcdevicePath, 'list', '--timeout', '1']))
+            .thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 0, devicesOutput, '')));
+        final List<IOSDevice> devices = await xcdevice.getAvailableTetheredIOSDevices();
+        expect(devices, hasLength(3));
+        expect(devices[0].id, 'd83d5bc53967baa0ee18626ba87b6254b2ab5418');
+        expect(devices[0].name, 'An iPhone (Space Gray)');
+        expect(await devices[0].sdkNameAndVersion, 'iOS 13.3');
+        expect(devices[0].cpuArchitecture, DarwinArch.arm64);
+        expect(devices[1].id, '98206e7a4afd4aedaff06e687594e089dede3c44');
+        expect(devices[1].name, 'iPad 1');
+        expect(await devices[1].sdkNameAndVersion, 'iOS 10.1');
+        expect(devices[1].cpuArchitecture, DarwinArch.armv7);
+        expect(devices[2].id, 'f577a7903cc54959be2e34bc4f7f80b7009efcf4');
+        expect(devices[2].name, 'iPad 2');
+        expect(await devices[2].sdkNameAndVersion, 'iOS 10.1');
+        expect(devices[2].cpuArchitecture, DarwinArch.arm64); // Defaults to arm64 for unknown architecture.
+      }, overrides: <Type, Generator>{
+        Platform: () => macPlatform,
+      });
+    });
 
-  testWithoutContext('isInstalledAndMeetsVersionCheck is true when macOS and installed and version is satisfied', () {
-    when(platform.isMacOS).thenReturn(true);
-    const String xcodePath = '/Applications/Xcode8.0.app/Contents/Developer';
-    when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
-      .thenReturn(ProcessResult(1, 0, xcodePath, ''));
-    when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-    when(mockXcodeProjectInterpreter.majorVersion).thenReturn(10);
-    when(mockXcodeProjectInterpreter.minorVersion).thenReturn(2);
+    group('diagnostics', () {
+      final FakePlatform macPlatform = FakePlatform.fromPlatform(const LocalPlatform());
+      macPlatform.operatingSystem = 'macos';
 
-    expect(xcode.isInstalledAndMeetsVersionCheck, isTrue);
-  });
+      testWithoutContext('Xcode not installed', () async {
+        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(false);
 
-  testWithoutContext('eulaSigned is false when clang is not installed', () {
-    when(processManager.runSync(<String>['/usr/bin/xcrun', 'clang']))
-        .thenThrow(const ProcessException('/usr/bin/xcrun', <String>['clang']));
+        expect(await xcdevice.getDiagnostics(), isEmpty);
+        verifyNever(processManager.run(any));
+      });
 
-    expect(xcode.eulaSigned, isFalse);
-  });
+      testWithoutContext('xcdevice fails', () async {
+        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
 
-  testWithoutContext('eulaSigned is false when clang output indicates EULA not yet accepted', () {
-    when(processManager.runSync(<String>['/usr/bin/xcrun', 'clang']))
-        .thenReturn(ProcessResult(1, 1, '', 'Xcode EULA has not been accepted.\nLaunch Xcode and accept the license.'));
+        const String xcdevicePath = '/path/to/xcdevice';
+        when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
+            .thenReturn(ProcessResult(1, 0, xcdevicePath, ''));
 
-    expect(xcode.eulaSigned, isFalse);
-  });
+        when(processManager.run(<String>[xcdevicePath, 'list', '--timeout', '1']))
+            .thenThrow(const ProcessException(xcdevicePath, <String>['list', '--timeout', '1']));
 
-  testWithoutContext('eulaSigned is true when clang output indicates EULA has been accepted', () {
-    when(processManager.runSync(<String>['/usr/bin/xcrun', 'clang']))
-        .thenReturn(ProcessResult(1, 1, '', 'clang: error: no input files'));
+        expect(await xcdevice.getDiagnostics(), isEmpty);
+      });
 
-    expect(xcode.eulaSigned, isTrue);
-  });
+      testUsingContext('returns error message with name', () async {
+        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
 
-  testWithoutContext('SDK name', () {
-    expect(getNameForSdk(SdkType.iPhone), 'iphoneos');
-    expect(getNameForSdk(SdkType.iPhoneSimulator), 'iphonesimulator');
-    expect(getNameForSdk(SdkType.macOS), 'macosx');
+        const String xcdevicePath = '/path/to/xcdevice';
+        when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
+            .thenReturn(ProcessResult(1, 0, xcdevicePath, ''));
+
+        const String devicesOutput = '''
+[
+   {
+    "simulator" : false,
+    "operatingSystemVersion" : "13.3 (17C54)",
+    "interface" : "usb",
+    "available" : false,
+    "platform" : "com.apple.platform.iphoneos",
+    "modelCode" : "iPhone8,1",
+    "identifier" : "98206e7a4afd4aedaff06e687594e089dede3c44",
+    "architecture" : "arm64",
+    "modelName" : "iPhone 6s",
+    "name" : "An iPhone (Space Gray)",
+    "error" : {
+      "code" : -9,
+      "failureReason" : "",
+      "underlyingErrors" : [
+        {
+          "code" : 5,
+          "failureReason" : "allowsSecureServices: 1. isConnected: 0. Platform: <DVTPlatform:0x7f804ce32880:'com.apple.platform.iphoneos':<DVTFilePath:0x7f804ce32800:'\/Users\/magder\/Applications\/Xcode_11-3-1.app\/Contents\/Developer\/Platforms\/iPhoneOS.platform'>>. DTDKDeviceIdentifierIsIDID: 0",
+          "description" : "📱<DVTiOSDevice (0x7f801f190450), iPhone, iPhone, 13.3 (17C54), d83d5bc53967baa0ee18626ba87b6254b2ab5418> -- Failed _shouldMakeReadyForDevelopment check even though device is not locked by passcode.",
+          "recoverySuggestion" : "",
+          "domain" : "com.apple.platform.iphoneos"
+        }
+      ],
+      "description" : "iPhone is not paired with your computer.",
+      "recoverySuggestion" : "To use iPhone with Xcode, unlock it and choose to trust this computer when prompted.",
+      "domain" : "com.apple.platform.iphoneos"
+    }
+  },
+  {
+    "simulator" : false,
+    "operatingSystemVersion" : "13.3 (17C54)",
+    "interface" : "usb",
+    "available" : false,
+    "platform" : "com.apple.platform.iphoneos",
+    "modelCode" : "iPhone8,1",
+    "identifier" : "d83d5bc53967baa0ee18626ba87b6254b2ab5418",
+    "architecture" : "arm64",
+    "modelName" : "iPhone 6s",
+    "name" : "iPhone",
+    "error" : {
+      "code" : -9,
+      "failureReason" : "",
+      "description" : "iPhone is not paired with your computer.",
+      "domain" : "com.apple.platform.iphoneos"
+    }
+  },
+  {
+    "simulator" : false,
+    "operatingSystemVersion" : "13.3 (17C54)",
+    "interface" : "network",
+    "available" : false,
+    "platform" : "com.apple.platform.iphoneos",
+    "modelCode" : "iPhone8,1",
+    "identifier" : "d83d5bc53967baa0ee18626ba87b6254b2ab5418",
+    "architecture" : "arm64",
+    "modelName" : "iPhone 6s",
+    "error" : {
+      "code" : -13,
+      "failureReason" : "",
+      "domain" : "com.apple.platform.iphoneos"
+    }
+  }
+]
+''';
+
+        when(processManager.run(<String>[xcdevicePath, 'list', '--timeout', '1']))
+            .thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 0, devicesOutput, '')));
+        final List<String> errors = await xcdevice.getDiagnostics();
+        expect(errors, hasLength(3));
+        expect(errors[0], '"An iPhone (Space Gray)" error: iPhone is not paired with your computer. To use iPhone with Xcode, unlock it and choose to trust this computer when prompted. (code -9)');
+        expect(errors[1], '"iPhone" error: iPhone is not paired with your computer. (code -9)');
+        expect(errors[2], 'Xcode pairing error (code -13)');
+      }, overrides: <Type, Generator>{
+        Platform: () => macPlatform,
+      });
+    });
   });
 }
 
 class MockLogger extends Mock implements Logger {}
+class MockXcode extends Mock implements Xcode {}


### PR DESCRIPTION
## Description

Xcode ships with a command line tool called `xcdevice` that produces a json array of all available devices, including iOS devices that can be deployed via Xcode over the network (Connect via network checkbox).  This PR filters out these network devices, but it's relevant to someday fixing https://github.com/flutter/flutter/issues/15072.

<img width="912" alt="Screen Shot 2020-01-30 at 6 57 46 PM" src="https://user-images.githubusercontent.com/682784/73509004-8a222080-4392-11ea-9579-9d7c63b7e175.png">

I checked to make sure `xcdevice` is available in Xcode 10.2 (minimum Xcode required by Flutter) and later.

Example output:
```json
{
  "simulator" : false,
  "operatingSystemVersion" : "13.3 (17C54)",
  "interface" : "usb",
  "available" : true,
  "platform" : "com.apple.platform.iphoneos",
  "modelCode" : "iPhone8,1",
  "identifier" : "d83d5bc53967baa0ee18626ba87b6254b2ab5418",
  "architecture" : "arm64",
  "modelName" : "iPhone 6s",
  "name" : "iPhone"
}
```
Since this provides the identifier, name, operating system, and architecture, we can get rid of all usages of `idevice_id` and `ideviceinfo` (cleanup happening in the next PR since this one was already getting too big).

Also, show any connection errors in doctor instead of crashing.  Example:
```
[!] Connected device                          
    • Error: iPhone is not paired with your computer. To use iPhone with Xcode, unlock it and choose to trust this computer when prompted. (code -9)
```

- Remove 2 libimobiledevice dependencies.
- Remove all codepaths that resulted in cryptic lockdown errors and instead return Xcode's nice errors and recovery suggestions, like "To use iPhone with Xcode, unlock it and choose to trust this computer when prompted."

## Related Issues
Part of https://github.com/flutter/flutter/issues/6118
Precursor to https://github.com/flutter/flutter/issues/15072 (will make networked devices discoverable when we stop filtering "network" interfaces).

Fixes https://github.com/flutter/flutter/issues/49375
Fixes https://github.com/flutter/flutter/issues/36524
Fixes https://github.com/flutter/flutter/issues/47727
Fixes https://github.com/flutter/flutter/issues/43398
Fixes https://github.com/flutter/flutter/issues/48057

Supersedes https://github.com/flutter/flutter/pull/49626
Supersedes https://github.com/flutter/flutter/pull/45657
Supersedes part of https://github.com/flutter/flutter/pull/36902?

## Tests

xcode_test, devices_test

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*