### PR TITLE
Expose insetPadding and clipBehavior in Dialog and AlertDialog.

### DIFF
--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -26,6 +26,8 @@ import 'theme_data.dart';
 // enum Department { treasury, state }
 // BuildContext context;
 
+const EdgeInsets _defaultInsetPadding = EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0);
+
 /// A material design dialog.
 ///
 /// This dialog widget does not have any opinion about the contents of the
@@ -49,7 +51,7 @@ class Dialog extends StatelessWidget {
     this.elevation,
     this.insetAnimationDuration = const Duration(milliseconds: 100),
     this.insetAnimationCurve = Curves.decelerate,
-    this.insetPadding = const EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0),
+    this.insetPadding = _defaultInsetPadding,
     this.clipBehavior = Clip.none,
     this.shape,
     this.child,
@@ -254,7 +256,7 @@ class AlertDialog extends StatelessWidget {
     this.backgroundColor,
     this.elevation,
     this.semanticLabel,
-    this.insetPadding = const EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0),
+    this.insetPadding = _defaultInsetPadding,
     this.clipBehavior = Clip.none,
     this.shape,
     this.scrollable = false,

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -53,8 +53,8 @@ class Dialog extends StatelessWidget {
     this.clipBehavior = Clip.none,
     this.shape,
     this.child,
-  }) : assert(clipBehavior != null)
-     , super(key: key);
+  }) : assert(clipBehavior != null),
+       super(key: key);
 
   /// {@template flutter.material.dialog.backgroundColor}
   /// The background color of the surface of this [Dialog].
@@ -91,9 +91,11 @@ class Dialog extends StatelessWidget {
   final Curve insetAnimationCurve;
 
   /// {@template flutter.material.dialog.insetPadding}
-  /// The amount of padding added to the outside of the dialog.
+  /// The amount of padding added to [MediaQueryData.viewInsets] on the outside
+  /// of the dialog. This defines the minimum space between the screen's edges
+  /// and the dialog.
   ///
-  /// Defaults to `const EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0)`.
+  /// Defaults to `EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0)`.
   /// {@endtemplate}
   final EdgeInsets insetPadding;
 
@@ -256,9 +258,9 @@ class AlertDialog extends StatelessWidget {
     this.clipBehavior = Clip.none,
     this.shape,
     this.scrollable = false,
-  }) : assert(contentPadding != null)
-     , assert(clipBehavior != null)
-     , super(key: key);
+  }) : assert(contentPadding != null),
+       assert(clipBehavior != null),
+       super(key: key);
 
   /// The (optional) title of the dialog is displayed in a large font at the top
   /// of the dialog.

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -49,9 +49,12 @@ class Dialog extends StatelessWidget {
     this.elevation,
     this.insetAnimationDuration = const Duration(milliseconds: 100),
     this.insetAnimationCurve = Curves.decelerate,
+    this.insetPadding = const EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0),
+    this.clipBehavior = Clip.none,
     this.shape,
     this.child,
-  }) : super(key: key);
+  }) : assert(clipBehavior != null)
+     , super(key: key);
 
   /// {@template flutter.material.dialog.backgroundColor}
   /// The background color of the surface of this [Dialog].
@@ -87,6 +90,24 @@ class Dialog extends StatelessWidget {
   /// {@endtemplate}
   final Curve insetAnimationCurve;
 
+  /// {@template flutter.material.dialog.insetPadding}
+  /// The amount of padding added to the outside of the dialog.
+  ///
+  /// Defaults to `const EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0)`.
+  /// {@endtemplate}
+  final EdgeInsets insetPadding;
+
+  /// {@template flutter.material.dialog.clipBehavior}
+  /// Controls how the contents of the Dialog are clipped (or not) to the given
+  /// [shape].
+  ///
+  /// See the enum [Clip] for details of all possible options and their common
+  /// use cases.
+  ///
+  /// Defaults to [Clip.none], and must not be null.
+  /// {@endtemplate}
+  final Clip clipBehavior;
+
   /// {@template flutter.material.dialog.shape}
   /// The shape of this dialog's border.
   ///
@@ -109,8 +130,9 @@ class Dialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final DialogTheme dialogTheme = DialogTheme.of(context);
+    final EdgeInsets effectivePadding = MediaQuery.of(context).viewInsets + (insetPadding ?? const EdgeInsets.all(0.0));
     return AnimatedPadding(
-      padding: MediaQuery.of(context).viewInsets + const EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0),
+      padding: effectivePadding,
       duration: insetAnimationDuration,
       curve: insetAnimationCurve,
       child: MediaQuery.removeViewInsets(
@@ -127,6 +149,7 @@ class Dialog extends StatelessWidget {
               elevation: elevation ?? dialogTheme.elevation ?? _defaultElevation,
               shape: shape ?? dialogTheme.shape ?? _defaultDialogShape,
               type: MaterialType.card,
+              clipBehavior: clipBehavior,
               child: child,
             ),
           ),
@@ -229,10 +252,13 @@ class AlertDialog extends StatelessWidget {
     this.backgroundColor,
     this.elevation,
     this.semanticLabel,
+    this.insetPadding = const EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0),
+    this.clipBehavior = Clip.none,
     this.shape,
     this.scrollable = false,
-  }) : assert(contentPadding != null),
-       super(key: key);
+  }) : assert(contentPadding != null)
+     , assert(clipBehavior != null)
+     , super(key: key);
 
   /// The (optional) title of the dialog is displayed in a large font at the top
   /// of the dialog.
