### PR TITLE
Remove usages of StackTraceMapper

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/build_script.dart
+++ b/packages/flutter_tools/lib/src/build_runner/build_script.dart
@@ -268,7 +268,6 @@ import 'dart:js';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:test_api/src/backend/stack_trace_formatter.dart'; // ignore: implementation_imports
-import 'package:test_api/src/util/stack_trace_mapper.dart'; // ignore: implementation_imports
 import 'package:test_api/src/remote_listener.dart'; // ignore: implementation_imports
 import 'package:test_api/src/suite_channel_manager.dart'; // ignore: implementation_imports
 
@@ -289,12 +288,7 @@ Future<void> main() async {
 }
 
 void internalBootstrapBrowserTest(Function getMain()) {
-  var channel =
-      serializeSuite(getMain, hidePrints: false, beforeLoad: () async {
-    var serialized =
-        await suiteChannel("test.browser.mapper").stream.first as Map;
-    if (serialized == null) return;
-  });
+  var channel = serializeSuite(getMain, hidePrints: false);
   postMessageChannel().pipe(channel);
 }
 StreamChannel serializeSuite(Function getMain(),
@@ -334,16 +328,6 @@ StreamChannel postMessageChannel() {
     window.location.origin,
   ]);
   return controller.foreign;
-}
-
-void setStackTraceMapper(StackTraceMapper mapper) {
-  var formatter = StackTraceFormatter.current;
-  if (formatter == null) {
-    throw StateError(
-        'setStackTraceMapper() may only be called within a test worker.');
-  }
-
-  formatter.configure(mapper: mapper);
 }
 ''');
     }

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -22,7 +22,6 @@ import 'package:shelf_web_socket/shelf_web_socket.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:test_api/src/backend/runtime.dart';
 import 'package:test_api/src/backend/suite_platform.dart';
-import 'package:test_api/src/util/stack_trace_mapper.dart';
 import 'package:test_core/src/runner/configuration.dart';
 import 'package:test_core/src/runner/environment.dart';
 import 'package:test_core/src/runner/platform.dart';

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -301,9 +301,6 @@ class FlutterWebPlatform extends PlatformPlugin {
   final Map<Runtime, Future<BrowserManager>> _browserManagers =
       <Runtime, Future<BrowserManager>>{};
 
-  // Mappers for Dartifying stack traces, indexed by test path.
-  final Map<String, StackTraceMapper> _mappers = <String, StackTraceMapper>{};
-
   // A handler that serves wrapper files used to bootstrap tests.
   shelf.Response _wrapperHandler(shelf.Request request) {
     final String path = globals.fs.path.fromUri(request.url);
@@ -346,7 +343,7 @@ class FlutterWebPlatform extends PlatformPlugin {
             globals.fs.path.relative(path, from: globals.fs.path.join(_root, 'test'))) +
         '.html'));
     final RunnerSuite suite = await browserManager
-        .load(path, suiteUrl, suiteConfig, message, mapper: _mappers[path]);
+        .load(path, suiteUrl, suiteConfig, message);
     if (_closed) {
       return null;
     }
@@ -696,9 +693,8 @@ class BrowserManager {
     String path,
     Uri url,
     SuiteConfiguration suiteConfig,
-    Object message, {
-    StackTraceMapper mapper,
-  }) async {
+    Object message,
+  ) async {
     url = url.replace(fragment: Uri.encodeFull(jsonEncode(<String, Object>{
       'metadata': suiteConfig.metadata.serialize(),
       'browser': _runtime.identifier,
@@ -737,7 +733,6 @@ class BrowserManager {
       try {
         controller = deserializeSuite(path, SuitePlatform(Runtime.chrome),
             suiteConfig, await _environment, suiteChannel, message);
-        controller.channel('test.browser.mapper').sink.add(mapper?.serialize());
 
         _controllers.add(controller);
         return await controller.suite;


### PR DESCRIPTION
This class will be replaced with a function type in `test_api`, clean up
usages ahead of time.

In `build_script.dart` the only reference to `StackTraceMapper` is in
the `browser_test.dart` file, but since nothing would call
`setStackTraceMapper` from that import it should be safe to remove the
definition. After reading a serialized mapper from the
`test.browser.mapper` channel, it was ignored.

In `flutter_web_platform.dart` we only were reading from `_mappers`,
never putting values in, so we can remove it entirely. The `load()`
function was never called with a `mapper` argument.