### PR TITLE
[flutter_tools] add more search paths for source maps

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
@@ -585,7 +585,9 @@ class ReleaseAssetServer {
   final List<Uri> _searchPaths = <Uri>[
     globals.fs.directory(getWebBuildDirectory()).uri,
     globals.fs.directory(Cache.flutterRoot).uri,
+    globals.fs.directory(Cache.flutterRoot).parent.uri,
     globals.fs.currentDirectory.uri,
+    globals.fs.directory(globals.fsUtils.homeDirPath).uri,
   ];
 
   Future<shelf.Response> handle(shelf.Request request) async {


### PR DESCRIPTION
## Description

The last time I updated these I didn't double check with an app out of tree. Additionally adds a search path for HOME, since that is where the pub cache will be. 

Fixes https://github.com/flutter/flutter/issues/51275