### PR TITLE
Don't use a default test randomize ordering seed

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_test_performance.dart
+++ b/dev/devicelab/bin/tasks/flutter_test_performance.dart
@@ -54,8 +54,6 @@ Future<int> runTest({bool coverage = false}) async {
     if (step == TestStep.starting && entry == 'Building flutter tool...') {
       // ignore this line
       step = TestStep.buildingFlutterTool;
-    } else if (step == TestStep.starting && entry.contains('Shuffling test order')) {
-      // ignore this line
     } else if (step == TestStep.testPassed && entry.contains('Collecting coverage information...')) {
       // ignore this line
     } else if (step.index < TestStep.runningPubGet.index && entry == 'Running "flutter pub get" in automated_tests...') {

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -106,11 +106,10 @@ class TestCommand extends FastFlutterCommand {
         help: 'The platform to run the unit tests on. Defaults to "tester".',
       )
       ..addOption('test-randomize-ordering-seed',
-        defaultsTo: '0',
-        help: 'If positive, use this as a seed to randomize the execution of '
-              'test cases (must be a 32bit unsigned integer).\n'
+        help: 'The seed to randomize the execution order of test cases.\n'
+              'Must be a 32bit unsigned integer or "random".\n'
               'If "random", pick a random seed to use.\n'
-              'If 0 or not set, do not randomize test case execution order.',
+              'If not passed, do not randomize test case execution order.',
       )
       ..addFlag('enable-vmservice',
         defaultsTo: false,

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -48,7 +48,7 @@ abstract class FlutterTestRunner {
     String icudtlPath,
     Directory coverageDirectory,
     bool web = false,
-    String randomSeed = '0',
+    String randomSeed,
   });
 }
 
@@ -79,7 +79,7 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
     String icudtlPath,
     Directory coverageDirectory,
     bool web = false,
-    String randomSeed = '0',
+    String randomSeed,
   }) async {
     // Configure package:test to use the Flutter engine for child processes.
     final String shellPath = globals.artifacts.getArtifactPath(Artifact.flutterTester);
@@ -102,7 +102,8 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
         ...<String>['--name', name],
       for (final String plainName in plainNames)
         ...<String>['--plain-name', plainName],
-      '--test-randomize-ordering-seed=$randomSeed',
+      if (randomSeed != null)
+        '--test-randomize-ordering-seed=$randomSeed',
     ];
     if (web) {
       final String tempBuildDir = globals.fs.systemTempDirectory

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -157,7 +157,7 @@ class FakeFlutterTestRunner implements FlutterTestRunner {
     String icudtlPath,
     Directory coverageDirectory,
     bool web = false,
-    String randomSeed = '0',
+    String randomSeed,
   }) async {
     lastEnableObservatoryValue = enableObservatory;
     return exitCode;


### PR DESCRIPTION
Fixes #51010

The test package differentiates between passing and not passing this
argument. A previous version had a bug that treated passing `0`
identically to not passing the argument, and the flutter test runner
relied on this bug by always passing a value and using a default of `0`.

- Remove the argument defaults throughout to make it clear that `null`
  is a valid value and the default.
- Remove the argument defaulting on the argument parser.
- Update the wording of the usage for this argument, this will also be
  updated on the `package:test` side.