### PR TITLE
[flutter_tools] cleanup build_tests to reduce mocking and globals usage

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
@@ -4,98 +4,77 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/memory.dart';
+import 'package:file_testing/file_testing.dart';
 import 'package:platform/platform.dart';
-import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
 
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build.dart';
 import 'package:flutter_tools/src/commands/build_linux.dart';
-import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/linux/makefile.dart';
 import 'package:flutter_tools/src/project.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
 
 import '../../src/common.dart';
 import '../../src/context.dart';
-import '../../src/mocks.dart';
 import '../../src/testbed.dart';
 
-void main() {
-  MockProcessManager mockProcessManager;
-  MockProcess mockProcess;
-  MockPlatform linuxPlatform;
-  MockPlatform notLinuxPlatform;
+final Platform linuxPlatform = FakePlatform(
+  operatingSystem: 'linux',
+  environment: <String, String>{
+    'FLUTTER_ROOT': '/',
+  }
+);
+final Platform notLinuxPlatform = FakePlatform(
+  operatingSystem: 'macos',
+  environment: <String, String>{
+    'FLUTTER_ROOT': '/',
+  }
+);
 
+
+void main() {
   setUpAll(() {
     Cache.disableLocking();
   });
 
+  FileSystem fileSystem;
+  ProcessManager processManager;
+
   setUp(() {
-    mockProcessManager = MockProcessManager();
-    mockProcess = MockProcess();
-    linuxPlatform = MockPlatform();
-    notLinuxPlatform = MockPlatform();
-    when(mockProcess.exitCode).thenAnswer((Invocation invocation) async {
-      return 0;
-    });
-    when(mockProcess.stderr).thenAnswer((Invocation invocation) {
-      return const Stream<List<int>>.empty();
-    });
-    when(mockProcess.stdout).thenAnswer((Invocation invocation) {
-      return Stream<List<int>>.fromIterable(<List<int>>[utf8.encode('STDOUT STUFF')]);
-    });
-    when(linuxPlatform.isLinux).thenReturn(true);
-    when(linuxPlatform.isWindows).thenReturn(false);
-    when(notLinuxPlatform.isLinux).thenReturn(false);
-    when(notLinuxPlatform.isWindows).thenReturn(false);
+    fileSystem = MemoryFileSystem.test();
   });
 
   // Creates the mock files necessary to look like a Flutter project.
   void setUpMockCoreProjectFiles() {
-    globals.fs.file('pubspec.yaml').createSync();
-    globals.fs.file('.packages').createSync();
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    fileSystem.file('pubspec.yaml').createSync();
+    fileSystem.file('.packages').createSync();
+    fileSystem.file(fileSystem.path.join('lib', 'main.dart')).createSync(recursive: true);
   }
 
   // Creates the mock files necessary to run a build.
   void setUpMockProjectFilesForBuild() {
-    globals.fs.file(globals.fs.path.join('linux', 'Makefile')).createSync(recursive: true);
+    fileSystem.file(fileSystem.path.join('linux', 'Makefile')).createSync(recursive: true);
     setUpMockCoreProjectFiles();
-  }
-
-  // Sets up mock expectation for running 'make'.
-  void expectMakeInvocationWithMode(String buildModeName) {
-    when(mockProcessManager.start(<String>[
-      'make',
-      '-C',
-      '/linux',
-      'BUILD=$buildModeName',
-    ])).thenAnswer((Invocation invocation) async {
-      return mockProcess;
-    });
   }
 
   testUsingContext('Linux build fails when there is no linux project', () async {
     final BuildCommand command = BuildCommand();
-    applyMocksToCommand(command);
     setUpMockCoreProjectFiles();
+
     expect(createTestCommandRunner(command).run(
       const <String>['build', 'linux']
     ), throwsToolExit(message: 'No Linux desktop project configured'));
   }, overrides: <Type, Generator>{
     Platform: () => linuxPlatform,
-    FileSystem: () => MemoryFileSystem(),
+    FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
   });
 
   testUsingContext('Linux build fails on non-linux platform', () async {
     final BuildCommand command = BuildCommand();
-    applyMocksToCommand(command);
     setUpMockProjectFilesForBuild();
 
     expect(createTestCommandRunner(command).run(
@@ -103,54 +82,72 @@ void main() {
     ), throwsToolExit());
   }, overrides: <Type, Generator>{
     Platform: () => notLinuxPlatform,
-    FileSystem: () => MemoryFileSystem(),
+    FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
   });
 
   testUsingContext('Linux build invokes make and writes temporary files', () async {
     final BuildCommand command = BuildCommand();
-    applyMocksToCommand(command);
+    processManager = FakeProcessManager.list(<FakeCommand>[
+      FakeCommand(command: const <String>[
+        'make',
+        '-C',
+        '/linux',
+        'BUILD=release',
+      ], onRun: () {
+
+      })
+    ]);
+
     setUpMockProjectFilesForBuild();
-    expectMakeInvocationWithMode('release');
 
     await createTestCommandRunner(command).run(
       const <String>['build', 'linux']
     );
-    expect(globals.fs.file('linux/flutter/ephemeral/generated_config.mk').existsSync(), true);
+    expect(fileSystem.file('linux/flutter/ephemeral/generated_config.mk'), exists);
   }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(),
-    ProcessManager: () => mockProcessManager,
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
     Platform: () => linuxPlatform,
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
   });
 
   testUsingContext('Handles argument error from missing make', () async {
     final BuildCommand command = BuildCommand();
-    applyMocksToCommand(command);
     setUpMockProjectFilesForBuild();
-    when(mockProcessManager.start(<String>[
-      'make',
-      '-C',
-      '/linux',
-      'BUILD=release',
-    ])).thenThrow(ArgumentError());
+    processManager = FakeProcessManager.list(<FakeCommand>[
+      FakeCommand(command: const <String>[
+        'make',
+        '-C',
+        '/linux',
+        'BUILD=release',
+      ], onRun: () {
+        throw ArgumentError();
+      }),
+    ]);
 
     expect(createTestCommandRunner(command).run(
       const <String>['build', 'linux']
     ), throwsToolExit(message: "make not found. Run 'flutter doctor' for more information."));
   }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(),
-    ProcessManager: () => mockProcessManager,
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
     Platform: () => linuxPlatform,
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
   });
 
   testUsingContext('Linux build does not spew stdout to status logger', () async {
     final BuildCommand command = BuildCommand();
-    applyMocksToCommand(command);
     setUpMockProjectFilesForBuild();
-    expectMakeInvocationWithMode('debug');
+    processManager = FakeProcessManager.list(<FakeCommand>[
+      const FakeCommand(command: <String>[
+        'make',
+        '-C',
+        '/linux',
+        'BUILD=debug',
+      ], stdout: 'STDOUT STUFF'),
+    ]);
 
     await createTestCommandRunner(command).run(
       const <String>['build', 'linux', '--debug']
@@ -158,59 +155,72 @@ void main() {
     expect(testLogger.statusText, isNot(contains('STDOUT STUFF')));
     expect(testLogger.traceText, contains('STDOUT STUFF'));
   }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(),
-    ProcessManager: () => mockProcessManager,
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
     Platform: () => linuxPlatform,
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
   });
 
   testUsingContext('Linux build --debug passes debug mode to make', () async {
     final BuildCommand command = BuildCommand();
-    applyMocksToCommand(command);
     setUpMockProjectFilesForBuild();
-    expectMakeInvocationWithMode('debug');
+    processManager = FakeProcessManager.list(<FakeCommand>[
+      const FakeCommand(command: <String>[
+        'make',
+        '-C',
+        '/linux',
+        'BUILD=debug',
+      ]),
+    ]);
+
 
     await createTestCommandRunner(command).run(
       const <String>['build', 'linux', '--debug']
     );
   }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(),
-    ProcessManager: () => mockProcessManager,
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
     Platform: () => linuxPlatform,
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
   });
 
   testUsingContext('Linux build --profile passes profile mode to make', () async {
     final BuildCommand command = BuildCommand();
-    applyMocksToCommand(command);
     setUpMockProjectFilesForBuild();
-    expectMakeInvocationWithMode('profile');
+    processManager = FakeProcessManager.list(<FakeCommand>[
+      const FakeCommand(command: <String>[
+        'make',
+        '-C',
+        '/linux',
+        'BUILD=profile',
+      ]),
+    ]);
 
     await createTestCommandRunner(command).run(
       const <String>['build', 'linux', '--profile']
     );
   }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(),
-    ProcessManager: () => mockProcessManager,
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
     Platform: () => linuxPlatform,
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
   });
 
   testUsingContext('linux can extract binary name from Makefile', () async {
-    globals.fs.file('linux/Makefile')
+    fileSystem.file('linux/Makefile')
       ..createSync(recursive: true)
       ..writeAsStringSync(r'''
 # Comment
 SOMETHING_ELSE=FOO
 BINARY_NAME=fizz_bar
 ''');
-    globals.fs.file('pubspec.yaml').createSync();
-    globals.fs.file('.packages').createSync();
+    fileSystem.file('pubspec.yaml').createSync();
+    fileSystem.file('.packages').createSync();
     final FlutterProject flutterProject = FlutterProject.current();
 
     expect(makefileExecutableName(flutterProject.linux), 'fizz_bar');
   }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(),
+    FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
   });
