### PR TITLE
Docs 'that that' fix #3

### DIFF
--- a/packages/flutter/test/physics/newton_test.dart
+++ b/packages/flutter/test/physics/newton_test.dart
@@ -39,7 +39,7 @@ void main() {
     expect(endPosition, greaterThan(startPosition));
     expect(endVelocity, lessThan(startVelocity));
 
-    // Verify that that the "through" FrictionSimulation ends up at
+    // Verify that the "through" FrictionSimulation ends up at
     // endPosition and endVelocity; implies that it computed the right
     // value for _drag.
     FrictionSimulation friction = FrictionSimulation.through(


### PR DESCRIPTION
Docs change in order to kick devicelab to run tests for https://github.com/flutter/engine/pull/16436