### PR TITLE
Reduce closure allocation in RenderObject.cleanRelayoutBoundary

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1584,10 +1584,13 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
     if (_relayoutBoundary != this) {
       _relayoutBoundary = null;
       _needsLayout = true;
-      visitChildren((RenderObject child) {
-        child._cleanRelayoutBoundary();
-      });
+      visitChildren(_cleanChildRelayoutBoundary);
     }
+  }
+
+  // Reduces closure allocation for visitChildren use cases.
+  static void _cleanChildRelayoutBoundary(RenderObject child) {
+    child._cleanRelayoutBoundary();
   }
 
   /// Bootstrap the rendering pipeline by scheduling the very first layout.
@@ -1724,9 +1727,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
       // The local relayout boundary has changed, must notify children in case
       // they also need updating. Otherwise, they will be confused about what
       // their actual relayout boundary is later.
-      visitChildren((RenderObject child) {
-        child._cleanRelayoutBoundary();
-      });
+      visitChildren(_cleanChildRelayoutBoundary);
     }
     _relayoutBoundary = relayoutBoundary;
     assert(!_debugMutationsLocked);


### PR DESCRIPTION
## Description

Changes visitChildren closure allocation to use static method instead.

## Related Issues

Discovered while profiling web EAP client project.

## Tests
Covered by gallery benchmark.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.
