### PR TITLE
Enable TextStyle hash test on the Web

### DIFF
--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -262,7 +262,7 @@ void main() {
     const TextStyle b = TextStyle(fontFamilyFallback: <String>['Noto'], shadows: <ui.Shadow>[ui.Shadow()], fontFeatures: <ui.FontFeature>[ui.FontFeature('abcd')]);
     expect(a.hashCode, a.hashCode);
     expect(a.hashCode, isNot(equals(b.hashCode)));
-  }, skip: kIsWeb);
+  });
 
   test('TextStyle foreground and color combos', () {
     const Color red = Color.fromARGB(255, 255, 0, 0);

--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -4,7 +4,6 @@
 
 import 'dart:ui' as ui show TextStyle, ParagraphStyle, FontFeature, Shadow;
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import '../flutter_test_alternative.dart';
 


### PR DESCRIPTION
## Description

Enable text style hash code tests on the Web. This change requires https://github.com/flutter/engine/commit/48d64c13e489e63a71a09b0bfe7bdc38ea8c52f0 to roll in before merging.

## Related Issues

https://github.com/flutter/flutter/issues/50651
