### PR TITLE
[flutter_tools] support iOS and macOS with split-debug-info and tree-shake-icons

### DIFF
--- a/packages/flutter_tools/bin/macos_assemble.sh
+++ b/packages/flutter_tools/bin/macos_assemble.sh
@@ -76,6 +76,7 @@ RunCommand "${FLUTTER_ROOT}/bin/flutter" --suppress-analytics               \
     -dTargetFile="${target_path}"                                           \
     -dBuildMode="${build_mode}"                                             \
     -dFontSubset="${icon_tree_shaker_flag}"                                 \
+    -dSplitDebugInfo="${SPLIT_DEBUG_INFO}"                                  \
     --build-inputs="${build_inputs_path}"                                   \
     --build-outputs="${build_outputs_path}"                                 \
     --output="${ephemeral_dir}"                                             \

--- a/packages/flutter_tools/bin/macos_assemble.sh
+++ b/packages/flutter_tools/bin/macos_assemble.sh
@@ -75,7 +75,7 @@ RunCommand "${FLUTTER_ROOT}/bin/flutter" --suppress-analytics               \
     -dTargetPlatform=darwin-x64                                             \
     -dTargetFile="${target_path}"                                           \
     -dBuildMode="${build_mode}"                                             \
-    -dFontSubset="${icon_tree_shaker_flag}"                                 \
+    -dTreeShakeIcons="${icon_tree_shaker_flag}"                             \
     -dSplitDebugInfo="${SPLIT_DEBUG_INFO}"                                  \
     --build-inputs="${build_inputs_path}"                                   \
     --build-outputs="${build_outputs_path}"                                 \

