### PR TITLE
[flutter_tools] remove globals from depfile usage

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/android.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/android.dart
@@ -63,7 +63,15 @@ abstract class AndroidAssetBundle extends Target {
     }
     if (_copyAssets) {
       final Depfile assetDepfile = await copyAssets(environment, outputDirectory);
-      assetDepfile.writeToFile(environment.buildDir.childFile('flutter_assets.d'));
+      final DepfileService depfileService = DepfileService(
+        fileSystem: globals.fs,
+        logger: globals.logger,
+        platform: globals.platform,
+      );
+      depfileService.writeToFile(
+        assetDepfile,
+        environment.buildDir.childFile('flutter_assets.d'),
+      );
     }
   }
 

--- a/packages/flutter_tools/lib/src/build_system/targets/assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/assets.dart
@@ -108,7 +108,15 @@ class CopyAssets extends Target {
       .childDirectory('flutter_assets');
     output.createSync(recursive: true);
     final Depfile depfile = await copyAssets(environment, output);
-    depfile.writeToFile(environment.buildDir.childFile('flutter_assets.d'));
+    final DepfileService depfileService = DepfileService(
+      fileSystem: globals.fs,
+      logger: globals.logger,
+      platform: globals.platform,
+    );
+    depfileService.writeToFile(
+      depfile,
+      environment.buildDir.childFile('flutter_assets.d'),
+    );
   }
 }
 

--- a/packages/flutter_tools/lib/src/build_system/targets/dart.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/dart.dart
@@ -114,7 +114,15 @@ class CopyFlutterBundle extends Target {
           .copySync(environment.outputDir.childFile('isolate_snapshot_data').path);
     }
     final Depfile assetDepfile = await copyAssets(environment, environment.outputDir);
-    assetDepfile.writeToFile(environment.buildDir.childFile('flutter_assets.d'));
+    final DepfileService depfileService = DepfileService(
+      fileSystem: globals.fs,
+      logger: globals.logger,
+      platform: globals.platform,
+    );
+    depfileService.writeToFile(
+      assetDepfile,
+      environment.buildDir.childFile('flutter_assets.d'),
+    );
   }
 
   @override

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -284,7 +284,15 @@ abstract class IosAssetBundle extends Target {
 
     // Copy the assets.
     final Depfile assetDepfile = await copyAssets(environment, assetDirectory);
-    assetDepfile.writeToFile(environment.buildDir.childFile('flutter_assets.d'));
+    final DepfileService depfileService = DepfileService(
+      fileSystem: globals.fs,
+      logger: globals.logger,
+      platform: globals.platform,
+    );
+    depfileService.writeToFile(
+      assetDepfile,
+      environment.buildDir.childFile('flutter_assets.d'),
+    );
 
 
     // Copy the plist from either the project or module.

--- a/packages/flutter_tools/lib/src/build_system/targets/linux.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/linux.dart
@@ -98,7 +98,15 @@ class UnpackLinuxDebug extends Target {
       }
     }
     final Depfile depfile = Depfile(inputs, outputs);
-    depfile.writeToFile(environment.buildDir.childFile('linux_engine_sources.d'));
+    final DepfileService depfileService = DepfileService(
+      fileSystem: globals.fs,
+      logger: globals.logger,
+      platform: globals.platform,
+    );
+    depfileService.writeToFile(
+      depfile,
+      environment.buildDir.childFile('linux_engine_sources.d'),
+    );
   }
 }
 
@@ -151,6 +159,14 @@ class DebugBundleLinuxAssets extends Target {
         .copySync(outputDirectory.childFile('kernel_blob.bin').path);
     }
     final Depfile depfile = await copyAssets(environment, outputDirectory);
-    depfile.writeToFile(environment.buildDir.childFile('flutter_assets.d'));
+    final DepfileService depfileService = DepfileService(
+      fileSystem: globals.fs,
+      logger: globals.logger,
+      platform: globals.platform,
+    );
+    depfileService.writeToFile(
+      depfile,
+      environment.buildDir.childFile('flutter_assets.d'),
+    );
   }
 }

