### PR TITLE
Fix LRUness of ScrollAwareImageProvider

### DIFF
--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -411,6 +411,9 @@ abstract class ImageProvider<T> {
   /// [ImageCache].
   @protected
   void resolveStreamForKey(ImageConfiguration configuration, ImageStream stream, T key, ImageErrorListener handleError) {
+    // This is an unusual edge case where someone has told us that they found
+    // the image we want before getting to this method. We should avoid calling
+    // load again, but still update the image cache with LRU information.
     if (stream.completer != null) {
       PaintingBinding.instance.imageCache.putIfAbsent(
         key,

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -411,6 +411,14 @@ abstract class ImageProvider<T> {
   /// [ImageCache].
   @protected
   void resolveStreamForKey(ImageConfiguration configuration, ImageStream stream, T key, ImageErrorListener handleError) {
+    if (stream.completer != null) {
+      PaintingBinding.instance.imageCache.putIfAbsent(
+        key,
+        () => stream.completer,
+        onError: handleError,
+      );
+      return;
+    }
     final ImageStreamCompleter completer = PaintingBinding.instance.imageCache.putIfAbsent(
       key,
       () => load(key, PaintingBinding.instance.instantiateImageCodec),

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -415,11 +415,12 @@ abstract class ImageProvider<T> {
     // the image we want before getting to this method. We should avoid calling
     // load again, but still update the image cache with LRU information.
     if (stream.completer != null) {
-      PaintingBinding.instance.imageCache.putIfAbsent(
+      final ImageStreamCompleter completer = PaintingBinding.instance.imageCache.putIfAbsent(
         key,
         () => stream.completer,
         onError: handleError,
       );
+      assert(identical(completer, stream.completer));
       return;
     }
     final ImageStreamCompleter completer = PaintingBinding.instance.imageCache.putIfAbsent(

--- a/packages/flutter/test/painting/image_test_utils.dart
+++ b/packages/flutter/test/painting/image_test_utils.dart
@@ -18,6 +18,7 @@ class TestImageProvider extends ImageProvider<TestImageProvider> {
 
   final Completer<ImageInfo> _completer = Completer<ImageInfo>.sync();
   ImageConfiguration configuration;
+  int loadCallCount = 0;
 
   @override
   Future<TestImageProvider> obtainKey(ImageConfiguration configuration) {
@@ -31,8 +32,10 @@ class TestImageProvider extends ImageProvider<TestImageProvider> {
   }
 
   @override
-  ImageStreamCompleter load(TestImageProvider key, DecoderCallback decode) =>
-      OneFrameImageStreamCompleter(_completer.future);
+  ImageStreamCompleter load(TestImageProvider key, DecoderCallback decode) {
+    loadCallCount += 1;
+    return OneFrameImageStreamCompleter(_completer.future);
+  }
 
   ImageInfo complete() {
     final ImageInfo imageInfo = ImageInfo(image: testImage);


### PR DESCRIPTION
## Description

https://github.com/flutter/flutter/pull/49389 introduced a subtle bug where, if an image got precached _while you are scrolling fast_, the scrolling image provider would not update the ImageCache's LRU information.  The test for this is very highly constructed to push this, as it would be very hard to do this in a real application.  I actually discovered this while working through a solution for https://github.com/flutter/flutter/issues/49456, where this will become more important, but it's fixable by itself so I'm splitting it out.


## Related Issues

The two linked bugs above.

## Tests

I added the following tests:

A test that precaches an image while scrolling fast, and then observes that our image overwrites it in the cache (cache size = 1) once it completes, still while scrolling fast.  This test is highly constructed, and would be very difficult to achieve in a real application without writing custom image providers.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
