### PR TITLE
[flutter_tools] Collect more information in ios-handshake failure event

### DIFF
--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -384,7 +384,12 @@ void main() {
             debuggingOptions: DebuggingOptions.enabled(const BuildInfo(BuildMode.debug, null, treeShakeIcons: false)),
             platformArgs: <String, dynamic>{},
         );
-        verify(mockUsage.sendEvent('ios-handshake', 'failure')).called(1);
+        verify(mockUsage.sendEvent(
+          'ios-handshake',
+          'failure',
+          label: anyNamed('label'),
+          value: anyNamed('value'),
+        )).called(1);
         verify(mockUsage.sendEvent('ios-handshake', 'mdns-failure')).called(1);
         verify(mockUsage.sendEvent('ios-handshake', 'fallback-failure')).called(1);
         expect(launchResult.started, isFalse);


### PR DESCRIPTION
## Description

Collect the exception/reason for the failure along with the port tried.

## Related Issues

https://github.com/flutter/flutter/issues/46705

## Tests

I added the following tests:

No tests. We will manually inspect the values in analytics, and then revert this if appropriate.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
