### PR TITLE
Update minimum version to Xcode 11.0

### DIFF
--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -19,8 +19,8 @@ import '../ios/devices.dart';
 import '../ios/xcodeproj.dart';
 import '../reporting/reporting.dart';
 
-const int kXcodeRequiredVersionMajor = 10;
-const int kXcodeRequiredVersionMinor = 2;
+const int kXcodeRequiredVersionMajor = 11;
+const int kXcodeRequiredVersionMinor = 0;
 
 enum SdkType {
   iPhone,

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -90,9 +90,9 @@ void main() {
 
   testWithoutContext('xcodebuild majorVersion returns major version', () {
     when(processManager.runSync(<String>[xcodebuild, '-version']))
-        .thenReturn(ProcessResult(1, 0, 'Xcode 10.3.3\nBuild version 8E3004b', ''));
+        .thenReturn(ProcessResult(1, 0, 'Xcode 11.4.1\nBuild version 11N111s', ''));
 
-    expect(xcodeProjectInterpreter.majorVersion, 10);
+    expect(xcodeProjectInterpreter.majorVersion, 11);
   });
 
   testWithoutContext('xcodebuild majorVersion is null when version has unexpected format', () {
@@ -102,7 +102,7 @@ void main() {
     expect(xcodeProjectInterpreter.majorVersion, isNull);
   });
 
-  testWithoutContext('xcodebuild inorVersion returns minor version', () {
+  testWithoutContext('xcodebuild minorVersion returns minor version', () {
     when(processManager.runSync(<String>[xcodebuild, '-version']))
         .thenReturn(ProcessResult(1, 0, 'Xcode 8.3.3\nBuild version 8E3004b', ''));
 

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -83,23 +83,23 @@ void main() {
 
     testWithoutContext('xcodeVersionSatisfactory is true when version meets minimum', () {
       when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-      when(mockXcodeProjectInterpreter.majorVersion).thenReturn(10);
-      when(mockXcodeProjectInterpreter.minorVersion).thenReturn(2);
+      when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
+      when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
 
       expect(xcode.isVersionSatisfactory, isTrue);
     });
 
     testWithoutContext('xcodeVersionSatisfactory is true when major version exceeds minimum', () {
       when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-      when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
-      when(mockXcodeProjectInterpreter.minorVersion).thenReturn(2);
+      when(mockXcodeProjectInterpreter.majorVersion).thenReturn(12);
+      when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
 
       expect(xcode.isVersionSatisfactory, isTrue);
     });
 
     testWithoutContext('xcodeVersionSatisfactory is true when minor version exceeds minimum', () {
       when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-      when(mockXcodeProjectInterpreter.majorVersion).thenReturn(10);
+      when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
       when(mockXcodeProjectInterpreter.minorVersion).thenReturn(3);
 
       expect(xcode.isVersionSatisfactory, isTrue);
@@ -126,8 +126,8 @@ void main() {
       when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
         .thenReturn(ProcessResult(1, 127, '', 'ERROR'));
       when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-      when(mockXcodeProjectInterpreter.majorVersion).thenReturn(10);
-      when(mockXcodeProjectInterpreter.minorVersion).thenReturn(2);
+      when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
+      when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
 
       expect(xcode.isInstalledAndMeetsVersionCheck, isFalse);
     });
@@ -138,8 +138,8 @@ void main() {
       when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
         .thenReturn(ProcessResult(1, 0, xcodePath, ''));
       when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-      when(mockXcodeProjectInterpreter.majorVersion).thenReturn(9);
-      when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
+      when(mockXcodeProjectInterpreter.majorVersion).thenReturn(10);
+      when(mockXcodeProjectInterpreter.minorVersion).thenReturn(2);
 
       expect(xcode.isInstalledAndMeetsVersionCheck, isFalse);
     });
@@ -150,8 +150,8 @@ void main() {
       when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
         .thenReturn(ProcessResult(1, 0, xcodePath, ''));
       when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-      when(mockXcodeProjectInterpreter.majorVersion).thenReturn(10);
-      when(mockXcodeProjectInterpreter.minorVersion).thenReturn(2);
+      when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
+      when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
 
       expect(xcode.isInstalledAndMeetsVersionCheck, isTrue);
     });

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -366,13 +366,13 @@ class FakeXcodeProjectInterpreter implements XcodeProjectInterpreter {
   bool get isInstalled => true;
 
   @override
-  String get versionText => 'Xcode 10.2';
+  String get versionText => 'Xcode 11.0';
 
   @override
-  int get majorVersion => 10;
+  int get majorVersion => 11;
 
   @override
-  int get minorVersion => 2;
+  int get minorVersion => 0;
 
   @override
   Future<Map<String, String>> getBuildSettings(


### PR DESCRIPTION
## Description

Updated minimum version of Xcode to match LUCI builder.  Xcode 11 was released September 2019.

## Related Issues

Tool change part of https://github.com/flutter/flutter/issues/49787.

## Tests

Updated xcodeproj_test and xcode_test.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*