### PR TITLE
ensure dart defines work on web and not web

### DIFF
--- a/packages/flutter/test/foundation/defines_test.dart
+++ b/packages/flutter/test/foundation/defines_test.dart
@@ -9,5 +9,6 @@ void main() {
   test('defines match expectations per platform', () {
     expect(kIsWeb, !const bool.fromEnvironment('dart.library.io'));
     expect(kIsWeb, !const bool.fromEnvironment('dart.library.isolate'));
+    expect(kIsWeb, const bool.fromEnvironment('dart.library.html'));
   });
 }

--- a/packages/flutter/test/foundation/defines_test.dart
+++ b/packages/flutter/test/foundation/defines_test.dart
@@ -1,0 +1,13 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('defines match expectations per platform', () {
+    expect(kIsWeb, !const bool.fromEnvironment('dart.library.io'));
+    expect(kIsWeb, !const bool.fromEnvironment('dart.library.isolate'));
+  });
+}


### PR DESCRIPTION
## Description

Verify that conditional imports will continue to work for web/not-web packages such as package:http