### PR TITLE
Support downloading font-subset for all platforms

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -1229,11 +1229,15 @@ class FontSubsetArtifacts extends EngineCachedArtifact {
       'linux': <String>['linux-x64', 'linux-x64/$artifactName.zip'],
       'windows': <String>['windows-x64', 'windows-x64/$artifactName.zip'],
     };
-    final List<String> binaryDirs = artifacts[globals.platform.operatingSystem];
-    if (binaryDirs == null) {
-      throwToolExit('Unsupported operating system: ${globals.platform.operatingSystem}');
+    if (cache.includeAllPlatforms) {
+      return artifacts.values.toList();
+    } else {
+      final List<String> binaryDirs = artifacts[globals.platform.operatingSystem];
+      if (binaryDirs == null) {
+        throwToolExit('Unsupported operating system: ${globals.platform.operatingSystem}');
+      }
+      return <List<String>>[binaryDirs];
     }
-    return <List<String>>[binaryDirs];
   }
 
   @override

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -499,6 +499,7 @@ void main() {
   testUsingContext('FontSubset artifacts on linux', () {
     final MockCache mockCache = MockCache();
     final FontSubsetArtifacts artifacts = FontSubsetArtifacts(mockCache);
+    when(mockCache.includeAllPlatforms).thenReturn(false);
     expect(artifacts.getBinaryDirs(), <List<String>>[<String>['linux-x64', 'linux-x64/font-subset.zip']]);
   }, overrides: <Type, Generator> {
     Platform: () => FakePlatform()..operatingSystem = 'linux',
@@ -507,6 +508,7 @@ void main() {
   testUsingContext('FontSubset artifacts on windows', () {
     final MockCache mockCache = MockCache();
     final FontSubsetArtifacts artifacts = FontSubsetArtifacts(mockCache);
+    when(mockCache.includeAllPlatforms).thenReturn(false);
     expect(artifacts.getBinaryDirs(), <List<String>>[<String>['windows-x64', 'windows-x64/font-subset.zip']]);
   }, overrides: <Type, Generator> {
     Platform: () => FakePlatform()..operatingSystem = 'windows',
@@ -515,6 +517,7 @@ void main() {
   testUsingContext('FontSubset artifacts on macos', () {
     final MockCache mockCache = MockCache();
     final FontSubsetArtifacts artifacts = FontSubsetArtifacts(mockCache);
+    when(mockCache.includeAllPlatforms).thenReturn(false);
     expect(artifacts.getBinaryDirs(), <List<String>>[<String>['darwin-x64', 'darwin-x64/font-subset.zip']]);
   }, overrides: <Type, Generator> {
     Platform: () => FakePlatform()..operatingSystem = 'macos',
@@ -523,7 +526,21 @@ void main() {
   testUsingContext('FontSubset artifacts on fuchsia', () {
     final MockCache mockCache = MockCache();
     final FontSubsetArtifacts artifacts = FontSubsetArtifacts(mockCache);
+    when(mockCache.includeAllPlatforms).thenReturn(false);
     expect(() => artifacts.getBinaryDirs(), throwsToolExit(message: 'Unsupported operating system: ${globals.platform.operatingSystem}'));
+  }, overrides: <Type, Generator> {
+    Platform: () => FakePlatform()..operatingSystem = 'fuchsia',
+  });
+
+  testUsingContext('FontSubset artifacts for all platforms', () {
+    final MockCache mockCache = MockCache();
+    final FontSubsetArtifacts artifacts = FontSubsetArtifacts(mockCache);
+    when(mockCache.includeAllPlatforms).thenReturn(true);
+    expect(artifacts.getBinaryDirs(), <List<String>>[
+        <String>['darwin-x64', 'darwin-x64/font-subset.zip'],
+        <String>['linux-x64', 'linux-x64/font-subset.zip'],
+        <String>['windows-x64', 'windows-x64/font-subset.zip'],
+    ]);
   }, overrides: <Type, Generator> {
     Platform: () => FakePlatform()..operatingSystem = 'fuchsia',
   });


### PR DESCRIPTION
## Description

Download font-subset for all platforms when calling `flutter precache -a`.

## Tests

Added test in `cache_test.dart`.