### PR TITLE
Android 10: System Gesture Exclusion Rects

### DIFF
--- a/packages/flutter/lib/services.dart
+++ b/packages/flutter/lib/services.dart
@@ -31,7 +31,7 @@ export 'src/services/raw_keyboard_macos.dart';
 export 'src/services/raw_keyboard_web.dart';
 export 'src/services/system_channels.dart';
 export 'src/services/system_chrome.dart';
-export 'src/services/system_gesture.dart';
+export 'src/services/system_gestures.dart';
 export 'src/services/system_navigator.dart';
 export 'src/services/system_sound.dart';
 export 'src/services/text_editing.dart';

--- a/packages/flutter/lib/services.dart
+++ b/packages/flutter/lib/services.dart
@@ -31,6 +31,7 @@ export 'src/services/raw_keyboard_macos.dart';
 export 'src/services/raw_keyboard_web.dart';
 export 'src/services/system_channels.dart';
 export 'src/services/system_chrome.dart';
+export 'src/services/system_gesture.dart';
 export 'src/services/system_navigator.dart';
 export 'src/services/system_sound.dart';
 export 'src/services/text_editing.dart';

--- a/packages/flutter/lib/src/services/system_gesture.dart
+++ b/packages/flutter/lib/src/services/system_gesture.dart
@@ -1,0 +1,50 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+
+import 'system_channels.dart';
+
+class SystemGesture {
+  static Future<void> setSystemGestureExclusionRects({
+    @required List<Rect> rects,
+    @required double devicePixelRatio,
+  }) async {
+    assert(devicePixelRatio != null);
+
+    try {
+      await SystemChannels.platform.invokeMethod<void>(
+        'SystemGestures.setSystemGestureExclusionRects',
+        _convertToListOfMaps(
+          rects: rects,
+          devicePixelRatio: devicePixelRatio
+        ),
+      );
+    } on Exception catch (error) {
+      throw 'Failed to set systemGestureExclusionRects: $error';
+    }
+  }
+
+  static List<Map<String, int>> _convertToListOfMaps({
+    List<Rect> rects,
+    double devicePixelRatio = 1.0,
+  }) {
+    assert(devicePixelRatio != null);
+
+    if (rects != null && rects.isNotEmpty) {
+      return rects.map<Map<String,int>>((Rect rect) {
+        return <String, int>{
+          'left': (rect.left * devicePixelRatio).toInt(),
+          'top': (rect.top * devicePixelRatio).toInt(),
+          'right': (rect.right * devicePixelRatio).toInt(),
+          'bottom': (rect.bottom * devicePixelRatio).toInt(),
+        };
+      }).toList();
+    }
+    return <Map<String, int>>[];
+  }
+}

--- a/packages/flutter/lib/src/services/system_gesture.dart
+++ b/packages/flutter/lib/src/services/system_gesture.dart
@@ -31,7 +31,7 @@ class SystemGesture {
 
   static List<Map<String, int>> _convertToListOfMaps({
     List<Rect> rects,
-    double devicePixelRatio = 1.0,
+    @required double devicePixelRatio,
   }) {
     assert(devicePixelRatio != null);
 
@@ -46,5 +46,40 @@ class SystemGesture {
       }).toList();
     }
     return <Map<String, int>>[];
+  }
+
+  static Future<List<Rect>> getSystemGestureExclusionRects({
+    @required double devicePixelRatio,
+  }) async {
+    assert(devicePixelRatio != null);
+
+    try {
+      final List<dynamic> rects = await SystemChannels.platform.invokeMethod(
+        'SystemGestures.getSystemGestureExclusionRects',
+      );
+      return _convertToListOfRects(
+        rects: rects,
+        devicePixelRatio: devicePixelRatio,
+      );
+    } on Exception catch (error) {
+      throw 'Failed to set systemGestureExclusionRects: $error';
+    }
+  }
+
+  static List<Rect> _convertToListOfRects({
+    List<dynamic> rects,
+    @required double devicePixelRatio,
+  }) {
+    assert(devicePixelRatio != null);
+
+    return rects.map((dynamic rect) {
+      final Map<String, dynamic> exclusionMap = rect as Map<String, dynamic>;
+      final double left = (exclusionMap['left'] as int).toDouble() / devicePixelRatio;
+      final double top = (exclusionMap['top'] as int).toDouble() / devicePixelRatio;
+      final double right = (exclusionMap['right'] as int).toDouble() / devicePixelRatio;
+      final double bottom = (exclusionMap['bottom'] as int).toDouble() / devicePixelRatio;
+
+      return Rect.fromLTRB(left, top, right, bottom);
+    }).toList();
   }
 }

