### PR TITLE
Reland "Track lastKnownRemoteTextEditingValue separately from received data"

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1276,7 +1276,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         break;
       default:
         // Finalize editing, but don't give up focus because this keyboard
-        //  action does not imply the user is done inputting information.
+        // action does not imply the user is done inputting information.
         _finalizeEditing(false);
         break;
     }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1651,7 +1651,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         value = formatter.formatEditUpdate(_value, value);
       _value = value;
       _updateRemoteEditingValueIfNeeded();
-    } else {
+    } else if (!isRepeat) {
       _value = value;
     }
     if (textChanged && widget.onChanged != null)

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1644,8 +1644,9 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   void _formatAndSetValue(TextEditingValue value) {
     // Check if the new value is the same as the current local value, or is the same
     // as the post-formatting value of the previous pass.
-    final bool textChanged = _value?.text != value?.text && value?.text != _lastFormattedUnmodifiedTextEditingValue?.text;
-    if (textChanged && widget.inputFormatters != null && widget.inputFormatters.isNotEmpty) {
+    final bool textChanged = _value?.text != value?.text;
+    final bool isRepeat = value?.text == _lastFormattedUnmodifiedTextEditingValue?.text;
+    if (textChanged && !isRepeat && widget.inputFormatters != null && widget.inputFormatters.isNotEmpty) {
       for (final TextInputFormatter formatter in widget.inputFormatters)
         value = formatter.formatEditUpdate(_value, value);
       _value = value;

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1223,6 +1223,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   // TextInputClient implementation:
 
   TextEditingValue _lastKnownRemoteTextEditingValue;
+  TextEditingValue _receivedRemoteTextEditingValue;
 
   @override
   TextEditingValue get currentTextEditingValue => _value;
@@ -1242,9 +1243,10 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         _obscureLatestCharIndex = _value.selection.baseOffset;
       }
     }
-    _lastKnownRemoteTextEditingValue = value;
+    print('Updating-remoteValue: ${value.text}');
+    _receivedRemoteTextEditingValue = value;
     _formatAndSetValue(value);
-
+    _lastKnownRemoteTextEditingValue = value;
     // To keep the cursor from blinking while typing, we want to restart the
     // cursor timer every time a new character is typed.
     _stopCursorTimer(resetCharTicks: false);
@@ -1369,8 +1371,9 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     if (!_hasInputConnection)
       return;
     final TextEditingValue localValue = _value;
-    if (localValue == _lastKnownRemoteTextEditingValue)
+    if (localValue == _receivedRemoteTextEditingValue)
       return;
+    print('Setting IMM: ${localValue.text}');
     _lastKnownRemoteTextEditingValue = localValue;
     _textInputConnection.setEditingState(localValue);
   }
