### PR TITLE
[flutter_tools] fix crash when IsolateRef returns sentinel

### DIFF
--- a/packages/flutter_tools/lib/src/ios/fallback_discovery.dart
+++ b/packages/flutter_tools/lib/src/ios/fallback_discovery.dart
@@ -133,9 +133,9 @@ class FallbackDiscovery {
         final VM vm = await vmService.getVM();
         for (final IsolateRef isolateRefs in vm.isolates) {
           final dynamic isolateResponse = await vmService.getIsolate(isolateRefs.id);
-          if (isolateResponse is! Isolate) {
+          if (isolateResponse is Sentinel) {
             // Might have been a Sentinel. Try again later.
-            throw Exception();
+            throw Exception('Expected Isolate but found Sentinel: $isolateResponse');
           }
           final LibraryRef library = (isolateResponse as Isolate).rootLib;
           if (library.uri.startsWith('package:$packageName')) {

--- a/packages/flutter_tools/lib/src/ios/fallback_discovery.dart
+++ b/packages/flutter_tools/lib/src/ios/fallback_discovery.dart
@@ -132,8 +132,12 @@ class FallbackDiscovery {
         final VmService vmService = await _vmServiceConnectUri(assumedWsUri.toString());
         final VM vm = await vmService.getVM();
         for (final IsolateRef isolateRefs in vm.isolates) {
-          final Isolate isolate = await vmService.getIsolate(isolateRefs.id) as Isolate;
-          final LibraryRef library = isolate.rootLib;
+          final dynamic isolateResponse = await vmService.getIsolate(isolateRefs.id);
+          if (isolateResponse is! Isolate) {
+            // Might have been a Sentinel. Try again later.
+            throw Exception();
+          }
+          final LibraryRef library = (isolateResponse as Isolate).rootLib;
           if (library.uri.startsWith('package:$packageName')) {
             UsageEvent(_kEventName, 'success').send();
             return Uri.parse('http://localhost:$hostPort');

--- a/packages/flutter_tools/test/general.shard/ios/fallback_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/fallback_discovery_test.dart
@@ -67,6 +67,35 @@ void main() {
     ), Uri.parse('http://localhost:1'));
   });
 
+  testUsingContext('Selects mdns discovery if VM service connecton fails due to Sentinel', () async {
+    when(mockVmService.getVM()).thenAnswer((Invocation invocation) async {
+      return VM()..isolates = <IsolateRef>[
+        IsolateRef(),
+      ];
+    });
+    when(mockVmService.getIsolate(any)).thenAnswer((Invocation invocation) async {
+      return Sentinel();
+    });
+
+    when(mockMDnsObservatoryDiscovery.getObservatoryUri(
+      'hello',
+      null, // Device
+      usesIpv6: false,
+      hostVmservicePort: 1,
+    )).thenAnswer((Invocation invocation) async {
+      return Uri.parse('http://localhost:1234');
+    });
+
+    expect(await fallbackDiscovery.discover(
+      assumedDevicePort: 23,
+      deivce: null,
+      hostVmservicePort: 1,
+      packageId: 'hello',
+      usesIpv6: false,
+       packageName: 'hello',
+    ), Uri.parse('http://localhost:1234'));
+  });
+
   testUsingContext('Selects mdns discovery if VM service connecton fails', () async {
     when(mockVmService.getVM()).thenThrow(Exception());
 


### PR DESCRIPTION
## Description

The IsolateRef might return a Sentinel if the backing Isolate was collected or doesn't exist due to some other error unknown to me.

Fixes https://github.com/flutter/flutter/issues/50610