### PR TITLE
Prevent Windows & Linux Cirrus cache from being re-downloaded

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -81,7 +81,7 @@ task:
     populate_script:
       - git fetch origin
       - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
-      - flutter precache
+      - flutter precache --android --ios --web
       - flutter doctor -v
   setup_script:
     - date
@@ -306,7 +306,7 @@ task:
     populate_script:
       - git fetch origin
       - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
-      - flutter precache
+      - flutter precache --android --ios --web
       - flutter doctor -v
   setup_script:
     - git clean -xffd --exclude=bin/cache/
@@ -478,7 +478,7 @@ task:
     populate_script:
       - git fetch origin
       - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
-      - flutter precache
+      - flutter precache --android --ios --web
       - flutter doctor -v
   pub_cache:
     folder: $HOME/.pub-cache

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -71,12 +71,18 @@ task:
   pub_cache:
     folder: $HOME/.pub-cache
     fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"
-  flutter_pkg_cache:
-    folder: bin/cache/pkg
+    populate_script:
+      - git fetch origin
+      - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
+      - flutter update-packages
+  all_flutter_cache:
+    folder: bin/cache/
     fingerprint_script: echo $OS; cat bin/internal/*.version
-  artifacts_cache:
-    folder: bin/cache/artifacts
-    fingerprint_script: echo $OS; cat bin/internal/*.version
+    populate_script:
+      - git fetch origin
+      - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
+      - flutter precache
+      - flutter doctor -v
   setup_script:
     - date
     - git clean -xffd --exclude=bin/cache/
@@ -84,7 +90,7 @@ task:
     - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
     - flutter config --no-analytics
     - flutter doctor -v
-    - flutter update-packages
+    - flutter update-packages --offline
     - ./dev/bots/accept_android_sdk_licenses.sh
     - date
   on_failure:
@@ -268,6 +274,9 @@ task:
         ANDROID_GALLERY_UPLOAD_KEY: ENCRYPTED[0f2aca35f05b26add5d9edea2a7449341269a2b7e22d5c667f876996e2e8bc44ff1369431ebf73b7c5581fd95d0e5902]
       script:
         - ./dev/bots/deploy_gallery.sh
+  cleanup_before_cache_upload_script:
+     # Remove volatile file to avoid unnecessary Cirrus cache invalidation.
+    - rm -f bin/cache/flutter_version_check.stamp
 
 # WINDOWS SHARDS
 task:
@@ -285,19 +294,25 @@ task:
     folder: $APPDATA\Pub\Cache
     fingerprint_script:
       - ps: $Environment:OS; Get-ChildItem -Path "$Environment:CIRRUS_WORKING_DIR" pubspec.yaml -Recurse | Select-String -Pattern "PUBSPEC CHECKSUM" -SimpleMatch
-  flutter_pkg_cache:
-    folder: bin\cache\pkg
+    populate_script:
+      - git fetch origin
+      - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
+      - flutter update-packages
+  all_flutter_cache:
+    folder: bin\cache\
     fingerprint_script: echo %OS% & type bin\internal\*.version
-  artifacts_cache:
-    folder: bin\cache\artifacts
-    fingerprint_script: echo %OS% & type bin\internal\*.version
+    populate_script:
+      - git fetch origin
+      - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
+      - flutter precache
+      - flutter doctor -v
   setup_script:
-    - git clean -xffd --exclude=bin\cache\
+    - git clean -xffd --exclude=bin/cache/
     - git fetch origin
     - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
     - flutter config --no-analytics
     - flutter doctor -v
-    - flutter update-packages
+    - flutter update-packages --offline
     - git fetch origin master
   matrix:
     - name: framework_tests-widgets-windows
@@ -436,6 +451,9 @@ task:
         - CMD /S /C "IF EXIST "bin\cache\pkg\tests\" RMDIR /S /Q bin\cache\pkg\tests"
         - git clone https://github.com/flutter/tests.git bin\cache\pkg\tests
         - dart --enable-asserts dev\customer_testing\run_tests.dart --skip-on-fetch-failure --skip-template bin/cache/pkg/tests/registry/*.test
+  cleanup_before_cache_upload_script:
+     # Remove volatile file to avoid unnecessary Cirrus cache invalidation.
+    - del /f bin\cache\flutter_version_check.stamp
 
 # MACOS SHARDS
 task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -277,6 +277,8 @@ task:
   cleanup_before_cache_upload_script:
      # Remove volatile file to avoid unnecessary Cirrus cache invalidation.
     - rm -f bin/cache/flutter_version_check.stamp
+    - rm -f bin/cache/flutter_tools.snapshot
+    - rm -f bin/cache/flutter_tools.stamp
 
 # WINDOWS SHARDS
 task:
@@ -454,6 +456,8 @@ task:
   cleanup_before_cache_upload_script:
      # Remove volatile file to avoid unnecessary Cirrus cache invalidation.
     - del /f bin\cache\flutter_version_check.stamp
+    - del /f bin\cache\flutter_tools.snapshot
+    - del /f bin\cache\flutter_tools.stamp
 
 # MACOS SHARDS
 task:
@@ -609,6 +613,8 @@ task:
   cleanup_before_cache_upload_script:
      # Remove volatile file to avoid unnecessary Cirrus cache invalidation.
     - rm -f bin/cache/flutter_version_check.stamp
+    - rm -f bin/cache/flutter_tools.snapshot
+    - rm -f bin/cache/flutter_tools.stamp
 docker_builder:
   # Only build a new docker image when we tag a release (for dev, beta, or
   # stable). Note: tagging a commit and pushing to a release branch are


### PR DESCRIPTION
## Description

1. Include the stamp files and Dart SDK in Cirrus cache to prevent full re-download.
2. `git clean -xffd --exclude=bin\cache\` wasn't working on Windows:
```
C:\Windows\Temp\flutter sdk>call git clean -xffd --exclude=bin\cache\ 
Removing bin/cache/
```
3. Windows and Linux version of https://github.com/flutter/flutter/pull/50496.
4. Add population scripts to caches.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*