--- a/packages/flutter_tools/lib/src/build_system/targets/macos.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/macos.dart
@@ -286,7 +286,15 @@ abstract class MacOSBundleFlutterAssets extends Target {
       .childDirectory('flutter_assets');
     assetDirectory.createSync(recursive: true);
     final Depfile depfile = await copyAssets(environment, assetDirectory);
-    depfile.writeToFile(environment.buildDir.childFile('flutter_assets.d'));
+    final DepfileService depfileService = DepfileService(
+      fileSystem: globals.fs,
+      logger: globals.logger,
+      platform: globals.platform,
+    );
+    depfileService.writeToFile(
+      depfile,
+      environment.buildDir.childFile('flutter_assets.d'),
+    );
 
     // Copy Info.plist template.
     assetDirectory.parent.childFile('Info.plist')

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -191,11 +191,19 @@ class Dart2JSTarget extends Target {
         '${dart2jsDeps.path}');
       return;
     }
-    final Depfile depfile = Depfile.parseDart2js(
+    final DepfileService depfileService = DepfileService(
+      fileSystem: globals.fs,
+      logger: globals.logger,
+      platform: globals.platform,
+    );
+    final Depfile depfile = depfileService.parseDart2js(
       environment.buildDir.childFile('main.dart.js.deps'),
       outputFile,
     );
-    depfile.writeToFile(environment.buildDir.childFile('dart2js.d'));
+    depfileService.writeToFile(
+      depfile,
+      environment.buildDir.childFile('dart2js.d'),
+    );
   }
 }
 
@@ -247,7 +255,15 @@ class WebReleaseBundle extends Target {
     final Directory outputDirectory = environment.outputDir.childDirectory('assets');
     outputDirectory.createSync(recursive: true);
     final Depfile depfile = await copyAssets(environment, environment.outputDir.childDirectory('assets'));
-    depfile.writeToFile(environment.buildDir.childFile('flutter_assets.d'));
+    final DepfileService depfileService = DepfileService(
+      fileSystem: globals.fs,
+      logger: globals.logger,
+      platform: globals.platform,
+    );
+    depfileService.writeToFile(
+      depfile,
+      environment.buildDir.childFile('flutter_assets.d'),
+    );
 
     final Directory webResources = environment.projectDir
       .childDirectory('web');
@@ -269,8 +285,10 @@ class WebReleaseBundle extends Target {
       outputResourcesFiles.add(outputFile);
     }
     final Depfile resourceFile = Depfile(inputResourceFiles, outputResourcesFiles);
-    resourceFile.writeToFile(environment.buildDir.childFile('web_resources.d'));
-
+    depfileService.writeToFile(
+      resourceFile,
+      environment.buildDir.childFile('web_resources.d'),
+    );
   }
 }
 
@@ -320,7 +338,15 @@ class WebServiceWorker extends Target {
     final String serviceWorker = generateServiceWorker(uriToHash);
     serviceWorkerFile
       .writeAsStringSync(serviceWorker);
-    depfile.writeToFile(environment.buildDir.childFile('service_worker.d'));
+    final DepfileService depfileService = DepfileService(
+      fileSystem: globals.fs,
+      logger: globals.logger,
+      platform: globals.platform,
+    );
+    depfileService.writeToFile(
+      depfile,
+      environment.buildDir.childFile('service_worker.d'),
+    );
   }
 }
 

--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -149,7 +149,12 @@ Future<void> buildWithAssemble({
     if (!outputDepfile.parent.existsSync()) {
       outputDepfile.parent.createSync(recursive: true);
     }
-    depfile.writeToFile(outputDepfile);
+    final DepfileService depfileService = DepfileService(
+      fileSystem: globals.fs,
+      logger: globals.logger,
+      platform: globals.platform,
+    );
+    depfileService.writeToFile(depfile, outputDepfile);
   }
 }
 

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -202,7 +202,12 @@ class AssembleCommand extends FlutterCommand {
     if (argResults.wasParsed('depfile')) {
       final File depfileFile = globals.fs.file(stringArg('depfile'));
       final Depfile depfile = Depfile(result.inputFiles, result.outputFiles);
-      depfile.writeToFile(globals.fs.file(depfileFile));
+      final DepfileService depfileService = DepfileService(
+        fileSystem: globals.fs,
+        logger: globals.logger,
+        platform: globals.platform,
+      );
+      depfileService.writeToFile(depfile, globals.fs.file(depfileFile));
     }
     return FlutterCommandResult.success();
   }

--- a/packages/flutter_tools/test/general.shard/build_system/depfile_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/depfile_test.dart
@@ -4,34 +4,40 @@
 
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/build_system/depfile.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:mockito/mockito.dart';
 import 'package:platform/platform.dart';
 
 import '../../src/common.dart';
