### PR TITLE
Convert Diagnosticable to a mixin

### DIFF
--- a/packages/flutter/lib/src/cupertino/colors.dart
+++ b/packages/flutter/lib/src/cupertino/colors.dart
@@ -675,7 +675,7 @@ class CupertinoColors {
 ///  * [CupertinoTheme.of], a static method that retrieves the ambient [CupertinoThemeData],
 ///    and then resolves [CupertinoDynamicColor]s used in the retrieved data.
 @immutable
-class CupertinoDynamicColor extends Color with DiagnosticableMixin implements Diagnosticable {
+class CupertinoDynamicColor extends Color with DiagnosticableMixin {
   /// Creates an adaptive [Color] that changes its effective color based on the
   /// [BuildContext] given. The default effective color is [color].
   ///

--- a/packages/flutter/lib/src/cupertino/colors.dart
+++ b/packages/flutter/lib/src/cupertino/colors.dart
@@ -675,7 +675,7 @@ class CupertinoColors {
 ///  * [CupertinoTheme.of], a static method that retrieves the ambient [CupertinoThemeData],
 ///    and then resolves [CupertinoDynamicColor]s used in the retrieved data.
 @immutable
-class CupertinoDynamicColor extends Color with DiagnosticableMixin {
+class CupertinoDynamicColor extends Color with Diagnosticable {
   /// Creates an adaptive [Color] that changes its effective color based on the
   /// [BuildContext] given. The default effective color is [color].
   ///

--- a/packages/flutter/lib/src/cupertino/icon_theme_data.dart
+++ b/packages/flutter/lib/src/cupertino/icon_theme_data.dart
@@ -8,7 +8,7 @@ import 'colors.dart';
 
 /// An [IconThemeData] subclass that automatically resolves its [color] when retrieved
 /// using [IconTheme.of].
-class CupertinoIconThemeData extends IconThemeData with DiagnosticableMixin {
+class CupertinoIconThemeData extends IconThemeData with Diagnosticable {
   /// Creates a [CupertinoIconThemeData].
   ///
   /// The opacity applies to both explicit and default icon colors. The value

--- a/packages/flutter/lib/src/cupertino/icon_theme_data.dart
+++ b/packages/flutter/lib/src/cupertino/icon_theme_data.dart
@@ -8,7 +8,7 @@ import 'colors.dart';
 
 /// An [IconThemeData] subclass that automatically resolves its [color] when retrieved
 /// using [IconTheme.of].
-class CupertinoIconThemeData extends IconThemeData with DiagnosticableMixin implements Diagnosticable {
+class CupertinoIconThemeData extends IconThemeData with DiagnosticableMixin {
   /// Creates a [CupertinoIconThemeData].
   ///
   /// The opacity applies to both explicit and default icon colors. The value

--- a/packages/flutter/lib/src/cupertino/text_theme.dart
+++ b/packages/flutter/lib/src/cupertino/text_theme.dart
@@ -107,7 +107,7 @@ TextStyle _resolveTextStyle(TextStyle style, BuildContext context, bool nullOk) 
 
 /// Cupertino typography theme in a [CupertinoThemeData].
 @immutable
-class CupertinoTextThemeData extends Diagnosticable {
+class CupertinoTextThemeData with DiagnosticableMixin {
   /// Create a [CupertinoTextThemeData].
   ///
   /// The [primaryColor] is used to derive TextStyle defaults of other attributes

--- a/packages/flutter/lib/src/cupertino/text_theme.dart
+++ b/packages/flutter/lib/src/cupertino/text_theme.dart
@@ -107,7 +107,7 @@ TextStyle _resolveTextStyle(TextStyle style, BuildContext context, bool nullOk) 
 
 /// Cupertino typography theme in a [CupertinoThemeData].
 @immutable
-class CupertinoTextThemeData with DiagnosticableMixin {
+class CupertinoTextThemeData with Diagnosticable {
   /// Create a [CupertinoTextThemeData].
   ///
   /// The [primaryColor] is used to derive TextStyle defaults of other attributes

--- a/packages/flutter/lib/src/cupertino/theme.dart
+++ b/packages/flutter/lib/src/cupertino/theme.dart
@@ -143,7 +143,7 @@ class _InheritedCupertinoTheme extends InheritedWidget {
 ///  * [ThemeData], a Material equivalent that also configures Cupertino
 ///    styling via a [CupertinoThemeData] subclass [MaterialBasedCupertinoThemeData].
 @immutable
-class CupertinoThemeData with DiagnosticableMixin {
+class CupertinoThemeData with Diagnosticable {
   /// Creates a [CupertinoTheme] styling specification.
   ///
   /// Unspecified parameters default to a reasonable iOS default style.

--- a/packages/flutter/lib/src/cupertino/theme.dart
+++ b/packages/flutter/lib/src/cupertino/theme.dart
@@ -143,7 +143,7 @@ class _InheritedCupertinoTheme extends InheritedWidget {
 ///  * [ThemeData], a Material equivalent that also configures Cupertino
 ///    styling via a [CupertinoThemeData] subclass [MaterialBasedCupertinoThemeData].
 @immutable
-class CupertinoThemeData extends Diagnosticable {
+class CupertinoThemeData with DiagnosticableMixin {
   /// Creates a [CupertinoTheme] styling specification.
   ///
   /// Unspecified parameters default to a reasonable iOS default style.

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -326,7 +326,7 @@ class ErrorSpacer extends DiagnosticsProperty<void> {
 /// Class for information provided to [FlutterExceptionHandler] callbacks.
 ///
 /// See [FlutterError.onError].
-class FlutterErrorDetails extends Diagnosticable {
+class FlutterErrorDetails with DiagnosticableMixin {
   /// Creates a [FlutterErrorDetails] object with the given arguments setting
   /// the object's properties.
   ///

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -478,7 +478,7 @@ class FlutterErrorDetails with Diagnosticable {
     return longMessage;
   }
 
-  DiagnosticableMixin _exceptionToDiagnosticable() {
+  Diagnosticable _exceptionToDiagnosticable() {
     if (exception is FlutterError) {
       return exception as FlutterError;
     }
@@ -501,7 +501,7 @@ class FlutterErrorDetails with Diagnosticable {
     if (kReleaseMode) {
       return DiagnosticsNode.message(formatException());
     }
-    final DiagnosticableMixin diagnosticable = _exceptionToDiagnosticable();
+    final Diagnosticable diagnosticable = _exceptionToDiagnosticable();
     DiagnosticsNode summary;
     if (diagnosticable != null) {
       final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
@@ -515,7 +515,7 @@ class FlutterErrorDetails with Diagnosticable {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     final DiagnosticsNode verb = ErrorDescription('thrown${ context != null ? ErrorDescription(" $context") : ""}');
-    final DiagnosticableMixin diagnosticable = _exceptionToDiagnosticable();
+    final Diagnosticable diagnosticable = _exceptionToDiagnosticable();
     if (exception is NullThrownError) {
       properties.add(ErrorDescription('The null value was $verb.'));
     } else if (exception is num) {

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -326,7 +326,7 @@ class ErrorSpacer extends DiagnosticsProperty<void> {
 /// Class for information provided to [FlutterExceptionHandler] callbacks.
 ///
 /// See [FlutterError.onError].
-class FlutterErrorDetails with DiagnosticableMixin {
+class FlutterErrorDetails with Diagnosticable {
   /// Creates a [FlutterErrorDetails] object with the given arguments setting
   /// the object's properties.
   ///

--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -3047,6 +3047,10 @@ class DiagnosticPropertiesBuilder {
 ///  * [DiagnosticsProperty], which should be used to create leaf diagnostic
 ///    nodes without properties or children. There are many
 ///    [DiagnosticsProperty] subclasses to handle common use cases.
+@Deprecated(
+  'Use "with DiagnosticableMixin" instead of "extends Diagnosticable"'
+  'This feature was deprecated after v1.7.11.'
+)
 abstract class Diagnosticable with DiagnosticableMixin {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.

--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -3018,9 +3018,9 @@ class DiagnosticPropertiesBuilder {
 }
 
 // Examples can assume:
-// class ExampleSuperclass with DiagnosticableMixin { String message; double stepWidth; double scale; double paintExtent; double hitTestExtent; double paintExtend; double maxWidth; bool primary; double progress; int maxLines; Duration duration; int depth; dynamic boxShadow; dynamic style; bool hasSize; Matrix4 transform; Map<Listenable, VoidCallback> handles; Color color; bool obscureText; ImageRepeat repeat; Size size; Widget widget; bool isCurrent; bool keepAlive; TextAlign textAlign; }
+// class ExampleSuperclass with Diagnosticable { String message; double stepWidth; double scale; double paintExtent; double hitTestExtent; double paintExtend; double maxWidth; bool primary; double progress; int maxLines; Duration duration; int depth; dynamic boxShadow; dynamic style; bool hasSize; Matrix4 transform; Map<Listenable, VoidCallback> handles; Color color; bool obscureText; ImageRepeat repeat; Size size; Widget widget; bool isCurrent; bool keepAlive; TextAlign textAlign; }
 
-/// A base class for providing string and [DiagnosticsNode] debug
+/// A mixin for providing string and [DiagnosticsNode] debug
 /// representations describing the properties of an object.
 ///
 /// The string debug representation is generated from the intermediate
@@ -3033,8 +3033,7 @@ class DiagnosticPropertiesBuilder {
 ///  * [DiagnosticableTree], which extends this class to also describe the
 ///    children of a tree structured object.
 ///  * [DiagnosticableMixin], which provides the implementation for
-///    [Diagnosticable], and can be used to add diagnostics to classes which
-///    already have a base class.
+///    [Diagnosticable].
 ///  * [DiagnosticableMixin.debugFillProperties], which lists best practices
 ///    for specifying the properties of a [DiagnosticsNode]. The most common use
 ///    case is to override [debugFillProperties] defining custom properties for
@@ -3047,15 +3046,7 @@ class DiagnosticPropertiesBuilder {
 ///  * [DiagnosticsProperty], which should be used to create leaf diagnostic
 ///    nodes without properties or children. There are many
 ///    [DiagnosticsProperty] subclasses to handle common use cases.
-@Deprecated(
-  'Use "with DiagnosticableMixin" instead of "extends Diagnosticable"'
-  'This feature was deprecated after v1.7.11.'
-)
-abstract class Diagnosticable with DiagnosticableMixin {
-  /// Abstract const constructor. This constructor enables subclasses to provide
-  /// const constructors so that they can be used in const expressions.
-  const Diagnosticable();
-}
+mixin Diagnosticable on DiagnosticableMixin { }
 
 /// A mixin class for providing string and [DiagnosticsNode] debug
 /// representations describing the properties of an object.
@@ -3342,7 +3333,7 @@ mixin DiagnosticableMixin {
 ///  * [DiagnosticableTreeMixin], a mixin that implements this class.
 ///  * [DiagnosticableMixin], which should be used instead of this class to
 ///    provide diagnostics for objects without children.
-abstract class DiagnosticableTree with DiagnosticableMixin {
+abstract class DiagnosticableTree with Diagnosticable {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
   const DiagnosticableTree();

--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -3018,7 +3018,7 @@ class DiagnosticPropertiesBuilder {
 }
 
 // Examples can assume:
-// class ExampleSuperclass extends Diagnosticable { String message; double stepWidth; double scale; double paintExtent; double hitTestExtent; double paintExtend; double maxWidth; bool primary; double progress; int maxLines; Duration duration; int depth; dynamic boxShadow; dynamic style; bool hasSize; Matrix4 transform; Map<Listenable, VoidCallback> handles; Color color; bool obscureText; ImageRepeat repeat; Size size; Widget widget; bool isCurrent; bool keepAlive; TextAlign textAlign; }
+// class ExampleSuperclass with DiagnosticableMixin { String message; double stepWidth; double scale; double paintExtent; double hitTestExtent; double paintExtend; double maxWidth; bool primary; double progress; int maxLines; Duration duration; int depth; dynamic boxShadow; dynamic style; bool hasSize; Matrix4 transform; Map<Listenable, VoidCallback> handles; Color color; bool obscureText; ImageRepeat repeat; Size size; Widget widget; bool isCurrent; bool keepAlive; TextAlign textAlign; }
 
 /// A base class for providing string and [DiagnosticsNode] debug
 /// representations describing the properties of an object.
@@ -3338,7 +3338,7 @@ mixin DiagnosticableMixin {
 ///  * [DiagnosticableTreeMixin], a mixin that implements this class.
 ///  * [DiagnosticableMixin], which should be used instead of this class to
 ///    provide diagnostics for objects without children.
-abstract class DiagnosticableTree extends Diagnosticable {
+abstract class DiagnosticableTree with DiagnosticableMixin {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
   const DiagnosticableTree();

--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -196,7 +196,7 @@ bool isSingleButton(int buttons) => buttons != 0 && (smallestButton(buttons) == 
 ///
 ///  * [Window.devicePixelRatio], which defines the device's current resolution.
 @immutable
-abstract class PointerEvent with DiagnosticableMixin {
+abstract class PointerEvent with Diagnosticable {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
   const PointerEvent({

--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -196,7 +196,7 @@ bool isSingleButton(int buttons) => buttons != 0 && (smallestButton(buttons) == 
 ///
 ///  * [Window.devicePixelRatio], which defines the device's current resolution.
 @immutable
-abstract class PointerEvent extends Diagnosticable {
+abstract class PointerEvent with DiagnosticableMixin {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
   const PointerEvent({

--- a/packages/flutter/lib/src/gestures/mouse_tracking.dart
+++ b/packages/flutter/lib/src/gestures/mouse_tracking.dart
@@ -30,7 +30,7 @@ typedef PointerHoverEventListener = void Function(PointerHoverEvent event);
 /// movements.
 ///
 /// This is added to a layer and managed by the [MouseRegion] widget.
-class MouseTrackerAnnotation with DiagnosticableMixin {
+class MouseTrackerAnnotation with Diagnosticable {
   /// Creates an annotation that can be used to find layers interested in mouse
   /// movements.
   const MouseTrackerAnnotation({this.onEnter, this.onHover, this.onExit});

--- a/packages/flutter/lib/src/gestures/mouse_tracking.dart
+++ b/packages/flutter/lib/src/gestures/mouse_tracking.dart
@@ -30,7 +30,7 @@ typedef PointerHoverEventListener = void Function(PointerHoverEvent event);
 /// movements.
 ///
 /// This is added to a layer and managed by the [MouseRegion] widget.
-class MouseTrackerAnnotation extends Diagnosticable {
+class MouseTrackerAnnotation with DiagnosticableMixin {
   /// Creates an annotation that can be used to find layers interested in mouse
   /// movements.
   const MouseTrackerAnnotation({this.onEnter, this.onHover, this.onExit});

--- a/packages/flutter/lib/src/material/app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/app_bar_theme.dart
@@ -27,7 +27,7 @@ import 'theme.dart';
 ///
 ///  * [ThemeData], which describes the overall theme information for the
 ///    application.
-class AppBarTheme with DiagnosticableMixin {
+class AppBarTheme with Diagnosticable {
   /// Creates a theme that can be used for [ThemeData.AppBarTheme].
   const AppBarTheme({
     this.brightness,

--- a/packages/flutter/lib/src/material/app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/app_bar_theme.dart
@@ -27,7 +27,7 @@ import 'theme.dart';
 ///
 ///  * [ThemeData], which describes the overall theme information for the
 ///    application.
-class AppBarTheme extends Diagnosticable {
+class AppBarTheme with DiagnosticableMixin {
   /// Creates a theme that can be used for [ThemeData.AppBarTheme].
   const AppBarTheme({
     this.brightness,

--- a/packages/flutter/lib/src/material/banner_theme.dart
+++ b/packages/flutter/lib/src/material/banner_theme.dart
@@ -23,7 +23,7 @@ import 'theme.dart';
 ///
 ///  * [ThemeData], which describes the overall theme information for the
 ///    application.
-class MaterialBannerThemeData extends Diagnosticable {
+class MaterialBannerThemeData with DiagnosticableMixin {
 
   /// Creates a theme that can be used for [MaterialBannerTheme] or
   /// [ThemeData.bannerTheme].

--- a/packages/flutter/lib/src/material/banner_theme.dart
+++ b/packages/flutter/lib/src/material/banner_theme.dart
@@ -23,7 +23,7 @@ import 'theme.dart';
 ///
 ///  * [ThemeData], which describes the overall theme information for the
 ///    application.
-class MaterialBannerThemeData with DiagnosticableMixin {
+class MaterialBannerThemeData with Diagnosticable {
 
   /// Creates a theme that can be used for [MaterialBannerTheme] or
   /// [ThemeData.bannerTheme].

--- a/packages/flutter/lib/src/material/bottom_app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/bottom_app_bar_theme.dart
@@ -25,7 +25,7 @@ import 'theme.dart';
 ///
 ///  * [ThemeData], which describes the overall theme information for the
 ///    application.
-class BottomAppBarTheme with DiagnosticableMixin {
+class BottomAppBarTheme with Diagnosticable {
   /// Creates a theme that can be used for [ThemeData.BottomAppBarTheme].
   const BottomAppBarTheme({
     this.color,

--- a/packages/flutter/lib/src/material/bottom_app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/bottom_app_bar_theme.dart
@@ -25,7 +25,7 @@ import 'theme.dart';
 ///
 ///  * [ThemeData], which describes the overall theme information for the
 ///    application.
-class BottomAppBarTheme extends Diagnosticable {
+class BottomAppBarTheme with DiagnosticableMixin {
   /// Creates a theme that can be used for [ThemeData.BottomAppBarTheme].
   const BottomAppBarTheme({
     this.color,

--- a/packages/flutter/lib/src/material/bottom_sheet_theme.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet_theme.dart
@@ -24,7 +24,7 @@ import 'package:flutter/rendering.dart';
 ///
 ///  * [ThemeData], which describes the overall theme information for the
 ///    application.
-class BottomSheetThemeData with DiagnosticableMixin {
+class BottomSheetThemeData with Diagnosticable {
   /// Creates a theme that can be used for [ThemeData.bottomSheetTheme].
   const BottomSheetThemeData({
     this.backgroundColor,

--- a/packages/flutter/lib/src/material/bottom_sheet_theme.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet_theme.dart
@@ -24,7 +24,7 @@ import 'package:flutter/rendering.dart';
 ///
 ///  * [ThemeData], which describes the overall theme information for the
 ///    application.
-class BottomSheetThemeData extends Diagnosticable {
+class BottomSheetThemeData with DiagnosticableMixin {
   /// Creates a theme that can be used for [ThemeData.bottomSheetTheme].
   const BottomSheetThemeData({
     this.backgroundColor,

--- a/packages/flutter/lib/src/material/button_bar_theme.dart
+++ b/packages/flutter/lib/src/material/button_bar_theme.dart
@@ -24,7 +24,7 @@ import 'theme.dart';
 ///    its subtree.
 ///  * [ButtonBar], which uses this to configure itself and its children
 ///    button widgets.
-class ButtonBarThemeData with DiagnosticableMixin {
+class ButtonBarThemeData with Diagnosticable {
   /// Constructs the set of properties used to configure [ButtonBar] widgets.
   ///
   /// Both [buttonMinWidth] and [buttonHeight] must be non-negative if they

--- a/packages/flutter/lib/src/material/button_bar_theme.dart
+++ b/packages/flutter/lib/src/material/button_bar_theme.dart
@@ -24,7 +24,7 @@ import 'theme.dart';
 ///    its subtree.
 ///  * [ButtonBar], which uses this to configure itself and its children
 ///    button widgets.
-class ButtonBarThemeData extends Diagnosticable {
+class ButtonBarThemeData with DiagnosticableMixin {
   /// Constructs the set of properties used to configure [ButtonBar] widgets.
   ///
   /// Both [buttonMinWidth] and [buttonHeight] must be non-negative if they

--- a/packages/flutter/lib/src/material/button_theme.dart
+++ b/packages/flutter/lib/src/material/button_theme.dart
@@ -248,7 +248,7 @@ class ButtonTheme extends InheritedTheme {
 /// A button theme can be specified as part of the overall Material theme
 /// using [ThemeData.buttonTheme]. The Material theme's button theme data
 /// can be overridden with [ButtonTheme].
-class ButtonThemeData extends Diagnosticable {
+class ButtonThemeData with DiagnosticableMixin {
   /// Create a button theme object that can be used with [ButtonTheme]
   /// or [ThemeData].
   ///

--- a/packages/flutter/lib/src/material/button_theme.dart
+++ b/packages/flutter/lib/src/material/button_theme.dart
@@ -248,7 +248,7 @@ class ButtonTheme extends InheritedTheme {
 /// A button theme can be specified as part of the overall Material theme
 /// using [ThemeData.buttonTheme]. The Material theme's button theme data
 /// can be overridden with [ButtonTheme].
-class ButtonThemeData with DiagnosticableMixin {
+class ButtonThemeData with Diagnosticable {
   /// Create a button theme object that can be used with [ButtonTheme]
   /// or [ThemeData].
   ///

--- a/packages/flutter/lib/src/material/card_theme.dart
+++ b/packages/flutter/lib/src/material/card_theme.dart
@@ -26,7 +26,7 @@ import 'theme.dart';
 ///
 ///  * [ThemeData], which describes the overall theme information for the
 ///    application.
-class CardTheme with DiagnosticableMixin {
+class CardTheme with Diagnosticable {
 
   /// Creates a theme that can be used for [ThemeData.cardTheme].
   ///

--- a/packages/flutter/lib/src/material/card_theme.dart
+++ b/packages/flutter/lib/src/material/card_theme.dart
@@ -26,7 +26,7 @@ import 'theme.dart';
 ///
 ///  * [ThemeData], which describes the overall theme information for the
 ///    application.
-class CardTheme extends Diagnosticable {
+class CardTheme with DiagnosticableMixin {
 
   /// Creates a theme that can be used for [ThemeData.cardTheme].
   ///

--- a/packages/flutter/lib/src/material/chip_theme.dart
+++ b/packages/flutter/lib/src/material/chip_theme.dart
@@ -168,7 +168,7 @@ class ChipTheme extends InheritedTheme {
 ///  * [Theme] widget, which performs a similar function to [ChipTheme],
 ///    but for overall themes.
 ///  * [ThemeData], which has a default [ChipThemeData].
-class ChipThemeData with DiagnosticableMixin {
+class ChipThemeData with Diagnosticable {
   /// Create a [ChipThemeData] given a set of exact values. All the values
   /// must be specified except for [shadowColor], [selectedShadowColor],
   /// [elevation], and [pressElevation], which may be null.

--- a/packages/flutter/lib/src/material/chip_theme.dart
+++ b/packages/flutter/lib/src/material/chip_theme.dart
@@ -168,7 +168,7 @@ class ChipTheme extends InheritedTheme {
 ///  * [Theme] widget, which performs a similar function to [ChipTheme],
 ///    but for overall themes.
 ///  * [ThemeData], which has a default [ChipThemeData].
-class ChipThemeData extends Diagnosticable {
+class ChipThemeData with DiagnosticableMixin {
   /// Create a [ChipThemeData] given a set of exact values. All the values
   /// must be specified except for [shadowColor], [selectedShadowColor],
   /// [elevation], and [pressElevation], which may be null.

--- a/packages/flutter/lib/src/material/color_scheme.dart
+++ b/packages/flutter/lib/src/material/color_scheme.dart
@@ -16,7 +16,7 @@ import 'theme_data.dart';
 /// The [Theme] has a color scheme, [ThemeData.colorScheme], which is constructed
 /// with [ColorScheme.fromSwatch].
 @immutable
-class ColorScheme with DiagnosticableMixin {
+class ColorScheme with Diagnosticable {
   /// Create a ColorScheme instance.
   const ColorScheme({
     @required this.primary,

--- a/packages/flutter/lib/src/material/color_scheme.dart
+++ b/packages/flutter/lib/src/material/color_scheme.dart
@@ -16,7 +16,7 @@ import 'theme_data.dart';
 /// The [Theme] has a color scheme, [ThemeData.colorScheme], which is constructed
 /// with [ColorScheme.fromSwatch].
 @immutable
-class ColorScheme extends Diagnosticable {
+class ColorScheme with DiagnosticableMixin {
   /// Create a ColorScheme instance.
   const ColorScheme({
     @required this.primary,

--- a/packages/flutter/lib/src/material/dialog_theme.dart
+++ b/packages/flutter/lib/src/material/dialog_theme.dart
@@ -27,7 +27,7 @@ import 'theme.dart';
 ///  * [Dialog], a material dialog that can be customized using this [DialogTheme].
 ///  * [ThemeData], which describes the overall theme information for the
 ///    application.
-class DialogTheme with DiagnosticableMixin {
+class DialogTheme with Diagnosticable {
   /// Creates a dialog theme that can be used for [ThemeData.dialogTheme].
   const DialogTheme({
     this.backgroundColor,

--- a/packages/flutter/lib/src/material/dialog_theme.dart
+++ b/packages/flutter/lib/src/material/dialog_theme.dart
@@ -27,7 +27,7 @@ import 'theme.dart';
 ///  * [Dialog], a material dialog that can be customized using this [DialogTheme].
 ///  * [ThemeData], which describes the overall theme information for the
 ///    application.
-class DialogTheme extends Diagnosticable {
+class DialogTheme with DiagnosticableMixin {
   /// Creates a dialog theme that can be used for [ThemeData.dialogTheme].
   const DialogTheme({
     this.backgroundColor,

--- a/packages/flutter/lib/src/material/divider_theme.dart
+++ b/packages/flutter/lib/src/material/divider_theme.dart
@@ -26,7 +26,7 @@ import 'theme.dart';
 ///
 ///  * [ThemeData], which describes the overall theme information for the
 ///    application.
-class DividerThemeData with DiagnosticableMixin {
+class DividerThemeData with Diagnosticable {
 
   /// Creates a theme that can be used for [DividerTheme] or
   /// [ThemeData.dividerTheme].

--- a/packages/flutter/lib/src/material/divider_theme.dart
+++ b/packages/flutter/lib/src/material/divider_theme.dart
@@ -26,7 +26,7 @@ import 'theme.dart';
 ///
 ///  * [ThemeData], which describes the overall theme information for the
 ///    application.
-class DividerThemeData extends Diagnosticable {
+class DividerThemeData with DiagnosticableMixin {
 
   /// Creates a theme that can be used for [DividerTheme] or
   /// [ThemeData.dividerTheme].

--- a/packages/flutter/lib/src/material/floating_action_button_theme.dart
+++ b/packages/flutter/lib/src/material/floating_action_button_theme.dart
@@ -26,7 +26,7 @@ import 'package:flutter/rendering.dart';
 ///
 ///  * [ThemeData], which describes the overall theme information for the
 ///    application.
-class FloatingActionButtonThemeData extends Diagnosticable {
+class FloatingActionButtonThemeData with DiagnosticableMixin {
   /// Creates a theme that can be used for
   /// [ThemeData.floatingActionButtonTheme].
   const FloatingActionButtonThemeData({

--- a/packages/flutter/lib/src/material/floating_action_button_theme.dart
+++ b/packages/flutter/lib/src/material/floating_action_button_theme.dart
@@ -26,7 +26,7 @@ import 'package:flutter/rendering.dart';
 ///
 ///  * [ThemeData], which describes the overall theme information for the
 ///    application.
-class FloatingActionButtonThemeData with DiagnosticableMixin {
+class FloatingActionButtonThemeData with Diagnosticable {
   /// Creates a theme that can be used for
   /// [ThemeData.floatingActionButtonTheme].
   const FloatingActionButtonThemeData({

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -3547,7 +3547,7 @@ class InputDecoration {
 /// The [InputDecoration.applyDefaults] method is used to combine a input
 /// decoration theme with an [InputDecoration] object.
 @immutable
-class InputDecorationTheme extends Diagnosticable {
+class InputDecorationTheme with DiagnosticableMixin {
   /// Creates a value for [ThemeData.inputDecorationTheme] that
   /// defines default values for [InputDecorator].
   ///

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -3547,7 +3547,7 @@ class InputDecoration {
 /// The [InputDecoration.applyDefaults] method is used to combine a input
 /// decoration theme with an [InputDecoration] object.
 @immutable
-class InputDecorationTheme with DiagnosticableMixin {
+class InputDecorationTheme with Diagnosticable {
   /// Creates a value for [ThemeData.inputDecorationTheme] that
   /// defines default values for [InputDecorator].
   ///

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -483,7 +483,7 @@ class CupertinoPageTransitionsBuilder extends PageTransitionsBuilder {
 ///  * [CupertinoPageTransitionsBuilder], which defines a horizontal page
 ///    transition that matches native iOS page transitions.
 @immutable
-class PageTransitionsTheme extends Diagnosticable {
+class PageTransitionsTheme with DiagnosticableMixin {
   /// Construct a PageTransitionsTheme.
   ///
   /// By default the list of builders is: [FadeUpwardsPageTransitionsBuilder]

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -483,7 +483,7 @@ class CupertinoPageTransitionsBuilder extends PageTransitionsBuilder {
 ///  * [CupertinoPageTransitionsBuilder], which defines a horizontal page
 ///    transition that matches native iOS page transitions.
 @immutable
-class PageTransitionsTheme with DiagnosticableMixin {
+class PageTransitionsTheme with Diagnosticable {
   /// Construct a PageTransitionsTheme.
   ///
   /// By default the list of builders is: [FadeUpwardsPageTransitionsBuilder]

--- a/packages/flutter/lib/src/material/popup_menu_theme.dart
+++ b/packages/flutter/lib/src/material/popup_menu_theme.dart
@@ -29,7 +29,7 @@ import 'theme.dart';
 ///
 ///  * [ThemeData], which describes the overall theme information for the
 ///    application.
-class PopupMenuThemeData with DiagnosticableMixin {
+class PopupMenuThemeData with Diagnosticable {
   /// Creates the set of properties used to configure [PopupMenuTheme].
   const PopupMenuThemeData({
     this.color,

--- a/packages/flutter/lib/src/material/popup_menu_theme.dart
+++ b/packages/flutter/lib/src/material/popup_menu_theme.dart
@@ -29,7 +29,7 @@ import 'theme.dart';
 ///
 ///  * [ThemeData], which describes the overall theme information for the
 ///    application.
-class PopupMenuThemeData extends Diagnosticable {
+class PopupMenuThemeData with DiagnosticableMixin {
   /// Creates the set of properties used to configure [PopupMenuTheme].
   const PopupMenuThemeData({
     this.color,

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -305,7 +305,7 @@ enum Thumb {
 /// {@macro flutter.material.slider.seeAlso.rangeSliderValueIndicatorShape}
 /// {@macro flutter.material.slider.seeAlso.rangeSliderTrackShape}
 /// {@macro flutter.material.slider.seeAlso.rangeSliderTickMarkShape}
-class SliderThemeData extends Diagnosticable {
+class SliderThemeData with DiagnosticableMixin {
   /// Create a [SliderThemeData] given a set of exact values. All the values
   /// must be specified.
   ///

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -305,7 +305,7 @@ enum Thumb {
 /// {@macro flutter.material.slider.seeAlso.rangeSliderValueIndicatorShape}
 /// {@macro flutter.material.slider.seeAlso.rangeSliderTrackShape}
 /// {@macro flutter.material.slider.seeAlso.rangeSliderTickMarkShape}
-class SliderThemeData with DiagnosticableMixin {
+class SliderThemeData with Diagnosticable {
   /// Create a [SliderThemeData] given a set of exact values. All the values
   /// must be specified.
   ///

--- a/packages/flutter/lib/src/material/snack_bar_theme.dart
+++ b/packages/flutter/lib/src/material/snack_bar_theme.dart
@@ -46,7 +46,7 @@ enum SnackBarBehavior {
 ///
 ///  * [ThemeData], which describes the overall theme information for the
 ///    application.
-class SnackBarThemeData extends Diagnosticable {
+class SnackBarThemeData with DiagnosticableMixin {
 
   /// Creates a theme that can be used for [ThemeData.snackBarTheme].
   ///

--- a/packages/flutter/lib/src/material/snack_bar_theme.dart
+++ b/packages/flutter/lib/src/material/snack_bar_theme.dart
@@ -46,7 +46,7 @@ enum SnackBarBehavior {
 ///
 ///  * [ThemeData], which describes the overall theme information for the
 ///    application.
-class SnackBarThemeData with DiagnosticableMixin {
+class SnackBarThemeData with Diagnosticable {
 
   /// Creates a theme that can be used for [ThemeData.snackBarTheme].
   ///

--- a/packages/flutter/lib/src/material/tab_bar_theme.dart
+++ b/packages/flutter/lib/src/material/tab_bar_theme.dart
@@ -23,7 +23,7 @@ import 'theme.dart';
 ///  * [TabBar], a widget that displays a horizontal row of tabs.
 ///  * [ThemeData], which describes the overall theme information for the
 ///    application.
-class TabBarTheme with DiagnosticableMixin {
+class TabBarTheme with Diagnosticable {
   /// Creates a tab bar theme that can be used with [ThemeData.tabBarTheme].
   const TabBarTheme({
     this.indicator,

--- a/packages/flutter/lib/src/material/tab_bar_theme.dart
+++ b/packages/flutter/lib/src/material/tab_bar_theme.dart
@@ -23,7 +23,7 @@ import 'theme.dart';
 ///  * [TabBar], a widget that displays a horizontal row of tabs.
 ///  * [ThemeData], which describes the overall theme information for the
 ///    application.
-class TabBarTheme extends Diagnosticable {
+class TabBarTheme with DiagnosticableMixin {
   /// Creates a tab bar theme that can be used with [ThemeData.tabBarTheme].
   const TabBarTheme({
     this.indicator,

--- a/packages/flutter/lib/src/material/text_theme.dart
+++ b/packages/flutter/lib/src/material/text_theme.dart
@@ -103,7 +103,7 @@ import 'typography.dart';
 ///    globally adjusted, such as the color scheme.
 ///  * <https://material.io/design/typography/>
 @immutable
-class TextTheme with DiagnosticableMixin {
+class TextTheme with Diagnosticable {
   /// Creates a text theme that uses the given values.
   ///
   /// Rather than creating a new text theme, consider using [Typography.black]

--- a/packages/flutter/lib/src/material/text_theme.dart
+++ b/packages/flutter/lib/src/material/text_theme.dart
@@ -103,7 +103,7 @@ import 'typography.dart';
 ///    globally adjusted, such as the color scheme.
 ///  * <https://material.io/design/typography/>
 @immutable
-class TextTheme extends Diagnosticable {
+class TextTheme with DiagnosticableMixin {
   /// Creates a text theme that uses the given values.
   ///
   /// Rather than creating a new text theme, consider using [Typography.black]

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -163,7 +163,7 @@ enum MaterialTapTargetSize {
 /// ```
 /// {@end-tool}
 @immutable
-class ThemeData with DiagnosticableMixin {
+class ThemeData with Diagnosticable {
   /// Create a [ThemeData] given a set of preferred values.
   ///
   /// Default values will be derived for arguments that are omitted.
@@ -1697,7 +1697,7 @@ class _FifoCache<K, V> {
 ///  * [ThemeData.visualDensity], where this property is used to specify the base
 ///    horizontal density of Material components.
 ///  * [Material design guidance on density](https://material.io/design/layout/applying-density.html).
-class VisualDensity with DiagnosticableMixin {
+class VisualDensity with Diagnosticable {
   /// A const constructor for [VisualDensity].
   ///
   /// All of the arguments must be non-null, and [horizontal] and [vertical]

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -163,7 +163,7 @@ enum MaterialTapTargetSize {
 /// ```
 /// {@end-tool}
 @immutable
-class ThemeData extends Diagnosticable {
+class ThemeData with DiagnosticableMixin {
   /// Create a [ThemeData] given a set of preferred values.
   ///
   /// Default values will be derived for arguments that are omitted.
@@ -1697,7 +1697,7 @@ class _FifoCache<K, V> {
 ///  * [ThemeData.visualDensity], where this property is used to specify the base
 ///    horizontal density of Material components.
 ///  * [Material design guidance on density](https://material.io/design/layout/applying-density.html).
-class VisualDensity extends Diagnosticable {
+class VisualDensity with DiagnosticableMixin {
   /// A const constructor for [VisualDensity].
   ///
   /// All of the arguments must be non-null, and [horizontal] and [vertical]

--- a/packages/flutter/lib/src/material/toggle_buttons_theme.dart
+++ b/packages/flutter/lib/src/material/toggle_buttons_theme.dart
@@ -24,7 +24,7 @@ import 'theme.dart';
 ///
 ///  * [ToggleButtonsTheme], which describes the actual configuration of a
 ///    toggle buttons theme.
-class ToggleButtonsThemeData extends Diagnosticable {
+class ToggleButtonsThemeData with DiagnosticableMixin {
   /// Creates the set of color and border properties used to configure
   /// [ToggleButtons].
   const ToggleButtonsThemeData({

--- a/packages/flutter/lib/src/material/toggle_buttons_theme.dart
+++ b/packages/flutter/lib/src/material/toggle_buttons_theme.dart
@@ -24,7 +24,7 @@ import 'theme.dart';
 ///
 ///  * [ToggleButtonsTheme], which describes the actual configuration of a
 ///    toggle buttons theme.
-class ToggleButtonsThemeData with DiagnosticableMixin {
+class ToggleButtonsThemeData with Diagnosticable {
   /// Creates the set of color and border properties used to configure
   /// [ToggleButtons].
   const ToggleButtonsThemeData({

--- a/packages/flutter/lib/src/material/tooltip_theme.dart
+++ b/packages/flutter/lib/src/material/tooltip_theme.dart
@@ -23,7 +23,7 @@ import 'theme.dart';
 ///    subtree.
 ///  * [TooltipThemeData], which describes the actual configuration of a
 ///    tooltip theme.
-class TooltipThemeData extends Diagnosticable {
+class TooltipThemeData with DiagnosticableMixin {
   /// Creates the set of properties used to configure [Tooltip]s.
   const TooltipThemeData({
     this.height,

--- a/packages/flutter/lib/src/material/tooltip_theme.dart
+++ b/packages/flutter/lib/src/material/tooltip_theme.dart
@@ -23,7 +23,7 @@ import 'theme.dart';
 ///    subtree.
 ///  * [TooltipThemeData], which describes the actual configuration of a
 ///    tooltip theme.
-class TooltipThemeData with DiagnosticableMixin {
+class TooltipThemeData with Diagnosticable {
   /// Creates the set of properties used to configure [Tooltip]s.
   const TooltipThemeData({
     this.height,

--- a/packages/flutter/lib/src/material/typography.dart
+++ b/packages/flutter/lib/src/material/typography.dart
@@ -82,7 +82,7 @@ enum ScriptCategory {
 ///    [ThemeData.primaryTextTheme], [ThemeData.accentTextTheme].
 ///  * <https://material.io/design/typography/>
 @immutable
-class Typography with DiagnosticableMixin {
+class Typography with Diagnosticable {
   /// Creates a typography instance.
   ///
   /// This constructor is identical to [Typography.material2014]. It is

--- a/packages/flutter/lib/src/material/typography.dart
+++ b/packages/flutter/lib/src/material/typography.dart
@@ -82,7 +82,7 @@ enum ScriptCategory {
 ///    [ThemeData.primaryTextTheme], [ThemeData.accentTextTheme].
 ///  * <https://material.io/design/typography/>
 @immutable
-class Typography extends Diagnosticable {
+class Typography with DiagnosticableMixin {
   /// Creates a typography instance.
   ///
   /// This constructor is identical to [Typography.material2014]. It is

--- a/packages/flutter/lib/src/painting/decoration.dart
+++ b/packages/flutter/lib/src/painting/decoration.dart
@@ -20,7 +20,7 @@ import 'image_provider.dart';
 /// shared between boxes; [BoxPainter] objects can cache resources to
 /// make painting on a particular surface faster.
 @immutable
-abstract class Decoration extends Diagnosticable {
+abstract class Decoration with DiagnosticableMixin {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
   const Decoration();

--- a/packages/flutter/lib/src/painting/decoration.dart
+++ b/packages/flutter/lib/src/painting/decoration.dart
@@ -20,7 +20,7 @@ import 'image_provider.dart';
 /// shared between boxes; [BoxPainter] objects can cache resources to
 /// make painting on a particular surface faster.
 @immutable
-abstract class Decoration with DiagnosticableMixin {
+abstract class Decoration with Diagnosticable {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
   const Decoration();

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -159,7 +159,7 @@ typedef ImageErrorListener = void Function(dynamic exception, StackTrace stackTr
 ///  * [ImageChunkListener], the means by which callers get notified of
 ///    these events.
 @immutable
-class ImageChunkEvent extends Diagnosticable {
+class ImageChunkEvent with DiagnosticableMixin {
   /// Creates a new chunk event.
   const ImageChunkEvent({
     @required this.cumulativeBytesLoaded,
@@ -212,7 +212,7 @@ class ImageChunkEvent extends Diagnosticable {
 ///
 ///  * [ImageProvider], which has an example that includes the use of an
 ///    [ImageStream] in a [Widget].
-class ImageStream extends Diagnosticable {
+class ImageStream with DiagnosticableMixin {
   /// Create an initially unbound image stream.
   ///
   /// Once an [ImageStreamCompleter] is available, call [setCompleter].
@@ -324,7 +324,7 @@ class ImageStream extends Diagnosticable {
 /// [ImageStreamListener] objects are rarely constructed directly. Generally, an
 /// [ImageProvider] subclass will return an [ImageStream] and automatically
 /// configure it with the right [ImageStreamCompleter] when possible.
-abstract class ImageStreamCompleter extends Diagnosticable {
+abstract class ImageStreamCompleter with DiagnosticableMixin {
   final List<ImageStreamListener> _listeners = <ImageStreamListener>[];
   ImageInfo _currentImage;
   FlutterErrorDetails _currentError;

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -159,7 +159,7 @@ typedef ImageErrorListener = void Function(dynamic exception, StackTrace stackTr
 ///  * [ImageChunkListener], the means by which callers get notified of
 ///    these events.
 @immutable
-class ImageChunkEvent with DiagnosticableMixin {
+class ImageChunkEvent with Diagnosticable {
   /// Creates a new chunk event.
   const ImageChunkEvent({
     @required this.cumulativeBytesLoaded,
@@ -212,7 +212,7 @@ class ImageChunkEvent with DiagnosticableMixin {
 ///
 ///  * [ImageProvider], which has an example that includes the use of an
 ///    [ImageStream] in a [Widget].
-class ImageStream with DiagnosticableMixin {
+class ImageStream with Diagnosticable {
   /// Create an initially unbound image stream.
   ///
   /// Once an [ImageStreamCompleter] is available, call [setCompleter].
@@ -324,7 +324,7 @@ class ImageStream with DiagnosticableMixin {
 /// [ImageStreamListener] objects are rarely constructed directly. Generally, an
 /// [ImageProvider] subclass will return an [ImageStream] and automatically
 /// configure it with the right [ImageStreamCompleter] when possible.
-abstract class ImageStreamCompleter with DiagnosticableMixin {
+abstract class ImageStreamCompleter with Diagnosticable {
   final List<ImageStreamListener> _listeners = <ImageStreamListener>[];
   ImageInfo _currentImage;
   FlutterErrorDetails _currentError;

--- a/packages/flutter/lib/src/painting/strut_style.dart
+++ b/packages/flutter/lib/src/painting/strut_style.dart
@@ -285,7 +285,7 @@ import 'text_style.dart';
 /// {@end-tool}
 ///
 @immutable
-class StrutStyle extends Diagnosticable {
+class StrutStyle with DiagnosticableMixin {
   /// Creates a strut style.
   ///
   /// The `package` argument must be non-null if the font family is defined in a

--- a/packages/flutter/lib/src/painting/strut_style.dart
+++ b/packages/flutter/lib/src/painting/strut_style.dart
@@ -285,7 +285,7 @@ import 'text_style.dart';
 /// {@end-tool}
 ///
 @immutable
-class StrutStyle with DiagnosticableMixin {
+class StrutStyle with Diagnosticable {
   /// Creates a strut style.
   ///
   /// The `package` argument must be non-null if the font family is defined in a

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -391,7 +391,7 @@ const String _kColorBackgroundWarning = 'Cannot provide both a backgroundColor a
 ///  * [TextStyle](https://api.flutter.dev/flutter/dart-ui/TextStyle-class.html), the class in the [dart:ui] library.
 ///
 @immutable
-class TextStyle extends Diagnosticable {
+class TextStyle with DiagnosticableMixin {
   /// Creates a text style.
   ///
   /// The `package` argument must be non-null if the font family is defined in a

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -391,7 +391,7 @@ const String _kColorBackgroundWarning = 'Cannot provide both a backgroundColor a
 ///  * [TextStyle](https://api.flutter.dev/flutter/dart-ui/TextStyle-class.html), the class in the [dart:ui] library.
 ///
 @immutable
-class TextStyle with DiagnosticableMixin {
+class TextStyle with Diagnosticable {
   /// Creates a text style.
   ///
   /// The `package` argument must be non-null if the font family is defined in a

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -525,7 +525,7 @@ class SliverConstraints extends Constraints {
 /// A sliver can occupy space in several different ways, which is why this class
 /// contains multiple values.
 @immutable
-class SliverGeometry with DiagnosticableMixin {
+class SliverGeometry with Diagnosticable {
   /// Creates an object that describes the amount of space occupied by a sliver.
   ///
   /// If the [layoutExtent] argument is null, [layoutExtent] defaults to the

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -525,7 +525,7 @@ class SliverConstraints extends Constraints {
 /// A sliver can occupy space in several different ways, which is why this class
 /// contains multiple values.
 @immutable
-class SliverGeometry extends Diagnosticable {
+class SliverGeometry with DiagnosticableMixin {
   /// Creates an object that describes the amount of space occupied by a sliver.
   ///
   /// If the [layoutExtent] argument is null, [layoutExtent] defaults to the

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -172,7 +172,7 @@ class CustomSemanticsAction {
 ///
 /// Typically obtained from [SemanticsNode.getSemanticsData].
 @immutable
-class SemanticsData extends Diagnosticable {
+class SemanticsData with DiagnosticableMixin {
   /// Creates a semantics data object.
   ///
   /// The [flags], [actions], [label], and [Rect] arguments must not be null.
@@ -3997,7 +3997,7 @@ String _concatStrings({
 /// See also:
 ///
 ///  * [OrdinalSortKey] for a sort key that sorts using an ordinal.
-abstract class SemanticsSortKey extends Diagnosticable implements Comparable<SemanticsSortKey> {
+abstract class SemanticsSortKey with DiagnosticableMixin implements Comparable<SemanticsSortKey> {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
   const SemanticsSortKey({this.name});

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -172,7 +172,7 @@ class CustomSemanticsAction {
 ///
 /// Typically obtained from [SemanticsNode.getSemanticsData].
 @immutable
-class SemanticsData with DiagnosticableMixin {
+class SemanticsData with Diagnosticable {
   /// Creates a semantics data object.
   ///
   /// The [flags], [actions], [label], and [Rect] arguments must not be null.
@@ -3997,7 +3997,7 @@ String _concatStrings({
 /// See also:
 ///
 ///  * [OrdinalSortKey] for a sort key that sorts using an ordinal.
-abstract class SemanticsSortKey with DiagnosticableMixin implements Comparable<SemanticsSortKey> {
+abstract class SemanticsSortKey with Diagnosticable implements Comparable<SemanticsSortKey> {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
   const SemanticsSortKey({this.name});

--- a/packages/flutter/lib/src/services/keyboard_key.dart
+++ b/packages/flutter/lib/src/services/keyboard_key.dart
@@ -19,7 +19,7 @@ import 'package:flutter/foundation.dart';
 ///    that are returned from [RawKeyEvent.physicalKey].
 ///  * [LogicalKeyboardKey], a class with static values that describe the keys
 ///    that are returned from [RawKeyEvent.logicalKey].
-abstract class KeyboardKey with DiagnosticableMixin {
+abstract class KeyboardKey with Diagnosticable {
   /// A const constructor so that subclasses may be const.
   const KeyboardKey();
 }

--- a/packages/flutter/lib/src/services/keyboard_key.dart
+++ b/packages/flutter/lib/src/services/keyboard_key.dart
@@ -19,7 +19,7 @@ import 'package:flutter/foundation.dart';
 ///    that are returned from [RawKeyEvent.physicalKey].
 ///  * [LogicalKeyboardKey], a class with static values that describe the keys
 ///    that are returned from [RawKeyEvent.logicalKey].
-abstract class KeyboardKey extends Diagnosticable {
+abstract class KeyboardKey with DiagnosticableMixin {
   /// A const constructor so that subclasses may be const.
   const KeyboardKey();
 }

--- a/packages/flutter/lib/src/services/raw_keyboard.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard.dart
@@ -236,7 +236,7 @@ abstract class RawKeyEventData {
 ///  * [RawKeyboard], which uses this interface to expose key data.
 ///  * [RawKeyboardListener], a widget that listens for raw key events.
 @immutable
-abstract class RawKeyEvent with DiagnosticableMixin {
+abstract class RawKeyEvent with Diagnosticable {
   /// Initializes fields for subclasses, and provides a const constructor for
   /// const subclasses.
   const RawKeyEvent({

--- a/packages/flutter/lib/src/services/raw_keyboard.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard.dart
@@ -236,7 +236,7 @@ abstract class RawKeyEventData {
 ///  * [RawKeyboard], which uses this interface to expose key data.
 ///  * [RawKeyboardListener], a widget that listens for raw key events.
 @immutable
-abstract class RawKeyEvent extends Diagnosticable {
+abstract class RawKeyEvent with DiagnosticableMixin {
   /// Initializes fields for subclasses, and provides a const constructor for
   /// const subclasses.
   const RawKeyEvent({

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -25,7 +25,7 @@ typedef ActionFactory = Action Function();
 ///
 /// If this intent returns false from [isEnabled], then its associated action will
 /// not be invoked if requested.
-class Intent extends Diagnosticable {
+class Intent with DiagnosticableMixin {
   /// A const constructor for an [Intent].
   ///
   /// The [key] argument must not be null.
@@ -73,7 +73,7 @@ class Intent extends Diagnosticable {
 ///    and allows redefining of actions for its descendants.
 ///  * [ActionDispatcher], a class that takes an [Action] and invokes it using a
 ///    [FocusNode] for context.
-abstract class Action extends Diagnosticable {
+abstract class Action with DiagnosticableMixin {
   /// A const constructor for an [Action].
   ///
   /// The [intentKey] parameter must not be null.
@@ -140,7 +140,7 @@ class CallbackAction extends Action {
 }
 
 /// An action manager that simply invokes the actions given to it.
-class ActionDispatcher extends Diagnosticable {
+class ActionDispatcher with DiagnosticableMixin {
   /// Const constructor so that subclasses can be const.
   const ActionDispatcher();
 

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -25,7 +25,7 @@ typedef ActionFactory = Action Function();
 ///
 /// If this intent returns false from [isEnabled], then its associated action will
 /// not be invoked if requested.
-class Intent with DiagnosticableMixin {
+class Intent with Diagnosticable {
   /// A const constructor for an [Intent].
   ///
   /// The [key] argument must not be null.
@@ -73,7 +73,7 @@ class Intent with DiagnosticableMixin {
 ///    and allows redefining of actions for its descendants.
 ///  * [ActionDispatcher], a class that takes an [Action] and invokes it using a
 ///    [FocusNode] for context.
-abstract class Action with DiagnosticableMixin {
+abstract class Action with Diagnosticable {
   /// A const constructor for an [Action].
   ///
   /// The [intentKey] parameter must not be null.
@@ -140,7 +140,7 @@ class CallbackAction extends Action {
 }
 
 /// An action manager that simply invokes the actions given to it.
-class ActionDispatcher with DiagnosticableMixin {
+class ActionDispatcher with Diagnosticable {
   /// Const constructor so that subclasses can be const.
   const ActionDispatcher();
 

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -1352,7 +1352,7 @@ enum FocusHighlightStrategy {
 ///    subtrees into groups and restrict focus to them.
 ///  * The [primaryFocus] global accessor, for convenient access from anywhere
 ///    to the current focus manager state.
-class FocusManager with DiagnosticableTreeMixin, ChangeNotifier implements Diagnosticable {
+class FocusManager with DiagnosticableTreeMixin, ChangeNotifier {
   /// Creates an object that manages the focus tree.
   ///
   /// This constructor is rarely called directly. To access the [FocusManager],

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -115,7 +115,7 @@ enum TraversalDirection {
 ///  * [DirectionalFocusTraversalPolicyMixin] a mixin class that implements
 ///    focus traversal in a direction.
 @immutable
-abstract class FocusTraversalPolicy with DiagnosticableMixin {
+abstract class FocusTraversalPolicy with Diagnosticable {
   /// A const constructor so subclasses can be const.
   const FocusTraversalPolicy();
 
@@ -806,7 +806,7 @@ class WidgetOrderTraversalPolicy extends FocusTraversalPolicy with DirectionalFo
 //
 // It's also a convenient place to put some utility functions having to do with
 // the sort data.
-class _ReadingOrderSortData with DiagnosticableMixin {
+class _ReadingOrderSortData with Diagnosticable {
   _ReadingOrderSortData(this.node)
       : assert(node != null),
         rect = node.rect,
@@ -886,7 +886,7 @@ class _ReadingOrderSortData with DiagnosticableMixin {
 
 // A class for containing group data while sorting in reading order while taking
 // into account the ambient directionality.
-class _ReadingOrderDirectionalGroupData with DiagnosticableMixin {
+class _ReadingOrderDirectionalGroupData with Diagnosticable {
   _ReadingOrderDirectionalGroupData(this.members);
 
   final List<_ReadingOrderSortData> members;
@@ -1105,7 +1105,7 @@ class ReadingOrderTraversalPolicy extends FocusTraversalPolicy with DirectionalF
 ///  * [LexicalFocusOrder], a focus order that assigns a string-based lexical
 ///    traversal order to a [FocusTraversalOrder] widget.
 @immutable
-abstract class FocusOrder with DiagnosticableMixin implements Comparable<FocusOrder> {
+abstract class FocusOrder with Diagnosticable implements Comparable<FocusOrder> {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
   const FocusOrder();

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -115,7 +115,7 @@ enum TraversalDirection {
 ///  * [DirectionalFocusTraversalPolicyMixin] a mixin class that implements
 ///    focus traversal in a direction.
 @immutable
-abstract class FocusTraversalPolicy extends Diagnosticable {
+abstract class FocusTraversalPolicy with DiagnosticableMixin {
   /// A const constructor so subclasses can be const.
   const FocusTraversalPolicy();
 
@@ -806,7 +806,7 @@ class WidgetOrderTraversalPolicy extends FocusTraversalPolicy with DirectionalFo
 //
 // It's also a convenient place to put some utility functions having to do with
 // the sort data.
-class _ReadingOrderSortData extends Diagnosticable {
+class _ReadingOrderSortData with DiagnosticableMixin {
   _ReadingOrderSortData(this.node)
       : assert(node != null),
         rect = node.rect,
@@ -886,7 +886,7 @@ class _ReadingOrderSortData extends Diagnosticable {
 
 // A class for containing group data while sorting in reading order while taking
 // into account the ambient directionality.
-class _ReadingOrderDirectionalGroupData extends Diagnosticable {
+class _ReadingOrderDirectionalGroupData with DiagnosticableMixin {
   _ReadingOrderDirectionalGroupData(this.members);
 
   final List<_ReadingOrderSortData> members;
@@ -1105,7 +1105,7 @@ class ReadingOrderTraversalPolicy extends FocusTraversalPolicy with DirectionalF
 ///  * [LexicalFocusOrder], a focus order that assigns a string-based lexical
 ///    traversal order to a [FocusTraversalOrder] widget.
 @immutable
-abstract class FocusOrder extends Diagnosticable implements Comparable<FocusOrder> {
+abstract class FocusOrder with DiagnosticableMixin implements Comparable<FocusOrder> {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
   const FocusOrder();

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1026,7 +1026,7 @@ typedef StateSetter = void Function(VoidCallback fn);
 ///    be read by descendant widgets.
 ///  * [Widget], for an overview of widgets in general.
 @optionalTypeArgs
-abstract class State<T extends StatefulWidget> with DiagnosticableMixin {
+abstract class State<T extends StatefulWidget> with Diagnosticable {
   /// The current configuration.
   ///
   /// A [State] object's configuration is the corresponding [StatefulWidget]

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1026,7 +1026,7 @@ typedef StateSetter = void Function(VoidCallback fn);
 ///    be read by descendant widgets.
 ///  * [Widget], for an overview of widgets in general.
 @optionalTypeArgs
-abstract class State<T extends StatefulWidget> extends Diagnosticable {
+abstract class State<T extends StatefulWidget> with DiagnosticableMixin {
   /// The current configuration.
   ///
   /// A [State] object's configuration is the corresponding [StatefulWidget]

--- a/packages/flutter/lib/src/widgets/icon_theme_data.dart
+++ b/packages/flutter/lib/src/widgets/icon_theme_data.dart
@@ -18,7 +18,7 @@ import 'framework.dart' show BuildContext;
 /// To obtain the current icon theme, use [IconTheme.of]. To convert an icon
 /// theme to a version with all the fields filled in, use [new
 /// IconThemeData.fallback].
-class IconThemeData extends Diagnosticable {
+class IconThemeData with DiagnosticableMixin {
   /// Creates an icon theme data.
   ///
   /// The opacity applies to both explicit and default icon colors. The value

--- a/packages/flutter/lib/src/widgets/icon_theme_data.dart
+++ b/packages/flutter/lib/src/widgets/icon_theme_data.dart
@@ -18,7 +18,7 @@ import 'framework.dart' show BuildContext;
 /// To obtain the current icon theme, use [IconTheme.of]. To convert an icon
 /// theme to a version with all the fields filled in, use [new
 /// IconThemeData.fallback].
-class IconThemeData with DiagnosticableMixin {
+class IconThemeData with Diagnosticable {
   /// Creates an icon theme data.
   ///
   /// The opacity applies to both explicit and default icon colors. The value

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -110,7 +110,7 @@ class KeySet<T extends KeyboardKey> {
 /// This is a thin wrapper around a [Set], but changes the equality comparison
 /// from an identity comparison to a contents comparison so that non-identical
 /// sets with the same keys in them will compare as equal.
-class LogicalKeySet extends KeySet<LogicalKeyboardKey> with DiagnosticableMixin implements Diagnosticable {
+class LogicalKeySet extends KeySet<LogicalKeyboardKey> with DiagnosticableMixin {
   /// A constructor for making a [LogicalKeySet] of up to four keys.
   ///
   /// If you need a set of more than four keys, use [LogicalKeySet.fromSet].
@@ -201,7 +201,7 @@ class ShortcutMapProperty extends DiagnosticsProperty<Map<LogicalKeySet, Intent>
 ///
 /// A [ShortcutManager] is obtained by calling [Shortcuts.of] on the context of
 /// the widget that you want to find a manager for.
-class ShortcutManager extends ChangeNotifier with DiagnosticableMixin implements Diagnosticable {
+class ShortcutManager extends ChangeNotifier with DiagnosticableMixin {
   /// Constructs a [ShortcutManager].
   ///
   /// The [shortcuts] argument must not  be null.

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -110,7 +110,7 @@ class KeySet<T extends KeyboardKey> {
 /// This is a thin wrapper around a [Set], but changes the equality comparison
 /// from an identity comparison to a contents comparison so that non-identical
 /// sets with the same keys in them will compare as equal.
-class LogicalKeySet extends KeySet<LogicalKeyboardKey> with DiagnosticableMixin {
+class LogicalKeySet extends KeySet<LogicalKeyboardKey> with Diagnosticable {
   /// A constructor for making a [LogicalKeySet] of up to four keys.
   ///
   /// If you need a set of more than four keys, use [LogicalKeySet.fromSet].
@@ -201,7 +201,7 @@ class ShortcutMapProperty extends DiagnosticsProperty<Map<LogicalKeySet, Intent>
 ///
 /// A [ShortcutManager] is obtained by calling [Shortcuts.of] on the context of
 /// the widget that you want to find a manager for.
-class ShortcutManager extends ChangeNotifier with DiagnosticableMixin {
+class ShortcutManager extends ChangeNotifier with Diagnosticable {
   /// Constructs a [ShortcutManager].
   ///
   /// The [shortcuts] argument must not  be null.

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -635,7 +635,7 @@ class _DiagnosticsPathNode {
 }
 
 List<_DiagnosticsPathNode> _followDiagnosticableChain(
-  List<DiagnosticableMixin> chain, {
+  List<Diagnosticable> chain, {
   String name,
   DiagnosticsTreeStyle style,
 }) {
@@ -644,7 +644,7 @@ List<_DiagnosticsPathNode> _followDiagnosticableChain(
     return path;
   DiagnosticsNode diagnostic = chain.first.toDiagnosticsNode(name: name, style: style);
   for (int i = 1; i < chain.length; i += 1) {
-    final DiagnosticableMixin target = chain[i];
+    final Diagnosticable target = chain[i];
     bool foundMatch = false;
     final List<DiagnosticsNode> children = diagnostic.getChildren();
     for (int j = 0; j < children.length; j += 1) {
@@ -1550,7 +1550,7 @@ mixin WidgetInspectorService {
       return true;
     }
     final Object value = node.value;
-    if (value is! DiagnosticableMixin) {
+    if (value is! Diagnosticable) {
       return true;
     }
     if (value is! Element || !isWidgetCreationTracked()) {

--- a/packages/flutter/test/foundation/diagnostics_test.dart
+++ b/packages/flutter/test/foundation/diagnostics_test.dart
@@ -180,7 +180,7 @@ void validatePropertyJsonSerializationHelper(final Map<String, Object> json, Dia
   }
   expect(json['propertyType'], equals(property.propertyType.toString()));
   expect(json.containsKey('defaultLevel'), isTrue);
-  if (property.value is DiagnosticableMixin) {
+  if (property.value is Diagnosticable) {
     expect(json['isDiagnosticableValue'], isTrue);
   } else {
     expect(json.containsKey('isDiagnosticableValue'), isFalse);


### PR DESCRIPTION
## Description

This converts `Diagnosticable` to be a mixin instead of an abstract class, so that it can be used to add diagnostics to classes which already have a base class.

It leaves in place the `DiagnosticableMixin` mixin, since there are some plugins that are still using it, and removing it would mean that those plugins wouldn't work with master branch Flutter anymore. `DiagnosticableMixin` will be removed once this mixin version of `Diagnosticable` makes its way to the stable branch.

## Related Issues

- https://github.com/flutter/flutter/issues/50498

## Tests

- No tests are needed, since we're just changing from a class to a mixin: the implementation stays the same.

## Breaking Change

- [X] No, this is *not* a breaking change, since no submitted customer tests use `Diagnosticable`.