### PR TITLE
Avoid unnecessary process creation

### DIFF
--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -679,8 +679,7 @@ class FlutterTestTestDriver extends FlutterTestDriver {
       'test',
       '--disable-service-auth-codes',
       '--machine',
-      '-d',
-      'flutter-tester',
+      '--start-paused',
     ], script: testFile, withDebugger: withDebugger, pauseOnExceptions: pauseOnExceptions, pidFile: pidFile, beforeStart: beforeStart);
   }
 

--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -679,7 +679,6 @@ class FlutterTestTestDriver extends FlutterTestDriver {
       'test',
       '--disable-service-auth-codes',
       '--machine',
-      '--start-paused',
     ], script: testFile, withDebugger: withDebugger, pauseOnExceptions: pauseOnExceptions, pidFile: pidFile, beforeStart: beforeStart);
   }
 


### PR DESCRIPTION
This stops leaking flutter_tester.exe from expression_evaluation_test.  We were launching a flutter_tester device that we don't need and we dont' try to kill.  Instead, just run the tests in `--start-paused` state.

Part of https://github.com/flutter/flutter/issues/51421 - unfortunately, we're still leaking some folders in this case.