### PR TITLE
Fix image tests that make faulty assumptions about lifecycle of image provider

### DIFF
--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -187,7 +187,8 @@ void main() {
     final GlobalKey mediaQueryKey1 = GlobalKey(debugLabel: 'mediaQueryKey1');
     final GlobalKey mediaQueryKey2 = GlobalKey(debugLabel: 'mediaQueryKey2');
     final GlobalKey imageKey = GlobalKey(debugLabel: 'image');
-    final TestImageProvider imageProvider = TestImageProvider();
+    final ConfigurationKeyedTestImageProvider imageProvider = ConfigurationKeyedTestImageProvider();
+    final DebouncingImageProvider debouncingProvider = DebouncingImageProvider(imageProvider);
 
     // Of the two nested MediaQuery objects, the innermost one,
     // mediaQuery2, should define the configuration of the imageProvider.
@@ -207,7 +208,7 @@ void main() {
           child: Image(
             excludeFromSemantics: true,
             key: imageKey,
-            image: imageProvider,
+            image: debouncingProvider,
           ),
         ),
       ),
@@ -234,7 +235,7 @@ void main() {
           child: Image(
             excludeFromSemantics: true,
             key: imageKey,
-            image: imageProvider,
+            image: debouncingProvider,
           ),
         ),
       ),
