### PR TITLE
Set bundle config rather than deprecated --system flag

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -456,7 +456,8 @@ task:
     - date
     - which flutter
     - bundle --version
-    - sudo bundle install --system --gemfile=dev/ci/mac/Gemfile
+    - bundle config set system 'true'
+    - sudo bundle install --gemfile=dev/ci/mac/Gemfile
     - git clean -xffd --exclude=bin/cache/
     - git fetch origin
     - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.

--- a/dev/ci/docker_linux/Dockerfile
+++ b/dev/ci/docker_linux/Dockerfile
@@ -132,7 +132,8 @@ RUN gem install bundler -N
 COPY ci/docker_linux/Gemfile /Gemfile
 COPY ci/docker_linux/Gemfile.lock /Gemfile.lock
 
-RUN bundle install --system
+RUN bundle config set system 'true' && \
+  bundle install --system
 
 # Install goldctl, for Golden testing
 # Last updated 2020-02-04 (update to rebuild Dockerfile with latest goldctl)


### PR DESCRIPTION
## Description

Follow the directions from the `bundler` deprecation message (seen in the `setup` of macos jobs or the docker build log), which looks like:

```
sudo bundle install --system --gemfile=dev/ci/mac/Gemfile
[DEPRECATED] The `--system` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set system 'true'`, and stop using this flag
```

## Related Issues

Fixes https://github.com/flutter/flutter/issues/49571.

## Tests

This is infra config, and is preventing future breakage when this command is removed from `bundle`. That it works can be verified by reading the output of the `setup` script in macos jobs, and seeing the deprecation warning message is no longer present.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*