### PR TITLE
remove unnecessary string escapes

### DIFF
--- a/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
+++ b/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
@@ -183,16 +183,16 @@ public class DummyPluginAClass {
       const String kExpectedPluginsDependenciesContent =
         '['
           '{'
-            '\"name\":\"plugin_a\",'
-            '\"dependencies\":[\"plugin_b\",\"plugin_c\"]'
+            '"name":"plugin_a",'
+            '"dependencies":["plugin_b","plugin_c"]'
           '},'
           '{'
-            '\"name\":\"plugin_b\",'
-            '\"dependencies\":[]'
+            '"name":"plugin_b",'
+            '"dependencies":[]'
           '},'
           '{'
-            '\"name\":\"plugin_c\",'
-            '\"dependencies\":[]'
+            '"name":"plugin_c",'
+            '"dependencies":[]'
           '}'
         ']';
       final String graphString = json.encode(dependencyGraph);

--- a/dev/devicelab/lib/framework/running_processes.dart
+++ b/dev/devicelab/lib/framework/running_processes.dart
@@ -85,7 +85,7 @@ Stream<RunningProcessInfo> windowsRunningProcesses(String processName) async* {
   // a process.
   // See: https://docs.microsoft.com/en-us/windows/desktop/cimwin32prov/win32-process
   final String script = processName != null
-      ? '"Get-CimInstance Win32_Process -Filter \\\"name=\'$processName\'\\\" | Select-Object ProcessId,CreationDate,CommandLine | Format-Table -AutoSize | Out-String -Width 4096"'
+      ? '"Get-CimInstance Win32_Process -Filter \\"name=\'$processName\'\\" | Select-Object ProcessId,CreationDate,CommandLine | Format-Table -AutoSize | Out-String -Width 4096"'
       : '"Get-CimInstance Win32_Process | Select-Object ProcessId,CreationDate,CommandLine | Format-Table -AutoSize | Out-String -Width 4096"';
   // Unfortunately, there doesn't seem to be a good way to get ProcessManager to
   // run this. May be a bug in Dart.

--- a/examples/flutter_gallery/lib/demo/fortnightly/fortnightly.dart
+++ b/examples/flutter_gallery/lib/demo/fortnightly/fortnightly.dart
@@ -76,7 +76,7 @@ class FruitPage extends StatelessWidget {
   static final String paragraph2 = '''Pomegranates on the other hand have become
  almost ubiquitous. You can find its juice in any bodega, Walmart, and even some
  gas stations. But at what cost? The pomegranate juice craze of the aughts made
- \"megafarmers\" Lynda and Stewart Resnick billions. Unfortunately, it takes a lot
+ "megafarmers" Lynda and Stewart Resnick billions. Unfortunately, it takes a lot
  of water to make that much pomegranate juice. Water the Resnicks get from their
  majority stake in the Kern Water Bank. How did one family come to hold control
  over water meant for the whole central valley of California? The story will shock you.

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -602,9 +602,9 @@ class AndroidProject extends FlutterProjectPlatform {
   @override
   String get pluginConfigKey => AndroidPlugin.kConfigKey;
 
-  static final RegExp _applicationIdPattern = RegExp('^\\s*applicationId\\s+[\'\"](.*)[\'\"]\\s*\$');
-  static final RegExp _kotlinPluginPattern = RegExp('^\\s*apply plugin\:\\s+[\'\"]kotlin-android[\'\"]\\s*\$');
-  static final RegExp _groupPattern = RegExp('^\\s*group\\s+[\'\"](.*)[\'\"]\\s*\$');
+  static final RegExp _applicationIdPattern = RegExp('^\\s*applicationId\\s+[\'"](.*)[\'"]\\s*\$');
+  static final RegExp _kotlinPluginPattern = RegExp('^\\s*apply plugin\:\\s+[\'"]kotlin-android[\'"]\\s*\$');
+  static final RegExp _groupPattern = RegExp('^\\s*group\\s+[\'"](.*)[\'"]\\s*\$');
 
   /// The Gradle root directory of the Android host app. This is the directory
   /// containing the `app/` subdirectory and the `settings.gradle` file that


### PR DESCRIPTION
## Description

Remove unnecessary string escapes.

```dart
'this string contains 2 \"double quotes\" '; // BAD
'this string contains 2 "double quotes" '; // OK
```

## Related Issues

None

## Tests

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
