### PR TITLE
Add width constraints for FlexibleSpaceBar.title in its expanded state, so that overflow of long titles can be handled

### DIFF
--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -394,7 +394,15 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
                   alignment: titleAlignment,
                   child: DefaultTextStyle(
                     style: titleStyle,
-                    child: title,
+                    child: LayoutBuilder(
+                      builder: (BuildContext context, BoxConstraints constraints) {
+                        return Container(
+                          width: constraints.maxWidth / scaleValue,
+                          alignment: titleAlignment,
+                          child: title,
+                        );
+                      }
+                    ),
                   ),
                 ),
               ),

--- a/packages/flutter/test/material/flexible_space_bar_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_test.dart
@@ -5,8 +5,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../rendering/mock_canvas.dart';
-
 void main() {
   testWidgets('FlexibleSpaceBar centers title on iOS', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -121,51 +119,33 @@ void main() {
 
   // This is a regression test for https://github.com/flutter/flutter/issues/14227
   testWidgets('FlexibleSpaceBar sets width constraints for the title', (WidgetTester tester) async {
-    const double width = 300;
-    const double height = 100;
-    const double minExtent = 100;
-    const double maxExtent = 200;
-
-    final FlexibleSpaceBarSettings customSettings = FlexibleSpaceBar.createSettings(
-      currentExtent: maxExtent,
-      minExtent: minExtent,
-      maxExtent: maxExtent,
-      child: AppBar(
-        flexibleSpace: FlexibleSpaceBar(
-          titlePadding: EdgeInsets.zero,
-          title: Container(
-            height: height,
-            child: Text(
-              'X' * 2000,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-            ),
-          ),
-        ),
-      ),
-    ) as FlexibleSpaceBarSettings;
-
+    const double height = 300.0;
+    double width;
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: Container(
-            width: width,
-            child: CustomScrollView(
-              primary: true,
-              slivers: <Widget>[
-                SliverPersistentHeader(
-                  floating: true,
-                  pinned: true,
-                  delegate: TestDelegate(settings: customSettings),
-                ),
-                SliverToBoxAdapter(
-                  child: Container(
-                    height: 1200.0,
-                    color: Colors.orange[400],
+          body: Builder(
+            builder: (BuildContext context) {
+              width = MediaQuery.of(context).size.width;
+              return CustomScrollView(
+                slivers: <Widget>[
+                  SliverAppBar(
+                    expandedHeight: height,
+                    pinned: true,
+                    stretch: true,
+                    flexibleSpace: FlexibleSpaceBar(
+                      titlePadding: EdgeInsets.zero,
+                      title: Text(
+                        'X' * 2000,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      centerTitle: false,
+                    ),
                   ),
-                ),
-              ],
-            ),
+                ],
+              );
+            }
           ),
         ),
       ),
@@ -175,10 +155,10 @@ void main() {
     // FlexibleSpaceBar is fully expanded, thus we expect the width to be
     // 1.5 times smaller than the full width.
     expect(
-      find.byType(Text),
-      paints..clipRect(rect: const Rect.fromLTWH(0, 0, width / 1.5, height)),
+      tester.getRect(find.byType(Text)),
+      Rect.fromLTRB(0, height - 30, (width / 1.5).floorToDouble(), height - 10),
     );
-  }, skip: isBrowser);
+  });
 
   testWidgets('FlexibleSpaceBar test titlePadding defaults', (WidgetTester tester) async {
     Widget buildFrame(TargetPlatform platform, bool centerTitle) {

--- a/packages/flutter/test/material/flexible_space_bar_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_test.dart
@@ -119,6 +119,7 @@ void main() {
 
   // This is a regression test for https://github.com/flutter/flutter/issues/14227
   testWidgets('FlexibleSpaceBar sets width constraints for the title', (WidgetTester tester) async {
+    const double titleFontSize = 20.0;
     const double height = 300.0;
     double width;
     await tester.pumpWidget(
@@ -139,6 +140,7 @@ void main() {
                         'X' * 2000,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(fontSize: titleFontSize),
                       ),
                       centerTitle: false,
                     ),
@@ -153,10 +155,16 @@ void main() {
 
     // The title is scaled and transformed to be 1.5 times bigger, when the
     // FlexibleSpaceBar is fully expanded, thus we expect the width to be
-    // 1.5 times smaller than the full width.
+    // 1.5 times smaller than the full width. The height of the text is the same
+    // as the font size, with 10 dps bottom margin.
     expect(
       tester.getRect(find.byType(Text)),
-      Rect.fromLTRB(0, height - 30, (width / 1.5).floorToDouble(), height - 10),
+      Rect.fromLTRB(
+        0,
+        height - titleFontSize - 10,
+        (width / 1.5).floorToDouble(),
+        height - 10,
+      ),
     );
   });
 

--- a/packages/flutter/test/material/flexible_space_bar_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_test.dart
@@ -135,7 +135,7 @@ void main() {
           titlePadding: EdgeInsets.zero,
           title: Container(
             height: height,
-            child:  Text(
+            child: Text(
               'X' * 2000,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,

--- a/packages/flutter/test/material/flexible_space_bar_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_test.dart
@@ -149,7 +149,7 @@ void main() {
       MaterialApp(
         home: Scaffold(
           body: Container(
-            width: 300,
+            width: width,
             child: CustomScrollView(
               primary: true,
               slivers: <Widget>[


### PR DESCRIPTION
Add width constraints for FlexibleSpaceBar.title in its expanded state, so that overflow of long titles can be handled.

See [this dartpad for reproducible example of the issue](https://dartpad.dartlang.org/68be44f60cb1b852a8c24cbbb539f359).

## Description

Add width constraints for FlexibleSpaceBar.title in its expanded state, so that overflow of long titles can be handled.

Before:
<img src="https://user-images.githubusercontent.com/1770678/75170465-71572180-572a-11ea-9e47-b044b426a853.png" width="200">
After:
<img src="https://user-images.githubusercontent.com/1770678/75170473-74521200-572a-11ea-87a9-27dbcc4d00d7.png" width="200">

Example with larger text scale factor:
<img src="https://user-images.githubusercontent.com/1770678/75236555-3dc5d700-57be-11ea-9348-c1a706095e16.png" width="200">

## Related Issues

Closes https://github.com/flutter/flutter/issues/14227

## Tests

I added the following tests:

- FlexibleSpaceBar sets width constraints for the title

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
