### PR TITLE
[flutter_tools] don't fix chrome window size, add more logs

### DIFF
--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -177,10 +177,6 @@ class ChromeLauncher {
       })
       .firstWhere((String line) => line.startsWith('DevTools listening'), orElse: () {
         return 'Failed to spawn stderr';
-      })
-      .timeout(const Duration(seconds: 60), onTimeout: () {
-        throwToolExit('Unable to connect to Chrome DevTools.');
-        return null;
       });
     final Uri remoteDebuggerUri = await _getRemoteDebuggerUrl(Uri.parse('http://localhost:$port'));
     return _connect(Chrome._(

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -138,9 +138,8 @@ class ChromeLauncher {
       '--no-default-browser-check',
       '--disable-default-apps',
       '--disable-translate',
-      '--window-size=2400,1800',
       if (headless)
-        ...<String>['--headless', '--disable-gpu', '--no-sandbox'],
+        ...<String>['--headless', '--disable-gpu', '--no-sandbox', '--window-size=2400,1800'],
       url,
     ];
 
@@ -161,17 +160,28 @@ class ChromeLauncher {
       }));
     }
 
+    process.stdout
+      .transform(utf8.decoder)
+      .transform(const LineSplitter())
+      .listen((String line) {
+        globals.printTrace('[CHROME]: $line');
+      });
+
     // Wait until the DevTools are listening before trying to connect.
     await process.stderr
-        .transform(utf8.decoder)
-        .transform(const LineSplitter())
-        .firstWhere((String line) => line.startsWith('DevTools listening'), orElse: () {
-          return 'Failed to spawn stderr';
-        })
-        .timeout(const Duration(seconds: 60), onTimeout: () {
-          throwToolExit('Unable to connect to Chrome DevTools.');
-          return null;
-        });
+      .transform(utf8.decoder)
+      .transform(const LineSplitter())
+      .map((String line) {
+        globals.printTrace('[CHROME]:$line');
+        return line;
+      })
+      .firstWhere((String line) => line.startsWith('DevTools listening'), orElse: () {
+        return 'Failed to spawn stderr';
+      })
+      .timeout(const Duration(seconds: 60), onTimeout: () {
+        throwToolExit('Unable to connect to Chrome DevTools.');
+        return null;
+      });
     final Uri remoteDebuggerUri = await _getRemoteDebuggerUrl(Uri.parse('http://localhost:$port'));
     return _connect(Chrome._(
       port,

--- a/packages/flutter_tools/test/general.shard/web/chrome_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/chrome_test.dart
@@ -72,15 +72,28 @@ void main() {
 
   test('can launch chrome and connect to the devtools', () => testbed.run(() async {
     await chromeLauncher.launch('example_url', skipCheck: true);
+
     final VerificationResult result = verify(globals.processManager.start(captureAny));
     expect(result.captured.single, containsAll(expectChromeArgs()));
+    expect(result.captured.single, isNot(contains('--window-size=2400,1800')));
   }));
 
   test('can launch chrome with a custom debug port', () => testbed.run(() async {
     await chromeLauncher.launch('example_url', skipCheck: true, debugPort: 10000);
     final VerificationResult result = verify(globals.processManager.start(captureAny));
+
     expect(result.captured.single, containsAll(expectChromeArgs(debugPort: 10000)));
+    expect(result.captured.single, isNot(contains('--window-size=2400,1800')));
   }));
+
+  test('can launch chrome headless', () => testbed.run(() async {
+    await chromeLauncher.launch('example_url', skipCheck: true, headless: true);
+    final VerificationResult result = verify(globals.processManager.start(captureAny));
+
+    expect(result.captured.single, containsAll(expectChromeArgs()));
+    expect(result.captured.single, contains('--window-size=2400,1800'));
+  }));
+
 
   test('can seed chrome temp directory with existing preferences', () => testbed.run(() async {
     final Directory dataDir = globals.fs.directory('chrome-stuff');


### PR DESCRIPTION
## Description

The addition of the window size param causes flutter run -d chrome to always launch in a large size. Also adds some extra logging to help debug the start failures.