### PR TITLE
Replace clean command test functions with test groups

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
@@ -18,86 +18,99 @@ import '../../src/common.dart';
 import '../../src/context.dart';
 
 void main() {
-  void test1() {
-    final MemoryFileSystem fs = MemoryFileSystem();
-    final MockXcodeProjectInterpreter mockXcodeProjectInterpreter = MockXcodeProjectInterpreter();
-    final MockXcode mockXcode = MockXcode();
-
-    final Directory currentDirectory = fs.currentDirectory;
-    final Directory buildDirectory = currentDirectory.childDirectory('build');
-    buildDirectory.createSync(recursive: true);
-
-    final FlutterProject projectUnderTest = FlutterProject.fromDirectory(currentDirectory);
-    projectUnderTest.ios.xcodeWorkspace.createSync(recursive: true);
-    projectUnderTest.macos.xcodeWorkspace.createSync(recursive: true);
-
-    projectUnderTest.dartTool.createSync(recursive: true);
-    projectUnderTest.android.ephemeralDirectory.createSync(recursive: true);
-    projectUnderTest.ios.ephemeralDirectory.createSync(recursive: true);
-    projectUnderTest.linux.ephemeralDirectory.createSync(recursive: true);
-    projectUnderTest.macos.ephemeralDirectory.createSync(recursive: true);
-    projectUnderTest.windows.ephemeralDirectory.createSync(recursive: true);
-
-    testUsingContext('$CleanCommand removes build and .dart_tool and ephemeral directories, cleans Xcode', () async {
-      when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
-      await CleanCommand().runCommand();
-
-      expect(buildDirectory.existsSync(), isFalse);
-      expect(projectUnderTest.dartTool.existsSync(), isFalse);
-      expect(projectUnderTest.android.ephemeralDirectory.existsSync(), isFalse);
-      expect(projectUnderTest.ios.ephemeralDirectory.existsSync(), isFalse);
-      expect(projectUnderTest.linux.ephemeralDirectory.existsSync(), isFalse);
-      expect(projectUnderTest.macos.ephemeralDirectory.existsSync(), isFalse);
-      expect(projectUnderTest.windows.ephemeralDirectory.existsSync(), isFalse);
-
-      verify(xcodeProjectInterpreter.cleanWorkspace(any, 'Runner')).called(2);
-    }, overrides: <Type, Generator>{
-      FileSystem: () => fs,
-      ProcessManager: () => FakeProcessManager.any(),
-      Xcode: () => mockXcode,
-      XcodeProjectInterpreter: () => mockXcodeProjectInterpreter,
-    });
-  }
-
-  void test2() {
-    final MockXcode mockXcode = MockXcode();
-    final MockPlatform windowsPlatform = MockPlatform();
-    testUsingContext('$CleanCommand prints a helpful error message on Windows', () async {
-      when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(false);
-      when(windowsPlatform.isWindows).thenReturn(true);
-
-      final MockFile mockFile = MockFile();
-      when(mockFile.existsSync()).thenReturn(true);
-
-      when(mockFile.deleteSync(recursive: true)).thenThrow(const FileSystemException('Deletion failed'));
-      final CleanCommand command = CleanCommand();
-      command.deleteFile(mockFile);
-      expect(testLogger.errorText, contains('A program may still be using a file'));
-      verify(mockFile.deleteSync(recursive: true)).called(1);
-    }, overrides: <Type, Generator>{
-      Platform: () => windowsPlatform,
-      Xcode: () => mockXcode,
+  group('clean command', () {
+    MockXcode mockXcode;
+    setUp(() {
+      mockXcode = MockXcode();
     });
 
-    testUsingContext('$CleanCommand handles missing permissions;', () async {
-      when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(false);
+    group('general', () {
+      MemoryFileSystem fs;
+      MockXcodeProjectInterpreter mockXcodeProjectInterpreter;
+      Directory buildDirectory;
+      FlutterProject projectUnderTest;
 
-      final MockFile mockFile = MockFile();
-      when(mockFile.existsSync()).thenThrow(const FileSystemException('OS error: Access Denied'));
-      when(mockFile.path).thenReturn('foo.dart');
+      setUp(() {
+        fs = MemoryFileSystem();
+        mockXcodeProjectInterpreter = MockXcodeProjectInterpreter();
 
-      final CleanCommand command = CleanCommand();
-      command.deleteFile(mockFile);
-      expect(testLogger.errorText, contains('Cannot clean foo.dart'));
-      verifyNever(mockFile.deleteSync(recursive: true));
-    }, overrides: <Type, Generator>{
-      Platform: () => windowsPlatform,
-      Xcode: () => mockXcode,
+        final Directory currentDirectory = fs.currentDirectory;
+        buildDirectory = currentDirectory.childDirectory('build');
+        buildDirectory.createSync(recursive: true);
+
+        projectUnderTest = FlutterProject.fromDirectory(currentDirectory);
+        projectUnderTest.ios.xcodeWorkspace.createSync(recursive: true);
+        projectUnderTest.macos.xcodeWorkspace.createSync(recursive: true);
+
+        projectUnderTest.dartTool.createSync(recursive: true);
+        projectUnderTest.android.ephemeralDirectory.createSync(recursive: true);
+        projectUnderTest.ios.ephemeralDirectory.createSync(recursive: true);
+        projectUnderTest.linux.ephemeralDirectory.createSync(recursive: true);
+        projectUnderTest.macos.ephemeralDirectory.createSync(recursive: true);
+        projectUnderTest.windows.ephemeralDirectory.createSync(recursive: true);
+      });
+
+      testUsingContext('$CleanCommand removes build and .dart_tool and ephemeral directories, cleans Xcode', () async {
+        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
+        await CleanCommand().runCommand();
+
+        expect(buildDirectory.existsSync(), isFalse);
+        expect(projectUnderTest.dartTool.existsSync(), isFalse);
+        expect(projectUnderTest.android.ephemeralDirectory.existsSync(), isFalse);
+        expect(projectUnderTest.ios.ephemeralDirectory.existsSync(), isFalse);
+        expect(projectUnderTest.linux.ephemeralDirectory.existsSync(), isFalse);
+        expect(projectUnderTest.macos.ephemeralDirectory.existsSync(), isFalse);
+        expect(projectUnderTest.windows.ephemeralDirectory.existsSync(), isFalse);
+
+        verify(xcodeProjectInterpreter.cleanWorkspace(any, 'Runner')).called(2);
+      }, overrides: <Type, Generator>{
+        FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager.any(),
+        Xcode: () => mockXcode,
+        XcodeProjectInterpreter: () => mockXcodeProjectInterpreter,
+      });
     });
-  }
 
-  test1();
-  test2();
+    group('Windows', () {
+      MockPlatform windowsPlatform;
+      setUp(() {
+        windowsPlatform = MockPlatform();
+      });
+
+      testUsingContext('$CleanCommand prints a helpful error message on Windows', () async {
+        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(false);
+        when(windowsPlatform.isWindows).thenReturn(true);
+
+        final MockFile mockFile = MockFile();
+        when(mockFile.existsSync()).thenReturn(true);
+
+        when(mockFile.deleteSync(recursive: true)).thenThrow(const FileSystemException('Deletion failed'));
+        final CleanCommand command = CleanCommand();
+        command.deleteFile(mockFile);
+        expect(testLogger.errorText, contains('A program may still be using a file'));
+        verify(mockFile.deleteSync(recursive: true)).called(1);
+      }, overrides: <Type, Generator>{
+        Platform: () => windowsPlatform,
+        Xcode: () => mockXcode,
+      });
+
+      testUsingContext('$CleanCommand handles missing permissions;', () async {
+        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(false);
+
+        final MockFile mockFile = MockFile();
+        when(mockFile.existsSync()).thenThrow(const FileSystemException('OS error: Access Denied'));
+        when(mockFile.path).thenReturn('foo.dart');
+
+        final CleanCommand command = CleanCommand();
+        command.deleteFile(mockFile);
+        expect(testLogger.errorText, contains('Cannot clean foo.dart'));
+        verifyNever(mockFile.deleteSync(recursive: true));
+      }, overrides: <Type, Generator>{
+        Platform: () => windowsPlatform,
+        Xcode: () => mockXcode,
+      });
+    });
+  });
 }
 
 class MockFile extends Mock implements File {}


### PR DESCRIPTION
## Description

Replace test1 and test2 clean command tests with test groups.  No test behavior changed.

## Tests

Refactored test, still passes.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*