### PR TITLE
Make Annotation's localPosition relative to object

### DIFF
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -30,8 +30,8 @@ class AnnotationEntry<T> {
   /// The annotation object that is found.
   final T annotation;
 
-  /// The target location described by the local coordinate space of the layer
-  /// that contains the annotation.
+  /// The target location described by the local coordinate space of the
+  /// annotation object.
   final Offset localPosition;
 
   @override
@@ -2470,16 +2470,15 @@ class AnnotatedRegionLayer<T> extends ContainerLayer {
   /// met.
   final T value;
 
-  /// The size of an optional clipping rectangle, used to control whether a
-  /// position is contained by the annotation.
+  /// The size of the annotated object.
   ///
-  /// If [size] is provided, then the annotation is only added if the target
+  /// If [size] is provided, then the annotation is found only if the target
   /// position is contained by the rectangle formed by [size] and [offset].
   /// Otherwise no such restriction is applied, and clipping can only be done by
   /// the ancestor layers.
   final Size size;
 
-  /// The offset of the optional clipping rectangle that is indicated by [size].
+  /// The position of the annotated object.
   ///
   /// The [offset] defaults to [Offset.zero] if not provided, and is ignored if
   /// [size] is not set.
@@ -2549,7 +2548,7 @@ class AnnotatedRegionLayer<T> extends ContainerLayer {
       final S typedValue = untypedValue as S;
       result.add(AnnotationEntry<S>(
         annotation: typedValue,
-        localPosition: localPosition,
+        localPosition: localPosition - offset,
       ));
     }
     return isAbsorbed;

--- a/packages/flutter/test/rendering/layer_annotations_test.dart
+++ b/packages/flutter/test/rendering/layer_annotations_test.dart
@@ -690,7 +690,7 @@ void main() {
       root.findAllAnnotations<int>(position).entries.toList(),
       _equalToAnnotationResult<int>(<AnnotationEntry<int>>[
         const AnnotationEntry<int>(annotation: 2, localPosition: position),
-        const AnnotationEntry<int>(annotation: 1, localPosition: position),
+        const AnnotationEntry<int>(annotation: 1, localPosition: Offset(10, 10)),
         const AnnotationEntry<int>(annotation: 1000, localPosition: position),
       ]),
     );


### PR DESCRIPTION
## Description

This PR changes how `AnnotatedRegionLayer` calculates `AnnotationEntry.localPosition` from the position relative to the layer to the position relative to the annotation object. 

Using the position relative to the layer was a design mistake. The offset of the layer is meaningless, and is unreliable. For example, a `Transform` widget will draw on the same layer with an offset if the transform matrix is a simple translation, or push a dedicated `TransformLayer` if the matrix is non-trivial. The former case will keep the previous coordinate origin (for example, the top left corner of the app), while the latter case will move the position origin since it's on a new layer. 

Moreover, the major (if not only) use case of `AnnotatedRegionLayer` is for render objects or widget to mark a region. It is expected that the `localPosition` is the position relative to the region, which is represented in `AnnotatedRegionLayer` by `offset` and `size`, while how the search is implemented under the hood should be transparent.

This change is also a first step of [the "annotation tree" project](https://github.com/flutter/flutter/issues/49568), which plans to move the annotations from the layer tree into an independent tree. As a result, they will no longer have access to their relative position to any layers.

## Related Issues

- Part of https://github.com/flutter/flutter/issues/49568
- Prerequisite to https://github.com/flutter/flutter/issues/33675

## Tests

I _changed_ the following tests:

* AnnotatedRegionLayer.findAllAnnotations should clip its annotation using size and offset (positive)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] Yes, this is a breaking change.
   - [x] I wrote a design doc: https://flutter.dev/go/base-annotations-local-position-on-region
   - [x] I got input from the developer relations team, specifically from: sfshaza2
   - [x] I wrote a migration guide: https://github.com/flutter/website/pull/3673 ( https://flutter.dev/docs/release/breaking-changes/annotations-return-local-position-relative-to-object )

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
