### PR TITLE
Update compile size benchmarks

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -409,6 +409,7 @@ class CompileTest {
     switch (deviceOperatingSystem) {
       case DeviceOperatingSystem.ios:
         options.insert(0, 'ios');
+        options.add('--tree-shake-icons');
         watch.start();
         await flutter('build', options: options);
         watch.stop();

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -410,6 +410,7 @@ class CompileTest {
       case DeviceOperatingSystem.ios:
         options.insert(0, 'ios');
         options.add('--tree-shake-icons');
+        options.add('--split-debug-info=infos/');
         watch.start();
         await flutter('build', options: options);
         watch.stop();
@@ -424,6 +425,7 @@ class CompileTest {
         options.insert(0, 'apk');
         options.add('--target-platform=android-arm');
         options.add('--tree-shake-icons');
+        options.add('--split-debug-info=infos/');
         watch.start();
         await flutter('build', options: options);
         watch.stop();


### PR DESCRIPTION
## Description

Use both tree-shake-icons and --split-debug-info for compile size tests