### PR TITLE
[Web] Add Material Card Infinite Scroll benchmark

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_card_infinite_scroll.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_card_infinite_scroll.dart
@@ -16,16 +16,14 @@ class BenchCardInfiniteScroll extends WidgetRecorder {
   static const String benchmarkName = 'bench_card_infinite_scroll';
 
   @override
-  Widget createWidget() {
-    return MaterialApp(
-      title: 'Infinite Card Scroll Benchmark',
-      home: _InfiniteScrollCards(),
-    );
-  }
+  Widget createWidget() => const MaterialApp(
+        title: 'Infinite Card Scroll Benchmark',
+        home: _InfiniteScrollCards(),
+      );
 }
 
 class _InfiniteScrollCards extends StatefulWidget {
-  _InfiniteScrollCards({Key key}) : super(key: key);
+  const _InfiniteScrollCards({Key key}) : super(key: key);
 
   @override
   State<_InfiniteScrollCards> createState() => _InfiniteScrollCardsState();
@@ -35,7 +33,7 @@ class _InfiniteScrollCardsState extends State<_InfiniteScrollCards> {
   ScrollController scrollController;
 
   double offset;
-  static const double distance = 500;
+  static const double distance = 1000;
   static const Duration stepDuration = Duration(seconds: 1);
 
   @override

--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_card_infinite_scroll.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_card_infinite_scroll.dart
@@ -1,0 +1,79 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import 'recorder.dart';
+import 'test_data.dart';
+
+/// Creates an infinite list of Material cards and scrolls it.
+class BenchCardInfiniteScroll extends WidgetRecorder {
+  BenchCardInfiniteScroll() : super(name: benchmarkName);
+
+  static const String benchmarkName = 'bench_card_infinite_scroll';
+
+  @override
+  Widget createWidget() {
+    return MaterialApp(
+      title: 'Infinite Card Scroll Benchmark',
+      home: _InfiniteScrollCards(),
+    );
+  }
+}
+
+class _InfiniteScrollCards extends StatefulWidget {
+  _InfiniteScrollCards({Key key}) : super(key: key);
+
+  @override
+  State<_InfiniteScrollCards> createState() => _InfiniteScrollCardsState();
+}
+
+class _InfiniteScrollCardsState extends State<_InfiniteScrollCards> {
+  ScrollController scrollController;
+
+  double offset;
+  static const double distance = 500;
+  static const Duration stepDuration = Duration(seconds: 1);
+
+  @override
+  void initState() {
+    super.initState();
+
+    scrollController = ScrollController();
+    offset = 0;
+
+    // Without the timer the animation doesn't begin.
+    Timer.run(() async {
+      while (true) {
+        await scrollController.animateTo(
+          offset + distance,
+          curve: Curves.linear,
+          duration: stepDuration,
+        );
+        offset += distance;
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      controller: scrollController,
+      itemBuilder: (BuildContext context, int index) {
+        return SizedBox(
+          height: 100.0,
+          child: Card(
+            elevation: 16.0,
+            child: Text(
+              lipsum[index % lipsum.length],
+              textAlign: TextAlign.center,
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/dev/benchmarks/macrobenchmarks/lib/web_benchmarks.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/web_benchmarks.dart
@@ -8,6 +8,7 @@ import 'dart:html' as html;
 
 import 'package:macrobenchmarks/src/web/bench_text_out_of_picture_bounds.dart';
 
+import 'src/web/bench_card_infinite_scroll.dart';
 import 'src/web/bench_draw_rect.dart';
 import 'src/web/bench_simple_lazy_text_scroll.dart';
 import 'src/web/bench_text_out_of_picture_bounds.dart';
@@ -16,6 +17,7 @@ import 'src/web/recorder.dart';
 typedef RecorderFactory = Recorder Function();
 
 final Map<String, RecorderFactory> benchmarks = <String, RecorderFactory>{
+  BenchCardInfiniteScroll.benchmarkName: () => BenchCardInfiniteScroll(),
   BenchDrawRect.benchmarkName: () => BenchDrawRect(),
   BenchTextOutOfPictureBounds.benchmarkName: () => BenchTextOutOfPictureBounds(),
   BenchSimpleLazyTextScroll.benchmarkName: () => BenchSimpleLazyTextScroll(),


### PR DESCRIPTION
## Description

Adds a benchmark that makes an infinite list of Material cards and scrolls it. This benchmark exercises more heavyweight rendering like shadows and clipping and paths.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.
<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
