### PR TITLE
Added a footer widget for ReorderableListView

### DIFF
--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -566,8 +566,10 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
     return LayoutBuilder(builder: (BuildContext context, BoxConstraints constraints) {
       const Key endWidgetKey = Key('DraggableList - End Widget');
       Widget finalDropArea;
+      AlignmentDirectional footerAlignment;
       switch (widget.scrollDirection) {
         case Axis.horizontal:
+          footerAlignment = AlignmentDirectional.centerStart;
           finalDropArea = SizedBox(
             key: endWidgetKey,
             width: _defaultDropAreaExtent,
@@ -576,6 +578,7 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
           break;
         case Axis.vertical:
         default:
+          footerAlignment = AlignmentDirectional.topCenter;
           finalDropArea = SizedBox(
             key: endWidgetKey,
             height: _defaultDropAreaExtent,
@@ -583,6 +586,7 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
           );
           break;
       }
+
       return SingleChildScrollView(
         scrollDirection: widget.scrollDirection,
         padding: widget.padding,
@@ -605,7 +609,7 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
                     minWidth: widget.scrollDirection == Axis.horizontal ? _defaultDropAreaExtent : 0,
                   ),
                   child: Align(
-                    alignment: widget.scrollDirection == Axis.horizontal ? Alignment.centerLeft : Alignment.topCenter,
+                    alignment: footerAlignment,
                     child: widget.footer,
                   ),
                 ),

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -595,16 +595,25 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
             for (int i = 0; i < widget.children.length; i += 1) _wrap(widget.children[i], i, constraints),
             if (widget.footer != null)
               // We need to wrap the widget.footer so we can reorder an item between
-              // the last item of the list and the footer itself
-              _wrap(SizedBox(
-                  key: Key('footer'),
-                  child: widget.footer,
+              // the last item of the list and the footer itself. If the footer
+              // is used instead of the finalDropArea it needs its own key,
+              // because _wrap() requires it.
+              _wrap(ConstrainedBox(
+                  key: endWidgetKey,
+                  constraints: BoxConstraints(
+                    minHeight: widget.scrollDirection == Axis.vertical ? _defaultDropAreaExtent : 0,
+                    minWidth: widget.scrollDirection == Axis.horizontal ? _defaultDropAreaExtent : 0,
+                  ),
+                  child: Align(
+                    alignment: Alignment.topCenter,
+                    child: widget.footer,
+                  ),
                 ),
                 widget.children.length,
                 constraints,
               ),
             // We don't need a final drop area when a footer is present
-            // as the footer should provide enough space to drag a list item
+            // as the footer provides enough space to drag a list item
             // to the last position of the list, which is above the footer.
             if (!widget.reverse && widget.footer == null) _wrap(finalDropArea, widget.children.length, constraints),
           ],

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -590,11 +590,25 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
         reverse: widget.reverse,
         child: _buildContainerForScrollDirection(
           children: <Widget>[
+            // 0 must be the first index at the start of the reversed list,
+            // so that items which get dragged to the start are ordered to start
             if (widget.reverse) _wrap(finalDropArea, 0, constraints),
             if (widget.header != null) widget.header,
             for (int i = 0; i < widget.children.length; i += 1) _wrap(widget.children[i], i, constraints),
-            if (widget.footer != null) widget.footer,
-            if (!widget.reverse) _wrap(finalDropArea, widget.children.length, constraints),
+            if (widget.footer != null)
+              // We need to wrap the widget.footer so we can reorder an item between
+              // the last item of the list and the footer itself
+              _wrap(SizedBox(
+                  key: Key('footer'),
+                  child: widget.footer,
+                ),
+                widget.children.length,
+                constraints,
+              ),
+            // We don't need a final drop area when a footer is present
+            // as the footer should provide enough space to drag a list item
+            // to the last position of the list, which is above the footer.
+            if (!widget.reverse && widget.footer == null) _wrap(finalDropArea, widget.children.length, constraints),
           ],
         ),
       );

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -590,7 +590,7 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
         reverse: widget.reverse,
         child: _buildContainerForScrollDirection(
           children: <Widget>[
-            if (widget.reverse) _wrap(finalDropArea, widget.children.length, constraints),
+            if (widget.reverse) _wrap(finalDropArea, 0, constraints),
             if (widget.header != null) widget.header,
             for (int i = 0; i < widget.children.length; i += 1) _wrap(widget.children[i], i, constraints),
             if (widget.footer != null) widget.footer,

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -590,9 +590,7 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
         reverse: widget.reverse,
         child: _buildContainerForScrollDirection(
           children: <Widget>[
-            // 0 must be the first index at the start of the reversed list,
-            // so that items which get dragged to the start are ordered to start
-            if (widget.reverse) _wrap(finalDropArea, 0, constraints),
+            if (widget.reverse) _wrap(finalDropArea, widget.children.length, constraints),
             if (widget.header != null) widget.header,
             for (int i = 0; i < widget.children.length; i += 1) _wrap(widget.children[i], i, constraints),
             if (widget.footer != null)

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -60,6 +60,7 @@ class ReorderableListView extends StatefulWidget {
   ReorderableListView({
     Key key,
     this.header,
+    this.footer,
     @required this.children,
     @required this.onReorder,
     this.scrollController,
@@ -79,6 +80,11 @@ class ReorderableListView extends StatefulWidget {
   ///
   /// If null, no header will appear before the list.
   final Widget header;
+
+  /// A non-reorderable footer widget to show after the list.
+  ///
+  /// If null, no footer will appear after the list.
+  final Widget footer;
 
   /// The widgets to display.
   final List<Widget> children;
@@ -149,6 +155,7 @@ class _ReorderableListViewState extends State<ReorderableListView> {
       builder: (BuildContext context) {
         return _ReorderableListContent(
           header: widget.header,
+          footer: widget.footer,
           children: widget.children,
           scrollController: widget.scrollController,
           scrollDirection: widget.scrollDirection,
@@ -175,6 +182,7 @@ class _ReorderableListViewState extends State<ReorderableListView> {
 class _ReorderableListContent extends StatefulWidget {
   const _ReorderableListContent({
     @required this.header,
+    @required this.footer,
     @required this.children,
     @required this.scrollController,
     @required this.scrollDirection,
@@ -184,6 +192,7 @@ class _ReorderableListContent extends StatefulWidget {
   });
 
   final Widget header;
+  final Widget footer;
   final List<Widget> children;
   final ScrollController scrollController;
   final Axis scrollDirection;
@@ -584,6 +593,7 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
             if (widget.reverse) _wrap(finalDropArea, widget.children.length, constraints),
             if (widget.header != null) widget.header,
             for (int i = 0; i < widget.children.length; i += 1) _wrap(widget.children[i], i, constraints),
+            if (widget.footer != null) widget.footer,
             if (!widget.reverse) _wrap(finalDropArea, widget.children.length, constraints),
           ],
         ),

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -605,7 +605,7 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
                     minWidth: widget.scrollDirection == Axis.horizontal ? _defaultDropAreaExtent : 0,
                   ),
                   child: Align(
-                    alignment: Alignment.topCenter,
+                    alignment: widget.scrollDirection == Axis.horizontal ? Alignment.centerLeft : Alignment.topCenter,
                     child: widget.footer,
                   ),
                 ),

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -136,7 +136,7 @@ void main() {
 
         // Replaces a call to setState({}()) because onReorder can't call it.
         // Otherwise this test fails because the Reorderable wants to switch
-        // the last two elements of the list, because we did't propagate the 
+        // the last two elements of the list, because we did't propagate the
         // changes from the listItems back to the ReorderableListView
         await tester.pumpWidget(
           build(footer: const Text('Footer Text')),

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -35,7 +35,6 @@ void main() {
       Widget footer,
       Axis scrollDirection = Axis.vertical,
       TextDirection textDirection = TextDirection.ltr,
-      bool reverse = false,
     }) {
       return MaterialApp(
         home: Directionality(
@@ -44,7 +43,6 @@ void main() {
             height: itemHeight * 10,
             width: itemHeight * 10,
             child: ReorderableListView(
-              reverse: reverse,
               header: header,
               footer: footer,
               children: listItems.map<Widget>(listItemToWidget).toList(),
@@ -92,22 +90,6 @@ void main() {
           tester,
           tester.getCenter(find.text('Item 4')),
           tester.getCenter(find.text('Item 1')),
-        );
-        expect(listItems, orderedEquals(<String>['Item 4', 'Item 1', 'Item 2', 'Item 3']));
-      });
-
-      testWidgets('allows reordering from the very bottom to the very top in reverse', (WidgetTester tester) async {
-        await tester.pumpWidget(build(
-          reverse: true,
-        ));
-        expect(listItems, orderedEquals(originalListItems));
-        await longPressDrag(
-          tester,
-          tester.getCenter(find.text('Item 4')),
-          // the list item needs to be dragged a good amout above the first item
-          // so that it reaches the finalDropArea otherwise the bug described 
-          // in https://github.com/flutter/flutter/issues/51359 doesn't happen
-          tester.getCenter(find.text('Item 1')) - const Offset(0, itemHeight * 2),
         );
         expect(listItems, orderedEquals(<String>['Item 4', 'Item 1', 'Item 2', 'Item 3']));
       });

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -121,10 +121,7 @@ void main() {
       testWidgets('properly reorders with a footer', (WidgetTester tester) async {
         await tester.pumpWidget(
           build(
-            footer: const SizedBox(
-              child: Text('Footer Text'),
-              height: itemHeight,
-            ),
+            footer: const Text('Footer Text'),
           ),
         );
         expect(find.text('Footer Text'), findsOneWidget);

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -30,7 +30,12 @@ void main() {
       );
     }
 
-    Widget build({ Widget header, Axis scrollDirection = Axis.vertical, TextDirection textDirection = TextDirection.ltr }) {
+    Widget build({
+      Widget header,
+      Widget footer,
+      Axis scrollDirection = Axis.vertical,
+      TextDirection textDirection = TextDirection.ltr,
+    }) {
       return MaterialApp(
         home: Directionality(
           textDirection: textDirection,
@@ -39,6 +44,7 @@ void main() {
             width: itemHeight * 10,
             child: ReorderableListView(
               header: header,
+              footer: footer,
               children: listItems.map<Widget>(listItemToWidget).toList(),
               scrollDirection: scrollDirection,
               onReorder: onReorder,
@@ -109,6 +115,19 @@ void main() {
           tester.getCenter(find.text('Item 4')) + const Offset(0.0, itemHeight * 2),
         );
         expect(find.text('Header Text'), findsOneWidget);
+        expect(listItems, orderedEquals(<String>['Item 2', 'Item 3', 'Item 4', 'Item 1']));
+      });
+
+      testWidgets('properly reorders with a footer', (WidgetTester tester) async {
+        await tester.pumpWidget(build(footer: const Text('Footer Text')));
+        expect(find.text('Footer Text'), findsOneWidget);
+        expect(listItems, orderedEquals(originalListItems));
+        await longPressDrag(
+          tester,
+          tester.getCenter(find.text('Item 1')),
+          tester.getCenter(find.text('Item 4')) + const Offset(0.0, itemHeight * 2),
+        );
+        expect(find.text('Footer Text'), findsOneWidget);
         expect(listItems, orderedEquals(<String>['Item 2', 'Item 3', 'Item 4', 'Item 1']));
       });
 
@@ -597,6 +616,34 @@ void main() {
           tester.getCenter(find.text('Item 3')),
         );
         expect(find.text('Header Text'), findsOneWidget);
+        expect(listItems, orderedEquals(<String>['Item 2', 'Item 4', 'Item 3', 'Item 1']));
+      });
+
+      testWidgets('properly reorders with a footer', (WidgetTester tester) async {
+        await tester.pumpWidget(build(
+          footer: const SizedBox(
+            width: itemHeight,
+            child: Text('Footer'),
+          ),
+          scrollDirection: Axis.horizontal),
+        );
+        expect(find.text('Footer'), findsOneWidget);
+        expect(listItems, orderedEquals(originalListItems));
+        await longPressDrag(
+          tester,
+          tester.getCenter(find.text('Item 1')),
+          tester.getCenter(find.text('Item 4')) + const Offset(itemHeight * 2, 0.0),
+        );
+        await tester.pumpAndSettle();
+        expect(find.text('Footer'), findsOneWidget);
+        expect(listItems, orderedEquals(<String>['Item 2', 'Item 3', 'Item 4', 'Item 1']));
+        await tester.pumpWidget(build(footer: const Text('Footer'), scrollDirection: Axis.horizontal));
+        await longPressDrag(
+          tester,
+          tester.getCenter(find.text('Item 4')),
+          tester.getCenter(find.text('Item 3')),
+        );
+        expect(find.text('Footer'), findsOneWidget);
         expect(listItems, orderedEquals(<String>['Item 2', 'Item 4', 'Item 3', 'Item 1']));
       });
 

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -120,9 +120,7 @@ void main() {
 
       testWidgets('properly reorders with a footer', (WidgetTester tester) async {
         await tester.pumpWidget(
-          build(
-            footer: const Text('Footer Text'),
-          ),
+          build(footer: const Text('Footer Text')),
         );
         expect(find.text('Footer Text'), findsOneWidget);
         expect(listItems, orderedEquals(originalListItems));
@@ -135,6 +133,22 @@ void main() {
         await tester.pumpAndSettle();
         expect(find.text('Footer Text'), findsOneWidget);
         expect(listItems, orderedEquals(<String>['Item 2', 'Item 3', 'Item 4', 'Item 1']));
+
+        // Replaces a call to setState({}()) because onReorder can't call it.
+        // Otherwise this test fails because the Reorderable wants to switch
+        // the last two elements of the list, because we did't propagate the 
+        // changes from the listItems back to the ReorderableListView
+        await tester.pumpWidget(
+          build(footer: const Text('Footer Text')),
+        );
+        await longPressDrag(
+          tester,
+          tester.getCenter(find.text('Item 4')),
+          tester.getCenter(find.text('Item 3')),
+        );
+        await tester.pumpAndSettle();
+        expect(find.text('Footer Text'), findsOneWidget);
+        expect(listItems, orderedEquals(<String>['Item 2', 'Item 4', 'Item 3', 'Item 1']));
       });
 
       testWidgets('properly determines the vertical drop area extents', (WidgetTester tester) async {

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -104,7 +104,10 @@ void main() {
         await longPressDrag(
           tester,
           tester.getCenter(find.text('Item 4')),
-          tester.getCenter(find.text('Item 1')),
+          // the list item needs to be dragged a good amout above the first item
+          // so that it reaches the finalDropArea otherwise the bug described 
+          // in https://github.com/flutter/flutter/issues/51359 doesn't happen
+          tester.getCenter(find.text('Item 1')) - const Offset(0, itemHeight * 2),
         );
         expect(listItems, orderedEquals(<String>['Item 4', 'Item 1', 'Item 2', 'Item 3']));
       });


### PR DESCRIPTION
## Description

This PR adds a footer widget to [ReorderableListView](https://api.flutter.dev/flutter/material/ReorderableListView-class.html). It works the same way as the existing header widget.
It also fixes the reordering in reversed list as described in https://github.com/flutter/flutter/issues/51359

## Related Issues

Fixes https://github.com/flutter/flutter/issues/21195

## Tests

I added the following tests:
- I've added two tests which are basically the same as the header tests. One for a horizontal and one for a vertical list.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.
<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
