### PR TITLE
Clean App.framework, Generated.xcconfig, flutter_export_environment.sh

### DIFF
--- a/packages/flutter_tools/lib/src/commands/clean.dart
+++ b/packages/flutter_tools/lib/src/commands/clean.dart
@@ -43,20 +43,16 @@ class CleanCommand extends FlutterCommand {
 
     deleteFile(flutterProject.dartTool);
 
-    final Directory androidEphemeralDirectory = flutterProject.android.ephemeralDirectory;
-    deleteFile(androidEphemeralDirectory);
+    deleteFile(flutterProject.android.ephemeralDirectory);
 
-    final Directory iosEphemeralDirectory = flutterProject.ios.ephemeralDirectory;
-    deleteFile(iosEphemeralDirectory);
+    deleteFile(flutterProject.ios.ephemeralDirectory);
+    deleteFile(flutterProject.ios.generatedXcodePropertiesFile);
+    deleteFile(flutterProject.ios.generatedEnvironmentVariableExportScript);
+    deleteFile(flutterProject.ios.compiledDartFramework);
 
-    final Directory linuxEphemeralDirectory = flutterProject.linux.ephemeralDirectory;
-    deleteFile(linuxEphemeralDirectory);
-
-    final Directory macosEphemeralDirectory = flutterProject.macos.ephemeralDirectory;
-    deleteFile(macosEphemeralDirectory);
-
-    final Directory windowsEphemeralDirectory = flutterProject.windows.ephemeralDirectory;
-    deleteFile(windowsEphemeralDirectory);
+    deleteFile(flutterProject.linux.ephemeralDirectory);
+    deleteFile(flutterProject.macos.ephemeralDirectory);
+    deleteFile(flutterProject.windows.ephemeralDirectory);
 
     return const FlutterCommandResult(ExitStatus.success);
   }
@@ -73,7 +69,7 @@ class CleanCommand extends FlutterCommand {
       final Directory xcodeWorkspace = xcodeProject.xcodeWorkspace;
       final XcodeProjectInfo projectInfo = await xcodeProjectInterpreter.getInfo(xcodeWorkspace.parent.path);
       for (final String scheme in projectInfo.schemes) {
-        xcodeProjectInterpreter.cleanWorkspace(xcodeWorkspace.path, scheme);
+        await xcodeProjectInterpreter.cleanWorkspace(xcodeWorkspace.path, scheme);
       }
     } catch (error) {
       globals.printTrace('Could not clean Xcode workspace: $error');

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -429,16 +429,6 @@ return result.exitCode != 0 &&
     result.stdout.contains('there are two concurrent builds running');
 }
 
