### PR TITLE
Add Gamepad support for the activation action

### DIFF
--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -847,6 +847,7 @@ class WidgetsApp extends StatefulWidget {
     // Activation
     LogicalKeySet(LogicalKeyboardKey.enter): const Intent(ActivateAction.key),
     LogicalKeySet(LogicalKeyboardKey.space): const Intent(ActivateAction.key),
+    LogicalKeySet(LogicalKeyboardKey.gameButtonA): const Intent(ActivateAction.key),
 
     // Keyboard traversal.
     LogicalKeySet(LogicalKeyboardKey.tab): const Intent(NextFocusAction.key),

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -96,6 +96,42 @@ void main() {
     expect(action.calls, equals(1));
   });
 
+  testWidgets('WidgetApp default activation key mappings work', (WidgetTester tester) async {
+    bool checked = false;
+    await tester.pumpWidget(
+      WidgetsApp(
+        key: key,
+        builder: (BuildContext context, Widget child) {
+          return Material(
+            child: Checkbox(
+              value: checked,
+              autofocus: true,
+              onChanged: (bool value) {
+                checked = value;
+              },
+            ),
+          );
+        },
+        color: const Color(0xFF123456),
+      ),
+    );
+
+    await tester.pump();
+
+    // Test three default buttons for the activation action
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+    expect(checked, isTrue);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.pumpAndSettle();
+    expect(checked, isFalse);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.gameButtonA);
+    await tester.pumpAndSettle();
+    expect(checked, isTrue);
+  });
+
   group('error control test', () {
     Future<void> expectFlutterError({
       GlobalKey<NavigatorState> key,

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -117,13 +118,18 @@ void main() {
     );
     await tester.pump();
 
-    // Test three default buttons for the activation action
-    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    // Test three default buttons for the activation action.
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
     await tester.pumpAndSettle();
     expect(checked, isTrue);
 
+    // Only space is used as an activation key on web.
+    if (kIsWeb) {
+      return;
+    }
+
     checked = false;
-    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
     await tester.pumpAndSettle();
     expect(checked, isTrue);
 

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -100,7 +100,6 @@ void main() {
     bool checked = false;
     await tester.pumpWidget(
       WidgetsApp(
-        key: key,
         builder: (BuildContext context, Widget child) {
           return Material(
             child: Checkbox(

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -98,6 +98,7 @@ void main() {
 
   testWidgets('WidgetsApp default activation key mappings work', (WidgetTester tester) async {
     bool checked = false;
+
     await tester.pumpWidget(
       WidgetsApp(
         builder: (BuildContext context, Widget child) {
@@ -114,19 +115,19 @@ void main() {
         color: const Color(0xFF123456),
       ),
     );
+    await tester.pump();
 
     // Test three default buttons for the activation action
-    await tester.pump();
     await tester.sendKeyEvent(LogicalKeyboardKey.enter);
     await tester.pumpAndSettle();
     expect(checked, isTrue);
 
-    await tester.pump();
+    checked = false;
     await tester.sendKeyEvent(LogicalKeyboardKey.space);
     await tester.pumpAndSettle();
-    expect(checked, isFalse);
+    expect(checked, isTrue);
 
-    await tester.pump();
+    checked = false;
     await tester.sendKeyEvent(LogicalKeyboardKey.gameButtonA);
     await tester.pumpAndSettle();
     expect(checked, isTrue);

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -96,7 +96,7 @@ void main() {
     expect(action.calls, equals(1));
   });
 
-  testWidgets('WidgetApp default activation key mappings work', (WidgetTester tester) async {
+  testWidgets('WidgetsApp default activation key mappings work', (WidgetTester tester) async {
     bool checked = false;
     await tester.pumpWidget(
       WidgetsApp(
@@ -115,17 +115,18 @@ void main() {
       ),
     );
 
-    await tester.pump();
-
     // Test three default buttons for the activation action
+    await tester.pump();
     await tester.sendKeyEvent(LogicalKeyboardKey.enter);
     await tester.pumpAndSettle();
     expect(checked, isTrue);
 
+    await tester.pump();
     await tester.sendKeyEvent(LogicalKeyboardKey.space);
     await tester.pumpAndSettle();
     expect(checked, isFalse);
 
+    await tester.pump();
     await tester.sendKeyEvent(LogicalKeyboardKey.gameButtonA);
     await tester.pumpAndSettle();
     expect(checked, isTrue);


### PR DESCRIPTION
## Description

In native apps, the <kbd>A</kbd> button on gamepads will trigger the activation action, e.g. when selecting semantic elements on the screen.

## Related Issues

 * Resolves #47697.

## Tests

I added the following tests:
 
 * Confirming that the default shortcut mapping properly works.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.