### PR TITLE
[flutter_tools] adds etag/cache control header to debug asset server

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
@@ -143,6 +143,9 @@ class WebAssetServer implements AssetReader {
     // Attempt to look up the file by URI.
     if (_files.containsKey(requestPath)) {
       final List<int> bytes = getFile(requestPath);
+      // Use the underlying buffer hashCode as a revision string. This buffer is
+      // replaced whenever the frontend_server produces new output files, which
+      // will also change the hashCode.
       final String etag = bytes.hashCode.toString();
       if (ifNoneMatch == etag) {
         return shelf.Response.notModified();

--- a/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
@@ -141,6 +141,7 @@ class WebAssetServer implements AssetReader {
       final List<int> bytes = getFile(requestPath);
       headers[HttpHeaders.contentLengthHeader] = bytes.length.toString();
       headers[HttpHeaders.contentTypeHeader] = 'application/javascript';
+      headers[HttpHeaders.etagHeader] = bytes.hashCode.toString();
       return shelf.Response.ok(bytes, headers: headers);
     }
     // If this is a sourcemap file, then it might be in the in-memory cache.
@@ -149,6 +150,7 @@ class WebAssetServer implements AssetReader {
       final List<int> bytes = getSourceMap(requestPath);
       headers[HttpHeaders.contentLengthHeader] = bytes.length.toString();
       headers[HttpHeaders.contentTypeHeader] = 'application/json';
+      headers[HttpHeaders.etagHeader] = bytes.hashCode.toString();
       return shelf.Response.ok(bytes, headers: headers);
     }
 

--- a/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
@@ -130,6 +130,10 @@ class WebAssetServer implements AssetReader {
       return shelf.Response.notFound('');
     }
 
+    // Track etag headers for better caching of resources.
+    final String ifNoneMatch = request.headers[HttpHeaders.ifNoneMatchHeader];
+    headers[HttpHeaders.cacheControlHeader] = 'max-age=0, must-revalidate';
+
     // NOTE: shelf removes leading `/` for some reason.
     final String requestPath = request.url.path.startsWith('/')
       ?  request.url.path
@@ -139,18 +143,26 @@ class WebAssetServer implements AssetReader {
     // Attempt to look up the file by URI.
     if (_files.containsKey(requestPath)) {
       final List<int> bytes = getFile(requestPath);
+      final String etag = bytes.hashCode.toString();
+      if (ifNoneMatch == etag) {
+        return shelf.Response.notModified();
+      }
       headers[HttpHeaders.contentLengthHeader] = bytes.length.toString();
       headers[HttpHeaders.contentTypeHeader] = 'application/javascript';
-      headers[HttpHeaders.etagHeader] = bytes.hashCode.toString();
+      headers[HttpHeaders.etagHeader] = etag;
       return shelf.Response.ok(bytes, headers: headers);
     }
     // If this is a sourcemap file, then it might be in the in-memory cache.
     // Attempt to lookup the file by URI.
     if (_sourcemaps.containsKey(requestPath)) {
       final List<int> bytes = getSourceMap(requestPath);
+      final String etag = bytes.hashCode.toString();
+      if (ifNoneMatch == etag) {
+        return shelf.Response.notModified();
+      }
       headers[HttpHeaders.contentLengthHeader] = bytes.length.toString();
       headers[HttpHeaders.contentTypeHeader] = 'application/json';
-      headers[HttpHeaders.etagHeader] = bytes.hashCode.toString();
+      headers[HttpHeaders.etagHeader] = etag;
       return shelf.Response.ok(bytes, headers: headers);
     }
 
@@ -167,6 +179,13 @@ class WebAssetServer implements AssetReader {
     if (!file.existsSync()) {
       return shelf.Response.notFound('');
     }
+
+    // For real files, use a serialized file stat as a revision
+    final String etag = file.lastModifiedSync().toIso8601String();
+    if (ifNoneMatch == etag) {
+      return shelf.Response.notModified();
+    }
+
     final int length = file.lengthSync();
     // Attempt to determine the file's mime type. if this is not provided some
     // browsers will refuse to render images/show video et cetera. If the tool
@@ -181,6 +200,7 @@ class WebAssetServer implements AssetReader {
     mimeType ??= _kDefaultMimeType;
     headers[HttpHeaders.contentLengthHeader] = length.toString();
     headers[HttpHeaders.contentTypeHeader] = mimeType;
+    headers[HttpHeaders.etagHeader] = etag;
     return shelf.Response.ok(file.openRead(), headers: headers);
   }
 

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -90,6 +90,7 @@ void main() {
     expect(response.headers, allOf(<Matcher>[
       containsPair('content-length', source.lengthSync().toString()),
       containsPair('content-type', 'application/javascript'),
+      containsPair('etag', isNotNull)
     ]));
     expect((await response.read().toList()).first, source.readAsBytesSync());
   }, overrides: <Type, Generator>{
@@ -144,6 +145,7 @@ void main() {
     expect(response.headers, allOf(<Matcher>[
       containsPair('content-length', source.lengthSync().toString()),
       containsPair('content-type', 'application/javascript'),
+      containsPair('etag', isNotNull)
     ]));
     expect((await response.read().toList()).first, source.readAsBytesSync());
   }, overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -125,7 +125,7 @@ void main() {
       }));
 
     expect(cachedResponse.statusCode, HttpStatus.notModified);
-    expect(cachedResponse.body, isEmpty);
+    expect(await cachedResponse.read().toList(), isEmpty);
   }));
 
   test('handles missing JavaScript files from in memory cache', () => testbed.run(() async {

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -125,6 +125,7 @@ void main() {
       }));
 
     expect(cachedResponse.statusCode, HttpStatus.notModified);
+    expect(cachedResponse.body, isEmpty);
   }));
 
   test('handles missing JavaScript files from in memory cache', () => testbed.run(() async {


### PR DESCRIPTION
## Description

Adds a revision etag header to requested JavaScript and source map files. The hashCode should match the underlying buffer the resource was constructed from.

fyi @grouma @jakemac53 

Fixes https://github.com/flutter/flutter/issues/51141