### PR TITLE
Change Focus.unfocus to take a disposition for where the focus should go.

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -715,6 +715,10 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
       return;
     }
     FocusScopeNode scope = enclosingScope;
+    if (scope == null) {
+      // Attempting to unfocus the root scope isn't allowed.
+      return;
+    }
     switch (disposition) {
       case UnfocusDisposition.scope:
         // Focus the nearest scope without focusing its "focused child" or
@@ -725,8 +729,9 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
         // If it can't request focus, then don't modify its focused children.
         if (scope.canRequestFocus) {
           // This prevents re-focusing the node that we just unfocused if we
-          // immediately hit "next" after unfocusing.
-          scope._focusedChildren.remove(this);
+          // immediately hit "next" after unfocusing, and also prevents the odd
+          // choices for refocusing of the next-to-last focused child.
+          scope._focusedChildren.clear();
         }
 
         while (!scope.canRequestFocus) {

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -1138,6 +1138,10 @@ class FocusScopeNode extends FocusNode {
 
   @override
   void _doRequestFocus({@required bool findFirstFocus}) {
+    // It is possible tha a previously focused child is no longer focusable.
+    while (focusedChild != null && !focusedChild.canRequestFocus)
+      _focusedChildren.removeLast();
+
     assert(findFirstFocus != null);
 
     // If findFirstFocus is false, then the request is to make this scope the

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -914,6 +914,7 @@ void main() {
 
     tester.testTextInput.log.clear();
     tester.testTextInput.closeConnection();
+    // A pump is needed to allow the focus change (unfocus) to be resolved.
     await tester.pump();
 
     // Widget does not have focus anymore.

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -914,6 +914,7 @@ void main() {
 
     tester.testTextInput.log.clear();
     tester.testTextInput.closeConnection();
+    await tester.pump();
 
     // Widget does not have focus anymore.
     expect(state.wantKeepAlive, false);

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -483,47 +483,7 @@ void main() {
       expect(scope1.focusedChild, equals(child1));
       expect(scope2.focusedChild, equals(child4));
     });
-    testWidgets('Unfocus with disposition root works properly', (WidgetTester tester) async {
-      final BuildContext context = await setupWidget(tester);
-      final FocusScopeNode scope1 = FocusScopeNode(debugLabel: 'scope1')..attach(context);
-      final FocusAttachment scope1Attachment = scope1.attach(context);
-      final FocusNode parent1 = FocusNode(debugLabel: 'parent1');
-      final FocusAttachment parent1Attachment = parent1.attach(context);
-      final FocusNode child1 = FocusNode(debugLabel: 'child1');
-      final FocusAttachment child1Attachment = child1.attach(context);
-      final FocusNode child2 = FocusNode(debugLabel: 'child2');
-      final FocusAttachment child2Attachment = child2.attach(context);
-      scope1Attachment.reparent(parent: tester.binding.focusManager.rootScope);
-      parent1Attachment.reparent(parent: scope1);
-      child1Attachment.reparent(parent: parent1);
-      child2Attachment.reparent(parent: parent1);
-
-      child1.requestFocus();
-      await tester.pump();
-      expect(scope1.focusedChild, equals(child1));
-
-      // Default is UnfocusDisposition.root.
-      child1.unfocus();
-      await tester.pump();
-      expect(scope1.focusedChild, isNull);
-      expect(child1.hasPrimaryFocus, isFalse);
-      expect(scope1.hasFocus, isFalse);
-      expect(FocusManager.instance.rootScope.hasPrimaryFocus, isTrue);
-
-      // Can re-focus child.
-      child1.requestFocus();
-      await tester.pump();
-      expect(scope1.focusedChild, equals(child1));
-      expect(FocusManager.instance.rootScope.hasPrimaryFocus, isFalse);
-
-      // When the scope is unfocused, the child gets unfocused.
-      scope1.unfocus(disposition: UnfocusDisposition.root);
-      await tester.pump();
-      expect(scope1.focusedChild, equals(child1));
-      expect(child1.hasPrimaryFocus, isFalse);
-      expect(scope1.hasFocus, isFalse);
-    });
-    testWidgets('Unfocus with disposition pop works properly', (WidgetTester tester) async {
+    testWidgets('Unfocus with disposition previouslyFocusedChild works properly', (WidgetTester tester) async {
       final BuildContext context = await setupWidget(tester);
       final FocusScopeNode scope1 = FocusScopeNode(debugLabel: 'scope1')..attach(context);
       final FocusAttachment scope1Attachment = scope1.attach(context);
@@ -562,7 +522,7 @@ void main() {
       expect(scope1.focusedChild, equals(child1));
       expect(scope2.focusedChild, equals(child3));
 
-      child1.unfocus(disposition: UnfocusDisposition.pop);
+      child1.unfocus(disposition: UnfocusDisposition.previouslyFocusedChild);
       await tester.pump();
       expect(scope1.focusedChild, equals(child2));
       expect(scope2.focusedChild, equals(child3));
@@ -582,7 +542,7 @@ void main() {
       expect(child3.hasPrimaryFocus, isFalse);
 
       // The same thing happens when unfocusing a second time.
-      child1.unfocus(disposition: UnfocusDisposition.pop);
+      child1.unfocus(disposition: UnfocusDisposition.previouslyFocusedChild);
       await tester.pump();
       expect(scope1.focusedChild, equals(child2));
       expect(scope2.focusedChild, equals(child3));
@@ -594,7 +554,7 @@ void main() {
       // When the scope gets unfocused, then the sibling scope gets focus.
       child1.requestFocus();
       await tester.pump();
-      scope1.unfocus(disposition: UnfocusDisposition.pop);
+      scope1.unfocus(disposition: UnfocusDisposition.previouslyFocusedChild);
       await tester.pump();
       expect(scope1.focusedChild, equals(child1));
       expect(scope2.focusedChild, equals(child3));
@@ -645,7 +605,7 @@ void main() {
       child1.unfocus(disposition: UnfocusDisposition.scope);
       await tester.pump();
       // Focused child doesn't change.
-      expect(scope1.focusedChild, equals(child1));
+      expect(scope1.focusedChild, equals(child2));
       expect(scope2.focusedChild, equals(child3));
       // Focus does change.
       expect(scope1.hasPrimaryFocus, isTrue);
@@ -666,7 +626,7 @@ void main() {
       // The same thing happens when unfocusing a second time.
       child1.unfocus(disposition: UnfocusDisposition.scope);
       await tester.pump();
-      expect(scope1.focusedChild, equals(child1));
+      expect(scope1.focusedChild, equals(child2));
       expect(scope2.focusedChild, equals(child3));
       expect(scope1.hasPrimaryFocus, isTrue);
       expect(scope2.hasFocus, isFalse);
@@ -1031,11 +991,11 @@ void main() {
     child1.unfocus();
     await tester.pump();
     expect(topFocus, isFalse);
-    expect(parent1Focus, isFalse);
+    expect(parent1Focus, isTrue);
     expect(child1Focus, isFalse);
     expect(parent2Focus, isFalse);
     expect(child2Focus, isFalse);
-    expect(topNotify, equals(1));
+    expect(topNotify, equals(0));
     expect(parent1Notify, equals(1));
     expect(child1Notify, equals(1));
     expect(parent2Notify, equals(0));
@@ -1044,12 +1004,12 @@ void main() {
     clear();
     child1.requestFocus();
     await tester.pump();
-    expect(topFocus, isTrue);
+    expect(topFocus, isFalse);
     expect(parent1Focus, isTrue);
     expect(child1Focus, isTrue);
     expect(parent2Focus, isFalse);
     expect(child2Focus, isFalse);
-    expect(topNotify, equals(1));
+    expect(topNotify, equals(0));
     expect(parent1Notify, equals(1));
     expect(child1Notify, equals(1));
     expect(parent2Notify, equals(0));

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -605,7 +605,7 @@ void main() {
       child1.unfocus(disposition: UnfocusDisposition.scope);
       await tester.pump();
       // Focused child doesn't change.
-      expect(scope1.focusedChild, equals(child2));
+      expect(scope1.focusedChild, isNull);
       expect(scope2.focusedChild, equals(child3));
       // Focus does change.
       expect(scope1.hasPrimaryFocus, isTrue);
@@ -626,7 +626,7 @@ void main() {
       // The same thing happens when unfocusing a second time.
       child1.unfocus(disposition: UnfocusDisposition.scope);
       await tester.pump();
-      expect(scope1.focusedChild, equals(child2));
+      expect(scope1.focusedChild, isNull);
       expect(scope2.focusedChild, equals(child3));
       expect(scope1.hasPrimaryFocus, isTrue);
       expect(scope2.hasFocus, isFalse);
@@ -634,7 +634,7 @@ void main() {
       expect(child2.hasPrimaryFocus, isFalse);
 
       // When the scope gets unfocused, then its parent scope (the root scope)
-      // gets focus.
+      // gets focus, but it doesn't mess with the focused children.
       child1.requestFocus();
       await tester.pump();
       scope1.unfocus(disposition: UnfocusDisposition.scope);

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -647,7 +647,7 @@ void main() {
       expect(child3.hasPrimaryFocus, isFalse);
       expect(FocusManager.instance.rootScope.hasPrimaryFocus, isTrue);
     });
-    testWidgets('Unfocus with disposition scope works properly when some nodes are unfocusable', (WidgetTester tester) async {
+    testWidgets('Unfocus works properly when some nodes are unfocusable', (WidgetTester tester) async {
       final BuildContext context = await setupWidget(tester);
       final FocusScopeNode scope1 = FocusScopeNode(debugLabel: 'scope1')..attach(context);
       final FocusAttachment scope1Attachment = scope1.attach(context);
@@ -693,6 +693,16 @@ void main() {
       expect(child3.hasPrimaryFocus, isTrue);
 
       child1.unfocus(disposition: UnfocusDisposition.scope);
+      await tester.pump();
+      expect(child3.hasPrimaryFocus, isTrue);
+      expect(scope1.focusedChild, equals(child1));
+      expect(scope2.focusedChild, equals(child3));
+      expect(scope1.hasPrimaryFocus, isFalse);
+      expect(scope2.hasFocus, isTrue);
+      expect(child1.hasPrimaryFocus, isFalse);
+      expect(child2.hasPrimaryFocus, isFalse);
+
+      child1.unfocus(disposition: UnfocusDisposition.previouslyFocusedChild);
       await tester.pump();
       expect(child3.hasPrimaryFocus, isTrue);
       expect(scope1.focusedChild, equals(child1));

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -316,7 +316,7 @@ void main() {
       await tester.pump();
       expect(tester.binding.focusManager.primaryFocus, isNot(equals(child2)));
       expect(tester.binding.focusManager.primaryFocus, isNot(equals(child1)));
-      expect(scope.focusedChild, isNull);
+      expect(scope.focusedChild, equals(child1));
       expect(scope.traversalDescendants.contains(child1), isFalse);
       expect(scope.traversalDescendants.contains(child2), isFalse);
     });
@@ -483,7 +483,47 @@ void main() {
       expect(scope1.focusedChild, equals(child1));
       expect(scope2.focusedChild, equals(child4));
     });
-    testWidgets('Unfocus works properly', (WidgetTester tester) async {
+    testWidgets('Unfocus with disposition root works properly', (WidgetTester tester) async {
+      final BuildContext context = await setupWidget(tester);
+      final FocusScopeNode scope1 = FocusScopeNode(debugLabel: 'scope1')..attach(context);
+      final FocusAttachment scope1Attachment = scope1.attach(context);
+      final FocusNode parent1 = FocusNode(debugLabel: 'parent1');
+      final FocusAttachment parent1Attachment = parent1.attach(context);
+      final FocusNode child1 = FocusNode(debugLabel: 'child1');
+      final FocusAttachment child1Attachment = child1.attach(context);
+      final FocusNode child2 = FocusNode(debugLabel: 'child2');
+      final FocusAttachment child2Attachment = child2.attach(context);
+      scope1Attachment.reparent(parent: tester.binding.focusManager.rootScope);
+      parent1Attachment.reparent(parent: scope1);
+      child1Attachment.reparent(parent: parent1);
+      child2Attachment.reparent(parent: parent1);
+
+      child1.requestFocus();
+      await tester.pump();
+      expect(scope1.focusedChild, equals(child1));
+
+      // Default is UnfocusDisposition.root.
+      child1.unfocus();
+      await tester.pump();
+      expect(scope1.focusedChild, isNull);
+      expect(child1.hasPrimaryFocus, isFalse);
+      expect(scope1.hasFocus, isFalse);
+      expect(FocusManager.instance.rootScope.hasPrimaryFocus, isTrue);
+
+      // Can re-focus child.
+      child1.requestFocus();
+      await tester.pump();
+      expect(scope1.focusedChild, equals(child1));
+      expect(FocusManager.instance.rootScope.hasPrimaryFocus, isFalse);
+
+      // When the scope is unfocused, the child gets unfocused.
+      scope1.unfocus(disposition: UnfocusDisposition.root);
+      await tester.pump();
+      expect(scope1.focusedChild, equals(child1));
+      expect(child1.hasPrimaryFocus, isFalse);
+      expect(scope1.hasFocus, isFalse);
+    });
+    testWidgets('Unfocus with disposition pop works properly', (WidgetTester tester) async {
       final BuildContext context = await setupWidget(tester);
       final FocusScopeNode scope1 = FocusScopeNode(debugLabel: 'scope1')..attach(context);
       final FocusAttachment scope1Attachment = scope1.attach(context);
@@ -510,27 +550,197 @@ void main() {
       child3Attachment.reparent(parent: parent2);
       child4Attachment.reparent(parent: parent2);
 
+      // Build up a history.
+      child4.requestFocus();
+      await tester.pump();
+      child2.requestFocus();
+      await tester.pump();
+      child3.requestFocus();
+      await tester.pump();
       child1.requestFocus();
       await tester.pump();
       expect(scope1.focusedChild, equals(child1));
-      expect(parent2.children.contains(child1), isFalse);
+      expect(scope2.focusedChild, equals(child3));
 
-      child1.unfocus();
+      child1.unfocus(disposition: UnfocusDisposition.pop);
       await tester.pump();
-      expect(scope1.focusedChild, isNull);
+      expect(scope1.focusedChild, equals(child2));
+      expect(scope2.focusedChild, equals(child3));
+      expect(scope1.hasFocus, isTrue);
+      expect(scope2.hasFocus, isFalse);
       expect(child1.hasPrimaryFocus, isFalse);
-      expect(scope1.hasFocus, isFalse);
+      expect(child2.hasPrimaryFocus, isTrue);
 
+      // Can re-focus child.
       child1.requestFocus();
       await tester.pump();
       expect(scope1.focusedChild, equals(child1));
-      expect(parent2.children.contains(child1), isFalse);
+      expect(scope2.focusedChild, equals(child3));
+      expect(scope1.hasFocus, isTrue);
+      expect(scope2.hasFocus, isFalse);
+      expect(child1.hasPrimaryFocus, isTrue);
+      expect(child3.hasPrimaryFocus, isFalse);
 
-      scope1.unfocus();
+      // The same thing happens when unfocusing a second time.
+      child1.unfocus(disposition: UnfocusDisposition.pop);
       await tester.pump();
-      expect(scope1.focusedChild, isNull);
+      expect(scope1.focusedChild, equals(child2));
+      expect(scope2.focusedChild, equals(child3));
+      expect(scope1.hasFocus, isTrue);
+      expect(scope2.hasFocus, isFalse);
       expect(child1.hasPrimaryFocus, isFalse);
+      expect(child2.hasPrimaryFocus, isTrue);
+
+      // When the scope gets unfocused, then the sibling scope gets focus.
+      child1.requestFocus();
+      await tester.pump();
+      scope1.unfocus(disposition: UnfocusDisposition.pop);
+      await tester.pump();
+      expect(scope1.focusedChild, equals(child1));
+      expect(scope2.focusedChild, equals(child3));
       expect(scope1.hasFocus, isFalse);
+      expect(scope2.hasFocus, isTrue);
+      expect(child1.hasPrimaryFocus, isFalse);
+      expect(child3.hasPrimaryFocus, isTrue);
+    });
+    testWidgets('Unfocus with disposition scope works properly', (WidgetTester tester) async {
+      final BuildContext context = await setupWidget(tester);
+      final FocusScopeNode scope1 = FocusScopeNode(debugLabel: 'scope1')..attach(context);
+      final FocusAttachment scope1Attachment = scope1.attach(context);
+      final FocusScopeNode scope2 = FocusScopeNode(debugLabel: 'scope2');
+      final FocusAttachment scope2Attachment = scope2.attach(context);
+      final FocusNode parent1 = FocusNode(debugLabel: 'parent1');
+      final FocusAttachment parent1Attachment = parent1.attach(context);
+      final FocusNode parent2 = FocusNode(debugLabel: 'parent2');
+      final FocusAttachment parent2Attachment = parent2.attach(context);
+      final FocusNode child1 = FocusNode(debugLabel: 'child1');
+      final FocusAttachment child1Attachment = child1.attach(context);
+      final FocusNode child2 = FocusNode(debugLabel: 'child2');
+      final FocusAttachment child2Attachment = child2.attach(context);
+      final FocusNode child3 = FocusNode(debugLabel: 'child3');
+      final FocusAttachment child3Attachment = child3.attach(context);
+      final FocusNode child4 = FocusNode(debugLabel: 'child4');
+      final FocusAttachment child4Attachment = child4.attach(context);
+      scope1Attachment.reparent(parent: tester.binding.focusManager.rootScope);
+      scope2Attachment.reparent(parent: tester.binding.focusManager.rootScope);
+      parent1Attachment.reparent(parent: scope1);
+      parent2Attachment.reparent(parent: scope2);
+      child1Attachment.reparent(parent: parent1);
+      child2Attachment.reparent(parent: parent1);
+      child3Attachment.reparent(parent: parent2);
+      child4Attachment.reparent(parent: parent2);
+
+      // Build up a history.
+      child4.requestFocus();
+      await tester.pump();
+      child2.requestFocus();
+      await tester.pump();
+      child3.requestFocus();
+      await tester.pump();
+      child1.requestFocus();
+      await tester.pump();
+      expect(scope1.focusedChild, equals(child1));
+      expect(scope2.focusedChild, equals(child3));
+
+      child1.unfocus(disposition: UnfocusDisposition.scope);
+      await tester.pump();
+      // Focused child doesn't change.
+      expect(scope1.focusedChild, equals(child1));
+      expect(scope2.focusedChild, equals(child3));
+      // Focus does change.
+      expect(scope1.hasPrimaryFocus, isTrue);
+      expect(scope2.hasFocus, isFalse);
+      expect(child1.hasPrimaryFocus, isFalse);
+      expect(child2.hasPrimaryFocus, isFalse);
+
+      // Can re-focus child.
+      child1.requestFocus();
+      await tester.pump();
+      expect(scope1.focusedChild, equals(child1));
+      expect(scope2.focusedChild, equals(child3));
+      expect(scope1.hasFocus, isTrue);
+      expect(scope2.hasFocus, isFalse);
+      expect(child1.hasPrimaryFocus, isTrue);
+      expect(child3.hasPrimaryFocus, isFalse);
+
+      // The same thing happens when unfocusing a second time.
+      child1.unfocus(disposition: UnfocusDisposition.scope);
+      await tester.pump();
+      expect(scope1.focusedChild, equals(child1));
+      expect(scope2.focusedChild, equals(child3));
+      expect(scope1.hasPrimaryFocus, isTrue);
+      expect(scope2.hasFocus, isFalse);
+      expect(child1.hasPrimaryFocus, isFalse);
+      expect(child2.hasPrimaryFocus, isFalse);
+
+      // When the scope gets unfocused, then its parent scope (the root scope)
+      // gets focus.
+      child1.requestFocus();
+      await tester.pump();
+      scope1.unfocus(disposition: UnfocusDisposition.scope);
+      await tester.pump();
+      expect(scope1.focusedChild, equals(child1));
+      expect(scope2.focusedChild, equals(child3));
+      expect(scope1.hasFocus, isFalse);
+      expect(scope2.hasFocus, isFalse);
+      expect(child1.hasPrimaryFocus, isFalse);
+      expect(child3.hasPrimaryFocus, isFalse);
+      expect(FocusManager.instance.rootScope.hasPrimaryFocus, isTrue);
+    });
+    testWidgets('Unfocus with disposition scope works properly when some nodes are unfocusable', (WidgetTester tester) async {
+      final BuildContext context = await setupWidget(tester);
+      final FocusScopeNode scope1 = FocusScopeNode(debugLabel: 'scope1')..attach(context);
+      final FocusAttachment scope1Attachment = scope1.attach(context);
+      final FocusScopeNode scope2 = FocusScopeNode(debugLabel: 'scope2');
+      final FocusAttachment scope2Attachment = scope2.attach(context);
+      final FocusNode parent1 = FocusNode(debugLabel: 'parent1');
+      final FocusAttachment parent1Attachment = parent1.attach(context);
+      final FocusNode parent2 = FocusNode(debugLabel: 'parent2');
+      final FocusAttachment parent2Attachment = parent2.attach(context);
+      final FocusNode child1 = FocusNode(debugLabel: 'child1');
+      final FocusAttachment child1Attachment = child1.attach(context);
+      final FocusNode child2 = FocusNode(debugLabel: 'child2');
+      final FocusAttachment child2Attachment = child2.attach(context);
+      final FocusNode child3 = FocusNode(debugLabel: 'child3');
+      final FocusAttachment child3Attachment = child3.attach(context);
+      final FocusNode child4 = FocusNode(debugLabel: 'child4');
+      final FocusAttachment child4Attachment = child4.attach(context);
+      scope1Attachment.reparent(parent: tester.binding.focusManager.rootScope);
+      scope2Attachment.reparent(parent: tester.binding.focusManager.rootScope);
+      parent1Attachment.reparent(parent: scope1);
+      parent2Attachment.reparent(parent: scope2);
+      child1Attachment.reparent(parent: parent1);
+      child2Attachment.reparent(parent: parent1);
+      child3Attachment.reparent(parent: parent2);
+      child4Attachment.reparent(parent: parent2);
+
+      // Build up a history.
+      child4.requestFocus();
+      await tester.pump();
+      child2.requestFocus();
+      await tester.pump();
+      child3.requestFocus();
+      await tester.pump();
+      child1.requestFocus();
+      await tester.pump();
+      expect(child1.hasPrimaryFocus, isTrue);
+
+      scope1.canRequestFocus = false;
+      await tester.pump();
+
+      expect(scope1.focusedChild, equals(child1));
+      expect(scope2.focusedChild, equals(child3));
+      expect(child3.hasPrimaryFocus, isTrue);
+
+      child1.unfocus(disposition: UnfocusDisposition.scope);
+      await tester.pump();
+      expect(child3.hasPrimaryFocus, isTrue);
+      expect(scope1.focusedChild, equals(child1));
+      expect(scope2.focusedChild, equals(child3));
+      expect(scope1.hasPrimaryFocus, isFalse);
+      expect(scope2.hasFocus, isTrue);
+      expect(child1.hasPrimaryFocus, isFalse);
+      expect(child2.hasPrimaryFocus, isFalse);
     });
     testWidgets('Key handling bubbles up and terminates when handled.', (WidgetTester tester) async {
       final Set<FocusNode> receivedAnEvent = <FocusNode>{};

--- a/packages/flutter/test/widgets/focus_scope_test.dart
+++ b/packages/flutter/test/widgets/focus_scope_test.dart
@@ -1428,10 +1428,10 @@ void main() {
 
     // Check FocusNode with child (focus1). Shouldn't affect children.
     await pumpTest(allowFocus1: false);
-    expect(Focus.of(container1.currentContext).hasFocus, isFalse);
+    expect(Focus.of(container1.currentContext).hasFocus, isTrue); // focus2 has focus.
     Focus.of(focus2.currentContext).requestFocus(); // Try to focus focus1
     await tester.pump();
-    expect(Focus.of(container1.currentContext).hasFocus, isFalse);
+    expect(Focus.of(container1.currentContext).hasFocus, isTrue); // focus2 still has focus.
     Focus.of(container1.currentContext).requestFocus(); // Now try to focus focus2
     await tester.pump();
     expect(Focus.of(container1.currentContext).hasFocus, isTrue);

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -6,9 +6,9 @@ import 'dart:collection';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:mockito/mockito.dart';
-import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
 
 final List<String> results = <String>[];
 
@@ -1227,6 +1227,58 @@ void main() {
         MaterialPageRoute<void>(
           builder: (BuildContext context) => const Text('dummy3'),
         )
+      );
+      await tester.pumpAndSettle();
+      final Element textOnPageThree = tester.element(find.text('dummy3'));
+      final FocusScopeNode focusNodeOnPageThree = FocusScope.of(textOnPageThree);
+      // The focus should be on third page.
+      expect(focusNodeOnPageOne.hasFocus, isFalse);
+      expect(focusNodeOnPageTwo.hasFocus, isFalse);
+      expect(focusNodeOnPageThree.hasFocus, isTrue);
+
+      // Pops two pages simultaneously.
+      navigatorKey.currentState.popUntil((Route<void> route) => route.isFirst);
+      await tester.pumpAndSettle();
+      // It should refocus page one after pops.
+      expect(focusNodeOnPageOne.hasFocus, isTrue);
+    });
+
+    testWidgets('focus traversal is correct when popping mutiple page simultaneously - with focused children', (WidgetTester tester) async {
+      // Regression test: https://github.com/flutter/flutter/issues/48903
+      final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+      await tester.pumpWidget(MaterialApp(
+        navigatorKey: navigatorKey,
+        home: const Text('dummy1'),
+      ));
+      final Element textOnPageOne = tester.element(find.text('dummy1'));
+      final FocusScopeNode focusNodeOnPageOne = FocusScope.of(textOnPageOne);
+      expect(focusNodeOnPageOne.hasFocus, isTrue);
+
+      // Pushes one page.
+      navigatorKey.currentState.push<void>(
+          MaterialPageRoute<void>(
+            builder: (BuildContext context) => const Material(child: TextField()),
+          )
+      );
+      await tester.pumpAndSettle();
+
+      final Element textOnPageTwo = tester.element(find.byType(TextField));
+      final FocusScopeNode focusNodeOnPageTwo = FocusScope.of(textOnPageTwo);
+      // The focus should be on second page.
+      expect(focusNodeOnPageOne.hasFocus, isFalse);
+      expect(focusNodeOnPageTwo.hasFocus, isTrue);
+
+      // Move the focus to another node.
+      focusNodeOnPageTwo.nextFocus();
+      await tester.pumpAndSettle();
+      expect(focusNodeOnPageTwo.hasFocus, isTrue);
+      expect(focusNodeOnPageTwo.hasPrimaryFocus, isFalse);
+
+      // Pushes another page.
+      navigatorKey.currentState.push<void>(
+          MaterialPageRoute<void>(
+            builder: (BuildContext context) => const Text('dummy3'),
+          )
       );
       await tester.pumpAndSettle();
       final Element textOnPageThree = tester.element(find.text('dummy3'));

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -1243,7 +1243,7 @@ void main() {
       expect(focusNodeOnPageOne.hasFocus, isTrue);
     });
 
-    testWidgets('focus traversal is correct when popping mutiple page simultaneously - with focused children', (WidgetTester tester) async {
+    testWidgets('focus traversal is correct when popping mutiple pages simultaneously - with focused children', (WidgetTester tester) async {
       // Regression test: https://github.com/flutter/flutter/issues/48903
       final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
       await tester.pumpWidget(MaterialApp(


### PR DESCRIPTION
## Description

When `Focus.unfocus` is called, the caller usually just thinks about wanting to remove focus from the node, but really, `unfocus` is a request to automatically pass the focus to another (hopefully useful) node.

This PR removes the `focusPrevious` flag from `unfocus`, and replaces it with a `disposition` enum that indicates where the focus should go from here.

The other value of the `UnfocusDisposition` enum is `UnfocusDisposition.scope`.

`UnfocusDisposition.previouslyFocusedChild ` is closest to what `focusPrevious` used to do: focus the nearest enclosing scope and use its `focusedChild` field to walk down the tree, finding the leaf `focusedChild`. This PR modifies it slightly so that it walks up to the nearest _focusable_ enclosing scope before trying to focus the children. This change addresses #48903

A new mode: `UnfocusDisposition.scope` will focus the nearest focusable enclosing scope of this node without trying to use the `FocusScopeNode.focusedChild` value to descend to the leaf focused child. This is useful as a default for both text field finalization and for what happens when `canRequestFocus` is set to false. It allows the scope to stay focused so that `nextFocus`/`previousFocus` still work as expected, but removes the focus from primary focus.

In addition to those changes, `unfocus` called on a `FocuScope` that wasn't the primary focus used to unfocus the primary focus instead. I removed that behavior, since it was buggy: if the primary focus was inside of a child scope, and you called unfocus on the parent scope, then the child scope could have focused another of its children instead, leaving the scope that you called `unfocus` on with `hasFocus` returning true still. If you want to remove the focus from the primary focus instead of the scope, that's easy enough to do: just call `primaryFocus.unfocus()`.

## Related Issues

- Fixes https://github.com/flutter/flutter/issues/48903

## Tests

- Added tests to check unfocus behavior, and to make sure that #48903 is fixed.

## Breaking Change

- [X] No, this is *not* a breaking change, as the `focusPrevious` argument doesn't appear in any customer tests.