### PR TITLE
Allow Android to be missing from multi-platform manifest

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -161,7 +161,11 @@ class FlutterManifest {
     if (isPlugin) {
       final YamlMap plugin = _flutterDescriptor['plugin'] as YamlMap;
       if (plugin.containsKey('platforms')) {
-        return plugin['platforms']['android']['package'] as String;
+        final YamlMap platforms = plugin['platforms'] as YamlMap;
+
+        if (platforms.containsKey('android')) {
+          return platforms['android']['package'] as String;
+        }
       } else {
         return plugin['androidPackage'] as String;
       }

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
@@ -387,7 +387,8 @@ flutter:
       expect(flutterManifest.isPlugin, true);
       expect(flutterManifest.androidPackage, 'com.example');
     });
-    test('allows a multi-plat plugin declaration', () async {
+
+    test('allows a multi-plat plugin declaration with android only', () async {
       const String manifest = '''
 name: test
 flutter:
@@ -400,6 +401,20 @@ flutter:
       final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
       expect(flutterManifest.isPlugin, true);
       expect(flutterManifest.androidPackage, 'com.example');
+    });
+
+    test('allows a multi-plat plugin declaration with ios only', () async {
+      const String manifest = '''
+name: test
+flutter:
+    plugin:
+      platforms:
+        ios:
+          pluginClass: HelloPlugin
+''';
+      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
+      expect(flutterManifest.isPlugin, true);
+      expect(flutterManifest.androidPackage, isNull);
     });
 
     testUsingContext('handles an invalid plugin declaration', () async {


### PR DESCRIPTION
## Description

Allow Android platform to be missing from a multi-platform manifest.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/50300.  

## Tests

Add flutter_manifest_test, fails on master, passes on this PR.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*