### PR TITLE
[flutter_tools] add missing vm_service dep to BUILD.gn

### DIFF
--- a/packages/flutter_tools/BUILD.gn
+++ b/packages/flutter_tools/BUILD.gn
@@ -46,6 +46,7 @@ dart_library("flutter_tools") {
     "//third_party/dart-pkg/pub/stack_trace",
     "//third_party/dart-pkg/pub/test",
     "//third_party/dart-pkg/pub/usage",
+    "//third_party/dart-pkg/pub/vm_service",
     "//third_party/dart-pkg/pub/web_socket_channel",
     "//third_party/dart-pkg/pub/webkit_inspection_protocol",
     "//third_party/dart-pkg/pub/xml",


### PR DESCRIPTION
## Description

The iOS fallback changes add a dependency on this package, but I forgot to update the BUILD.gn file