### PR TITLE
[flutter_tools] Don't try to run pub before the version command

### DIFF
--- a/packages/flutter_tools/lib/src/commands/version.dart
+++ b/packages/flutter_tools/lib/src/commands/version.dart
@@ -17,10 +17,16 @@ import '../version.dart';
 
 class VersionCommand extends FlutterCommand {
   VersionCommand() : super() {
-    usesPubOption(hide: true);
     argParser.addFlag('force',
       abbr: 'f',
       help: 'Force switch to older Flutter versions that do not include a version command',
+    );
+    // Don't use usesPubOption here. That will cause the version command to
+    // require a pubspec.yaml file, which it doesn't need.
+    argParser.addFlag('pub',
+      defaultsTo: true,
+      hide: true,
+      help: 'Whether to run "flutter pub get" after switching versions.',
     );
   }
 
@@ -138,7 +144,7 @@ class VersionCommand extends FlutterCommand {
     globals.printStatus(flutterVersion.toString());
 
     final String projectRoot = findProjectRoot();
-    if (projectRoot != null && shouldRunPub) {
+    if (projectRoot != null && boolArg('pub')) {
       globals.printStatus('');
       await pub.get(
         context: PubContext.pubUpgrade,

--- a/packages/flutter_tools/test/commands.shard/hermetic/version_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/version_test.dart
@@ -170,6 +170,17 @@ void main() {
       ProcessManager: () => MockProcessManager(failGitTag: true),
       Stdio: () => mockStdio,
     });
+
+    testUsingContext('Does not run pub when outside a project', () async {
+      final VersionCommand command = VersionCommand();
+      await createTestCommandRunner(command).run(<String>[
+        'version',
+      ]);
+      expect(testLogger.statusText, equals('v10.0.0\r\nv20.0.0\n'));
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => MockProcessManager(),
+      Stdio: () => mockStdio,
+    });
   });
 }
 


### PR DESCRIPTION
## Description

https://github.com/flutter/flutter/pull/45628 added `usesPubOption` to the version command to allow skipping running `pub` after changing versions. This unintentionally also caused it to try to run `pub` before doing any work, which makes it fail if there no Flutter project can be found the tool cwd.

Instead of using `FlutterCommand.usesPubOption`, this PR gives the version command its own pub option.

## Related Issues

https://github.com/flutter/flutter/issues/51388

## Tests

I added the following tests:

Added a test that pub is not called if there is no project.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
