### PR TITLE
Fix flutter doctor (pluginsPath) check for Mac

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -4,6 +4,8 @@
 
 import 'dart:async';
 
+import 'package:meta/meta.dart';
+
 import 'android/android_studio_validator.dart';
 import 'android/android_workflow.dart';
 import 'artifacts.dart';
@@ -848,6 +850,7 @@ class IntelliJValidatorOnMac extends IntelliJValidator {
     return validators;
   }
 
+  @visibleForTesting
   String get plistFile {
     _plistFile ??= globals.fs.path.join(installPath, 'Contents', 'Info.plist');
     return _plistFile;
@@ -866,10 +869,15 @@ class IntelliJValidatorOnMac extends IntelliJValidator {
 
   @override
   String get pluginsPath {
+    if (_pluginsPath != null) {
+      return _pluginsPath;
+    }
+
     final String altLocation = PlistParser.instance.getValueFromFile(plistFile, 'JetBrainsToolboxApp');
 
     if (altLocation != null) {
-      return altLocation + '.plugins';
+      _pluginsPath = altLocation + '.plugins';
+      return _pluginsPath;
     }
 
     final List<String> split = version.split('.');
@@ -880,13 +888,15 @@ class IntelliJValidatorOnMac extends IntelliJValidator {
 
     final String major = split[0];
     final String minor = split[1];
-    return globals.fs.path.join(
+    _pluginsPath = globals.fs.path.join(
       globals.fsUtils.homeDirPath,
       'Library',
       'Application Support',
       '$id$major.$minor',
     );
+    return _pluginsPath;
   }
+  String _pluginsPath;
 }
 
 class DeviceValidator extends DoctorValidator {

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -859,15 +859,22 @@ class IntelliJValidatorOnMac extends IntelliJValidator {
 
   @override
   String get pluginsPath {
-    final List<String> split = version.split('.');
-    final String major = split[0];
-    final String minor = split[1];
-    return globals.fs.path.join(
-      globals.fsUtils.homeDirPath,
-      'Library',
-      'Application Support',
-      '$id$major.$minor',
-    );
+    final String plistFile = globals.fs.path.join(installPath, 'Contents', 'Info.plist');
+    final String altLocation = PlistParser.instance.getValueFromFile(plistFile, 'JetBrainsToolboxApp');
+
+    if (altLocation == null) {
+      final List<String> split = version.split('.');
+      final String major = split[0];
+      final String minor = split[1];
+      return globals.fs.path.join(
+        globals.fsUtils.homeDirPath,
+        'Library',
+        'Application Support',
+        '$id$major.$minor',
+      );
+    }
+
+    return altLocation + '.plugins';
   }
 }
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
@@ -74,16 +74,9 @@ void main() {
 
       final IntelliJValidatorOnMac validatorViaToolbox = IntelliJValidatorOnMac('Test', 'Test', pathViaToolbox);
       expect(validatorViaToolbox.plistFile, 'test/data/intellij/mac_via_toolbox/Contents/Info.plist');
-      expect(validatorViaToolbox.pluginsPath, '/Users/lynn/Library/Application Support/JetBrains/Toolbox/apps/IDEA-U/ch-0/193.6494.35/IntelliJ IDEA.app.plugins');
 
       final IntelliJValidatorOnMac validatorNotViaToolbox = IntelliJValidatorOnMac('Test', 'Test', pathNotViaToolbox);
       expect(validatorNotViaToolbox.plistFile, 'test/data/intellij/mac_not_via_toolbox/Contents/Info.plist');
-      expect(validatorNotViaToolbox.pluginsPath, globals.fs.path.join(
-        globals.fsUtils.homeDirPath,
-        'Library',
-        'Application Support',
-        'Test2019.3',
-      ));
     }, overrides: <Type, Generator>{
       PlistParser: () => const PlistParser(),
     });

--- a/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_tools/src/base/user_messages.dart';
 import 'package:flutter_tools/src/doctor.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/ios/plist_parser.dart';
 import 'package:flutter_tools/src/proxy_validator.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/vscode/vscode.dart';
@@ -66,6 +67,26 @@ void main() {
       expect(message.message, contains('Flutter plugin version 0.1.3'));
       expect(message.message, contains('recommended minimum version'));
     }, overrides: noColorTerminalOverride);
+
+    testUsingContext('intellij plugins path checking on mac', () async {
+      final String pathViaToolbox = globals.fs.path.join('test', 'data', 'intellij', 'mac_via_toolbox');
+      final String pathNotViaToolbox = globals.fs.path.join('test', 'data', 'intellij', 'mac_not_via_toolbox');
+
+      final IntelliJValidatorOnMac validatorViaToolbox = IntelliJValidatorOnMac('Test', 'Test', pathViaToolbox);
+      expect(validatorViaToolbox.plistFile, 'test/data/intellij/mac_via_toolbox/Contents/Info.plist');
+      expect(validatorViaToolbox.pluginsPath, '/Users/lynn/Library/Application Support/JetBrains/Toolbox/apps/IDEA-U/ch-0/193.6494.35/IntelliJ IDEA.app.plugins');
+
+      final IntelliJValidatorOnMac validatorNotViaToolbox = IntelliJValidatorOnMac('Test', 'Test', pathNotViaToolbox);
+      expect(validatorNotViaToolbox.plistFile, 'test/data/intellij/mac_not_via_toolbox/Contents/Info.plist');
+      expect(validatorNotViaToolbox.pluginsPath, globals.fs.path.join(
+        globals.fsUtils.homeDirPath,
+        'Library',
+        'Application Support',
+        'Test2019.3',
+      ));
+    }, overrides: <Type, Generator>{
+      PlistParser: () => const PlistParser(),
+    });
 
     testUsingContext('vs code validator when both installed', () async {
       final ValidationResult result = await VsCodeValidatorTestTargets.installedWithExtension.validate();

--- a/packages/flutter_tools/test/data/intellij/mac_not_via_toolbox/Contents/Info.plist
+++ b/packages/flutter_tools/test/data/intellij/mac_not_via_toolbox/Contents/Info.plist
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC '-//Apple Computer//DTD PLIST 1.0//EN' 'http://www.apple.com/DTDs/PropertyList-1.0.dtd'>
+<plist version="1.0">
+ <dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>English</string>
+  <key>CFBundleExecutable</key>
+  <string>jetbrains-toolbox-launcher</string>
+  <key>CFBundleGetInfoString</key>
+  <string/>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>NSHumanReadableCopyright</key>
+  <string>Copyright (c) JetBrains s.r.o.</string>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+  <key>NSUIElement</key>
+  <false/>
+  <key>LSUIElement</key>
+  <true/>
+  <key>CFBundleName</key>
+  <string>IntelliJ IDEA Ultimate 2019.3.3</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.jetbrains.apps.activator.linkapp.pcom.jetbrains.apps.activator__ntelli_ltimate_2019_3_3</string>
+  <key>CFBundleVersion</key>
+  <string>2019.3.3</string>
+  <key>CFBundleLongVersionString</key>
+  <string>2019.3.3</string>
+  <key>CFBundleShortVersionString</key>
+  <string>2019.3.3</string>
+  <key>CFBundleIconFile</key>
+  <string>icon.icns</string>
+ </dict>
+</plist>

--- a/packages/flutter_tools/test/data/intellij/mac_via_toolbox/Contents/Info.plist
+++ b/packages/flutter_tools/test/data/intellij/mac_via_toolbox/Contents/Info.plist
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC '-//Apple Computer//DTD PLIST 1.0//EN' 'http://www.apple.com/DTDs/PropertyList-1.0.dtd'>
+<plist version="1.0">
+ <dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>English</string>
+  <key>CFBundleExecutable</key>
+  <string>jetbrains-toolbox-launcher</string>
+  <key>CFBundleGetInfoString</key>
+  <string/>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>NSHumanReadableCopyright</key>
+  <string>Copyright (c) JetBrains s.r.o.</string>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+  <key>NSUIElement</key>
+  <false/>
+  <key>LSUIElement</key>
+  <true/>
+  <key>CFBundleName</key>
+  <string>IntelliJ IDEA Ultimate 2019.3.3</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.jetbrains.apps.activator.linkapp.pcom.jetbrains.apps.activator__ntelli_ltimate_2019_3_3</string>
+  <key>CFBundleVersion</key>
+  <string>2019.3.3</string>
+  <key>CFBundleLongVersionString</key>
+  <string>2019.3.3</string>
+  <key>CFBundleShortVersionString</key>
+  <string>2019.3.3</string>
+  <key>CFBundleIconFile</key>
+  <string>icon.icns</string>
+  <key>JetBrainsToolboxApp</key>
+  <string>/Users/lynn/Library/Application Support/JetBrains/Toolbox/apps/IDEA-U/ch-0/193.6494.35/IntelliJ IDEA.app</string>
+ </dict>
+</plist>


### PR DESCRIPTION
## Description

Flutter plugin & Dart plugin installation checking may fail when using `flutter doctor` on Mac. 

However, they are both installed.

<img width="898" alt="brew-doctor" src="https://user-images.githubusercontent.com/6159817/74016320-31bfd400-49cd-11ea-95d6-f5000ced05cf.png">

It failed just because it checked the wrong directory.

If you install IDEA via JetBrain ToolBox, the default plugin directory is something like this one:

```
/Users/lynn/Library/Application Support/JetBrains/Toolbox/apps/IDEA-U/ch-0/193.6015.39/IntelliJ IDEA.app.plugins
```

So, we should read the Info.plist first then decide where to check for plugins.

`flutter doctor` after fix ↓

<img width="939" alt="brew-doctor-2" src="https://user-images.githubusercontent.com/6159817/74017066-7e57df00-49ce-11ea-853c-6664c0eef70a.png">

