### PR TITLE
Revert "Retry cURL downloads"

### DIFF
--- a/bin/internal/update_dart_sdk.sh
+++ b/bin/internal/update_dart_sdk.sh
@@ -81,7 +81,7 @@ if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != `cat "$ENGINE_STAMP"` ]; t
   mkdir -m 755 -p -- "$DART_SDK_PATH"
   DART_SDK_ZIP="$FLUTTER_ROOT/bin/cache/$DART_ZIP_NAME"
 
-  curl --retry-connrefused --retry 3 --retry-delay 5 --continue-at - --location --output "$DART_SDK_ZIP" "$DART_SDK_URL" 2>&1 || {
+  curl --continue-at - --location --output "$DART_SDK_ZIP" "$DART_SDK_URL" 2>&1 || {
     echo
     echo "Failed to retrieve the Dart SDK from: $DART_SDK_URL"
     echo "If you're located in China, please see this page:"


### PR DESCRIPTION
Reverts flutter/flutter#50731

Reason for revert: Dart HHH infrastructure including Golem builders are using older images which have older curl which does not support these flags. Upgrading images takes long time - so in the interim we are forced to revert to avoid accumulating gap in coverage. 