### PR TITLE
Revert "catch release builds pre-submit"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -569,12 +569,11 @@ task:
 
     - name: verify_binaries_codesigned-macos # macos-only
       # TODO(fujino): remove this `only_if` after https://github.com/flutter/flutter/issues/44372
-      only_if: "$CIRRUS_BASE_BRANCH != 'master'"
+      only_if: "$CIRRUS_BRANCH == 'dev' || $CIRRUS_BRANCH == 'beta' || $CIRRUS_BRANCH == 'stable' || $CIRRUS_BRANCH =~ '.*hotfix.*'"
       depends_on:
         - analyze-linux
       script:
         - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
-        - ./bin/flutter precache # ensure cached binaries are present
         - dart --enable-asserts ./dev/bots/codesign.dart
 
 docker_builder:


### PR DESCRIPTION
Reverts flutter/flutter#50515.

The `verify_binaries_codesigned-macos` test ran post-submit. I think I need to add `&& $CIRRUS_BRANCH != master`, but will try that in another PR.