### PR TITLE
[flutter_tools] Disable analytics on more bots

### DIFF
--- a/packages/flutter_tools/lib/src/base/bot_detector.dart
+++ b/packages/flutter_tools/lib/src/base/bot_detector.dart
@@ -66,6 +66,11 @@ class BotDetector {
       || _platform.environment['CHROME_HEADLESS'] == '1'
       || _platform.environment.containsKey('BUILDBOT_BUILDERNAME')
       || _platform.environment.containsKey('SWARMING_TASK_ID')
+
+      // Property when running on borg.
+      || _platform.environment.containsKey('BORG_ALLOC_DIR')
+
+      // Property when running on Azure.
       || await _azureDetector.isRunningOnAzure;
   }
 }

--- a/packages/flutter_tools/test/general.shard/base/bot_detector_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/bot_detector_test.dart
@@ -67,6 +67,11 @@ void main() {
         when(mockHttpClientRequest.headers).thenReturn(mockHttpHeaders);
         expect(await botDetector.isRunningOnBot, isTrue);
       });
+
+      testWithoutContext('returns true when running on borg', () async {
+        fakePlatform.environment['BORG_ALLOC_DIR'] = 'true';
+        expect(await botDetector.isRunningOnBot, isTrue);
+      });
     });
   });
 


### PR DESCRIPTION
## Description

Disable analytics when running on borg.

## Related Issues

https://github.com/flutter/flutter/issues/4709

## Tests

I added the following tests:

Added a test to bot_detector_test.dart.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
