### PR TITLE
[flutter_tools] remove automatic multiroot scheme

### DIFF
--- a/dev/integration_tests/codegen/lib/message.dart
+++ b/dev/integration_tests/codegen/lib/message.dart
@@ -1,0 +1,1 @@
+String get message => 'Thanks for using PourOverSupremeFiesta by Coffee by Flutter Inc.';

--- a/dev/integration_tests/codegen/lib/message.dart
+++ b/dev/integration_tests/codegen/lib/message.dart
@@ -1,1 +1,0 @@
-String get message => 'Thanks for using PourOverSupremeFiesta by Coffee by Flutter Inc.';

--- a/dev/integration_tests/simple_codegen/build.yaml
+++ b/dev/integration_tests/simple_codegen/build.yaml
@@ -6,3 +6,4 @@ builders:
       - simpleBuilder
     build_extensions: {'.spec':['.dart']}
     auto_apply: all_packages
+    build_to: source

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -11,7 +11,6 @@ import '../../build_info.dart';
 import '../../compile.dart';
 import '../../dart/package_map.dart';
 import '../../globals.dart' as globals;
-import '../../project.dart';
 import '../build_system.dart';
 import '../depfile.dart';
 import 'assets.dart';
@@ -156,9 +155,7 @@ class Dart2JSTarget extends Target {
     final bool csp = environment.defines[kCspMode] == 'true';
     final BuildMode buildMode = getBuildModeForName(environment.defines[kBuildMode]);
     final String specPath = globals.fs.path.join(globals.artifacts.getArtifactPath(Artifact.flutterWebSdk), 'libraries.json');
-    final String packageFile = FlutterProject.fromDirectory(environment.projectDir).hasBuilders
-      ? PackageMap.globalGeneratedPackagesPath
-      : PackageMap.globalPackagesPath;
+    final String packageFile = PackageMap.globalPackagesPath;
     final File outputFile = environment.buildDir.childFile('main.dart.js');
 
     final ProcessResult result = await globals.processManager.run(<String>[

--- a/packages/flutter_tools/lib/src/codegen.dart
+++ b/packages/flutter_tools/lib/src/codegen.dart
@@ -131,7 +131,7 @@ class CodeGeneratingResidentCompiler implements ResidentCompiler {
   static Future<ResidentCompiler> create({
     @required ResidentCompiler residentCompiler,
     @required FlutterProject flutterProject,
-    bool runCold,
+    bool runCold = false,
   }) async {
     if (runCold) {
       return residentCompiler;

--- a/packages/flutter_tools/lib/src/codegen.dart
+++ b/packages/flutter_tools/lib/src/codegen.dart
@@ -4,18 +4,11 @@
 
 import 'package:meta/meta.dart';
 
-import 'artifacts.dart';
 import 'base/context.dart';
 import 'build_info.dart';
 import 'compile.dart';
-import 'dart/package_map.dart';
 import 'globals.dart' as globals;
 import 'project.dart';
-
-// Arbitrarily chosen multi-root file scheme. This is used to configure the
-// frontend_server to resolve a package uri to multiple filesystem directories.
-// In this case, the source directory and a generated directory.
-const String kMultiRootScheme = 'org-dartlang-app';
 
 /// The [CodeGenerator] instance.
 ///
@@ -25,9 +18,6 @@ CodeGenerator get codeGenerator => context.get<CodeGenerator>();
 
 /// A wrapper for a build_runner process which delegates to a generated
 /// build script.
-///
-/// This is only enabled if [experimentalBuildEnabled] is true, and only for
-/// external flutter users.
 abstract class CodeGenerator {
   const CodeGenerator();
 
@@ -40,18 +30,6 @@ abstract class CodeGenerator {
   // Generates a synthetic package under .dart_tool/flutter_tool which is in turn
   // used to generate a build script.
   Future<void> generateBuildScript(FlutterProject flutterProject);
-
-  /// Create generated packages file which adds a multi-root scheme to the user's
-  /// project directory. Currently we only replace the root package with a multi-root
-  /// scheme. To support codegen on arbitrary packages we would need to do
-  /// this for each dependency.
-  void updatePackages(FlutterProject flutterProject) {
-    final String oldPackagesContents = globals.fs.file(PackageMap.globalPackagesPath).readAsStringSync();
-    final String appName = flutterProject.manifest.appName;
-    final String newPackagesContents = oldPackagesContents.replaceFirst('$appName:lib/', '$appName:$kMultiRootScheme:/');
-    final String generatedPackagesPath = globals.fs.path.setExtension(PackageMap.globalPackagesPath, '.generated');
-    globals.fs.file(generatedPackagesPath).writeAsStringSync(newPackagesContents);
-  }
 }
 
 class UnsupportedCodeGenerator extends CodeGenerator {
@@ -97,7 +75,6 @@ class CodeGeneratingKernelCompiler implements KernelCompiler {
     @required BuildMode buildMode,
     bool trackWidgetCreation,
     List<String> extraFrontEndOptions,
-    // These arguments are currently unused.
     String sdkRoot,
     String packagesPath,
     List<String> fileSystemRoots,
@@ -108,13 +85,7 @@ class CodeGeneratingKernelCompiler implements KernelCompiler {
     String platformDill,
     List<String> dartDefines,
   }) async {
-    if (fileSystemRoots != null || fileSystemScheme != null || depFilePath != null || targetModel != null || sdkRoot != null || packagesPath != null) {
-      globals.printTrace('fileSystemRoots, fileSystemScheme, depFilePath, targetModel, '
-        'sdkRoot, packagesPath are not supported when using the experimental '
-        'build* pipeline');
-    }
     final FlutterProject flutterProject = FlutterProject.current();
-    codeGenerator.updatePackages(flutterProject);
     final CodegenDaemon codegenDaemon = await codeGenerator.daemon(flutterProject);
     codegenDaemon.startBuild();
     await for (final CodegenStatus codegenStatus in codegenDaemon.buildResults) {
@@ -135,12 +106,9 @@ class CodeGeneratingKernelCompiler implements KernelCompiler {
       trackWidgetCreation: trackWidgetCreation,
       extraFrontEndOptions: extraFrontEndOptions,
       sdkRoot: sdkRoot,
-      packagesPath: PackageMap.globalGeneratedPackagesPath,
-      fileSystemRoots: <String>[
-        globals.fs.path.join(flutterProject.generated.path, 'lib${globals.platform.pathSeparator}'),
-        globals.fs.path.join(flutterProject.directory.path, 'lib${globals.platform.pathSeparator}'),
-      ],
-      fileSystemScheme: kMultiRootScheme,
+      packagesPath: packagesPath,
+      fileSystemRoots: fileSystemRoots,
+      fileSystemScheme: fileSystemScheme,
       depFilePath: depFilePath,
       targetModel: targetModel,
       initializeFromDill: initializeFromDill,
@@ -152,7 +120,7 @@ class CodeGeneratingKernelCompiler implements KernelCompiler {
 /// An implementation of a [ResidentCompiler] which runs a [BuildRunner] before
 /// talking to the CFE.
 class CodeGeneratingResidentCompiler implements ResidentCompiler {
-  CodeGeneratingResidentCompiler._(this._residentCompiler, this._codegenDaemon, this._flutterProject);
+  CodeGeneratingResidentCompiler._(this._residentCompiler, this._codegenDaemon);
 
   /// Creates a new [ResidentCompiler] and configures a [BuildDaemonClient] to
   /// run builds.
@@ -161,37 +129,10 @@ class CodeGeneratingResidentCompiler implements ResidentCompiler {
   /// compiler will only be initialized with the correct configuration for
   /// codegen mode.
   static Future<ResidentCompiler> create({
+    @required ResidentCompiler residentCompiler,
     @required FlutterProject flutterProject,
-    @required BuildMode buildMode,
-    bool trackWidgetCreation = false,
-    CompilerMessageConsumer compilerMessageConsumer = globals.printError,
-    bool unsafePackageSerialization = false,
-    String outputPath,
-    String initializeFromDill,
-    bool runCold = false,
-    TargetPlatform targetPlatform,
-    @required List<String> dartDefines,
+    bool runCold,
   }) async {
-    codeGenerator.updatePackages(flutterProject);
-    final ResidentCompiler residentCompiler = ResidentCompiler(
-      globals.artifacts.getArtifactPath(
-        Artifact.flutterPatchedSdkPath,
-        platform: targetPlatform,
-        mode: buildMode,
-      ),
-      buildMode: buildMode,
-      trackWidgetCreation: trackWidgetCreation,
-      packagesPath: PackageMap.globalGeneratedPackagesPath,
-      fileSystemRoots: <String>[
-        globals.fs.path.join(flutterProject.generated.path, 'lib${globals.platform.pathSeparator}'),
-        globals.fs.path.join(flutterProject.directory.path, 'lib${globals.platform.pathSeparator}'),
-      ],
-      fileSystemScheme: kMultiRootScheme,
-      targetModel: TargetModel.flutter,
-      unsafePackageSerialization: unsafePackageSerialization,
-      initializeFromDill: initializeFromDill,
-      dartDefines: dartDefines,
-    );
     if (runCold) {
       return residentCompiler;
     }
@@ -203,12 +144,11 @@ class CodeGeneratingResidentCompiler implements ResidentCompiler {
     if (status == CodegenStatus.Failed) {
       globals.printError('Code generation failed, build may have compile errors.');
     }
-    return CodeGeneratingResidentCompiler._(residentCompiler, codegenDaemon, flutterProject);
+    return CodeGeneratingResidentCompiler._(residentCompiler, codegenDaemon);
   }
 
   final ResidentCompiler _residentCompiler;
   final CodegenDaemon _codegenDaemon;
-  final FlutterProject _flutterProject;
 
   @override
   void accept() {
@@ -230,17 +170,11 @@ class CodeGeneratingResidentCompiler implements ResidentCompiler {
     if (_codegenDaemon.lastStatus == CodegenStatus.Failed) {
       globals.printError('Code generation failed, build may have compile errors.');
     }
-    // Update the generated packages file if the original packages file has changes.
-    if (globals.fs.statSync(PackageMap.globalPackagesPath).modified.millisecondsSinceEpoch >
-        globals.fs.statSync(PackageMap.globalGeneratedPackagesPath).modified.millisecondsSinceEpoch) {
-      codeGenerator.updatePackages(_flutterProject);
-      invalidatedFiles.add(globals.fs.file(PackageMap.globalGeneratedPackagesPath).uri);
-    }
     return _residentCompiler.recompile(
       mainPath,
       invalidatedFiles,
       outputPath: outputPath,
-      packagesFilePath: PackageMap.globalGeneratedPackagesPath,
+      packagesFilePath: packagesFilePath,
     );
   }
 

--- a/packages/flutter_tools/lib/src/dart/package_map.dart
+++ b/packages/flutter_tools/lib/src/dart/package_map.dart
@@ -19,8 +19,6 @@ class PackageMap {
 
   static String get globalPackagesPath => _globalPackagesPath ?? kPackagesFileName;
 
-  static String get globalGeneratedPackagesPath => globals.fs.path.setExtension(globalPackagesPath, '.generated');
-
   static set globalPackagesPath(String value) {
     _globalPackagesPath = value;
   }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -94,13 +94,6 @@ class FlutterDevice {
           .absolute.uri.toString(),
         dartDefines: dartDefines,
       );
-    } else if (flutterProject.hasBuilders) {
-      generator = await CodeGeneratingResidentCompiler.create(
-        targetPlatform: targetPlatform,
-        buildMode: buildMode,
-        flutterProject: flutterProject,
-        dartDefines: dartDefines,
-      );
     } else {
       generator = ResidentCompiler(
         globals.artifacts.getArtifactPath(
@@ -116,6 +109,12 @@ class FlutterDevice {
         experimentalFlags: experimentalFlags,
         dartDefines: dartDefines,
       );
+      if (flutterProject.hasBuilders) {
+        generator = await CodeGeneratingResidentCompiler.create(
+          residentCompiler: generator,
+          flutterProject: flutterProject,
+        );
+      }
     }
     return FlutterDevice(
       device,

--- a/packages/flutter_tools/lib/src/test/test_compiler.dart
+++ b/packages/flutter_tools/lib/src/test/test_compiler.dart
@@ -93,20 +93,7 @@ class TestCompiler {
   /// Create the resident compiler used to compile the test.
   @visibleForTesting
   Future<ResidentCompiler> createCompiler() async {
-    if (flutterProject.hasBuilders) {
-      return CodeGeneratingResidentCompiler.create(
-        flutterProject: flutterProject,
-        buildMode: buildMode,
-        trackWidgetCreation: trackWidgetCreation,
-        compilerMessageConsumer: _reportCompilerMessage,
-        initializeFromDill: testFilePath,
-        // We already ran codegen once at the start, we only need to
-        // configure builders.
-        runCold: true,
-        dartDefines: const <String>[],
-      );
-    }
-    return ResidentCompiler(
+    final ResidentCompiler residentCompiler = ResidentCompiler(
       globals.artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath),
       packagesPath: PackageMap.globalPackagesPath,
       buildMode: buildMode,
@@ -116,6 +103,13 @@ class TestCompiler {
       unsafePackageSerialization: false,
       dartDefines: const <String>[],
     );
+    if (flutterProject.hasBuilders) {
+      return CodeGeneratingResidentCompiler.create(
+        residentCompiler: residentCompiler,
+        flutterProject: flutterProject,
+      );
+    }
+    return residentCompiler;
   }
 
   // Handle a compilation request.


### PR DESCRIPTION
## Description

A multi-root scheme confuses IDEs and breakpoint setting, see https://github.com/flutter/flutter/issues/50198

The multi-root scheme is only required if the final generated dart source from a builder is left in the .dart_tool directory. If the builder uses the SharedPartBuilder or build_to: source, then no multiroot scheme is required.

Since the default behavior of flutter run is to not use a multiroot scheme, and because users not using the `builders` key are otherwise able to run their applications, I do not believe it had a lot of value. Also, it seems unlikely to be a breaking change