### PR TITLE
use raw strings to avoid escaping

### DIFF
--- a/dev/bots/test/analyze_test.dart
+++ b/dev/bots/test/analyze_test.dart
@@ -49,7 +49,7 @@ void main() {
         'test/analyze-test-input/root/packages/foo/deprecation.dart:41: Deprecation notice does not match required pattern.\n'
         'test/analyze-test-input/root/packages/foo/deprecation.dart:48: End of deprecation notice does not match required pattern.\n'
         'test/analyze-test-input/root/packages/foo/deprecation.dart:51: Unexpected deprecation notice indent.\n'
-        .replaceAll('/', Platform.isWindows ? '\\' : '/')
+        .replaceAll('/', Platform.isWindows ? r'\' : '/')
       )
       +
       'See: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes\n'
@@ -65,7 +65,7 @@ void main() {
       (
         'The following 1 file does not have the right license header:\n'
         'test/analyze-test-input/root/packages/foo/foo.dart\n'
-        .replaceAll('/', Platform.isWindows ? '\\' : '/')
+        .replaceAll('/', Platform.isWindows ? r'\' : '/')
       )
       +
       'The expected license header is:\n'
@@ -85,7 +85,7 @@ void main() {
       (
         'test/analyze-test-input/root/packages/foo/spaces.txt:5: trailing U+0020 space character\n'
         'test/analyze-test-input/root/packages/foo/spaces.txt:9: trailing blank line\n'
-        .replaceAll('/', Platform.isWindows ? '\\' : '/')
+        .replaceAll('/', Platform.isWindows ? r'\' : '/')
       )
       +
       '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'

--- a/dev/devicelab/bin/tasks/gradle_migrate_settings_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_migrate_settings_test.dart
@@ -73,7 +73,7 @@ Future<void> main() async {
 
       section('Override settings.gradle V2');
 
-      const String deprecatedFileContentV2 = '''
+      const String deprecatedFileContentV2 = r'''
 include ':app'
 
 def flutterProjectRoot = rootProject.projectDir.parentFile.toPath()
@@ -86,8 +86,8 @@ if (pluginsFile.exists()) {
 
 plugins.each { name, path ->
     def pluginDirectory = flutterProjectRoot.resolve(path).resolve('android').toFile()
-    include ":\$name"
-    project(":\$name").projectDir = pluginDirectory
+    include ":$name"
+    project(":$name").projectDir = pluginDirectory
 }
 ''';
       settingsGradle.writeAsStringSync(deprecatedFileContentV2, flush: true);

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -588,7 +588,7 @@ String extractCloudAuthTokenArg(List<String> rawArgs) {
 
 final RegExp _obsRegExp =
   RegExp('An Observatory debugger .* is available at: ');
-final RegExp _obsPortRegExp = RegExp('(\\S+:(\\d+)/\\S*)\$');
+final RegExp _obsPortRegExp = RegExp(r'(\S+:(\d+)/\S*)$');
 final RegExp _obsUriRegExp = RegExp(r'((http|//)[a-zA-Z0-9:/=_\-\.\[\]]+)');
 
 /// Tries to extract a port from the string.

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -774,7 +774,7 @@ class ListStatistics {
 
 class _UnzipListEntry {
   factory _UnzipListEntry.fromLine(String line) {
-    final List<String> data = line.trim().split(RegExp('\\s+'));
+    final List<String> data = line.trim().split(RegExp(r'\s+'));
     assert(data.length == 8);
     return _UnzipListEntry._(
       uncompressedSize:  int.parse(data[0]),

--- a/dev/snippets/test/snippets_test.dart
+++ b/dev/snippets/test/snippets_test.dart
@@ -64,7 +64,7 @@ main() {
     test('generates application snippets', () async {
       final File inputFile = File(path.join(tmpDir.absolute.path, 'snippet_in.txt'))
         ..createSync(recursive: true)
-        ..writeAsStringSync('''
+        ..writeAsStringSync(r'''
 A description of the snippet.
 
 On several lines.
@@ -75,7 +75,7 @@ const String name = 'snippet';
 
 ```dart
 void main() {
-  print('The actual \$name.');
+  print('The actual $name.');
 }
 ```
 ''');
@@ -93,7 +93,7 @@ void main() {
       );
       expect(html, contains('<div>HTML Bits</div>'));
       expect(html, contains('<div>More HTML Bits</div>'));
-      expect(html, contains('print(&#39;The actual \$name.&#39;);'));
+      expect(html, contains(r'print(&#39;The actual $name.&#39;);'));
       expect(html, contains('A description of the snippet.\n'));
       expect(
           html,
@@ -112,14 +112,14 @@ void main() {
     test('generates sample snippets', () async {
       final File inputFile = File(path.join(tmpDir.absolute.path, 'snippet_in.txt'))
         ..createSync(recursive: true)
-        ..writeAsStringSync('''
+        ..writeAsStringSync(r'''
 A description of the snippet.
 
 On several lines.
 
 ```code
 void main() {
-  print('The actual \$name.');
+  print('The actual $name.');
 }
 ```
 ''');
@@ -131,7 +131,7 @@ void main() {
       );
       expect(html, contains('<div>HTML Bits</div>'));
       expect(html, contains('<div>More HTML Bits</div>'));
-      expect(html, contains('  print(&#39;The actual \$name.&#39;);'));
+      expect(html, contains(r'  print(&#39;The actual $name.&#39;);'));
       expect(html, contains('<div class="snippet-description">{@end-inject-html}A description of the snippet.\n\n'
           'On several lines.{@inject-html}</div>\n'));
       expect(html, contains('main() {'));
@@ -140,14 +140,14 @@ void main() {
     test('generates dartpad snippets', () async {
       final File inputFile = File(path.join(tmpDir.absolute.path, 'snippet_in.txt'))
         ..createSync(recursive: true)
-        ..writeAsStringSync('''
+        ..writeAsStringSync(r'''
 A description of the snippet.
 
 On several lines.
 
 ```code
 void main() {
-  print('The actual \$name.');
+  print('The actual $name.');
 }
 ```
 ''');
@@ -167,14 +167,14 @@ void main() {
     test('generates snippet application metadata', () async {
       final File inputFile = File(path.join(tmpDir.absolute.path, 'snippet_in.txt'))
         ..createSync(recursive: true)
-        ..writeAsStringSync('''
+        ..writeAsStringSync(r'''
 A description of the snippet.
 
 On several lines.
 
 ```code
 void main() {
-  print('The actual \$name.');
+  print('The actual $name.');
 }
 ```
 ''');

--- a/dev/tools/test/localization/gen_l10n_test.dart
+++ b/dev/tools/test/localization/gen_l10n_test.dart
@@ -433,9 +433,9 @@ void main() {
       }
 
       if (Platform.isWindows) {
-        expect(generator.arbPathStrings.first, 'lib\\l10n\\app_en_US.arb');
-        expect(generator.arbPathStrings.elementAt(1), 'lib\\l10n\\app_es.arb');
-        expect(generator.arbPathStrings.elementAt(2), 'lib\\l10n\\app_zh.arb');
+        expect(generator.arbPathStrings.first, r'lib\l10n\app_en_US.arb');
+        expect(generator.arbPathStrings.elementAt(1), r'lib\l10n\app_es.arb');
+        expect(generator.arbPathStrings.elementAt(2), r'lib\l10n\app_zh.arb');
       } else {
         expect(generator.arbPathStrings.first, 'lib/l10n/app_en_US.arb');
         expect(generator.arbPathStrings.elementAt(1), 'lib/l10n/app_es.arb');
@@ -610,7 +610,8 @@ void main() {
       expect(generator.classMethods, isNotEmpty);
       expect(
         generator.classMethods.first,
-        '''  String get title {
+        '''
+  String get title {
     return Intl.message(
       'Title',
       locale: _localeName,
@@ -655,9 +656,10 @@ void main() {
       expect(generator.classMethods, isNotEmpty);
       expect(
         generator.classMethods.first,
-        '''  String itemNumber(Object value) {
+        r'''
+  String itemNumber(Object value) {
     return Intl.message(
-      'Item \${value}',
+      'Item ${value}',
       locale: _localeName,
       name: 'itemNumber',
       desc: 'Item placement in list.',
@@ -704,13 +706,14 @@ void main() {
         expect(generator.classMethods, isNotEmpty);
         expect(
           generator.classMethods.first,
-          '''  String springBegins(DateTime springStartDate) {
+          r'''
+  String springBegins(DateTime springStartDate) {
     final DateFormat springStartDateDateFormat = DateFormat.yMMMMEEEEd(_localeName);
     final String springStartDateString = springStartDateDateFormat.format(springStartDate);
 
     String springBegins(Object springStartDate) {
       return Intl.message(
-        'Spring begins on \${springStartDate}',
+        'Spring begins on ${springStartDate}',
         locale: _localeName,
         name: 'springBegins',
         desc: 'The first day of spring',
@@ -831,13 +834,14 @@ void main() {
         expect(generator.classMethods, isNotEmpty);
         expect(
           generator.classMethods.first,
-          '''  String springGreetings(DateTime springStartDate, Object helloWorld) {
+          r'''
+  String springGreetings(DateTime springStartDate, Object helloWorld) {
     final DateFormat springStartDateDateFormat = DateFormat.yMMMMEEEEd(_localeName);
     final String springStartDateString = springStartDateDateFormat.format(springStartDate);
 
     String springGreetings(Object springStartDate, Object helloWorld) {
       return Intl.message(
-        "Since it's \${springStartDate}, it's finally spring! \${helloWorld}!",
+        "Since it's ${springStartDate}, it's finally spring! ${helloWorld}!",
         locale: _localeName,
         name: 'springGreetings',
         desc: "A realization that it's finally the spring season, followed by a greeting.",
@@ -888,7 +892,8 @@ void main() {
         expect(generator.classMethods, isNotEmpty);
         expect(
           generator.classMethods.first,
-          '''  String springRange(DateTime springStartDate, DateTime springEndDate) {
+          '''
+  String springRange(DateTime springStartDate, DateTime springEndDate) {
     final DateFormat springStartDateDateFormat = DateFormat.yMMMMEEEEd(_localeName);
     final String springStartDateString = springStartDateDateFormat.format(springStartDate);
 
@@ -944,7 +949,8 @@ void main() {
         expect(generator.classMethods, isNotEmpty);
         expect(
           generator.classMethods.first,
-          '''  String helloWorlds(int count, DateTime currentDate) {
+          r'''
+  String helloWorlds(int count, DateTime currentDate) {
     final DateFormat currentDateDateFormat = DateFormat.yMMMMEEEEd(_localeName);
     final String currentDateString = currentDateDateFormat.format(currentDate);
 
@@ -954,10 +960,10 @@ void main() {
       locale: _localeName,
       name: 'helloWorlds',
       args: <Object>[count, currentDate],
-      one: 'Hello World, today is \${currentDateString}',
-      two: 'Hello two worlds, today is \${currentDateString}',
-      many: 'Hello all \${count} worlds, today is \${currentDateString}',
-      other: 'Hello other \${count} worlds, today is \${currentDateString}'
+      one: 'Hello World, today is ${currentDateString}',
+      two: 'Hello two worlds, today is ${currentDateString}',
+      many: 'Hello all ${count} worlds, today is ${currentDateString}',
+      other: 'Hello other ${count} worlds, today is ${currentDateString}'
       );
     }
     return helloWorlds(count, currentDateString);
@@ -1001,7 +1007,8 @@ void main() {
         expect(generator.classMethods, isNotEmpty);
         expect(
           generator.classMethods.first,
-          '''  String courseCompletion(double progress) {
+          r'''
+  String courseCompletion(double progress) {
     final NumberFormat progressNumberFormat = NumberFormat.compact(
       locale: _localeName,
     );
@@ -1009,7 +1016,7 @@ void main() {
 
     String courseCompletion(Object progress) {
       return Intl.message(
-        'You have completed \${progress} of the course.',
+        'You have completed ${progress} of the course.',
         locale: _localeName,
         name: 'courseCompletion',
         desc: 'The amount of progress the student has made in their class.',
@@ -1070,7 +1077,8 @@ void main() {
           expect(generator.classMethods, isNotEmpty);
           expect(
             generator.classMethods.first,
-            '''  String courseCompletion(double progress) {
+            '''
+  String courseCompletion(double progress) {
     final NumberFormat progressNumberFormat = NumberFormat.$numberFormat(
       locale: _localeName,
       decimalDigits: 2,
@@ -1133,7 +1141,8 @@ void main() {
           expect(generator.classMethods, isNotEmpty);
           expect(
             generator.classMethods.first,
-            '''  String courseCompletion(double progress) {
+            '''
+  String courseCompletion(double progress) {
     final NumberFormat progressNumberFormat = NumberFormat.$numberFormat(_localeName);
     final String progressString = progressNumberFormat.format(progress);
 
@@ -1223,7 +1232,8 @@ void main() {
         expect(generator.classMethods, isNotEmpty);
         expect(
           generator.classMethods.first,
-          '''  String helloWorlds(int count) {
+          r'''
+  String helloWorlds(int count) {
     return Intl.plural(
       count,
       locale: _localeName,
@@ -1232,9 +1242,9 @@ void main() {
       zero: 'Hello',
       one: 'Hello World',
       two: 'Hello two worlds',
-      few: 'Hello \${count} worlds',
-      many: 'Hello all \${count} worlds',
-      other: 'Hello other \${count} worlds'
+      few: 'Hello ${count} worlds',
+      many: 'Hello all ${count} worlds',
+      other: 'Hello other ${count} worlds'
     );
   }
 '''
@@ -1273,18 +1283,19 @@ void main() {
         expect(generator.classMethods, isNotEmpty);
         expect(
           generator.classMethods.first,
-        '''  String helloWorlds(int count, Object adjective) {
+          r'''
+  String helloWorlds(int count, Object adjective) {
     return Intl.plural(
       count,
       locale: _localeName,
       name: 'helloWorlds',
       args: <Object>[count, adjective],
       zero: 'Hello',
-      one: 'Hello \${adjective} World',
-      two: 'Hello two \${adjective} worlds',
-      few: 'Hello \${count} \${adjective} worlds',
-      many: 'Hello all \${count} \${adjective} worlds',
-      other: 'Hello other \${count} \${adjective} worlds'
+      one: 'Hello ${adjective} World',
+      two: 'Hello two ${adjective} worlds',
+      few: 'Hello ${count} ${adjective} worlds',
+      many: 'Hello all ${count} ${adjective} worlds',
+      other: 'Hello other ${count} ${adjective} worlds'
     );
   }
 '''
@@ -1326,7 +1337,8 @@ void main() {
         expect(generator.classMethods, isNotEmpty);
         expect(
           generator.classMethods.first,
-          '''  String helloWorlds(int count, DateTime currentDate) {
+          r'''
+  String helloWorlds(int count, DateTime currentDate) {
     final DateFormat currentDateDateFormat = DateFormat.yMMMMEEEEd(_localeName);
     final String currentDateString = currentDateDateFormat.format(currentDate);
 
@@ -1336,10 +1348,10 @@ void main() {
       locale: _localeName,
       name: 'helloWorlds',
       args: <Object>[count, currentDate],
-      one: 'Hello World, today is \${currentDateString}',
-      two: 'Hello two worlds, today is \${currentDateString}',
-      many: 'Hello all \${count} worlds, today is \${currentDateString}',
-      other: 'Hello other \${count} worlds, today is \${currentDateString}'
+      one: 'Hello World, today is ${currentDateString}',
+      two: 'Hello two worlds, today is ${currentDateString}',
+      many: 'Hello all ${count} worlds, today is ${currentDateString}',
+      other: 'Hello other ${count} worlds, today is ${currentDateString}'
       );
     }
     return helloWorlds(count, currentDateString);
@@ -1383,7 +1395,8 @@ void main() {
         expect(generator.classMethods, isNotEmpty);
         expect(
           generator.classMethods.first,
-          '''  String helloWorlds(int count, int population) {
+          r'''
+  String helloWorlds(int count, int population) {
     final NumberFormat populationNumberFormat = NumberFormat.compactLong(
       locale: _localeName,
     );
@@ -1395,10 +1408,10 @@ void main() {
       locale: _localeName,
       name: 'helloWorlds',
       args: <Object>[count, population],
-      one: 'Hello World of \${populationString} citizens',
-      two: 'Hello two worlds with \${populationString} total citizens',
-      many: 'Hello all \${count} worlds, with a total of \${populationString} citizens',
-      other: 'Hello other \${count} worlds, with a total of \${populationString} citizens'
+      one: 'Hello World of ${populationString} citizens',
+      two: 'Hello two worlds with ${populationString} total citizens',
+      many: 'Hello all ${count} worlds, with a total of ${populationString} citizens',
+      other: 'Hello other ${count} worlds, with a total of ${populationString} citizens'
       );
     }
     return helloWorlds(count, populationString);

--- a/dev/tools/vitool/lib/vitool.dart
+++ b/dev/tools/vitool/lib/vitool.dart
@@ -460,7 +460,7 @@ class _Transform {
 }
 
 
-const String _transformCommandAtom = ' *([^(]+)\\(([^)]*)\\)';
+const String _transformCommandAtom = r' *([^(]+)\(([^)]*)\)';
 final RegExp _transformValidator = RegExp('^($_transformCommandAtom)*\$');
 final RegExp _transformCommand = RegExp(_transformCommandAtom);
 
@@ -522,7 +522,7 @@ Matrix3 _matrix(double a, double b, double c, double d, double e, double f) {
 
 // Matches a pixels expression e.g "14px".
 // First group is just the number.
-final RegExp _pixelsExp = RegExp('^([0-9]+)px\$');
+final RegExp _pixelsExp = RegExp(r'^([0-9]+)px$');
 
 /// Parses a pixel expression, e.g "14px", and returns the number.
 /// Throws an [ArgumentError] if the given string doesn't match the pattern.

--- a/dev/tools/vitool/test/vitool_test.dart
+++ b/dev/tools/vitool/test/vitool_test.dart
@@ -559,7 +559,7 @@ void main() {
             ),
           ]);
 
-      expect(animation.toDart('_AnimatedIconData', '_\$data1'),
+      expect(animation.toDart('_AnimatedIconData', r'_$data1'),
           'const _AnimatedIconData _\$data1 = const _AnimatedIconData(\n'
           '  const Size(48.0, 48.0),\n'
           '  const <_PathFrames>[\n'

--- a/examples/flutter_gallery/lib/demo/material/text_form_field_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/text_form_field_demo.dart
@@ -250,7 +250,7 @@ class TextFormFieldDemoState extends State<TextFormFieldDemo> {
                     decoration: const InputDecoration(
                       border: OutlineInputBorder(),
                       labelText: 'Salary',
-                      prefixText: '\$',
+                      prefixText: r'$',
                       suffixText: 'USD',
                       suffixStyle: TextStyle(color: Colors.green),
                     ),

--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -1819,7 +1819,7 @@ class StringProperty extends DiagnosticsProperty<String> {
       // Escape linebreaks in multiline strings to avoid confusing output when
       // the parent of this node is trying to display all properties on the same
       // line.
-      text = text.replaceAll('\n', '\\n');
+      text = text.replaceAll('\n', r'\n');
     }
 
     if (quoted && text != null) {

--- a/packages/flutter/test/foundation/error_reporting_test.dart
+++ b/packages/flutter/test/foundation/error_reporting_test.dart
@@ -70,22 +70,22 @@ Future<void> main() async {
       },
     ));
     expect(console.join('\n'), matches(
-      '^══╡ EXCEPTION CAUGHT BY ERROR HANDLING TEST ╞═══════════════════════════════════════════════════════\n'
-      'The following assertion was thrown testing the error handling logic:\n'
-      'Message goes here\\.\n'
-      '\'[^\']+flutter/test/foundation/error_reporting_test\\.dart\':\n'
-      'Failed assertion: line [0-9]+ pos [0-9]+: \'false\'\n'
-      '\n'
-      'When the exception was thrown, this was the stack:\n'
-      '#0      getSampleStack\\.<anonymous closure> \\([^)]+flutter/test/foundation/error_reporting_test\\.dart:[0-9]+:[0-9]+\\)\n'
-      '#2      getSampleStack \\([^)]+flutter/test/foundation/error_reporting_test\\.dart:[0-9]+:[0-9]+\\)\n'
-      '#3      main \\([^)]+flutter/test/foundation/error_reporting_test\\.dart:[0-9]+:[0-9]+\\)\n'
-      '(.+\n)+' // TODO(ianh): when fixing #4021, also filter out frames from the test infrastructure below the first call to our main()
-      '\\(elided [0-9]+ frames from class _RawReceivePortImpl and dart:async\\)\n'
-      '\n'
-      'line 1 of extra information\n'
-      'line 2 of extra information\n'
-      '════════════════════════════════════════════════════════════════════════════════════════════════════\$',
+      r'^══╡ EXCEPTION CAUGHT BY ERROR HANDLING TEST ╞═══════════════════════════════════════════════════════\n'
+      r'The following assertion was thrown testing the error handling logic:\n'
+      r'Message goes here\.\n'
+      r"'[^']+flutter/test/foundation/error_reporting_test\.dart':\n"
+      r"Failed assertion: line [0-9]+ pos [0-9]+: 'false'\n"
+      r'\n'
+      r'When the exception was thrown, this was the stack:\n'
+      r'#0      getSampleStack\.<anonymous closure> \([^)]+flutter/test/foundation/error_reporting_test\.dart:[0-9]+:[0-9]+\)\n'
+      r'#2      getSampleStack \([^)]+flutter/test/foundation/error_reporting_test\.dart:[0-9]+:[0-9]+\)\n'
+      r'#3      main \([^)]+flutter/test/foundation/error_reporting_test\.dart:[0-9]+:[0-9]+\)\n'
+      r'(.+\n)+' // TODO(ianh): when fixing #4021, also filter out frames from the test infrastructure below the first call to our main()
+      r'\(elided [0-9]+ frames from class _RawReceivePortImpl and dart:async\)\n'
+      r'\n'
+      r'line 1 of extra information\n'
+      r'line 2 of extra information\n'
+      r'════════════════════════════════════════════════════════════════════════════════════════════════════$',
     ));
     console.clear();
     FlutterError.dumpErrorToConsole(FlutterErrorDetails(
@@ -102,16 +102,16 @@ Future<void> main() async {
       exception: getAssertionErrorWithLongMessage(),
     ));
     expect(console.join('\n'), matches(
-      '^══╡ EXCEPTION CAUGHT BY FLUTTER FRAMEWORK ╞═════════════════════════════════════════════════════════\n'
-      'The following assertion was thrown:\n'
-      'word word word word word word word word word word word word word word word word word word word word\n'
-      'word word word word word word word word word word word word word word word word word word word word\n'
-      'word word word word word word word word word word word word word word word word word word word word\n'
-      'word word word word word word word word word word word word word word word word word word word word\n'
-      'word word word word word word word word word word word word word word word word word word word word\n'
-      '\'[^\']+flutter/test/foundation/error_reporting_test\\.dart\':\n'
-      'Failed assertion: line [0-9]+ pos [0-9]+: \'false\'\n'
-      '════════════════════════════════════════════════════════════════════════════════════════════════════\$',
+      r'^══╡ EXCEPTION CAUGHT BY FLUTTER FRAMEWORK ╞═════════════════════════════════════════════════════════\n'
+      r'The following assertion was thrown:\n'
+      r'word word word word word word word word word word word word word word word word word word word word\n'
+      r'word word word word word word word word word word word word word word word word word word word word\n'
+      r'word word word word word word word word word word word word word word word word word word word word\n'
+      r'word word word word word word word word word word word word word word word word word word word word\n'
+      r'word word word word word word word word word word word word word word word word word word word word\n'
+      r"'[^']+flutter/test/foundation/error_reporting_test\.dart':\n"
+      r"Failed assertion: line [0-9]+ pos [0-9]+: 'false'\n"
+      r'════════════════════════════════════════════════════════════════════════════════════════════════════$',
     ));
     console.clear();
     FlutterError.dumpErrorToConsole(FlutterErrorDetails(
@@ -143,21 +143,21 @@ Future<void> main() async {
       },
     ));
     expect(console.join('\n'), matches(
-      '^══╡ EXCEPTION CAUGHT BY ERROR HANDLING TEST ╞═══════════════════════════════════════════════════════\n'
-      'The following assertion was thrown testing the error handling logic:\n'
-      '\'[^\']+flutter/test/foundation/error_reporting_test\\.dart\':[\n ]'
-      'Failed[\n ]assertion:[\n ]line[\n ][0-9]+[\n ]pos[\n ][0-9]+:[\n ]\'false\':[\n ]is[\n ]not[\n ]true\\.\n'
-      '\n'
-      'When the exception was thrown, this was the stack:\n'
-      '#0      getSampleStack\\.<anonymous closure> \\([^)]+flutter/test/foundation/error_reporting_test\\.dart:[0-9]+:[0-9]+\\)\n'
-      '#2      getSampleStack \\([^)]+flutter/test/foundation/error_reporting_test\\.dart:[0-9]+:[0-9]+\\)\n'
-      '#3      main \\([^)]+flutter/test/foundation/error_reporting_test\\.dart:[0-9]+:[0-9]+\\)\n'
-      '(.+\n)+' // TODO(ianh): when fixing #4021, also filter out frames from the test infrastructure below the first call to our main()
-      '\\(elided [0-9]+ frames from class _RawReceivePortImpl and dart:async\\)\n'
-      '\n'
-      'line 1 of extra information\n'
-      'line 2 of extra information\n'
-      '════════════════════════════════════════════════════════════════════════════════════════════════════\$',
+      r'^══╡ EXCEPTION CAUGHT BY ERROR HANDLING TEST ╞═══════════════════════════════════════════════════════\n'
+      r'The following assertion was thrown testing the error handling logic:\n'
+      r"'[^']+flutter/test/foundation/error_reporting_test\.dart':[\n ]"
+      r"Failed[\n ]assertion:[\n ]line[\n ][0-9]+[\n ]pos[\n ][0-9]+:[\n ]'false':[\n ]is[\n ]not[\n ]true\.\n"
+      r'\n'
+      r'When the exception was thrown, this was the stack:\n'
+      r'#0      getSampleStack\.<anonymous closure> \([^)]+flutter/test/foundation/error_reporting_test\.dart:[0-9]+:[0-9]+\)\n'
+      r'#2      getSampleStack \([^)]+flutter/test/foundation/error_reporting_test\.dart:[0-9]+:[0-9]+\)\n'
+      r'#3      main \([^)]+flutter/test/foundation/error_reporting_test\.dart:[0-9]+:[0-9]+\)\n'
+      r'(.+\n)+' // TODO(ianh): when fixing #4021, also filter out frames from the test infrastructure below the first call to our main()
+      r'\(elided [0-9]+ frames from class _RawReceivePortImpl and dart:async\)\n'
+      r'\n'
+      r'line 1 of extra information\n'
+      r'line 2 of extra information\n'
+      r'════════════════════════════════════════════════════════════════════════════════════════════════════$',
     ));
     console.clear();
     FlutterError.dumpErrorToConsole(FlutterErrorDetails(
@@ -175,11 +175,11 @@ Future<void> main() async {
       exception: exception,
     ));
     expect(console.join('\n'), matches(
-      '^══╡ EXCEPTION CAUGHT BY FLUTTER FRAMEWORK ╞═════════════════════════════════════════════════════════\n'
-      'The following NoSuchMethodError was thrown:\n'
-      'Receiver: 5\n'
-      'Tried calling: foo = 2, 4\n'
-      '════════════════════════════════════════════════════════════════════════════════════════════════════\$',
+      r'^══╡ EXCEPTION CAUGHT BY FLUTTER FRAMEWORK ╞═════════════════════════════════════════════════════════\n'
+      r'The following NoSuchMethodError was thrown:\n'
+      r'Receiver: 5\n'
+      r'Tried calling: foo = 2, 4\n'
+      r'════════════════════════════════════════════════════════════════════════════════════════════════════$',
     ));
     console.clear();
     FlutterError.dumpErrorToConsole(FlutterErrorDetails(
@@ -196,10 +196,10 @@ Future<void> main() async {
       exception: 'hello',
     ));
     expect(console.join('\n'), matches(
-      '^══╡ EXCEPTION CAUGHT BY FLUTTER FRAMEWORK ╞═════════════════════════════════════════════════════════\n'
-      'The following message was thrown:\n'
-      'hello\n'
-      '════════════════════════════════════════════════════════════════════════════════════════════════════\$',
+      r'^══╡ EXCEPTION CAUGHT BY FLUTTER FRAMEWORK ╞═════════════════════════════════════════════════════════\n'
+      r'The following message was thrown:\n'
+      r'hello\n'
+      r'════════════════════════════════════════════════════════════════════════════════════════════════════$',
     ));
     console.clear();
     FlutterError.dumpErrorToConsole(const FlutterErrorDetails(

--- a/packages/flutter/test/widgets/text_test.dart
+++ b/packages/flutter/test/widgets/text_test.dart
@@ -165,7 +165,7 @@ void main() {
     final SemanticsTester semantics = SemanticsTester(tester);
     await tester.pumpWidget(
       const Text(
-        '\$\$',
+        r'$$',
         semanticsLabel: 'Double dollars',
         textDirection: TextDirection.ltr,
       )
@@ -191,7 +191,7 @@ void main() {
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,
-        child: Text('\$\$', semanticsLabel: 'Double dollars')),
+        child: Text(r'$$', semanticsLabel: 'Double dollars')),
     );
 
     expect(

--- a/packages/flutter_driver/lib/src/driver/web_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/web_driver.dart
@@ -212,17 +212,18 @@ class FlutterWebConnection {
     }
 
     try {
-      result = await waitFor<dynamic>(() => _driver.execute('r'
-          'eturn \$flutterDriverResult', <String>[]),
-          matcher: isNotNull,
-          timeout: duration ?? const Duration(days: 30));
+      result = await waitFor<dynamic>(
+        () => _driver.execute(r'return $flutterDriverResult', <String>[]),
+        matcher: isNotNull,
+        timeout: duration ?? const Duration(days: 30),
+      );
     } catch (_) {
       // Returns null if exception thrown.
       return null;
     } finally {
       // Resets the result.
-      _driver.execute('''
-        \$flutterDriverResult = null
+      _driver.execute(r'''
+        $flutterDriverResult = null
       ''', <void>[]);
     }
     return result;
@@ -243,7 +244,7 @@ class FlutterWebConnection {
 /// Waits until extension is installed.
 Future<void> waitUntilExtensionInstalled(sync_io.WebDriver driver, Duration timeout) async {
   await waitFor<void>(() =>
-      driver.execute('return typeof(window.\$flutterDriver)', <String>[]),
+      driver.execute(r'return typeof(window.$flutterDriver)', <String>[]),
       matcher: 'function',
       timeout: timeout ?? const Duration(days: 365));
 }

--- a/packages/flutter_driver/lib/src/extension/_extension_web.dart
+++ b/packages/flutter_driver/lib/src/extension/_extension_web.dart
@@ -19,12 +19,12 @@ import 'dart:js_util' as js_util;
 ///
 ///  * [_extension_io.dart], which has the dart:io implementation
 void registerWebServiceExtension(Future<Map<String, dynamic>> Function(Map<String, String>) call) {
-  js_util.setProperty(html.window, '\$flutterDriver', allowInterop((dynamic message) async {
+  js_util.setProperty(html.window, r'$flutterDriver', allowInterop((dynamic message) async {
     // ignore: undefined_function, undefined_identifier
     final Map<String, String> params = Map<String, String>.from(
         jsonDecode(message as String) as Map<String, dynamic>);
     final Map<String, dynamic> result = Map<String, dynamic>.from(
         await call(params));
-    context['\$flutterDriverResult'] = json.encode(result);
+    context[r'$flutterDriverResult'] = json.encode(result);
   }));
 }

--- a/packages/flutter_driver/test/src/web_tests/web_extension_test.dart
+++ b/packages/flutter_driver/test/src/web_tests/web_extension_test.dart
@@ -20,7 +20,7 @@ void main() {
     test('web_extension should register a function', () {
       expect(() => registerWebServiceExtension(call),
           returnsNormally);
-      expect(js.context.hasProperty('\$flutterDriver'), true);
+      expect(js.context.hasProperty(r'$flutterDriver'), true);
     });
   });
 }

--- a/packages/flutter_tools/lib/src/base/file_system.dart
+++ b/packages/flutter_tools/lib/src/base/file_system.dart
@@ -114,7 +114,7 @@ class FileSystemUtils {
   ///
   /// On Windows it replaces all '\' with '\\'. On other platforms, it returns the
   /// path unchanged.
-  String escapePath(String path) => _platform.isWindows ? path.replaceAll('\\', '\\\\') : path;
+  String escapePath(String path) => _platform.isWindows ? path.replaceAll(r'\', r'\\') : path;
 
   /// Returns true if the file system [entity] has not been modified since the
   /// latest modification to [referenceFile].

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -409,7 +409,7 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
       } on FileNotFoundException {
         // iOS tooling not found; likely not running OSX; let [fromPlist] be null
       }
-      if (fromPlist != null && !fromPlist.contains('\$')) {
+      if (fromPlist != null && !fromPlist.contains(r'$')) {
         // Info.plist has no build variables in product bundle ID.
         return fromPlist;
       }

--- a/packages/flutter_tools/lib/src/vscode/vscode.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode.dart
@@ -163,7 +163,7 @@ class VsCode {
 
     if (localAppData != null) {
       searchLocations.add(_VsCodeInstallLocation(
-        globals.fs.path.join(localAppData, 'Programs\\Microsoft VS Code'),
+        globals.fs.path.join(localAppData, r'Programs\Microsoft VS Code'),
         '.vscode',
       ));
     }
@@ -179,7 +179,7 @@ class VsCode {
     ));
     if (localAppData != null) {
       searchLocations.add(_VsCodeInstallLocation(
-        globals.fs.path.join(localAppData, 'Programs\\Microsoft VS Code Insiders'),
+        globals.fs.path.join(localAppData, r'Programs\Microsoft VS Code Insiders'),
         '.vscode-insiders',
         isInsiders: true,
       ));

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -100,7 +100,7 @@ class ChromeDevice extends Device {
     String version = 'unknown';
     if (globals.platform.isWindows) {
       final ProcessResult result = await globals.processManager.run(<String>[
-        r'reg', 'query', 'HKEY_CURRENT_USER\\Software\\Google\\Chrome\\BLBeacon', '/v', 'version',
+        r'reg', 'query', r'HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon', '/v', 'version',
       ]);
       if (result.exitCode == 0) {
         final List<String> parts = (result.stdout as String).split(RegExp(r'\s+'));

--- a/packages/flutter_tools/test/commands.shard/permeable/analyze_once_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/analyze_once_test.dart
@@ -37,7 +37,7 @@ void main() {
       if (globals.platform.isWindows) {
         flutterRootUri
             ..write('/')
-            ..write(canonicalizedFlutterRootPath.replaceAll('\\', '/'));
+            ..write(canonicalizedFlutterRootPath.replaceAll(r'\', '/'));
       } else {
         flutterRootUri.write(canonicalizedFlutterRootPath);
       }

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -40,15 +40,15 @@ void main() {
 
   group('network errors', () {
     testUsingContext('retries if gradle fails while downloading', () async {
-      const String errorMessage = '''
+      const String errorMessage = r'''
 Exception in thread "main" java.io.FileNotFoundException: https://downloads.gradle.org/distributions/gradle-4.1.1-all.zip
 at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1872)
 at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1474)
 at sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:254)
 at org.gradle.wrapper.Download.downloadInternal(Download.java:58)
 at org.gradle.wrapper.Download.download(Download.java:44)
-at org.gradle.wrapper.Install\$1.call(Install.java:61)
-at org.gradle.wrapper.Install\$1.call(Install.java:48)
+at org.gradle.wrapper.Install$1.call(Install.java:61)
+at org.gradle.wrapper.Install$1.call(Install.java:48)
 at org.gradle.wrapper.ExclusiveFileAccessManager.access(ExclusiveFileAccessManager.java:65)
 at org.gradle.wrapper.Install.createDist(Install.java:48)
 at org.gradle.wrapper.WrapperExecutor.execute(WrapperExecutor.java:128)
@@ -66,7 +66,7 @@ at org.gradle.wrapper.GradleWrapperMain.main(GradleWrapperMain.java:61)''';
     });
 
     testUsingContext('retries if gradle fails downloading with proxy error', () async {
-      const String errorMessage = '''
+      const String errorMessage = r'''
 Exception in thread "main" java.io.IOException: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 400 Bad Request"
 at sun.net.www.protocol.http.HttpURLConnection.doTunneling(HttpURLConnection.java:2124)
 at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:183)
@@ -75,8 +75,8 @@ at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.
 at sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:254)
 at org.gradle.wrapper.Download.downloadInternal(Download.java:58)
 at org.gradle.wrapper.Download.download(Download.java:44)
-at org.gradle.wrapper.Install\$1.call(Install.java:61)
-at org.gradle.wrapper.Install\$1.call(Install.java:48)
+at org.gradle.wrapper.Install$1.call(Install.java:61)
+at org.gradle.wrapper.Install$1.call(Install.java:48)
 at org.gradle.wrapper.ExclusiveFileAccessManager.access(ExclusiveFileAccessManager.java:65)
 at org.gradle.wrapper.Install.createDist(Install.java:48)
 at org.gradle.wrapper.WrapperExecutor.execute(WrapperExecutor.java:128)
@@ -113,7 +113,7 @@ Exception in thread "main" java.lang.RuntimeException: Timeout of 120000 reached
     });
 
     testUsingContext('retries if remote host closes connection', () async {
-      const String errorMessage = '''
+      const String errorMessage = r'''
 Downloading https://services.gradle.org/distributions/gradle-5.6.2-all.zip
 Exception in thread "main" javax.net.ssl.SSLHandshakeException: Remote host closed connection during handshake
 	at sun.security.ssl.SSLSocketImpl.readRecord(SSLSocketImpl.java:994)
@@ -129,8 +129,8 @@ Exception in thread "main" javax.net.ssl.SSLHandshakeException: Remote host clos
 	at sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:263)
 	at org.gradle.wrapper.Download.downloadInternal(Download.java:58)
 	at org.gradle.wrapper.Download.download(Download.java:44)
-	at org.gradle.wrapper.Install\$1.call(Install.java:61)
-	at org.gradle.wrapper.Install\$1.call(Install.java:48)
+	at org.gradle.wrapper.Install$1.call(Install.java:61)
+	at org.gradle.wrapper.Install$1.call(Install.java:48)
 	at org.gradle.wrapper.ExclusiveFileAccessManager.access(ExclusiveFileAccessManager.java:65)
 	at org.gradle.wrapper.Install.createDist(Install.java:48)
 	at org.gradle.wrapper.WrapperExecutor.execute(WrapperExecutor.java:128)
@@ -175,7 +175,7 @@ Exception in thread "main" java.io.FileNotFoundException: https://downloads.grad
     });
 
     testUsingContext('retries if the connection is reset', () async {
-      const String errorMessage = '''
+      const String errorMessage = r'''
 Downloading https://services.gradle.org/distributions/gradle-5.6.2-all.zip
 Exception in thread "main" java.net.SocketException: Connection reset
 	at java.net.SocketInputStream.read(SocketInputStream.java:210)
@@ -194,8 +194,8 @@ Exception in thread "main" java.net.SocketException: Connection reset
 	at sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:263)
 	at org.gradle.wrapper.Download.downloadInternal(Download.java:58)
 	at org.gradle.wrapper.Download.download(Download.java:44)
-	at org.gradle.wrapper.Install\$1.call(Install.java:61)
-	at org.gradle.wrapper.Install\$1.call(Install.java:48)
+	at org.gradle.wrapper.Install$1.call(Install.java:61)
+	at org.gradle.wrapper.Install$1.call(Install.java:48)
 	at org.gradle.wrapper.ExclusiveFileAccessManager.access(ExclusiveFileAccessManager.java:65)
 	at org.gradle.wrapper.Install.createDist(Install.java:48)
 	at org.gradle.wrapper.WrapperExecutor.execute(WrapperExecutor.java:128)

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -457,7 +457,7 @@ void main() {
     });
 
     testUsingContext('create settings_aar.gradle when current settings.gradle loads plugins', () {
-      const String currentSettingsGradle = '''
+      const String currentSettingsGradle = r'''
 include ':app'
 
 def flutterProjectRoot = rootProject.projectDir.parentFile.toPath()
@@ -470,8 +470,8 @@ if (pluginsFile.exists()) {
 
 plugins.each { name, path ->
     def pluginDirectory = flutterProjectRoot.resolve(path).resolve('android').toFile()
-    include ":\$name"
-    project(":\$name").projectDir = pluginDirectory
+    include ":$name"
+    project(":$name").projectDir = pluginDirectory
 }
 ''';
 

--- a/packages/flutter_tools/test/general.shard/base/file_system_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/file_system_test.dart
@@ -105,8 +105,8 @@ void main() {
         fileSystem: fileSystem,
         platform: FakePlatform(operatingSystem: 'windows'),
       );
-      expect(fsUtils.escapePath('C:\\foo\\bar\\cool.dart'), 'C:\\\\foo\\\\bar\\\\cool.dart');
-      expect(fsUtils.escapePath('foo\\bar\\cool.dart'), 'foo\\\\bar\\\\cool.dart');
+      expect(fsUtils.escapePath(r'C:\foo\bar\cool.dart'), r'C:\\foo\\bar\\cool.dart');
+      expect(fsUtils.escapePath(r'foo\bar\cool.dart'), r'foo\\bar\\cool.dart');
       expect(fsUtils.escapePath('C:/foo/bar/cool.dart'), 'C:/foo/bar/cool.dart');
     });
 
@@ -118,7 +118,7 @@ void main() {
       );
       expect(fsUtils.escapePath('/foo/bar/cool.dart'), '/foo/bar/cool.dart');
       expect(fsUtils.escapePath('foo/bar/cool.dart'), 'foo/bar/cool.dart');
-      expect(fsUtils.escapePath('foo\\cool.dart'), 'foo\\cool.dart');
+      expect(fsUtils.escapePath(r'foo\cool.dart'), r'foo\cool.dart');
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/base/logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/logger_test.dart
@@ -282,7 +282,7 @@ void main() {
           );
           logger.printStatus('Rude Interrupting Cow');
           status.stop();
-          final String a = currentPlatform().isWindows ? '\\' : '⣽';
+          final String a = currentPlatform().isWindows ? r'\' : '⣽';
           final String b = currentPlatform().isWindows ? '|' : '⣻';
 
           expect(

--- a/packages/flutter_tools/test/general.shard/compile_incremental_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_incremental_test.dart
@@ -126,13 +126,13 @@ void main() {
     await _recompile(streamController, generator, mockFrontendServerStdIn,
       'result abc\nline1\nline2\nabc\nabc /path/to/main.dart.dill 0\n');
 
-    await _accept(streamController, generator, mockFrontendServerStdIn, '^accept\\n\$');
+    await _accept(streamController, generator, mockFrontendServerStdIn, r'^accept\n$');
 
     await _recompile(streamController, generator, mockFrontendServerStdIn,
       'result abc\nline1\nline2\nabc\nabc /path/to/main.dart.dill 0\n');
     // No sources returned from reject command.
     await _reject(streamController, generator, mockFrontendServerStdIn, 'result abc\nabc\n',
-      '^reject\\n\$');
+      r'^reject\n$');
     verifyNoMoreInteractions(mockFrontendServerStdIn);
     expect(mockFrontendServerStdIn.getAndClear(), isEmpty);
     expect(testLogger.errorText, equals(
@@ -193,7 +193,7 @@ Future<void> _recompile(
   );
   expect(output.outputFilename, equals('/path/to/main.dart.dill'));
   final String commands = mockFrontendServerStdIn.getAndClear();
-  final RegExp re = RegExp('^recompile (.*)\\n/path/to/main.dart\\n(.*)\\n\$');
+  final RegExp re = RegExp(r'^recompile (.*)\n/path/to/main.dart\n(.*)\n$');
   expect(commands, matches(re));
   final Match match = re.firstMatch(commands);
   expect(match[1] == match[2], isTrue);

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -388,7 +388,7 @@ apply plugin: 'kotlin-android'
               });
             }
         );
-        when(mockPlistUtils.getValueFromFile(any, any)).thenReturn('\$(PRODUCT_BUNDLE_IDENTIFIER)');
+        when(mockPlistUtils.getValueFromFile(any, any)).thenReturn(r'$(PRODUCT_BUNDLE_IDENTIFIER)');
         expect(await project.ios.productBundleIdentifier, 'io.flutter.someProject');
       });
 
@@ -403,7 +403,7 @@ apply plugin: 'kotlin-android'
             });
           }
         );
-        when(mockPlistUtils.getValueFromFile(any, any)).thenReturn('\$(PRODUCT_BUNDLE_IDENTIFIER).\$(SUFFIX)');
+        when(mockPlistUtils.getValueFromFile(any, any)).thenReturn(r'$(PRODUCT_BUNDLE_IDENTIFIER).$(SUFFIX)');
         expect(await project.ios.productBundleIdentifier, 'io.flutter.someProject.suffix');
       });
       testWithMocks('empty surrounded by quotes', () async {

--- a/packages/flutter_tools/test/general.shard/web/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devices_test.dart
@@ -117,7 +117,7 @@ void main() {
     when(mockProcessManager.run(<String>[
       'reg',
       'query',
-      'HKEY_CURRENT_USER\\Software\\Google\\Chrome\\BLBeacon',
+      r'HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon',
       '/v',
       'version',
     ])).thenAnswer((Invocation invocation) async {

--- a/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart
@@ -196,7 +196,7 @@ class FuchsiaRemoteConnection {
     sshConfigPath ??= Platform.environment['FUCHSIA_SSH_CONFIG'];
     if (address == null) {
       throw FuchsiaRemoteConnectionError(
-          'No address supplied, and \$FUCHSIA_DEVICE_URL not found.');
+          r'No address supplied, and $FUCHSIA_DEVICE_URL not found.');
     }
     const String interfaceDelimiter = '%';
     if (address.contains(interfaceDelimiter)) {


### PR DESCRIPTION
## Description

A raw string can be used to avoid escaping only backslashes and dollars.

**BAD:**
```dart
var s = 'A string with only \\ and \$';
```

**GOOD:**
```dart
var s = r'A string with only \ and $';
```

## Related Issues

None

## Tests

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
