### PR TITLE
Docs 'a a' fix #1

### DIFF
--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -1919,7 +1919,7 @@ class TestWidgetInspectorService extends Object with WidgetInspectorService {
       // No new locations were rebuilt.
       expect(event, isNot(contains('newLocations')));
 
-      // Triggering a a rebuild of one widget in this app causes the whole app
+      // Triggering a rebuild of one widget in this app causes the whole app
       // to repaint.
       expect(data.length, equals(18));
 


### PR DESCRIPTION
Docs change in order to kick devicelab to run tests for https://github.com/flutter/engine/pull/16436