### PR TITLE
[flutter_tools] fix frontend server generated entrypoint

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -515,7 +515,7 @@ class _ExperimentalResidentWebRunner extends ResidentWebRunner {
           'import "$generatedImport";',
         'Future<void> main() async {',
         if (hasWebPlugins)
-          '  registerPlugins(webPluginRegistry);'
+          '  registerPlugins(webPluginRegistry);',
         '  await ui.webOnlyInitializePlatform();',
         '  entrypoint.main();',
         '}',


### PR DESCRIPTION
## Description

A  missing comma prevented webOnlyInitializePlatform from being called, stoping the frontend_server workflow from being launch-able. This PR adds the missing command and a basic expectation to the existing smoke unit test.

cc @vsmenon @jakemac53 