### PR TITLE
Don't download android nor ios artifacts

### DIFF
--- a/dev/bots/run_fuchsia_tests.sh
+++ b/dev/bots/run_fuchsia_tests.sh
@@ -74,8 +74,8 @@ find $flutter_dir -name ".packages" | xargs rm
 
 cd $flutter_dir/dev/benchmarks/test_apps/stocks/
 
-$flutter_bin precache --fuchsia
-$flutter_bin precache --flutter_runner
+$flutter_bin precache --fuchsia --no-android --no-ios
+$flutter_bin precache --flutter_runner --no-android --no-ios
 
 $flutter_bin pub get
 $flutter_bin drive -v --target=test_driver/stock_view.dart


### PR DESCRIPTION
These artifacts aren't needed for Fuchsia driver tests.