@@ -219,53 +229,45 @@ BINARY_NAME=fizz_bar
     final CommandRunner<void> runner = createTestCommandRunner(BuildCommand());
 
     expect(() => runner.run(<String>['build', 'linux']),
-        throwsToolExit());
+      throwsToolExit());
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: false),
   });
 
   testUsingContext('Release build prints an under-construction warning', () async {
     final BuildCommand command = BuildCommand();
-    applyMocksToCommand(command);
     setUpMockProjectFilesForBuild();
-    expectMakeInvocationWithMode('release');
+    processManager = FakeProcessManager.list(<FakeCommand>[
+      const FakeCommand(command: <String>[
+        'make',
+        '-C',
+        '/linux',
+        'BUILD=release',
+      ]),
+    ]);
 
     await createTestCommandRunner(command).run(
       const <String>['build', 'linux']
     );
-
     expect(testLogger.statusText, contains('🚧'));
   }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(),
-    ProcessManager: () => mockProcessManager,
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
     Platform: () => linuxPlatform,
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
   });
 
   testUsingContext('hidden when not enabled on Linux host', () {
-    when(globals.platform.isLinux).thenReturn(true);
-
     expect(BuildLinuxCommand().hidden, true);
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: false),
-    Platform: () => MockPlatform(),
+    Platform: () => notLinuxPlatform,
   });
 
   testUsingContext('Not hidden when enabled and on Linux host', () {
-    when(globals.platform.isLinux).thenReturn(true);
-
     expect(BuildLinuxCommand().hidden, false);
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
-    Platform: () => MockPlatform(),
+    Platform: () => linuxPlatform,
   });
