### PR TITLE
Detect sync vs async obtainKey in ResizeImage

### DIFF
--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -728,7 +728,7 @@ class ResizeImage extends ImageProvider<_SizeAwareCacheKey> {
   @override
   Future<_SizeAwareCacheKey> obtainKey(ImageConfiguration configuration) {
     Completer<_SizeAwareCacheKey> completer;
-    // If the imageProvider future is synchronous, then we will be able to fill in result with
+    // If the imageProvider.obtainKey future is synchronous, then we will be able to fill in result with
     // a value before completer is initialized below.
     SynchronousFuture<_SizeAwareCacheKey> result;
     imageProvider.obtainKey(configuration).then((Object key) {

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -726,9 +726,28 @@ class ResizeImage extends ImageProvider<_SizeAwareCacheKey> {
   }
 
   @override
-  Future<_SizeAwareCacheKey> obtainKey(ImageConfiguration configuration) async {
-    final Object providerCacheKey = await imageProvider.obtainKey(configuration);
-    return _SizeAwareCacheKey(providerCacheKey, width, height);
+  Future<_SizeAwareCacheKey> obtainKey(ImageConfiguration configuration) {
+    Completer<_SizeAwareCacheKey> completer;
+    // If the imageProvider future is synchronous, then we will be able to fill in result with
+    // a value before completer is initialized below.
+    SynchronousFuture<_SizeAwareCacheKey> result;
+    imageProvider.obtainKey(configuration).then((Object key) {
+      if (completer == null) {
+        // This future has completed synchronously (completer was never assigned),
+        // so we can directly create the synchronous result to return.
+        result = SynchronousFuture<_SizeAwareCacheKey>(_SizeAwareCacheKey(key, width, height));
+      } else {
+        // This future did not synchronously complete.
+        completer.complete(_SizeAwareCacheKey(key, width, height));
+      }
+    });
+    if (result != null) {
+      return result;
+    }
+    // If the code reaches here, it means the the imageProvider.obtainKey was not
+    // completed sync, so we initialize the completer for completion later.
+    completer = Completer<_SizeAwareCacheKey>();
+    return completer.future;
   }
 }
 

--- a/packages/flutter/test/painting/image_provider_test.dart
+++ b/packages/flutter/test/painting/image_provider_test.dart
@@ -400,12 +400,6 @@ void main() {
     final MemoryImage memoryImage = MemoryImage(bytes);
     final ResizeImage resizeImage = ResizeImage(memoryImage, width: 123, height: 321);
 
-    final DecoderCallback decode = (Uint8List bytes, {int cacheWidth, int cacheHeight}) {
-      expect(cacheWidth, 123);
-      expect(cacheHeight, 321);
-      return PaintingBinding.instance.instantiateImageCodec(bytes, cacheWidth: cacheWidth, cacheHeight: cacheHeight);
-    };
-
     bool isAsync = false;
     resizeImage.obtainKey(ImageConfiguration.empty).then((Object key) {
       expect(isAsync, false);
@@ -418,12 +412,6 @@ void main() {
     final Uint8List bytes = Uint8List.fromList(kTransparentImage);
     final MockMemoryImage memoryImage = MockMemoryImage(bytes);
     final ResizeImage resizeImage = ResizeImage(memoryImage, width: 123, height: 321);
-
-    final DecoderCallback decode = (Uint8List bytes, {int cacheWidth, int cacheHeight}) {
-      expect(cacheWidth, 123);
-      expect(cacheHeight, 321);
-      return PaintingBinding.instance.instantiateImageCodec(bytes, cacheWidth: cacheWidth, cacheHeight: cacheHeight);
-    };
 
     bool isAsync = false;
     resizeImage.obtainKey(ImageConfiguration.empty).then((Object key) {
@@ -464,7 +452,7 @@ Future<Size> _resolveAndGetSize(ImageProvider imageProvider,
 }
 
 class MockMemoryImage extends MemoryImage {
-  MockMemoryImage(Uint8List bytes) : super(bytes) {}
+  MockMemoryImage(Uint8List bytes) : super(bytes);
 
   @override
   Future<MemoryImage> obtainKey(ImageConfiguration configuration) {

--- a/packages/flutter/test/painting/image_provider_test.dart
+++ b/packages/flutter/test/painting/image_provider_test.dart
@@ -410,7 +410,7 @@ void main() {
 
   test('ResizeImage handles async obtainKey', () async {
     final Uint8List bytes = Uint8List.fromList(kTransparentImage);
-    final MockMemoryImage memoryImage = MockMemoryImage(bytes);
+    final AsyncKeyMemoryImage memoryImage = AsyncKeyMemoryImage(bytes);
     final ResizeImage resizeImage = ResizeImage(memoryImage, width: 123, height: 321);
 
     bool isAsync = false;
@@ -451,8 +451,10 @@ Future<Size> _resolveAndGetSize(ImageProvider imageProvider,
   return await completer.future;
 }
 
-class MockMemoryImage extends MemoryImage {
-  MockMemoryImage(Uint8List bytes) : super(bytes);
+// This version of MemoryImage guarantees obtainKey returns a future that has not been
+// completed synchronously.
+class AsyncKeyMemoryImage extends MemoryImage {
+  AsyncKeyMemoryImage(Uint8List bytes) : super(bytes);
 
   @override
   Future<MemoryImage> obtainKey(ImageConfiguration configuration) {

--- a/packages/flutter/test/painting/image_provider_test.dart
+++ b/packages/flutter/test/painting/image_provider_test.dart
@@ -395,6 +395,44 @@ void main() {
     resizeImage.load(await resizeImage.obtainKey(ImageConfiguration.empty), decode);
   });
 
+  test('ResizeImage handles sync obtainKey', () async {
+    final Uint8List bytes = Uint8List.fromList(kTransparentImage);
+    final MemoryImage memoryImage = MemoryImage(bytes);
+    final ResizeImage resizeImage = ResizeImage(memoryImage, width: 123, height: 321);
+
+    final DecoderCallback decode = (Uint8List bytes, {int cacheWidth, int cacheHeight}) {
+      expect(cacheWidth, 123);
+      expect(cacheHeight, 321);
+      return PaintingBinding.instance.instantiateImageCodec(bytes, cacheWidth: cacheWidth, cacheHeight: cacheHeight);
+    };
+
+    bool isAsync = false;
+    resizeImage.obtainKey(ImageConfiguration.empty).then((Object key) {
+      expect(isAsync, false);
+    });
+    isAsync = true;
+    expect(isAsync, true);
+  });
+
+  test('ResizeImage handles async obtainKey', () async {
+    final Uint8List bytes = Uint8List.fromList(kTransparentImage);
+    final MockMemoryImage memoryImage = MockMemoryImage(bytes);
+    final ResizeImage resizeImage = ResizeImage(memoryImage, width: 123, height: 321);
+
+    final DecoderCallback decode = (Uint8List bytes, {int cacheWidth, int cacheHeight}) {
+      expect(cacheWidth, 123);
+      expect(cacheHeight, 321);
+      return PaintingBinding.instance.instantiateImageCodec(bytes, cacheWidth: cacheWidth, cacheHeight: cacheHeight);
+    };
+
+    bool isAsync = false;
+    resizeImage.obtainKey(ImageConfiguration.empty).then((Object key) {
+      expect(isAsync, true);
+    });
+    isAsync = true;
+    expect(isAsync, true);
+  });
+
   test('File image with empty file throws expected error (load)', () async {
     final Completer<StateError> error = Completer<StateError>();
     FlutterError.onError = (FlutterErrorDetails details) {
@@ -423,6 +461,15 @@ Future<Size> _resolveAndGetSize(ImageProvider imageProvider,
   );
   stream.addListener(listener);
   return await completer.future;
+}
+
+class MockMemoryImage extends MemoryImage {
+  MockMemoryImage(Uint8List bytes) : super(bytes) {}
+
+  @override
+  Future<MemoryImage> obtainKey(ImageConfiguration configuration) {
+    return Future<MemoryImage>(() => this);
+  }
 }
 
 class MockHttpClient extends Mock implements HttpClient {}


### PR DESCRIPTION
## Description

See b/148093947

ResizeImage's obtain key wraps the child ImageProvider's key in its own key. When the child key is obtained synchronously, this wrapping causes it to complete on the next frame, which causes a flicker in the image.

## Tests

Tests handling of sync and async `obtainKey`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.