### PR TITLE
Fall back to global cache and platform if null when injected into constructor

### DIFF
--- a/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
@@ -298,6 +298,56 @@ Future<void> main() async {
         }
       }
 
+      // This builds all build modes' frameworks by default
+      section('Build podspec');
+
+      const String cocoapodsOutputDirectoryName = 'flutter-frameworks-cocoapods';
+
+      await inDirectory(projectDir, () async {
+        await flutter(
+          'build',
+          options: <String>[
+            'ios-framework',
+            '--cocoapods',
+            '--force', // Allow podspec creation on master.
+            '--output=$cocoapodsOutputDirectoryName'
+          ],
+        );
+      });
+
+      final String cocoapodsOutputPath = path.join(projectDir.path, cocoapodsOutputDirectoryName);
+      for (final String mode in <String>['Debug', 'Profile', 'Release']) {
+        checkFileExists(path.join(
+          cocoapodsOutputPath,
+          mode,
+          'Flutter.podspec',
+        ));
+
+        checkDirectoryExists(path.join(
+          cocoapodsOutputPath,
+          mode,
+          'App.framework',
+        ));
+
+        checkDirectoryExists(path.join(
+          cocoapodsOutputPath,
+          mode,
+          'FlutterPluginRegistrant.framework',
+        ));
+
+        checkDirectoryExists(path.join(
+          cocoapodsOutputPath,
+          mode,
+          'device_info.framework',
+        ));
+
+        checkDirectoryExists(path.join(
+          cocoapodsOutputPath,
+          mode,
+          'package_info.framework',
+        ));
+      }
+
       return TaskResult.success(null);
     } on TaskResult catch (taskResult) {
       return taskResult;

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -641,6 +641,13 @@ void checkFileNotExists(String file) {
   }
 }
 
