### PR TITLE
[flutter_tools] fix path escaping on in depfile generation

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -898,6 +898,9 @@ class FlutterTask extends BaseFlutterTask {
         for (File depfile in getDependenciesFiles()) {
           sources += readDependencies(depfile)
         }
+        sources.collect {
+            println it
+        }
         return sources + project.files('pubspec.yaml')
     }
 

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -898,9 +898,6 @@ class FlutterTask extends BaseFlutterTask {
         for (File depfile in getDependenciesFiles()) {
           sources += readDependencies(depfile)
         }
-        sources.collect {
-            println it
-        }
         return sources + project.files('pubspec.yaml')
     }
 

--- a/packages/flutter_tools/lib/src/build_system/depfile.dart
+++ b/packages/flutter_tools/lib/src/build_system/depfile.dart
@@ -73,14 +73,14 @@ class Depfile {
 
   void _writeFilesToBuffer(List<File> files, StringBuffer buffer) {
     for (final File outputFile in files) {
+      // Escape file spaces.
+      final String path = outputFile.path.replaceAll(r' ', r'\ ');
       if (globals.platform.isWindows) {
-        // Paths in a depfile have to be escaped on windows.
-        final String escapedPath = outputFile.path
-          .replaceAll(r'\', r'\\')
-          .replaceAll(r' ', r'\ ');
+        // Foward slashes in a depfile have to be escaped on windows.
+        final String escapedPath = path.replaceAll(r'\', r'\\');
         buffer.write(' $escapedPath');
       } else {
-        buffer.write(' ${outputFile.path}');
+        buffer.write(' $path');
       }
     }
   }

--- a/packages/flutter_tools/lib/src/build_system/depfile.dart
+++ b/packages/flutter_tools/lib/src/build_system/depfile.dart
@@ -73,13 +73,15 @@ class Depfile {
 
   void _writeFilesToBuffer(List<File> files, StringBuffer buffer) {
     for (final File outputFile in files) {
-      // Escape file spaces.
-      final String path = outputFile.path.replaceAll(r' ', r'\ ');
       if (globals.platform.isWindows) {
-        // Foward slashes in a depfile have to be escaped on windows.
-        final String escapedPath = path.replaceAll(r'\', r'\\');
-        buffer.write(' $escapedPath');
+        // Foward slashes and spaces in a depfile have to be escaped on windows.
+        final String path = outputFile.path
+          .replaceAll(r'\', r'\\')
+          .replaceAll(r' ', r'\ ');
+        buffer.write(' $path');
       } else {
+        final String path = outputFile.path
+          .replaceAll(r' ', r'\ ');
         buffer.write(' $path');
       }
     }

--- a/packages/flutter_tools/lib/src/build_system/depfile.dart
+++ b/packages/flutter_tools/lib/src/build_system/depfile.dart
@@ -75,7 +75,9 @@ class Depfile {
     for (final File outputFile in files) {
       if (globals.platform.isWindows) {
         // Paths in a depfile have to be escaped on windows.
-        final String escapedPath = outputFile.path.replaceAll(r'\', r'\\');
+        final String escapedPath = outputFile.path
+          .replaceAll(r'\', r'\\')
+          .replaceAll(r' ', r'\ ');
         buffer.write(' $escapedPath');
       } else {
         buffer.write(' ${outputFile.path}');

--- a/packages/flutter_tools/test/general.shard/build_system/depfile_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/depfile_test.dart
@@ -6,6 +6,7 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/build_system/depfile.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:platform/platform.dart';
 
 import '../../src/common.dart';
 import '../../src/testbed.dart';
@@ -65,6 +66,23 @@ C:\\a.txt: C:\\b.txt
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem(style: FileSystemStyle.windows),
   }));
+
+  test('Can escape depfile with windows file paths and spaces in directory names', () => testbed.run(() {
+    final File inputFile = globals.fs.directory(r'Hello Flutter').childFile('a.txt').absolute
+      ..createSync(recursive: true);
+    final File outputFile = globals.fs.directory(r'Hello Flutter').childFile('b.txt').absolute
+      ..createSync();
+    final Depfile depfile = Depfile(<File>[inputFile], <File>[outputFile]);
+    final File outputDepfile = globals.fs.file('depfile');
+    depfile.writeToFile(outputDepfile);
+
+    expect(outputDepfile.readAsStringSync(), contains(r'C:\\Hello\ Flutter\\a.txt'));
+    expect(outputDepfile.readAsStringSync(), contains(r'C:\\Hello\ Flutter\\b.txt'));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => MemoryFileSystem(style: FileSystemStyle.windows),
+    Platform: () => FakePlatform(operatingSystem: 'windows'),
+  }));
+
 
   test('Resillient to weird whitespace', () => testbed.run(() {
     final File depfileSource = globals.fs.file('example.d')..writeAsStringSync(r'''

--- a/packages/flutter_tools/test/general.shard/build_system/depfile_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/depfile_test.dart
@@ -83,6 +83,22 @@ C:\\a.txt: C:\\b.txt
     Platform: () => FakePlatform(operatingSystem: 'windows'),
   }));
 
+  test('Can escape depfile with spaces in directory names', () => testbed.run(() {
+    final File inputFile = globals.fs.directory(r'Hello Flutter').childFile('a.txt').absolute
+      ..createSync(recursive: true);
+    final File outputFile = globals.fs.directory(r'Hello Flutter').childFile('b.txt').absolute
+      ..createSync();
+    final Depfile depfile = Depfile(<File>[inputFile], <File>[outputFile]);
+    final File outputDepfile = globals.fs.file('depfile');
+    depfile.writeToFile(outputDepfile);
+
+    expect(outputDepfile.readAsStringSync(), contains(r'/Hello\ Flutter/a.txt'));
+    expect(outputDepfile.readAsStringSync(), contains(r'/Hello\ Flutter/b.txt'));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => MemoryFileSystem(style: FileSystemStyle.posix),
+    Platform: () => FakePlatform(operatingSystem: 'linux'),
+  }));
+
 
   test('Resillient to weird whitespace', () => testbed.run(() {
     final File depfileSource = globals.fs.file('example.d')..writeAsStringSync(r'''


### PR DESCRIPTION
## Description

When a depfile is generated for gradle build, empty spaces ` ` need to be escaped when creating the depfile. I verified this works locally on my computer, and created a unit test for the right escaping.

https://github.com/flutter/flutter/issues/16604