### PR TITLE
Image provider fix

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_aware_image_provider.dart
+++ b/packages/flutter/lib/src/widgets/scroll_aware_image_provider.dart
@@ -81,6 +81,7 @@ class ScrollAwareImageProvider<T> extends ImageProvider<T> {
     // Something else got this image into the cache. Return it.
     if (PaintingBinding.instance.imageCache.containsKey(key)) {
       imageProvider.resolveStreamForKey(configuration, stream, key, handleError);
+      return;
     }
     // The context has gone out of the tree - ignore it.
     if (context.context == null) {

--- a/packages/flutter/test/widgets/scroll_aware_image_provider_test.dart
+++ b/packages/flutter/test/widgets/scroll_aware_image_provider_test.dart
@@ -315,9 +315,13 @@ void main() {
     expect(imageCache.containsKey(testImageProvider), false);
     expect(imageCache.currentSize, 0);
 
+    // Simulate a case where somone else has managed to complete this stream -
+    // so it can land in the cache right before we stop scrolling fast.
+    // If we miss the early return, we will fail.
     testImageProvider.complete();
 
     imageCache.putIfAbsent(testImageProvider, () => testImageProvider.load(testImageProvider, PaintingBinding.instance.instantiateImageCodec));
+    // We've stopped scrolling fast.
     physics.recommendDeferredLoadingValue = false;
     await tester.idle();
 

--- a/packages/flutter/test/widgets/scroll_aware_image_provider_test.dart
+++ b/packages/flutter/test/widgets/scroll_aware_image_provider_test.dart
@@ -327,10 +327,6 @@ void main() {
 
     expect(imageCache.containsKey(testImageProvider), true);
     expect(imageCache.currentSize, 1);
-
-
-
-    expect(testImageProvider.configuration, null);
     expect(stream.completer, null);
   });
 }
@@ -364,6 +360,8 @@ class RecordingPhysics extends ScrollPhysics {
   }
 }
 
+// Ignore this so that we can mutate whether we defer loading or not at specific
+// times without worrying about actual scrolling mechanics.
 // ignore: must_be_immutable
 class ControllablePhysics extends ScrollPhysics {
   ControllablePhysics({ ScrollPhysics parent }) : super(parent: parent);

--- a/packages/flutter/test/widgets/scroll_aware_image_provider_test.dart
+++ b/packages/flutter/test/widgets/scroll_aware_image_provider_test.dart
@@ -13,8 +13,8 @@ void main() {
     imageCache.clear();
   });
 
