### PR TITLE
improve web benchmark error reporting

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_build_material_checkbox.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_build_material_checkbox.dart
@@ -18,10 +18,15 @@ class BenchBuildMaterialCheckbox extends WidgetBuildRecorder {
 
   @override
   Widget createWidget() {
-    return Column(
-      children: List<Widget>.generate(10, (int i) {
-        return _buildRow();
-      }),
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: Material(
+        child: Column(
+          children: List<Widget>.generate(10, (int i) {
+            return _buildRow();
+          }),
+        ),
+      ),
     );
   }
 

--- a/dev/benchmarks/macrobenchmarks/lib/src/web/recorder.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/recorder.dart
@@ -219,6 +219,11 @@ abstract class WidgetRecorder extends Recorder implements _RecordingWidgetsBindi
   }
 
   @override
+  void _onError(dynamic error, StackTrace stackTrace) {
+    _profileCompleter.completeError(error, stackTrace);
+  }
+
+  @override
   Future<Profile> run() {
     final _RecordingWidgetsBinding binding =
         _RecordingWidgetsBinding.ensureInitialized();
@@ -287,6 +292,11 @@ abstract class WidgetBuildRecorder extends Recorder implements _RecordingWidgets
       final Profile profile = _generateProfile();
       _profileCompleter.complete(profile);
     }
+  }
+
+  @override
+  void _onError(dynamic error, StackTrace stackTrace) {
+    _profileCompleter.completeError(error, stackTrace);
   }
 
   @override
@@ -512,9 +522,19 @@ double _computeStandardDeviationForPopulation(Iterable<double> population) {
 /// Implemented by recorders that use [_RecordingWidgetsBinding] to receive
 /// frame life-cycle calls.
 abstract class _RecordingWidgetsBindingListener {
+  /// Whether the binding should continue pumping frames.
   bool _shouldContinue();
+
+  /// Called just before calling [SchedulerBinding.handleDrawFrame].
   void _frameWillDraw();
+
+  /// Called immediately after calling [SchedulerBinding.handleDrawFrame].
   void _frameDidDraw();
+
+  /// Reports an error.
+  ///
+  /// The implementation is expected to halt benchmark execution as soon as possible.
+  void _onError(dynamic error, StackTrace stackTrace);
 }
 
 /// A variant of [WidgetsBinding] that collaborates with a [Recorder] to decide
@@ -543,8 +563,20 @@ class _RecordingWidgetsBinding extends BindingBase
   }
 
   _RecordingWidgetsBindingListener _listener;
+  bool _hasErrored = false;
 
   void _beginRecording(_RecordingWidgetsBindingListener recorder, Widget widget) {
+    final FlutterExceptionHandler originalOnError = FlutterError.onError;
+
+    // Fail hard and fast on errors. Benchmarks should not have any errors.
+    FlutterError.onError = (FlutterErrorDetails details) {
+      if (_hasErrored) {
+        return;
+      }
+      _listener._onError(details.exception, details.stack);
+      _hasErrored = true;
+      originalOnError(details);
+    };
     _listener = recorder;
     runApp(widget);
   }
@@ -555,19 +587,28 @@ class _RecordingWidgetsBinding extends BindingBase
 
   @override
   void handleBeginFrame(Duration rawTimeStamp) {
+    // Don't keep on truckin' if there's an error.
+    if (_hasErrored) {
+      return;
+    }
     _benchmarkStopped = !_listener._shouldContinue();
     super.handleBeginFrame(rawTimeStamp);
   }
 
   @override
   void scheduleFrame() {
-    if (!_benchmarkStopped) {
+    // Don't keep on truckin' if there's an error.
+    if (!_benchmarkStopped && !_hasErrored) {
       super.scheduleFrame();
     }
   }
 
   @override
   void handleDrawFrame() {
+    // Don't keep on truckin' if there's an error.
+    if (_hasErrored) {
+      return;
+    }
     _listener._frameWillDraw();
     super.handleDrawFrame();
     _listener._frameDidDraw();

--- a/dev/devicelab/lib/tasks/web_benchmarks.dart
+++ b/dev/devicelab/lib/tasks/web_benchmarks.dart
@@ -53,6 +53,12 @@ Future<TaskResult> runWebBenchmark({ @required bool useCanvasKit }) async {
         }
         collectedProfiles.add(profile);
         return Response.ok('Profile received');
+      } else if (request.requestedUri.path.endsWith('/on-error')) {
+        final Map<String, dynamic> errorDetails = json.decode(await request.readAsString()) as Map<String, dynamic>;
+        server.close();
+        // Keep the stack trace as a string. It's thrown in the browser, not this Dart VM.
+        profileData.completeError('${errorDetails['error']}\n${errorDetails['stackTrace']}');
+        return Response.ok('');
       } else if (request.requestedUri.path.endsWith('/next-benchmark')) {
         if (benchmarks == null) {
           benchmarks = (json.decode(await request.readAsString()) as List<dynamic>).cast<String>();


### PR DESCRIPTION
## Description

* Aggressively stop benchmarks in the presence of errors
* Forward errors to localhost for forwarding to test results
* Wrap the checkbox in `Material` and `Directionality`. Otherwise it fails assertions in debug mode (probably for good reason). This was not noticed in benchmarks because we don't run them in debug mode.