### PR TITLE
Bumping tool_coverage-linux  to 14G of memory to avoid OOM kills

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -164,10 +164,10 @@ task:
     - name: tool_coverage-linux # linux-only
       only_if: "$CIRRUS_BRANCH == 'master'"
       environment:
-        # As of October 2019, the tool_coverage-linux shard needed at least 12G of RAM to run without
+        # As of February 2020, the tool_coverage-linux shard needed at least 14G of RAM to run without
         # getting OOM-killed, and even 8 CPUs took 25 minutes.
         CPU: 8
-        MEMORY: 12G
+        MEMORY: 14G
         CODECOV_TOKEN: ENCRYPTED[7c76a7f8c9264f3b7f3fd63fcf186f93c62c4dfe43ec288861c2f506d456681032b89efe7b7a139c82156350ca2c752c]
       script:
         - dart --enable-asserts ./dev/bots/test.dart


### PR DESCRIPTION
Bumping the memory limit for tool_coverage-linux to 14G because it keeps getting OOM-killed.

Submitting right away to fix the build.

TBR= @Hixie