### PR TITLE
[flutter_tools] use uri resolution for asset requests

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
@@ -160,7 +160,6 @@ class WebAssetServer implements AssetReader {
       final Uri potential = globals.fs.directory(getAssetBuildDirectory())
         .uri.resolve( requestPath.replaceFirst('/assets/', ''));
       file = globals.fs.file(potential);
-      print('LOOKING AT $potential, ${file.path}: ${file.existsSync()}');
     }
 
     if (!file.existsSync()) {

--- a/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
@@ -157,11 +157,10 @@ class WebAssetServer implements AssetReader {
     // If all of the lookups above failed, the file might have been an asset.
     // Try and resolve the path relative to the built asset directory.
     if (!file.existsSync()) {
-      final String assetPath = requestPath.replaceFirst('/assets/', '');
-      file = globals.fs.file(
-        globals.fs.path.join(getAssetBuildDirectory(),
-        globals.fs.path.relative(assetPath)),
-      );
+      final Uri potential = globals.fs.directory(getAssetBuildDirectory())
+        .uri.resolve( requestPath.replaceFirst('/assets/', ''));
+      file = globals.fs.file(potential);
+      print('LOOKING AT $potential, ${file.path}: ${file.existsSync()}');
     }
 
     if (!file.existsSync()) {

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -150,6 +150,20 @@ void main() {
     Platform: () => windows,
   }));
 
+   test('serves asset files from in filesystem with url-encoded paths', () => testbed.run(() async {
+    final File source = globals.fs.file(globals.fs.path.join('build', 'flutter_assets', Uri.encodeFull('abcd象形字.md')))
+      ..createSync(recursive: true)
+      ..writeAsBytesSync(kTransparentImage);
+    final Response response = await webAssetServer
+      .handleRequest(Request('GET', Uri.parse('http://foobar/assets/abcd%25E8%25B1%25A1%25E5%25BD%25A2%25E5%25AD%2597.md')));
+
+    expect(response.headers, allOf(<Matcher>[
+      containsPair('content-length', source.lengthSync().toString()),
+      containsPair('content-type', 'image/png'),
+    ]));
+    expect((await response.read().toList()).first, source.readAsBytesSync());
+  }));
+
    test('serves asset files from in filesystem with known mime type on Windows', () => testbed.run(() async {
     final File source = globals.fs.file(globals.fs.path.join('build', 'flutter_assets', 'foo.png'))
       ..createSync(recursive: true)

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -151,11 +151,11 @@ void main() {
   }));
 
    test('serves asset files from in filesystem with url-encoded paths', () => testbed.run(() async {
-    final File source = globals.fs.file(globals.fs.path.join('build', 'flutter_assets', Uri.encodeFull('abcd象形字.md')))
+    final File source = globals.fs.file(globals.fs.path.join('build', 'flutter_assets', Uri.encodeFull('abcd象形字.png')))
       ..createSync(recursive: true)
       ..writeAsBytesSync(kTransparentImage);
     final Response response = await webAssetServer
-      .handleRequest(Request('GET', Uri.parse('http://foobar/assets/abcd%25E8%25B1%25A1%25E5%25BD%25A2%25E5%25AD%2597.md')));
+      .handleRequest(Request('GET', Uri.parse('http://foobar/assets/abcd%25E8%25B1%25A1%25E5%25BD%25A2%25E5%25AD%2597.png')));
 
     expect(response.headers, allOf(<Matcher>[
       containsPair('content-length', source.lengthSync().toString()),


### PR DESCRIPTION
## Description

The debug flutter run server was not properly accounting for URI encoded assets. See: https://github.com/flutter/engine/pull/16630

Instead of path munging, use Uri.resolve