### PR TITLE
Fix Path Separator in Service Workers

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -314,7 +314,7 @@ class WebServiceWorker extends Target {
       for (File file in contents)
         // Do not force caching of source maps.
         if (!file.path.endsWith('main.dart.js.map'))
-        '/${globals.fs.path.relative(file.path, from: environment.outputDir.path)}':
+        '/${globals.fs.path.toUri(globals.fs.path.relative(file.path, from: environment.outputDir.path)).toString()}':
           md5.convert(await file.readAsBytes()).toString(),
     };
     final File serviceWorkerFile = environment.outputDir

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -405,7 +405,7 @@ void main() {
   });
 
   test('WebServiceWorker generates a service_worker for a web resource folder', () => testbed.run(() async {
-    environment.outputDir.childFile('a/a.txt')
+    environment.outputDir.childDirectory('a').childFile('a.txt')
       ..createSync(recursive: true)
       ..writeAsStringSync('A');
     await const WebServiceWorker().build(environment);

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -405,7 +405,7 @@ void main() {
   });
 
   test('WebServiceWorker generates a service_worker for a web resource folder', () => testbed.run(() async {
-    environment.outputDir.childFile('a.txt')
+    environment.outputDir.childFile('a/a.txt')
       ..createSync(recursive: true)
       ..writeAsStringSync('A');
     await const WebServiceWorker().build(environment);
@@ -413,10 +413,10 @@ void main() {
     expect(environment.outputDir.childFile('flutter_service_worker.js'), exists);
     // Contains file hash.
     expect(environment.outputDir.childFile('flutter_service_worker.js').readAsStringSync(),
-      contains('"/a.txt": "7fc56270e7a70fa81a5935b72eacbe29"'));
+      contains('"/a/a.txt": "7fc56270e7a70fa81a5935b72eacbe29"'));
     expect(environment.buildDir.childFile('service_worker.d'), exists);
     // Depends on resource file.
-    expect(environment.buildDir.childFile('service_worker.d').readAsStringSync(), contains('a.txt'));
+    expect(environment.buildDir.childFile('service_worker.d').readAsStringSync(), contains('a/a.txt'));
   }));
 }
 


### PR DESCRIPTION
The path separator generated by `path.relative` varies depending on the operating system. Such generation can cause created service workers to have a back-slash in keys of `RESOURCES` instead of a forward-slash, which can cause strings to become improper, thus making the JavaScript file error creating.

This fix converts the generated path to URI again to create a string that is consistent across operating systems.