### PR TITLE
Turn back on macOS shard Cirrus caching

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -467,8 +467,6 @@ task:
         - dart --enable-asserts dev\customer_testing\run_tests.dart --skip-on-fetch-failure --skip-template bin/cache/pkg/tests/registry/*.test
 
 # MACOS SHARDS
-# Mac doesn't use caches because they apparently take longer to populate and save
-# than just fetching the data in the first place.
 task:
   osx_instance:
     image: catalina-flutter # see https://cirrus-ci.org/guide/macOS/ for list of images (we should update regularly)
@@ -481,6 +479,21 @@ task:
     COCOAPODS_DISABLE_STATS: true
     CPU: 2
     MEMORY: 8G
+  all_flutter_cache:
+    folder: bin/cache/
+    fingerprint_script: echo $OS; cat bin/internal/*.version
+    populate_script:
+      - git fetch origin
+      - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
+      - flutter precache
+      - flutter doctor -v
+  pub_cache:
+    folder: $HOME/.pub-cache
+    fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"
+    populate_script:
+      - git fetch origin
+      - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
+      - flutter update-packages
   setup_script:
     - date
     - which flutter
@@ -492,7 +505,7 @@ task:
     - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
     - flutter config --no-analytics
     - flutter doctor -v
-    - flutter update-packages
+    - flutter update-packages --offline
     - date
     - which flutter
   on_failure:
@@ -605,7 +618,9 @@ task:
       script:
         - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
         - dart --enable-asserts ./dev/bots/codesign.dart
-
+  cleanup_before_cache_upload_script:
+     # Remove volatile file to avoid unnecessary Cirrus cache invalidation.
+    - rm -f bin/cache/flutter_version_check.stamp
 docker_builder:
   # Only build a new docker image when we tag a release (for dev, beta, or
   # stable). Note: tagging a commit and pushing to a release branch are


### PR DESCRIPTION
## Description

This was previously attempted in https://github.com/flutter/flutter/pull/50496 and reverted in https://github.com/flutter/flutter/pull/50661 due to ongoing Cirrus macOS networking flakes causing constant recaching.

[Networking is much improved](https://github.com/flutter/flutter/issues/50730), try again.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*