@@ -1634,7 +1637,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   }
 
   void _formatAndSetValue(TextEditingValue value) {
-    final bool textChanged = _value?.text != value?.text;
+    final bool textChanged = _value?.text != value?.text && value?.text != _lastKnownRemoteTextEditingValue?.text;
     if (textChanged && widget.inputFormatters != null && widget.inputFormatters.isNotEmpty) {
       for (final TextInputFormatter formatter in widget.inputFormatters)
         value = formatter.formatEditUpdate(_value, value);
@@ -1645,6 +1648,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     }
     if (textChanged && widget.onChanged != null)
       widget.onChanged(value.text);
+    print('Finish Format: ${_value.text}');
   }
 
   void _onCursorColorTick() {

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1651,7 +1651,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         value = formatter.formatEditUpdate(_value, value);
       _value = value;
       _updateRemoteEditingValueIfNeeded();
-    } else if (!isRepeat || !textChanged) {
+    } else {
       _value = value;
     }
     if (textChanged && widget.onChanged != null)

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1644,13 +1644,14 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   }
 
   void _formatAndSetValue(TextEditingValue value) {
+    // Check if the new value is the same as the current local value, or is the same
+    // as the post-formatting value of the previous pass.
     final bool textChanged = _value?.text != value?.text && value?.text != _lastKnownRemoteTextEditingValue?.text;
     if (textChanged && widget.inputFormatters != null && widget.inputFormatters.isNotEmpty) {
       for (final TextInputFormatter formatter in widget.inputFormatters)
         value = formatter.formatEditUpdate(_value, value);
       _value = value;
-      // _updateRemoteEditingValueIfNeeded();
-      _updateRemoteEditingValueIfNeeded()
+      _updateRemoteEditingValueIfNeeded();
     } else {
       _value = value;
     }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1651,7 +1651,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         value = formatter.formatEditUpdate(_value, value);
       _value = value;
       _updateRemoteEditingValueIfNeeded();
-    } else if (!isRepeat) {
+    } else if (!isRepeat || !textChanged) {
       _value = value;
     }
     if (textChanged && widget.onChanged != null)

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4259,25 +4259,23 @@ void main() {
 
     List<String> referenceLog = [];
     referenceLog.add('[1]: , a');
-    referenceLog.add('[1]: normal a');
-    referenceLog.add('[2]: a, aa');
-    referenceLog.add('[2]: normal aa');
-    referenceLog.add('[3]: aa, aaa');
-    referenceLog.add('[3]: normal aaa');
-    referenceLog.add('[4]: aaa, aa');
-    referenceLog.add('[4]: deleting aa');
-    referenceLog.add('[5]: aa, aaa');
-    referenceLog.add('[5]: normal aaaaa');
-    referenceLog.add('[6]: aaaaa, aaaa');
+    referenceLog.add('[1]: normal aa');
+    referenceLog.add('[2]: aa, aaa');
+    referenceLog.add('[2]: normal aaaa');
+    referenceLog.add('[3]: aaaa, aa');
+    referenceLog.add('[3]: deleting a');
+    referenceLog.add('[4]: a, aaa');
+    referenceLog.add('[4]: normal aaaaaaaa');
+    referenceLog.add('[5]: aaaaaaaa, aaaa');
+    referenceLog.add('[5]: deleting aaa');
+    referenceLog.add('[6]: aaa, aa');
     referenceLog.add('[6]: deleting aaaa');
-    referenceLog.add('[7]: aaaa, aa');
-    referenceLog.add('[7]: deleting aaaaa');
-    referenceLog.add('[8]: aaaaa, aaaaaaa');
-    referenceLog.add('[8]: normal aaaaaaaa');
-    referenceLog.add('[9]: aaaaaaaa, aa');
-    referenceLog.add('[9]: deleting aaaaaaa');
-    referenceLog.add('[10]: aaaaaaa, aaaaaaaaa');
-    referenceLog.add('[10]: normal aaaaaaaaaa');
+    referenceLog.add('[7]: aaaa, aaaaaaa');
+    referenceLog.add('[7]: normal aaaaaaaaaaaaaa');
+    referenceLog.add('[8]: aaaaaaaaaaaaaa, aa');
+    referenceLog.add('[8]: deleting aaaaaa');
+    referenceLog.add('[9]: aaaaaa, aaaaaaaaa');
+    referenceLog.add('[9]: normal aaaaaaaaaaaaaaaaaa');
 
     expect(formatter.log, referenceLog);
   });