@@ -394,6 +420,12 @@ class AlertDialog extends StatelessWidget {
   ///    value is used.
   final String semanticLabel;
 
+  /// {@macro flutter.material.dialog.insetPadding}
+  final EdgeInsets insetPadding;
+
+  /// {@macro flutter.material.dialog.clipBehavior}
+  final Clip clipBehavior;
+
   /// {@macro flutter.material.dialog.shape}
   final ShapeBorder shape;
 
@@ -518,6 +550,8 @@ class AlertDialog extends StatelessWidget {
     return Dialog(
       backgroundColor: backgroundColor,
       elevation: elevation,
+      insetPadding: insetPadding,
+      clipBehavior: clipBehavior,
       shape: shape,
       child: dialogChild,
     );

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -98,7 +98,7 @@ class Dialog extends StatelessWidget {
   final EdgeInsets insetPadding;
 
   /// {@template flutter.material.dialog.clipBehavior}
-  /// Controls how the contents of the Dialog are clipped (or not) to the given
+  /// Controls how the contents of the dialog are clipped (or not) to the given
   /// [shape].
   ///
   /// See the enum [Clip] for details of all possible options and their common

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -155,6 +155,20 @@ void main() {
     expect(content.text.style, contentTextStyle);
   });
 
+  testWidgets('Custom clipBehavior', (WidgetTester tester) async {
+    const AlertDialog dialog = AlertDialog(
+      actions: <Widget>[],
+      clipBehavior: Clip.antiAlias,
+    );
+    await tester.pumpWidget(_buildAppWithDialog(dialog));
+
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
+
+    final Material materialWidget = _getMaterialFromDialog(tester);
+    expect(materialWidget.clipBehavior, Clip.antiAlias);
+  });
+
   testWidgets('Custom dialog shape', (WidgetTester tester) async {
     const RoundedRectangleBorder customBorder =
       RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(16.0)));
@@ -748,6 +762,47 @@ void main() {
       tester.getRect(find.byType(Placeholder)),
       const Rect.fromLTRB(40.0, 24.0, 800.0 - 40.0, 600.0 - 24.0),
     );
+  });
+
+  testWidgets('Dialog insetPadding added to outside of dialog', (WidgetTester tester) async {
+    // The default testing screen (800, 600)
+    const Rect screenRect = Rect.fromLTRB(0.0, 0.0, 800.0, 600.0);
+
+    // Test with no padding
+    await tester.pumpWidget(
+      const MediaQuery(
+        data: MediaQueryData(
+          viewInsets: EdgeInsets.all(0.0),
+        ),
+        child: Dialog(
+          child: Placeholder(),
+          insetPadding: null,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(tester.getRect(find.byType(Placeholder)), screenRect);
+
+    // Test with an insetPadding
+    await tester.pumpWidget(
+      const MediaQuery(
+        data: MediaQueryData(
+          viewInsets: EdgeInsets.all(0.0),
+        ),
+        child: Dialog(
+          insetPadding: EdgeInsets.fromLTRB(10.0, 20.0, 30.0, 40.0),
+          child: Placeholder(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(tester.getRect(find.byType(Placeholder)),
+        Rect.fromLTRB(
+          screenRect.left + 10.0,
+          screenRect.top + 20.0,
+          screenRect.right - 30.0,
+          screenRect.bottom - 40.0,
+        ));
   });
 
   testWidgets('Dialog widget contains route semantics from title', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

Currently the `Dialog` class has a hard coded padding used for the outer part of the dialog. This makes it hard for large dialogs like the Date Picker to use more of the screen. In addition, there is no way to specify the `clipBehavior` used by the Dialog's internal `Material` widget. This means that there is no way to have the dialog's content clipped to the given shape, as it defaults to `Clip.none`.

This PR exposes new `insetPadding` and `clipBehavior` parameters to the constructors for the `Dialog` and `AlertDialog` classes.

## Related Issues

Closes #50757

## Tests

I added tests to the `dialog_test.dart` that tests both of these parameters.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
