### PR TITLE
don't do a version check when invoking flutter in `test_test.dart`

### DIFF
--- a/packages/flutter_tools/test/commands.shard/permeable/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/test_test.dart
@@ -248,6 +248,7 @@ Future<ProcessResult> _runFlutterTest(
     globals.fs.path.absolute(globals.fs.path.join('bin', 'flutter_tools.dart')),
     'test',
     '--no-color',
+    '--no-version-check',
     ...extraArguments,
     testPath,
   ];


### PR DESCRIPTION
## Description

In #51366, a test regex fails when the tool prints out warning that a newer version of flutter exists. We shouldn't run the version check in this test.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/51366

## Tests

I modified a test to no longer make the version check, which will prevent flaking.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*