### PR TITLE
Print frame begin time in summary

### DIFF
--- a/packages/flutter_driver/lib/src/driver/timeline_summary.dart
+++ b/packages/flutter_driver/lib/src/driver/timeline_summary.dart
@@ -171,15 +171,18 @@ class TimelineSummary {
   List<Duration> _extractBeginEndEvents(String name) {
     return _extractDurations(
       name,
-      (TimelineEvent beginEvent, TimelineEvent endEvent) =>
-          Duration(microseconds: endEvent.timestampMicros - beginEvent.timestampMicros),
+      (TimelineEvent beginEvent, TimelineEvent endEvent) {
+        return Duration(microseconds: endEvent.timestampMicros - beginEvent.timestampMicros);
+      },
     );
   }
 
   List<Duration> _extractBeginTimestamps(String name) {
     final List<Duration> result = _extractDurations(
       name,
-      (TimelineEvent beginEvent, TimelineEvent endEvent) => Duration(microseconds: beginEvent.timestampMicros),
+      (TimelineEvent beginEvent, TimelineEvent endEvent) {
+        return Duration(microseconds: beginEvent.timestampMicros);
+      },
     );
 
     // Align timestamps so the first event is at 0.

--- a/packages/flutter_driver/lib/src/driver/timeline_summary.dart
+++ b/packages/flutter_driver/lib/src/driver/timeline_summary.dart
@@ -103,6 +103,9 @@ class TimelineSummary {
       'frame_rasterizer_times': _extractGpuRasterizerDrawDurations()
         .map<int>((Duration duration) => duration.inMicroseconds)
         .toList(),
+      'frame_begin_times': _extractBeginTimestamps('Frame')
+        .map<int>((Duration duration) => duration.inMicroseconds)
+        .toList()
     };
   }
 
@@ -142,10 +145,10 @@ class TimelineSummary {
       .toList();
   }
 
-  /// Extracts Duration list that are reported as a pair of begin/end events.
-  ///
-  /// See: https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU
-  List<Duration> _extractBeginEndEvents(String name) {
+  List<Duration> _extractDurations(
+    String name,
+    Duration extractor(TimelineEvent beginEvent, TimelineEvent endEvent),
+  ) {
     final List<Duration> result = <Duration>[];
 
     // Timeline does not guarantee that the first event is the "begin" event.
@@ -155,10 +158,34 @@ class TimelineSummary {
       final TimelineEvent beginEvent = events.current;
       if (events.moveNext()) {
         final TimelineEvent endEvent = events.current;
-        result.add(Duration(microseconds: endEvent.timestampMicros - beginEvent.timestampMicros));
+        result.add(extractor(beginEvent, endEvent));
       }
     }
 
+    return result;
+  }
+
+  /// Extracts Duration list that are reported as a pair of begin/end events.
+  ///
+  /// See: https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU
+  List<Duration> _extractBeginEndEvents(String name) {
+    return _extractDurations(
+      name,
+      (TimelineEvent beginEvent, TimelineEvent endEvent) =>
+          Duration(microseconds: endEvent.timestampMicros - beginEvent.timestampMicros),
+    );
+  }
+
+  List<Duration> _extractBeginTimestamps(String name) {
+    final List<Duration> result = _extractDurations(
+      name,
+      (TimelineEvent beginEvent, TimelineEvent endEvent) => Duration(microseconds: beginEvent.timestampMicros),
+    );
+
+    // Align timestamps so the first event is at 0.
+    for (int i = result.length - 1; i >= 0; i -= 1) {
+      result[i] = result[i] - result[0];
+    }
     return result;
   }
 

--- a/packages/flutter_driver/test/src/real_tests/timeline_summary_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/timeline_summary_test.dart
@@ -330,6 +330,7 @@ void main() {
             'frame_count': 3,
             'frame_build_times': <int>[17000, 9000, 19000],
             'frame_rasterizer_times': <int>[18000, 10000, 20000],
+            'frame_begin_times': <int>[0, 18000, 28000],
           },
         );
       });
@@ -382,6 +383,7 @@ void main() {
           'frame_count': 3,
           'frame_build_times': <int>[17000, 9000, 19000],
           'frame_rasterizer_times': <int>[18000, 10000, 20000],
+          'frame_begin_times': <int>[0, 18000, 28000],
         });
       });
     });


### PR DESCRIPTION
Together with a video screenshot, this will help determine which frame or animation is slow.

This aims to help triaging  https://github.com/flutter/flutter/issues/48248

Tested by timeline_summary_test.dart.

