### PR TITLE
Throw when trying to load an empty file

### DIFF
--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -746,7 +746,7 @@ class FileImage extends ImageProvider<FileImage> {
 
     final Uint8List bytes = await file.readAsBytes();
     if (bytes.lengthInBytes == 0)
-      return null;
+      throw StateError('$file is empty and cannot be loaded as an image.');
 
     return await decode(bytes);
   }


### PR DESCRIPTION
## Description

Analysis at https://github.com/flutter/flutter/issues/44579

Rather than throwing an assertion here, this should be a runtime error. This also makes it clearer why the load failed and properly uses the error handling mechanisms we have in place.

/cc @slightfoot @escamoteur 

## Related Issues

Fixes https://github.com/flutter/flutter/issues/44579

## Tests

I added the following tests:

Tests that we throw a state error when trying to load an empty file.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
