### PR TITLE
Validate text selection before updating it inside of EditableText

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -189,7 +189,7 @@ class TextEditingController extends ValueNotifier<TextEditingValue> {
   /// in a separate statement. To change both the [text] and the [selection]
   /// change the controller's [value].
   set selection(TextSelection newSelection) {
-    if (!isSelectionValid(newSelection))
+    if (!isSelectionWithinTextBounds(newSelection))
       throw FlutterError('invalid text selection: $newSelection');
     value = value.copyWith(selection: newSelection, composing: TextRange.empty);
   }
@@ -221,9 +221,8 @@ class TextEditingController extends ValueNotifier<TextEditingValue> {
     value = value.copyWith(composing: TextRange.empty);
   }
 
-  /// Check that the [selection] is valid, and not outside of the bounds of
-  /// [text].
-  bool isSelectionValid(TextSelection selection) {
+  /// Check that the [selection] is inside of the bounds of [text].
+  bool isSelectionWithinTextBounds(TextSelection selection) {
     return selection.start <= text.length && selection.end <= text.length;
   }
 }
@@ -1539,7 +1538,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     // We return early if the selection is not valid. This can happen when the
     // text of [EditableText] is updated at the same time as the selection is
     // changed by a gesture event.
-    if (!widget.controller.isSelectionValid(selection))
+    if (!widget.controller.isSelectionWithinTextBounds(selection))
       return;
 
     widget.controller.selection = selection;

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -189,7 +189,7 @@ class TextEditingController extends ValueNotifier<TextEditingValue> {
   /// in a separate statement. To change both the [text] and the [selection]
   /// change the controller's [value].
   set selection(TextSelection newSelection) {
-    if (newSelection.start > text.length || newSelection.end > text.length)
+    if (!isSelectionValid(newSelection))
       throw FlutterError('invalid text selection: $newSelection');
     value = value.copyWith(selection: newSelection, composing: TextRange.empty);
   }
@@ -219,6 +219,12 @@ class TextEditingController extends ValueNotifier<TextEditingValue> {
   /// actions, not during the build, layout, or paint phases.
   void clearComposing() {
     value = value.copyWith(composing: TextRange.empty);
+  }
+
+  /// Check that the [selection] is valid, and not outside of the bounds of
+  /// [text].
+  bool isSelectionValid(TextSelection selection) {
+    return selection.start <= text.length && selection.end <= text.length;
   }
 }
 
@@ -1530,6 +1536,12 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   }
 
   void _handleSelectionChanged(TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {
+    // We return early if the selection is not valid. This can happen when the
+    // text of [EditableText] is updated at the same time as the selection is
+    // changed by a gesture event.
+    if (!widget.controller.isSelectionValid(selection))
+      return;
+
     widget.controller.selection = selection;
 
     // This will show the keyboard for all selection changes on the

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -3379,6 +3379,30 @@ void main() {
     }
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/35848
+  testWidgets('Clearing text field does not cause exception', (WidgetTester tester) async {
+    final TextEditingController controller = TextEditingController(
+      text: 'Prefilled text.',
+    );
+
+    await tester.pumpWidget(
+      boilerplate(
+        child: TextField(
+          controller: controller,
+          decoration: InputDecoration(
+            suffixIcon: IconButton(
+              icon: Icon(Icons.close),
+              onPressed: controller.clear,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(IconButton));
+    expect(controller.text, null);
+  });
+
   testWidgets('maxLength limits input.', (WidgetTester tester) async {
     final TextEditingController textController = TextEditingController();
 

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -3391,7 +3391,7 @@ void main() {
           controller: controller,
           decoration: InputDecoration(
             suffixIcon: IconButton(
-              icon: Icon(Icons.close),
+              icon: const Icon(Icons.close),
               onPressed: controller.clear,
             ),
           ),

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -3380,7 +3380,7 @@ void main() {
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/35848
-  testWidgets('Clearing text field does not cause exception', (WidgetTester tester) async {
+  testWidgets('Clearing text field with suffixIcon does not cause text selection exception', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController(
       text: 'Prefilled text.',
     );
@@ -3400,7 +3400,7 @@ void main() {
     );
 
     await tester.tap(find.byType(IconButton));
-    expect(controller.text, null);
+    expect(controller.text, '');
   });
 
   testWidgets('maxLength limits input.', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

#### Reproducible example: [See dartpad](https://dartpad.dartlang.org/0c8069eb160d50440ba2961f8d4c7a05)

For `TextField`s with a suffixIcon, if we tap on the suffixIcon we will get two tap events:
1. The `onTap` gesture will be activated for the `IconButton`, which is clearing the TextField.
2. As we're tapping inside of the `TextField`, we will also have a tap event for the [`TextSelectionGestureDetector`](https://github.com/flutter/flutter/blob/0b8abb4724/packages/flutter/lib/src/widgets/text_selection.dart#L1135) that selects text. 

For the `TextSelectionGestureDetector` to figure out what text to select it uses the [`_textPainter`](https://github.com/flutter/flutter/blob/f15c887c6349b10a0802e7d191cb109e7a70a17d/packages/flutter/lib/src/rendering/editable.dart#L244). Inside of the [`EditableText.selectWordEdge`](https://github.com/flutter/flutter/blob/f15c887c6349b10a0802e7d191cb109e7a70a17d/packages/flutter/lib/src/rendering/editable.dart#L1659) we call `_textPainter.getPositionForOffset`. The `_textPainter` contains the text before we cleared it, thus we are getting invalid positions to select.

To fix this, we're now checking that the new selection is valid before updating it.


## Related Issues

Fixes https://github.com/flutter/flutter/issues/35848

## Tests

I added the following tests:

- Clearing text field with suffixIcon does not cause text selection exception
## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
