### PR TITLE
Disable tests using gauge

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -463,11 +463,11 @@ tasks:
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
 
-  post_backdrop_filter_perf_ios__timeline_summary:
-    description: >
-      Measures the runtime performance of animations after a backdrop filter is removed on iOS.
-    stage: devicelab_ios
-    required_agent_capabilities: ["mac/iphonexs"]
+  # post_backdrop_filter_perf_ios__timeline_summary:
+  #   description: >
+  #     Measures the runtime performance of animations after a backdrop filter is removed on iOS.
+  #   stage: devicelab_ios
+  #   required_agent_capabilities: ["mac/iphonexs"]
 
   complex_layout_scroll_perf_ios__timeline_summary:
     description: >
@@ -560,11 +560,11 @@ tasks:
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
 
-  simple_animation_perf_iphonexs:
-    description: >
-      Measure CPU/GPU usage percentages of a simple animation.
-    stage: devicelab_ios
-    required_agent_capabilities: ["mac/iphonexs"]
+  # simple_animation_perf_iphonexs:
+  #   description: >
+  #     Measure CPU/GPU usage percentages of a simple animation.
+  #   stage: devicelab_ios
+  #   required_agent_capabilities: ["mac/iphonexs"]
 
   smoke_catalina_start_up_ios:
     description: >


### PR DESCRIPTION
This test is flaking at an unacceptable rate, and is incompatible with certain versions of iOS and certain versions of Xcode that we need to be able to test on.

It is also preventing another test from detecting regresions on an iPhoneX, which is what the target was original set up for.

/cc @digiter @godofredoc @keyonghan 

issue tracking this: https://github.com/flutter/flutter/issues/45435

See also: https://github.com/flutter/flutter/issues/49787

I plan to land this TBR on red to make infra less flaky.