### PR TITLE
Revert "install goldctl in docker build"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,7 +23,6 @@ environment:
 # LINUX SHARDS
 task:
   container:
-    # https://cirrus-ci.org/guide/docker-builder-vm/#dockerfile-as-a-ci-environment
     dockerfile: "dev/ci/docker_linux/Dockerfile"
     cpu: $CPU
     memory: $MEMORY
@@ -36,7 +35,7 @@ task:
     CPU: 1 # 0.1-8 without compute credits, 0.1-30 with (yes, you can go fractional)
     MEMORY: 4G # 256M-24G without compute credits, 256M-90G with
     CIRRUS_WORKING_DIR: "/tmp/$FLUTTER_SDK_PATH_WITH_SPACE"
-    CIRRUS_DOCKER_CONTEXT: "dev/"
+    CIRRUS_DOCKER_CONTEXT: "dev/ci/docker_linux"
     PATH: "$CIRRUS_WORKING_DIR/bin:$CIRRUS_WORKING_DIR/bin/cache/dart-sdk/bin:$PATH"
     ANDROID_SDK_ROOT: "/opt/android_sdk"
   pub_cache:
@@ -76,8 +75,10 @@ task:
         # We use 3 CPUs because that's the minimum required to get framework_tests-widgets-linux
         # running fast enough that it is not the long pole, as of OCtober 2019.
         CPU: 3
+        GOLDCTL: "$CIRRUS_WORKING_DIR/depot_tools/goldctl"
         GOLD_SERVICE_ACCOUNT: ENCRYPTED[3afeea5ac7201151c3d0dc9648862f0462b5e4f55dc600ca8b692319622f7c3eda3d577b1b16cc2ef0311b7314c1c095]
       script:
+        - ./dev/bots/download_goldctl.sh
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: framework_tests-libraries-linux
@@ -87,8 +88,10 @@ task:
         # framework_tests-libraries-linux shard running fast enough that it is not the long pole, as
         # of October 2019.
         CPU: 3
+        GOLDCTL: "$CIRRUS_WORKING_DIR/depot_tools/goldctl"
         GOLD_SERVICE_ACCOUNT: ENCRYPTED[3afeea5ac7201151c3d0dc9648862f0462b5e4f55dc600ca8b692319622f7c3eda3d577b1b16cc2ef0311b7314c1c095]
       script:
+        - ./dev/bots/download_goldctl.sh
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: framework_tests-misc-linux
@@ -150,8 +153,10 @@ task:
         # As of October 2019, the Web shards needed more than 6G of RAM.
         CPU: 2
         MEMORY: 8G
+        GOLDCTL: "$CIRRUS_WORKING_DIR/depot_tools/goldctl"
         GOLD_SERVICE_ACCOUNT: ENCRYPTED[3afeea5ac7201151c3d0dc9648862f0462b5e4f55dc600ca8b692319622f7c3eda3d577b1b16cc2ef0311b7314c1c095]
       script:
+        - ./dev/bots/download_goldctl.sh
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: web_tests-1-linux
@@ -160,8 +165,10 @@ task:
         # As of October 2019, the Web shards needed more than 6G of RAM.
         CPU: 2
         MEMORY: 8G
+        GOLDCTL: "$CIRRUS_WORKING_DIR/depot_tools/goldctl"
         GOLD_SERVICE_ACCOUNT: ENCRYPTED[3afeea5ac7201151c3d0dc9648862f0462b5e4f55dc600ca8b692319622f7c3eda3d577b1b16cc2ef0311b7314c1c095]
       script:
+        - ./dev/bots/download_goldctl.sh
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: web_tests-2-linux
@@ -170,8 +177,10 @@ task:
         # As of October 2019, the Web shards needed more than 6G of RAM.
         CPU: 2
         MEMORY: 8G
+        GOLDCTL: "$CIRRUS_WORKING_DIR/depot_tools/goldctl"
         GOLD_SERVICE_ACCOUNT: ENCRYPTED[3afeea5ac7201151c3d0dc9648862f0462b5e4f55dc600ca8b692319622f7c3eda3d577b1b16cc2ef0311b7314c1c095]
       script:
+        - ./dev/bots/download_goldctl.sh
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: web_tests-3-linux
@@ -180,8 +189,10 @@ task:
         # As of October 2019, the Web shards needed more than 6G of RAM.
         CPU: 2
         MEMORY: 8G
+        GOLDCTL: "$CIRRUS_WORKING_DIR/depot_tools/goldctl"
         GOLD_SERVICE_ACCOUNT: ENCRYPTED[3afeea5ac7201151c3d0dc9648862f0462b5e4f55dc600ca8b692319622f7c3eda3d577b1b16cc2ef0311b7314c1c095]
       script:
+        - ./dev/bots/download_goldctl.sh
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: web_tests-4-linux
@@ -190,8 +201,10 @@ task:
         # As of October 2019, the Web shards needed more than 6G of RAM.
         CPU: 2
         MEMORY: 8G
+        GOLDCTL: "$CIRRUS_WORKING_DIR/depot_tools/goldctl"
         GOLD_SERVICE_ACCOUNT: ENCRYPTED[3afeea5ac7201151c3d0dc9648862f0462b5e4f55dc600ca8b692319622f7c3eda3d577b1b16cc2ef0311b7314c1c095]
       script:
