### PR TITLE
Upgrade dartdoc to 0.30.1

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -111,7 +111,7 @@ if [[ -d "$FLUTTER_PUB_CACHE" ]]; then
 fi
 
 # Install and activate dartdoc.
-"$PUB" global activate dartdoc 0.29.3
+"$PUB" global activate dartdoc 0.30.1
 
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc.


### PR DESCRIPTION
Fixes to the search box are the most noticeable change from the last version.  However, since the last release didn't make it to Flutter, this change also includes a removal of `<base href>` and a subsequent change to how links are generated.  A quick scan of Flutter docs suggests this works OK but there may be special cases I'm not aware of.  See release notes for more details.

Release Notes:
  * https://github.com/dart-lang/dartdoc/releases/tag/v0.30.0
  * https://github.com/dart-lang/dartdoc/releases/tag/v0.30.0%2B1
  * https://github.com/dart-lang/dartdoc/releases/tag/v0.30.1
