### PR TITLE
[flutter_tools] Handle asynchronous errors writing to stdio

### DIFF
--- a/packages/flutter_tools/lib/src/base/io.dart
+++ b/packages/flutter_tools/lib/src/base/io.dart
@@ -47,6 +47,7 @@ import 'dart:io' as io
 import 'package:meta/meta.dart';
 
 import '../globals.dart' as globals;
+import 'async_guard.dart';
 import 'context.dart';
 import 'process.dart';
 
@@ -271,15 +272,15 @@ class Stdio {
   void _stdioWrite(io.IOSink sink, String message, {
     void Function(String, dynamic, StackTrace) fallback,
   }) {
-    try {
+    asyncGuard<void>(() async {
       sink.write(message);
-    } catch (err, stack) {
+    }, onError: (Object error, StackTrace stackTrace) {
       if (fallback == null) {
         print(message);
       } else {
-        fallback(message, err, stack);
+        fallback(message, error, stackTrace);
       }
-    }
+    });
   }
 
   /// Adds [stream] to [stdout].


### PR DESCRIPTION
## Description

The Dart core libraries transform an otherwise synchronous `FileSystemException` that can happen when writing to `stdout` and `stderr` into an asynchronous exception, not catchable by a try-catch. This PR changes such a try-catch into an `asyncGuard` call so that the tool doesn't crash on writing to `stdout` or `stderr`. 

## Related Issues

Crash in crash logging.

## Tests

I added the following tests:

Test in logger_test.dart

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
