### PR TITLE
Map arm64e devices to arm64 devices

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -142,7 +142,7 @@ class AOTSnapshotter {
       genSnapshotArgs.add('--no-use-integer-division');
     }
 
-    // The name of the debug file must contain additonal information about
+    // The name of the debug file must contain additional information about
     // the architecture, since a single build command may produce
     // multiple debug files.
     final String archName = getNameForTargetPlatform(platform, darwinArch: darwinArch);

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -390,6 +390,7 @@ DarwinArch getIOSArchForName(String arch) {
     case 'armv7':
       return DarwinArch.armv7;
     case 'arm64':
+    case 'arm64e': // iPhone XS/XS Max/XR and higher. arm64 runs on arm64e devices.
       return DarwinArch.arm64;
     case 'x86_64':
       return DarwinArch.x86_64;

--- a/packages/flutter_tools/test/general.shard/build_info_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_info_test.dart
@@ -85,4 +85,12 @@ void main() {
     expect(getNameForTargetPlatform(TargetPlatform.ios, darwinArch: DarwinArch.x86_64), 'ios-x86_64');
     expect(getNameForTargetPlatform(TargetPlatform.android), isNot(contains('ios')));
   });
+
+  test('getIOSArchForName on Darwin arches', () {
+    expect(getIOSArchForName('armv7'), DarwinArch.armv7);
+    expect(getIOSArchForName('arm64'), DarwinArch.arm64);
+    expect(getIOSArchForName('arm64e'), DarwinArch.arm64);
+    expect(getIOSArchForName('x86_64'), DarwinArch.x86_64);
+    expect(() => getIOSArchForName('bogus'), throwsAssertionError);
+  });
 }


### PR DESCRIPTION
## Description

Map an arm64e device to the arm64 engine artifact, and be careful about not passing arm64e into any AOT build bits.  

This seems safe because when I target an arm64e device in Xcode, it also uses arm64 everywhere EXCEPT `VALID_ARCHS`, which we don't override.
```
export ARCHS="armv7 arm64"
export ARCHS_STANDARD="armv7 arm64"
export ARCHS_STANDARD_32_64_BIT="armv7 arm64"
export ARCHS_STANDARD_32_BIT=armv7
export ARCHS_STANDARD_64_BIT=arm64
export ARCHS_STANDARD_INCLUDING_64_BIT="armv7 arm64"
export ARCHS_UNIVERSAL_IPHONE_OS="armv7 arm64"
export VALID_ARCHS="arm64 arm64e armv7 armv7s"
```

## Related Issues

Fixes https://github.com/flutter/flutter/issues/42129

## Tests

Add getIOSArchForName test.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*