### PR TITLE
Clear flaky flag on web benchmarks

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -711,16 +711,12 @@ tasks:
       Runs Web benchmarks on Chrome on a Linux machine using the HTML rendering backend.
     stage: devicelab
     required_agent_capabilities: ["linux-vm"]
-    # TODO(yjbanov): This is a new test. Marking temporarily as flaky while debugging on devicelab.
-    flaky: true
 
   web_benchmarks_canvaskit:
     description: >
       Runs Web benchmarks on Chrome on a Linux machine using the CanvasKit rendering backend.
     stage: devicelab
     required_agent_capabilities: ["linux-vm"]
-    # TODO(yjbanov): This is a new test. Marking temporarily as flaky while debugging on devicelab.
-    flaky: true
 
   # run_without_leak_linux:
   #   description: >


### PR DESCRIPTION
The web benchmarks have been very stable. It's time to remove the flaky flag.

<img width="52" alt="Screen Shot 2020-02-12 at 8 38 14 PM" src="https://user-images.githubusercontent.com/211513/74401940-a16ffd80-4dd7-11ea-916e-f2fb97bf60be.png">
