### PR TITLE
Discover devices in parallel instead of serially waiting for each device type

### DIFF
--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -27,7 +27,7 @@ class DevicesCommand extends FlutterCommand {
         exitCode: 1);
     }
 
-    final List<Device> devices = await deviceManager.getAllConnectedDevices().toList();
+    final List<Device> devices = await deviceManager.getAllConnectedDevices();
 
     if (devices.isEmpty) {
       globals.printStatus(

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -878,7 +878,7 @@ class DeviceValidator extends DoctorValidator {
 
   @override
   Future<ValidationResult> validate() async {
-    final List<Device> devices = await deviceManager.getAllConnectedDevices().toList();
+    final List<Device> devices = await deviceManager.getAllConnectedDevices();
     List<ValidationMessage> messages;
     if (devices.isEmpty) {
       final List<String> diagnostics = await deviceManager.getDeviceDiagnostics();

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -718,7 +718,7 @@ abstract class FlutterCommand extends Command<void> {
        globals.printStatus(userMessages.flutterFoundSpecifiedDevices(devices.length, deviceManager.specifiedDeviceId));
       } else {
         globals.printStatus(userMessages.flutterSpecifyDeviceWithAllOption);
-        devices = await deviceManager.getAllConnectedDevices().toList();
+        devices = await deviceManager.getAllConnectedDevices();
       }
       globals.printStatus('');
       await Device.printDevices(devices);
@@ -738,7 +738,7 @@ abstract class FlutterCommand extends Command<void> {
     }
     if (deviceList.length > 1) {
       globals.printStatus(userMessages.flutterSpecifyDevice);
-      deviceList = await deviceManager.getAllConnectedDevices().toList();
+      deviceList = await deviceManager.getAllConnectedDevices();
       globals.printStatus('');
       await Device.printDevices(deviceList);
       return null;
@@ -804,7 +804,7 @@ mixin DeviceBasedDevelopmentArtifacts on FlutterCommand {
     // If there are no attached devices, use the default configuration.
     // Otherwise, only add development artifacts which correspond to a
     // connected device.
-    final List<Device> devices = await deviceManager.getDevices().toList();
+    final List<Device> devices = await deviceManager.getDevices();
     if (devices.isEmpty) {
       return super.requiredArtifacts;
     }

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -95,7 +95,7 @@ void main() {
         return Future<List<Device>>.value(<Device>[mockDevice]);
       });
       when(deviceManager.getDevices()).thenAnswer((Invocation invocation) {
-        return Stream<Device>.value(mockDevice);
+        return Future<List<Device>>.value(<Device>[mockDevice]);
       });
       globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
       globals.fs.file('pubspec.yaml').createSync();
@@ -215,7 +215,7 @@ void main() {
 
         const List<Device> noDevices = <Device>[];
         when(mockDeviceManager.getDevices()).thenAnswer(
-          (Invocation invocation) => Stream<Device>.fromIterable(noDevices)
+          (Invocation invocation) => Future<List<Device>>.value(noDevices)
         );
         when(mockDeviceManager.findTargetDevices(any)).thenAnswer(
           (Invocation invocation) => Future<List<Device>>.value(noDevices)
@@ -245,7 +245,7 @@ void main() {
 
         // Called as part of requiredArtifacts()
         when(mockDeviceManager.getDevices()).thenAnswer(
-          (Invocation invocation) => Stream<Device>.fromIterable(<Device>[])
+          (Invocation invocation) => Future<List<Device>>.value(<Device>[])
         );
         // No devices are attached, we just want to verify update the cache
         // BEFORE checking for devices
@@ -308,7 +308,7 @@ void main() {
         )).thenReturn('/path/to/sdk');
 
         when(mockDeviceManager.getDevices()).thenAnswer(
-          (Invocation invocation) => Stream<Device>.fromIterable(<Device>[mockDevice]),
+          (Invocation invocation) => Future<List<Device>>.value(<Device>[mockDevice])
         );
 
         when(mockDeviceManager.findTargetDevices(any)).thenAnswer(
@@ -366,9 +366,7 @@ void main() {
       setUpAll(() {
         final FakeDevice fakeDevice = FakeDevice();
         when(mockDeviceManager.getDevices()).thenAnswer((Invocation invocation) {
-          return Stream<Device>.fromIterable(<Device>[
-            fakeDevice,
-          ]);
+          return Future<List<Device>>.value(<Device>[fakeDevice]);
         });
         when(mockDeviceManager.findTargetDevices(any)).thenAnswer(
           (Invocation invocation) => Future<List<Device>>.value(<Device>[fakeDevice])
@@ -454,7 +452,7 @@ void main() {
 
     testUsingContext('should only request artifacts corresponding to connected devices', () async {
       when(mockDeviceManager.getDevices()).thenAnswer((Invocation invocation) {
-        return Stream<Device>.fromIterable(<Device>[
+        return Future<List<Device>>.value(<Device>[
           MockDevice(TargetPlatform.android_arm),
         ]);
       });
@@ -465,7 +463,7 @@ void main() {
       }));
 
       when(mockDeviceManager.getDevices()).thenAnswer((Invocation invocation) {
-        return Stream<Device>.fromIterable(<Device>[
+        return Future<List<Device>>.value(<Device>[
           MockDevice(TargetPlatform.ios),
         ]);
       });
@@ -476,7 +474,7 @@ void main() {
       }));
 
       when(mockDeviceManager.getDevices()).thenAnswer((Invocation invocation) {
-        return Stream<Device>.fromIterable(<Device>[
+        return Future<List<Device>>.value(<Device>[
           MockDevice(TargetPlatform.ios),
           MockDevice(TargetPlatform.android_arm),
         ]);
@@ -489,7 +487,7 @@ void main() {
       }));
 
       when(mockDeviceManager.getDevices()).thenAnswer((Invocation invocation) {
-        return Stream<Device>.fromIterable(<Device>[
+        return Future<List<Device>>.value(<Device>[
           MockDevice(TargetPlatform.web_javascript),
         ]);
       });
@@ -510,7 +508,7 @@ void main() {
       setUpAll(() {
         final FakeDevice fakeDevice = FakeDevice().._targetPlatform = TargetPlatform.web_javascript;
         when(mockDeviceManager.getDevices()).thenAnswer(
-          (Invocation invocation) => Stream<Device>.fromIterable(<Device>[fakeDevice])
+          (Invocation invocation) => Future<List<Device>>.value(<Device>[fakeDevice])
         );
         when(mockDeviceManager.findTargetDevices(any)).thenAnswer(
           (Invocation invocation) => Future<List<Device>>.value(<Device>[fakeDevice])
@@ -612,7 +610,7 @@ class TestRunCommand extends RunCommand {
   @override
   // ignore: must_call_super
   Future<void> validateCommand() async {
-    devices = await deviceManager.getDevices().toList();
+    devices = await deviceManager.getDevices();
   }
 }
 

--- a/packages/flutter_tools/test/general.shard/device_test.dart
+++ b/packages/flutter_tools/test/general.shard/device_test.dart
@@ -18,7 +18,7 @@ void main() {
     testUsingContext('getDevices', () async {
       // Test that DeviceManager.getDevices() doesn't throw.
       final DeviceManager deviceManager = DeviceManager();
-      final List<Device> devices = await deviceManager.getDevices().toList();
+      final List<Device> devices = await deviceManager.getDevices();
       expect(devices, isList);
     });
 
@@ -30,7 +30,7 @@ void main() {
       final DeviceManager deviceManager = TestDeviceManager(devices);
 
       Future<void> expectDevice(String id, List<Device> expected) async {
-        expect(await deviceManager.getDevicesById(id).toList(), expected);
+        expect(await deviceManager.getDevicesById(id), expected);
       }
       await expectDevice('01abfc49119c410e', <Device>[device2]);
       await expectDevice('Nexus 5X', <Device>[device2]);
@@ -170,9 +170,7 @@ class TestDeviceManager extends DeviceManager {
   bool isAlwaysSupportedOverride;
 
   @override
-  Stream<Device> getAllConnectedDevices() {
-    return Stream<Device>.fromIterable(allDevices);
-  }
+  Future<List<Device>> getAllConnectedDevices() async => allDevices;
 
   @override
   bool isDeviceSupportedForProject(Device device, FlutterProject flutterProject) {

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -201,16 +201,15 @@ class FakeDeviceManager implements DeviceManager {
   }
 
   @override
-  Stream<Device> getAllConnectedDevices() => Stream<Device>.fromIterable(devices);
+  Future<List<Device>> getAllConnectedDevices() async => devices;
 
   @override
-  Stream<Device> getDevicesById(String deviceId) {
-    return Stream<Device>.fromIterable(
-        devices.where((Device device) => device.id == deviceId));
+  Future<List<Device>> getDevicesById(String deviceId) async {
+    return devices.where((Device device) => device.id == deviceId).toList();
   }
 
   @override
-  Stream<Device> getDevices() {
+  Future<List<Device>> getDevices() {
     return hasSpecifiedDeviceId
         ? getDevicesById(specifiedDeviceId)
         : getAllConnectedDevices();


### PR DESCRIPTION
## Description

For the next part of wireless iOS device support, make all the `DeviceDiscovery.devices` calls run at the same time in a `Future.wait<List<Device>>()`.  This is necessary so the network device timeouts (to be introduced in the next PR) increase the time linearly instead of exponentially.

Breaking out just this change to make the next PR smaller, and changing the Stream=>List return value in the signature created some churn.

## Related Issues

Another piece of https://github.com/flutter/flutter/issues/15072.

## Tests

Updated tests to use lists instead of streams.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*