### PR TITLE
Create plugin symlinks for Windows and Linux

### DIFF
--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
+++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
@@ -9,6 +9,7 @@ import '../base/process.dart';
 import '../build_info.dart';
 import '../cache.dart';
 import '../globals.dart' as globals;
+import '../plugins.dart';
 import '../project.dart';
 import '../reporting/reporting.dart';
 
@@ -38,6 +39,7 @@ export PROJECT_DIR=${linuxProject.project.directory.path}
   linuxProject.generatedMakeConfigFile
     ..createSync(recursive: true)
     ..writeAsStringSync(buffer.toString());
+  createPluginSymlinks(linuxProject.project);
 
   if (!buildInfo.isDebug) {
     const String warning = '🚧 ';

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -901,8 +901,8 @@ Future<void> _writeWebPluginRegistrant(FlutterProject project, List<Plugin> plug
 /// If |force| is true, the symlinks will be recreated, otherwise they will
 /// be created only if missing.
 ///
-/// This uses [project.flutterPluginsDependenciesFile], so should only be run
-/// after refreshPluginList has been run since the last plugin change.
+/// This uses [project.flutterPluginsDependenciesFile], so it should only be
+/// run after refreshPluginList has been run since the last plugin change.
 void createPluginSymlinks(FlutterProject project, {bool force = false}) {
   Map<String, dynamic> platformPlugins;
   final String pluginFileContent = _readFileContent(project.flutterPluginsDependenciesFile);
@@ -916,13 +916,15 @@ void createPluginSymlinks(FlutterProject project, {bool force = false}) {
     _createPlatformPluginSymlinks(
       project.windows.pluginSymlinkDirectory,
       platformPlugins[project.windows.pluginConfigKey] as List<dynamic>,
-      force: force);
+      force: force,
+    );
   }
   if (featureFlags.isLinuxEnabled && project.linux.existsSync()) {
     _createPlatformPluginSymlinks(
       project.linux.pluginSymlinkDirectory,
       platformPlugins[project.linux.pluginConfigKey] as List<dynamic>,
-      force: force);
+      force: force,
+    );
   }
 }
 