@@ -4315,7 +4313,7 @@ class MockTextFormatter extends TextInputFormatter {
   }
 
   TextEditingValue _formatText(TextEditingValue value) {
-    String result = 'a' * _counter;
+    String result = 'a' * _counter * 2;
     log.add('[$_counter]: normal $result');
     return TextEditingValue(text: result);
   }

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4211,7 +4211,7 @@ void main() {
   });
 
   testWidgets('updateEditingValue filters multiple calls from formatter', (WidgetTester tester) async {
-    MockTextFormatter formatter = MockTextFormatter();
+    final MockTextFormatter formatter = MockTextFormatter();
     await tester.pumpWidget(
       MediaQuery(
         data: const MediaQueryData(devicePixelRatio: 1.0),
@@ -4244,20 +4244,20 @@ void main() {
     expect(tester.testTextInput.editingState['text'], equals('test'));
     expect(state.wantKeepAlive, true);
 
-    state.updateEditingValue(TextEditingValue(text: ''));
-    state.updateEditingValue(TextEditingValue(text: 'a'));
-    state.updateEditingValue(TextEditingValue(text: 'aa'));
-    state.updateEditingValue(TextEditingValue(text: 'aaa'));
-    state.updateEditingValue(TextEditingValue(text: 'aa'));
-    state.updateEditingValue(TextEditingValue(text: 'aaa'));
-    state.updateEditingValue(TextEditingValue(text: 'aaaa'));
-    state.updateEditingValue(TextEditingValue(text: 'aa'));
-    state.updateEditingValue(TextEditingValue(text: 'aaaaaaa'));
-    state.updateEditingValue(TextEditingValue(text: 'aa'));
-    state.updateEditingValue(TextEditingValue(text: 'aaaaaaaaa'));
-    state.updateEditingValue(TextEditingValue(text: 'aaaaaaaaa')); // Skipped
+    state.updateEditingValue(const TextEditingValue(text: ''));
+    state.updateEditingValue(const TextEditingValue(text: 'a'));
+    state.updateEditingValue(const TextEditingValue(text: 'aa'));
+    state.updateEditingValue(const TextEditingValue(text: 'aaa'));
+    state.updateEditingValue(const TextEditingValue(text: 'aa'));
+    state.updateEditingValue(const TextEditingValue(text: 'aaa'));
+    state.updateEditingValue(const TextEditingValue(text: 'aaaa'));
+    state.updateEditingValue(const TextEditingValue(text: 'aa'));
+    state.updateEditingValue(const TextEditingValue(text: 'aaaaaaa'));
+    state.updateEditingValue(const TextEditingValue(text: 'aa'));
+    state.updateEditingValue(const TextEditingValue(text: 'aaaaaaaaa'));
+    state.updateEditingValue(const TextEditingValue(text: 'aaaaaaaaa')); // Skipped
 
-    List<String> referenceLog = [];
+    final List<String> referenceLog = [];
     referenceLog.add('[1]: , a');
     referenceLog.add('[1]: normal aa');
     referenceLog.add('[2]: aa, aaa');

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4257,7 +4257,7 @@ void main() {
     state.updateEditingValue(const TextEditingValue(text: 'aaaaaaaaa'));
     state.updateEditingValue(const TextEditingValue(text: 'aaaaaaaaa')); // Skipped
 
-    final List<String> referenceLog = [];
+    final List<String> referenceLog = <String>[];
     referenceLog.add('[1]: , a');
     referenceLog.add('[1]: normal aa');
     referenceLog.add('[2]: aa, aaa');
@@ -4281,9 +4281,8 @@ void main() {
   });
 }
 
-@immutable
 class MockTextFormatter extends TextInputFormatter {
-  MockTextFormatter() : _counter = 0, log = [];
+  MockTextFormatter() : _counter = 0, log = <String>[];
 
   int _counter;
   List<String> log;
@@ -4307,13 +4306,13 @@ class MockTextFormatter extends TextInputFormatter {
 
   TextEditingValue _handleTextDeletion(
       TextEditingValue oldValue, TextEditingValue newValue) {
-    String result = 'a' * (_counter - 2);
+    final String result = 'a' * (_counter - 2);
     log.add('[$_counter]: deleting $result');
     return TextEditingValue(text: result);
   }
 
   TextEditingValue _formatText(TextEditingValue value) {
-    String result = 'a' * _counter * 2;
+    final String result = 'a' * _counter * 2;
     log.add('[$_counter]: normal $result');
     return TextEditingValue(text: result);
   }

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4257,25 +4257,26 @@ void main() {
     state.updateEditingValue(const TextEditingValue(text: 'aaaaaaaaa'));
     state.updateEditingValue(const TextEditingValue(text: 'aaaaaaaaa')); // Skipped
 
-    final List<String> referenceLog = <String>[];
-    referenceLog.add('[1]: , a');
-    referenceLog.add('[1]: normal aa');
-    referenceLog.add('[2]: aa, aaa');
-    referenceLog.add('[2]: normal aaaa');
-    referenceLog.add('[3]: aaaa, aa');
-    referenceLog.add('[3]: deleting a');
-    referenceLog.add('[4]: a, aaa');
-    referenceLog.add('[4]: normal aaaaaaaa');
-    referenceLog.add('[5]: aaaaaaaa, aaaa');
-    referenceLog.add('[5]: deleting aaa');
-    referenceLog.add('[6]: aaa, aa');
-    referenceLog.add('[6]: deleting aaaa');
-    referenceLog.add('[7]: aaaa, aaaaaaa');
-    referenceLog.add('[7]: normal aaaaaaaaaaaaaa');
-    referenceLog.add('[8]: aaaaaaaaaaaaaa, aa');
-    referenceLog.add('[8]: deleting aaaaaa');
-    referenceLog.add('[9]: aaaaaa, aaaaaaaaa');
-    referenceLog.add('[9]: normal aaaaaaaaaaaaaaaaaa');
+    const List<String> referenceLog = <String>[
+      '[1]: , a',
+      '[1]: normal aa',
+      '[2]: aa, aaa',
+      '[2]: normal aaaa',
+      '[3]: aaaa, aa',
+      '[3]: deleting a',
+      '[4]: a, aaa',
+      '[4]: normal aaaaaaaa',
+      '[5]: aaaaaaaa, aaaa',
+      '[5]: deleting aaa',
+      '[6]: aaa, aa',
+      '[6]: deleting aaaa',
+      '[7]: aaaa, aaaaaaa',
+      '[7]: normal aaaaaaaaaaaaaa',
+      '[8]: aaaaaaaaaaaaaa, aa',
+      '[8]: deleting aaaaaa',
+      '[9]: aaaaaa, aaaaaaaaa',
+      '[9]: normal aaaaaaaaaaaaaaaaaa',
+    ];
 
     expect(formatter.log, referenceLog);
   });

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4209,6 +4209,116 @@ void main() {
     final dynamic exception = tester.takeException();
     expect(exception, isNull);
   });
+
+  testWidgets('updateEditingValue filters multiple calls from formatter', (WidgetTester tester) async {
+    MockTextFormatter formatter = MockTextFormatter();
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(devicePixelRatio: 1.0),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: FocusScope(
+            node: focusScopeNode,
+            autofocus: true,
+            child: EditableText(
+              backgroundCursorColor: Colors.grey,
+              controller: controller,
+              focusNode: focusNode,
+              maxLines: 1, // Sets text keyboard implicitly.
+              style: textStyle,
+              cursorColor: cursorColor,
+              inputFormatters: <TextInputFormatter>[formatter],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(EditableText));
+    await tester.showKeyboard(find.byType(EditableText));
+    controller.text = 'test';
+    await tester.idle();
+
+    final EditableTextState state =
+        tester.state<EditableTextState>(find.byType(EditableText));
+    expect(tester.testTextInput.editingState['text'], equals('test'));
+    expect(state.wantKeepAlive, true);
+
+    state.updateEditingValue(TextEditingValue(text: ''));
+    state.updateEditingValue(TextEditingValue(text: 'a'));
+    state.updateEditingValue(TextEditingValue(text: 'aa'));
+    state.updateEditingValue(TextEditingValue(text: 'aaa'));
+    state.updateEditingValue(TextEditingValue(text: 'aa'));
+    state.updateEditingValue(TextEditingValue(text: 'aaa'));
+    state.updateEditingValue(TextEditingValue(text: 'aaaa'));
+    state.updateEditingValue(TextEditingValue(text: 'aa'));
+    state.updateEditingValue(TextEditingValue(text: 'aaaaaaa'));
+    state.updateEditingValue(TextEditingValue(text: 'aa'));
+    state.updateEditingValue(TextEditingValue(text: 'aaaaaaaaa'));
+    state.updateEditingValue(TextEditingValue(text: 'aaaaaaaaa')); // Skipped
+
+    List<String> referenceLog = [];
+    referenceLog.add('[1]: , a');
+    referenceLog.add('[1]: normal a');
+    referenceLog.add('[2]: a, aa');
+    referenceLog.add('[2]: normal aa');
+    referenceLog.add('[3]: aa, aaa');
+    referenceLog.add('[3]: normal aaa');
+    referenceLog.add('[4]: aaa, aa');
+    referenceLog.add('[4]: deleting aa');
+    referenceLog.add('[5]: aa, aaa');
+    referenceLog.add('[5]: normal aaaaa');
+    referenceLog.add('[6]: aaaaa, aaaa');
+    referenceLog.add('[6]: deleting aaaa');
+    referenceLog.add('[7]: aaaa, aa');
+    referenceLog.add('[7]: deleting aaaaa');
+    referenceLog.add('[8]: aaaaa, aaaaaaa');
+    referenceLog.add('[8]: normal aaaaaaaa');
+    referenceLog.add('[9]: aaaaaaaa, aa');
+    referenceLog.add('[9]: deleting aaaaaaa');
+    referenceLog.add('[10]: aaaaaaa, aaaaaaaaa');
+    referenceLog.add('[10]: normal aaaaaaaaaa');
+
+    expect(formatter.log, referenceLog);
+  });
+}
+
+@immutable
+class MockTextFormatter extends TextInputFormatter {
+  MockTextFormatter() : _counter = 0, log = [];
+
+  int _counter;
+  List<String> log;
+
+  @override
+  TextEditingValue formatEditUpdate(
+    TextEditingValue oldValue,
+    TextEditingValue newValue,
+  ) {
+    _counter++;
+    log.add('[$_counter]: ${oldValue.text}, ${newValue.text}');
+    TextEditingValue finalValue;
+    if (newValue.text.length < oldValue.text.length) {
+      finalValue = _handleTextDeletion(oldValue, newValue);
+    } else {
+      finalValue = _formatText(newValue);
+    }
+    return finalValue;
+  }
+
+
+  TextEditingValue _handleTextDeletion(
+      TextEditingValue oldValue, TextEditingValue newValue) {
+    String result = 'a' * (_counter - 2);
+    log.add('[$_counter]: deleting $result');
+    return TextEditingValue(text: result);
+  }
+
+  TextEditingValue _formatText(TextEditingValue value) {
+    String result = 'a' * _counter;
+    log.add('[$_counter]: normal $result');
+    return TextEditingValue(text: result);
+  }
 }
 
 class MockTextSelectionControls extends Mock implements TextSelectionControls {

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4236,12 +4236,12 @@ void main() {
 
     await tester.tap(find.byType(EditableText));
     await tester.showKeyboard(find.byType(EditableText));
-    controller.text = 'test';
+    controller.text = '';
     await tester.idle();
 
     final EditableTextState state =
         tester.state<EditableTextState>(find.byType(EditableText));
-    expect(tester.testTextInput.editingState['text'], equals('test'));
+    expect(tester.testTextInput.editingState['text'], equals(''));
     expect(state.wantKeepAlive, true);
 
     state.updateEditingValue(const TextEditingValue(text: ''));


### PR DESCRIPTION
Reland https://github.com/flutter/flutter/pull/49406

The original patch was causing failures in G3 where they override EditableTextState

Exploring workarounds.