### PR TITLE
[flutter_tools] Rework iOS vmservice handshake failure usage event

### DIFF
--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -386,7 +386,7 @@ void main() {
         );
         verify(mockUsage.sendEvent(
           'ios-handshake',
-          'failure',
+          'failure-other',
           label: anyNamed('label'),
           value: anyNamed('value'),
         )).called(1);


### PR DESCRIPTION
## Description

Improves the ios-handshake/failure event:
- Reports the device-side port instead of the host-side port.
- Stops reporting the port as an event value.
- Uses different event actions for different failure kinds.
- Filters uri out of HttpException for the event label to focus on potential problematic device-side ports.

## Related Issues

Making analytics data more useful.

## Tests

I added the following tests:

Updated existing tests.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
