### PR TITLE
fix cupertino selection handle paint with transparent color 

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection.dart
@@ -260,26 +260,24 @@ class _TextSelectionHandlePainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    final Paint paint = Paint()
-        ..color = color
-        ..strokeWidth = 2.0;
-    canvas.drawCircle(
-      const Offset(_kSelectionHandleRadius, _kSelectionHandleRadius),
-      _kSelectionHandleRadius,
-      paint,
+    const double halfStrokeWidth = 1.0;
+    final Paint paint = Paint()..color = color;
+    final Rect circle = Rect.fromCircle(
+      center: const Offset(_kSelectionHandleRadius, _kSelectionHandleRadius),
+      radius: _kSelectionHandleRadius,
     );
-    // Draw line so it slightly overlaps the circle.
-    canvas.drawLine(
+    final Rect line = Rect.fromPoints(
       const Offset(
-        _kSelectionHandleRadius,
+        _kSelectionHandleRadius - halfStrokeWidth,
         2 * _kSelectionHandleRadius - _kSelectionHandleOverlap,
       ),
-      Offset(
-        _kSelectionHandleRadius,
-        size.height,
-      ),
-      paint,
+      Offset(_kSelectionHandleRadius + halfStrokeWidth, size.height),
     );
+    final Path path = Path()
+      ..addOval(circle)
+    // Draw line so it slightly overlaps the circle.
+      ..addRect(line);
+    canvas.drawPath(path, paint);
   }
 
   @override

--- a/packages/flutter/test/cupertino/text_selection_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_test.dart
@@ -62,4 +62,40 @@ void main() {
       expect(cupertinoTextSelectionControls.canSelectAll(key.currentState), false);
     });
   });
+
+  group('cupertino handles', () {
+    testWidgets('draws transparent handle correctly', (WidgetTester tester) async {
+      await tester.pumpWidget(RepaintBoundary(
+        child: CupertinoTheme(
+          data: const CupertinoThemeData(
+            primaryColor: Color(0x550000AA),
+          ),
+          child: Builder(
+            builder: (BuildContext context) {
+              return Container(
+                color: CupertinoColors.white,
+                height: 800,
+                width: 800,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 250),
+                  child: FittedBox(
+                    child: cupertinoTextSelectionControls.buildHandle(
+                      context,
+                      TextSelectionHandleType.right,
+                      10.0,
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      ));
+
+      await expectLater(
+        find.byType(RepaintBoundary),
+        matchesGoldenFile('transparent_handle.png'),
+      );
+    });
+  });
 }

--- a/packages/flutter/test/cupertino/text_selection_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_test.dart
@@ -94,7 +94,7 @@ void main() {
 
       await expectLater(
         find.byType(RepaintBoundary),
-        matchesGoldenFile('transparent_handle.png'),
+        matchesGoldenFile('text_selection.handle.transparent.png'),
       );
     });
   });


### PR DESCRIPTION
## Description

use single `drawPath` instead of `drawCircle`+`drawLine` to avoid increase of alpha at intersection
before:
![before](https://user-images.githubusercontent.com/14371067/73574320-06f2ee80-44a8-11ea-8e48-199411fc6c4e.png)

after:
![after](https://user-images.githubusercontent.com/14371067/73574323-09eddf00-44a8-11ea-8de9-cfd2563090f5.png)

## Related Issues
fixes #49907
similar issue fixed yesterday: #49825
## Tests

I added the following tests:
- golden test in `cupertino/text_selection_test.dart` which is almost the same as one in `test/material/text_selection_test.dart` from this PR #49830

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
