### PR TITLE
Pass RouteSettings into all callers of showGeneralDialog.

### DIFF
--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -976,6 +976,7 @@ Future<T> showCupertinoDialog<T>({
   @required BuildContext context,
   @required WidgetBuilder builder,
   bool useRootNavigator = true,
+  RouteSettings routeSettings,
 }) {
   assert(builder != null);
   assert(useRootNavigator != null);
@@ -990,5 +991,6 @@ Future<T> showCupertinoDialog<T>({
     },
     transitionBuilder: _buildCupertinoDialogTransitions,
     useRootNavigator: useRootNavigator,
+    routeSettings: routeSettings,
   );
 }

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -223,8 +223,8 @@ class AboutListTile extends StatelessWidget {
 /// The licenses shown on the [LicensePage] are those returned by the
 /// [LicenseRegistry] API, which can be used to add more licenses to the list.
 ///
-/// The [context] and [useRootNavigator] arguments are passed to [showDialog],
-/// the documentation for which discusses how it is used.
+/// The [context], [useRootNavigator] and [routeSettings] arguments are passed to
+/// [showDialog], the documentation for which discusses how it is used.
 void showAboutDialog({
   @required BuildContext context,
   String applicationName,
@@ -233,6 +233,7 @@ void showAboutDialog({
   String applicationLegalese,
   List<Widget> children,
   bool useRootNavigator = true,
+  RouteSettings routeSettings,
 }) {
   assert(context != null);
   assert(useRootNavigator != null);
@@ -248,6 +249,7 @@ void showAboutDialog({
         children: children,
       );
     },
+    routeSettings: routeSettings,
   );
 }
 

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -1086,8 +1086,8 @@ typedef SelectableDayPredicate = bool Function(DateTime day);
 /// provided by [Directionality]. If both [locale] and [textDirection] are not
 /// null, [textDirection] overrides the direction chosen for the [locale].
 ///
-/// The [context] and [useRootNavigator] arguments are passed to [showDialog],
-/// the documentation for which discusses how it is used.
+/// The [context], [useRootNavigator] and [routeSettings] arguments are passed to
+/// [showDialog], the documentation for which discusses how it is used.
 ///
 /// The [builder] parameter can be used to wrap the dialog widget
 /// to add inherited widgets like [Theme].
@@ -1137,6 +1137,7 @@ Future<DateTime> showDatePicker({
   TextDirection textDirection,
   TransitionBuilder builder,
   bool useRootNavigator = true,
+  RouteSettings routeSettings,
 }) async {
   assert(initialDate != null);
   assert(firstDate != null);
@@ -1182,5 +1183,6 @@ Future<DateTime> showDatePicker({
     builder: (BuildContext context) {
       return builder == null ? child : builder(context, child);
     },
+    routeSettings: routeSettings,
   );
 }

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -872,6 +872,9 @@ Widget _buildMaterialDialogTransitions(BuildContext context, Animation<double> a
 /// By default, `useRootNavigator` is `true` and the dialog route created by
 /// this method is pushed to the root navigator.
 ///
+/// The `routeSettings` argument is passed to [showGeneralDialog],
+/// see [RouteSettings] for details.
+///
 /// If the application has multiple [Navigator] objects, it may be necessary to
 /// call `Navigator.of(context, rootNavigator: true).pop(result)` to close the
 /// dialog rather than just `Navigator.pop(context, result)`.
@@ -900,6 +903,7 @@ Future<T> showDialog<T>({
   Widget child,
   WidgetBuilder builder,
   bool useRootNavigator = true,
+  RouteSettings routeSettings,
 }) {
   assert(child == null || builder == null);
   assert(useRootNavigator != null);
@@ -926,5 +930,6 @@ Future<T> showDialog<T>({
     transitionDuration: const Duration(milliseconds: 150),
     transitionBuilder: _buildMaterialDialogTransitions,
     useRootNavigator: useRootNavigator,
+    routeSettings: routeSettings,
   );
 }

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -1749,8 +1749,8 @@ class _TimePickerDialogState extends State<_TimePickerDialog> {
 /// ```
 /// {@end-tool}
 ///
-/// The [context] and [useRootNavigator] arguments are passed to [showDialog],
-/// the documentation for which discusses how it is used.
+/// The [context], [useRootNavigator] and [routeSettings] arguments are passed to
+/// [showDialog], the documentation for which discusses how it is used.
 ///
 /// The [builder] parameter can be used to wrap the dialog widget
 /// to add inherited widgets like [Localizations.override],
@@ -1799,6 +1799,7 @@ Future<TimeOfDay> showTimePicker({
   @required TimeOfDay initialTime,
   TransitionBuilder builder,
   bool useRootNavigator = true,
+  RouteSettings routeSettings,
 }) async {
   assert(context != null);
   assert(initialTime != null);
@@ -1812,6 +1813,7 @@ Future<TimeOfDay> showTimePicker({
     builder: (BuildContext context) {
       return builder == null ? dialog : builder(context, dialog);
     },
+    routeSettings: routeSettings,
   );
 }
 

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1727,6 +1727,9 @@ class _DialogRoute<T> extends PopupRoute<T> {
 /// and leaves off the screen. By default, the transition is a linear fade of
 /// the page's contents.
 ///
+/// The `routeSettings` will be used in the construction of the dialog's route.
+/// See [RouteSettings] for more details.
+///
 /// Returns a [Future] that resolves to the value (if any) that was passed to
 /// [Navigator.pop] when the dialog was closed.
 ///
@@ -1743,6 +1746,7 @@ Future<T> showGeneralDialog<T>({
   Duration transitionDuration,
   RouteTransitionsBuilder transitionBuilder,
   bool useRootNavigator = true,
+  RouteSettings routeSettings,
 }) {
   assert(pageBuilder != null);
   assert(useRootNavigator != null);
@@ -1754,6 +1758,7 @@ Future<T> showGeneralDialog<T>({
     barrierColor: barrierColor,
     transitionDuration: transitionDuration,
     transitionBuilder: transitionBuilder,
+    settings: routeSettings,
   ));
 }
 


### PR DESCRIPTION
## Description

NOTE: this is a recreation of @hpoul's #38631, as I wasn't able to push changes to that branch and the author appears to have moved on. 

### Original description:

Right now there is no way to customize the `RouteSettings` when using the `showDialog` functions. I can't think of a good reason to omit this, since it's pretty useful for e.g. analytics to track page names.

## Related Issues

* #31261

## Tests

I added the following tests:

* added test for `showDialog` to demonstrate how it is passed to the `NavigatorObserver`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.