--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -172,7 +172,7 @@ BuildApp() {
     -dBuildMode=${build_mode}                                             \
     -dIosArchs="${ARCHS}"                                                 \
     -dSplitDebugInfo="${SPLIT_DEBUG_INFO}"                                \
-    -dFontSubset="${icon_tree_shaker_flag}"                               \
+    -dTreeShakeIcons="${icon_tree_shaker_flag}"                           \
     -dTrackWidgetCreation="${track_widget_creation_flag}"                 \
     -dEnableBitcode="${bitcode_flag}"                                     \
     "${build_mode}_ios_bundle_flutter_assets"

--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -171,6 +171,7 @@ BuildApp() {
     -dTargetFile="${target_path}"                                         \
     -dBuildMode=${build_mode}                                             \
     -dIosArchs="${ARCHS}"                                                 \
+    -dSplitDebugInfo="${SPLIT_DEBUG_INFO}"                                \
     -dFontSubset="${icon_tree_shaker_flag}"                               \
     -dTrackWidgetCreation="${track_widget_creation_flag}"                 \
     -dEnableBitcode="${bitcode_flag}"                                     \

--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -163,7 +163,7 @@ class AOTSnapshotter {
     // multiple debug files.
     final String archName = getNameForTargetPlatform(platform, darwinArch: darwinArch);
     final String debugFilename = 'app.$archName.symbols';
-    if (splitDebugInfo != null) {
+    if (splitDebugInfo?.isNotEmpty ?? false) {
       globals.fs.directory(splitDebugInfo)
         .createSync(recursive: true);
     }
@@ -173,7 +173,7 @@ class AOTSnapshotter {
       // Faster async/await
       '--no-causal-async-stacks',
       '--lazy-async-stacks',
-      if (splitDebugInfo != null) ...<String>[
+      if (splitDebugInfo?.isNotEmpty ?? false) ...<String>[
         '--dwarf-stack-traces',
         '--save-debugging-info=${globals.fs.path.join(splitDebugInfo, debugFilename)}'
       ]

--- a/packages/flutter_tools/lib/src/build_system/targets/assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/assets.dart
@@ -49,7 +49,7 @@ Future<Depfile> copyAssets(Environment environment, Directory outputDirectory) a
       try {
         // This will result in strange looking files, for example files with `/`
         // on Windows or files that end up getting URI encoded such as `#.ext`
-        // to `%23.ext`.  However, we have to keep it this way since the
+        // to `%23.ext`. However, we have to keep it this way since the
         // platform channels in the framework will URI encode these values,
         // and the native APIs will look for files this way.
         final File file = globals.fs.file(globals.fs.path.join(outputDirectory.path, entry.key));

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -17,6 +17,7 @@ import '../depfile.dart';
 import '../exceptions.dart';
 import 'assets.dart';
 import 'dart.dart';
+import 'icon_tree_shaker.dart';
 
 /// Supports compiling a dart kernel file to an assembly file.
 ///
@@ -237,6 +238,7 @@ abstract class IosAssetBundle extends Target {
   List<Source> get inputs => const <Source>[
     Source.pattern('{BUILD_DIR}/App'),
     Source.pattern('{PROJECT_DIR}/pubspec.yaml'),
+    ...IconTreeShaker.inputs,
   ];
 
   @override

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -19,6 +19,7 @@ import 'build.dart';
 class BuildIOSCommand extends BuildSubCommand {
   BuildIOSCommand() {
     addTreeShakeIconsFlag();
+    addSplitDebugInfoOption();
     addBuildModeFlags(defaultToRelease: false);
     usesTargetOption();
     usesFlavorOption();

--- a/packages/flutter_tools/lib/src/commands/build_macos.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos.dart
@@ -18,6 +18,7 @@ import 'build.dart';
 class BuildMacosCommand extends BuildSubCommand {
   BuildMacosCommand() {
     addTreeShakeIconsFlag();
+    addSplitDebugInfoOption();
     usesTargetOption();
     addBuildModeFlags();
   }

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -85,8 +85,6 @@ Future<void> buildMacOS({
       'OBJROOT=${globals.fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Intermediates.noindex')}',
       'SYMROOT=${globals.fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Products')}',
       'COMPILER_INDEX_STORE_ENABLE=NO',
-      if (buildInfo.treeShakeIcons)
-        'TREE_SHAKE_ICONS=true',
       ...environmentVariablesAsXcodeBuildSettings(globals.platform)
     ], trace: true);
   } finally {

--- a/packages/flutter_tools/test/general.shard/base/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/build_test.dart
@@ -715,6 +715,39 @@ void main() {
       ]);
     }, overrides: contextOverrides);
 
+    testUsingContext('builds shared library for android-arm without dwarf stack traces due to empty string', () async {
+      globals.fs.file('main.dill').writeAsStringSync('binary magic');
+
+      final String outputPath = globals.fs.path.join('build', 'foo');
+      globals.fs.directory(outputPath).createSync(recursive: true);
+
+      final int genSnapshotExitCode = await snapshotter.build(
+        platform: TargetPlatform.android_arm,
+        buildMode: BuildMode.release,
+        mainPath: 'main.dill',
+        packagesPath: '.packages',
+        outputPath: outputPath,
+        bitcode: false,
+        splitDebugInfo: '',
+      );
+
+      expect(genSnapshotExitCode, 0);
+      expect(genSnapshot.callCount, 1);
+      expect(genSnapshot.snapshotType.platform, TargetPlatform.android_arm);
+      expect(genSnapshot.snapshotType.mode, BuildMode.release);
+      expect(genSnapshot.additionalArgs, <String>[
+        '--deterministic',
+        '--snapshot_kind=app-aot-elf',
+        '--elf=build/foo/app.so',
+        '--strip',
+        '--no-sim-use-hardfp',
+        '--no-use-integer-division',
+        '--no-causal-async-stacks',
+        '--lazy-async-stacks',
+        'main.dill',
+      ]);
+    }, overrides: contextOverrides);
+
     testUsingContext('builds shared library for android-arm64', () async {
       globals.fs.file('main.dill').writeAsStringSync('binary magic');
 


### PR DESCRIPTION
## Description

Plumbs the split-debug-info flag though iOS and macOS now that we're on assemble. Updates the flag logic so that an empty string is interpreted as asking for unsplit. This simplifies the logic of passing the flag through bash.

Fixes https://github.com/flutter/flutter/issues/48726