### PR TITLE
Fix custom Elements that wants to decorate State.build

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -4437,13 +4437,7 @@ class StatefulElement extends ComponentElement {
   }
 
   @override
-  Widget build() {
-    if (_didChangeDependencies) {
-      _state.didChangeDependencies();
-      _didChangeDependencies = false;
-    }
-    return state.build(this);
-  }
+  Widget build() => _state.build(this);
 
   /// The [State] instance associated with this location in the tree.
   ///
@@ -4491,6 +4485,15 @@ class StatefulElement extends ComponentElement {
       return true;
     }());
     super._firstBuild();
+  }
+
+  @override
+  void performRebuild() {
+    if (_didChangeDependencies) {
+      _state.didChangeDependencies();
+      _didChangeDependencies = false;
+    }
+    super.performRebuild();
   }
 
   @override

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -739,6 +739,7 @@ void main() {
     expect(state.didChangeDependenciesCount, 3);
     expect(state.deactivatedCount, 2);
   });
+
   testWidgets('StatefulElement subclass can decorate State.build', (WidgetTester tester) async {
     bool isDidChangeDependenciesDecorated;
     bool isBuildDecorated;
@@ -765,11 +766,17 @@ void main() {
 }
 
 class Decorate extends StatefulWidget {
-  const Decorate({Key key, this.didChangeDependencies, this.build}) : super(key: key);
+  const Decorate({
+    Key key,
+    @required this.didChangeDependencies,
+    @required this.build
+  }) :
+    assert(didChangeDependencies != null),
+    assert(build != null),
+    super(key: key);
 
   final void Function(bool isInBuild) didChangeDependencies;
   final void Function(bool isInBuild) build;
-
 
   @override
   _DecorateState createState() => _DecorateState();
@@ -798,12 +805,12 @@ class _DecorateState extends State<Decorate> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    widget.didChangeDependencies?.call((context as DecorateElement).isDecorated);
+    widget.didChangeDependencies.call((context as DecorateElement).isDecorated);
   }
   @override
   Widget build(covariant DecorateElement context) {
     context.dependOnInheritedWidgetOfExactType<Inherited>();
-    widget.build?.call(context.isDecorated);
+    widget.build.call(context.isDecorated);
     return Container();
   }
 }

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -739,6 +739,73 @@ void main() {
     expect(state.didChangeDependenciesCount, 3);
     expect(state.deactivatedCount, 2);
   });
+  testWidgets('StatefulElement subclass can decorate State.build', (WidgetTester tester) async {
+    bool isDidChangeDependenciesDecorated;
+    bool isBuildDecorated;
+
+    final Widget child = Decorate(
+      didChangeDependencies: (bool value) {
+        isDidChangeDependenciesDecorated = value;
+      },
+      build: (bool value) {
+        isBuildDecorated = value;
+      }
+    );
+
+    await tester.pumpWidget(Inherited(0, child: child));
+
+    expect(isBuildDecorated, isTrue);
+    expect(isDidChangeDependenciesDecorated, isFalse);
+
+    await tester.pumpWidget(Inherited(1, child: child));
+
+    expect(isBuildDecorated, isTrue);
+    expect(isDidChangeDependenciesDecorated, isFalse);
+  });
+}
+
+class Decorate extends StatefulWidget {
+  const Decorate({Key key, this.didChangeDependencies, this.build}) : super(key: key);
+
+  final void Function(bool isInBuild) didChangeDependencies;
+  final void Function(bool isInBuild) build;
+
+
+  @override
+  _DecorateState createState() => _DecorateState();
+
+  @override
+  DecorateElement createElement() => DecorateElement(this);
+}
+
+class DecorateElement extends StatefulElement {
+  DecorateElement(Decorate widget): super(widget);
+
+  bool isDecorated = false;
+
+  @override
+  Widget build() {
+    try {
+      isDecorated = true;
+      return super.build();
+    } finally {
+      isDecorated = false;
+    }
+  }
+}
+
+class _DecorateState extends State<Decorate> {
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    widget.didChangeDependencies?.call((context as DecorateElement).isDecorated);
+  }
+  @override
+  Widget build(covariant DecorateElement context) {
+    context.dependOnInheritedWidgetOfExactType<Inherited>();
+    widget.build?.call(context.isDecorated);
+    return Container();
+  }
 }
 
 class NullChildTest extends Widget {


### PR DESCRIPTION
## Description

With the recent changes on didChangeDependencies, it broke custom elements that override `StatefulElement.build`.

This extract `didChangeDependencies` from `StatefulElemement.build` to put it in a more reasonnable place.

## Related Issues

Fix to the issue described in https://github.com/flutter/flutter/pull/49527
## Tests

I added the following tests:

StatefulElement subclass can decorate State.build

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