@@ -247,7 +248,8 @@ void main() {
     final GlobalKey mediaQueryKey1 = GlobalKey(debugLabel: 'mediaQueryKey1');
     final GlobalKey mediaQueryKey2 = GlobalKey(debugLabel: 'mediaQueryKey2');
     final GlobalKey imageKey = GlobalKey(debugLabel: 'image');
-    final TestImageProvider imageProvider = TestImageProvider();
+    final ConfigurationKeyedTestImageProvider imageProvider = ConfigurationKeyedTestImageProvider();
+    final DebouncingImageProvider debouncingProvider = DebouncingImageProvider(imageProvider);
 
     // This is just a variation on the previous test. In this version the location
     // of the Image changes and the MediaQuery widgets do not.
@@ -264,7 +266,7 @@ void main() {
             child: Image(
               excludeFromSemantics: true,
               key: imageKey,
-              image: imageProvider,
+              image: debouncingProvider,
             ),
           ),
           MediaQuery(
@@ -302,7 +304,7 @@ void main() {
             child: Image(
               excludeFromSemantics: true,
               key: imageKey,
-              image: imageProvider,
+              image: debouncingProvider,
             ),
           ),
         ],
@@ -310,6 +312,137 @@ void main() {
     );
 
     expect(imageProvider._lastResolvedConfiguration.devicePixelRatio, 10.0);
+  });
+
+  testWidgets('Verify ImageProvider does not inherit configuration when it does not key to it', (WidgetTester tester) async {
+    final GlobalKey mediaQueryKey1 = GlobalKey(debugLabel: 'mediaQueryKey1');
+    final GlobalKey mediaQueryKey2 = GlobalKey(debugLabel: 'mediaQueryKey2');
+    final GlobalKey imageKey = GlobalKey(debugLabel: 'image');
+    final TestImageProvider imageProvider = TestImageProvider();
+    final DebouncingImageProvider debouncingProvider = DebouncingImageProvider(imageProvider);
+
+    // Of the two nested MediaQuery objects, the innermost one,
+    // mediaQuery2, should define the configuration of the imageProvider.
+    await tester.pumpWidget(
+      MediaQuery(
+        key: mediaQueryKey1,
+        data: const MediaQueryData(
+          devicePixelRatio: 10.0,
+          padding: EdgeInsets.zero,
+        ),
+        child: MediaQuery(
+          key: mediaQueryKey2,
+          data: const MediaQueryData(
+            devicePixelRatio: 5.0,
+            padding: EdgeInsets.zero,
+          ),
+          child: Image(
+            excludeFromSemantics: true,
+            key: imageKey,
+            image: debouncingProvider,
+          ),
+        ),
+      ),
+    );
+
+    expect(imageProvider._lastResolvedConfiguration.devicePixelRatio, 5.0);
+
+    // This is the same widget hierarchy as before except that the
+    // two MediaQuery objects have exchanged places. The imageProvider
+    // should be resolved again, with the new innermost MediaQuery.
+    await tester.pumpWidget(
+      MediaQuery(
+        key: mediaQueryKey2,
+        data: const MediaQueryData(
+          devicePixelRatio: 5.0,
+          padding: EdgeInsets.zero,
+        ),
+        child: MediaQuery(
+          key: mediaQueryKey1,
+          data: const MediaQueryData(
+            devicePixelRatio: 10.0,
+            padding: EdgeInsets.zero,
+          ),
+          child: Image(
+            excludeFromSemantics: true,
+            key: imageKey,
+            image: debouncingProvider,
+          ),
+        ),
+      ),
+    );
+
+    expect(imageProvider._lastResolvedConfiguration.devicePixelRatio, 5.0);
+  });
+
+  testWidgets('Verify ImageProvider does not inherit configuration when it does not key to it again', (WidgetTester tester) async {
+    final GlobalKey mediaQueryKey1 = GlobalKey(debugLabel: 'mediaQueryKey1');
+    final GlobalKey mediaQueryKey2 = GlobalKey(debugLabel: 'mediaQueryKey2');
+    final GlobalKey imageKey = GlobalKey(debugLabel: 'image');
+    final TestImageProvider imageProvider = TestImageProvider();
+    final DebouncingImageProvider debouncingProvider = DebouncingImageProvider(imageProvider);
+
+    // This is just a variation on the previous test. In this version the location
+    // of the Image changes and the MediaQuery widgets do not.
+    await tester.pumpWidget(
+      Row(
+        textDirection: TextDirection.ltr,
+        children: <Widget> [
+          MediaQuery(
+            key: mediaQueryKey2,
+            data: const MediaQueryData(
+              devicePixelRatio: 5.0,
+              padding: EdgeInsets.zero,
+            ),
+            child: Image(
+              excludeFromSemantics: true,
+              key: imageKey,
+              image: debouncingProvider,
+            ),
+          ),
+          MediaQuery(
+            key: mediaQueryKey1,
+            data: const MediaQueryData(
+              devicePixelRatio: 10.0,
+              padding: EdgeInsets.zero,
+            ),
+            child: Container(width: 100.0),
+          ),
+        ],
+      ),
+    );
+
+    expect(imageProvider._lastResolvedConfiguration.devicePixelRatio, 5.0);
+
+    await tester.pumpWidget(
+      Row(
+        textDirection: TextDirection.ltr,
+        children: <Widget> [
+          MediaQuery(
+            key: mediaQueryKey2,
+            data: const MediaQueryData(
+              devicePixelRatio: 5.0,
+              padding: EdgeInsets.zero,
+            ),
+            child: Container(width: 100.0),
+          ),
+          MediaQuery(
+            key: mediaQueryKey1,
+            data: const MediaQueryData(
+              devicePixelRatio: 10.0,
+              padding: EdgeInsets.zero,
+            ),
+            child: Image(
+              excludeFromSemantics: true,
+              key: imageKey,
+              image: debouncingProvider,
+            ),
+          ),
+        ],
+      ),
+    );
+
+    expect(imageProvider._lastResolvedConfiguration.devicePixelRatio, 5.0);
   });
 
   testWidgets('Verify Image stops listening to ImageStream', (WidgetTester tester) async {
@@ -1225,7 +1358,33 @@ void main() {
   });
 }
 
