### PR TITLE
Use the FlutterVersion defined in context

### DIFF
--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -226,7 +226,7 @@ class VMService {
     }
 
     _peer.registerMethod('flutterVersion', (rpc.Parameters params) async {
-      final FlutterVersion version = FlutterVersion();
+      final FlutterVersion version = context.get<FlutterVersion>() ?? FlutterVersion();
       final Map<String, Object> versionJson = version.toJson();
       versionJson['frameworkRevisionShort'] = version.frameworkRevisionShort;
       versionJson['engineRevisionShort'] = version.engineRevisionShort;

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/version.dart';
 import 'package:flutter_tools/src/vmservice.dart';
 import 'package:json_rpc_2/json_rpc_2.dart' as rpc;
 import 'package:mockito/mockito.dart';
@@ -20,6 +21,8 @@ import '../src/context.dart';
 import '../src/mocks.dart';
 
 class MockPeer implements rpc.Peer {
+
+  Function _versionFn = (dynamic _) => null;
 
   @override
   rpc.ErrorCallback get onUnhandledError => null;
@@ -52,6 +55,9 @@ class MockPeer implements rpc.Peer {
   @override
   void registerMethod(String name, Function callback) {
     registeredMethods.add(name);
+    if (name == 'flutterVersion') {
+      _versionFn = callback;
+    }
   }
 
   @override
@@ -157,6 +163,9 @@ class MockPeer implements rpc.Peer {
         ] : <dynamic>[],
       };
     }
+    if (method == 'flutterVersion') {
+      return _versionFn(parameters);
+    }
     return null;
   }
 
@@ -168,6 +177,7 @@ class MockPeer implements rpc.Peer {
 
 void main() {
   MockStdio mockStdio;
+  final MockFlutterVersion mockVersion = MockFlutterVersion();
   group('VMService', () {
 
     setUp(() {
@@ -316,7 +326,25 @@ void main() {
         platform: FakePlatform(),
       ),
     });
+
+    testUsingContext('returns correct FlutterVersion', () {
+      FakeAsync().run((FakeAsync time) async {
+        final MockPeer mockPeer = MockPeer();
+        VMService(mockPeer, null, null, null, null, null, MockDevice(), null);
+
+        expect(mockPeer.registeredMethods, contains('flutterVersion'));
+        expect(await mockPeer.sendRequest('flutterVersion'), equals(mockVersion.toJson()));
+      });
+    }, overrides: <Type, Generator>{
+      FlutterVersion: () => mockVersion,
+    });
   });
 }
 
 class MockDevice extends Mock implements Device {}
+
+class MockFlutterVersion extends Mock implements FlutterVersion {
+  @override
+  Map<String, Object> toJson() => const <String, Object>{'Mock': 'Version'};
+}
+

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -347,4 +347,3 @@ class MockFlutterVersion extends Mock implements FlutterVersion {
   @override
   Map<String, Object> toJson() => const <String, Object>{'Mock': 'Version'};
 }
-


### PR DESCRIPTION
 All usages of objects defined in `Context` should grab them from context instance first.