-import '../../src/testbed.dart';
 
 void main() {
-  Testbed testbed;
+  FileSystem fileSystem;
+  DepfileService depfileService;
 
   setUp(() {
-    testbed = Testbed();
+    fileSystem = MemoryFileSystem.test();
+    depfileService = DepfileService(
+      logger: MockLogger(),
+      fileSystem: fileSystem,
+      platform: FakePlatform(operatingSystem: 'linux'),
+    );
   });
-  test('Can parse depfile from file', () => testbed.run(() {
-    final File depfileSource = globals.fs.file('example.d')..writeAsStringSync('''
+  test('Can parse depfile from file', () {
+    final File depfileSource = fileSystem.file('example.d')..writeAsStringSync('''
 a.txt: b.txt
 ''');
-    final Depfile depfile = Depfile.parse(depfileSource);
+    final Depfile depfile = depfileService.parse(depfileSource);
 
     expect(depfile.inputs.single.path, 'b.txt');
     expect(depfile.outputs.single.path, 'a.txt');
-  }));
+  });
 
-  test('Can parse depfile with multiple inputs', () => testbed.run(() {
-    final File depfileSource = globals.fs.file('example.d')..writeAsStringSync('''
+  test('Can parse depfile with multiple inputs', () {
+    final File depfileSource = fileSystem.file('example.d')..writeAsStringSync('''
 a.txt: b.txt c.txt d.txt
 ''');
-    final Depfile depfile = Depfile.parse(depfileSource);
+    final Depfile depfile = depfileService.parse(depfileSource);
 
     expect(depfile.inputs.map((File file) => file.path), <String>[
       'b.txt',
@@ -39,13 +45,13 @@ a.txt: b.txt c.txt d.txt
       'd.txt',
     ]);
     expect(depfile.outputs.single.path, 'a.txt');
-  }));
+  });
 
-  test('Can parse depfile with multiple outputs', () => testbed.run(() {
-    final File depfileSource = globals.fs.file('example.d')..writeAsStringSync('''
+  test('Can parse depfile with multiple outputs', () {
+    final File depfileSource = fileSystem.file('example.d')..writeAsStringSync('''
 a.txt c.txt d.txt: b.txt
 ''');
-    final Depfile depfile = Depfile.parse(depfileSource);
+    final Depfile depfile = depfileService.parse(depfileSource);
 
     expect(depfile.inputs.single.path, 'b.txt');
     expect(depfile.outputs.map((File file) => file.path), <String>[
@@ -53,120 +59,122 @@ a.txt c.txt d.txt: b.txt
       'c.txt',
       'd.txt',
     ]);
-  }));
+  });
 
-  test('Can parse depfile with windows file paths', () => testbed.run(() {
-    final File depfileSource = globals.fs.file('example.d')..writeAsStringSync(r'''
+  test('Can parse depfile with windows file paths', () {
+    fileSystem = MemoryFileSystem.test(style: FileSystemStyle.windows);
+    depfileService = DepfileService(
+      logger: MockLogger(),
+      fileSystem: fileSystem,
+      platform: FakePlatform(operatingSystem: 'windows'),
+    );
+    final File depfileSource = fileSystem.file('example.d')..writeAsStringSync(r'''
 C:\\a.txt: C:\\b.txt
 ''');
-    final Depfile depfile = Depfile.parse(depfileSource);
+    final Depfile depfile = depfileService.parse(depfileSource);
 
     expect(depfile.inputs.single.path, r'C:\b.txt');
     expect(depfile.outputs.single.path, r'C:\a.txt');
-  }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(style: FileSystemStyle.windows),
-  }));
+  });
 
-  test('Can escape depfile with windows file paths and spaces in directory names', () => testbed.run(() {
-    final File inputFile = globals.fs.directory(r'Hello Flutter').childFile('a.txt').absolute
+  test('Can escape depfile with windows file paths and spaces in directory names', () {
+    fileSystem = MemoryFileSystem.test(style: FileSystemStyle.windows);
+    depfileService = DepfileService(
+      logger: MockLogger(),
+      fileSystem: fileSystem,
+      platform: FakePlatform(operatingSystem: 'windows'),
+    );
+    final File inputFile = fileSystem.directory(r'Hello Flutter').childFile('a.txt').absolute
       ..createSync(recursive: true);
-    final File outputFile = globals.fs.directory(r'Hello Flutter').childFile('b.txt').absolute
+    final File outputFile = fileSystem.directory(r'Hello Flutter').childFile('b.txt').absolute
       ..createSync();
     final Depfile depfile = Depfile(<File>[inputFile], <File>[outputFile]);
-    final File outputDepfile = globals.fs.file('depfile');
-    depfile.writeToFile(outputDepfile);
+    final File outputDepfile = fileSystem.file('depfile');
+    depfileService.writeToFile(depfile, outputDepfile);
 
     expect(outputDepfile.readAsStringSync(), contains(r'C:\\Hello\ Flutter\\a.txt'));
     expect(outputDepfile.readAsStringSync(), contains(r'C:\\Hello\ Flutter\\b.txt'));
-  }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(style: FileSystemStyle.windows),
-    Platform: () => FakePlatform(operatingSystem: 'windows'),
-  }));
+  });
 
-  test('Can escape depfile with spaces in directory names', () => testbed.run(() {
-    final File inputFile = globals.fs.directory(r'Hello Flutter').childFile('a.txt').absolute
+  test('Can escape depfile with spaces in directory names', () {
+    final File inputFile = fileSystem.directory(r'Hello Flutter').childFile('a.txt').absolute
       ..createSync(recursive: true);
-    final File outputFile = globals.fs.directory(r'Hello Flutter').childFile('b.txt').absolute
+    final File outputFile = fileSystem.directory(r'Hello Flutter').childFile('b.txt').absolute
       ..createSync();
     final Depfile depfile = Depfile(<File>[inputFile], <File>[outputFile]);
-    final File outputDepfile = globals.fs.file('depfile');
-    depfile.writeToFile(outputDepfile);
+    final File outputDepfile = fileSystem.file('depfile');
+    depfileService.writeToFile(depfile, outputDepfile);
 
     expect(outputDepfile.readAsStringSync(), contains(r'/Hello\ Flutter/a.txt'));
     expect(outputDepfile.readAsStringSync(), contains(r'/Hello\ Flutter/b.txt'));
-  }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(style: FileSystemStyle.posix),
-    Platform: () => FakePlatform(operatingSystem: 'linux'),
-  }));
+  });
 
 
-  test('Resillient to weird whitespace', () => testbed.run(() {
-    final File depfileSource = globals.fs.file('example.d')..writeAsStringSync(r'''
+  test('Resillient to weird whitespace', () {
+    final File depfileSource = fileSystem.file('example.d')..writeAsStringSync(r'''
 a.txt
   : b.txt    c.txt
 
 
 ''');
-    final Depfile depfile = Depfile.parse(depfileSource);
+    final Depfile depfile = depfileService.parse(depfileSource);
 
     expect(depfile.inputs, hasLength(2));
     expect(depfile.outputs.single.path, 'a.txt');
-  }));
+  });
 
-  test('Resillient to duplicate files', () => testbed.run(() {
-    final File depfileSource = globals.fs.file('example.d')..writeAsStringSync(r'''
+  test('Resillient to duplicate files', () {
+    final File depfileSource = fileSystem.file('example.d')..writeAsStringSync(r'''
 a.txt: b.txt b.txt
 ''');
-    final Depfile depfile = Depfile.parse(depfileSource);
+    final Depfile depfile = depfileService.parse(depfileSource);
 
     expect(depfile.inputs.single.path, 'b.txt');
     expect(depfile.outputs.single.path, 'a.txt');
-  }));
+  });
 
-  test('Resillient to malformed file, missing :', () => testbed.run(() {
-    final File depfileSource = globals.fs.file('example.d')..writeAsStringSync(r'''
+  test('Resillient to malformed file, missing :', () {
+    final File depfileSource = fileSystem.file('example.d')..writeAsStringSync(r'''
 a.text b.txt
 ''');
-    final Depfile depfile = Depfile.parse(depfileSource);
+    final Depfile depfile = depfileService.parse(depfileSource);
 
     expect(depfile.inputs, isEmpty);
     expect(depfile.outputs, isEmpty);
-  }));
+  });
 
-  test('Can parse dart2js output format', () => testbed.run(() {
-    final File dart2jsDependencyFile = globals.fs.file('main.dart.js.deps')..writeAsStringSync(r'''
+  test('Can parse dart2js output format', () {
+    final File dart2jsDependencyFile = fileSystem.file('main.dart.js.deps')..writeAsStringSync(r'''
 file:///Users/foo/collection.dart
 file:///Users/foo/algorithms.dart
 file:///Users/foo/canonicalized_map.dart
 ''');
 
-    final Depfile depfile = Depfile.parseDart2js(dart2jsDependencyFile, globals.fs.file('foo.dart.js'));
+    final Depfile depfile = depfileService.parseDart2js(dart2jsDependencyFile, fileSystem.file('foo.dart.js'));
 
     expect(depfile.inputs.map((File file) => file.path), <String>[
-      globals.fs.path.absolute(globals.fs.path.join('Users', 'foo', 'collection.dart')),
-      globals.fs.path.absolute(globals.fs.path.join('Users', 'foo', 'algorithms.dart')),
-      globals.fs.path.absolute(globals.fs.path.join('Users', 'foo', 'canonicalized_map.dart')),
+      fileSystem.path.absolute(fileSystem.path.join('Users', 'foo', 'collection.dart')),
+      fileSystem.path.absolute(fileSystem.path.join('Users', 'foo', 'algorithms.dart')),
+      fileSystem.path.absolute(fileSystem.path.join('Users', 'foo', 'canonicalized_map.dart')),
     ]);
     expect(depfile.outputs.single.path, 'foo.dart.js');
-  }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(style: FileSystemStyle.posix)
-  }));
+  });
 
-  test('Can parse handle invalid uri', () => testbed.run(() {
-    final File dart2jsDependencyFile = globals.fs.file('main.dart.js.deps')..writeAsStringSync('''
+  test('Can parse handle invalid uri', () {
+    final File dart2jsDependencyFile = fileSystem.file('main.dart.js.deps')..writeAsStringSync('''
 file:///Users/foo/collection.dart
 abcdevf
 file:///Users/foo/canonicalized_map.dart
 ''');
 
-    final Depfile depfile = Depfile.parseDart2js(dart2jsDependencyFile, globals.fs.file('foo.dart.js'));
+    final Depfile depfile = depfileService.parseDart2js(dart2jsDependencyFile, fileSystem.file('foo.dart.js'));
 
     expect(depfile.inputs.map((File file) => file.path), <String>[
-      globals.fs.path.absolute(globals.fs.path.join('Users', 'foo', 'collection.dart')),
-      globals.fs.path.absolute(globals.fs.path.join('Users', 'foo', 'canonicalized_map.dart')),
+      fileSystem.path.absolute(fileSystem.path.join('Users', 'foo', 'collection.dart')),
+      fileSystem.path.absolute(fileSystem.path.join('Users', 'foo', 'canonicalized_map.dart')),
     ]);
     expect(depfile.outputs.single.path, 'foo.dart.js');
-  }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(style: FileSystemStyle.posix)
-  }));
+  });
 }
+
+class MockLogger extends Mock implements Logger {}

--- a/packages/flutter_tools/test/general.shard/build_system/depfile_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/depfile_test.dart
@@ -23,7 +23,7 @@ void main() {
       platform: FakePlatform(operatingSystem: 'linux'),
     );
   });
-  test('Can parse depfile from file', () {
+  testWithoutContext('Can parse depfile from file', () {
     final File depfileSource = fileSystem.file('example.d')..writeAsStringSync('''
 a.txt: b.txt
 ''');
@@ -33,7 +33,7 @@ a.txt: b.txt
     expect(depfile.outputs.single.path, 'a.txt');
   });
 
-  test('Can parse depfile with multiple inputs', () {
+  testWithoutContext('Can parse depfile with multiple inputs', () {
     final File depfileSource = fileSystem.file('example.d')..writeAsStringSync('''
 a.txt: b.txt c.txt d.txt
 ''');
@@ -47,7 +47,7 @@ a.txt: b.txt c.txt d.txt
     expect(depfile.outputs.single.path, 'a.txt');
   });
 
-  test('Can parse depfile with multiple outputs', () {
+  testWithoutContext('Can parse depfile with multiple outputs', () {
     final File depfileSource = fileSystem.file('example.d')..writeAsStringSync('''
 a.txt c.txt d.txt: b.txt
 ''');
@@ -61,7 +61,7 @@ a.txt c.txt d.txt: b.txt
     ]);
   });
 
-  test('Can parse depfile with windows file paths', () {
+  testWithoutContext('Can parse depfile with windows file paths', () {
     fileSystem = MemoryFileSystem.test(style: FileSystemStyle.windows);
     depfileService = DepfileService(
       logger: MockLogger(),
@@ -77,7 +77,7 @@ C:\\a.txt: C:\\b.txt
     expect(depfile.outputs.single.path, r'C:\a.txt');
   });
 
-  test('Can escape depfile with windows file paths and spaces in directory names', () {
+  testWithoutContext('Can escape depfile with windows file paths and spaces in directory names', () {
     fileSystem = MemoryFileSystem.test(style: FileSystemStyle.windows);
     depfileService = DepfileService(
       logger: MockLogger(),
@@ -96,7 +96,7 @@ C:\\a.txt: C:\\b.txt
     expect(outputDepfile.readAsStringSync(), contains(r'C:\\Hello\ Flutter\\b.txt'));
   });
 
-  test('Can escape depfile with spaces in directory names', () {
+  testWithoutContext('Can escape depfile with spaces in directory names', () {
     final File inputFile = fileSystem.directory(r'Hello Flutter').childFile('a.txt').absolute
       ..createSync(recursive: true);
     final File outputFile = fileSystem.directory(r'Hello Flutter').childFile('b.txt').absolute
@@ -110,7 +110,7 @@ C:\\a.txt: C:\\b.txt
   });
 
 
-  test('Resillient to weird whitespace', () {
+  testWithoutContext('Resillient to weird whitespace', () {
     final File depfileSource = fileSystem.file('example.d')..writeAsStringSync(r'''
 a.txt
   : b.txt    c.txt
@@ -123,7 +123,7 @@ a.txt
     expect(depfile.outputs.single.path, 'a.txt');
   });
 
-  test('Resillient to duplicate files', () {
+  testWithoutContext('Resillient to duplicate files', () {
     final File depfileSource = fileSystem.file('example.d')..writeAsStringSync(r'''
 a.txt: b.txt b.txt
 ''');
@@ -133,7 +133,7 @@ a.txt: b.txt b.txt
     expect(depfile.outputs.single.path, 'a.txt');
   });
 
-  test('Resillient to malformed file, missing :', () {
+  testWithoutContext('Resillient to malformed file, missing :', () {
     final File depfileSource = fileSystem.file('example.d')..writeAsStringSync(r'''
 a.text b.txt
 ''');
@@ -143,7 +143,7 @@ a.text b.txt
     expect(depfile.outputs, isEmpty);
   });
 
-  test('Can parse dart2js output format', () {
+  testWithoutContext('Can parse dart2js output format', () {
     final File dart2jsDependencyFile = fileSystem.file('main.dart.js.deps')..writeAsStringSync(r'''
 file:///Users/foo/collection.dart
 file:///Users/foo/algorithms.dart
@@ -160,7 +160,7 @@ file:///Users/foo/canonicalized_map.dart
     expect(depfile.outputs.single.path, 'foo.dart.js');
   });
 
-  test('Can parse handle invalid uri', () {
+  testWithoutContext('Can parse handle invalid uri', () {
     final File dart2jsDependencyFile = fileSystem.file('main.dart.js.deps')..writeAsStringSync('''
 file:///Users/foo/collection.dart
 abcdevf

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -24,6 +24,7 @@ void main() {
   Environment environment;
   MockPlatform mockPlatform;
   MockPlatform  mockWindowsPlatform;
+  DepfileService depfileService;
 
   setUp(() {
     mockPlatform = MockPlatform();
@@ -53,6 +54,11 @@ void main() {
           kTargetFile: globals.fs.path.join('foo', 'lib', 'main.dart'),
         }
       );
+      depfileService = DepfileService(
+      fileSystem: globals.fs,
+      logger: globals.logger,
+      platform: globals.platform,
+    );
       environment.buildDir.createSync(recursive: true);
     }, overrides: <Type, Generator>{
       Platform: () => mockPlatform,
@@ -315,7 +321,7 @@ void main() {
     await const Dart2JSTarget().build(environment);
 
     expect(environment.buildDir.childFile('dart2js.d').existsSync(), true);
-    final Depfile depfile = Depfile.parse(environment.buildDir.childFile('dart2js.d'));
+    final Depfile depfile = depfileService.parse(environment.buildDir.childFile('dart2js.d'));
 
     expect(depfile.inputs.single.path, globals.fs.path.absolute('a.dart'));
     expect(depfile.outputs.single.path,


### PR DESCRIPTION
## Description

refactors depfile.dart and tests to no longer use globals.