### PR TITLE
Add parameter to Scaffold so its possible to disable open Drawer drag gesture

### DIFF
--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -232,6 +232,7 @@ class DrawerController extends StatefulWidget {
     this.dragStartBehavior = DragStartBehavior.start,
     this.scrimColor,
     this.edgeDragWidth,
+    this.enableDragGesture = true,
   }) : assert(child != null),
        assert(dragStartBehavior != null),
        assert(alignment != null),
@@ -277,6 +278,11 @@ class DrawerController extends StatefulWidget {
   ///
   /// By default, the color used is [Colors.black54]
   final Color scrimColor;
+
+  /// Determines if the [Drawer] can be opened and closed with a drag gesture.
+  ///
+  /// By default, the drag gesture is enabled.
+  final bool enableDragGesture;
 
   /// The width of the area within which a horizontal swipe will open the
   /// drawer.
@@ -505,18 +511,22 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
     }
 
     if (_controller.status == AnimationStatus.dismissed) {
-      return Align(
-        alignment: _drawerOuterAlignment,
-        child: GestureDetector(
-          key: _gestureDetectorKey,
-          onHorizontalDragUpdate: _move,
-          onHorizontalDragEnd: _settle,
-          behavior: HitTestBehavior.translucent,
-          excludeFromSemantics: true,
-          dragStartBehavior: widget.dragStartBehavior,
-          child: Container(width: dragAreaWidth),
-        ),
-      );
+      if (widget.enableDragGesture) {
+        return Align(
+          alignment: _drawerOuterAlignment,
+          child: GestureDetector(
+            key: _gestureDetectorKey,
+            onHorizontalDragUpdate: _move,
+            onHorizontalDragEnd: _settle,
+            behavior: HitTestBehavior.translucent,
+            excludeFromSemantics: true,
+            dragStartBehavior: widget.dragStartBehavior,
+            child: Container(width: dragAreaWidth),
+          ),
+        );
+      } else {
+        return const SizedBox.shrink();
+      }
     } else {
       bool platformHasBackButton;
       switch (Theme.of(context).platform) {
@@ -530,53 +540,58 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
           break;
       }
       assert(platformHasBackButton != null);
-      return GestureDetector(
-        key: _gestureDetectorKey,
-        onHorizontalDragDown: _handleDragDown,
-        onHorizontalDragUpdate: _move,
-        onHorizontalDragEnd: _settle,
-        onHorizontalDragCancel: _handleDragCancel,
-        excludeFromSemantics: true,
-        dragStartBehavior: widget.dragStartBehavior,
-        child: RepaintBoundary(
-          child: Stack(
-            children: <Widget>[
-              BlockSemantics(
-                child: ExcludeSemantics(
-                  // On Android, the back button is used to dismiss a modal.
-                  excluding: platformHasBackButton,
-                  child: GestureDetector(
-                    onTap: close,
-                    child: Semantics(
-                      label: MaterialLocalizations.of(context)?.modalBarrierDismissLabel,
-                      child: MouseRegion(
-                        opaque: true,
-                        child: Container( // The drawer's "scrim"
-                          color: _scrimColorTween.evaluate(_controller),
-                        ),
+      final Widget drawer = RepaintBoundary(
+        child: Stack(
+          children: <Widget>[
+            BlockSemantics(
+              child: ExcludeSemantics(
+                // On Android, the back button is used to dismiss a modal.
+                excluding: platformHasBackButton,
+                child: GestureDetector(
+                  onTap: close,
+                  child: Semantics(
+                    label: MaterialLocalizations.of(context)?.modalBarrierDismissLabel,
+                    child: MouseRegion(
+                      opaque: true,
+                      child: Container( // The drawer's "scrim"
+                        color: _scrimColorTween.evaluate(_controller),
                       ),
                     ),
                   ),
                 ),
               ),
-              Align(
-                alignment: _drawerOuterAlignment,
-                child: Align(
-                  alignment: _drawerInnerAlignment,
-                  widthFactor: _controller.value,
-                  child: RepaintBoundary(
-                    child: FocusScope(
-                      key: _drawerKey,
-                      node: _focusScopeNode,
-                      child: widget.child,
-                    ),
+            ),
+            Align(
+              alignment: _drawerOuterAlignment,
+              child: Align(
+                alignment: _drawerInnerAlignment,
+                widthFactor: _controller.value,
+                child: RepaintBoundary(
+                  child: FocusScope(
+                    key: _drawerKey,
+                    node: _focusScopeNode,
+                    child: widget.child,
                   ),
                 ),
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       );
+      if (widget.enableDragGesture) {
+        return GestureDetector(
+          key: _gestureDetectorKey,
+          onHorizontalDragDown: _handleDragDown,
+          onHorizontalDragUpdate: _move,
+          onHorizontalDragEnd: _settle,
+          onHorizontalDragCancel: _handleDragCancel,
+          excludeFromSemantics: true,
+          dragStartBehavior: widget.dragStartBehavior,
+          child: drawer,
+        );
+      } else {
+        return drawer;
+      }
     }
   }
   @override

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -232,7 +232,7 @@ class DrawerController extends StatefulWidget {
     this.dragStartBehavior = DragStartBehavior.start,
     this.scrimColor,
     this.edgeDragWidth,
-    this.enableDragGesture = true,
+    this.enableOpenDragGesture = true,
   }) : assert(child != null),
        assert(dragStartBehavior != null),
        assert(alignment != null),
@@ -279,10 +279,10 @@ class DrawerController extends StatefulWidget {
   /// By default, the color used is [Colors.black54]
   final Color scrimColor;
 
-  /// Determines if the [Drawer] can be opened and closed with a drag gesture.
+  /// Determines if the [Drawer] can be opened with a drag gesture.
   ///
   /// By default, the drag gesture is enabled.
-  final bool enableDragGesture;
+  final bool enableOpenDragGesture;
 
   /// The width of the area within which a horizontal swipe will open the
   /// drawer.
@@ -511,7 +511,7 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
     }
 
     if (_controller.status == AnimationStatus.dismissed) {
-      if (widget.enableDragGesture) {
+      if (widget.enableOpenDragGesture) {
         return Align(
           alignment: _drawerOuterAlignment,
           child: GestureDetector(
@@ -540,58 +540,53 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
           break;
       }
       assert(platformHasBackButton != null);
-      final Widget drawer = RepaintBoundary(
-        child: Stack(
-          children: <Widget>[
-            BlockSemantics(
-              child: ExcludeSemantics(
-                // On Android, the back button is used to dismiss a modal.
-                excluding: platformHasBackButton,
-                child: GestureDetector(
-                  onTap: close,
-                  child: Semantics(
-                    label: MaterialLocalizations.of(context)?.modalBarrierDismissLabel,
-                    child: MouseRegion(
-                      opaque: true,
-                      child: Container( // The drawer's "scrim"
-                        color: _scrimColorTween.evaluate(_controller),
+      return GestureDetector(
+        key: _gestureDetectorKey,
+        onHorizontalDragDown: _handleDragDown,
+        onHorizontalDragUpdate: _move,
+        onHorizontalDragEnd: _settle,
+        onHorizontalDragCancel: _handleDragCancel,
+        excludeFromSemantics: true,
+        dragStartBehavior: widget.dragStartBehavior,
+        child: RepaintBoundary(
+          child: Stack(
+            children: <Widget>[
+              BlockSemantics(
+                child: ExcludeSemantics(
+                  // On Android, the back button is used to dismiss a modal.
+                  excluding: platformHasBackButton,
+                  child: GestureDetector(
+                    onTap: close,
+                    child: Semantics(
+                      label: MaterialLocalizations.of(context)?.modalBarrierDismissLabel,
+                      child: MouseRegion(
+                        opaque: true,
+                        child: Container( // The drawer's "scrim"
+                          color: _scrimColorTween.evaluate(_controller),
+                        ),
                       ),
                     ),
                   ),
                 ),
               ),
-            ),
-            Align(
-              alignment: _drawerOuterAlignment,
-              child: Align(
-                alignment: _drawerInnerAlignment,
-                widthFactor: _controller.value,
-                child: RepaintBoundary(
-                  child: FocusScope(
-                    key: _drawerKey,
-                    node: _focusScopeNode,
-                    child: widget.child,
+              Align(
+                alignment: _drawerOuterAlignment,
+                child: Align(
+                  alignment: _drawerInnerAlignment,
+                  widthFactor: _controller.value,
+                  child: RepaintBoundary(
+                    child: FocusScope(
+                      key: _drawerKey,
+                      node: _focusScopeNode,
+                      child: widget.child,
+                    ),
                   ),
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       );
-      if (widget.enableDragGesture) {
-        return GestureDetector(
-          key: _gestureDetectorKey,
-          onHorizontalDragDown: _handleDragDown,
-          onHorizontalDragUpdate: _move,
-          onHorizontalDragEnd: _settle,
-          onHorizontalDragCancel: _handleDragCancel,
-          excludeFromSemantics: true,
-          dragStartBehavior: widget.dragStartBehavior,
-          child: drawer,
-        );
-      } else {
-        return drawer;
-      }
     }
   }
   @override

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -1011,6 +1011,8 @@ class Scaffold extends StatefulWidget {
     this.extendBodyBehindAppBar = false,
     this.drawerScrimColor,
     this.drawerEdgeDragWidth,
+    this.drawerEnableDragGesture = true,
+    this.endDrawerEnableDragGesture = true,
   }) : assert(primary != null),
        assert(extendBody != null),
        assert(extendBodyBehindAppBar != null),
@@ -1312,6 +1314,18 @@ class Scaffold extends StatefulWidget {
   /// example, if `TextDirection.of(context)` is set to [TextDirection.ltr],
   /// 20.0 will be added to `MediaQuery.of(context).padding.left`.
   final double drawerEdgeDragWidth;
+
+  /// Determines if the [Scaffold.drawer] can be opened and closed with a drag
+  /// gesture.
+  ///
+  /// By default, the drag gesture is enabled.
+  final bool drawerEnableDragGesture;
+
+  /// Determines if the [Scaffold.endDrawer] can be opened and closed with a
+  /// drag gesture.
+  ///
+  /// By default, the drag gesture is enabled.
+  final bool endDrawerEnableDragGesture;
 
   /// This flag is deprecated and fixes and issue with incorrect clipping
   /// and positioning of the [SnackBar] set to [SnackBarBehavior.floating].
@@ -2230,6 +2244,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
           dragStartBehavior: widget.drawerDragStartBehavior,
           scrimColor: widget.drawerScrimColor,
           edgeDragWidth: widget.drawerEdgeDragWidth,
+          enableDragGesture: widget.endDrawerEnableDragGesture,
         ),
         _ScaffoldSlot.endDrawer,
         // remove the side padding from the side we're not touching
@@ -2254,6 +2269,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
           dragStartBehavior: widget.drawerDragStartBehavior,
           scrimColor: widget.drawerScrimColor,
           edgeDragWidth: widget.drawerEdgeDragWidth,
+          enableDragGesture: widget.drawerEnableDragGesture,
         ),
         _ScaffoldSlot.drawer,
         // remove the side padding from the side we're not touching

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -1115,9 +1115,10 @@ class Scaffold extends StatefulWidget {
   /// To close the drawer, use [Navigator.pop].
   ///
   /// {@tool dartpad --template=stateful_widget_material}
-  /// To disable the drawer edge swipe, set the [Scaffold.drawerEdgeWidth] to 0.
-  /// Then, use [ScaffoldState.openDrawer] to open the drawer and
-  /// [Navigator.pop] to close it.
+  /// To disable the drawer edge swipe, set the
+  /// [Scaffold.drawerEnableOpenDragGesture] to false. Then, use
+  /// [ScaffoldState.openDrawer] to open the drawer and [Navigator.pop] to close
+  /// it.
   ///
   /// ```dart
   /// final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
@@ -1155,7 +1156,8 @@ class Scaffold extends StatefulWidget {
   ///         ),
   ///       ),
   ///     ),
-  ///     drawerEdgeDragWidth: 0.0, // Disable opening the drawer with a swipe gesture.
+  ///     // Disable opening the drawer with a swipe gesture.
+  ///     drawerEnableOpenDragGesture: false,
   ///   );
   /// }
   /// ```
@@ -1173,9 +1175,10 @@ class Scaffold extends StatefulWidget {
   /// To close the drawer, use [Navigator.pop].
   ///
   /// {@tool dartpad --template=stateful_widget_material}
-  /// To disable the drawer edge swipe, set the [Scaffold.drawerEdgeWidth]
-  /// to 0. Then, use [ScaffoldState.openEndDrawer] to open the drawer and
-  /// [Navigator.pop] to close it.
+  /// To disable the drawer edge swipe, set the
+  /// [Scaffold.endDrawerEnableOpenDragGesture] to false. Then, use
+  /// [ScaffoldState.openEndDrawer] to open the drawer and [Navigator.pop] to
+  /// close it.
   ///
   /// ```dart
   /// final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
@@ -1213,7 +1216,8 @@ class Scaffold extends StatefulWidget {
   ///         ),
   ///       ),
   ///     ),
-  ///     drawerEdgeDragWidth: 0.0, // Disable opening the drawer with a swipe gesture.
+  ///     // Disable opening the end drawer with a swipe gesture.
+  ///     endDrawerEnableOpenDragGesture: false,
   ///   );
   /// }
   /// ```

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -1011,8 +1011,8 @@ class Scaffold extends StatefulWidget {
     this.extendBodyBehindAppBar = false,
     this.drawerScrimColor,
     this.drawerEdgeDragWidth,
-    this.drawerEnableDragGesture = true,
-    this.endDrawerEnableDragGesture = true,
+    this.drawerEnableOpenDragGesture = true,
+    this.endDrawerEnableOpenDragGesture = true,
   }) : assert(primary != null),
        assert(extendBody != null),
        assert(extendBodyBehindAppBar != null),
@@ -1315,17 +1315,17 @@ class Scaffold extends StatefulWidget {
   /// 20.0 will be added to `MediaQuery.of(context).padding.left`.
   final double drawerEdgeDragWidth;
 
-  /// Determines if the [Scaffold.drawer] can be opened and closed with a drag
+  /// Determines if the [Scaffold.drawer] can be opened with a drag
   /// gesture.
   ///
   /// By default, the drag gesture is enabled.
-  final bool drawerEnableDragGesture;
+  final bool drawerEnableOpenDragGesture;
 
-  /// Determines if the [Scaffold.endDrawer] can be opened and closed with a
+  /// Determines if the [Scaffold.endDrawer] can be opened with a
   /// drag gesture.
   ///
   /// By default, the drag gesture is enabled.
-  final bool endDrawerEnableDragGesture;
+  final bool endDrawerEnableOpenDragGesture;
 
   /// This flag is deprecated and fixes and issue with incorrect clipping
   /// and positioning of the [SnackBar] set to [SnackBarBehavior.floating].
@@ -2244,7 +2244,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
           dragStartBehavior: widget.drawerDragStartBehavior,
           scrimColor: widget.drawerScrimColor,
           edgeDragWidth: widget.drawerEdgeDragWidth,
-          enableDragGesture: widget.endDrawerEnableDragGesture,
+          enableOpenDragGesture: widget.endDrawerEnableOpenDragGesture,
         ),
         _ScaffoldSlot.endDrawer,
         // remove the side padding from the side we're not touching
@@ -2269,7 +2269,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
           dragStartBehavior: widget.drawerDragStartBehavior,
           scrimColor: widget.drawerScrimColor,
           edgeDragWidth: widget.drawerEdgeDragWidth,
-          enableDragGesture: widget.drawerEnableDragGesture,
+          enableOpenDragGesture: widget.drawerEnableOpenDragGesture,
         ),
         _ScaffoldSlot.drawer,
         // remove the side padding from the side we're not touching

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -1596,14 +1596,14 @@ void main() {
     expect(scaffoldState.isDrawerOpen, true);
   });
 
-  testWidgets('Drawer does not open or close with drag gesture when it is disabled', (WidgetTester tester) async {
+  testWidgets('Drawer does not open with a drag gesture when it is disabled', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
           drawer: const Drawer(
             child: Text('Drawer'),
           ),
-          drawerEnableDragGesture: true,
+          drawerEnableOpenDragGesture: true,
           body: const Text('Scaffold Body'),
           appBar: AppBar(
             centerTitle: true,
@@ -1615,7 +1615,7 @@ void main() {
     ScaffoldState scaffoldState = tester.state(find.byType(Scaffold));
     expect(scaffoldState.isDrawerOpen, false);
 
-    // Test that we can open and close drawer with drag gesture when
+    // Test that we can open the drawer with a drag gesture when
     // `Scaffold.drawerEnableDragGesture` is true.
     await tester.dragFrom(const Offset(0, 100), const Offset(300, 0));
     await tester.pumpAndSettle();
@@ -1631,7 +1631,7 @@ void main() {
           drawer: const Drawer(
             child: Text('Drawer'),
           ),
-          drawerEnableDragGesture: false,
+          drawerEnableOpenDragGesture: false,
           body: const Text('Scaffold body'),
           appBar: AppBar(
             centerTitle: true,
@@ -1643,13 +1643,13 @@ void main() {
     scaffoldState = tester.state(find.byType(Scaffold));
     expect(scaffoldState.isDrawerOpen, false);
 
-    // Test that we cannot open drawer with drag gesture when
+    // Test that we cannot open the drawer with a drag gesture when
     // `Scaffold.drawerEnableDragGesture` is false.
     await tester.dragFrom(const Offset(0, 100), const Offset(300, 0));
     await tester.pumpAndSettle();
     expect(scaffoldState.isDrawerOpen, false);
 
-    // Test that we cannot close drawer with drag gesture when
+    // Test that we can close drawer with a drag gesture when
     // `Scaffold.drawerEnableDragGesture` is false.
     final Finder drawerOpenButton = find.byType(IconButton).first;
     await tester.tap(drawerOpenButton);
@@ -1658,10 +1658,10 @@ void main() {
 
     await tester.dragFrom(const Offset(300, 100), const Offset(-300, 0));
     await tester.pumpAndSettle();
-    expect(scaffoldState.isDrawerOpen, true);
+    expect(scaffoldState.isDrawerOpen, false);
   });
 
-  testWidgets('End drawer does not open or close with drag gesture when it is disabled', (WidgetTester tester) async {
+  testWidgets('End drawer does not open with a drag gesture when it is disabled', (WidgetTester tester) async {
     double screenWidth;
     await tester.pumpWidget(
       MaterialApp(
@@ -1672,7 +1672,7 @@ void main() {
               endDrawer: const Drawer(
                 child: Text('Drawer'),
               ),
-              endDrawerEnableDragGesture: true,
+              endDrawerEnableOpenDragGesture: true,
               body: const Text('Scaffold Body'),
               appBar: AppBar(
                 centerTitle: true,
@@ -1686,7 +1686,7 @@ void main() {
     ScaffoldState scaffoldState = tester.state(find.byType(Scaffold));
     expect(scaffoldState.isEndDrawerOpen, false);
 
-    // Test that we can open and close end drawer with drag gesture when
+    // Test that we can open the end drawer with a drag gesture when
     // `Scaffold.endDrawerEnableDragGesture` is true.
     await tester.dragFrom(Offset(screenWidth - 1, 100), const Offset(-300, 0));
     await tester.pumpAndSettle();
@@ -1702,7 +1702,7 @@ void main() {
           endDrawer: const Drawer(
             child: Text('Drawer'),
           ),
-          endDrawerEnableDragGesture: false,
+          endDrawerEnableOpenDragGesture: false,
           body: const Text('Scaffold body'),
           appBar: AppBar(
             centerTitle: true,
@@ -1714,13 +1714,13 @@ void main() {
     scaffoldState = tester.state(find.byType(Scaffold));
     expect(scaffoldState.isEndDrawerOpen, false);
 
-    // Test that we cannot open end drawer with drag gesture when
+    // Test that we cannot open the end drawer with a drag gesture when
     // `Scaffold.endDrawerEnableDragGesture` is false.
     await tester.dragFrom(Offset(screenWidth - 1, 100), const Offset(-300, 0));
     await tester.pumpAndSettle();
     expect(scaffoldState.isEndDrawerOpen, false);
 
-    // Test that we cannot close end drawer with drag gesture when
+    // Test that we can close the end drawer a with drag gesture when
     // `Scaffold.endDrawerEnableDragGesture` is false.
     final Finder endDrawerOpenButton = find.byType(IconButton).first;
     await tester.tap(endDrawerOpenButton);
@@ -1729,7 +1729,7 @@ void main() {
 
     await tester.dragFrom(Offset(screenWidth - 300, 100), const Offset(300, 0));
     await tester.pumpAndSettle();
-    expect(scaffoldState.isEndDrawerOpen, true);
+    expect(scaffoldState.isEndDrawerOpen, false);
   });
 
   testWidgets('Nested scaffold body insets', (WidgetTester tester) async {

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -1596,6 +1596,105 @@ void main() {
     expect(scaffoldState.isDrawerOpen, true);
   });
 
+  testWidgets('Drawer does not open with gesture drag when it is disabled', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          drawer: const Drawer(
+            child: Text('Drawer'),
+          ),
+          drawerEnableDragGesture: false,
+          body: const Text('Scaffold body'),
+          appBar: AppBar(
+            centerTitle: true,
+            title: const Text('Title'),
+          ),
+        ),
+      ),
+    );
+    ScaffoldState scaffoldState = tester.state(find.byType(Scaffold));
+    expect(scaffoldState.isDrawerOpen, false);
+
+    await tester.dragFrom(const Offset(0, 100), const Offset(300, 0));
+    await tester.pumpAndSettle();
+    expect(scaffoldState.isDrawerOpen, false);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          drawer: const Drawer(
+            child: Text('Drawer'),
+          ),
+          drawerEnableDragGesture: true,
+          body: const Text('Scaffold Body'),
+          appBar: AppBar(
+            centerTitle: true,
+            title: const Text('Title'),
+          ),
+        ),
+      ),
+    );
+    scaffoldState = tester.state(find.byType(Scaffold));
+    expect(scaffoldState.isDrawerOpen, false);
+
+    await tester.dragFrom(const Offset(0, 100), const Offset(300, 0));
+    await tester.pumpAndSettle();
+    expect(scaffoldState.isDrawerOpen, true);
+  });
+
+  testWidgets('End drawer does not open with gesture drag when it is disabled', (WidgetTester tester) async {
+    double screenWidth;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (BuildContext context) {
+            screenWidth = MediaQuery.of(context).size.width;
+            return Scaffold(
+              endDrawer: const Drawer(
+                child: Text('Drawer'),
+              ),
+              endDrawerEnableDragGesture: false,
+              body: const Text('Scaffold body'),
+              appBar: AppBar(
+                centerTitle: true,
+                title: const Text('Title'),
+              ),
+            );
+          }
+        ),
+      ),
+    );
+    ScaffoldState scaffoldState = tester.state(find.byType(Scaffold));
+    expect(scaffoldState.isEndDrawerOpen, false);
+
+
+    await tester.dragFrom(Offset(screenWidth - 1, 100), const Offset(-300, 0));
+    await tester.pumpAndSettle();
+    expect(scaffoldState.isEndDrawerOpen, false);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          endDrawer: const Drawer(
+            child: Text('Drawer'),
+          ),
+          endDrawerEnableDragGesture: true,
+          body: const Text('Scaffold Body'),
+          appBar: AppBar(
+            centerTitle: true,
+            title: const Text('Title'),
+          ),
+        ),
+      ),
+    );
+    scaffoldState = tester.state(find.byType(Scaffold));
+    expect(scaffoldState.isEndDrawerOpen, false);
+
+    await tester.dragFrom(Offset(screenWidth - 1, 100), const Offset(-300, 0));
+    await tester.pumpAndSettle();
+    expect(scaffoldState.isEndDrawerOpen, true);
+  });
+
   testWidgets('Nested scaffold body insets', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/20295
     final Key bodyKey = UniqueKey();

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -1596,29 +1596,7 @@ void main() {
     expect(scaffoldState.isDrawerOpen, true);
   });
 
-  testWidgets('Drawer does not open with gesture drag when it is disabled', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          drawer: const Drawer(
-            child: Text('Drawer'),
-          ),
-          drawerEnableDragGesture: false,
-          body: const Text('Scaffold body'),
-          appBar: AppBar(
-            centerTitle: true,
-            title: const Text('Title'),
-          ),
-        ),
-      ),
-    );
-    ScaffoldState scaffoldState = tester.state(find.byType(Scaffold));
-    expect(scaffoldState.isDrawerOpen, false);
-
-    await tester.dragFrom(const Offset(0, 100), const Offset(300, 0));
-    await tester.pumpAndSettle();
-    expect(scaffoldState.isDrawerOpen, false);
-
+  testWidgets('Drawer does not open or close with gesture drag when it is disabled', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
@@ -1634,15 +1612,56 @@ void main() {
         ),
       ),
     );
+    ScaffoldState scaffoldState = tester.state(find.byType(Scaffold));
+    expect(scaffoldState.isDrawerOpen, false);
+
+    // Test that we can open and close drawer with drag gesture when
+    // `Scaffold.drawerEnableDragGesture` is true.
+    await tester.dragFrom(const Offset(0, 100), const Offset(300, 0));
+    await tester.pumpAndSettle();
+    expect(scaffoldState.isDrawerOpen, true);
+
+    await tester.dragFrom(const Offset(300, 100), const Offset(-300, 0));
+    await tester.pumpAndSettle();
+    expect(scaffoldState.isDrawerOpen, false);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          drawer: const Drawer(
+            child: Text('Drawer'),
+          ),
+          drawerEnableDragGesture: false,
+          body: const Text('Scaffold body'),
+          appBar: AppBar(
+            centerTitle: true,
+            title: const Text('Title'),
+          ),
+        ),
+      ),
+    );
     scaffoldState = tester.state(find.byType(Scaffold));
     expect(scaffoldState.isDrawerOpen, false);
 
+    // Test that we cannot open drawer with drag gesture when
+    // `Scaffold.drawerEnableDragGesture` is false.
     await tester.dragFrom(const Offset(0, 100), const Offset(300, 0));
+    await tester.pumpAndSettle();
+    expect(scaffoldState.isDrawerOpen, false);
+
+    // Test that we cannot close drawer with drag gesture when
+    // `Scaffold.drawerEnableDragGesture` is false.
+    final Finder drawerOpenButton = find.byType(IconButton).first;
+    await tester.tap(drawerOpenButton);
+    await tester.pumpAndSettle();
+    expect(scaffoldState.isDrawerOpen, true);
+
+    await tester.dragFrom(const Offset(300, 100), const Offset(-300, 0));
     await tester.pumpAndSettle();
     expect(scaffoldState.isDrawerOpen, true);
   });
 
-  testWidgets('End drawer does not open with gesture drag when it is disabled', (WidgetTester tester) async {
+  testWidgets('End drawer does not open or close with gesture drag when it is disabled', (WidgetTester tester) async {
     double screenWidth;
     await tester.pumpWidget(
       MaterialApp(
@@ -1653,8 +1672,8 @@ void main() {
               endDrawer: const Drawer(
                 child: Text('Drawer'),
               ),
-              endDrawerEnableDragGesture: false,
-              body: const Text('Scaffold body'),
+              endDrawerEnableDragGesture: true,
+              body: const Text('Scaffold Body'),
               appBar: AppBar(
                 centerTitle: true,
                 title: const Text('Title'),
@@ -1667,8 +1686,13 @@ void main() {
     ScaffoldState scaffoldState = tester.state(find.byType(Scaffold));
     expect(scaffoldState.isEndDrawerOpen, false);
 
-
+    // Test that we can open and close end drawer with drag gesture when
+    // `Scaffold.endDrawerEnableDragGesture` is true.
     await tester.dragFrom(Offset(screenWidth - 1, 100), const Offset(-300, 0));
+    await tester.pumpAndSettle();
+    expect(scaffoldState.isEndDrawerOpen, true);
+
+    await tester.dragFrom(Offset(screenWidth - 300, 100), const Offset(300, 0));
     await tester.pumpAndSettle();
     expect(scaffoldState.isEndDrawerOpen, false);
 
@@ -1678,8 +1702,8 @@ void main() {
           endDrawer: const Drawer(
             child: Text('Drawer'),
           ),
-          endDrawerEnableDragGesture: true,
-          body: const Text('Scaffold Body'),
+          endDrawerEnableDragGesture: false,
+          body: const Text('Scaffold body'),
           appBar: AppBar(
             centerTitle: true,
             title: const Text('Title'),
@@ -1690,7 +1714,20 @@ void main() {
     scaffoldState = tester.state(find.byType(Scaffold));
     expect(scaffoldState.isEndDrawerOpen, false);
 
+    // Test that we cannot open end drawer with drag gesture when
+    // `Scaffold.endDrawerEnableDragGesture` is false.
     await tester.dragFrom(Offset(screenWidth - 1, 100), const Offset(-300, 0));
+    await tester.pumpAndSettle();
+    expect(scaffoldState.isEndDrawerOpen, false);
+
+    // Test that we cannot close end drawer with drag gesture when
+    // `Scaffold.endDrawerEnableDragGesture` is false.
+    final Finder endDrawerOpenButton = find.byType(IconButton).first;
+    await tester.tap(endDrawerOpenButton);
+    await tester.pumpAndSettle();
+    expect(scaffoldState.isEndDrawerOpen, true);
+
+    await tester.dragFrom(Offset(screenWidth - 300, 100), const Offset(300, 0));
     await tester.pumpAndSettle();
     expect(scaffoldState.isEndDrawerOpen, true);
   });

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -1596,7 +1596,7 @@ void main() {
     expect(scaffoldState.isDrawerOpen, true);
   });
 
-  testWidgets('Drawer does not open or close with gesture drag when it is disabled', (WidgetTester tester) async {
+  testWidgets('Drawer does not open or close with drag gesture when it is disabled', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
@@ -1661,7 +1661,7 @@ void main() {
     expect(scaffoldState.isDrawerOpen, true);
   });
 
-  testWidgets('End drawer does not open or close with gesture drag when it is disabled', (WidgetTester tester) async {
+  testWidgets('End drawer does not open or close with drag gesture when it is disabled', (WidgetTester tester) async {
     double screenWidth;
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
## Description

There is currently no way of disabling the edge drag gesture for either of the `Drawer`s in `Scaffold`, you can only set the `Scaffold.drawerEdgeDragWidth` to 0 (which will disable both).

This PR add the two arguments `Scaffold.drawerEnableDragGesture` and `Scaffold.endDrawerEnableDragGesture` to support disabling the drag gesture to open either the `Scaffold.drawer` or `Scaffold.endDrawer`.


## Related Issues

Fixes https://github.com/flutter/flutter/issues/49804
Relates to https://github.com/flutter/flutter/issues/31127

## Tests

I added the following tests:

- Drawer does not open with a drag gesture when it is disabled
- End drawer does not open with a drag gesture when it is disabled

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
