### PR TITLE
[flutter_tools] move dwds imports to not require g3 visibility

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
@@ -29,8 +29,8 @@ import '../compile.dart';
 import '../convert.dart';
 import '../devfs.dart';
 import '../globals.dart' as globals;
-import 'bootstrap.dart';
-import 'chrome.dart';
+import '../web/bootstrap.dart';
+import '../web/chrome.dart';
 
 /// A web server which handles serving JavaScript and assets.
 ///

--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -31,9 +31,9 @@ import '../resident_runner.dart';
 import '../run_hot.dart';
 import '../web/chrome.dart';
 import '../web/compile.dart';
-import '../web/devfs_web.dart';
 import '../web/web_device.dart';
 import '../web/web_runner.dart';
+import 'devfs_web.dart';
 
 /// Injectable factory to create a [ResidentWebRunner].
 class DwdsWebRunnerFactory extends WebRunnerFactory {

--- a/packages/flutter_tools/test/general.shard/forbidden_imports_test.dart
+++ b/packages/flutter_tools/test/general.shard/forbidden_imports_test.dart
@@ -158,11 +158,13 @@ void main() {
     }
   });
 
-  test('no unauthorized imports of build_runner', () {
+  test('no unauthorized imports of build_runner or dwds', () {
     final List<String> whitelistedPaths = <String>[
       globals.fs.path.join(flutterTools, 'test', 'src', 'build_runner'),
       globals.fs.path.join(flutterTools, 'lib', 'src', 'build_runner'),
       globals.fs.path.join(flutterTools, 'lib', 'executable.dart'),
+      globals.fs.path.join(flutterTools, 'lib', 'devfs_web.dart'),
+      globals.fs.path.join(flutterTools, 'lib', 'resident_web_runner.dart'),
     ];
     bool _isNotWhitelisted(FileSystemEntity entity) => whitelistedPaths.every((String path) => !entity.path.contains(path));
 
@@ -177,6 +179,7 @@ void main() {
           if (line.startsWith(RegExp(r'import.*package:build_runner_core/build_runner_core.dart')) ||
               line.startsWith(RegExp(r'import.*package:build_runner/build_runner.dart')) ||
               line.startsWith(RegExp(r'import.*package:build_config/build_config.dart')) ||
+              line.startsWith(RegExp(r'import.*dwds:*.dart')) ||
               line.startsWith(RegExp(r'import.*build_runner/.*.dart'))) {
             final String relativePath = globals.fs.path.relative(file.path, from:flutterTools);
             fail('$relativePath imports a build_runner package');

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
@@ -16,7 +16,7 @@ import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:flutter_tools/src/build_runner/resident_web_runner.dart';
 import 'package:flutter_tools/src/web/chrome.dart';
-import 'package:flutter_tools/src/web/devfs_web.dart';
+import 'package:flutter_tools/src/build_runner/devfs_web.dart';
 import 'package:flutter_tools/src/web/web_device.dart';
 import 'package:mockito/mockito.dart';
 import 'package:platform/platform.dart';

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -19,7 +19,7 @@ import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:flutter_tools/src/web/chrome.dart';
-import 'package:flutter_tools/src/web/devfs_web.dart';
+import 'package:flutter_tools/src/build_runner/devfs_web.dart';
 import 'package:flutter_tools/src/web/web_device.dart';
 import 'package:mockito/mockito.dart';
 import 'package:platform/platform.dart';

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/convert.dart';
-import 'package:flutter_tools/src/web/devfs_web.dart';
+import 'package:flutter_tools/src/build_runner/devfs_web.dart';
 import 'package:mockito/mockito.dart';
 import 'package:package_config/discovery.dart';
 import 'package:package_config/packages.dart';

--- a/packages/flutter_tools/test/general.shard/web/web_asset_server_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/web_asset_server_test.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
-import 'package:flutter_tools/src/web/devfs_web.dart';
+import 'package:flutter_tools/src/build_runner/devfs_web.dart';
 import 'package:shelf/shelf.dart';
 
 import '../../src/common.dart';


### PR DESCRIPTION
## Description

So that we don't have to coordinate rolls of flutter_tools and dwds. The existing build_runner paths are excluded from g3 sources, so they can be resued.