### PR TITLE
Nested TickerMode cannot turn tickers back on

### DIFF
--- a/packages/flutter/test/material/debug_test.dart
+++ b/packages/flutter/test/material/debug_test.dart
@@ -132,6 +132,7 @@ void main() {
       '     Offstage\n'
       '     _ModalScopeStatus\n'
       '     _ModalScope<dynamic>-[LabeledGlobalKey<_ModalScopeState<dynamic>>#969b7]\n'
+      '     _EffectiveTickerMode\n'
       '     TickerMode\n'
       '     _OverlayEntryWidget-[LabeledGlobalKey<_OverlayEntryWidgetState>#545d0]\n'
       '     _Theatre\n'

--- a/packages/flutter/test/widgets/ticker_mode_test.dart
+++ b/packages/flutter/test/widgets/ticker_mode_test.dart
@@ -1,0 +1,133 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Nested TickerMode cannot turn tickers back on', (WidgetTester tester) async {
+    int outerTickCount = 0;
+    int innerTickCount = 0;
+
+    Widget nestedTickerModes({bool innerEnabled, bool outerEnabled}) {
+      return Directionality(
+        textDirection: TextDirection.rtl,
+        child: TickerMode(
+          enabled: outerEnabled,
+          child: Row(
+            children: <Widget>[
+              _TickingWidget(
+                onTick: () {
+                  outerTickCount++;
+                },
+              ),
+              TickerMode(
+                enabled: innerEnabled,
+                child: _TickingWidget(
+                  onTick: () {
+                    innerTickCount++;
+                  },
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(
+      nestedTickerModes(
+        outerEnabled: false,
+        innerEnabled: true,
+      ),
+    );
+
+    expect(outerTickCount, 0);
+    expect(innerTickCount, 0);
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(seconds: 1));
+    expect(outerTickCount, 0);
+    expect(innerTickCount, 0);
+
+    await tester.pumpWidget(
+      nestedTickerModes(
+        outerEnabled: true,
+        innerEnabled: false,
+      ),
+    );
+    outerTickCount = 0;
+    innerTickCount = 0;
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(seconds: 1));
+    expect(outerTickCount, 4);
+    expect(innerTickCount, 0);
+
+    await tester.pumpWidget(
+      nestedTickerModes(
+        outerEnabled: true,
+        innerEnabled: true,
+      ),
+    );
+    outerTickCount = 0;
+    innerTickCount = 0;
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(seconds: 1));
+    expect(outerTickCount, 4);
+    expect(innerTickCount, 4);
+
+    await tester.pumpWidget(
+      nestedTickerModes(
+        outerEnabled: false,
+        innerEnabled: false,
+      ),
+    );
+    outerTickCount = 0;
+    innerTickCount = 0;
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(seconds: 1));
+    expect(outerTickCount, 0);
+    expect(innerTickCount, 0);
+  });
+}
+
+class _TickingWidget extends StatefulWidget {
+  const _TickingWidget({this.onTick});
+
+  final VoidCallback onTick;
+
+  @override
+  State<_TickingWidget> createState() => _TickingWidgetState();
+}
+
+class _TickingWidgetState extends State<_TickingWidget> with SingleTickerProviderStateMixin {
+  Ticker _ticker;
+
+  @override
+  void initState() {
+    super.initState();
+    _ticker = createTicker((Duration _) {
+      widget.onTick();
+    })..start();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container();
+  }
+
+  @override
+  void dispose() {
+    _ticker.dispose();
+    super.dispose();
+  }
+}


### PR DESCRIPTION
## Description

Prior to this change a nested TickerMode could override an ancestor TickerMode and turn tickers back on:

```dart
TickerMode(
  enabled: false,
  child: TickerMode(
    enabled: true,
   child: ... // <- Tickers are ticking here again.
  ),
);
```

It doesn't seem to make much sense to turn tickers off for a non-leaf part of a subtree. This change makes it so that if something is wrapped in `TickerMode(enabled: false)` tickers are off for the entire subtree. Descendant TickerModes cannot turn tickers back on in this subtree.

## Related Issues

None

## Tests

I added the following tests:

* Wrapping TickerMode can turn off ticking in routes
* Nested TickerMode cannot turn tickers back on

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
