### PR TITLE
Fix expression evaluation test leaking flutter_tester processes.

### DIFF
--- a/packages/flutter_tools/test/integration.shard/expression_evaluation_test.dart
+++ b/packages/flutter_tools/test/integration.shard/expression_evaluation_test.dart
@@ -107,7 +107,7 @@ void batch2() {
   }
 
   Future<void> cleanProject() async {
-    await _flutter?.quit();
+    await _flutter?.waitForCompletion();
     tryToDelete(tempDir);
   }
 

--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -679,8 +679,6 @@ class FlutterTestTestDriver extends FlutterTestDriver {
       'test',
       '--disable-service-auth-codes',
       '--machine',
-      '-d',
-      'flutter-tester',
     ], script: testFile, withDebugger: withDebugger, pauseOnExceptions: pauseOnExceptions, pidFile: pidFile, beforeStart: beforeStart);
   }
 
@@ -737,6 +735,28 @@ class FlutterTestTestDriver extends FlutterTestDriver {
     } catch (e) {
       // Not valid JSON, so likely some other output.
       return null;
+    }
+  }
+
+  Future<void> waitForCompletion() async {
+    final done = Completer<bool>();
+    // Waiting for `{"success":true,"type":"done",...}` line indicating
+    // end of test run.
+    final subscription = _stdout.stream.listen((String line) async {
+      final Map<String, dynamic> json = _parseJsonResponse(line);
+      if (json != null && json['type'] != null && json['success'] != null) {
+        done.complete(json['type'] == 'done' && json['success'] == true);
+      }
+    });
+
+    await resume();
+
+    final Future<dynamic> timeoutFuture =
+        Future<dynamic>.delayed(defaultTimeout);
+    await Future.any<dynamic>(<Future<dynamic>>[done.future, timeoutFuture]);
+    await subscription.cancel();
+    if (!done.isCompleted) {
+      await quit();
     }
   }
 }

--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -739,15 +739,16 @@ class FlutterTestTestDriver extends FlutterTestDriver {
   }
 
   Future<void> waitForCompletion() async {
-    final done = Completer<bool>();
+    final Completer<bool> done = Completer<bool>();
     // Waiting for `{"success":true,"type":"done",...}` line indicating
     // end of test run.
-    final subscription = _stdout.stream.listen((String line) async {
-      final Map<String, dynamic> json = _parseJsonResponse(line);
-      if (json != null && json['type'] != null && json['success'] != null) {
-        done.complete(json['type'] == 'done' && json['success'] == true);
-      }
-    });
+    final StreamSubscription<String> subscription = _stdout.stream.listen(
+        (String line) async {
+          final Map<String, dynamic> json = _parseJsonResponse(line);
+          if (json != null && json['type'] != null && json['success'] != null) {
+            done.complete(json['type'] == 'done' && json['success'] == true);
+          }
+        });
 
     await resume();
 


### PR DESCRIPTION
Let flutter_tester process complete, wait for it completion, kill the test only if didn't complete on time.

Fixes https://github.com/flutter/flutter/issues/51421