### PR TITLE
Ensure to close connection to VM after collecting coverage

### DIFF
--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -181,7 +181,10 @@ Future<Map<String, dynamic>> collect(Uri serviceUri, bool Function(String) libra
 }) async {
   final VMService vmService = await connector(serviceUri);
   await vmService.getVM();
-  return _getAllCoverage(vmService, libraryPredicate);
+  final Map<String, dynamic> result = await _getAllCoverage(
+      vmService, libraryPredicate);
+  await vmService.close();
+  return result;
 }
 
 Future<Map<String, dynamic>> _getAllCoverage(VMService service, bool Function(String) libraryPredicate) async {

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -452,6 +452,8 @@ class VMService {
   Future<void> getVM() async => await vm.reload();
 
   Future<void> refreshViews({ bool waitForViews = false }) => vm.refreshViews(waitForViews: waitForViews);
+
+  Future<void> close() async => await _peer.close();
 }
 
 /// An error that is thrown when constructing/updating a service object.

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -33,13 +33,11 @@ class MockPeer implements rpc.Peer {
   }
 
   @override
-  bool get isClosed {
-    throw 'unexpected call to isClosed';
-  }
+  bool get isClosed => _isClosed;
 
   @override
   Future<dynamic> close() async {
-    throw 'unexpected call to close()';
+    _isClosed = true;
   }
 
   @override
@@ -70,6 +68,7 @@ class MockPeer implements rpc.Peer {
   List<String> registeredMethods = <String>[];
 
   bool isolatesEnabled = false;
+  bool _isClosed = false;
 
   Future<void> _getVMLatch;
   Completer<void> _currentGetVMLatchCompleter;
@@ -213,13 +212,12 @@ void main() {
       WebSocketConnector: () => (String url, {CompressionOptions compression}) async => throw const SocketException('test'),
     });
 
-    testUsingContext('closing VMService closes peer', () {
-      FakeAsync().run((FakeAsync time) async {
-        final MockPeer mockPeer = MockPeer();
-        final VMService vmService = VMService(mockPeer, null, null, null, null, null, MockDevice(), null);
-        await vmService.close();
-        expect(mockPeer.registeredMethods, contains('close'));
-      });
+    testUsingContext('closing VMService closes Peer', () async {
+      final MockPeer mockPeer = MockPeer();
+      final VMService vmService = VMService(mockPeer, null, null, null, null, null, MockDevice(), null);
+      expect(mockPeer.isClosed, equals(false));
+      await vmService.close();
+      expect(mockPeer.isClosed, equals(true));
     });
 
     testUsingContext('refreshViews', () {

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -213,6 +213,15 @@ void main() {
       WebSocketConnector: () => (String url, {CompressionOptions compression}) async => throw const SocketException('test'),
     });
 
+    testUsingContext('closing VMService closes peer', () {
+      FakeAsync().run((FakeAsync time) async {
+        final MockPeer mockPeer = MockPeer();
+        final VMService vmService = VMService(mockPeer, null, null, null, null, null, MockDevice(), null);
+        await vmService.close();
+        expect(mockPeer.registeredMethods, contains('close'));
+      });
+    });
+
     testUsingContext('refreshViews', () {
       FakeAsync().run((FakeAsync time) {
         bool done = false;


### PR DESCRIPTION
This avoids having many unused conections open. Each connection can hang
on to a significant amount of memory, not closing them is effectively a
big memory leak.

This should reduce the memory consumption of `tool/tool_coverage.dart`

Issue https://github.com/dart-lang/sdk/issues/40627