-String readGeneratedXcconfig(String appPath) {
-  final String generatedXcconfigPath =
-      globals.fs.path.join(globals.fs.currentDirectory.path, appPath, 'Flutter', 'Generated.xcconfig');
-  final File generatedXcconfigFile = globals.fs.file(generatedXcconfigPath);
-  if (!generatedXcconfigFile.existsSync()) {
-    return null;
-  }
-  return generatedXcconfigFile.readAsStringSync();
-}
-
 Future<void> diagnoseXcodeBuildFailure(XcodeBuildResult result) async {
   if (result.xcodeBuildExecution != null &&
       result.xcodeBuildExecution.buildForPhysicalDevice &&

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -352,8 +352,8 @@ class XcodeProjectInterpreter {
     }
   }
 
-  void cleanWorkspace(String workspacePath, String scheme) {
-    _processUtils.runSync(<String>[
+  Future<void> cleanWorkspace(String workspacePath, String scheme) async {
+    await _processUtils.run(<String>[
       _executable,
       '-workspace',
       workspacePath,

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -567,6 +567,10 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
     .childDirectory('Flutter')
     .childFile('Generated.xcconfig');
 
+  Directory get compiledDartFramework => _flutterLibRoot
+      .childDirectory('Flutter')
+      .childDirectory('App.framework');
+
   Directory get pluginRegistrantHost {
     return isModule
         ? _flutterLibRoot

--- a/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
@@ -44,7 +44,12 @@ void main() {
 
         projectUnderTest.dartTool.createSync(recursive: true);
         projectUnderTest.android.ephemeralDirectory.createSync(recursive: true);
+
         projectUnderTest.ios.ephemeralDirectory.createSync(recursive: true);
+        projectUnderTest.ios.generatedXcodePropertiesFile.createSync(recursive: true);
+        projectUnderTest.ios.generatedEnvironmentVariableExportScript.createSync(recursive: true);
+        projectUnderTest.ios.compiledDartFramework.createSync(recursive: true);
+
         projectUnderTest.linux.ephemeralDirectory.createSync(recursive: true);
         projectUnderTest.macos.ephemeralDirectory.createSync(recursive: true);
         projectUnderTest.windows.ephemeralDirectory.createSync(recursive: true);
@@ -57,7 +62,12 @@ void main() {
         expect(buildDirectory.existsSync(), isFalse);
         expect(projectUnderTest.dartTool.existsSync(), isFalse);
         expect(projectUnderTest.android.ephemeralDirectory.existsSync(), isFalse);
+
         expect(projectUnderTest.ios.ephemeralDirectory.existsSync(), isFalse);
+        expect(projectUnderTest.ios.generatedXcodePropertiesFile.existsSync(), isFalse);
+        expect(projectUnderTest.ios.generatedEnvironmentVariableExportScript.existsSync(), isFalse);
+        expect(projectUnderTest.ios.compiledDartFramework.existsSync(), isFalse);
+
         expect(projectUnderTest.linux.ephemeralDirectory.existsSync(), isFalse);
         expect(projectUnderTest.macos.ephemeralDirectory.existsSync(), isFalse);
         expect(projectUnderTest.windows.ephemeralDirectory.existsSync(), isFalse);

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -224,12 +224,12 @@ void main() {
       'FLUTTER_XCODE_CODE_SIGN_STYLE': 'Manual',
       'FLUTTER_XCODE_ARCHS': 'arm64'
     });
-    when(processManager.runSync(
+    when(processManager.run(
       any,
       workingDirectory: anyNamed('workingDirectory')))
-      .thenReturn(ProcessResult(1, 0, '', ''));
-    xcodeProjectInterpreter.cleanWorkspace('workspace_path', 'Runner');
-    final List<dynamic> captured = verify(processManager.runSync(
+      .thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 0, '', '')));
+    await xcodeProjectInterpreter.cleanWorkspace('workspace_path', 'Runner');
+    final List<dynamic> captured = verify(processManager.run(
       captureAny,
       workingDirectory: anyNamed('workingDirectory'),
       environment: anyNamed('environment'))).captured;

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -383,7 +383,7 @@ class FakeXcodeProjectInterpreter implements XcodeProjectInterpreter {
   }
 
   @override
-  void cleanWorkspace(String workspacePath, String scheme) {
+  Future<void> cleanWorkspace(String workspacePath, String scheme) {
   }
 
   @override

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -384,6 +384,7 @@ class FakeXcodeProjectInterpreter implements XcodeProjectInterpreter {
 
   @override
   Future<void> cleanWorkspace(String workspacePath, String scheme) {
+    return null;
   }
 
   @override


### PR DESCRIPTION
## Description

Mitigate https://github.com/flutter/flutter/issues/50568 by removing the old `App.framework` during `flutter clean` so users can get unstuck.
Also remove `Generated.xcconfig` and `flutter_export_environment.sh` while we're at it.

## Related Issues

Mitigates https://github.com/flutter/flutter/issues/50568.  Much safer potential hotfix than bigger fix at https://github.com/flutter/flutter/pull/51453.
Part of https://github.com/flutter/flutter/issues/12631.

## Tests

Updated xcodeproj_test, clean_test.

Followed the very smart advice in https://github.com/flutter/flutter/issues/12631#issuecomment-555218745 
> TL;DR make sure `flutter build ios && flutter clean && flutter build ios` works both with and without iOS platform plugins.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*