### PR TITLE
[flutter_tools] ensure all source maps load correctly for release and profile

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -400,6 +400,7 @@ class _ResidentWebRunner extends ResidentWebRunner {
       urlTunneller: urlTunneller,
       buildMode: debuggingOptions.buildInfo.mode,
       enableDwds: _enableDwds,
+      entrypoint: globals.fs.file(target).uri,
     );
     final Uri url = await device.devFS.create();
     if (debuggingOptions.buildInfo.isDebug) {

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -289,6 +289,7 @@ void main() {
         urlTunneller: null,
         buildMode: BuildMode.debug,
         enableDwds: false,
+        entrypoint: Uri.base,
       );
       webDevFS.requireJS.createSync(recursive: true);
       webDevFS.dartSdk.createSync(recursive: true);

--- a/packages/flutter_tools/test/general.shard/web/web_asset_server_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/web_asset_server_test.dart
@@ -94,7 +94,7 @@ void main() {
 
   test('release asset server serves content from project directory', () => testbed.run(() async {
     final ReleaseAssetServer assetServer = ReleaseAssetServer(Uri.base);
-    globals.fs.file(globals.fs.path.join('lib', 'bar.dart'))
+    globals.fs.file(globals.fs.path.join('bar.dart'))
       ..createSync(recursive: true)
       ..writeAsStringSync('void main() { }');
     final Response response = await assetServer

--- a/packages/flutter_tools/test/general.shard/web/web_asset_server_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/web_asset_server_test.dart
@@ -40,7 +40,7 @@ void main() {
   });
 
   test('release asset server serves correct mime type and content length for png', () => testbed.run(() async {
-    final ReleaseAssetServer assetServer = ReleaseAssetServer();
+    final ReleaseAssetServer assetServer = ReleaseAssetServer(Uri.base);
     globals.fs.file(globals.fs.path.join('build', 'web', 'assets', 'foo.png'))
       ..createSync(recursive: true)
       ..writeAsBytesSync(kTransparentImage);
@@ -54,7 +54,7 @@ void main() {
   }));
 
   test('release asset server serves correct mime type and content length for JavaScript', () => testbed.run(() async {
-    final ReleaseAssetServer assetServer = ReleaseAssetServer();
+    final ReleaseAssetServer assetServer = ReleaseAssetServer(Uri.base);
     globals.fs.file(globals.fs.path.join('build', 'web', 'assets', 'foo.js'))
       ..createSync(recursive: true)
       ..writeAsStringSync('function main() {}');
@@ -68,7 +68,7 @@ void main() {
   }));
 
   test('release asset server serves correct mime type and content length for html', () => testbed.run(() async {
-    final ReleaseAssetServer assetServer = ReleaseAssetServer();
+    final ReleaseAssetServer assetServer = ReleaseAssetServer(Uri.base);
     globals.fs.file(globals.fs.path.join('build', 'web', 'assets', 'foo.html'))
       ..createSync(recursive: true)
       ..writeAsStringSync('<!doctype html><html></html>');
@@ -82,7 +82,7 @@ void main() {
   }));
 
   test('release asset server serves content from flutter root', () => testbed.run(() async {
-    final ReleaseAssetServer assetServer = ReleaseAssetServer();
+    final ReleaseAssetServer assetServer = ReleaseAssetServer(Uri.base);
     globals.fs.file(globals.fs.path.join('flutter', 'bar.dart'))
       ..createSync(recursive: true)
       ..writeAsStringSync('void main() { }');
@@ -93,7 +93,7 @@ void main() {
   }));
 
   test('release asset server serves content from project directory', () => testbed.run(() async {
-    final ReleaseAssetServer assetServer = ReleaseAssetServer();
+    final ReleaseAssetServer assetServer = ReleaseAssetServer(Uri.base);
     globals.fs.file(globals.fs.path.join('lib', 'bar.dart'))
       ..createSync(recursive: true)
       ..writeAsStringSync('void main() { }');


### PR DESCRIPTION
Its not yet clear exactly when this broke, though it could have been either the likely candidate: the tool change for the frontend_server, though that didn't modify release builds much. Alternatively, the sm structure from the engine changed and we need to adapt to it

Fixes https://github.com/flutter/flutter/issues/50692