--- a/packages/flutter/lib/src/services/system_gestures.dart
+++ b/packages/flutter/lib/src/services/system_gestures.dart
@@ -9,7 +9,30 @@ import 'package:flutter/foundation.dart';
 
 import 'system_channels.dart';
 
+/// Provides access to Android APIs involving system gestures.
+///
+/// Starting from Android 10, Android users can enable system gesture
+/// navigation, reserving the edges of the device's screen
+/// for system level gestures. These APIs provide a way to resolve
+/// gesture conflicts and receive system gesture information from the
+/// device.
 class SystemGestures {
+  /// Sets system gesture exclusion rectangles for Android devices.
+  ///
+  /// Sets a list of [Rect]s within the application where the system should not
+  /// intercept touch or other pointing device gestures. A sample use-case for
+  /// this API is an image editing app with drag handles to crop an image. A
+  /// developer may want to set exclusion rects where the drag handles are if
+  /// they get too close to the edges of the screen.
+  ///
+  /// While this gesture exclusions API can fix gesture conflicts for some
+  /// applications, it is better to avoid using this API if possible. Using
+  /// this API can cause confusion for users who expect a swipe from the
+  /// edge of the screen to perform a system action. Hence, this API is meant
+  /// to be an escape hatch there is no alternative.
+  ///
+  /// The [devicePixelRatio] must not be null, and is typically received by
+  /// calling MediaQuery.of(context).devicePixelRatio.
   static Future<void> setSystemGestureExclusionRects({
     @required List<Rect> rects,
     @required double devicePixelRatio,
@@ -48,6 +71,14 @@ class SystemGestures {
     return <Map<String, int>>[];
   }
 
+  /// Gets system gesture exclusion rectangles for Android devices.
+  ///
+  /// Receives a list of [Rect]s within the application where the system will
+  /// not intercept touch or other pointing device gestures. It returns an
+  /// empty list if no system gesture exclusion rects have been set.
+  ///
+  /// The [devicePixelRatio] must not be null, and is typically received by
+  /// calling MediaQuery.of(context).devicePixelRatio.
   static Future<List<Rect>> getSystemGestureExclusionRects({
     @required double devicePixelRatio,
   }) async {

--- a/packages/flutter/lib/src/services/system_gestures.dart
+++ b/packages/flutter/lib/src/services/system_gestures.dart
@@ -25,6 +25,12 @@ class SystemGestures {
   /// developer may want to set exclusion rects where the drag handles are if
   /// they get too close to the edges of the screen.
   ///
+  /// The system also puts a limit of 200 pixels on the vertical extent of the
+  /// exclusions it takes into account on each edge. For example, if 400
+  /// vertical pixels were requested from the left edge of the screen, only
+  /// the top 200 pixels will be excluded, while the bottom 200 pixels will
+  /// continue to be reserved for system level gestures.
+  ///
   /// While this gesture exclusions API can fix gesture conflicts for some
   /// applications, it is better to avoid using this API if possible. Using
   /// this API can cause confusion for users who expect a swipe from the

--- a/packages/flutter/lib/src/services/system_gestures.dart
+++ b/packages/flutter/lib/src/services/system_gestures.dart
@@ -9,7 +9,7 @@ import 'package:flutter/foundation.dart';
 
 import 'system_channels.dart';
 
-class SystemGesture {
+class SystemGestures {
   static Future<void> setSystemGestureExclusionRects({
     @required List<Rect> rects,
     @required double devicePixelRatio,

--- a/packages/flutter/lib/src/services/system_gestures.dart
+++ b/packages/flutter/lib/src/services/system_gestures.dart
@@ -37,6 +37,9 @@ class SystemGestures {
   /// edge of the screen to perform a system action. Hence, this API is meant
   /// to be an escape hatch there is no alternative.
   ///
+  /// To clear the system gesture exclusion rects, call this function with
+  /// [rects] set to null.
+  ///
   /// The [devicePixelRatio] must not be null, and is typically received by
   /// calling MediaQuery.of(context).devicePixelRatio.
   static Future<void> setSystemGestureExclusionRects({
@@ -54,7 +57,7 @@ class SystemGestures {
         ),
       );
     } on Exception catch (error) {
-      throw 'Failed to set systemGestureExclusionRects: $error';
+      throw 'Failed to set system gesture exclusion rects: $error';
     }
   }
 
@@ -99,7 +102,7 @@ class SystemGestures {
         devicePixelRatio: devicePixelRatio,
       );
     } on Exception catch (error) {
-      throw 'Failed to set systemGestureExclusionRects: $error';
+      throw 'Failed to get system gesture exclusion rects: $error';
     }
   }
 

--- a/packages/flutter/test/services/system_gestures_test.dart
+++ b/packages/flutter/test/services/system_gestures_test.dart
@@ -1,0 +1,54 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('setSystemGestureExclusionRects control test', (WidgetTester tester) async {
+    final List<MethodCall> log = <MethodCall>[];
+
+    SystemChannels.platform.setMockMethodCallHandler((MethodCall methodCall) async {
+      log.add(methodCall);
+    });
+
+    await SystemGestures.setSystemGestureExclusionRects(
+      rects: <Rect>[const Rect.fromLTRB(0, 0, 100, 100)],
+      devicePixelRatio: 1.0,
+    );
+
+    expect(log, hasLength(1));
+    expect(log.single, isMethodCall(
+      'SystemGestures.setSystemGestureExclusionRects',
+      arguments: <Map<String, int>>[
+        <String, int>{
+          'left': 0,
+          'top': 0,
+          'right': 100,
+          'bottom': 100,
+        }
+      ],
+    ));
+  });
+
+  testWidgets('getSystemGestureExclusionRects control test', (WidgetTester tester) async {
+    SystemChannels.platform.setMockMethodCallHandler((MethodCall methodCall) async {
+      return <Map<String, int>>[
+        <String, int>{
+          'left': 0,
+          'top': 0,
+          'right': 100,
+          'bottom': 100,
+        }
+      ];
+    });
+
+    final List<Rect> result = await SystemGestures.getSystemGestureExclusionRects(
+      devicePixelRatio: 1.0,
+    );
+    expect(result, <Rect>[const Rect.fromLTRB(0, 0, 100, 100)]);
+  });
+}


### PR DESCRIPTION
## Description

Exposes setSystemGestureExclusionRects and getSystemGestureExclusionRects to the Flutter framework.

### Sample code
When `_setRects` is true, the top left side of the application ignores system level gesture navigation. Otherwise, it takes precedence over the app's gestures.

```dart
import 'package:flutter/material.dart';
import 'package:flutter/services.dart';

void main() => runApp(MyApp());

class MyApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      home: MyHomePage(),
    );
  }
}

class MyHomePage extends StatefulWidget {
  @override
  _MyHomePageState createState() => _MyHomePageState();
}

class _MyHomePageState extends State<MyHomePage> {
  bool _setRects = true;

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(),
      body: Column(
        mainAxisAlignment: MainAxisAlignment.center,
        children: <Widget>[
          Center(
            child: RaisedButton(
              onPressed: () async {
                List<Rect> rect;
                if (_setRects)
                  rect = null;
                else
                  rect = [Rect.fromLTRB(0, 0, 100, 100)];

                setState(() {
                  _setRects = !_setRects;
                });
                await SystemGestures.setSystemGestureExclusionRects(
                  rects: rect,
                  devicePixelRatio: MediaQuery.of(context).devicePixelRatio,
                );
              },
              child: Text('Toggle Exclusion Rects'),
            ),
          ),
          Text(_setRects ? 'On' : 'Off'),
        ],
      ),
    );
  }
}

```

## Related Issues

Fixes https://github.com/flutter/flutter/issues/39858

## Tests

I added the following tests:
- Control test for setSystemGestureExclusionRects
- Control test for getSystemGestureExclusionRects

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
