### PR TITLE
Avoid caching image load failures that are retriable

### DIFF
--- a/packages/flutter/lib/src/painting/_network_image_io.dart
+++ b/packages/flutter/lib/src/painting/_network_image_io.dart
@@ -8,8 +8,8 @@ import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/painting.dart';
 
+import 'binding.dart';
 import 'debug.dart';
 import 'image_provider.dart' as image_provider;
 import 'image_stream.dart';

--- a/packages/flutter/test/painting/image_provider_test.dart
+++ b/packages/flutter/test/painting/image_provider_test.dart
@@ -10,6 +10,7 @@ import 'dart:typed_data';
 import 'package:file/memory.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 
@@ -40,6 +41,50 @@ void main() {
     group('Image cache', () {
       tearDown(() {
         imageCache.clear();
+      });
+
+      test('AssetImageProvider - evicts on failure to load', () async {
+        final Completer<FlutterError> error = Completer<FlutterError>();
+        FlutterError.onError = (FlutterErrorDetails details) {
+          error.complete(details.exception as FlutterError);
+        };
+
+        const ImageProvider provider = ExactAssetImage('does-not-exist');
+        final Object key = await provider.obtainKey(ImageConfiguration.empty);
+        expect(imageCache.statusForKey(provider).untracked, true);
+        expect(imageCache.pendingImageCount, 0);
+
+        provider.resolve(ImageConfiguration.empty);
+
+        expect(imageCache.statusForKey(key).pending, true);
+        expect(imageCache.pendingImageCount, 1);
+
+        await error.future;
+
+        expect(imageCache.statusForKey(provider).untracked, true);
+        expect(imageCache.pendingImageCount, 0);
+      });
+
+      test('AssetImageProvider - evicts on null load', () async {
+        final Completer<StateError> error = Completer<StateError>();
+        FlutterError.onError = (FlutterErrorDetails details) {
+          error.complete(details.exception as StateError);
+        };
+
+        final ImageProvider provider = ExactAssetImage('does-not-exist', bundle: TestAssetBundle());
+        final Object key = await provider.obtainKey(ImageConfiguration.empty);
+        expect(imageCache.statusForKey(provider).untracked, true);
+        expect(imageCache.pendingImageCount, 0);
+
+        provider.resolve(ImageConfiguration.empty);
+
+        expect(imageCache.statusForKey(key).pending, true);
+        expect(imageCache.pendingImageCount, 1);
+
+        await error.future;
+
+        expect(imageCache.statusForKey(provider).untracked, true);
+        expect(imageCache.pendingImageCount, 0);
       });
 
       test('ImageProvider can evict images', () async {
@@ -168,7 +213,7 @@ void main() {
       expect(uncaught, false);
     });
 
-    test('File image with empty file throws expected error - (image cache)', () async {
+    test('File image with empty file throws expected error and evicts from cache', () async {
       final Completer<StateError> error = Completer<StateError>();
       FlutterError.onError = (FlutterErrorDetails details) {
         error.complete(details.exception as StateError);
@@ -177,9 +222,17 @@ void main() {
       final File file = fs.file('/empty.png')..createSync(recursive: true);
       final FileImage provider = FileImage(file);
 
+      expect(imageCache.statusForKey(provider).untracked, true);
+      expect(imageCache.pendingImageCount, 0);
+
       provider.resolve(ImageConfiguration.empty);
 
+      expect(imageCache.statusForKey(provider).pending, true);
+      expect(imageCache.pendingImageCount, 1);
+
       expect(await error.future, isStateError);
+      expect(imageCache.statusForKey(provider).untracked, true);
+      expect(imageCache.pendingImageCount, 0);
     });
 
     group('NetworkImage', () {
@@ -194,7 +247,7 @@ void main() {
         debugNetworkImageHttpClientProvider = null;
       });
 
-      test('Expect thrown exception with statusCode', () async {
+      test('Expect thrown exception with statusCode - evicts from cache', () async {
         final int errorStatusCode = HttpStatus.notFound;
         const String requestUrl = 'foo-url';
 
@@ -207,13 +260,24 @@ void main() {
         final Completer<dynamic> caughtError = Completer<dynamic>();
 
         final ImageProvider imageProvider = NetworkImage(nonconst(requestUrl));
+        expect(imageCache.pendingImageCount, 0);
+        expect(imageCache.statusForKey(imageProvider).untracked, true);
+
         final ImageStream result = imageProvider.resolve(ImageConfiguration.empty);
+
+        expect(imageCache.pendingImageCount, 1);
+        expect(imageCache.statusForKey(imageProvider).pending, true);
+
         result.addListener(ImageStreamListener((ImageInfo info, bool syncCall) {
         }, onError: (dynamic error, StackTrace stackTrace) {
           caughtError.complete(error);
         }));
 
         final dynamic err = await caughtError.future;
+
+        expect(imageCache.pendingImageCount, 0);
+        expect(imageCache.statusForKey(imageProvider).untracked, true);
+
         expect(
           err,
           isA<NetworkImageLoadException>()
@@ -465,3 +529,10 @@ class AsyncKeyMemoryImage extends MemoryImage {
 class MockHttpClient extends Mock implements HttpClient {}
 class MockHttpClientRequest extends Mock implements HttpClientRequest {}
 class MockHttpClientResponse extends Mock implements HttpClientResponse {}
+
+class TestAssetBundle extends CachingAssetBundle {
+  @override
+  Future<ByteData> load(String key) async {
+    return null;
+  }
+}

--- a/packages/flutter/test/painting/image_provider_test.dart
+++ b/packages/flutter/test/painting/image_provider_test.dart
@@ -35,6 +35,8 @@ void main() {
 
   tearDown(() {
     FlutterError.onError = oldError;
+    PaintingBinding.instance.imageCache.clear();
+    PaintingBinding.instance.imageCache.clearLiveImages();
   });
 
   group('ImageProvider', () {

--- a/packages/flutter/test/painting/image_provider_test.dart
+++ b/packages/flutter/test/painting/image_provider_test.dart
@@ -65,7 +65,7 @@ void main() {
 
         expect(imageCache.statusForKey(provider).untracked, true);
         expect(imageCache.pendingImageCount, 0);
-      });
+      }, skip: isBrowser);
 
       test('AssetImageProvider - evicts on null load', () async {
         final Completer<StateError> error = Completer<StateError>();
@@ -87,7 +87,7 @@ void main() {
 
         expect(imageCache.statusForKey(provider).untracked, true);
         expect(imageCache.pendingImageCount, 0);
-      });
+      }, skip: isBrowser);
 
       test('ImageProvider can evict images', () async {
         final Uint8List bytes = Uint8List.fromList(kTransparentImage);


### PR DESCRIPTION
## Description

If an image source fails to supply the image in a way that might change on a subsequent call, avoid having the cache hold on to a key for it.

For network images, the network may become available later, or the server will have the image later. Same for asset images, which might be network backed or be changed by hot reload/restart, and for file images, which may have file contents written at a later point in time.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/47270

## Tests

I added the following tests:

Added tests for asset images, updated existing tests for network and file images to check eviction on failure conditions.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

/cc @rogersxiao

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
