### PR TITLE
[flutter_tool] Make the registrant import relative to the entrypoint

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/build_script.dart
+++ b/packages/flutter_tools/lib/src/build_runner/build_script.dart
@@ -351,13 +351,14 @@ class FlutterWebShellBuilder implements Builder {
       return;
     }
     final AssetId outputId = buildStep.inputId.changeExtension('_web_entrypoint.dart');
+    final String pluginRegistrantPath = _getPluginRegistrantPath(dartEntrypointId.path);
     if (hasPlugins) {
       await buildStep.writeAsString(outputId, '''
 import 'dart:ui' as ui;
 
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
-import 'generated_plugin_registrant.dart';
+import '$pluginRegistrantPath';
 import "${path.url.basename(buildStep.inputId.path)}" as entrypoint;
 
 Future<void> main() async {
@@ -382,6 +383,13 @@ Future<void> main() async {
 }
 ''');
     }
+  }
+
+  /// Gets the relative path to the generated plugin registrant from the app
+  /// app entrypoint.
+  String _getPluginRegistrantPath(String entrypoint) {
+    return path.url.relative('lib/generated_plugin_registrant.dart',
+        from: path.url.dirname(entrypoint));
   }
 
   @override

--- a/packages/flutter_tools/test/general.shard/build_runner/build_script_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_runner/build_script_test.dart
@@ -71,7 +71,7 @@ void main() {
   });
 
   test('FlutterWebShellBuilder correctly imports registrant', () async {
-    AssetId nestedEntrypoint = AssetId('hello_world', 'lib/src/nested_main.dart');
+    final AssetId nestedEntrypoint = AssetId('hello_world', 'lib/src/nested_main.dart');
     when(mockBuildStep.inputId).thenReturn(nestedEntrypoint);
 
     const FlutterWebShellBuilder builder = FlutterWebShellBuilder(

--- a/packages/flutter_tools/test/general.shard/build_runner/build_script_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_runner/build_script_test.dart
@@ -69,6 +69,21 @@ void main() {
     verify(mockBuildStep.writeAsString(any,
         argThat(isNot(contains('registerPlugins(webPluginRegistry)'))))).called(1);
   });
+
+  test('FlutterWebShellBuilder correctly imports registrant', () async {
+    AssetId nestedEntrypoint = AssetId('hello_world', 'lib/src/nested_main.dart');
+    when(mockBuildStep.inputId).thenReturn(nestedEntrypoint);
+
+    const FlutterWebShellBuilder builder = FlutterWebShellBuilder(
+      hasPlugins: true,
+      initializePlatform: true,
+    );
+
+    await builder.build(mockBuildStep);
+
+    verify(mockBuildStep.writeAsString(any,
+        argThat(contains("import '../generated_plugin_registrant.dart';")))).called(1);
+  });
 }
 
 class MockBuildStep extends Mock implements BuildStep {}


### PR DESCRIPTION
## Description

If the entrypoint is in a subfolder of `lib/` (e.g. `lib/src/`) then `import 'generated_plugin_registrant.dart';` will fail because the plugin registrant is in `lib/`.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/48361

## Tests

Added a test in `flutter_tool/test/general.shard/build_runner/build_script_test.dart`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