-}
-
-class MockProcessManager extends Mock implements ProcessManager {}
-class MockProcess extends Mock implements Process {}
-class MockPlatform extends Mock implements Platform {
-  @override
-  Map<String, String> environment = <String, String>{
-    'FLUTTER_ROOT': '/',
-  };
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -5,24 +5,18 @@
 import 'package:args/command_runner.dart';
 import 'package:file/memory.dart';
 import 'package:platform/platform.dart';
-
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build.dart';
 import 'package:flutter_tools/src/commands/build_macos.dart';
-import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/project.dart';
-import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
 
 import '../../src/common.dart';
 import '../../src/context.dart';
-import '../../src/mocks.dart';
 import '../../src/testbed.dart';
 
 class FakeXcodeProjectInterpreterWithProfile extends FakeXcodeProjectInterpreter {
@@ -36,109 +30,104 @@ class FakeXcodeProjectInterpreterWithProfile extends FakeXcodeProjectInterpreter
   }
 }
 
+final Platform macosPlatform = FakePlatform(
+  operatingSystem: 'macos',
+  environment: <String, String>{
+    'FLUTTER_ROOT': '/',
+  }
+);
+final Platform notMacosPlatform = FakePlatform(
+  operatingSystem: 'linux',
+  environment: <String, String>{
+    'FLUTTER_ROOT': '/',
+  }
+);
+
 void main() {
-  MockProcessManager mockProcessManager;
-  MockProcess mockProcess;
-  MockPlatform macosPlatform;
-  MockPlatform notMacosPlatform;
+  FileSystem fileSystem;
 
   setUpAll(() {
     Cache.disableLocking();
   });
 
   setUp(() {
-    mockProcessManager = MockProcessManager();
-    mockProcess = MockProcess();
-    macosPlatform = MockPlatform();
-    notMacosPlatform = MockPlatform();
-    when(mockProcess.exitCode).thenAnswer((Invocation invocation) async {
-      return 0;
-    });
-    when(mockProcess.stderr).thenAnswer((Invocation invocation) {
-      return const Stream<List<int>>.empty();
-    });
-    when(mockProcess.stdout).thenAnswer((Invocation invocation) {
-      return Stream<List<int>>.fromIterable(<List<int>>[utf8.encode('STDOUT STUFF')]);
-    });
-    when(macosPlatform.isMacOS).thenReturn(true);
-    when(macosPlatform.isWindows).thenReturn(false);
-    when(notMacosPlatform.isMacOS).thenReturn(false);
-    when(notMacosPlatform.isWindows).thenReturn(false);
+    fileSystem = MemoryFileSystem.test();
   });
 
   // Sets up the minimal mock project files necessary to look like a Flutter project.
   void createCoreMockProjectFiles() {
-    globals.fs.file('pubspec.yaml').createSync();
-    globals.fs.file('.packages').createSync();
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    fileSystem.file('pubspec.yaml').createSync();
+    fileSystem.file('.packages').createSync();
+    fileSystem.file(fileSystem.path.join('lib', 'main.dart')).createSync(recursive: true);
   }
 
   // Sets up the minimal mock project files necessary for macOS builds to succeed.
   void createMinimalMockProjectFiles() {
-    globals.fs.directory(globals.fs.path.join('macos', 'Runner.xcworkspace')).createSync(recursive: true);
+    fileSystem.directory(fileSystem.path.join('macos', 'Runner.xcworkspace')).createSync(recursive: true);
     createCoreMockProjectFiles();
   }
 
-  // Mocks the process manager to handle an xcodebuild call to build the app
+  // Creates a FakeCommand for the xcodebuild call to build the app
   // in the given configuration.
-  void setUpMockXcodeBuildHandler(String configuration) {
-    final FlutterProject flutterProject = FlutterProject.fromDirectory(globals.fs.currentDirectory);
-    final Directory flutterBuildDir = globals.fs.directory(getMacOSBuildDirectory());
-    when(mockProcessManager.start(<String>[
-      '/usr/bin/env',
-      'xcrun',
-      'xcodebuild',
-      '-workspace', flutterProject.macos.xcodeWorkspace.path,
-      '-configuration', configuration,
-      '-scheme', 'Runner',
-      '-derivedDataPath', flutterBuildDir.absolute.path,
-      'OBJROOT=${globals.fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Intermediates.noindex')}',
-      'SYMROOT=${globals.fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Products')}',
-      'COMPILER_INDEX_STORE_ENABLE=NO',
-    ])).thenAnswer((Invocation invocation) async {
-      globals.fs.file(globals.fs.path.join('macos', 'Flutter', 'ephemeral', '.app_filename'))
-        ..createSync(recursive: true)
-        ..writeAsStringSync('example.app');
-      return mockProcess;
-    });
+  FakeCommand setUpMockXcodeBuildHandler(String configuration) {
+    final FlutterProject flutterProject = FlutterProject.fromDirectory(fileSystem.currentDirectory);
+    final Directory flutterBuildDir = fileSystem.directory(getMacOSBuildDirectory());
+    return FakeCommand(
+      command: <String>[
+        '/usr/bin/env',
+        'xcrun',
+        'xcodebuild',
+        '-workspace', flutterProject.macos.xcodeWorkspace.path,
+        '-configuration', configuration,
+        '-scheme', 'Runner',
+        '-derivedDataPath', flutterBuildDir.absolute.path,
+        'OBJROOT=${fileSystem.path.join(flutterBuildDir.absolute.path, 'Build', 'Intermediates.noindex')}',
+        'SYMROOT=${fileSystem.path.join(flutterBuildDir.absolute.path, 'Build', 'Products')}',
+        'COMPILER_INDEX_STORE_ENABLE=NO',
+      ],
+      stdout: 'STDOUT STUFF',
+      onRun: () {
+        fileSystem.file(fileSystem.path.join('macos', 'Flutter', 'ephemeral', '.app_filename'))
+          ..createSync(recursive: true)
+          ..writeAsStringSync('example.app');
+      }
+    );
   }
 
   testUsingContext('macOS build fails when there is no macos project', () async {
     final BuildCommand command = BuildCommand();
-    applyMocksToCommand(command);
     createCoreMockProjectFiles();
+
     expect(createTestCommandRunner(command).run(
       const <String>['build', 'macos']
     ), throwsToolExit(message: 'No macOS desktop project configured'));
   }, overrides: <Type, Generator>{
     Platform: () => macosPlatform,
-    FileSystem: () => MemoryFileSystem(),
+    FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
   });
 
   testUsingContext('macOS build fails on non-macOS platform', () async {
     final BuildCommand command = BuildCommand();
-    applyMocksToCommand(command);
-    globals.fs.file('pubspec.yaml').createSync();
-    globals.fs.file('.packages').createSync();
-    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    fileSystem.file('pubspec.yaml').createSync();
+    fileSystem.file('.packages').createSync();
+    fileSystem.file(fileSystem.path.join('lib', 'main.dart'))
+      .createSync(recursive: true);
 
     expect(createTestCommandRunner(command).run(
       const <String>['build', 'macos']
     ), throwsToolExit());
   }, overrides: <Type, Generator>{
     Platform: () => notMacosPlatform,
-    FileSystem: () => MemoryFileSystem(),
+    FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
   });
 
   testUsingContext('macOS build does not spew stdout to status logger', () async {
     final BuildCommand command = BuildCommand();
-    applyMocksToCommand(command);
     createMinimalMockProjectFiles();
-    setUpMockXcodeBuildHandler('Debug');
 
     await createTestCommandRunner(command).run(
       const <String>['build', 'macos', '--debug']
@@ -146,40 +135,42 @@ void main() {
     expect(testLogger.statusText, isNot(contains('STDOUT STUFF')));
     expect(testLogger.traceText, contains('STDOUT STUFF'));
   }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(),
-    ProcessManager: () => mockProcessManager,
+    FileSystem: () => fileSystem,
+    ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
+      setUpMockXcodeBuildHandler('Debug')
+    ]),
     Platform: () => macosPlatform,
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
   });
 
   testUsingContext('macOS build invokes xcode build (debug)', () async {
     final BuildCommand command = BuildCommand();
-    applyMocksToCommand(command);
     createMinimalMockProjectFiles();
-    setUpMockXcodeBuildHandler('Debug');
 
     await createTestCommandRunner(command).run(
       const <String>['build', 'macos', '--debug']
     );
   }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(),
-    ProcessManager: () => mockProcessManager,
+    FileSystem: () => fileSystem,
+    ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
+      setUpMockXcodeBuildHandler('Debug')
+    ]),
     Platform: () => macosPlatform,
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
   });
 
   testUsingContext('macOS build invokes xcode build (profile)', () async {
     final BuildCommand command = BuildCommand();
-    applyMocksToCommand(command);
     createMinimalMockProjectFiles();
-    setUpMockXcodeBuildHandler('Profile');
 
     await createTestCommandRunner(command).run(
       const <String>['build', 'macos', '--profile']
     );
   }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(),
-    ProcessManager: () => mockProcessManager,
+    FileSystem: () => fileSystem,
+    ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
+      setUpMockXcodeBuildHandler('Profile')
+    ]),
     Platform: () => macosPlatform,
     XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithProfile(),
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
@@ -187,16 +178,16 @@ void main() {
 
   testUsingContext('macOS build invokes xcode build (release)', () async {
     final BuildCommand command = BuildCommand();
-    applyMocksToCommand(command);
     createMinimalMockProjectFiles();
-    setUpMockXcodeBuildHandler('Release');
 
     await createTestCommandRunner(command).run(
       const <String>['build', 'macos', '--release']
     );
   }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(),
-    ProcessManager: () => mockProcessManager,
+    FileSystem: () => fileSystem,
+    ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
+      setUpMockXcodeBuildHandler('Release')
+    ]),
     Platform: () => macosPlatform,
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
   });
