### PR TITLE
[web] Fix typo apple-mobile-web-app-status-bar-style

### DIFF
--- a/examples/flutter_gallery/web/index.html
+++ b/examples/flutter_gallery/web/index.html
@@ -10,7 +10,7 @@ found in the LICENSE file. -->
 
   <!-- iOS meta tags & icons -->
   <meta name="apple-mobile-web-app-capable" content="yes">
-  <meta name="apple-mobile-web-status-bar-style" content="black">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="Flutter Gallery">
   <link rel="apple-touch-icon" href="/icons/Icon-192.png">
   <link rel="shortcut icon" type="image/png" href="/favicon.png"/>

--- a/packages/flutter_tools/templates/app/web/index.html.tmpl
+++ b/packages/flutter_tools/templates/app/web/index.html.tmpl
@@ -7,7 +7,7 @@
 
   <!-- iOS meta tags & icons -->
   <meta name="apple-mobile-web-app-capable" content="yes">
-  <meta name="apple-mobile-web-status-bar-style" content="black">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="{{projectName}}">
   <link rel="apple-touch-icon" href="/icons/Icon-192.png">
 


### PR DESCRIPTION
As you can see here: https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html, the `meta` tag is missing a `-app`.