### PR TITLE
Bumping tool_coverage-linux to 16G of memory to avoid OOM kil…

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -164,10 +164,10 @@ task:
     - name: tool_coverage-linux # linux-only
       only_if: "$CIRRUS_BRANCH == 'master'"
       environment:
-        # As of February 2020, the tool_coverage-linux shard needed at least 14G of RAM to run without
+        # As of February 2020, the tool_coverage-linux shard needed at least 16G of RAM to run without
         # getting OOM-killed, and even 8 CPUs took 25 minutes.
         CPU: 8
-        MEMORY: 14G
+        MEMORY: 16G
         CODECOV_TOKEN: ENCRYPTED[7c76a7f8c9264f3b7f3fd63fcf186f93c62c4dfe43ec288861c2f506d456681032b89efe7b7a139c82156350ca2c752c]
       script:
         - dart --enable-asserts ./dev/bots/test.dart


### PR DESCRIPTION
Bumping to 16G, since 14G didn't seem to be enough.

TBR= @Hixie 