### PR TITLE
[flutter_tools] don't print shuffling message when shuffle is zero or  null

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_test_performance.dart
+++ b/dev/devicelab/bin/tasks/flutter_test_performance.dart
@@ -54,8 +54,6 @@ Future<int> runTest({bool coverage = false}) async {
     if (step == TestStep.starting && entry == 'Building flutter tool...') {
       // ignore this line
       step = TestStep.buildingFlutterTool;
-    } else if (step == TestStep.starting && entry.contains('Shuffling test order')) {
-      // ignore this line
     } else if (step == TestStep.testPassed && entry.contains('Collecting coverage information...')) {
       // ignore this line
     } else if (step.index < TestStep.runningPubGet.index && entry == 'Running "flutter pub get" in automated_tests...') {

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -102,7 +102,8 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
         ...<String>['--name', name],
       for (final String plainName in plainNames)
         ...<String>['--plain-name', plainName],
-      '--test-randomize-ordering-seed=$randomSeed',
+      if (randomSeed != null && randomSeed != '0')
+        '--test-randomize-ordering-seed=$randomSeed',
     ];
     if (web) {
       final String tempBuildDir = globals.fs.systemTempDirectory


### PR DESCRIPTION
## Description

don't pass shuffle if the user does not want to shuffle, since this results in test printing out a message confirming the seed.

Fixes https://github.com/flutter/flutter/issues/51010