@@ -205,35 +196,22 @@ void main() {
     final CommandRunner<void> runner = createTestCommandRunner(BuildCommand());
 
     expect(() => runner.run(<String>['build', 'macos']),
-        throwsToolExit());
+      throwsToolExit());
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: false),
   });
 
   testUsingContext('hidden when not enabled on macOS host', () {
-    when(globals.platform.isMacOS).thenReturn(true);
-
     expect(BuildMacosCommand().hidden, true);
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: false),
-    Platform: () => MockPlatform(),
+    Platform: () => macosPlatform,
   });
 
   testUsingContext('Not hidden when enabled and on macOS host', () {
-    when(globals.platform.isMacOS).thenReturn(true);
-
     expect(BuildMacosCommand().hidden, false);
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
-    Platform: () => MockPlatform(),
+    Platform: () => macosPlatform,
   });
-}
-
-class MockProcessManager extends Mock implements ProcessManager {}
-class MockProcess extends Mock implements Process {}
-class MockPlatform extends Mock implements Platform {
-  @override
-  Map<String, String> environment = <String, String>{
-    'FLUTTER_ROOT': '/',
-  };
 }

--- a/packages/flutter_tools/test/src/fake_process_manager.dart
+++ b/packages/flutter_tools/test/src/fake_process_manager.dart
@@ -8,7 +8,6 @@ import 'dart:io' as io show ProcessSignal;
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
-
 import 'common.dart';
 
 export 'package:process/process.dart' show ProcessManager;


### PR DESCRIPTION
## Description

* Removes MockPlatform in favor of FakePlatform
* Removes MockProcessManager in favor of FakeProcessManager
* Updates test to consistent style of setUp declared FileSystem, reducing globals
* minor formatting changes