### PR TITLE
change capability for test tiles_scroll_perf_iphonexs__timeline_summary

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -400,7 +400,8 @@ tasks:
     description: >
       Measures the runtime performance of the tiles tab in the Complex Layout sample app on iPhone XS.
     stage: devicelab_ios
-    required_agent_capabilities: ["mac/iphonexs"]
+    # TODO(keyonghan): change with https://github.com/flutter/flutter/issues/50383
+    required_agent_capabilities: ["mac/ios"]
 
   flutter_gallery_ios32__start_up:
     description: >


### PR DESCRIPTION
We are changing the capability of `tiles_scroll_perf_iphonexs__timeline_summary` to `mac/ios` for now. 

The context is that we have disabled `mac/iphonexs` devicelab host, and there is no iphone X device available. 