### PR TITLE
[flutter_tools] remove dependencies checks from gen_snapshot

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -10,7 +10,6 @@ import '../artifacts.dart';
 import '../build_info.dart';
 import '../bundle.dart';
 import '../compile.dart';
-import '../dart/package_map.dart';
 import '../globals.dart' as globals;
 import '../macos/xcode.dart';
 import '../project.dart';
@@ -108,22 +107,9 @@ class AOTSnapshotter {
     // TODO(cbracken): replace IOSArch with TargetPlatform.ios_{armv7,arm64}.
     assert(platform != TargetPlatform.ios || darwinArch != null);
 
-    final PackageMap packageMap = PackageMap(packagesPath);
-    final String packageMapError = packageMap.checkValid();
-    if (packageMapError != null) {
-      globals.printError(packageMapError);
-      return 1;
-    }
-
     final Directory outputDir = globals.fs.directory(outputPath);
     outputDir.createSync(recursive: true);
 
-    final String skyEnginePkg = _getPackagePath(packageMap, 'sky_engine');
-    final String uiPath = globals.fs.path.join(skyEnginePkg, 'lib', 'ui', 'ui.dart');
-    final String vmServicePath = globals.fs.path.join(skyEnginePkg, 'sdk_ext', 'vmservice_io.dart');
-
-    final List<String> inputPaths = <String>[uiPath, vmServicePath, mainPath];
-    final Set<String> outputPaths = <String>{};
     final List<String> genSnapshotArgs = <String>[
       '--deterministic',
     ];
@@ -135,13 +121,11 @@ class AOTSnapshotter {
     final String assembly = globals.fs.path.join(outputDir.path, 'snapshot_assembly.S');
     if (platform == TargetPlatform.ios || platform == TargetPlatform.darwin_x64) {
       // Assembly AOT snapshot.
-      outputPaths.add(assembly);
       genSnapshotArgs.add('--snapshot_kind=app-aot-assembly');
       genSnapshotArgs.add('--assembly=$assembly');
       genSnapshotArgs.add('--strip');
     } else {
       final String aotSharedLibrary = globals.fs.path.join(outputDir.path, 'app.so');
-      outputPaths.add(aotSharedLibrary);
       genSnapshotArgs.add('--snapshot_kind=app-aot-elf');
       genSnapshotArgs.add('--elf=$aotSharedLibrary');
       genSnapshotArgs.add('--strip');
@@ -166,13 +150,6 @@ class AOTSnapshotter {
 
     genSnapshotArgs.add(mainPath);
 
-    // TODO(jonahwilliams): fully remove input checks once all callers are
-    // using assemble.
-    final Iterable<String> missingInputs = inputPaths.where((String p) => !globals.fs.isFileSync(p));
-    if (missingInputs.isNotEmpty) {
-      globals.printTrace('Missing input files: $missingInputs from $inputPaths');
-    }
-
     final SnapshotType snapshotType = SnapshotType(platform, buildMode);
     final int genSnapshotExitCode =
       await _timedStep('snapshot(CompileTime)', 'aot-snapshot',
@@ -185,12 +162,6 @@ class AOTSnapshotter {
       globals.printError('Dart snapshot generator failed with exit code $genSnapshotExitCode');
       return genSnapshotExitCode;
     }
-
-    // Write path to gen_snapshot, since snapshots have to be re-generated when we roll
-    // the Dart SDK.
-    // TODO(jonahwilliams): remove when all callers are using assemble.
-    final String genSnapshotPath = GenSnapshot.getSnapshotterPath(snapshotType);
-    outputDir.childFile('gen_snapshot.d').writeAsStringSync('gen_snapshot.d: $genSnapshotPath\n');
 
     // On iOS and macOS, we use Xcode to compile the snapshot into a dynamic library that the
     // end-developer can link into their app.
@@ -337,10 +308,6 @@ class AOTSnapshotter {
       TargetPlatform.ios,
       TargetPlatform.darwin_x64,
     ].contains(platform);
-  }
-
-  String _getPackagePath(PackageMap packageMap, String package) {
-    return globals.fs.path.dirname(globals.fs.path.fromUri(packageMap.map[package]));
   }
 
   /// This method is used to measure duration of an action and emit it into

--- a/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
@@ -63,22 +63,10 @@ void main() {
       } else {
         assert(false);
       }
-      final String skyEngineLine = globals.platform.isWindows
-        ? r'sky_engine:file:///C:/bin/cache/pkg/sky_engine/lib/'
-        : 'sky_engine:file:///bin/cache/pkg/sky_engine/lib/';
-      globals.fs.file('.packages')
-        ..createSync()
-        ..writeAsStringSync('''
-# Generated
-$skyEngineLine
-flutter_tools:lib/''');
+
       final String engineArtifacts = globals.fs.path.join('bin', 'cache',
           'artifacts', 'engine');
       final List<String> paths = <String>[
-        globals.fs.path.join('bin', 'cache', 'pkg', 'sky_engine', 'lib', 'ui',
-          'ui.dart'),
-        globals.fs.path.join('bin', 'cache', 'pkg', 'sky_engine', 'sdk_ext',
-            'vmservice_io.dart'),
         globals.fs.path.join('bin', 'cache', 'dart-sdk', 'bin', 'dart'),
         globals.fs.path.join('bin', 'cache', 'dart-sdk', 'bin', 'dart.exe'),
         globals.fs.path.join(engineArtifacts, getNameForHostPlatform(hostPlatform),


### PR DESCRIPTION

## Description

The depfile produced by the gen_snapshot wrapper code is no longer used, instead we rely on assemble APIs Target input/output/depfile to work. Now that both Android and iOS use assemble, there are no callers besides the direct usage of build aot. This direct usage doesn't need the depfile as it does not support any caching today.