+/// Checks that the directory exists, otherwise throws a [FileSystemException].
+void checkDirectoryExists(String directory) {
+  if (!exists(Directory(directory))) {
+    throw FileSystemException('Expected directory to exist.', directory);
+  }
+}
+
 /// Check that `collection` contains all entries in `values`.
 void checkCollectionContains<T>(Iterable<T> values, Iterable<T> collection) {
   for (final T value in values) {

--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -9,7 +9,6 @@ import '../bundle.dart';
 import '../commands/build_linux.dart';
 import '../commands/build_macos.dart';
 import '../commands/build_windows.dart';
-import '../globals.dart' as globals;
 import '../runner/flutter_command.dart';
 import 'build_aar.dart';
 import 'build_aot.dart';
@@ -31,8 +30,6 @@ class BuildCommand extends FlutterCommand {
     addSubcommand(BuildIOSFrameworkCommand(
       aotBuilder: AotBuilder(),
       bundleBuilder: BundleBuilder(),
-      cache: globals.cache,
-      platform: globals.platform,
     ));
     addSubcommand(BuildBundleCommand(verboseHelp: verboseHelp));
     addSubcommand(BuildWebCommand());

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
@@ -134,7 +134,6 @@ void main() {
           when(mockGitTagVersion.y).thenReturn(13);
           when(mockGitTagVersion.z).thenReturn(11);
           when(mockGitTagVersion.hotfix).thenReturn(13);
-          when(mockGitTagVersion.commits).thenReturn(0);
 
           when(mockFlutterVersion.frameworkVersion).thenReturn(frameworkVersion);
 
@@ -143,78 +142,107 @@ void main() {
             ..writeAsStringSync(licenseText);
         });
 
-        testUsingContext('contains license and version', () async {
-          final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
-            aotBuilder: MockAotBuilder(),
-            bundleBuilder: MockBundleBuilder(),
-            platform: fakePlatform,
-            flutterVersion: mockFlutterVersion,
-            cache: mockCache
-          );
-          command.produceFlutterPodspec(BuildMode.debug, outputDirectory);
+        group('on master channel', () {
+          setUp(() {
+            when(mockGitTagVersion.commits).thenReturn(100);
+          });
 
-          final File expectedPodspec = outputDirectory.childFile('Flutter.podspec');
-          final String podspecContents = expectedPodspec.readAsStringSync();
-          expect(podspecContents, contains('\'1.13.1113\''));
-          expect(podspecContents, contains('# $frameworkVersion'));
-          expect(podspecContents, contains(licenseText));
-        }, overrides: <Type, Generator>{
-          FileSystem: () => memoryFileSystem,
-          ProcessManager: () => FakeProcessManager.any(),
+          testUsingContext('created when forced', () async {
+            final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
+                aotBuilder: MockAotBuilder(),
+                bundleBuilder: MockBundleBuilder(),
+                platform: fakePlatform,
+                flutterVersion: mockFlutterVersion,
+                cache: mockCache
+            );
+            command.produceFlutterPodspec(BuildMode.debug, outputDirectory, force: true);
+
+            final File expectedPodspec = outputDirectory.childFile('Flutter.podspec');
+            expect(expectedPodspec.existsSync(), isTrue);
+          }, overrides: <Type, Generator>{
+            FileSystem: () => memoryFileSystem,
+            ProcessManager: () => FakeProcessManager.any(),
+          });
         });
 
-        testUsingContext('debug URL', () async {
-          final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
-            aotBuilder: MockAotBuilder(),
-            bundleBuilder: MockBundleBuilder(),
-            platform: fakePlatform,
-            flutterVersion: mockFlutterVersion,
-            cache: mockCache
-          );
-          command.produceFlutterPodspec(BuildMode.debug, outputDirectory);
+        group('not on master channel', () {
+          setUp(() {
+            when(mockGitTagVersion.commits).thenReturn(0);
+          });
 
-          final File expectedPodspec = outputDirectory.childFile('Flutter.podspec');
-          final String podspecContents = expectedPodspec.readAsStringSync();
-          expect(podspecContents, contains('\'$storageBaseUrl/flutter_infra/flutter/$engineRevision/ios/artifacts.zip\''));
-        }, overrides: <Type, Generator>{
-          FileSystem: () => memoryFileSystem,
-          ProcessManager: () => FakeProcessManager.any(),
-        });
+          testUsingContext('contains license and version', () async {
+            final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
+                aotBuilder: MockAotBuilder(),
+                bundleBuilder: MockBundleBuilder(),
+                platform: fakePlatform,
+                flutterVersion: mockFlutterVersion,
+                cache: mockCache
+            );
+            command.produceFlutterPodspec(BuildMode.debug, outputDirectory);
 
-        testUsingContext('profile URL', () async {
-          final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
-            aotBuilder: MockAotBuilder(),
-            bundleBuilder: MockBundleBuilder(),
-            platform: fakePlatform,
-            flutterVersion: mockFlutterVersion,
-            cache: mockCache
-          );
-          command.produceFlutterPodspec(BuildMode.profile, outputDirectory);
+            final File expectedPodspec = outputDirectory.childFile('Flutter.podspec');
+            final String podspecContents = expectedPodspec.readAsStringSync();
+            expect(podspecContents, contains('\'1.13.1113\''));
+            expect(podspecContents, contains('# $frameworkVersion'));
+            expect(podspecContents, contains(licenseText));
+          }, overrides: <Type, Generator>{
+            FileSystem: () => memoryFileSystem,
+            ProcessManager: () => FakeProcessManager.any(),
+          });
 
-          final File expectedPodspec = outputDirectory.childFile('Flutter.podspec');
-          final String podspecContents = expectedPodspec.readAsStringSync();
-          expect(podspecContents, contains('\'$storageBaseUrl/flutter_infra/flutter/$engineRevision/ios-profile/artifacts.zip\''));
-        }, overrides: <Type, Generator>{
-          FileSystem: () => memoryFileSystem,
-          ProcessManager: () => FakeProcessManager.any(),
-        });
+          testUsingContext('debug URL', () async {
+            final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
+                aotBuilder: MockAotBuilder(),
+                bundleBuilder: MockBundleBuilder(),
+                platform: fakePlatform,
+                flutterVersion: mockFlutterVersion,
+                cache: mockCache
+            );
+            command.produceFlutterPodspec(BuildMode.debug, outputDirectory);
 
-        testUsingContext('release URL', () async {
-          final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
-            aotBuilder: MockAotBuilder(),
-            bundleBuilder: MockBundleBuilder(),
-            platform: fakePlatform,
-            flutterVersion: mockFlutterVersion,
-            cache: mockCache
-          );
-          command.produceFlutterPodspec(BuildMode.release, outputDirectory);
+            final File expectedPodspec = outputDirectory.childFile('Flutter.podspec');
+            final String podspecContents = expectedPodspec.readAsStringSync();
+            expect(podspecContents, contains('\'$storageBaseUrl/flutter_infra/flutter/$engineRevision/ios/artifacts.zip\''));
+          }, overrides: <Type, Generator>{
+            FileSystem: () => memoryFileSystem,
+            ProcessManager: () => FakeProcessManager.any(),
+          });
 
-          final File expectedPodspec = outputDirectory.childFile('Flutter.podspec');
-          final String podspecContents = expectedPodspec.readAsStringSync();
-          expect(podspecContents, contains('\'$storageBaseUrl/flutter_infra/flutter/$engineRevision/ios-release/artifacts.zip\''));
-        }, overrides: <Type, Generator>{
-          FileSystem: () => memoryFileSystem,
-          ProcessManager: () => FakeProcessManager.any(),
+          testUsingContext('profile URL', () async {
+            final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
+                aotBuilder: MockAotBuilder(),
+                bundleBuilder: MockBundleBuilder(),
+                platform: fakePlatform,
+                flutterVersion: mockFlutterVersion,
+                cache: mockCache
+            );
+            command.produceFlutterPodspec(BuildMode.profile, outputDirectory);
+
+            final File expectedPodspec = outputDirectory.childFile('Flutter.podspec');
+            final String podspecContents = expectedPodspec.readAsStringSync();
+            expect(podspecContents, contains('\'$storageBaseUrl/flutter_infra/flutter/$engineRevision/ios-profile/artifacts.zip\''));
+          }, overrides: <Type, Generator>{
+            FileSystem: () => memoryFileSystem,
+            ProcessManager: () => FakeProcessManager.any(),
+          });
+
+          testUsingContext('release URL', () async {
+            final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
+                aotBuilder: MockAotBuilder(),
+                bundleBuilder: MockBundleBuilder(),
+                platform: fakePlatform,
+                flutterVersion: mockFlutterVersion,
+                cache: mockCache
+            );
+            command.produceFlutterPodspec(BuildMode.release, outputDirectory);
+
+            final File expectedPodspec = outputDirectory.childFile('Flutter.podspec');
+            final String podspecContents = expectedPodspec.readAsStringSync();
+            expect(podspecContents, contains('\'$storageBaseUrl/flutter_infra/flutter/$engineRevision/ios-release/artifacts.zip\''));
+          }, overrides: <Type, Generator>{
+            FileSystem: () => memoryFileSystem,
+            ProcessManager: () => FakeProcessManager.any(),
+          });
         });
       });
     });


### PR DESCRIPTION
## Description

- `globals.cache` is nil when the build command is created, it's populated later.  Instead, lazily set the cache property to `globals.cache` if it's not injected by a test.
- Previously the `--cocoapods` flag was forbidden on the master branch to force a valid semantic version on the podspec.  Add a `--force` flag for integration testing on the master channel.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/50364.

## Tests

Added unit test for the `--force` flag and an integration test for the `--cocoapods` flag.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*