### PR TITLE
unnecessary escapes fixes

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_attach_test_android.dart
+++ b/dev/devicelab/bin/tasks/flutter_attach_test_android.dart
@@ -128,7 +128,7 @@ void main() {
         // If the next line fails, your device may not support regexp search.
         final String observatoryLine = await device.adb(<String>['logcat', '-e', 'Observatory listening on http:', '-m', '1', '-T', currentTime]);
         print('Found observatory line: $observatoryLine');
-        final String observatoryUri = RegExp('Observatory listening on ((http|\\/\\/)[a-zA-Z0-9:/=_\\-\\.\\[\\]]+)').firstMatch(observatoryLine)[1];
+        final String observatoryUri = RegExp(r'Observatory listening on ((http|\/\/)[a-zA-Z0-9:/=_\-\.\[\]]+)').firstMatch(observatoryLine)[1];
         print('Extracted observatory port: $observatoryUri');
 
         section('Launching attach with given port');

--- a/dev/devicelab/bin/tasks/flutter_attach_test_android.dart
+++ b/dev/devicelab/bin/tasks/flutter_attach_test_android.dart
@@ -128,7 +128,7 @@ void main() {
         // If the next line fails, your device may not support regexp search.
         final String observatoryLine = await device.adb(<String>['logcat', '-e', 'Observatory listening on http:', '-m', '1', '-T', currentTime]);
         print('Found observatory line: $observatoryLine');
-        final String observatoryUri = RegExp(r'Observatory listening on ((http|\/\/)[a-zA-Z0-9:/=_\-\.\[\]]+)').firstMatch(observatoryLine)[1];
+        final String observatoryUri = RegExp(r'Observatory listening on ((http|//)[a-zA-Z0-9:/=_\-\.\[\]]+)').firstMatch(observatoryLine)[1];
         print('Extracted observatory port: $observatoryUri');
 
         section('Launching attach with given port');

--- a/dev/devicelab/bin/tasks/flutter_attach_test_android.dart
+++ b/dev/devicelab/bin/tasks/flutter_attach_test_android.dart
@@ -128,7 +128,7 @@ void main() {
         // If the next line fails, your device may not support regexp search.
         final String observatoryLine = await device.adb(<String>['logcat', '-e', 'Observatory listening on http:', '-m', '1', '-T', currentTime]);
         print('Found observatory line: $observatoryLine');
-        final String observatoryUri = RegExp('Observatory listening on ((http|\/\/)[a-zA-Z0-9:/=_\\-\.\\[\\]]+)').firstMatch(observatoryLine)[1];
+        final String observatoryUri = RegExp('Observatory listening on ((http|\\/\\/)[a-zA-Z0-9:/=_\\-\\.\\[\\]]+)').firstMatch(observatoryLine)[1];
         print('Extracted observatory port: $observatoryUri');
 
         section('Launching attach with given port');

--- a/dev/devicelab/bin/tasks/named_isolates_test.dart
+++ b/dev/devicelab/bin/tasks/named_isolates_test.dart
@@ -47,7 +47,7 @@ void main() {
     await device.shellExec('am', <String>['start', '-n', _kActivityId]);
     final String observatoryLine = await device.adb(<String>['logcat', '-e', 'Observatory listening on http:', '-m', '1', '-T', currentTime]);
     print('Found observatory line: $observatoryLine');
-    final String observatoryUri = RegExp(r'Observatory listening on ((http|\/\/)[a-zA-Z0-9:/=_\-\.\[\]]+)').firstMatch(observatoryLine)[1];
+    final String observatoryUri = RegExp(r'Observatory listening on ((http|//)[a-zA-Z0-9:/=_\-\.\[\]]+)').firstMatch(observatoryLine)[1];
     print('Extracted observatory port: $observatoryUri');
     final Process attachProcess =
       await _run(device: device, command: <String>['attach', '--debug-uri',

--- a/dev/devicelab/bin/tasks/named_isolates_test.dart
+++ b/dev/devicelab/bin/tasks/named_isolates_test.dart
@@ -47,7 +47,7 @@ void main() {
     await device.shellExec('am', <String>['start', '-n', _kActivityId]);
     final String observatoryLine = await device.adb(<String>['logcat', '-e', 'Observatory listening on http:', '-m', '1', '-T', currentTime]);
     print('Found observatory line: $observatoryLine');
-    final String observatoryUri = RegExp('Observatory listening on ((http|\\/\\/)[a-zA-Z0-9:/=_\\-\\.\\[\\]]+)').firstMatch(observatoryLine)[1];
+    final String observatoryUri = RegExp(r'Observatory listening on ((http|\/\/)[a-zA-Z0-9:/=_\-\.\[\]]+)').firstMatch(observatoryLine)[1];
     print('Extracted observatory port: $observatoryUri');
     final Process attachProcess =
       await _run(device: device, command: <String>['attach', '--debug-uri',

--- a/dev/devicelab/bin/tasks/named_isolates_test.dart
+++ b/dev/devicelab/bin/tasks/named_isolates_test.dart
@@ -47,7 +47,7 @@ void main() {
     await device.shellExec('am', <String>['start', '-n', _kActivityId]);
     final String observatoryLine = await device.adb(<String>['logcat', '-e', 'Observatory listening on http:', '-m', '1', '-T', currentTime]);
     print('Found observatory line: $observatoryLine');
-    final String observatoryUri = RegExp('Observatory listening on ((http|\/\/)[a-zA-Z0-9:/=_\\-\.\\[\\]]+)').firstMatch(observatoryLine)[1];
+    final String observatoryUri = RegExp('Observatory listening on ((http|\\/\\/)[a-zA-Z0-9:/=_\\-\\.\\[\\]]+)').firstMatch(observatoryLine)[1];
     print('Extracted observatory port: $observatoryUri');
     final Process attachProcess =
       await _run(device: device, command: <String>['attach', '--debug-uri',

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -589,7 +589,7 @@ String extractCloudAuthTokenArg(List<String> rawArgs) {
 final RegExp _obsRegExp =
   RegExp('An Observatory debugger .* is available at: ');
 final RegExp _obsPortRegExp = RegExp('(\\S+:(\\d+)/\\S*)\$');
-final RegExp _obsUriRegExp = RegExp('((http|\\/\\/)[a-zA-Z0-9:/=_\\-\\.\\[\\]]+)');
+final RegExp _obsUriRegExp = RegExp(r'((http|\/\/)[a-zA-Z0-9:/=_\-\.\[\]]+)');
 
 /// Tries to extract a port from the string.
 ///

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -589,7 +589,7 @@ String extractCloudAuthTokenArg(List<String> rawArgs) {
 final RegExp _obsRegExp =
   RegExp('An Observatory debugger .* is available at: ');
 final RegExp _obsPortRegExp = RegExp('(\\S+:(\\d+)/\\S*)\$');
-final RegExp _obsUriRegExp = RegExp(r'((http|\/\/)[a-zA-Z0-9:/=_\-\.\[\]]+)');
+final RegExp _obsUriRegExp = RegExp(r'((http|//)[a-zA-Z0-9:/=_\-\.\[\]]+)');
 
 /// Tries to extract a port from the string.
 ///

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -589,7 +589,7 @@ String extractCloudAuthTokenArg(List<String> rawArgs) {
 final RegExp _obsRegExp =
   RegExp('An Observatory debugger .* is available at: ');
 final RegExp _obsPortRegExp = RegExp('(\\S+:(\\d+)/\\S*)\$');
-final RegExp _obsUriRegExp = RegExp('((http|\/\/)[a-zA-Z0-9:/=_\\-\.\\[\\]]+)');
+final RegExp _obsUriRegExp = RegExp('((http|\\/\\/)[a-zA-Z0-9:/=_\\-\\.\\[\\]]+)');
 
 /// Tries to extract a port from the string.
 ///

--- a/dev/devicelab/lib/tasks/hot_mode_tests.dart
+++ b/dev/devicelab/lib/tasks/hot_mode_tests.dart
@@ -55,7 +55,7 @@ TaskFunction createHotModeTest({String deviceIdOverride, Map<String, String> env
               .transform<String>(utf8.decoder)
               .transform<String>(const LineSplitter())
               .listen((String line) {
-            if (line.contains('\] Reloaded ')) {
+            if (line.contains('] Reloaded ')) {
               if (hotReloadCount == 0) {
                 // Update the file and reload again.
                 final File appDartSource = file(path.join(
@@ -108,7 +108,7 @@ TaskFunction createHotModeTest({String deviceIdOverride, Map<String, String> env
               .transform<String>(utf8.decoder)
               .transform<String>(const LineSplitter())
               .listen((String line) {
-            if (line.contains('\] Reloaded ')) {
+            if (line.contains('] Reloaded ')) {
               process.stdin.writeln('q');
             }
             print('stdout: $line');

--- a/dev/devicelab/lib/tasks/run_without_leak.dart
+++ b/dev/devicelab/lib/tasks/run_without_leak.dart
@@ -32,7 +32,7 @@ TaskFunction createRunWithoutLeakTest(dynamic dir) {
           .transform<String>(utf8.decoder)
           .transform<String>(const LineSplitter())
           .listen((String line) {
-        if (line.contains('\] For a more detailed help message, press "h". To detach, press "d"; to quit, press "q"')) {
+        if (line.contains('] For a more detailed help message, press "h". To detach, press "d"; to quit, press "q"')) {
           process.stdin.writeln('q');
         }
         print('stdout: $line');

--- a/dev/tools/lib/roll_dev.dart
+++ b/dev/tools/lib/roll_dev.dart
@@ -168,7 +168,7 @@ String getFullTag() {
 }
 
 Match parseFullTag(String version) {
-  final RegExp versionPattern = RegExp('^v([0-9]+)\.([0-9]+)\.([0-9]+)-([0-9]+)-g([a-f0-9]+)\$');
+  final RegExp versionPattern = RegExp(r'^v([0-9]+)\.([0-9]+)\.([0-9]+)-([0-9]+)-g([a-f0-9]+)$');
   return versionPattern.matchAsPrefix(version);
 }
 

--- a/dev/tools/localization/bin/gen_missing_localizations.dart
+++ b/dev/tools/localization/bin/gen_missing_localizations.dart
@@ -75,7 +75,7 @@ bool isPluralVariation(String key, Map<String, dynamic> bundle) {
 
 void updateMissingResources(String localizationPath, String groupPrefix) {
   final Directory localizationDir = Directory(localizationPath);
-  final RegExp filenamePattern = RegExp('${groupPrefix}_(\\w+)\.arb');
+  final RegExp filenamePattern = RegExp('${groupPrefix}_(\\w+)\\.arb');
 
   final Set<String> requiredKeys = resourceKeys(loadBundle(File(path.join(localizationPath, '${groupPrefix}_en.arb'))));
 

--- a/dev/tools/localization/gen_l10n_templates.dart
+++ b/dev/tools/localization/gen_l10n_templates.dart
@@ -66,8 +66,8 @@ import 'messages_all.dart';
 /// Callers can lookup localized strings with an instance of @(className) returned
 /// by `@(className).of(context)`.
 ///
-/// Applications need to include `@(className).delegate()` in their app\'s
-/// localizationDelegates list, and the locales they support in the app\'s
+/// Applications need to include `@(className).delegate()` in their app's
+/// localizationDelegates list, and the locales they support in the app's
 /// supportedLocales list. For example:
 ///
 /// ```

--- a/dev/tools/test/localization/gen_l10n_test.dart
+++ b/dev/tools/test/localization/gen_l10n_test.dart
@@ -952,12 +952,12 @@ void main() {
       return Intl.plural(
         count,
       locale: _localeName,
-      name: \'helloWorlds\',
+      name: 'helloWorlds',
       args: <Object>[count, currentDate],
-      one: \'Hello World, today is \${currentDateString}\',
-      two: \'Hello two worlds, today is \${currentDateString}\',
-      many: \'Hello all \${count} worlds, today is \${currentDateString}\',
-      other: \'Hello other \${count} worlds, today is \${currentDateString}\'
+      one: 'Hello World, today is \${currentDateString}',
+      two: 'Hello two worlds, today is \${currentDateString}',
+      many: 'Hello all \${count} worlds, today is \${currentDateString}',
+      other: 'Hello other \${count} worlds, today is \${currentDateString}'
       );
     }
     return helloWorlds(count, currentDateString);
@@ -1334,12 +1334,12 @@ void main() {
       return Intl.plural(
         count,
       locale: _localeName,
-      name: \'helloWorlds\',
+      name: 'helloWorlds',
       args: <Object>[count, currentDate],
-      one: \'Hello World, today is \${currentDateString}\',
-      two: \'Hello two worlds, today is \${currentDateString}\',
-      many: \'Hello all \${count} worlds, today is \${currentDateString}\',
-      other: \'Hello other \${count} worlds, today is \${currentDateString}\'
+      one: 'Hello World, today is \${currentDateString}',
+      two: 'Hello two worlds, today is \${currentDateString}',
+      many: 'Hello all \${count} worlds, today is \${currentDateString}',
+      other: 'Hello other \${count} worlds, today is \${currentDateString}'
       );
     }
     return helloWorlds(count, currentDateString);
@@ -1393,12 +1393,12 @@ void main() {
       return Intl.plural(
         count,
       locale: _localeName,
-      name: \'helloWorlds\',
+      name: 'helloWorlds',
       args: <Object>[count, population],
-      one: \'Hello World of \${populationString} citizens\',
-      two: \'Hello two worlds with \${populationString} total citizens\',
-      many: \'Hello all \${count} worlds, with a total of \${populationString} citizens\',
-      other: \'Hello other \${count} worlds, with a total of \${populationString} citizens\'
+      one: 'Hello World of \${populationString} citizens',
+      two: 'Hello two worlds with \${populationString} total citizens',
+      many: 'Hello all \${count} worlds, with a total of \${populationString} citizens',
+      other: 'Hello other \${count} worlds, with a total of \${populationString} citizens'
       );
     }
     return helloWorlds(count, populationString);

--- a/dev/tools/vitool/lib/vitool.dart
+++ b/dev/tools/vitool/lib/vitool.dart
@@ -292,7 +292,7 @@ class SvgPath {
   final List<SvgPathCommand> commands;
   final double opacity;
 
-  static const String _pathCommandAtom = ' *([a-zA-Z]) *([\-\.0-9 ,]*)';
+  static const String _pathCommandAtom = r' *([a-zA-Z]) *([\-\.0-9 ,]*)';
   static final RegExp _pathCommandValidator = RegExp('^($_pathCommandAtom)*\$');
   static final RegExp _pathCommandMatcher = RegExp(_pathCommandAtom);
 

--- a/examples/flutter_gallery/lib/demo/fortnightly/fortnightly.dart
+++ b/examples/flutter_gallery/lib/demo/fortnightly/fortnightly.dart
@@ -66,11 +66,11 @@ class ShortAppBar extends StatelessWidget {
 }
 
 class FruitPage extends StatelessWidget {
-  static final String paragraph1 = '''Have you ever held a quince? It\'s strange;
- covered in a fuzz somewhere between peach skin and a spider web. And it\'s
- hard as soft lumber. You\'d be forgiven for thinking it\'s veneered Larch-wood.
- But inhale the aroma and you\'ll instantly know you have something wonderful.
- Its scent can fill a room for days. And all this before you\'ve even cooked it.
+  static final String paragraph1 = '''Have you ever held a quince? It's strange;
+ covered in a fuzz somewhere between peach skin and a spider web. And it's
+ hard as soft lumber. You'd be forgiven for thinking it's veneered Larch-wood.
+ But inhale the aroma and you'll instantly know you have something wonderful.
+ Its scent can fill a room for days. And all this before you've even cooked it.
 '''.replaceAll('\n', '');
 
   static final String paragraph2 = '''Pomegranates on the other hand have become

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -642,7 +642,7 @@ ${globals.terminal.bolden('Consuming the Module')}
 
   for (final String buildMode in buildModes) {
     globals.printStatus('''
-      ${buildMode}Implementation \'$androidPackage:flutter_$buildMode:$buildNumber\'''');
+      ${buildMode}Implementation '$androidPackage:flutter_$buildMode:$buildNumber\'''');
   }
 
   globals.printStatus('''

--- a/packages/flutter_tools/lib/src/android/gradle_utils.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_utils.dart
@@ -128,7 +128,7 @@ distributionUrl=https\\://services.gradle.org/distributions/gradle-$gradleVersio
 }
 const String _defaultGradleVersion = '5.6.2';
 
-final RegExp _androidPluginRegExp = RegExp('com\.android\.tools\.build\:gradle\:(\\d+\.\\d+\.\\d+\)');
+final RegExp _androidPluginRegExp = RegExp('com\\.android\\.tools\\.build:gradle:\\(\\d+\\.\\d+\\.\\d+\\)');
 
 /// Returns the Gradle version that the current Android plugin depends on when found,
 /// otherwise it returns a default version.

--- a/packages/flutter_tools/lib/src/android/gradle_utils.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_utils.dart
@@ -128,7 +128,7 @@ distributionUrl=https\\://services.gradle.org/distributions/gradle-$gradleVersio
 }
 const String _defaultGradleVersion = '5.6.2';
 
-final RegExp _androidPluginRegExp = RegExp('com\\.android\\.tools\\.build:gradle:\\(\\d+\\.\\d+\\.\\d+\\)');
+final RegExp _androidPluginRegExp = RegExp(r'com\.android\.tools\.build:gradle:\(\d+\.\d+\.\d+\)');
 
 /// Returns the Gradle version that the current Android plugin depends on when found,
 /// otherwise it returns a default version.

--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -350,7 +350,7 @@ List<String> _wrapTextAsLines(String text, { int start = 0, int columnWidth, @re
   // reconstitute the original string. This is useful for manipulating "visible"
   // characters in the presence of ANSI control codes.
   List<_AnsiRun> splitWithCodes(String input) {
-    final RegExp characterOrCode = RegExp('(\u001b[[0-9;]*m|.)', multiLine: true);
+    final RegExp characterOrCode = RegExp('(\u001b\\[[0-9;]*m|.)', multiLine: true);
     List<_AnsiRun> result = <_AnsiRun>[];
     final StringBuffer current = StringBuffer();
     for (final Match match in characterOrCode.allMatches(input)) {

--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -350,7 +350,7 @@ List<String> _wrapTextAsLines(String text, { int start = 0, int columnWidth, @re
   // reconstitute the original string. This is useful for manipulating "visible"
   // characters in the presence of ANSI control codes.
   List<_AnsiRun> splitWithCodes(String input) {
-    final RegExp characterOrCode = RegExp('(\u001b\[[0-9;]*m|.)', multiLine: true);
+    final RegExp characterOrCode = RegExp('(\u001b[[0-9;]*m|.)', multiLine: true);
     List<_AnsiRun> result = <_AnsiRun>[];
     final StringBuffer current = StringBuffer();
     for (final Match match in characterOrCode.allMatches(input)) {

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -82,7 +82,7 @@ class _FuchsiaLogReader extends DeviceLogReader {
     // the correct fuchsia module.
     final RegExp matchRegExp = _app == null
         ? _flutterLogOutput
-        : RegExp('INFO: ${_app.name}(\.cmx)?\\(flutter\\): ');
+        : RegExp('INFO: ${_app.name}(\\.cmx)?\\(flutter\\): ');
     return Stream<String>.eventTransformed(
       lines,
       (EventSink<String> output) => _FuchsiaLogSink(output, matchRegExp, startTime),

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -603,7 +603,7 @@ class AndroidProject extends FlutterProjectPlatform {
   String get pluginConfigKey => AndroidPlugin.kConfigKey;
 
   static final RegExp _applicationIdPattern = RegExp('^\\s*applicationId\\s+[\'"](.*)[\'"]\\s*\$');
-  static final RegExp _kotlinPluginPattern = RegExp('^\\s*apply plugin\:\\s+[\'"]kotlin-android[\'"]\\s*\$');
+  static final RegExp _kotlinPluginPattern = RegExp('^\\s*apply plugin\\:\\s+[\'"]kotlin-android[\'"]\\s*\$');
   static final RegExp _groupPattern = RegExp('^\\s*group\\s+[\'"](.*)[\'"]\\s*\$');
 
   /// The Gradle root directory of the Android host app. This is the directory

--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -94,7 +94,7 @@ class ProtocolDiscovery {
   }
 
   Match _getPatternMatch(String line) {
-    final RegExp r = RegExp('${RegExp.escape(serviceName)} listening on ((http|\\/\\/)[a-zA-Z0-9:/=_\\-\\.\\[\\]]+)');
+    final RegExp r = RegExp(RegExp.escape(serviceName) + r' listening on ((http|\/\/)[a-zA-Z0-9:/=_\-\.\[\]]+)');
     return r.firstMatch(line);
   }
 

--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -94,7 +94,7 @@ class ProtocolDiscovery {
   }
 
   Match _getPatternMatch(String line) {
-    final RegExp r = RegExp(RegExp.escape(serviceName) + r' listening on ((http|\/\/)[a-zA-Z0-9:/=_\-\.\[\]]+)');
+    final RegExp r = RegExp(RegExp.escape(serviceName) + r' listening on ((http|//)[a-zA-Z0-9:/=_\-\.\[\]]+)');
     return r.firstMatch(line);
   }
 

--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -94,7 +94,7 @@ class ProtocolDiscovery {
   }
 
   Match _getPatternMatch(String line) {
-    final RegExp r = RegExp('${RegExp.escape(serviceName)} listening on ((http|\/\/)[a-zA-Z0-9:/=_\\-\.\\[\\]]+)');
+    final RegExp r = RegExp('${RegExp.escape(serviceName)} listening on ((http|\\/\\/)[a-zA-Z0-9:/=_\\-\\.\\[\\]]+)');
     return r.firstMatch(line);
   }
 

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -193,7 +193,7 @@ class WebDevices extends PollingDeviceDiscovery {
 
 @visibleForTesting
 String parseVersionForWindows(String input) {
-  return input.split(RegExp('\w')).last;
+  return input.split(RegExp(r'\w')).last;
 }
 
 

--- a/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
@@ -408,7 +408,7 @@ class FuchsiaRemoteConnection {
     // loopback device, so connecting to the IPv4 loopback would fail when the
     // target address is IPv6 link-local.
     final String addr = _useIpV6Loopback
-        ? 'http://\[$_ipv6Loopback\]:$port'
+        ? 'http://[$_ipv6Loopback]:$port'
         : 'http://$_ipv4Loopback:$port';
     final Uri uri = Uri.parse(addr);
     return uri;


### PR DESCRIPTION
## Description

Follow-up on #50096 with more checks.

## Related Issues

None

## Tests

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
