### PR TITLE
Update test expectations after using --lazy-async-stacks in JIT mode

### DIFF
--- a/packages/flutter/test/foundation/error_reporting_test.dart
+++ b/packages/flutter/test/foundation/error_reporting_test.dart
@@ -81,6 +81,11 @@ Future<void> main() async {
       r'#2      getSampleStack \([^)]+flutter/test/foundation/error_reporting_test\.dart:[0-9]+:[0-9]+\)\n'
       r'#3      main \([^)]+flutter/test/foundation/error_reporting_test\.dart:[0-9]+:[0-9]+\)\n'
       r'(.+\n)+' // TODO(ianh): when fixing #4021, also filter out frames from the test infrastructure below the first call to our main()
+      r'\(elided one frame from dart:async\)\n'
+      r'\n'
+      r'line 1 of extra information\n'
+      r'line 2 of extra information\n'
+      r'════════════════════════════════════════════════════════════════════════════════════════════════════$',
     ));
     console.clear();
     FlutterError.dumpErrorToConsole(FlutterErrorDetails(
@@ -148,6 +153,11 @@ Future<void> main() async {
       r'#2      getSampleStack \([^)]+flutter/test/foundation/error_reporting_test\.dart:[0-9]+:[0-9]+\)\n'
       r'#3      main \([^)]+flutter/test/foundation/error_reporting_test\.dart:[0-9]+:[0-9]+\)\n'
       r'(.+\n)+' // TODO(ianh): when fixing #4021, also filter out frames from the test infrastructure below the first call to our main()
+      r'\(elided one frame from dart:async\)\n'
+      r'\n'
+      r'line 1 of extra information\n'
+      r'line 2 of extra information\n'
+      r'════════════════════════════════════════════════════════════════════════════════════════════════════$',
     ));
     console.clear();
     FlutterError.dumpErrorToConsole(FlutterErrorDetails(

--- a/packages/flutter/test/foundation/stack_trace_test.dart
+++ b/packages/flutter/test/foundation/stack_trace_test.dart
@@ -16,11 +16,13 @@ void main() {
     expect(filtered[0], matches(r'^#0 +main\.<anonymous closure> \(.*stack_trace_test\.dart:[0-9]+:[0-9]+\)$'));
     expect(filtered[1], matches(r'^#1 +Declarer\.test\.<anonymous closure>.<anonymous closure>.<anonymous closure> \(package:test_api/.+:[0-9]+:[0-9]+\)$'));
     expect(filtered[2], equals('<asynchronous suspension>'));
+    expect(filtered.last, matches(r'^\(elided one frame from package:stack_trace\)$'));
   });
 
   test('FlutterError.defaultStackFilter (async test body)', () async {
     final List<String> filtered = FlutterError.defaultStackFilter(StackTrace.current.toString().trimRight().split('\n')).toList();
     expect(filtered.length, greaterThanOrEqualTo(3));
     expect(filtered[0], matches(r'^#0 +main\.<anonymous closure> \(.*stack_trace_test\.dart:[0-9]+:[0-9]+\)$'));
+    expect(filtered.last, matches(r'^\(elided one frame from package:stack_trace\)$'));
   });
 }


### PR DESCRIPTION
This is the accompanying change for [0]: We should include this change together with the roll.

[0] https://github.com/flutter/engine/pull/16556