### PR TITLE
catch release builds pre-submit

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -568,11 +568,12 @@ task:
 
     - name: verify_binaries_codesigned-macos # macos-only
       # TODO(fujino): remove this `only_if` after https://github.com/flutter/flutter/issues/44372
-      only_if: "$CIRRUS_BRANCH == 'dev' || $CIRRUS_BRANCH == 'beta' || $CIRRUS_BRANCH == 'stable' || $CIRRUS_BRANCH =~ '.*hotfix.*'"
+      only_if: "$CIRRUS_BASE_BRANCH != 'master'"
       depends_on:
         - analyze-linux
       script:
         - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
+        - ./bin/flutter precache # ensure cached binaries are present
         - dart --enable-asserts ./dev/bots/codesign.dart
 
 docker_builder:


### PR DESCRIPTION
## Description

Currently, this test only runs post-submit for release and hotfix branches. This change will make it run pre & post for any PR that isn't merging into master.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/50384

## Tests

This causes an existing test to run in more situations.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*