### PR TITLE
Fix Gold flake from gsutil fallback

### DIFF
--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -341,7 +341,8 @@ class AnimationController extends Animation<double>
   /// Stops the animation controller and sets the current value of the
   /// animation.
   ///
-  /// The new value is clamped to the range set by [lowerBound] and [upperBound].
+  /// The new value is clamped to the range set by [lowerBound] and
+  /// [upperBound].
   ///
   /// Value listeners are notified even if this does not change the value.
   /// Status listeners are notified if the animation was previously playing.

--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -142,13 +142,13 @@ abstract class FlutterGoldenFileComparator extends GoldenFileComparator {
       String suffix = '',
       bool onCirrus = false,
     }) {
+    const FileSystem fs = LocalFileSystem();
     if (onCirrus) {
-      return io.Directory.systemTemp.createTemp(
+      return fs.systemTempDirectory.childDirectory(
         'skia_goldens$suffix'
-      ) as Directory;
+      );
     }
 
-    const FileSystem fs = LocalFileSystem();
     final Directory flutterRoot = fs.directory(platform.environment[_kFlutterRootKey]);
     final Directory comparisonRoot = flutterRoot.childDirectory(
       fs.path.join(

--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -143,10 +143,9 @@ abstract class FlutterGoldenFileComparator extends GoldenFileComparator {
       bool onCirrus = false,
     }) {
     if (onCirrus) {
-      final Directory tempDirectory = io.Directory.systemTemp.createTemp(
+      return io.Directory.systemTemp.createTemp(
         'skia_goldens$suffix'
       ) as Directory;
-      return tempDirectory;
     }
 
     const FileSystem fs = LocalFileSystem();

--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -136,7 +136,19 @@ abstract class FlutterGoldenFileComparator extends GoldenFileComparator {
   /// maintain thread safety while using the `goldctl` tool.
   @protected
   @visibleForTesting
-  static Directory getBaseDirectory(LocalFileComparator defaultComparator, Platform platform, {String suffix = ''}) {
+  static Directory getBaseDirectory(
+    LocalFileComparator defaultComparator,
+    Platform platform, {
+      String suffix = '',
+      bool onCirrus = false,
+    }) {
+    if (onCirrus) {
+      final Directory tempDirectory = io.Directory.systemTemp.createTemp(
+        'skia_goldens$suffix'
+      ) as Directory;
+      return tempDirectory;
+    }
+
     const FileSystem fs = LocalFileSystem();
     final Directory flutterRoot = fs.directory(platform.environment[_kFlutterRootKey]);
     final Directory comparisonRoot = flutterRoot.childDirectory(
@@ -221,6 +233,7 @@ class FlutterSkiaGoldFileComparator extends FlutterGoldenFileComparator {
       defaultComparator,
       platform,
       suffix: '${math.Random().nextInt(10000)}',
+      onCirrus: platform.environment.containsKey('CIRRUS_CI'),
     );
     baseDirectory.createSync(recursive: true);
 
@@ -303,6 +316,7 @@ class FlutterPreSubmitFileComparator extends FlutterGoldenFileComparator {
       defaultComparator,
       platform,
       suffix: '${math.Random().nextInt(10000)}',
+      onCirrus: platform.environment.containsKey('CIRRUS_CI'),
     );
 
     if (!baseDirectory.existsSync())

--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -139,9 +139,9 @@ abstract class FlutterGoldenFileComparator extends GoldenFileComparator {
   static Directory getBaseDirectory(
     LocalFileComparator defaultComparator,
     Platform platform, {
-      String suffix = '',
-      bool local = false,
-    }) {
+    String suffix = '',
+    bool local = false,
+  }) {
     const FileSystem fs = LocalFileSystem();
     final Directory flutterRoot = fs.directory(platform.environment[_kFlutterRootKey]);
     Directory comparisonRoot;

--- a/packages/flutter_goldens/test/flutter_goldens_test.dart
+++ b/packages/flutter_goldens/test/flutter_goldens_test.dart
@@ -469,7 +469,7 @@ void main() {
       );
     });
 
-    test('calculates the basedir correctly from defaultComparator', () async {
+    test('calculates the basedir correctly from defaultComparator for local testing', () async {
       final MockLocalFileComparator defaultComparator = MockLocalFileComparator();
       final Directory flutterRoot = fs.directory(platform.environment['FLUTTER_ROOT'])
         ..createSync(recursive: true);
@@ -478,6 +478,7 @@ void main() {
       final Directory basedir = FlutterGoldenFileComparator.getBaseDirectory(
         defaultComparator,
         platform,
+        local: true,
       );
       expect(
         basedir.uri,

--- a/packages/flutter_goldens/test/flutter_goldens_test.dart
+++ b/packages/flutter_goldens/test/flutter_goldens_test.dart
@@ -43,10 +43,7 @@ void main() {
   setUp(() {
     fs = MemoryFileSystem();
     platform = FakePlatform(
-      environment: <String, String>{
-        'FLUTTER_ROOT': _kFlutterRoot,
-        'GOLD_SERVICE_ACCOUNT': 'service account',
-      },
+      environment: <String, String>{'FLUTTER_ROOT': _kFlutterRoot},
       operatingSystem: 'macos'
     );
     process = MockProcessManager();

--- a/packages/flutter_goldens/test/flutter_goldens_test.dart
+++ b/packages/flutter_goldens/test/flutter_goldens_test.dart
@@ -82,7 +82,7 @@ void main() {
       ));
     });
 
-    test('gsuti is checked when authorization file is present', () async {
+    test('gsutil is checked when authorization file is present', () async {
       final File authFile = fs.file('/workDirectory/temp/auth_opt.json')
         ..createSync(recursive: true);
       authFile.writeAsStringSync(authTemplate(gsutil: true));

--- a/packages/flutter_goldens/test/json_templates.dart
+++ b/packages/flutter_goldens/test/json_templates.dart
@@ -2,6 +2,18 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+String authTemplate({
+  bool gsutil = false,
+}) {
+  return '''
+    {
+      "Luci":false,
+      "ServiceAccount":"${gsutil ? '' : '/packages/flutter/test/widgets/serviceAccount.json'}",
+      "GSUtil":$gsutil
+    }
+  ''';
+}
+
 /// JSON response template for Skia Gold expectations request:
 /// https://flutter-gold.skia.org/json/expectations/commit/HEAD
 String rawExpectationsTemplate() {

--- a/packages/flutter_goldens/test/json_templates.dart
+++ b/packages/flutter_goldens/test/json_templates.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// JSON template for the contents of the auth_opt.json file created by goldctl.
 String authTemplate({
   bool gsutil = false,
 }) {

--- a/packages/flutter_goldens_client/lib/skia_client.dart
+++ b/packages/flutter_goldens_client/lib/skia_client.dart
@@ -98,7 +98,7 @@ class SkiaGoldClient {
   /// will only be called once for each instance of
   /// [FlutterSkiaGoldFileComparator].
   Future<void> auth() async {
-    if (_clientIsAuthorized())
+    if (await clientIsAuthorized())
       return;
 
     if (_serviceAccount.isEmpty) {
@@ -604,12 +604,15 @@ class SkiaGoldClient {
 
   /// Returns a boolean value to prevent the client from re-authorizing itself
   /// for multiple tests.
-  bool _clientIsAuthorized() {
+  Future<bool> clientIsAuthorized() async {
     final File authFile = workDirectory?.childFile(fs.path.join(
       'temp',
       'auth_opt.json',
     ));
-    return authFile.existsSync();
+    final String contents = await authFile.readAsString();
+    final Map<String, dynamic> decoded = json.decode(contents) as Map<String, dynamic>;
+    final bool usingGsutil = decoded['GSUtil'] as bool;
+    return await authFile.exists() && !usingGsutil;
   }
 }
 

--- a/packages/flutter_goldens_client/lib/skia_client.dart
+++ b/packages/flutter_goldens_client/lib/skia_client.dart
@@ -609,10 +609,13 @@ class SkiaGoldClient {
       'temp',
       'auth_opt.json',
     ));
-    final String contents = await authFile.readAsString();
-    final Map<String, dynamic> decoded = json.decode(contents) as Map<String, dynamic>;
-    final bool usingGsutil = decoded['GSUtil'] as bool;
-    return await authFile.exists() && !usingGsutil;
+
+    if(await authFile.exists()) {
+      final String contents = await authFile.readAsString();
+      final Map<String, dynamic> decoded = json.decode(contents) as Map<String, dynamic>;
+      return !(decoded['GSUtil'] as bool);
+    }
+    return false;
   }
 }
 


### PR DESCRIPTION
## Description

This fixes the flake in #49917 
The flake is caused by the fact that, for some PRs, an empty auth method is used in presubmit testing for contributors that cannot decrypt the service account. This empty auth method still creates an authorization file, although it is empty. This file was cached after the fact in a randomly generated folder. Later on, another PR may randomly choose the same directory and need authentication for tryjobs, but thinks it's already authenticated. 💣 💥 

Additional re-factoring is already scheduled here to support Luci testing, with the eventual goal of removing the need for a service account at all. That work is being tracked by #49837 and #49749. 

## Related Issues

Fixes #49917
Fixes #50148

## Tests

Client will re-authorize if gsutil is enabled

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