-  RecordingPhysics _findPhysics(WidgetTester tester) {
-    return Scrollable.of(find.byType(TestWidget).evaluate().first).position.physics as RecordingPhysics;
+  T _findPhysics<T extends ScrollPhysics>(WidgetTester tester) {
+    return Scrollable.of(find.byType(TestWidget).evaluate().first).position.physics as T;
   }
 
   ScrollMetrics _findMetrics(WidgetTester tester) {
@@ -83,7 +83,7 @@ void main() {
     testImageProvider.complete();
 
     expect(imageCache.currentSize, 1);
-    expect(_findPhysics(tester).velocities, <double>[0]);
+    expect(_findPhysics<RecordingPhysics>(tester).velocities, <double>[0]);
   });
 
   testWidgets('ScrollAwareImageProvider does not delay if in scrollable that is scrolling slowly', (WidgetTester tester) async {
@@ -119,7 +119,7 @@ void main() {
       curve: Curves.fastLinearToSlowEaseIn,
     );
     await tester.pump();
-    final RecordingPhysics physics = _findPhysics(tester);
+    final RecordingPhysics physics = _findPhysics<RecordingPhysics>(tester);
 
     expect(physics.velocities.length, 0);
     final ImageStream stream = imageProvider.resolve(ImageConfiguration.empty);
@@ -177,7 +177,7 @@ void main() {
       curve: Curves.fastLinearToSlowEaseIn,
     );
     await tester.pump();
-    final RecordingPhysics physics = _findPhysics(tester);
+    final RecordingPhysics physics = _findPhysics<RecordingPhysics>(tester);
 
     expect(physics.velocities.length, 0);
     final ImageStream stream = imageProvider.resolve(ImageConfiguration.empty);
@@ -245,7 +245,7 @@ void main() {
       curve: Curves.fastLinearToSlowEaseIn,
     );
     await tester.pump();
-    final RecordingPhysics physics = _findPhysics(tester);
+    final RecordingPhysics physics = _findPhysics<RecordingPhysics>(tester);
 
     expect(physics.velocities.length, 0);
     final ImageStream stream = imageProvider.resolve(ImageConfiguration.empty);
@@ -281,6 +281,54 @@ void main() {
 
     expect(imageCache.currentSize, 0);
   });
+
+  testWidgets('ScrollAwareImageProvider resolves from ImageCache and does not set completer twice', (WidgetTester tester) async {
+    final GlobalKey<TestWidgetState> key = GlobalKey<TestWidgetState>();
+    final ScrollController scrollController = ScrollController();
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: SingleChildScrollView(
+        physics: ControllablePhysics(),
+        controller: scrollController,
+        child: TestWidget(key),
+      ),
+    ));
+
+    final DisposableBuildContext context = DisposableBuildContext(key.currentState);
+    const TestImage testImage = TestImage(width: 10, height: 10);
+    final TestImageProvider testImageProvider = TestImageProvider(testImage);
+    final ScrollAwareImageProvider<TestImageProvider> imageProvider = ScrollAwareImageProvider<TestImageProvider>(
+      context: context,
+      imageProvider: testImageProvider,
+    );
+
+    expect(testImageProvider.configuration, null);
+    expect(imageCache.containsKey(testImageProvider), false);
+
+    final ControllablePhysics physics = _findPhysics<ControllablePhysics>(tester);
+    physics.recommendDeferredLoadingValue = true;
+
+    final ImageStream stream = imageProvider.resolve(ImageConfiguration.empty);
+
+    expect(testImageProvider.configuration, null);
+    expect(stream.completer, null);
+    expect(imageCache.containsKey(testImageProvider), false);
+    expect(imageCache.currentSize, 0);
+
+    testImageProvider.complete();
+
+    imageCache.putIfAbsent(testImageProvider, () => testImageProvider.load(testImageProvider, PaintingBinding.instance.instantiateImageCodec));
+    physics.recommendDeferredLoadingValue = false;
+    await tester.idle();
+
+    expect(imageCache.containsKey(testImageProvider), true);
+    expect(imageCache.currentSize, 1);
+
+
+
+    expect(testImageProvider.configuration, null);
+    expect(stream.completer, null);
+  });
 }
 
 class TestWidget extends StatefulWidget {
@@ -309,5 +357,22 @@ class RecordingPhysics extends ScrollPhysics {
   bool recommendDeferredLoading(double velocity, ScrollMetrics metrics, BuildContext context) {
     velocities.add(velocity);
     return super.recommendDeferredLoading(velocity, metrics, context);
+  }
+}
+
+// ignore: must_be_immutable
+class ControllablePhysics extends ScrollPhysics {
+  ControllablePhysics({ ScrollPhysics parent }) : super(parent: parent);
+
+  bool recommendDeferredLoadingValue = false;
+
+  @override
+  ControllablePhysics applyTo(ScrollPhysics ancestor) {
+    return ControllablePhysics(parent: buildParent(ancestor));
+  }
+
+  @override
+  bool recommendDeferredLoading(double velocity, ScrollMetrics metrics, BuildContext context) {
+    return recommendDeferredLoadingValue;
   }
 }


### PR DESCRIPTION
## Description

Missing early return if the image cache had the image resulted in trying to set the completer multiple times - discovered on internal roll.

Adds the return and a test that fails without the return.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