-class TestImageProvider extends ImageProvider<TestImageProvider> {
+class ConfigurationAwareKey {
+  const ConfigurationAwareKey(this.provider, this.configuration)
+    : assert(provider != null),
+      assert(configuration != null);
+
+  final ImageProvider provider;
+  final ImageConfiguration configuration;
+
+  @override
+  int get hashCode => hashValues(provider, configuration);
+
+  @override
+  bool operator ==(Object other) {
+    return other is ConfigurationAwareKey
+        && other.provider == provider
+        && other.configuration == configuration;
+  }
+}
+
+class ConfigurationKeyedTestImageProvider extends TestImageProvider {
+  @override
+  Future<ConfigurationAwareKey> obtainKey(ImageConfiguration configuration) {
+    return SynchronousFuture<ConfigurationAwareKey>(ConfigurationAwareKey(this, configuration));
+  }
+}
+
+class TestImageProvider extends ImageProvider<Object> {
   TestImageProvider({ImageStreamCompleter streamCompleter}) {
     _streamCompleter = streamCompleter
       ?? OneFrameImageStreamCompleter(_completer.future);
@@ -1239,18 +1398,18 @@ class TestImageProvider extends ImageProvider<TestImageProvider> {
   bool _loadCalled = false;
 
   @override
-  Future<TestImageProvider> obtainKey(ImageConfiguration configuration) {
+  Future<Object> obtainKey(ImageConfiguration configuration) {
     return SynchronousFuture<TestImageProvider>(this);
   }
 
   @override
-  void resolveStreamForKey(ImageConfiguration configuration, ImageStream stream, TestImageProvider key, ImageErrorListener handleError) {
+  void resolveStreamForKey(ImageConfiguration configuration, ImageStream stream, Object key, ImageErrorListener handleError) {
     _lastResolvedConfiguration = configuration;
     super.resolveStreamForKey(configuration, stream, key, handleError);
   }
 
   @override
-  ImageStreamCompleter load(TestImageProvider key, DecoderCallback decode) {
+  ImageStreamCompleter load(Object key, DecoderCallback decode) {
     _loadCalled = true;
     return _streamCompleter;
   }
@@ -1322,4 +1481,25 @@ class TestImage implements ui.Image {
 
   @override
   String toString() => '[$width\u00D7$height]';
+}
+
+class DebouncingImageProvider extends ImageProvider<Object> {
+  DebouncingImageProvider(this.imageProvider);
+
+  static Set<Object> seenKeys = <Object>{};
+
+  final ImageProvider<Object> imageProvider;
+
+  @override
+  void resolveStreamForKey(ImageConfiguration configuration, ImageStream stream, Object key, ImageErrorListener handleError) {
+    if (seenKeys.add(key)) {
+      imageProvider.resolveStreamForKey(configuration, stream, key, handleError);
+    }
+  }
+
+  @override
+  Future<Object> obtainKey(ImageConfiguration configuration) => imageProvider.obtainKey(configuration);
+
+  @override
+  ImageStreamCompleter load(Object key, DecoderCallback decode) => imageProvider.load(key, decode);
 }

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -349,7 +349,7 @@ void main() {
 
     // This is the same widget hierarchy as before except that the
     // two MediaQuery objects have exchanged places. The imageProvider
-    // should be resolved again, with the new innermost MediaQuery.
+    // should not be resolved again, because it does not key to configuration.
     await tester.pumpWidget(
       MediaQuery(
         key: mediaQueryKey2,

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -23,6 +23,10 @@ Future<ui.Image> createTestImage([List<int> bytes = kTransparentImage]) async {
 }
 
 void main() {
+  setUp(() {
+    DebouncingImageProvider.seenKeys.clear();
+  });
+
   testWidgets('Verify Image resets its RenderImage when changing providers', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
     final TestImageProvider imageProvider1 = TestImageProvider();

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -23,10 +23,6 @@ Future<ui.Image> createTestImage([List<int> bytes = kTransparentImage]) async {
 }
 
 void main() {
-  setUp(() {
-    DebouncingImageProvider.seenKeys.clear();
-  });
-
   testWidgets('Verify Image resets its RenderImage when changing providers', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
     final TestImageProvider imageProvider1 = TestImageProvider();
@@ -192,7 +188,8 @@ void main() {
     final GlobalKey mediaQueryKey2 = GlobalKey(debugLabel: 'mediaQueryKey2');
     final GlobalKey imageKey = GlobalKey(debugLabel: 'image');
     final ConfigurationKeyedTestImageProvider imageProvider = ConfigurationKeyedTestImageProvider();
-    final DebouncingImageProvider debouncingProvider = DebouncingImageProvider(imageProvider);
+    final Set<Object> seenKeys = <Object>{};
+    final DebouncingImageProvider debouncingProvider = DebouncingImageProvider(imageProvider, seenKeys);
 
     // Of the two nested MediaQuery objects, the innermost one,
     // mediaQuery2, should define the configuration of the imageProvider.
@@ -253,7 +250,8 @@ void main() {
     final GlobalKey mediaQueryKey2 = GlobalKey(debugLabel: 'mediaQueryKey2');
     final GlobalKey imageKey = GlobalKey(debugLabel: 'image');
     final ConfigurationKeyedTestImageProvider imageProvider = ConfigurationKeyedTestImageProvider();
-    final DebouncingImageProvider debouncingProvider = DebouncingImageProvider(imageProvider);
+    final Set<Object> seenKeys = <Object>{};
+    final DebouncingImageProvider debouncingProvider = DebouncingImageProvider(imageProvider, seenKeys);
 
     // This is just a variation on the previous test. In this version the location
     // of the Image changes and the MediaQuery widgets do not.
@@ -323,7 +321,8 @@ void main() {
     final GlobalKey mediaQueryKey2 = GlobalKey(debugLabel: 'mediaQueryKey2');
     final GlobalKey imageKey = GlobalKey(debugLabel: 'image');
     final TestImageProvider imageProvider = TestImageProvider();
-    final DebouncingImageProvider debouncingProvider = DebouncingImageProvider(imageProvider);
+    final Set<Object> seenKeys = <Object>{};
+    final DebouncingImageProvider debouncingProvider = DebouncingImageProvider(imageProvider, seenKeys);
 
     // Of the two nested MediaQuery objects, the innermost one,
     // mediaQuery2, should define the configuration of the imageProvider.
@@ -384,7 +383,8 @@ void main() {
     final GlobalKey mediaQueryKey2 = GlobalKey(debugLabel: 'mediaQueryKey2');
     final GlobalKey imageKey = GlobalKey(debugLabel: 'image');
     final TestImageProvider imageProvider = TestImageProvider();
-    final DebouncingImageProvider debouncingProvider = DebouncingImageProvider(imageProvider);
+    final Set<Object> seenKeys = <Object>{};
+    final DebouncingImageProvider debouncingProvider = DebouncingImageProvider(imageProvider, seenKeys);
 
     // This is just a variation on the previous test. In this version the location
     // of the Image changes and the MediaQuery widgets do not.
@@ -1491,10 +1491,9 @@ class TestImage implements ui.Image {
 }
 
 class DebouncingImageProvider extends ImageProvider<Object> {
-  DebouncingImageProvider(this.imageProvider);
+  DebouncingImageProvider(this.imageProvider, this.seenKeys);
 
-  static Set<Object> seenKeys = <Object>{};
-
+  final Set<Object> seenKeys;
   final ImageProvider<Object> imageProvider;
 
   @override

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -1367,14 +1367,17 @@ class ConfigurationAwareKey {
   final ImageConfiguration configuration;
 
   @override
-  int get hashCode => hashValues(provider, configuration);
-
-  @override
   bool operator ==(Object other) {
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
     return other is ConfigurationAwareKey
         && other.provider == provider
         && other.configuration == configuration;
   }
+
+  @override
+  int get hashCode => hashValues(provider, configuration);
 }
 
 class ConfigurationKeyedTestImageProvider extends TestImageProvider {

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -1493,6 +1493,13 @@ class TestImage implements ui.Image {
 class DebouncingImageProvider extends ImageProvider<Object> {
   DebouncingImageProvider(this.imageProvider, this.seenKeys);
 
+  /// A set of keys that will only get resolved the _first_ time they are seen.
+  ///
+  /// If an ImageProvider produces the same key for two different image
+  /// configurations, it should only actually resolve once using this provider.
+  /// However, if it does care about image configuration, it should make the
+  /// property or properties it cares about part of the key material it
+  /// produces.
   final Set<Object> seenKeys;
   final ImageProvider<Object> imageProvider;
 


### PR DESCRIPTION
## Description

Two tests, as written, assume that they will always get called `resolveStreamForKey`, even if they are wrapped by a provider that avoids calling this again if it knows the cache has the key.

They're faulty because they do not return a key that shows they care about image configuration.  Today, AssetImage does this (since it cares about devicePixelRatio), but other image classes do not (since they don't care about the configuration from the context).

The tests succeed today because the Image widget does not use any such providers.  However, I'm working on making it do just that to deal with https://github.com/flutter/flutter/issues/49456. 

I do not believe this should count as a breaking change - it's fixing a test that had faulty assumptions. I still expect to do #49356 without a breaking change, but I will make sure to run it through a manual run of Google tests to be more confident of that.

## Tests

I added the following tests:

Tests that assert the existing behavior for providers that report caring about image configuration, and updated the existing test to be wrapped in a debouncing provider that doesn't call it if the key says it doesn't care.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
