### PR TITLE
Remove ideviceinfo, idevice_id artifacts

### DIFF
--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -43,8 +43,6 @@ enum Artifact {
   /// The summary dill for the dartdevc target.
   webPlatformKernelDill,
   iosDeploy,
-  ideviceinfo,
-  ideviceId,
   idevicesyslog,
   idevicescreenshot,
   ideviceinstaller,
@@ -108,10 +106,6 @@ String _artifactToFileName(Artifact artifact, [ TargetPlatform platform, BuildMo
       return 'kernel_worker.dart.snapshot';
     case Artifact.iosDeploy:
       return 'ios-deploy';
-    case Artifact.ideviceinfo:
-      return 'ideviceinfo';
-    case Artifact.ideviceId:
-      return 'idevice_id';
     case Artifact.idevicesyslog:
       return 'idevicesyslog';
     case Artifact.idevicescreenshot:
@@ -256,8 +250,6 @@ class CachedArtifacts extends Artifacts {
         final String artifactFileName = _artifactToFileName(artifact);
         final String engineDir = _getEngineArtifactsPath(platform, mode);
         return _fileSystem.path.join(engineDir, artifactFileName);
-      case Artifact.ideviceId:
-      case Artifact.ideviceinfo:
       case Artifact.idevicescreenshot:
       case Artifact.idevicesyslog:
         final String artifactFileName = _artifactToFileName(artifact);
@@ -512,8 +504,6 @@ class LocalEngineArtifacts extends Artifacts {
         return _fileSystem.path.join(dartSdkPath, 'bin', 'snapshots', artifactFileName);
       case Artifact.kernelWorkerSnapshot:
         return _fileSystem.path.join(_hostEngineOutPath, 'dart-sdk', 'bin', 'snapshots', artifactFileName);
-      case Artifact.ideviceId:
-      case Artifact.ideviceinfo:
       case Artifact.idevicescreenshot:
       case Artifact.idevicesyslog:
         return _cache.getArtifactDirectory('libimobiledevice').childFile(artifactFileName).path;

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -1268,8 +1268,8 @@ class IosUsbArtifacts extends CachedArtifact {
   // missing.
   static const Map<String, List<String>> _kExecutables = <String, List<String>>{
     'libimobiledevice': <String>[
-      'idevice_id',
-      'ideviceinfo',
+      'idevicescreenshot',
+      'idevicesyslog',
     ],
   };
 

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -24,83 +24,18 @@ import '../reporting/reporting.dart';
 import 'code_signing.dart';
 import 'xcodeproj.dart';
 
-/// Specialized exception for expected situations where the ideviceinfo
-/// tool responds with exit code 255 / 'No device found' message
-class IOSDeviceNotFoundError implements Exception {
-  const IOSDeviceNotFoundError(this.message);
-
-  final String message;
-
-  @override
-  String toString() => message;
-}
-
-/// Exception representing an attempt to find information on an iOS device
-/// that failed because the user had not paired the device with the host yet.
-class IOSDeviceNotTrustedError implements Exception {
-  const IOSDeviceNotTrustedError(this.message, this.lockdownCode);
-
-  /// The error message to show to the user.
-  final String message;
-
-  /// The associated `lockdownd` error code.
-  final LockdownReturnCode lockdownCode;
-
-  @override
-  String toString() => '$message (lockdownd error code ${lockdownCode.code})';
-}
-
-/// Class specifying possible return codes from `lockdownd`.
-///
-/// This contains only a subset of the return codes that `lockdownd` can return,
-/// as we only care about a limited subset. These values should be kept in sync with
-/// https://github.com/libimobiledevice/libimobiledevice/blob/26373b3/include/libimobiledevice/lockdown.h#L37
-class LockdownReturnCode {
-  const LockdownReturnCode._(this.code);
-
-  /// Creates a new [LockdownReturnCode] from the specified OS exit code.
-  ///
-  /// If the [code] maps to one of the known codes, a `const` instance will be
-  /// returned.
-  factory LockdownReturnCode.fromCode(int code) {
-    final Map<int, LockdownReturnCode> knownCodes = <int, LockdownReturnCode>{
-      pairingDialogResponsePending.code: pairingDialogResponsePending,
-      invalidHostId.code: invalidHostId,
-    };
-
-    return knownCodes.containsKey(code) ? knownCodes[code] : LockdownReturnCode._(code);
-  }
-
-  /// The OS exit code.
-  final int code;
-
-  /// Error code indicating that the pairing dialog has been shown to the user,
-  /// and the user has not yet responded as to whether to trust the host.
-  static const LockdownReturnCode pairingDialogResponsePending = LockdownReturnCode._(19);
-
-  /// Error code indicating that the host is not trusted.
-  ///
-  /// This can happen if the user explicitly says "do not trust this  computer"
-  /// or if they revoke all trusted computers in the device settings.
-  static const LockdownReturnCode invalidHostId = LockdownReturnCode._(21);
-}
-
 class IMobileDevice {
   IMobileDevice()
-      : _ideviceIdPath = globals.artifacts.getArtifactPath(Artifact.ideviceId, platform: TargetPlatform.ios),
-        _ideviceinfoPath = globals.artifacts.getArtifactPath(Artifact.ideviceinfo, platform: TargetPlatform.ios),
-        _idevicesyslogPath = globals.artifacts.getArtifactPath(Artifact.idevicesyslog, platform: TargetPlatform.ios),
+      : _idevicesyslogPath = globals.artifacts.getArtifactPath(Artifact.idevicesyslog, platform: TargetPlatform.ios),
         _idevicescreenshotPath = globals.artifacts.getArtifactPath(Artifact.idevicescreenshot, platform: TargetPlatform.ios);
 
-  final String _ideviceIdPath;
-  final String _ideviceinfoPath;
   final String _idevicesyslogPath;
   final String _idevicescreenshotPath;
 
   bool get isInstalled {
     _isInstalled ??= processUtils.exitsHappySync(
       <String>[
-        _ideviceIdPath,
+        _idevicescreenshotPath,
         '-h',
       ],
       environment: Map<String, String>.fromEntries(
@@ -110,68 +45,6 @@ class IMobileDevice {
     return _isInstalled;
   }
   bool _isInstalled;
-
-  Future<String> getAvailableDeviceIDs() async {
-    try {
-      final ProcessResult result = await globals.processManager.run(
-        <String>[
-          _ideviceIdPath,
-          '-l',
-        ],
-        environment: Map<String, String>.fromEntries(
-          <MapEntry<String, String>>[globals.cache.dyLdLibEntry]
-        ),
-      );
-      if (result.exitCode != 0) {
-        throw ToolExit('idevice_id returned an error:\n${result.stderr}');
-      }
-      return result.stdout as String;
-    } on ProcessException {
-      throw ToolExit('Failed to invoke idevice_id. Run flutter doctor.');
-    }
-  }
-
-  Future<String> getInfoForDevice(String deviceID, String key) async {
-    try {
-      final ProcessResult result = await globals.processManager.run(
-        <String>[
-          _ideviceinfoPath,
-          '-u',
-          deviceID,
-          '-k',
-          key,
-        ],
-        environment: Map<String, String>.fromEntries(
-          <MapEntry<String, String>>[globals.cache.dyLdLibEntry]
-        ),
-      );
-      final String stdout = result.stdout as String;
-      final String stderr = result.stderr as String;
-      if (result.exitCode == 255 && stdout != null && stdout.contains('No device found')) {
-        throw IOSDeviceNotFoundError('ideviceinfo could not find device:\n$stdout. Try unlocking attached devices.');
-      }
-      if (result.exitCode == 255 && stderr != null && stderr.contains('Could not connect to lockdownd')) {
-        if (stderr.contains('error code -${LockdownReturnCode.pairingDialogResponsePending.code}')) {
-          throw const IOSDeviceNotTrustedError(
-            'Device info unavailable. Is the device asking to "Trust This Computer?"',
-            LockdownReturnCode.pairingDialogResponsePending,
-          );
-        }
-        if (stderr.contains('error code -${LockdownReturnCode.invalidHostId.code}')) {
-          throw const IOSDeviceNotTrustedError(
-            'Device info unavailable. Device pairing "trust" may have been revoked.',
-            LockdownReturnCode.invalidHostId,
-          );
-        }
-      }
-      if (result.exitCode != 0) {
-        throw ToolExit('ideviceinfo returned an error:\n$stderr');
-      }
-      return stdout.trim();
-    } on ProcessException {
-      throw ToolExit('Failed to invoke ideviceinfo. Run flutter doctor.');
-    }
-  }
 
   /// Starts `idevicesyslog` and returns the running process.
   Future<Process> startLogger(String deviceID) {

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -420,14 +420,14 @@ void main() {
       final IosUsbArtifacts iosUsbArtifacts = IosUsbArtifacts('libimobiledevice', mockCache);
       when(mockCache.getArtifactDirectory(any)).thenReturn(globals.fs.currentDirectory);
       iosUsbArtifacts.location.createSync();
-      final File ideviceIdFile = iosUsbArtifacts.location.childFile('idevice_id')
+      final File ideviceScreenshotFile = iosUsbArtifacts.location.childFile('idevicescreenshot')
         ..createSync();
-      iosUsbArtifacts.location.childFile('ideviceinfo')
+      iosUsbArtifacts.location.childFile('idevicesyslog')
         ..createSync();
 
       expect(iosUsbArtifacts.isUpToDateInner(), true);
 
-      ideviceIdFile.deleteSync();
+      ideviceScreenshotFile.deleteSync();
 
       expect(iosUsbArtifacts.isUpToDateInner(), false);
     }, overrides: <Type, Generator>{


### PR DESCRIPTION
## Description

Remove ideviceinfo and idevice_id code. Made dead by https://github.com/flutter/flutter/pull/49854.

## Tests

Updated cache_test, and mac_test. 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*