### PR TITLE
[gen_l10n] Locale resolution integration test

### DIFF
--- a/packages/flutter_tools/test/integration.shard/gen_l10n_test.dart
+++ b/packages/flutter_tools/test/integration.shard/gen_l10n_test.dart
@@ -23,13 +23,10 @@ import 'test_utils.dart';
 // loaded workstation, so the test could time out on a heavily loaded bot.
 void main() {
   Directory tempDir;
-  final GenL10nProject _project = GenL10nProject();
   FlutterRunTestDriver _flutter;
 
   setUp(() async {
     tempDir = createResolvedTempDirectorySync('gen_l10n_test.');
-    await _project.setUpIn(tempDir);
-    _flutter = FlutterRunTestDriver(tempDir);
   });
 
   tearDown(() async {
@@ -48,7 +45,69 @@ void main() {
     }
   }
 
-  test('generated l10n classes produce expected localized strings', () async {
+  // test('generated l10n classes produce expected localized strings', () async {
+  //   final GenL10nProject _project = GenL10nProject();
+  //   await _project.setUpIn(tempDir);
+  //   _flutter = FlutterRunTestDriver(tempDir);
+
+  //   // Get the intl packages before running gen_l10n.
+  //   final String flutterBin = globals.platform.isWindows ? 'flutter.bat' : 'flutter';
+  //   final String flutterPath = globals.fs.path.join(getFlutterRoot(), 'bin', flutterBin);
+  //   runCommand(<String>[flutterPath, 'pub', 'get']);
+
+  //   // Generate lib/l10n/app_localizations.dart
+  //   final String genL10nPath = globals.fs.path.join(getFlutterRoot(), 'dev', 'tools', 'localization', 'bin', 'gen_l10n.dart');
+  //   final String dartBin = globals.platform.isWindows ? 'dart.exe' : 'dart';
+  //   final String dartPath = globals.fs.path.join(getFlutterRoot(), 'bin', 'cache', 'dart-sdk', 'bin', dartBin);
+  //   runCommand(<String>[dartPath, genL10nPath]);
+
+  //   // Run the app defined in GenL10nProject.main and wait for it to
+  //   // send '#l10n END' to its stdout.
+  //   final Completer<void> l10nEnd = Completer<void>();
+  //   final StringBuffer stdout = StringBuffer();
+  //   final StreamSubscription<String> subscription = _flutter.stdout.listen((String line) {
+  //     if (line.contains('#l10n')) {
+  //       stdout.writeln(line.substring(line.indexOf('#l10n')));
+  //     }
+  //     if (line.contains('#l10n END')) {
+  //       l10nEnd.complete();
+  //     }
+  //   });
+  //   await _flutter.run();
+  //   await l10nEnd.future;
+  //   await subscription.cancel();
+  //   expect(stdout.toString(),
+  //     '#l10n 0 (Hello World)\n'
+  //     '#l10n 1 (Hello World)\n'
+  //     '#l10n 2 (Hello World)\n'
+  //     '#l10n 3 (Hello World on Friday, January 1, 1960)\n'
+  //     '#l10n 4 (Hello world argument on 1/1/1960 at 00:00)\n'
+  //     '#l10n 5 (Hello World from 1960 to 2020)\n'
+  //     '#l10n 6 (Hello for 123)\n'
+  //     '#l10n 7 (Hello for price USD123.00)\n'
+  //     '#l10n 8 (Hello)\n'
+  //     '#l10n 9 (Hello World)\n'
+  //     '#l10n 10 (Hello two worlds)\n'
+  //     '#l10n 11 (Hello on Friday, January 1, 1960)\n'
+  //     '#l10n 12 (Hello World, on Friday, January 1, 1960)\n'
+  //     '#l10n 13 (Hello two worlds, on Friday, January 1, 1960)\n'
+  //     '#l10n 14 (Hello)\n'
+  //     '#l10n 15 (Hello new World)\n'
+  //     '#l10n 16 (Hello two new worlds)\n'
+  //     '#l10n 17 (Hello other 0 worlds, with a total of 100 citizens)\n'
+  //     '#l10n 18 (Hello World of 101 citizens)\n'
+  //     '#l10n 19 (Hello two worlds with 102 total citizens)\n'
+  //     '#l10n 20 ([Hello] #World#)\n'
+  //     '#l10n 21 ([Hello] -World- #123#)\n'
+  //     '#l10n END\n'
+  //   );
+  // });
+
+  test('locales with country code specified resolves to general locale if message is undefined', () async {
+    final GenL10nLocaleResolutionProject _project = GenL10nLocaleResolutionProject();
+    await _project.setUpIn(tempDir);
+    _flutter = FlutterRunTestDriver(tempDir);
+
     // Get the intl packages before running gen_l10n.
     final String flutterBin = globals.platform.isWindows ? 'flutter.bat' : 'flutter';
     final String flutterPath = globals.fs.path.join(getFlutterRoot(), 'bin', flutterBin);
@@ -76,28 +135,19 @@ void main() {
     await l10nEnd.future;
     await subscription.cancel();
     expect(stdout.toString(),
-      '#l10n 0 (Hello World)\n'
-      '#l10n 1 (Hello World)\n'
+      // Uses messages in app_en_CA.arb
+      '#l10n 0 (Hello, Canadian World)\n'
+      '#l10n 1 (Hello for price CAD123.00)\n'
+      // Uses messages in app_en.arb, since the app_en_CA.arb
+      // equivalents are untranslated
       '#l10n 2 (Hello World)\n'
-      '#l10n 3 (Hello World on Friday, January 1, 1960)\n'
-      '#l10n 4 (Hello world argument on 1/1/1960 at 00:00)\n'
-      '#l10n 5 (Hello World from 1960 to 2020)\n'
-      '#l10n 6 (Hello for 123)\n'
-      '#l10n 7 (Hello for price USD123.00)\n'
-      '#l10n 8 (Hello)\n'
-      '#l10n 9 (Hello World)\n'
-      '#l10n 10 (Hello two worlds)\n'
-      '#l10n 11 (Hello on Friday, January 1, 1960)\n'
-      '#l10n 12 (Hello World, on Friday, January 1, 1960)\n'
-      '#l10n 13 (Hello two worlds, on Friday, January 1, 1960)\n'
-      '#l10n 14 (Hello)\n'
-      '#l10n 15 (Hello new World)\n'
-      '#l10n 16 (Hello two new worlds)\n'
-      '#l10n 17 (Hello other 0 worlds, with a total of 100 citizens)\n'
-      '#l10n 18 (Hello World of 101 citizens)\n'
-      '#l10n 19 (Hello two worlds with 102 total citizens)\n'
-      '#l10n 20 ([Hello] #World#)\n'
-      '#l10n 21 ([Hello] -World- #123#)\n'
+      '#l10n 3 (Hello World)\n'
+      '#l10n 4 (Hello World on Friday, January 1, 1960)\n'
+      // Date is automatically represented as "1960-01-01" instead of
+      // "01-01-1960" since locale is passed into DateFormat.
+      '#l10n 5 (Hello world argument on 1960-01-01 at 00:00)\n'
+      '#l10n 6 (Hello World from 1960 to 2020)\n'
+      '#l10n 7 (Hello for 123)\n'
       '#l10n END\n'
     );
   });

--- a/packages/flutter_tools/test/integration.shard/gen_l10n_test.dart
+++ b/packages/flutter_tools/test/integration.shard/gen_l10n_test.dart
@@ -45,63 +45,63 @@ void main() {
     }
   }
 
-  // test('generated l10n classes produce expected localized strings', () async {
-  //   final GenL10nProject _project = GenL10nProject();
-  //   await _project.setUpIn(tempDir);
-  //   _flutter = FlutterRunTestDriver(tempDir);
+  test('generated l10n classes produce expected localized strings', () async {
+    final GenL10nProject _project = GenL10nProject();
+    await _project.setUpIn(tempDir);
+    _flutter = FlutterRunTestDriver(tempDir);
 
-  //   // Get the intl packages before running gen_l10n.
-  //   final String flutterBin = globals.platform.isWindows ? 'flutter.bat' : 'flutter';
-  //   final String flutterPath = globals.fs.path.join(getFlutterRoot(), 'bin', flutterBin);
-  //   runCommand(<String>[flutterPath, 'pub', 'get']);
+    // Get the intl packages before running gen_l10n.
+    final String flutterBin = globals.platform.isWindows ? 'flutter.bat' : 'flutter';
+    final String flutterPath = globals.fs.path.join(getFlutterRoot(), 'bin', flutterBin);
+    runCommand(<String>[flutterPath, 'pub', 'get']);
 
-  //   // Generate lib/l10n/app_localizations.dart
-  //   final String genL10nPath = globals.fs.path.join(getFlutterRoot(), 'dev', 'tools', 'localization', 'bin', 'gen_l10n.dart');
-  //   final String dartBin = globals.platform.isWindows ? 'dart.exe' : 'dart';
-  //   final String dartPath = globals.fs.path.join(getFlutterRoot(), 'bin', 'cache', 'dart-sdk', 'bin', dartBin);
-  //   runCommand(<String>[dartPath, genL10nPath]);
+    // Generate lib/l10n/app_localizations.dart
+    final String genL10nPath = globals.fs.path.join(getFlutterRoot(), 'dev', 'tools', 'localization', 'bin', 'gen_l10n.dart');
+    final String dartBin = globals.platform.isWindows ? 'dart.exe' : 'dart';
+    final String dartPath = globals.fs.path.join(getFlutterRoot(), 'bin', 'cache', 'dart-sdk', 'bin', dartBin);
+    runCommand(<String>[dartPath, genL10nPath]);
 
-  //   // Run the app defined in GenL10nProject.main and wait for it to
-  //   // send '#l10n END' to its stdout.
-  //   final Completer<void> l10nEnd = Completer<void>();
-  //   final StringBuffer stdout = StringBuffer();
-  //   final StreamSubscription<String> subscription = _flutter.stdout.listen((String line) {
-  //     if (line.contains('#l10n')) {
-  //       stdout.writeln(line.substring(line.indexOf('#l10n')));
-  //     }
-  //     if (line.contains('#l10n END')) {
-  //       l10nEnd.complete();
-  //     }
-  //   });
-  //   await _flutter.run();
-  //   await l10nEnd.future;
-  //   await subscription.cancel();
-  //   expect(stdout.toString(),
-  //     '#l10n 0 (Hello World)\n'
-  //     '#l10n 1 (Hello World)\n'
-  //     '#l10n 2 (Hello World)\n'
-  //     '#l10n 3 (Hello World on Friday, January 1, 1960)\n'
-  //     '#l10n 4 (Hello world argument on 1/1/1960 at 00:00)\n'
-  //     '#l10n 5 (Hello World from 1960 to 2020)\n'
-  //     '#l10n 6 (Hello for 123)\n'
-  //     '#l10n 7 (Hello for price USD123.00)\n'
-  //     '#l10n 8 (Hello)\n'
-  //     '#l10n 9 (Hello World)\n'
-  //     '#l10n 10 (Hello two worlds)\n'
-  //     '#l10n 11 (Hello on Friday, January 1, 1960)\n'
-  //     '#l10n 12 (Hello World, on Friday, January 1, 1960)\n'
-  //     '#l10n 13 (Hello two worlds, on Friday, January 1, 1960)\n'
-  //     '#l10n 14 (Hello)\n'
-  //     '#l10n 15 (Hello new World)\n'
-  //     '#l10n 16 (Hello two new worlds)\n'
-  //     '#l10n 17 (Hello other 0 worlds, with a total of 100 citizens)\n'
-  //     '#l10n 18 (Hello World of 101 citizens)\n'
-  //     '#l10n 19 (Hello two worlds with 102 total citizens)\n'
-  //     '#l10n 20 ([Hello] #World#)\n'
-  //     '#l10n 21 ([Hello] -World- #123#)\n'
-  //     '#l10n END\n'
-  //   );
-  // });
+    // Run the app defined in GenL10nProject.main and wait for it to
+    // send '#l10n END' to its stdout.
+    final Completer<void> l10nEnd = Completer<void>();
+    final StringBuffer stdout = StringBuffer();
+    final StreamSubscription<String> subscription = _flutter.stdout.listen((String line) {
+      if (line.contains('#l10n')) {
+        stdout.writeln(line.substring(line.indexOf('#l10n')));
+      }
+      if (line.contains('#l10n END')) {
+        l10nEnd.complete();
+      }
+    });
+    await _flutter.run();
+    await l10nEnd.future;
+    await subscription.cancel();
+    expect(stdout.toString(),
+      '#l10n 0 (Hello World)\n'
+      '#l10n 1 (Hello World)\n'
+      '#l10n 2 (Hello World)\n'
+      '#l10n 3 (Hello World on Friday, January 1, 1960)\n'
+      '#l10n 4 (Hello world argument on 1/1/1960 at 00:00)\n'
+      '#l10n 5 (Hello World from 1960 to 2020)\n'
+      '#l10n 6 (Hello for 123)\n'
+      '#l10n 7 (Hello for price USD123.00)\n'
+      '#l10n 8 (Hello)\n'
+      '#l10n 9 (Hello World)\n'
+      '#l10n 10 (Hello two worlds)\n'
+      '#l10n 11 (Hello on Friday, January 1, 1960)\n'
+      '#l10n 12 (Hello World, on Friday, January 1, 1960)\n'
+      '#l10n 13 (Hello two worlds, on Friday, January 1, 1960)\n'
+      '#l10n 14 (Hello)\n'
+      '#l10n 15 (Hello new World)\n'
+      '#l10n 16 (Hello two new worlds)\n'
+      '#l10n 17 (Hello other 0 worlds, with a total of 100 citizens)\n'
+      '#l10n 18 (Hello World of 101 citizens)\n'
+      '#l10n 19 (Hello two worlds with 102 total citizens)\n'
+      '#l10n 20 ([Hello] #World#)\n'
+      '#l10n 21 ([Hello] -World- #123#)\n'
+      '#l10n END\n'
+    );
+  });
 
   test('locales with country code specified resolves to general locale if message is undefined', () async {
     final GenL10nLocaleResolutionProject _project = GenL10nLocaleResolutionProject();

--- a/packages/flutter_tools/test/integration.shard/gen_l10n_test.dart
+++ b/packages/flutter_tools/test/integration.shard/gen_l10n_test.dart
@@ -143,11 +143,26 @@ void main() {
       '#l10n 2 (Hello World)\n'
       '#l10n 3 (Hello World)\n'
       '#l10n 4 (Hello World on Friday, January 1, 1960)\n'
-      // Date is automatically represented as "1960-01-01" instead of
-      // "01-01-1960" since locale is passed into DateFormat.
       '#l10n 5 (Hello world argument on 1960-01-01 at 00:00)\n'
       '#l10n 6 (Hello World from 1960 to 2020)\n'
       '#l10n 7 (Hello for 123)\n'
+      // All plurals are included in app_en_CA.arb because the 'intl'
+      // package's message lookup does not allow for untranslated
+      // plurals to fallback to the general language (en) messages.
+      '#l10n 8 (Hello, Canadians)\n'
+      '#l10n 9 (Hello Canadian World)\n'
+      '#l10n 10 (Hello two Canadian worlds)\n'
+      '#l10n 11 (Hello on Friday, January 1, 1960)\n'
+      '#l10n 12 (Hello World, on Friday, January 1, 1960)\n'
+      '#l10n 13 (Hello two worlds, on Friday, January 1, 1960)\n'
+      '#l10n 14 (Hello Canadians)\n'
+      '#l10n 15 (Hello new Canadian World)\n'
+      '#l10n 16 (Hello two new Canadian worlds)\n'
+      '#l10n 17 (Hello other 0 worlds, with a total of 100 citizens)\n'
+      '#l10n 18 (Hello World of 101 citizens)\n'
+      '#l10n 19 (Hello two worlds with 102 total citizens)\n'
+      '#l10n 20 ([Hello] #World#)\n'
+      '#l10n 21 ([Hello] Canadian -World- #123#)\n'
       '#l10n END\n'
     );
   });

--- a/packages/flutter_tools/test/integration.shard/test_data/gen_l10n_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/gen_l10n_project.dart
@@ -35,7 +35,8 @@ dependencies:
 ''';
 
   @override
-  final String main = r'''
+  String get main => _main;
+  static const String _main = r'''
 import 'package:flutter/material.dart';
 
 import 'l10n/app_localizations.dart';
@@ -242,6 +243,90 @@ void main() {
       "count": {},
       "hello": {},
       "world": {}
+    }
+  }
+}
+''';
+
+
+}
+
+class GenL10nLocaleResolutionProject extends GenL10nProject {
+  @override
+  Future<void> setUpIn(Directory dir) {
+    this.dir = dir;
+    writeFile(globals.fs.path.join(dir.path, 'lib', 'l10n', 'app_en_CA.arb'), appEnCa);
+    return super.setUpIn(dir);
+  }
+
+  @override
+  String get main => _main;
+  static const String _main = r'''
+import 'package:flutter/material.dart';
+
+import 'l10n/app_localizations.dart';
+
+class Home extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    try {
+      print('get localizations');
+      final AppLocalizations localizations = AppLocalizations.of(context);
+      print('localizations: $localizations');
+      print('localizations.helloWorld');
+      final List<String> results = <String>[
+        '${localizations.helloWorld}',
+        '${localizations.helloCost("price", 123)}',
+        '${localizations.hello("World")}',
+        '${localizations.greeting("Hello", "World")}',
+        '${localizations.helloWorldOn(DateTime(1960))}',
+        '${localizations.helloOn("world argument", DateTime(1960), DateTime(1960))}',
+        '${localizations.helloWorldDuring(DateTime(1960), DateTime(2020))}',
+        '${localizations.helloFor(123)}',
+      ];
+      int n = 0;
+      for (final String result in results) {
+        print('#l10n $n ($result)\n');
+        n += 1;
+      }
+    } finally {
+      print('#l10n END\n');
+    }
+    return Container();
+  }
+}
+
+void main() {
+  runApp(
+    MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: <Locale>[
+        Locale('en', 'CA'),
+      ],
+      home: Home(),
+    ),
+  );
+}
+''';
+
+  final String appEnCa = r'''
+{
+  "@@locale": "en_CA",
+
+  "helloWorld": "Hello, Canadian World",
+  "@helloWorld": {
+    "description": "The conventional newborn programmer greeting"
+  },
+
+  "helloCost": "Hello for {price} {value}",
+  "@helloCost": {
+    "description": "A message with string and int (currency) parameters",
+    "placeholders": {
+      "price": {},
+      "value": {
+        "type": "int",
+        "format": "currency"
+      }
     }
   }
 }

--- a/packages/flutter_tools/test/integration.shard/test_data/gen_l10n_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/gen_l10n_project.dart
@@ -35,8 +35,7 @@ dependencies:
 ''';
 
   @override
-  String get main => _main;
-  static const String _main = r'''
+  String get main => r'''
 import 'package:flutter/material.dart';
 
 import 'l10n/app_localizations.dart';
@@ -260,8 +259,7 @@ class GenL10nLocaleResolutionProject extends GenL10nProject {
   }
 
   @override
-  String get main => _main;
-  static const String _main = r'''
+  String get main => r'''
 import 'package:flutter/material.dart';
 
 import 'l10n/app_localizations.dart';
@@ -270,19 +268,36 @@ class Home extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     try {
-      print('get localizations');
       final AppLocalizations localizations = AppLocalizations.of(context);
-      print('localizations: $localizations');
-      print('localizations.helloWorld');
       final List<String> results = <String>[
+        // Uses messages in app_en_CA.arb
         '${localizations.helloWorld}',
         '${localizations.helloCost("price", 123)}',
+        // Uses messages in app_en.arb, since the app_en_CA.arb
+        // equivalents are untranslated
         '${localizations.hello("World")}',
         '${localizations.greeting("Hello", "World")}',
         '${localizations.helloWorldOn(DateTime(1960))}',
         '${localizations.helloOn("world argument", DateTime(1960), DateTime(1960))}',
         '${localizations.helloWorldDuring(DateTime(1960), DateTime(2020))}',
         '${localizations.helloFor(123)}',
+        // All plurals are included in app_en_CA.arb because the 'intl'
+        // package's message lookup does not allow for untranslated
+        // plurals to fallback to the general language (en) messages.
+        '${localizations.helloWorlds(0)}',
+        '${localizations.helloWorlds(1)}',
+        '${localizations.helloWorlds(2)}',
+        '${localizations.helloWorldsOn(0, DateTime(1960))}',
+        '${localizations.helloWorldsOn(1, DateTime(1960))}',
+        '${localizations.helloWorldsOn(2, DateTime(1960))}',
+        '${localizations.helloAdjectiveWorlds(0, "new")}',
+        '${localizations.helloAdjectiveWorlds(1, "new")}',
+        '${localizations.helloAdjectiveWorlds(2, "new")}',
+        '${localizations.helloWorldPopulation(0, 100)}',
+        '${localizations.helloWorldPopulation(1, 101)}',
+        '${localizations.helloWorldPopulation(2, 102)}',
+        '${localizations.helloWorldInterpolation("Hello", "World")}',
+        '${localizations.helloWorldsInterpolation(123, "Hello", "World")}',
       ];
       int n = 0;
       for (final String result in results) {
@@ -327,6 +342,57 @@ void main() {
         "type": "int",
         "format": "currency"
       }
+    }
+  },
+
+  "helloWorlds": "{count,plural, =0{Hello, Canadians} =1{Hello Canadian World} =2{Hello two Canadian worlds} few{Hello {count} Canadian worlds} many{Hello all {count} Canadian worlds} other{Hello other {count} Canadian worlds}}",
+  "@helloWorlds": {
+    "description": "A plural message",
+    "placeholders": {
+      "count": {}
+    }
+  },
+
+  "helloWorldsOn": "{count,plural, =0{Hello on {date}} =1{Hello Canadian World, on {date}} =2{Hello two Canadian worlds, on {date}} other{Hello other {count} Canadian worlds, on {date}}}",
+  "@helloWorldsOn": {
+    "description": "A plural message with an additional date parameter",
+    "placeholders": {
+      "count": {},
+      "date": {
+        "type": "DateTime",
+        "format": "yMMMMEEEEd"
+      }
+    }
+  },
+
+  "helloAdjectiveWorlds": "{count,plural, =0{Hello Canadians} =1{Hello {adjective} Canadian World} =2{Hello two {adjective} Canadian worlds} other{Hello other {count} {adjective} Canadian worlds}}",
+  "@helloAdjectiveWorlds": {
+    "description": "A plural message with an additional parameter",
+    "placeholders": {
+      "count": {},
+      "adjective": {}
+    }
+  },
+
+  "helloWorldPopulation": "{count,plural, =1{Hello World of {population} Canadian citizens} =2{Hello two worlds with {population} total Canadian citizens} many{Hello all {count} worlds, with a total of {population} Canadian citizens} other{Hello other {count} worlds, with a total of {population} Canadian citizens}}",
+  "@helloWorldPopulation": {
+    "description": "A plural message with an additional integer parameter",
+    "placeholders": {
+      "count": {},
+      "population": {
+        "type": "int",
+        "format": "compactLong"
+      }
+    }
+  },
+
+  "helloWorldsInterpolation": "{count,plural, other {[{hello}] Canadian -{world}- #{count}#}}",
+  "@helloWorldsInterpolation": {
+    "description": "A plural message with parameters that need string interpolation braces",
+    "placeholders": {
+      "count": {},
+      "hello": {},
+      "world": {}
     }
   }
 }


### PR DESCRIPTION
## Description

Adds an integration test to ensure that when a locale with a country code is specified, those messages are used. When the messages are not specified in the arb file for that country, but exist for the general language, it resolves to use the general language's messages if they exist. 

I noticed that this doesn't work with plural messages in the test (it won't work in any existing app for that matter). For example, if there is a plural message in `app_en.arb` that is not available in `app_en_CA.arb`, it will cause the app to crash. It fails on: 
```

════════ Exception caught by widgets library ═══════════════════════════════════
The following ArgumentError was thrown building Home(dirty, dependencies: [_LocalizationsScope-[GlobalKey#b34d2]]):
Invalid argument(s): The 'other' named argument must be provided

The relevant error-causing widget was
    Home 
package:locale_bug/main.dart:44
When the exception was thrown, this was the stack...
```

This is likely occurring because app contains a plural message for the general language, but not for the specific country. This is likely because the `intl` library attempts a lookup on the plural message for the country's locale, but since it doesn't exist, the code in the `intl` library for `pluralLogic` fails and throws an exception. I'm not entirely sure what to do about this now, so I left those messages out of the test. cc/ @HansMuller 

## Related Issues

n/a

## Tests

I added the following tests:

Adds more test coverage.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