@@ -951,7 +953,7 @@ void _createPlatformPluginSymlinks(Directory symlinkDirectory, List<dynamic> pla
       if (globals.platform.isWindows && (e.osError?.errorCode ?? 0) == 1314) {
         throwToolExit(
           'Building with plugins requires symlink support. '
-          'Please enable Developer Mode in your system settings.'
+          'Please enable Developer Mode in your system settings.\n\n$e'
         );
       }
       rethrow;

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -963,6 +963,9 @@ class WindowsProject extends FlutterProjectPlatform {
   /// Ideally this will be replaced in the future with inspection of the project.
   File get nameFile => ephemeralDirectory.childFile('exe_filename');
 
+  /// The directory to write plugin symlinks.
+  Directory get pluginSymlinkDirectory => ephemeralDirectory.childDirectory('.plugin_symlinks');
+
   Future<void> ensureReadyForPlatformSpecificTooling() async {}
 }
 
@@ -996,6 +999,9 @@ class LinuxProject extends FlutterProjectPlatform {
   /// Contains definitions for FLUTTER_ROOT, LOCAL_ENGINE, and more flags for
   /// the build.
   File get generatedMakeConfigFile => ephemeralDirectory.childFile('generated_config.mk');
+
+  /// The directory to write plugin symlinks.
+  Directory get pluginSymlinkDirectory => ephemeralDirectory.childDirectory('.plugin_symlinks');
 
   Future<void> ensureReadyForPlatformSpecificTooling() async {}
 }

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter_tools/src/plugins.dart';
+
 import '../artifacts.dart';
 import '../base/common.dart';
 import '../base/logger.dart';
@@ -39,6 +41,7 @@ Future<void> buildWindows(WindowsProject windowsProject, BuildInfo buildInfo, {S
     environment['LOCAL_ENGINE'] = globals.fs.path.basename(engineOutPath);
   }
   writePropertySheet(windowsProject.generatedPropertySheetFile, environment);
+  createPluginSymlinks(windowsProject.project);
 
   final String vcvarsScript = visualStudio.vcvarsPath;
   if (vcvarsScript == null) {

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter_tools/src/plugins.dart';
-
 import '../artifacts.dart';
 import '../base/common.dart';
 import '../base/logger.dart';
@@ -11,6 +9,7 @@ import '../base/process.dart';
 import '../build_info.dart';
 import '../cache.dart';
 import '../globals.dart' as globals;
+import '../plugins.dart';
 import '../project.dart';
 import '../reporting/reporting.dart';
 import 'msbuild_utils.dart';

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -73,10 +73,12 @@ void main() {
       windowsProject = MockWindowsProject();
       when(flutterProject.windows).thenReturn(windowsProject);
       when(windowsProject.pluginConfigKey).thenReturn('windows');
+      when(windowsProject.pluginSymlinkDirectory).thenReturn(flutterProject.directory.childDirectory('windows').childDirectory('symlinks'));
       when(windowsProject.existsSync()).thenReturn(false);
       linuxProject = MockLinuxProject();
       when(flutterProject.linux).thenReturn(linuxProject);
       when(linuxProject.pluginConfigKey).thenReturn('linux');
+      when(linuxProject.pluginSymlinkDirectory).thenReturn(flutterProject.directory.childDirectory('linux').childDirectory('symlinks'));
       when(linuxProject.existsSync()).thenReturn(false);
 
       when(mockClock.now()).thenAnswer(
@@ -820,6 +822,66 @@ web_plugin_with_nested:${webPluginWithNestedFile.childDirectory('lib').uri.toStr
 
         expect(registrant.existsSync(), isTrue);
         expect(registrant.readAsStringSync(), contains("import 'package:web_plugin_with_nested/src/web_plugin.dart';"));
+      }, overrides: <Type, Generator>{
+        FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager.any(),
+        FeatureFlags: () => featureFlags,
+      });
+    });
+
+    group('createPluginSymlinks', () {
+      MockFeatureFlags featureFlags;
+
+      setUp(() {
+        featureFlags = MockFeatureFlags();
+        when(featureFlags.isLinuxEnabled).thenReturn(true);
+        when(featureFlags.isWindowsEnabled).thenReturn(true);
+      });
+
+      testUsingContext('Symlinks are created for Linux plugins', () {
+        when(linuxProject.existsSync()).thenReturn(true);
+        configureDummyPackageAsPlugin();
+        refreshPluginsList(flutterProject);
+
+        createPluginSymlinks(flutterProject);
+        expect(linuxProject.pluginSymlinkDirectory.childLink('apackage').existsSync(), true);
+      }, overrides: <Type, Generator>{
+        FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager.any(),
+        FeatureFlags: () => featureFlags,
+      });
+
+      testUsingContext('Symlinks are created for Windows plugins', () {
+        when(windowsProject.existsSync()).thenReturn(true);
+        configureDummyPackageAsPlugin();
+        refreshPluginsList(flutterProject);
+
+        createPluginSymlinks(flutterProject);
+        expect(windowsProject.pluginSymlinkDirectory.childLink('apackage').existsSync(), true);
+      }, overrides: <Type, Generator>{
+        FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager.any(),
+        FeatureFlags: () => featureFlags,
+      });
+
+      testUsingContext('Existing symlinks are removed when no longer in use', () {
+        when(linuxProject.existsSync()).thenReturn(true);
+        when(windowsProject.existsSync()).thenReturn(true);
+        refreshPluginsList(flutterProject);
+
+        final List<File> dummyFiles = <File>[
+          flutterProject.linux.pluginSymlinkDirectory.childFile('dummy'),
+          flutterProject.windows.pluginSymlinkDirectory.childFile('dummy'),
+        ];
+        for (final File file in dummyFiles) {
+          file.createSync(recursive: true);
+        }
+
+        createPluginSymlinks(flutterProject);
+
+        for (final File file in dummyFiles) {
+          expect(file.existsSync(), false);
+        }
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),


### PR DESCRIPTION
## Description

This makes ephemeral symlinks to each plugin, for use by build systems.
This is similar to the logic implemented in the Podfile on iOS and
macOS, but managed internally to the Flutter tool.

This allows for build system integrations (e.g., .sln references to
projects) not to have developer-specific paths, as with iOS/macOS.

## Related Issues

Exploration for addressing #32719 and #32720
Related to #41146

## Tests

I added the following tests: createPluginSymlink test group

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
