### PR TITLE
Docs 'a a' fix #2

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -327,7 +327,7 @@ bool _validate(YamlMap manifest) {
   final List<String> errors = <String>[];
   for (final MapEntry<dynamic, dynamic> kvp in manifest.entries) {
     if (kvp.key is! String) {
-      errors.add('Expected YAML key to be a a string, but got ${kvp.key}.');
+      errors.add('Expected YAML key to be a string, but got ${kvp.key}.');
       continue;
     }
     switch (kvp.key as String) {


### PR DESCRIPTION
Docs change in order to kick devicelab to run tests for https://github.com/flutter/engine/pull/16436