### PR TITLE
update cache for flutter test/fast command

### DIFF
--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -23,7 +23,7 @@ import '../test/runner.dart';
 import '../test/test_wrapper.dart';
 import '../test/watcher.dart';
 
-class TestCommand extends FastFlutterCommand {
+class TestCommand extends FlutterCommand {
   TestCommand({
     bool verboseHelp = false,
     this.testWrapper = const TestWrapper(),

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -639,15 +639,6 @@ abstract class FlutterCommand extends Command<void> {
     );
   }
 
-  /// Populate the cache.
-  ///
-  /// This should be called before any command is run, and before pub get is run
-  /// to make sure that the Dart SDK is available and any precompiled dart files
-  /// have the right snapshot version.
-  Future<void> _maybeUpdateCache() async {
-
-  }
-
   /// Perform validation then call [runCommand] to execute the command.
   /// Return a [Future] that completes with an exit code
   /// indicating whether execution was successful.

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -27,6 +27,7 @@ void main() {
   setUp(() {
     fs = MemoryFileSystem();
     fs.file('pubspec.yaml').createSync();
+    fs.file('.packages').createSync();
     fs.directory('test').childFile('some_test.dart').createSync(recursive: true);
   });
 

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -19,7 +19,6 @@ import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
-import 'flutter_command_runner_test.dart';
 import 'utils.dart';
 
 void main() {
@@ -41,15 +40,6 @@ void main() {
         (Invocation _) => DateTime.fromMillisecondsSinceEpoch(mockTimes.removeAt(0))
       );
       when(mockProcessInfo.maxRss).thenReturn(10);
-    });
-
-    testUsingContext('FastFlutterCommand updates artifacts', () async {
-      final FakeFastCommand fakeFlutterCommand = FakeFastCommand()..result = FlutterCommandResult.success();
-      await fakeFlutterCommand.run();
-      expect(fakeFlutterCommand.runCalled, true);
-      verify(cache.updateAll(<DevelopmentArtifact>{DevelopmentArtifact.universal})).called(1);
-    }, overrides: <Type, Generator>{
-      Cache: () => cache,
     });
 
     testUsingContext('honors shouldUpdateCache false', () async {
@@ -437,20 +427,4 @@ class FakeSignals implements Signals {
 
   @override
   Stream<Object> get errors => delegate.errors;
-}
-
-class FakeFastCommand extends FastFlutterCommand {
-  FlutterCommandResult result;
-  bool runCalled = false;
-  @override
-  String get description => 'FakeFastCommand';
-
-  @override
-  String get name => 'FakeFastCommand';
-
-  @override
-  Future<FlutterCommandResult> runCommand() async {
-    runCalled = true;
-    return result;
-  }
 }

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -19,6 +19,7 @@ import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import 'flutter_command_runner_test.dart';
 import 'utils.dart';
 
 void main() {
@@ -40,6 +41,15 @@ void main() {
         (Invocation _) => DateTime.fromMillisecondsSinceEpoch(mockTimes.removeAt(0))
       );
       when(mockProcessInfo.maxRss).thenReturn(10);
+    });
+
+    testUsingContext('FastFlutterCommand updates artifacts', () async {
+      final FakeFastCommand fakeFlutterCommand = FakeFastCommand()..result = FlutterCommandResult.success();
+      await fakeFlutterCommand.run();
+      expect(fakeFlutterCommand.runCalled, true);
+      verify(cache.updateAll(<DevelopmentArtifact>{DevelopmentArtifact.universal})).called(1);
+    }, overrides: <Type, Generator>{
+      Cache: () => cache,
     });
 
     testUsingContext('honors shouldUpdateCache false', () async {
@@ -427,4 +437,20 @@ class FakeSignals implements Signals {
 
   @override
   Stream<Object> get errors => delegate.errors;
+}
+
+class FakeFastCommand extends FastFlutterCommand {
+  FlutterCommandResult result;
+  bool runCalled = false;
+  @override
+  String get description => 'FakeFastCommand';
+
+  @override
+  String get name => 'FakeFastCommand';
+
+  @override
+  Future<FlutterCommandResult> runCommand() async {
+    runCalled = true;
+    return result;
+  }
 }


### PR DESCRIPTION
## Description

`flutter test` doesn't get the updated Dart SDK if it has changed.  Now it will.

## Related Issues

Fixses #25866 

## Tests

I added the following tests:

Test that we update the cache for a fast command

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
