### PR TITLE
Remove invalid assert for TextHeightBehavior

### DIFF
--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -346,7 +346,6 @@ class TextPainter {
   ui.TextHeightBehavior get textHeightBehavior => _textHeightBehavior;
   ui.TextHeightBehavior _textHeightBehavior;
   set textHeightBehavior(ui.TextHeightBehavior value) {
-    assert(value != null);
     if (_textHeightBehavior == value)
       return;
     _textHeightBehavior = value;

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -730,6 +730,13 @@ void main() {
     expect(painter.inlinePlaceholderBoxes[13], const TextBox.fromLTRBD(351, 30, 401, 60, TextDirection.ltr));
   }, skip: isBrowser);
 
+  test('TextPainter set TextHeightBehavior null test', () {
+    final TextPainter painter = TextPainter(textHeightBehavior: TextHeightBehavior())
+      ..textDirection = TextDirection.ltr;
+
+    painter.textHeightBehavior = null;
+  });
+
   test('TextPainter line metrics', () {
     final TextPainter painter = TextPainter()
       ..textDirection = TextDirection.ltr;

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -730,10 +730,12 @@ void main() {
     expect(painter.inlinePlaceholderBoxes[13], const TextBox.fromLTRBD(351, 30, 401, 60, TextDirection.ltr));
   }, skip: isBrowser);
 
+  // Null values are valid. See https://github.com/flutter/flutter/pull/48346#issuecomment-584839221
   test('TextPainter set TextHeightBehavior null test', () {
-    final TextPainter painter = TextPainter(textHeightBehavior: TextHeightBehavior())
+    final TextPainter painter = TextPainter(textHeightBehavior: null)
       ..textDirection = TextDirection.ltr;
 
+    painter.textHeightBehavior = TextHeightBehavior();
     painter.textHeightBehavior = null;
   });
 

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -735,7 +735,7 @@ void main() {
     final TextPainter painter = TextPainter(textHeightBehavior: null)
       ..textDirection = TextDirection.ltr;
 
-    painter.textHeightBehavior = TextHeightBehavior();
+    painter.textHeightBehavior = const TextHeightBehavior();
     painter.textHeightBehavior = null;
   });
 


### PR DESCRIPTION
## Description

https://github.com/flutter/flutter/pull/48346#issuecomment-584839221 caught an extra assert that slipped in. Remove this.

`null` is a valid value for this and there should not be an assert here.