### PR TITLE
Move the localization_utils camelCase function to LocaleInfo

### DIFF
--- a/dev/tools/localization/bin/gen_localizations.dart
+++ b/dev/tools/localization/bin/gen_localizations.dart
@@ -151,7 +151,7 @@ String generateArbBasedLocalizationSubclasses({
         output.writeln(generateClassDeclaration(
           scriptBaseLocale,
           generatedClassPrefix,
-          '$generatedClassPrefix${camelCase(languageLocale)}',
+          '$generatedClassPrefix${languageLocale.camelCase()}',
         ));
         output.writeln(generateConstructor(scriptBaseLocale));
         final Map<String, String> scriptResources = localeToResources[scriptBaseLocale];
@@ -175,7 +175,7 @@ String generateArbBasedLocalizationSubclasses({
           output.writeln(generateClassDeclaration(
             locale,
             generatedClassPrefix,
-            '$generatedClassPrefix${camelCase(scriptBaseLocale)}',
+            '$generatedClassPrefix${scriptBaseLocale.camelCase()}',
           ));
           output.writeln(generateConstructor(locale));
           final Map<String, String> localeResources = localeToResources[locale];
@@ -201,7 +201,7 @@ String generateArbBasedLocalizationSubclasses({
         output.writeln(generateClassDeclaration(
           locale,
           generatedClassPrefix,
-          '$generatedClassPrefix${camelCase(languageLocale)}',
+          '$generatedClassPrefix${languageLocale.camelCase()}',
         ));
         output.writeln(generateConstructor(locale));
         for (final String key in localeResources.keys) {
@@ -267,7 +267,7 @@ $factoryDeclaration
     if (languageToLocales[language].length == 1) {
       output.writeln('''
     case '$language':
-      return $generatedClassPrefix${camelCase(languageToLocales[language][0])}($factoryArguments);''');
+      return $generatedClassPrefix${(languageToLocales[language][0]).camelCase()}($factoryArguments);''');
     } else if (!languageToScriptCodes.containsKey(language)) { // Does not distinguish between scripts. Switch on countryCode directly.
       output.writeln('''
     case '$language': {
@@ -279,11 +279,11 @@ $factoryDeclaration
         final String countryCode = locale.countryCode;
         output.writeln('''
         case '$countryCode':
-          return $generatedClassPrefix${camelCase(locale)}($factoryArguments);''');
+          return $generatedClassPrefix${locale.camelCase()}($factoryArguments);''');
       }
       output.writeln('''
       }
-      return $generatedClassPrefix${camelCase(LocaleInfo.fromString(language))}($factoryArguments);
+      return $generatedClassPrefix${LocaleInfo.fromString(language).camelCase()}($factoryArguments);
     }''');
     } else { // Language has scriptCode, add additional switch logic.
       bool hasCountryCode = false;
@@ -309,7 +309,7 @@ $factoryDeclaration
             final String countryCode = locale.countryCode;
             output.writeln('''
             case '$countryCode':
-              return $generatedClassPrefix${camelCase(locale)}($factoryArguments);''');
+              return $generatedClassPrefix${locale.camelCase()}($factoryArguments);''');
           }
         }
         // Return a fallback locale that matches scriptCode, but not countryCode.
@@ -321,7 +321,7 @@ $factoryDeclaration
           }''');
           }
           output.writeln('''
-          return $generatedClassPrefix${camelCase(scriptLocale)}($factoryArguments);
+          return $generatedClassPrefix${scriptLocale.camelCase()}($factoryArguments);
         }''');
         } else {
           // Not Explicitly defined, fallback to first locale with the same language and
@@ -334,7 +334,7 @@ $factoryDeclaration
           }''');
             }
             output.writeln('''
-          return $generatedClassPrefix${camelCase(scriptLocale)}($factoryArguments);
+          return $generatedClassPrefix${scriptLocale.camelCase()}($factoryArguments);
         }''');
             break;
           }
@@ -354,13 +354,13 @@ $factoryDeclaration
           final String countryCode = locale.countryCode;
           output.writeln('''
         case '$countryCode':
-          return $generatedClassPrefix${camelCase(locale)}($factoryArguments);''');
+          return $generatedClassPrefix${locale.camelCase()}($factoryArguments);''');
         }
         output.writeln('''
       }''');
       }
       output.writeln('''
-      return $generatedClassPrefix${camelCase(LocaleInfo.fromString(language))}($factoryArguments);
+      return $generatedClassPrefix${LocaleInfo.fromString(language).camelCase()}($factoryArguments);
     }''');
     }
   }

--- a/dev/tools/localization/gen_cupertino_localizations.dart
+++ b/dev/tools/localization/gen_cupertino_localizations.dart
@@ -38,7 +38,7 @@ ConstructorGenerator generateCupertinoConstructor = (LocaleInfo locale) {
   /// Create an instance of the translation bundle for ${describeLocale(localeName)}.
   ///
   /// For details on the meaning of the arguments, see [GlobalCupertinoLocalizations].
-  const CupertinoLocalization${camelCase(locale)}({
+  const CupertinoLocalization${locale.camelCase()}({
     String localeName = '$localeName',
     @required intl.DateFormat fullYearFormat,
     @required intl.DateFormat dayFormat,

--- a/dev/tools/localization/gen_material_localizations.dart
+++ b/dev/tools/localization/gen_material_localizations.dart
@@ -38,7 +38,7 @@ ConstructorGenerator generateMaterialConstructor = (LocaleInfo locale) {
   /// Create an instance of the translation bundle for ${describeLocale(localeName)}.
   ///
   /// For details on the meaning of the arguments, see [GlobalMaterialLocalizations].
-  const MaterialLocalization${camelCase(locale)}({
+  const MaterialLocalization${locale.camelCase()}({
     String localeName = '$localeName',
     @required intl.DateFormat fullYearFormat,
     @required intl.DateFormat mediumDateFormat,

--- a/dev/tools/localization/localizations_utils.dart
+++ b/dev/tools/localization/localizations_utils.dart
@@ -112,6 +112,13 @@ class LocaleInfo implements Comparable<LocaleInfo> {
   final int length;             // The number of fields. Ranges from 1-3.
   final String originalString;  // Original un-parsed locale string.
 
+  String camelCase() {
+    return originalString
+      .split('_')
+      .map<String>((String part) => part.substring(0, 1).toUpperCase() + part.substring(1).toLowerCase())
+      .join('');
+  }
+
   @override
   bool operator ==(Object other) {
     return other is LocaleInfo
@@ -218,13 +225,6 @@ void checkCwdIsRepoRoot(String commandName) {
       'current working directory is: ${Directory.current.path}'
     );
   }
-}
-
-String camelCase(LocaleInfo locale) {
-  return locale.originalString
-    .split('_')
-    .map<String>((String part) => part.substring(0, 1).toUpperCase() + part.substring(1).toLowerCase())
-    .join('');
 }
 
 GeneratorOptions parseArgs(List<String> rawArgs) {
@@ -364,7 +364,7 @@ String generateClassDeclaration(
   String classNamePrefix,
   String superClass,
 ) {
-  final String camelCaseName = camelCase(locale);
+  final String camelCaseName = locale.camelCase();
   return '''
 
 /// The translations for ${describeLocale(locale.originalString)} (`${locale.originalString}`).


### PR DESCRIPTION
Make the camelCase() function, which could only be applied to a LocaleInfo object, a LocaleInfo method.

Trivial cleanup in anticipation of localization_utils.dart being a little more widely used.

The existing tests apply to this change.