### PR TITLE
v1.12.13+hotfix.8 cherry-picks - Do not use logcat -T on pre-lollipop Android

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -10,7 +10,7 @@ import '../android/android_builder.dart';
 import '../android/android_sdk.dart';
 import '../android/android_workflow.dart';
 import '../application_package.dart';
-import '../base/common.dart' show throwToolExit;
+import '../base/common.dart' show throwToolExit, unawaited;
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
@@ -854,22 +854,36 @@ class _AdbLogReader extends DeviceLogReader {
   @override
   String get name => device.name;
 
-  void _start() {
+  Future<void> _start() async {
+    final String lastTimestamp = device.lastLogcatTimestamp;
     // Start the adb logcat process and filter logs by the "flutter" tag.
-    final List<String> args = <String>['shell', '-x', 'logcat', '-v', 'time', '-s', 'flutter'];
-    processUtils.start(device.adbCommandForDevice(args)).then<void>((Process process) {
-      _process = process;
-      // We expect logcat streams to occasionally contain invalid utf-8,
-      // see: https://github.com/flutter/flutter/pull/8864.
-      const Utf8Decoder decoder = Utf8Decoder(reportErrors: false);
-      _process.stdout.transform<String>(decoder).transform<String>(const LineSplitter()).listen(_onLine);
-      _process.stderr.transform<String>(decoder).transform<String>(const LineSplitter()).listen(_onLine);
-      _process.exitCode.whenComplete(() {
-        if (_linesController.hasListener) {
-          _linesController.close();
-        }
-      });
-    });
+    final List<String> args = <String>[
+      'logcat',
+      '-v',
+      'time',
+    ];
+    // logcat -T is not supported on Android releases before Lollipop.
+    const int kLollipopVersionCode = 21;
+    final int apiVersion = int.tryParse(await device._apiVersion);
+    if (apiVersion != null && apiVersion >= kLollipopVersionCode) {
+      args.addAll(<String>[
+        '-T',
+        lastTimestamp ?? '', // Empty `-T` means the timestamp of the logcat command invocation.
+      ]);
+    }
+
+    _process = await processUtils.start(device.adbCommandForDevice(args));
+
+    // We expect logcat streams to occasionally contain invalid utf-8,
+    // see: https://github.com/flutter/flutter/pull/8864.
+    const Utf8Decoder decoder = Utf8Decoder(reportErrors: false);
+    _process.stdout.transform<String>(decoder).transform<String>(const LineSplitter()).listen(_onLine);
+    _process.stderr.transform<String>(decoder).transform<String>(const LineSplitter()).listen(_onLine);
+    unawaited(_process.exitCode.whenComplete(() {
+      if (_linesController.hasListener) {
+        _linesController.close();
+      }
+    }));
   }
 
   // 'W/ActivityManager(pid): '


### PR DESCRIPTION
## Description

This cherry-picks into stable v1.12.13:
- https://github.com/flutter/flutter/pull/45743 (cc @blasten)
- https://github.com/flutter/flutter/pull/49327 (cc @jason-simmons)

To fix flutter apps not running on pre-4.4 (Lollipop) Android.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/45732
Fixes #47609
Fixes #47112

## Tests

I added the following tests:

This adds two unit tests of the android logreader.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*