### PR TITLE
[WIP] add BoxDecoration back to dialog and action sheet

### DIFF
--- a/packages/flutter/lib/src/cupertino/action_sheet.dart
+++ b/packages/flutter/lib/src/cupertino/action_sheet.dart
@@ -32,6 +32,20 @@ const TextStyle _kActionSheetContentStyle = TextStyle(
   textBaseline: TextBaseline.alphabetic,
 );
 
+// This decoration is applied to the blurred backdrop to lighten the blurred
+// image. Brightening is done to counteract the dark modal barrier that
+// appears behind the alert. The overlay blend mode does the brightening.
+// The white color doesn't paint any white, it's just the basis for the
+// overlay blend mode.
+//
+// The decoration is needed for `CupertinoActionSheet` to not appear excessively
+// transparent when placed above a PlatformView. See
+// https://github.com/flutter/flutter/issues/50183.
+const BoxDecoration _kAlertBlurOverlayDecoration = BoxDecoration(
+  color: CupertinoColors.white,
+  backgroundBlendMode: BlendMode.overlay,
+);
+
 // Translucent, very light gray that is painted on top of the blurred backdrop
 // as the action sheet's background color.
 // TODO(LongCatIsLooong): https://github.com/flutter/flutter/issues/39272. Use
@@ -215,9 +229,12 @@ class CupertinoActionSheet extends StatelessWidget {
           borderRadius: BorderRadius.circular(12.0),
           child: BackdropFilter(
             filter: ImageFilter.blur(sigmaX: _kBlurAmount, sigmaY: _kBlurAmount),
-            child: _CupertinoAlertRenderWidget(
-              contentSection: Builder(builder: _buildContent),
-              actionsSection: _buildActions(),
+            child: Container(
+              decoration: _kAlertBlurOverlayDecoration,
+              child: _CupertinoAlertRenderWidget(
+                contentSection: Builder(builder: _buildContent),
+                actionsSection: _buildActions(),
+              ),
             ),
           ),
         ),

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -5,7 +5,7 @@
 // @dart = 2.8
 
 import 'dart:math' as math;
-import 'dart:ui' show ImageFilter;
+import 'dart:ui' show ImageFilter, Brightness;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
@@ -51,12 +51,26 @@ const TextStyle _kCupertinoDialogActionStyle = TextStyle(
 const double _kCupertinoDialogWidth = 270.0;
 const double _kAccessibilityCupertinoDialogWidth = 310.0;
 
-const double _kBlurAmount = 20.0;
+const double _kBlurAmount = 29.5;
 const double _kEdgePadding = 20.0;
 const double _kMinButtonHeight = 45.0;
 const double _kMinButtonFontSize = 10.0;
 const double _kDialogCornerRadius = 14.0;
 const double _kDividerThickness = 1.0;
+
+// _kCupertinoDialogBlurOverlayDecoration is applied to the blurred backdrop to
+// lighten the blurred image. Brightening is done to counteract the dark modal
+// barrier that appears behind the dialog. The overlay blend mode does the
+// brightening. The white color doesn't paint any white, it's just the basis
+// for the overlay blend mode.
+//
+// The decoration is needed for `CupertinoPopupSurface` to not appear excessively
+// transparent when placed above a PlatformView. See
+// https://github.com/flutter/flutter/issues/50183.
+const BoxDecoration _kCupertinoDialogBlurOverlayDecoration = BoxDecoration(
+  color: CupertinoColors.white,
+  backgroundBlendMode: BlendMode.overlay,
+);
 
 // A translucent color that is painted on top of the blurred backdrop as the
 // dialog's background color
@@ -354,13 +368,23 @@ class CupertinoPopupSurface extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    BoxDecoration decoration;
+
+    switch (MediaQuery.platformBrightnessOf(context)) {
+      case Brightness.light:
+      case Brightness.dark:
+    }
+
     return ClipRRect(
       borderRadius: BorderRadius.circular(_kDialogCornerRadius),
       child: BackdropFilter(
         filter: ImageFilter.blur(sigmaX: _kBlurAmount, sigmaY: _kBlurAmount),
         child: Container(
-          color: isSurfacePainted ? CupertinoDynamicColor.resolve(_kDialogColor, context) : null,
-          child: child,
+          decoration: _kCupertinoDialogBlurOverlayDecoration,
+          child: Container(
+            color: isSurfacePainted ? CupertinoDynamicColor.resolve(_kDialogColor, context) : null,
+            child: child,
+          ),
         ),
       ),
     );

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -67,10 +67,19 @@ const double _kDividerThickness = 1.0;
 // The decoration is needed for `CupertinoPopupSurface` to not appear excessively
 // transparent when placed above a PlatformView. See
 // https://github.com/flutter/flutter/issues/50183.
-const BoxDecoration _kCupertinoDialogBlurOverlayDecoration = BoxDecoration(
-  color: CupertinoColors.white,
-  backgroundBlendMode: BlendMode.overlay,
+const BoxDecoration _kCupertinoDialogBlurDecorationLight = BoxDecoration(
+  color: Color(0xFFE6E6E6),
+  backgroundBlendMode: BlendMode.luminosity,
 );
+const BoxDecoration _kCupertinoDialogBlurDecorationDark = BoxDecoration(
+  color: Color(0xFF191919),
+  backgroundBlendMode: BlendMode.luminosity,
+);
+const BoxDecoration _kCupertinoDialogSaturationDecoration = BoxDecoration(
+  color: Color(0xFFFF0000),
+  backgroundBlendMode: BlendMode.dst,
+);
+
 
 // A translucent color that is painted on top of the blurred backdrop as the
 // dialog's background color
@@ -211,7 +220,7 @@ class CupertinoAlertDialog extends StatelessWidget {
     ];
 
     return Container(
-      color: CupertinoDynamicColor.resolve(_kDialogColor, context),
+      //color: CupertinoDynamicColor.resolve(_kDialogColor, context),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -372,18 +381,25 @@ class CupertinoPopupSurface extends StatelessWidget {
 
     switch (MediaQuery.platformBrightnessOf(context)) {
       case Brightness.light:
+        decoration = _kCupertinoDialogBlurDecorationLight;
+        break;
       case Brightness.dark:
+        decoration = _kCupertinoDialogBlurDecorationDark;
+        break;
     }
 
     return ClipRRect(
       borderRadius: BorderRadius.circular(_kDialogCornerRadius),
       child: BackdropFilter(
         filter: ImageFilter.blur(sigmaX: _kBlurAmount, sigmaY: _kBlurAmount),
-        child: Container(
-          decoration: _kCupertinoDialogBlurOverlayDecoration,
-          child: Container(
-            color: isSurfacePainted ? CupertinoDynamicColor.resolve(_kDialogColor, context) : null,
-            child: child,
+        child: DecoratedBox(
+            decoration: _kCupertinoDialogSaturationDecoration,
+          child: DecoratedBox(
+          decoration: decoration,
+            child: Container(
+              color: null,//isSurfacePainted ? CupertinoDynamicColor.resolve(_kDialogColor, context) : null,
+              child: child,
+            ),
           ),
         ),
       ),

--- a/packages/flutter/test/cupertino/action_sheet_test.dart
+++ b/packages/flutter/test/cupertino/action_sheet_test.dart
@@ -31,6 +31,32 @@ void main() {
     expect(find.text('Action Sheet'), findsNothing);
   });
 
+  testWidgets(
+    'Action sheets contain BoxDecoration with overlay blend mode',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        createAppWithButtonThatLaunchesActionSheet(
+          const CupertinoActionSheet(
+            title: Text('Action Sheet'),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Go'));
+      await tester.pump();
+
+      expect(
+        find.widgetWithText(DecoratedBox, 'Action Sheet')
+          .evaluate()
+          .map((Element element) => element.widget)
+          .whereType<DecoratedBox>()
+          .map((DecoratedBox box) => box.decoration)
+          .whereType<BoxDecoration>()
+          .any((BoxDecoration decoration) => decoration.backgroundBlendMode == BlendMode.overlay),
+        isTrue,
+      );
+  });
+
   testWidgets('Verify that a tap on title section (not buttons) does not dismiss an action sheet', (WidgetTester tester) async {
     await tester.pumpWidget(
       createAppWithButtonThatLaunchesActionSheet(

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -149,7 +149,9 @@ void main() {
 
     expect(
       find.byType(CupertinoAlertDialog),
-      paints..rect(color: const Color(0xBF1E1E1E)),
+      paints
+        ..rect(color: const Color(0xFFFFFFFF))
+        ..rect(color: const Color(0xBF1E1E1E)),
     );
   });
 
@@ -247,6 +249,30 @@ void main() {
 
     expect(widget.style.color.withAlpha(255), CupertinoColors.systemRed.color);
     expect(widget.style.fontWeight, equals(FontWeight.w600));
+  });
+
+  testWidgets(
+    'Dialog contains BoxDecoration with overlay blend mode',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: MediaQuery(
+            data: MediaQueryData(viewInsets: EdgeInsets.zero),
+            child: CupertinoAlertDialog(content: Text('Ok')),
+          ),
+        ),
+      );
+
+      expect(
+        find.widgetWithText(DecoratedBox, 'Ok')
+          .evaluate()
+          .map((Element element) => element.widget)
+          .whereType<DecoratedBox>()
+          .map((DecoratedBox box) => box.decoration)
+          .whereType<BoxDecoration>()
+          .any((BoxDecoration decoration) => decoration.backgroundBlendMode == BlendMode.overlay),
+        isTrue,
+      );
   });
 
   testWidgets('Dialog disabled action style', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

Add the `BoxDecoration` with overlay blendMode back, to mitigate https://github.com/flutter/flutter/issues/50183. Breaks one test.

## Screenshots
Looks fine to me in general but there's an unwanted glowing effect in dark mode around the action sheet.

Light Mode  | Dark Mode
 --- | --- 
![Simulator Screen Shot - iPhone 11 Pro - 2020-02-25 at 10 08 07](https://user-images.githubusercontent.com/31859944/75275056-c3468880-57b8-11ea-8a8e-dcfcc4ec72df.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-02-25 at 10 09 06](https://user-images.githubusercontent.com/31859944/75275073-c9d50000-57b8-11ea-89a2-2d34c9d10f0c.png) 
![Simulator Screen Shot - iPhone 11 Pro - 2020-02-25 at 10 08 32](https://user-images.githubusercontent.com/31859944/75275098-d3f6fe80-57b8-11ea-831d-4fdddfc455ad.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-02-25 at 10 09 13](https://user-images.githubusercontent.com/31859944/75275121-db1e0c80-57b8-11ea-8f45-296d2e6199a0.png)
![Simulator Screen Shot - iPhone 11 Pro - 2020-02-25 at 10 10 43](https://user-images.githubusercontent.com/31859944/75275128-df4a2a00-57b8-11ea-8c18-6fa688a5eea3.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-02-25 at 10 11 07](https://user-images.githubusercontent.com/31859944/75275141-e40ede00-57b8-11ea-8119-209c2018971c.png)









## Related Issues

https://github.com/flutter/flutter/issues/50183

## Tests

I added the following tests:

- Dialog contains BoxDecoration with overlay blend mode.
- Action sheets contain BoxDecoration with overlay blend mode

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