+        - ./dev/bots/download_goldctl.sh
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: web_tests-5-linux
@@ -200,8 +213,10 @@ task:
         # As of October 2019, the Web shards needed more than 6G of RAM.
         CPU: 2
         MEMORY: 8G
+        GOLDCTL: "$CIRRUS_WORKING_DIR/depot_tools/goldctl"
         GOLD_SERVICE_ACCOUNT: ENCRYPTED[3afeea5ac7201151c3d0dc9648862f0462b5e4f55dc600ca8b692319622f7c3eda3d577b1b16cc2ef0311b7314c1c095]
       script:
+        - ./dev/bots/download_goldctl.sh
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: web_tests-6-linux
@@ -210,8 +225,10 @@ task:
         # As of October 2019, the Web shards needed more than 6G of RAM.
         CPU: 2
         MEMORY: 8G
+        GOLDCTL: "$CIRRUS_WORKING_DIR/depot_tools/goldctl"
         GOLD_SERVICE_ACCOUNT: ENCRYPTED[3afeea5ac7201151c3d0dc9648862f0462b5e4f55dc600ca8b692319622f7c3eda3d577b1b16cc2ef0311b7314c1c095]
       script:
+        - ./dev/bots/download_goldctl.sh
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: web_tests-7_last-linux # last Web shard must end with _last
@@ -220,8 +237,10 @@ task:
         # As of October 2019, the Web shards needed more than 6G of RAM.
         CPU: 2
         MEMORY: 8G
+        GOLDCTL: "$CIRRUS_WORKING_DIR/depot_tools/goldctl"
         GOLD_SERVICE_ACCOUNT: ENCRYPTED[3afeea5ac7201151c3d0dc9648862f0462b5e4f55dc600ca8b692319622f7c3eda3d577b1b16cc2ef0311b7314c1c095]
       script:
+        - ./dev/bots/download_goldctl.sh
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: build_tests-linux

--- a/dev/ci/docker_linux/Dockerfile
+++ b/dev/ci/docker_linux/Dockerfile
@@ -107,7 +107,7 @@ RUN dpkg-query -L nodejs
 RUN /usr/bin/npm --verbose install -g firebase-tools
 # TODO(dnfield): Remove this once Firebase has a fix upstream for
 # https://github.com/flutter/flutter/issues/34435
-COPY ci/docker_linux/patch_firebase.sh /root/patch_firebase.sh
+COPY patch_firebase.sh /root/patch_firebase.sh
 RUN /root/patch_firebase.sh
 
 # Install golang more recent than in repo (necessary for dashing to build)
@@ -124,18 +124,11 @@ RUN $GOBINARY get -u github.com/technosophos/dashing
 RUN locale-gen en_US "en_US.UTF-8" && dpkg-reconfigure locales
 ENV LANG en_US.UTF-8
 
-# Install fastlane via pinned Gemfile & Gemfile.lock
 # Skip all the documentation (-N) since it's just on CI.
 RUN gem install bundler -N
 
 # Gemfile last edited 1/6/2019 (update to trigger a rebuild of Docker image)
-COPY ci/docker_linux/Gemfile /Gemfile
-COPY ci/docker_linux/Gemfile.lock /Gemfile.lock
+COPY Gemfile /Gemfile
+COPY Gemfile.lock /Gemfile.lock
 
 RUN bundle install --system
-
-# Install goldctl, for Golden testing
-# Last updated 1/8/19 (update to rebuild Dockerfile with latest goldctl)
-COPY bots/download_goldctl.sh /download_goldctl.sh
-ENV GOLDCTL '/depot_tools/goldctl'
-RUN /download_goldctl.sh

--- a/dev/ci/docker_linux/docker_build.sh
+++ b/dev/ci/docker_linux/docker_build.sh
@@ -3,12 +3,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-# Capture the directory this script resides in
-SCRIPT_DIRECTORY="$(dirname $(readlink -f "$0"))"
-
-# Set context to flutter/dev
-CONTEXT="${SCRIPT_DIRECTORY}/../.."
-
 TAG="${CIRRUS_TAG:-latest}"
 
 # Convert "+" to "-" to make hotfix tags legal Docker tag names.
@@ -18,7 +12,4 @@ TAG=${TAG/+/-}
 # pull to make sure we are not rebuilding for nothing
 sudo docker pull "gcr.io/flutter-cirrus/build-flutter-image:$TAG"
 
-sudo docker build "$@" \
-  --tag "gcr.io/flutter-cirrus/build-flutter-image:$TAG" \
-  --file "$SCRIPT_DIRECTORY/Dockerfile" \
-  "$CONTEXT"
+sudo docker build "$@" --tag "gcr.io/flutter-cirrus/build-flutter-image:$TAG" .


### PR DESCRIPTION
Reverts flutter/flutter#46640

Speculative fix for flakiness discussed in https://github.com/flutter/flutter/issues/49917

Theory is that because goldctl is no longer getting the latest version on each run, the version currently used on linux is too stale and suffering from occasional bugs around authorization.  This is the primary difference right now between the Windows and Mac builds, which are not flaking similarly and are running on latest.