### PR TITLE
Remove dead code IMobileDevice.isWorking

### DIFF
--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -45,7 +45,6 @@ enum Artifact {
   iosDeploy,
   ideviceinfo,
   ideviceId,
-  idevicename,
   idevicesyslog,
   idevicescreenshot,
   ideviceinstaller,
@@ -113,8 +112,6 @@ String _artifactToFileName(Artifact artifact, [ TargetPlatform platform, BuildMo
       return 'ideviceinfo';
     case Artifact.ideviceId:
       return 'idevice_id';
-    case Artifact.idevicename:
-      return 'idevicename';
     case Artifact.idevicesyslog:
       return 'idevicesyslog';
     case Artifact.idevicescreenshot:
@@ -263,7 +260,6 @@ class CachedArtifacts extends Artifacts {
       case Artifact.ideviceinfo:
       case Artifact.idevicescreenshot:
       case Artifact.idevicesyslog:
-      case Artifact.idevicename:
         final String artifactFileName = _artifactToFileName(artifact);
         return _cache.getArtifactDirectory('libimobiledevice').childFile(artifactFileName).path;
       case Artifact.iosDeploy:
@@ -515,7 +511,6 @@ class LocalEngineArtifacts extends Artifacts {
         return _fileSystem.path.join(_hostEngineOutPath, 'dart-sdk', 'bin', 'snapshots', artifactFileName);
       case Artifact.ideviceId:
       case Artifact.ideviceinfo:
-      case Artifact.idevicename:
       case Artifact.idevicescreenshot:
       case Artifact.idevicesyslog:
         return _cache.getArtifactDirectory('libimobiledevice').childFile(artifactFileName).path;

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -89,13 +89,11 @@ class IMobileDevice {
   IMobileDevice()
       : _ideviceIdPath = globals.artifacts.getArtifactPath(Artifact.ideviceId, platform: TargetPlatform.ios),
         _ideviceinfoPath = globals.artifacts.getArtifactPath(Artifact.ideviceinfo, platform: TargetPlatform.ios),
-        _idevicenamePath = globals.artifacts.getArtifactPath(Artifact.idevicename, platform: TargetPlatform.ios),
         _idevicesyslogPath = globals.artifacts.getArtifactPath(Artifact.idevicesyslog, platform: TargetPlatform.ios),
         _idevicescreenshotPath = globals.artifacts.getArtifactPath(Artifact.idevicescreenshot, platform: TargetPlatform.ios);
 
   final String _ideviceIdPath;
   final String _ideviceinfoPath;
-  final String _idevicenamePath;
   final String _idevicesyslogPath;
   final String _idevicescreenshotPath;
 
@@ -112,56 +110,6 @@ class IMobileDevice {
     return _isInstalled;
   }
   bool _isInstalled;
-
-  /// Returns true if libimobiledevice is installed and working as expected.
-  ///
-  /// Older releases of libimobiledevice fail to work with iOS 10.3 and above.
-  Future<bool> get isWorking async {
-    if (_isWorking != null) {
-      return _isWorking;
-    }
-    if (!isInstalled) {
-      _isWorking = false;
-      return _isWorking;
-    }
-    // If usage info is printed in a hyphenated id, we need to update.
-    const String fakeIphoneId = '00008020-001C2D903C42002E';
-    final Map<String, String> executionEnv = Map<String, String>.fromEntries(
-      <MapEntry<String, String>>[globals.cache.dyLdLibEntry]
-    );
-    final ProcessResult ideviceResult = (await processUtils.run(
-      <String>[
-        _ideviceinfoPath,
-        '-u',
-        fakeIphoneId,
-      ],
-      environment: executionEnv,
-    )).processResult;
-    if ((ideviceResult.stdout as String).contains('Usage: ideviceinfo')) {
-      _isWorking = false;
-      return _isWorking;
-    }
-
-    // If no device is attached, we're unable to detect any problems. Assume all is well.
-    final ProcessResult result = (await processUtils.run(
-      <String>[
-        _ideviceIdPath,
-        '-l',
-      ],
-      environment: executionEnv,
-    )).processResult;
-    if (result.exitCode == 0 && (result.stdout as String).isEmpty) {
-      _isWorking = true;
-    } else {
-      // Check that we can look up the names of any attached devices.
-      _isWorking = await processUtils.exitsHappy(
-        <String>[_idevicenamePath],
-        environment: executionEnv,
-      );
-    }
-    return _isWorking;
-  }
-  bool _isWorking;
 
   Future<String> getAvailableDeviceIDs() async {
     try {

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -56,16 +56,6 @@ void main() {
       );
     });
 
-    testUsingContext('isWorking returns false if libimobiledevice is not installed', () async {
-      when(mockProcessManager.runSync(
-        <String>[ideviceIdPath, '-h'], environment: anyNamed('environment'),
-      )).thenReturn(ProcessResult(123, 1, '', ''));
-      expect(await globals.iMobileDevice.isWorking, false);
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-      Artifacts: () => mockArtifacts,
-    });
-
     testUsingContext('getAvailableDeviceIDs throws ToolExit when libimobiledevice is not installed', () async {
       when(mockProcessManager.run(
         <String>[ideviceIdPath, '-l'],


### PR DESCRIPTION
## Description

`IMobileDevice.isWorking` is dead code and was only referenced in a unit test.
Removing the dead getter also made `Artifacts.idevicename` dead, too.  Remove it.

## Tests

Deleted `isWorking` tests.  Nothing was testing `idevicename`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*