### PR TITLE
Use BUILD_LIBRARY_FOR_DISTRIBUTION build setting for generating add-to-app frameworks

### DIFF
--- a/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
@@ -218,7 +218,7 @@ Future<void> main() async {
         );
       }
 
-      section("Check all modes' have plugin dylib");
+      section('Check all modes have plugins');
 
       for (final String mode in <String>['Debug', 'Profile', 'Release']) {
         final String pluginFrameworkPath = path.join(
@@ -238,6 +238,17 @@ Future<void> main() async {
           'device_info.framework',
           'device_info',
         ));
+
+        checkFileExists(path.join(
+          outputPath,
+          mode,
+          'device_info.xcframework',
+          'ios-armv7_arm64',
+          'device_info.framework',
+          'Headers',
+          'DeviceInfoPlugin.h',
+        ));
+
         final String simulatorFrameworkPath = path.join(
           outputPath,
           mode,
@@ -246,10 +257,23 @@ Future<void> main() async {
           'device_info.framework',
           'device_info',
         );
+
+        final String simulatorFrameworkHeaderPath = path.join(
+          outputPath,
+          mode,
+          'device_info.xcframework',
+          'ios-armv7_arm64',
+          'device_info.framework',
+          'Headers',
+          'DeviceInfoPlugin.h',
+        );
+
         if (mode == 'Debug') {
           checkFileExists(simulatorFrameworkPath);
+          checkFileExists(simulatorFrameworkHeaderPath);
         } else {
           checkFileNotExists(simulatorFrameworkPath);
+          checkFileNotExists(simulatorFrameworkHeaderPath);
         }
       }
 

--- a/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
@@ -262,7 +262,7 @@ Future<void> main() async {
           outputPath,
           mode,
           'device_info.xcframework',
-          'ios-armv7_arm64',
+          'ios-x86_64-simulator',
           'device_info.framework',
           'Headers',
           'DeviceInfoPlugin.h',

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -475,7 +475,8 @@ end
         '-destination generic/platform=iOS',
         'SYMROOT=${iPhoneBuildOutput.path}',
         'BITCODE_GENERATION_MODE=$bitcodeGenerationMode',
-        'ONLY_ACTIVE_ARCH=NO' // No device targeted, so build all valid architectures.
+        'ONLY_ACTIVE_ARCH=NO', // No device targeted, so build all valid architectures.
+        'BUILD_LIBRARY_FOR_DISTRIBUTION=YES',
       ];
 
       RunResult buildPluginsResult = await processUtils.run(
@@ -500,8 +501,8 @@ end
           '-destination generic/platform=iOS',
           'SYMROOT=${simulatorBuildOutput.path}',
           'ARCHS=x86_64',
-          'ONLY_ACTIVE_ARCH=NO'
-          // No device targeted, so build all valid architectures.
+          'ONLY_ACTIVE_ARCH=NO', // No device targeted, so build all valid architectures.
+          'BUILD_LIBRARY_FOR_DISTRIBUTION=YES',
         ];
 
         buildPluginsResult = await processUtils.run(

--- a/packages/flutter_tools/templates/module/ios/host_app_ephemeral_cocoapods/Podfile.copy.tmpl
+++ b/packages/flutter_tools/templates/module/ios/host_app_ephemeral_cocoapods/Podfile.copy.tmpl
@@ -10,17 +10,5 @@ target 'Runner' do
   install_flutter_plugin_pods flutter_application_path
 end
 
-post_install do |installer|
-  installer.pods_project.targets.each do |target|
-    # Aggregate targets do not have a headers build phase.
-    if target.respond_to?('headers_build_phase')
-      target.headers_build_phase.files.each do |file|
-        # Make headers public so they can be imported by the host application.
-        file.settings = { 'ATTRIBUTES' => ['Public'] }
-      end
-    end
-  end
-end
-
 # Prevent Cocoapods from embedding a second Flutter framework and causing an error with the new Xcode build system.
 install! 'cocoapods', :disable_input_output_paths => true


### PR DESCRIPTION
## Description

Xcode 11 introduced a build setting `BUILD_LIBRARY_FOR_DISTRIBUTION` that copies headers into frameworks that will be distributed as stand-alone frameworks.  Remove the workaround that forced all headers to be public through CocoaPods when building module frameworks to be embedded into host apps.

## Related Issues

Reported in https://github.com/flutter/flutter/issues/48859#issuecomment-580409715.
Introduced in https://github.com/flutter/flutter/pull/40927.

## Tests

Updated build_ios_framework_module_test

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*