### PR TITLE
nit: Add a short comment explain path dependencies

### DIFF
--- a/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
@@ -27,6 +27,11 @@ dependencies:
 
 {{#withPluginHook}}
   {{pluginProjectName}}:
+    # When depending on this package from a real application you should use:
+    #   {{pluginProjectName}}: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version. 
     path: ../
 {{/withPluginHook}}
 


### PR DESCRIPTION
In line with: https://github.com/flutter/plugins/pull/2511

Motivation being that `example/pubspec.yaml` should have a comment making it clear that path dependencies only works in the this context.