### PR TITLE
Add debugDoingBuild flag

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2054,7 +2054,7 @@ abstract class BuildContext {
 
   /// Determines if [widget] is in the process of updating.
   ///
-  /// This flag will return `true` if [widget] is in a life-cycles that both:
+  /// This flag will return `true` if [widget] is in a lifecycle that both:
   /// - declaratively updates a tree ([Widget] tree, [RenderObject] tree)
   /// - can consume an [InheritedWidget]
   /// 

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2052,6 +2052,19 @@ abstract class BuildContext {
   /// managing the rendering pipeline for this context.
   BuildOwner get owner;
 
+  /// Determines if [widget] is in the process of updating.
+  ///
+  /// This flag will return `true` if [widget] is in one of those life-cycles:
+  /// - [StatelessWidget.build]
+  /// - [State.build]
+  /// - [RenderObjectWidget.createRenderObject]
+  /// - [RenderObjectWidget.updateRenderObject]
+  ///
+  /// Othwerwise, it will return `false`.
+  ///
+  /// Always Returns `null` in release mode.
+  bool get debugDoingBuild;
+
   /// The current [RenderObject] for the widget. If the widget is a
   /// [RenderObjectWidget], this is the render object that the widget created
   /// for itself. Otherwise, it is the render object of the first descendant
@@ -4448,6 +4461,10 @@ abstract class ComponentElement extends Element {
 
   Element _child;
 
+  bool _debugDoingBuild = false;
+  @override
+  bool get debugDoingBuild => _debugDoingBuild;
+
   @override
   void mount(Element parent, dynamic newSlot) {
     super.mount(parent, newSlot);
@@ -4475,9 +4492,18 @@ abstract class ComponentElement extends Element {
     assert(_debugSetAllowIgnoredCallsToMarkNeedsBuild(true));
     Widget built;
     try {
+      assert(() {
+        _debugDoingBuild = true;
+        return true;
+      }());
       built = build();
+      assert(() {
+        _debugDoingBuild = false;
+        return true;
+      }());
       debugWidgetBuilderValue(widget, built);
     } catch (e, stack) {
+      _debugDoingBuild = false;
       built = ErrorWidget.builder(
         _debugReportException(
           ErrorDescription('building $this'),
@@ -5270,6 +5296,10 @@ abstract class RenderObjectElement extends Element {
   RenderObject get renderObject => _renderObject;
   RenderObject _renderObject;
 
+  bool _debugDoingBuild = false;
+  @override
+  bool get debugDoingBuild => _debugDoingBuild;
+
   RenderObjectElement _ancestorRenderObjectElement;
 
   RenderObjectElement _findAncestorRenderObjectElement() {
@@ -5326,7 +5356,15 @@ abstract class RenderObjectElement extends Element {
   @override
   void mount(Element parent, dynamic newSlot) {
     super.mount(parent, newSlot);
+    assert(() {
+      _debugDoingBuild = true;
+      return true;
+    }());
     _renderObject = widget.createRenderObject(this);
+    assert(() {
+      _debugDoingBuild = false;
+      return true;
+    }());
     assert(() {
       _debugUpdateRenderObjectOwner();
       return true;
@@ -5344,7 +5382,15 @@ abstract class RenderObjectElement extends Element {
       _debugUpdateRenderObjectOwner();
       return true;
     }());
+    assert(() {
+      _debugDoingBuild = true;
+      return true;
+    }());
     widget.updateRenderObject(this, renderObject);
+    assert(() {
+      _debugDoingBuild = false;
+      return true;
+    }());
     _dirty = false;
   }
 
@@ -5357,7 +5403,15 @@ abstract class RenderObjectElement extends Element {
 
   @override
   void performRebuild() {
+    assert(() {
+      _debugDoingBuild = true;
+      return true;
+    }());
     widget.updateRenderObject(this, renderObject);
+    assert(() {
+      _debugDoingBuild = false;
+      return true;
+    }());
     _dirty = false;
   }
 

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2062,7 +2062,7 @@ abstract class BuildContext {
   ///
   /// Othwerwise, it will return `false`.
   ///
-  /// Always Returns `null` in release mode.
+  /// Always returns `false` in release mode.
   bool get debugDoingBuild;
 
   /// The current [RenderObject] for the widget. If the widget is a

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2052,21 +2052,20 @@ abstract class BuildContext {
   /// managing the rendering pipeline for this context.
   BuildOwner get owner;
 
-  /// Determines if [widget] is in the process of updating.
+  /// Whether the [widget] is currently updating the widget or render tree.
   ///
-  /// This flag will return `true` if [widget] is in a lifecycle that both:
-  /// - declaratively updates a tree ([Widget] tree, [RenderObject] tree)
-  /// - can consume an [InheritedWidget]
-  /// 
-  /// This includes:
-  /// - [StatelessWidget.build]
-  /// - [State.build]
-  /// - [RenderObjectWidget.createRenderObject]
-  /// - [RenderObjectWidget.updateRenderObject]
+  /// For [StatefullWidget]s and [StatelessWidget]s this flag is true while
+  /// their respective build methods are executing.
+  /// [RenderObjectWidget]s set this to true while creating or configuring their
+  /// associated [RenderObject]s.
+  /// Other [Widget] types may set this to true for conceptually similar phases
+  /// of their lifecycle.
   ///
-  /// Othwerwise, it will return `false`.
+  /// When this is true, it is safe for [widget] to establish a dependency to an
+  /// [InheritedWidget] by calling [dependOnInheritedElement] or
+  /// [dependOnInheritedWidgetOfExactType].
   ///
-  /// Always returns `false` in release mode.
+  /// Accessing this flag in release mode is not valid.
   bool get debugDoingBuild;
 
   /// The current [RenderObject] for the widget. If the widget is a

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2054,7 +2054,11 @@ abstract class BuildContext {
 
   /// Determines if [widget] is in the process of updating.
   ///
-  /// This flag will return `true` if [widget] is in one of those life-cycles:
+  /// This flag will return `true` if [widget] is in a life-cycles that both:
+  /// - declaratively updates a tree ([Widget] tree, [RenderObject] tree)
+  /// - can consume an [InheritedWidget]
+  /// 
+  /// This includes:
   /// - [StatelessWidget.build]
   /// - [State.build]
   /// - [RenderObjectWidget.createRenderObject]

--- a/packages/flutter/test/foundation/diagnostics_json_test.dart
+++ b/packages/flutter/test/foundation/diagnostics_json_test.dart
@@ -225,6 +225,9 @@ class _TestElement extends Element {
   void performRebuild() {
     // Intentionally left empty.
   }
+
+  @override
+  bool get debugDoingBuild => throw UnimplementedError();
 }
 
 class TestTree extends Object with DiagnosticableTreeMixin {


### PR DESCRIPTION
## Description

Adds a `debugDoingBuild` flag on `BuildContext`.
This allows libraries to know if the widget associated with a `BuildContext` is in the process of updating.

It can further be used by libraries to do some assertions to make sure the library is used correctly.


## Related Issues

closes #49505

## Tests

I added the following tests:

On `framework_test.dart` a few tests that asserts the behavior of `BuildContext.debugDoingBuild` for `StatelessWidget`/`StatefuWidget`/`RenderObjectWidget`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
