### PR TITLE
[flutter_tools] add missing period to end of filter

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -65,7 +65,7 @@ class GenSnapshot {
       // Filter out gen_snapshot's warning message about stripping debug symbols
       // from ELF library snapshots.
       const String kStripWarning = 'Warning: Generating ELF library without DWARF debugging information.';
-      const String kAssemblyStripWarning = 'Warning: Generating assembly code without DWARF debugging information';
+      const String kAssemblyStripWarning = 'Warning: Generating assembly code without DWARF debugging information.';
       outputFilter = (String line) => line != kStripWarning && line != kAssemblyStripWarning ? line : null;
     }
 


### PR DESCRIPTION
## Description

Output on module build:

```
jonahwilliams-macbookpro2:foo jonahwilliams$ flutter build ios-framework
Running "flutter pub get" in foo...                                 0.4s
Building frameworks for com.example.foo in debug mode...
 ├─Populating Flutter.framework...                                  0.2s
 ├─Adding placeholder App.framework for debug...                   155ms
 ├─Assembling Flutter resources for App.framework...                7.0s
 └─Moving to build/ios/framework/Debug                              0.0s
Building frameworks for com.example.foo in profile mode...
 ├─Populating Flutter.framework...                                  0.2s
 ├─Building Dart AOT for App.framework...                          20.0s
 ├─Assembling Flutter resources for App.framework...                0.1s
 └─Moving to build/ios/framework/Profile                            0.0s
Building frameworks for com.example.foo in release mode...
 ├─Populating Flutter.framework...                                  1.5s
 ├─Building Dart AOT for App.framework...                          16.2s
 ├─Assembling Flutter resources for App.framework...                0.1s
 └─Moving to build/ios/framework/Release                            0.0s
Frameworks written to /Users/jonahwilliams/Documents/foo/build/ios/framework.
```