### PR TITLE
Add logging to diagnose timeouts on integration test

### DIFF
--- a/packages/flutter_tools/test/integration.shard/hot_reload_test.dart
+++ b/packages/flutter_tools/test/integration.shard/hot_reload_test.dart
@@ -131,6 +131,7 @@ void main() {
     final Completer<void> sawDebuggerPausedMessage2 = Completer<void>();
     final StreamSubscription<String> subscription = _flutter.stdout.listen(
       (String line) {
+        print('LOG:"$line"');
         if (line.contains('(((TICK 1)))')) {
           expect(sawTick1.isCompleted, isFalse);
           sawTick1.complete();


### PR DESCRIPTION
## Description

I thought this was fixed after running on CI several times before submitting. Adding some logging here so I can diagnose if there are further timeouts.