### PR TITLE
Add textHeightBehavior and textWidhBasis to AnimatedDefaultTextStyle

### DIFF
--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -1505,8 +1505,9 @@ class _SliverAnimatedOpacityState extends ImplicitlyAnimatedWidgetState<SliverAn
 /// without explicit style) over a given duration whenever the given style
 /// changes.
 ///
-/// The [textAlign], [softWrap], [textOverflow], and [maxLines] properties are
-/// not animated and take effect immediately when changed.
+/// The [textAlign], [softWrap], [textOverflow], [maxLines], [textWidthBasis]
+/// and [textHeightBehavior] properties are not animated and take effect
+/// immediately when changed.
 ///
 /// Here's an illustration of what using this widget looks like, using a [curve]
 /// of [Curves.elasticInOut].

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -2,8 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui' as ui show TextHeightBehavior;
+
 import 'package:flutter/animation.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/painting.dart';
 import 'package:flutter/rendering.dart';
 import 'package:vector_math/vector_math_64.dart';
 
@@ -1529,6 +1532,8 @@ class AnimatedDefaultTextStyle extends ImplicitlyAnimatedWidget {
     this.softWrap = true,
     this.overflow = TextOverflow.clip,
     this.maxLines,
+    this.textWidthBasis = TextWidthBasis.parent,
+    this.textHeightBehavior,
     Curve curve = Curves.linear,
     @required Duration duration,
     VoidCallback onEnd,
@@ -1537,6 +1542,7 @@ class AnimatedDefaultTextStyle extends ImplicitlyAnimatedWidget {
        assert(softWrap != null),
        assert(overflow != null),
        assert(maxLines == null || maxLines > 0),
+       assert(textWidthBasis != null),
        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// The widget below this widget in the tree.
@@ -1575,6 +1581,14 @@ class AnimatedDefaultTextStyle extends ImplicitlyAnimatedWidget {
   /// See [DefaultTextStyle.maxLines] for more details.
   final int maxLines;
 
+  /// The strategy to use when calculating the width of the Text.
+  ///
+  /// See [TextWidthBasis] for possible values and their implications.
+  final TextWidthBasis textWidthBasis;
+
+  /// {@macro flutter.dart:ui.textHeightBehavior}
+  final ui.TextHeightBehavior textHeightBehavior;
+
   @override
   _AnimatedDefaultTextStyleState createState() => _AnimatedDefaultTextStyleState();
 
@@ -1586,6 +1600,8 @@ class AnimatedDefaultTextStyle extends ImplicitlyAnimatedWidget {
     properties.add(FlagProperty('softWrap', value: softWrap, ifTrue: 'wrapping at box width', ifFalse: 'no wrapping except at line break characters', showName: true));
     properties.add(EnumProperty<TextOverflow>('overflow', overflow, defaultValue: null));
     properties.add(IntProperty('maxLines', maxLines, defaultValue: null));
+    properties.add(EnumProperty<TextWidthBasis>('textWidthBasis', textWidthBasis, defaultValue: TextWidthBasis.parent));
+    properties.add(DiagnosticsProperty<ui.TextHeightBehavior>('textHeightBehavior', textHeightBehavior, defaultValue: null));
   }
 }
 
@@ -1605,6 +1621,8 @@ class _AnimatedDefaultTextStyleState extends AnimatedWidgetBaseState<AnimatedDef
       softWrap: widget.softWrap,
       overflow: widget.overflow,
       maxLines: widget.maxLines,
+      textWidthBasis: widget.textWidthBasis,
+      textHeightBehavior: widget.textHeightBehavior,
       child: widget.child,
     );
   }

--- a/packages/flutter/test/widgets/default_text_style_test.dart
+++ b/packages/flutter/test/widgets/default_text_style_test.dart
@@ -93,7 +93,7 @@ void main() {
     expect(text2.overflow, TextOverflow.fade);
     expect(text2.maxLines, 3);
     expect(text2.textWidthBasis, TextWidthBasis.longestLine);
-    expect(text2.textHeightBehavior, ui.TextHeightBehavior(applyHeightToFirstAscent: false));
+    expect(text2.textHeightBehavior, const ui.TextHeightBehavior(applyHeightToFirstAscent: false));
 
     await tester.pump(const Duration(milliseconds: 1000));
 
@@ -105,6 +105,6 @@ void main() {
     expect(text3.overflow, TextOverflow.fade);
     expect(text3.maxLines, 3);
     expect(text2.textWidthBasis, TextWidthBasis.longestLine);
-    expect(text2.textHeightBehavior, ui.TextHeightBehavior(applyHeightToFirstAscent: false));
+    expect(text2.textHeightBehavior, const ui.TextHeightBehavior(applyHeightToFirstAscent: false));
   });
 }

--- a/packages/flutter/test/widgets/default_text_style_test.dart
+++ b/packages/flutter/test/widgets/default_text_style_test.dart
@@ -2,8 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui' as ui show TextHeightBehavior;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter/painting.dart';
 
 void main() {
   testWidgets('DefaultTextStyle changes propagate to Text', (WidgetTester tester) async {
@@ -67,6 +70,8 @@ void main() {
     expect(text1.softWrap, isTrue);
     expect(text1.overflow, TextOverflow.clip);
     expect(text1.maxLines, isNull);
+    expect(text1.textWidthBasis, TextWidthBasis.parent);
+    expect(text1.textHeightBehavior, isNull);
 
     await tester.pumpWidget(const AnimatedDefaultTextStyle(
       style: s2,
@@ -74,6 +79,8 @@ void main() {
       softWrap: false,
       overflow: TextOverflow.fade,
       maxLines: 3,
+      textWidthBasis: TextWidthBasis.longestLine,
+      textHeightBehavior: ui.TextHeightBehavior(applyHeightToFirstAscent: false),
       child: textWidget,
       duration: Duration(milliseconds: 1000),
     ));
@@ -85,6 +92,8 @@ void main() {
     expect(text2.softWrap, false);
     expect(text2.overflow, TextOverflow.fade);
     expect(text2.maxLines, 3);
+    expect(text2.textWidthBasis, TextWidthBasis.longestLine);
+    expect(text2.textHeightBehavior, ui.TextHeightBehavior(applyHeightToFirstAscent: false));
 
     await tester.pump(const Duration(milliseconds: 1000));
 
@@ -95,5 +104,7 @@ void main() {
     expect(text3.softWrap, false);
     expect(text3.overflow, TextOverflow.fade);
     expect(text3.maxLines, 3);
+    expect(text2.textWidthBasis, TextWidthBasis.longestLine);
+    expect(text2.textHeightBehavior, ui.TextHeightBehavior(applyHeightToFirstAscent: false));
   });
 }


### PR DESCRIPTION
These properties are in DefaultTextStyle and were missing in AnimatedDefaultTextStyle, causing them to not be inherited properly.

Add the missing properties.

cc @johnsonmh for discovering the bug!
