### PR TITLE
Update covariant_templates_test after changes to TypeError.

### DIFF
--- a/packages/flutter/test/foundation/covariant_templates_test.dart
+++ b/packages/flutter/test/foundation/covariant_templates_test.dart
@@ -18,6 +18,6 @@ void main() {
     final A<X> ayAsAx = ay;
     expect(() {
       ayAsAx.u = X();
-    }, throwsAssertionError);
+    }, throwsA(isA<TypeError>()));
   });
 }


### PR DESCRIPTION
TypeError no longer implements AssertionError after https://github.com/dart-lang/sdk/issues/40317.
