### PR TITLE
Expose showButtonMenu of PopupMenuButtonState

### DIFF
--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -1037,10 +1037,50 @@ class PopupMenuButton<T> extends StatefulWidget {
   final bool captureInheritedThemes;
 
   @override
-  _PopupMenuButtonState<T> createState() => _PopupMenuButtonState<T>();
+  PopupMenuButtonState<T> createState() => PopupMenuButtonState<T>();
 }
 
-class _PopupMenuButtonState<T> extends State<PopupMenuButton<T>> {
+/// The [State] for a [PopupMenuButton].
+///
+/// See [showButtonMenu] for a way to programmatically open the popup menu
+/// of your button state.
+class PopupMenuButtonState<T> extends State<PopupMenuButton<T>> {
+  /// A method to show a popup menu with the items supplied to
+  /// [PopupMenuButton.itemBuilder] at the position of your [PopupMenuButton].
+  ///
+  /// By default, it is called when the user taps the button and [PopupMenuButton.enabled]
+  /// is set to `true`. Moreover, you can open the button by calling the method manually.
+  ///
+  /// {@tool sample}
+  ///
+  /// You would access your [PopupMenuButtonState] using a [GlobalKey].
+  /// With the following setup, you can show the menu of the button
+  /// via `globalKey.currentState.showButtonMenu`.
+  ///
+  /// ```dart
+  /// class ExampleWidget extends StatelessWidget {
+  ///   final GlobalKey<PopupMenuButtonState<int>> globalKey = GlobalKey();
+  ///
+  ///   @override
+  ///   Widget build(BuildContext context) {
+  ///     return PopupMenuButton<int>(
+  ///       key: globalKey,
+  ///       itemBuilder: (BuildContext context) {
+  ///         return <PopupMenuEntry<int>>[
+  ///           const PopupMenuItem<int>(
+  ///             value: 1,
+  ///             child: Text('Tap me please!'),
+  ///           ),
+  ///         ];
+  ///       },
+  ///     );
+  ///   }
+  ///
+  ///   void showButtonMenu() => globalKey.currentState.showButtonMenu();
+  /// }
+  /// ```
+  ///
+  /// {@end-tool}
   void showButtonMenu() {
     final PopupMenuThemeData popupMenuTheme = PopupMenuTheme.of(context);
     final RenderBox button = context.findRenderObject() as RenderBox;

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -1051,36 +1051,8 @@ class PopupMenuButtonState<T> extends State<PopupMenuButton<T>> {
   /// By default, it is called when the user taps the button and [PopupMenuButton.enabled]
   /// is set to `true`. Moreover, you can open the button by calling the method manually.
   ///
-  /// {@tool sample}
-  ///
-  /// You would access your [PopupMenuButtonState] using a [GlobalKey].
-  /// With the following setup, you can show the menu of the button
-  /// via `globalKey.currentState.showButtonMenu`.
-  ///
-  /// ```dart
-  /// class ExampleWidget extends StatelessWidget {
-  ///   final GlobalKey<PopupMenuButtonState<int>> globalKey = GlobalKey();
-  ///
-  ///   @override
-  ///   Widget build(BuildContext context) {
-  ///     return PopupMenuButton<int>(
-  ///       key: globalKey,
-  ///       itemBuilder: (BuildContext context) {
-  ///         return <PopupMenuEntry<int>>[
-  ///           const PopupMenuItem<int>(
-  ///             value: 1,
-  ///             child: Text('Tap me please!'),
-  ///           ),
-  ///         ];
-  ///       },
-  ///     );
-  ///   }
-  ///
-  ///   void showButtonMenu() => globalKey.currentState.showButtonMenu();
-  /// }
-  /// ```
-  ///
-  /// {@end-tool}
+  /// You would access your [PopupMenuButtonState] using a [GlobalKey] and
+  /// show the menu of the button with `globalKey.currentState.showButtonMenu`.
   void showButtonMenu() {
     final PopupMenuThemeData popupMenuTheme = PopupMenuTheme.of(context);
     final RenderBox button = context.findRenderObject() as RenderBox;

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -1197,6 +1197,41 @@ void main() {
     expect(rootObserver.menuCount, 1);
     expect(nestedObserver.menuCount, 0);
   });
+
+  testWidgets('PopupMenuButton calling showButtonMenu manually', (WidgetTester tester) async {
+    final GlobalKey<PopupMenuButtonState<int>> globalKey = GlobalKey();
+
+    await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Column(
+              children: <Widget>[
+                PopupMenuButton<int>(
+                  key: globalKey,
+                  itemBuilder: (BuildContext context) {
+                    return <PopupMenuEntry<int>>[
+                      const PopupMenuItem<int>(
+                        value: 1,
+                        child: Text('Tap me please!'),
+                      ),
+                    ];
+                  },
+                ),
+              ],
+            ),
+          ),
+        )
+    );
+
+    expect(find.text('Tap me please!'), findsNothing);
+
+    globalKey.currentState.showButtonMenu();
+    // The PopupMenuItem will appear after an animation, hence,
+    // we have to first wait for the tester to settle.
+    await tester.pumpAndSettle();
+
+    expect(find.text('Tap me please!'), findsOneWidget);
+  });
 }
 
 class TestApp extends StatefulWidget {


### PR DESCRIPTION
Moved (again). Original https://github.com/flutter/flutter/pull/42830; previous https://github.com/flutter/flutter/pull/44170.

## Description

It can be useful to be able to call `showButtonMenu` of a `PopupMenuButton` programmatically instead of it only being called when the user taps the button. There already is a `showMenu` function, however, that would require obtaining the position of the button manually and passing the items again. By exposing `showButtonMenu`, it is very easy to show the menu at the right place with the right items manually.

## Tests

I added the following tests:

 * Ensuring that the exposed method can be called and works correctly.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.