### PR TITLE
Make onImage re-entrant safe

### DIFF
--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -88,11 +88,15 @@ Future<void> precacheImage(
   ImageStreamListener listener;
   listener = ImageStreamListener(
     (ImageInfo image, bool sync) {
-      completer.complete();
+      if (!completer.isCompleted) {
+        completer.complete();
+      }
       stream.removeListener(listener);
     },
     onError: (dynamic exception, StackTrace stackTrace) {
-      completer.complete();
+      if (!completer.isCompleted) {
+        completer.complete();
+      }
       stream.removeListener(listener);
       if (onError != null) {
         onError(exception, stackTrace);

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -639,13 +639,17 @@ void main() {
       )
     );
 
-    expect(imageStreamCompleter.listeners.length, 2);
-    imageStreamCompleter.listeners.toList()[1].onImage(null, null);
+    // Two listeners - one is the listener added by precacheImage, the other by the ImageCache.
+    final List<ImageStreamListener> listeners = imageStreamCompleter.listeners.toList();
+    expect(listeners.length, 2);
 
-    expect(imageStreamCompleter.listeners.length, 1);
-    imageStreamCompleter.listeners.toList()[0].onImage(null, null);
+    // Make sure the first listener can be called re-entrantly
+    listeners[1].onImage(null, null);
+    listeners[1].onImage(null, null);
 
-    expect(imageStreamCompleter.listeners.length, 0);
+    // Make sure the second listener can be called re-entrantly.
+    listeners[0].onImage(null, null);
+    listeners[0].onImage(null, null);
   });
 
   testWidgets('Precache completes with onError on error', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

This is a compatible refactoring to the work done in https://github.com/flutter/flutter/pull/25159 (for https://github.com/flutter/flutter/issues/25143).

That logic works well, but it's a little more brittle than it needs to be - for example, it checks that there are two listeners, but has no idea which listeners they are, and it fails to check that calls to `onImage` are safe to be re-entrant (which is part of the contract of `onImage`).  In a highly pathological case, one could imagine single pull request where we make a change such that the `ImageCache` doesn't listen in this case, and also change the logic so that `precacheImage` removes its listener registration in some subsequent frame _and_ anything else adds a listener. The test would still pass, but the bug would re-emerge.

This may sound very hypothetical, but it's similar to something I'm observing in working through ways to fix #48731 and #49456 

/cc @truongsinh - I'd appreciate any feedback you have on this as the original author of the test, or if you think I'm missing something here.

## Tests

Updated the existing test to exercise the same bug in a slightly different way.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
(I do not think we should consider this a breaking change, since it is correcting a slightly incorrect test)

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
