### PR TITLE
Make `codesign.dart` integration test easier to run locally

### DIFF
--- a/dev/bots/codesign.dart
+++ b/dev/bots/codesign.dart
@@ -5,7 +5,7 @@
 import 'dart:io';
 import 'package:path/path.dart' as path;
 
-String get repoRoot => path.normalize(path.join(path.dirname(Platform.script.path), '..', '..'));
+String get repoRoot => path.normalize(path.join(path.dirname(Platform.script.toFilePath()), '..', '..'));
 String get cacheDirectory => path.normalize(path.join(repoRoot, 'bin', 'cache'));
 
 /// Check mime-type of file at [filePath] to determine if it is binary

--- a/dev/bots/codesign.dart
+++ b/dev/bots/codesign.dart
@@ -23,6 +23,7 @@ bool isBinary(String filePath) {
 
 /// Find every binary file in the given [rootDirectory]
 List<String> findBinaryPaths([String rootDirectory]) {
+  rootDirectory ??= cacheDirectory;
   final ProcessResult result = Process.runSync(
     'find',
     <String>[
@@ -64,7 +65,8 @@ void main() {
   final List<String> failures = <String>[];
 
   if (!Platform.isMacOS) {
-    print('Warning! This script only works on macOS, as it requires Xcode.');
+    print('Error! Expected operating system "macos", actual operating system '
+      'is: "${Platform.operatingSystem}"');
     exit(1);
   }
 


### PR DESCRIPTION
Add two checks before running test to make this script more user-friendly to run locally from the command line.

1. Check platform is macOS.
1. Check the cache is up to date.