### PR TITLE
Expose InputDecoration to customize TextField in SearchDelegate

### DIFF
--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -201,6 +201,25 @@ abstract class SearchDelegate<T> {
     );
   }
 
+  /// The decoration used to style the [TextField].
+  ///
+  /// See also:
+  ///
+  ///  * [InputDecoration.border], which is set to [InputBorder.none].
+  ///  * [InputDecoration.hintText], which is set to [searchFieldLabel].
+  ///  * [InputDecoration.hintText], which is set to [ThemeData.inputDecorationTheme.hintStyle].
+    InputDecoration inputDecoration(BuildContext context) {
+    assert(context != null);
+    final InputDecoration inputDecoration = InputDecoration();
+    assert(inputDecoration != null);
+    final ThemeData theme = Theme.of(context);
+    assert(theme != null);
+    return inputDecoration.copyWith(
+      border: InputBorder.none,
+      hintText: searchFieldLabel,
+      hintStyle: theme.inputDecorationTheme.hintStyle,
+    );
+  }
   /// The current query string shown in the [AppBar].
   ///
   /// The user manipulates this string via the keyboard.
@@ -467,6 +486,7 @@ class _SearchPageState<T> extends State<_SearchPage<T>> {
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterialLocalizations(context));
     final ThemeData theme = widget.delegate.appBarTheme(context);
+    final InputDecoration inputDecoration = widget.delegate.inputDecoration(context);
     final String searchFieldLabel = widget.delegate.searchFieldLabel
       ?? MaterialLocalizations.of(context).searchFieldLabel;
     Widget body;
@@ -516,11 +536,7 @@ class _SearchPageState<T> extends State<_SearchPage<T>> {
             onSubmitted: (String _) {
               widget.delegate.showResults(context);
             },
-            decoration: InputDecoration(
-              border: InputBorder.none,
-              hintText: searchFieldLabel,
-              hintStyle: theme.inputDecorationTheme.hintStyle,
-            ),
+            decoration: inputDecoration,
           ),
           actions: widget.delegate.buildActions(context),
         ),


### PR DESCRIPTION
## Description

This PR adds ability to override InputDecoration for the SearchDelegate's TextField. This way it provides customization.

## Related Issues

https://github.com/flutter/flutter/issues/45498
https://github.com/flutter/flutter/issues/34127 (Only the hintText part)

## Tests

I added the following tests:


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
