### PR TITLE
Bumping tool_coverage-linux to 24G of memory to avoid OOM kills

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -164,10 +164,10 @@ task:
     - name: tool_coverage-linux # linux-only
       only_if: "$CIRRUS_BRANCH == 'master'"
       environment:
-        # As of February 2020, the tool_coverage-linux shard needed at least 16G of RAM to run without
+        # As of February 2020, the tool_coverage-linux shard needed at least 24G of RAM to run without
         # getting OOM-killed, and even 8 CPUs took 25 minutes.
         CPU: 8
-        MEMORY: 16G
+        MEMORY: 24G
         CODECOV_TOKEN: ENCRYPTED[7c76a7f8c9264f3b7f3fd63fcf186f93c62c4dfe43ec288861c2f506d456681032b89efe7b7a139c82156350ca2c752c]
       script:
         - dart --enable-asserts ./dev/bots/test.dart


### PR DESCRIPTION
OK, I'm just going to double the original 12G to 24G and see if that's enough. It has been making more progress with more memory, so it's not an infinite loop (probably), but still is getting OOM killed.

Something has clearly changed, but looking at the commits, I can't see it: the OOM kills started on a PR that was an error message change.

TBR= @Hixie