### PR TITLE
Avoid including a potentially animated invisible image

### DIFF
--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -12,7 +12,6 @@ import 'framework.dart';
 import 'image.dart';
 import 'implicit_animations.dart';
 import 'transitions.dart';
-import 'value_listenable_builder.dart';
 
 // Examples can assume:
 // Uint8List bytes;

--- a/packages/flutter/test/widgets/fade_in_image_test.dart
+++ b/packages/flutter/test/widgets/fade_in_image_test.dart
@@ -209,6 +209,28 @@ Future<void> main() async {
       expect(findFadeInImage(tester).state, same(state));
     });
 
+    testWidgets('does not keep the placeholder in the tree if it is invisible', (WidgetTester tester) async {
+      final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);
+      final TestImageProvider imageProvider = TestImageProvider(targetImage);
+
+      await tester.pumpWidget(FadeInImage(
+        placeholder: placeholderProvider,
+        image: imageProvider,
+        fadeOutDuration: animationDuration,
+        fadeInDuration: animationDuration,
+        excludeFromSemantics: true,
+      ));
+
+      placeholderProvider.complete();
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Image), findsNWidgets(2));
+
+      imageProvider.complete();
+      await tester.pumpAndSettle();
+      expect(find.byType(Image), findsOneWidget);
+    });
+
     testWidgets('re-fades in the image when the target image is updated', (WidgetTester tester) async {
       final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);
       final TestImageProvider imageProvider = TestImageProvider(targetImage);
@@ -285,7 +307,7 @@ Future<void> main() async {
       expect(findFadeInImage(tester).target.opacity, moreOrLessEquals(1));
     });
 
-    group(ImageProvider, () {
+    group('ImageProvider', () {
 
       testWidgets('memory placeholder cacheWidth and cacheHeight is passed through', (WidgetTester tester) async {
         final Uint8List testBytes = Uint8List.fromList(kTransparentImage);


### PR DESCRIPTION
## Description

Currently, FadeInImage continues to build the placeholder even if it's invisible.  This is really sad if the placeholder is a multi frame looping animation, or just a large chunk of memory that no one else needs.

Just listening to the animation for the placeholder, when the status is completed for the current animation, setState to trigger a rebuild.


## Related Issues

https://github.com/flutter/flutter/issues/35592

## Tests

I added the following tests:

Test that when the animation completes on the placeholder, it's no longer in the tree.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
