### PR TITLE
Retry Gradle command when failing to download a resource

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -108,6 +108,7 @@ final GradleHandledError networkErrorHandler = GradleHandledError(
     'javax.net.ssl.SSLHandshakeException: Remote host closed connection during handshake',
     'java.net.SocketException: Connection reset',
     'java.io.FileNotFoundException',
+    'Gateway Time-out'
   ]),
   handler: ({
     String line,
@@ -116,8 +117,8 @@ final GradleHandledError networkErrorHandler = GradleHandledError(
     bool shouldBuildPluginAsAar,
   }) async {
     globals.printError(
-      '$warningMark Gradle threw an error while trying to update itself. '
-      'Retrying the update...'
+      '$warningMark Gradle threw an error while downloading artifacts from the network. '
+      'Retrying to download...'
     );
     return GradleBuildStatus.retry;
   },

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -39,7 +39,7 @@ void main() {
   });
 
   group('network errors', () {
-    testUsingContext('throws toolExit if gradle fails while downloading', () async {
+    testUsingContext('retries if gradle fails while downloading', () async {
       const String errorMessage = '''
 Exception in thread "main" java.io.FileNotFoundException: https://downloads.gradle.org/distributions/gradle-4.1.1-all.zip
 at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1872)
@@ -59,13 +59,13 @@ at org.gradle.wrapper.GradleWrapperMain.main(GradleWrapperMain.java:61)''';
 
       expect(testLogger.errorText,
         contains(
-          'Gradle threw an error while trying to update itself. '
-          'Retrying the update...'
+          'Gradle threw an error while downloading artifacts from the network. '
+          'Retrying to download...'
         )
       );
     });
 
-    testUsingContext('throw toolExit if gradle fails downloading with proxy error', () async {
+    testUsingContext('retries if gradle fails downloading with proxy error', () async {
       const String errorMessage = '''
 Exception in thread "main" java.io.IOException: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 400 Bad Request"
 at sun.net.www.protocol.http.HttpURLConnection.doTunneling(HttpURLConnection.java:2124)
@@ -87,13 +87,13 @@ at org.gradle.wrapper.GradleWrapperMain.main(GradleWrapperMain.java:61)''';
 
       expect(testLogger.errorText,
         contains(
-          'Gradle threw an error while trying to update itself. '
-          'Retrying the update...'
+          'Gradle threw an error while downloading artifacts from the network. '
+          'Retrying to download...'
         )
       );
     });
 
-    testUsingContext('throws toolExit if gradle times out waiting for exclusive access to zip', () async {
+    testUsingContext('retries if gradle times out waiting for exclusive access to zip', () async {
       const String errorMessage = '''
 Exception in thread "main" java.lang.RuntimeException: Timeout of 120000 reached waiting for exclusive access to file: /User/documents/gradle-5.6.2-all.zip
 	at org.gradle.wrapper.ExclusiveFileAccessManager.access(ExclusiveFileAccessManager.java:61)
@@ -106,13 +106,13 @@ Exception in thread "main" java.lang.RuntimeException: Timeout of 120000 reached
 
       expect(testLogger.errorText,
         contains(
-          'Gradle threw an error while trying to update itself. '
-          'Retrying the update...'
+          'Gradle threw an error while downloading artifacts from the network. '
+          'Retrying to download...'
         )
       );
     });
 
-    testUsingContext('throws toolExit if remote host closes connection', () async {
+    testUsingContext('retries if remote host closes connection', () async {
       const String errorMessage = '''
 Downloading https://services.gradle.org/distributions/gradle-5.6.2-all.zip
 Exception in thread "main" javax.net.ssl.SSLHandshakeException: Remote host closed connection during handshake
@@ -141,13 +141,13 @@ Exception in thread "main" javax.net.ssl.SSLHandshakeException: Remote host clos
 
       expect(testLogger.errorText,
         contains(
-          'Gradle threw an error while trying to update itself. '
-          'Retrying the update...'
+          'Gradle threw an error while downloading artifacts from the network. '
+          'Retrying to download...'
         )
       );
     });
 
-    testUsingContext('throws toolExit if file opening fails', () async {
+    testUsingContext('retries if file opening fails', () async {
       const String errorMessage = r'''
 Downloading https://services.gradle.org/distributions/gradle-3.5.0-all.zip
 Exception in thread "main" java.io.FileNotFoundException: https://downloads.gradle-dn.com/distributions/gradle-3.5.0-all.zip
@@ -168,13 +168,13 @@ Exception in thread "main" java.io.FileNotFoundException: https://downloads.grad
 
       expect(testLogger.errorText,
         contains(
-          'Gradle threw an error while trying to update itself. '
-          'Retrying the update...'
+          'Gradle threw an error while downloading artifacts from the network. '
+          'Retrying to download...'
         )
       );
     });
 
-    testUsingContext('throws toolExit if the connection is reset', () async {
+    testUsingContext('retries if the connection is reset', () async {
       const String errorMessage = '''
 Downloading https://services.gradle.org/distributions/gradle-5.6.2-all.zip
 Exception in thread "main" java.net.SocketException: Connection reset
@@ -206,8 +206,33 @@ Exception in thread "main" java.net.SocketException: Connection reset
 
       expect(testLogger.errorText,
         contains(
-          'Gradle threw an error while trying to update itself. '
-          'Retrying the update...'
+          'Gradle threw an error while downloading artifacts from the network. '
+          'Retrying to download...'
+        )
+      );
+    });
+
+    testUsingContext('retries if Gradle could not get a resource', () async {
+      const String errorMessage = '''
+A problem occurred configuring root project 'android'.
+> Could not resolve all artifacts for configuration ':classpath'.
+   > Could not resolve net.sf.proguard:proguard-gradle:6.0.3.
+     Required by:
+         project : > com.android.tools.build:gradle:3.3.0
+      > Could not resolve net.sf.proguard:proguard-gradle:6.0.3.
+         > Could not parse POM https://jcenter.bintray.com/net/sf/proguard/proguard-gradle/6.0.3/proguard-gradle-6.0.3.pom
+            > Could not resolve net.sf.proguard:proguard-parent:6.0.3.
+               > Could not resolve net.sf.proguard:proguard-parent:6.0.3.
+                  > Could not get resource 'https://jcenter.bintray.com/net/sf/proguard/proguard-parent/6.0.3/proguard-parent-6.0.3.pom'.
+                     > Could not GET 'https://jcenter.bintray.com/net/sf/proguard/proguard-parent/6.0.3/proguard-parent-6.0.3.pom'. Received status code 504 from server: Gateway Time-out''';
+
+      expect(testErrorMessage(errorMessage, networkErrorHandler), isTrue);
+      expect(await networkErrorHandler.handler(), equals(GradleBuildStatus.retry));
+
+      expect(testLogger.errorText,
+        contains(
+          'Gradle threw an error while downloading artifacts from the network. '
+          'Retrying to download...'
         )
       );
     });


### PR DESCRIPTION
## Description

Retries the gradle command if a resource can't be fetched due to a time out.


## Tests

Unit tests

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
