### PR TITLE
Fix pub version mismatch

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -758,6 +758,14 @@ Future<void> _pubRunTest(String workingDirectory, {
     deleteFile(path.join(flutterRoot, 'bin', 'cache', 'flutter_tools.snapshot'));
     deleteFile(path.join(flutterRoot, 'bin', 'cache', 'flutter_tools.stamp'));
   }
+  // Ensure we run `pub get` with the same version of pub we will run `pub test` with.
+  final Stream<String> getOutput = runAndGetStdout(
+    pub,
+    <String>['get'],
+    workingDirectory: workingDirectory,
+    environment: pubEnvironment,
+  );
+  await getOutput.forEach(print);
   if (useFlutterTestFormatter) {
     final FlutterCompactFormatter formatter = FlutterCompactFormatter();
     Stream<String> testOutput;


### PR DESCRIPTION
Flutter HHH is red because of a pub version mismatch: https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket.appspot.com/8888035760929825280/+/steps/flutter_test_framework_tests/0/stdout

```
acoharkes@dacoharkes-l:~/flt/engine/flutter/dev/bots$ pub get
Resolving dependencies... 
Got dependencies!
dacoharkes@dacoharkes-l:~/flt/engine/flutter/dev/bots$ ../../bin/cache/dart-sdk/bin/pub run test -rcompact -j2 --no-color
The ".dart_tool/package_config.json" file is not recognized by "pub" version, please run "pub get".
dacoharkes@dacoharkes-l:~/flt/engine/flutter/dev/bots$ pub get
Resolving dependencies... 
Got dependencies!
dacoharkes@dacoharkes-l:~/flt/engine/flutter/dev/bots$ ../../bin/cache/dart-sdk/bin/pub run test -rcompact -j2 --no-color
The ".dart_tool/package_config.json" file is not recognized by "pub" version, please run "pub get".
dacoharkes@dacoharkes-l:~/flt/engine/flutter/dev/bots$ ../../bin/cache/dart-sdk/bin/pub get
Resolving dependencies... 
Got dependencies!
dacoharkes@dacoharkes-l:~/flt/engine/flutter/dev/bots$ ../../bin/cache/dart-sdk/bin/pub run test -rcompact -j2 --no-color
Precompiling executable... (8.4s)
Precompiled test:test.
...
```

cc @mkustermann 