### PR TITLE
Revert "[flutter_tool] Where possible, catch only subtypes of Exception"

### DIFF
--- a/packages/flutter_tools/analysis_options.yaml
+++ b/packages/flutter_tools/analysis_options.yaml
@@ -7,4 +7,3 @@ linter:
   rules:
     unawaited_futures: true
     curly_braces_in_flow_control_structures: true
-    avoid_catches_without_on_clauses: true

--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -62,8 +62,7 @@ Future<int> run(
       try {
         await runner.run(args);
         return await _exit(0);
-      // This catches all exceptions to send to crash logging, etc.
-      } catch (error, stackTrace) {  // ignore: avoid_catches_without_on_clauses
+      } catch (error, stackTrace) {
         firstError = error;
         firstStackTrace = stackTrace;
         return await _handleToolError(
@@ -136,8 +135,7 @@ Future<int> _handleToolError(
       await _informUserOfCrash(args, error, stackTrace, errorString);
 
       return _exit(1);
-    // This catch catches all exceptions to ensure the message below is printed.
-    } catch (error) { // ignore: avoid_catches_without_on_clauses
+    } catch (error) {
       globals.stdio.stderrWrite(
         'Unable to generate crash report due to secondary error: $error\n'
         'please let us know at https://github.com/flutter/flutter/issues.\n',
@@ -245,7 +243,7 @@ Future<String> _doctorText() async {
     );
 
     return logger.statusText;
-  } on Exception catch (error, trace) {
+  } catch (error, trace) {
     return 'encountered exception: $error\n\n${trace.toString().trim()}\n';
   }
 }
@@ -273,9 +271,7 @@ Future<int> _exit(int code) async {
       globals.printTrace('exiting with code $code');
       exit(code);
       completer.complete();
-    // This catches all exceptions becauce the error is propagated on the
-    // completer.
-    } catch (error, stackTrace) { // ignore: avoid_catches_without_on_clauses
+    } catch (error, stackTrace) {
       completer.completeError(error, stackTrace);
     }
   });

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -177,7 +177,7 @@ class AndroidDevice extends Device {
       } finally {
         console.destroy();
       }
-    } on Exception catch (e) {
+    } catch (e) {
       globals.printTrace('Failed to fetch avd name for emulator at $host:$port: $e');
       // If we fail to connect to the device, we should not fail so just return
       // an empty name. This data is best-effort.
@@ -299,7 +299,7 @@ class AndroidDevice extends Device {
         return true;
       }
       globals.printError('The ADB at "${getAdbPath(androidSdk)}" is too old; please install version 1.0.39 or later.');
-    } on Exception catch (error, trace) {
+    } catch (error, trace) {
       globals.printError('Error running ADB: $error', stackTrace: trace);
     }
 
@@ -335,7 +335,7 @@ class AndroidDevice extends Device {
       }
 
       return true;
-    } on Exception catch (e, stacktrace) {
+    } catch (e, stacktrace) {
       globals.printError('Unexpected failure from adb: $e');
       globals.printError('Stacktrace: $stacktrace');
       return false;
@@ -366,7 +366,7 @@ class AndroidDevice extends Device {
     try {
       final RunResult listOut = await runAdbCheckedAsync(<String>['shell', 'pm', 'list', 'packages', app.id]);
       return LineSplitter.split(listOut.stdout).contains('package:${app.id}');
-    } on Exception catch (error) {
+    } catch (error) {
       globals.printTrace('$error');
       return false;
     }
@@ -432,7 +432,7 @@ class AndroidDevice extends Device {
         throwOnError: true,
       );
       uninstallOut = uninstallResult.stdout;
-    } on Exception catch (error) {
+    } catch (error) {
       globals.printError('adb uninstall failed: $error');
       return false;
     }
@@ -631,7 +631,7 @@ class AndroidDevice extends Device {
       }
 
       return LaunchResult.succeeded(observatoryUri: observatoryUri);
-    } on Exception catch (error) {
+    } catch (error) {
       globals.printError('Error waiting for a debug connection: $error');
       return LaunchResult.failed();
     } finally {
@@ -696,7 +696,7 @@ class AndroidDevice extends Device {
       output = runAdbCheckedSync(<String>[
         'shell', '-x', 'logcat', '-v', 'time', '-t', '1'
       ]);
-    } on Exception catch (error) {
+    } catch (error) {
       globals.printError('Failed to extract the most recent timestamp from the Android log: $error.');
       return null;
     }

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -492,7 +492,7 @@ class AndroidSdk {
         .map((FileSystemEntity entity) {
           try {
             return Version.parse(entity.basename);
-          } on Exception {
+          } catch (error) {
             return null;
           }
         })
@@ -518,7 +518,7 @@ class AndroidSdk {
               .group(1);
           platformVersion = int.parse(versionString);
         }
-      } on Exception {
+      } catch (error) {
         return null;
       }
 
@@ -583,7 +583,7 @@ class AndroidSdk {
             return fileSystem.path.join(javaHome, 'bin', 'java');
           }
         }
-      } on Exception catch (_) { /* ignore */ }
+      } catch (_) { /* ignore */ }
     }
 
     // Fallback to PATH based lookup.

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -93,7 +93,7 @@ class AndroidStudio implements Comparable<AndroidStudio> {
       installPath = globals.fs
           .file(globals.fs.path.join(homeDotDir.path, 'system', '.home'))
           .readAsStringSync();
-    } on Exception {
+    } catch (e) {
       // ignored, installPath will be null, which is handled below
     }
     if (installPath != null && globals.fs.isDirectorySync(installPath)) {
@@ -200,7 +200,7 @@ class AndroidStudio implements Comparable<AndroidStudio> {
             _checkForStudio(directory.path);
           }
         }
-      } on Exception catch (e) {
+      } catch (e) {
         globals.printTrace('Exception while looking for Android Studio: $e');
       }
     }

--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -122,7 +122,7 @@ class AndroidValidator extends DoctorValidator {
           final List<String> versionLines = (result.stderr as String).split('\n');
           javaVersionText = versionLines.length >= 2 ? versionLines[1] : versionLines[0];
         }
-      } on Exception catch (error) {
+      } catch (error) {
         _logger.printTrace(error.toString());
       }
       if (javaVersionText == null || javaVersionText.isEmpty) {
@@ -287,7 +287,7 @@ class AndroidLicenseValidator extends DoctorValidator {
         final List<String> versionLines = (result.stderr as String).split('\n');
         javaVersion = versionLines.length >= 2 ? versionLines[1] : versionLines[0];
       }
-    } on Exception catch (error) {
+    } catch (error) {
       globals.printTrace(error.toString());
     }
     if (javaVersion == null) {
@@ -389,7 +389,7 @@ class AndroidLicenseValidator extends DoctorValidator {
           globals.stdio.addStdoutStream(process.stdout),
           globals.stdio.addStderrStream(process.stderr),
         ]);
-      } on Exception catch (err, stack) {
+      } catch (err, stack) {
         globals.printTrace('Echoing stdout or stderr from the license subprocess failed:');
         globals.printTrace('$err\n$stack');
       }

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -128,7 +128,7 @@ class _ManifestAssetBundle implements AssetBundle {
     FlutterManifest flutterManifest;
     try {
       flutterManifest = FlutterManifest.createFromPath(manifestPath);
-    } on Exception catch (e) {
+    } catch (e) {
       globals.printStatus('Error detected in pubspec.yaml:', emphasis: true);
       globals.printError('$e');
       return 1;

--- a/packages/flutter_tools/lib/src/base/async_guard.dart
+++ b/packages/flutter_tools/lib/src/base/async_guard.dart
@@ -112,9 +112,7 @@ Future<T> asyncGuard<T>(
       if (!completer.isCompleted) {
         completer.complete(result);
       }
-    // This catches all exceptions so that they can be propagated to the
-    // caller-supplied error handling or the completer.
-    } catch (e, s) { // ignore: avoid_catches_without_on_clauses
+    } catch (e, s) {
       handleError(e, s);
     }
   }, onError: (Object e, StackTrace s) {

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -364,8 +364,7 @@ class WindowsStdoutLogger extends StdoutLogger {
       ? message
       : message.replaceAll('🔥', '')
                .replaceAll('✗', 'X')
-               .replaceAll('✓', '√')
-               .replaceAll('🔨', '');
+               .replaceAll('✓', '√');
     _stdio.stdoutWrite(windowsMessage);
   }
 }

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -136,7 +136,7 @@ abstract class OperatingSystemUtils {
         return findFreePort(ipv6: true);
       }
       _logger.printTrace('findFreePort failed: $e');
-    } on Exception catch (e) {
+    } catch (e) {
       // Failures are signaled by a return value of 0 from this function.
       _logger.printTrace('findFreePort failed: $e');
     } finally {

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -367,7 +367,7 @@ class _DefaultProcessUtils implements ProcessUtils {
           stdioFuture = stdioFuture.timeout(const Duration(seconds: 1));
         }
         await stdioFuture;
-      } on Exception catch (_) {
+      } catch (_) {
         // Ignore errors on the process' stdout and stderr streams. Just capture
         // whatever we got, and use the exit code
       }
@@ -539,7 +539,7 @@ class _DefaultProcessUtils implements ProcessUtils {
     _traceCommand(cli);
     try {
       return _processManager.runSync(cli, environment: environment).exitCode == 0;
-    } on Exception catch (error) {
+    } catch (error) {
       _logger.printTrace('$cli failed with $error');
       return false;
     }
@@ -553,7 +553,7 @@ class _DefaultProcessUtils implements ProcessUtils {
     _traceCommand(cli);
     try {
       return (await _processManager.run(cli, environment: environment)).exitCode == 0;
-    } on Exception catch (error) {
+    } catch (error) {
       _logger.printTrace('$cli failed with $error');
       return false;
     }

--- a/packages/flutter_tools/lib/src/base/signals.dart
+++ b/packages/flutter_tools/lib/src/base/signals.dart
@@ -117,7 +117,7 @@ class _DefaultSignals implements Signals {
     for (final SignalHandler handler in _handlersList[s]) {
       try {
         await asyncGuard<void>(() async => handler(s));
-      } on Exception catch (e) {
+      } catch (e) {
         if (_errorStreamController.hasListener) {
           _errorStreamController.add(e);
         }

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -395,7 +395,8 @@ DarwinArch getIOSArchForName(String arch) {
     case 'x86_64':
       return DarwinArch.x86_64;
   }
-  throw Exception('Unsupported iOS arch name "$arch"');
+  assert(false);
+  return null;
 }
 
 String getNameForTargetPlatform(TargetPlatform platform, {DarwinArch darwinArch}) {
@@ -476,7 +477,8 @@ AndroidArch getAndroidArchForName(String platform) {
     case 'android-x86':
       return AndroidArch.x86;
   }
-  throw Exception('Unsupported Android arch name "$platform"');
+  assert(false);
+  return null;
 }
 
 String getNameForAndroidArch(AndroidArch arch) {

--- a/packages/flutter_tools/lib/src/build_system/build_system.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_system.dart
@@ -582,7 +582,7 @@ class _BuildInstance {
           previousFile.deleteSync();
         }
       }
-    } on Exception catch (exception, stackTrace) {
+    } catch (exception, stackTrace) {
       // TODO(jonahwilliams): throw specific exception for expected errors to mark
       // as non-fatal. All others should be fatal.
       node.target.clearStamp(environment);

--- a/packages/flutter_tools/lib/src/build_system/file_hash_store.dart
+++ b/packages/flutter_tools/lib/src/build_system/file_hash_store.dart
@@ -115,8 +115,8 @@ class FileHashStore {
     FileStorage fileStorage;
     try {
       fileStorage = FileStorage.fromBuffer(data);
-    } on Exception catch (err) {
-      _logger.printTrace('Filestorage format changed: $err');
+    } catch (err) {
+      _logger.printTrace('Filestorage format changed');
       cacheFile.deleteSync();
       return;
     }

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -374,8 +374,8 @@ class ReleaseIosApplicationBundle extends IosAssetBundle {
 Future<RunResult> createStubAppFramework(File outputFile, SdkType sdk, { bool include32Bit = true }) async {
   try {
     outputFile.createSync(recursive: true);
-  } on Exception catch (e) {
-    throwToolExit('Failed to create App.framework stub at ${outputFile.path}: $e');
+  } catch (e) {
+    throwToolExit('Failed to create App.framework stub at ${outputFile.path}');
   }
 
   final Directory tempDir = globals.fs.systemTempDirectory.createTempSync('flutter_tools_stub_source.');
@@ -418,8 +418,8 @@ Future<RunResult> createStubAppFramework(File outputFile, SdkType sdk, { bool in
       tempDir.deleteSync(recursive: true);
     } on FileSystemException catch (_) {
       // Best effort. Sometimes we can't delete things from system temp.
-    } on Exception catch (e) {
-      throwToolExit('Failed to create App.framework stub at ${outputFile.path}: $e');
+    } catch (e) {
+      throwToolExit('Failed to create App.framework stub at ${outputFile.path}');
     }
   }
 }

--- a/packages/flutter_tools/lib/src/build_system/targets/macos.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/macos.dart
@@ -329,7 +329,7 @@ abstract class MacOSBundleFlutterAssets extends Target {
       try {
         final File sourceFile = environment.buildDir.childFile('app.dill');
         sourceFile.copySync(assetDirectory.childFile('kernel_blob.bin').path);
-      } on Exception catch (err) {
+      } catch (err) {
         throw Exception('Failed to copy app.dill: $err');
       }
       // Copy precompiled runtimes.
@@ -342,7 +342,7 @@ abstract class MacOSBundleFlutterAssets extends Target {
             assetDirectory.childFile('vm_snapshot_data').path);
         globals.fs.file(isolateSnapshotData).copySync(
             assetDirectory.childFile('isolate_snapshot_data').path);
-      } on Exception catch (err) {
+      } catch (err) {
         throw Exception('Failed to copy precompiled runtimes: $err');
       }
     }

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -403,7 +403,7 @@ class Cache {
     if (!cachedFile.existsSync()) {
       try {
         await downloadFile(url, cachedFile);
-      } on Exception catch (e) {
+      } catch (e) {
         throwToolExit('Failed to fetch third-party artifact $url: $e');
       }
     }
@@ -597,8 +597,7 @@ abstract class CachedArtifact extends ArtifactSet {
         try {
           await cache.downloadFile(url, tempFile);
           status.stop();
-        // The exception is rethrown, so don't catch only Exceptions.
-        } catch (exception) { // ignore: avoid_catches_without_on_clauses
+        } catch (exception) {
           status.cancel();
           rethrow;
         }

--- a/packages/flutter_tools/lib/src/commands/analyze_base.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_base.dart
@@ -33,7 +33,7 @@ abstract class AnalyzeBase {
         } finally {
           resultsFile.close();
         }
-      } on Exception catch (e) {
+      } catch (e) {
         globals.printError('Failed to save output to "${argResults['write']}": $e');
       }
     }

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -104,7 +104,7 @@ class AssembleCommand extends FlutterCommand {
         CustomDimensions.commandBuildBundleTargetPlatform: localEnvironment.defines['TargetPlatform'],
         CustomDimensions.commandBuildBundleIsModule: '${futterProject.isModule}',
       };
-    } on Exception {
+    } catch (err) {
       // We've failed to send usage.
     }
     return const <CustomDimensions, String>{};

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -114,7 +114,7 @@ class AttachCommand extends FlutterCommand {
     }
     try {
       return int.parse(stringArg('debug-port'));
-    } on Exception catch (error) {
+    } catch (error) {
       throwToolExit('Invalid port for `--debug-port`: $error');
     }
     return null;
@@ -222,7 +222,7 @@ class AttachCommand extends FlutterCommand {
         try {
           isolateDiscoveryProtocol = device.getIsolateDiscoveryProtocol(module);
           observatoryUri = Stream<Uri>.value(await isolateDiscoveryProtocol.uri).asBroadcastStream();
-        } on Exception {
+        } catch (_) {
           isolateDiscoveryProtocol?.dispose();
           final List<ForwardedPort> ports = device.portForwarder.forwardedPorts.toList();
           for (final ForwardedPort port in ports) {
@@ -292,7 +292,7 @@ class AttachCommand extends FlutterCommand {
             globals.fs.currentDirectory,
             LaunchMode.attach,
           );
-        } on Exception catch (error) {
+        } catch (error) {
           throwToolExit(error.toString());
         }
         result = await app.runner.waitForAppToFinish();

--- a/packages/flutter_tools/lib/src/commands/clean.dart
+++ b/packages/flutter_tools/lib/src/commands/clean.dart
@@ -75,7 +75,7 @@ class CleanCommand extends FlutterCommand {
       for (final String scheme in projectInfo.schemes) {
         xcodeProjectInterpreter.cleanWorkspace(xcodeWorkspace.path, scheme);
       }
-    } on Exception catch (error) {
+    } catch (error) {
       globals.printTrace('Could not clean Xcode workspace: $error');
     } finally {
       xcodeStatus?.stop();

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -264,7 +264,7 @@ class CreateCommand extends FlutterCommand {
         outputFile.writeAsStringSync(samplesJson);
         globals.printStatus('Wrote samples JSON to "$outputFilePath"');
       }
-    } on Exception catch (e) {
+    } catch (e) {
       throwToolExit('Failed to write samples JSON to "$outputFilePath": $e', exitCode: 2);
     }
   }

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -175,7 +175,7 @@ class Daemon {
           completer.complete(request['result']);
         }
       }
-    } on Exception catch (error, trace) {
+    } catch (error, trace) {
       _send(<String, dynamic>{
         'id': id,
         'error': _toJsonable(error),
@@ -414,7 +414,7 @@ class DaemonDomain extends Domain {
       return <String, Object>{
         'platforms': result,
       };
-    } on Exception catch (err, stackTrace) {
+    } catch (err, stackTrace) {
       sendEvent('log', <String, dynamic>{
         'log': 'Failed to parse project metadata',
         'stackTrace': stackTrace.toString(),
@@ -596,7 +596,7 @@ class AppDomain extends Domain {
           appStartedCompleter: appStartedCompleter,
         );
         _sendAppEvent(app, 'stop');
-      } on Exception catch (error, trace) {
+      } catch (error, trace) {
         _sendAppEvent(app, 'stop', <String, dynamic>{
           'error': _toJsonable(error),
           'trace': '$trace',
@@ -780,7 +780,7 @@ class DeviceDomain extends Domain {
         try {
           final Map<String, Object> response = await _deviceToMap(device);
           sendEvent(eventName, response);
-        } on Exception catch (err) {
+        } catch (err) {
           globals.printError('$err');
         }
       });

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -261,7 +261,7 @@ $ex
       try {
         await window.setLocation(const math.Point<int>(0, 0));
         await window.setSize(math.Rectangle<int>(0, 0, x, y));
-      } on Exception {
+      } catch (_) {
        // Error might be thrown in some browsers.
       }
 
@@ -278,7 +278,7 @@ $ex
 
     try {
       await testRunner(<String>[testFile], environment);
-    } on Exception catch (error, stackTrace) {
+    } catch (error, stackTrace) {
       if (error is ToolExit) {
         rethrow;
       }

--- a/packages/flutter_tools/lib/src/commands/generate.dart
+++ b/packages/flutter_tools/lib/src/commands/generate.dart
@@ -52,8 +52,8 @@ class GenerateCommand extends FlutterCommand {
         globals.printError(stackData[0] as String);
         globals.printError(stackData[1] as String);
         globals.printError(StackTrace.fromString(stackData[2] as String).toString());
-      } on Exception catch (err) {
-        globals.printError('Error reading error in ${errorFile.path}: $err');
+      } catch (err) {
+        globals.printError('Error reading error in ${errorFile.path}');
       }
     }
     return FlutterCommandResult.fail();

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -98,8 +98,7 @@ class PackagesGetCommand extends FlutterCommand {
       );
       pubGetTimer.stop();
       flutterUsage.sendTiming('pub', 'get', pubGetTimer.elapsed, label: 'success');
-    // Not limiting to catching Exception because the exception is rethrown.
-    } catch (_) { // ignore: avoid_catches_without_on_clauses
+    } catch (_) {
       pubGetTimer.stop();
       flutterUsage.sendTiming('pub', 'get', pubGetTimer.elapsed, label: 'failure');
       rethrow;

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -420,7 +420,7 @@ class RunCommand extends RunCommandBase {
           dillOutputPath: stringArg('output-dill'),
           ipv6: ipv6,
         );
-      } on Exception catch (error) {
+      } catch (error) {
         throwToolExit(error.toString());
       }
       final DateTime appStartedTime = systemClock.now();

--- a/packages/flutter_tools/lib/src/commands/screenshot.dart
+++ b/packages/flutter_tools/lib/src/commands/screenshot.dart
@@ -116,7 +116,7 @@ class ScreenshotCommand extends FlutterCommand {
     );
     try {
       await device.takeScreenshot(outputFile);
-    } on Exception catch (error) {
+    } catch (error) {
       throwToolExit('Error taking screenshot: $error');
     }
     _showOutputFileInfo(outputFile);

--- a/packages/flutter_tools/lib/src/commands/unpack.dart
+++ b/packages/flutter_tools/lib/src/commands/unpack.dart
@@ -150,7 +150,7 @@ class ArtifactUnpacker {
       } else {
         globals.printTrace('Artifacts for version $targetHash already present.');
       }
-    } on Exception catch (error, stackTrace) {
+    } catch (error, stackTrace) {
       globals.printError(stackTrace.toString());
       globals.printError(error.toString());
       return false;
@@ -200,8 +200,8 @@ class ArtifactUnpacker {
       }
 
       globals.printTrace('Copied artifacts from $sourceDirectory.');
-    } on Exception catch (e, stackTrace) {
-      globals.printError(e.toString());
+    } catch (e, stackTrace) {
+      globals.printError(e.message as String);
       globals.printError(stackTrace.toString());
       return false;
     }

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -210,7 +210,7 @@ class UpgradeCommandRunner {
         throwOnError: true,
         workingDirectory: workingDirectory,
       );
-    } on Exception {
+    } catch (e) {
       throwToolExit(
         'Unable to upgrade Flutter: no origin repository configured. '
         "Run 'git remote add origin "
@@ -279,7 +279,7 @@ class UpgradeCommandRunner {
       final FlutterVersion newFlutterVersion = FlutterVersion(const SystemClock(), workingDirectory);
       alreadyUpToDate = newFlutterVersion.channel == oldFlutterVersion.channel &&
         newFlutterVersion.frameworkRevision == oldFlutterVersion.frameworkRevision;
-    } on Exception catch (e) {
+    } catch (e) {
       globals.printTrace('Failed to determine FlutterVersion after upgrade fast-forward: $e');
     }
     return alreadyUpToDate;

--- a/packages/flutter_tools/lib/src/commands/version.dart
+++ b/packages/flutter_tools/lib/src/commands/version.dart
@@ -116,8 +116,8 @@ class VersionCommand extends FlutterCommand {
         throwOnError: true,
         workingDirectory: Cache.flutterRoot,
       );
-    } on Exception catch (e) {
-      throwToolExit('Unable to checkout version branch for version $version: $e');
+    } catch (e) {
+      throwToolExit('Unable to checkout version branch for version $version.');
     }
 
     final FlutterVersion flutterVersion = FlutterVersion();

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -180,8 +180,7 @@ class _DefaultPub implements Pub {
           retry: true,
         );
         status.stop();
-      // The exception is rethrown, so don't catch only Exceptions.
-      } catch (exception) { // ignore: avoid_catches_without_on_clauses
+      } catch (exception) {
         status.cancel();
         rethrow;
       }
@@ -323,7 +322,7 @@ class _DefaultPub implements Pub {
         globals.stdio.addStdoutStream(process.stdout),
         globals.stdio.addStderrStream(process.stderr),
       ]);
-    } on Exception catch (err, stack) {
+    } catch (err, stack) {
       globals.printTrace('Echoing stdout or stderr from the pub subprocess failed:');
       globals.printTrace('$err\n$stack');
     }

--- a/packages/flutter_tools/lib/src/desktop_device.dart
+++ b/packages/flutter_tools/lib/src/desktop_device.dart
@@ -116,7 +116,7 @@ abstract class DesktopDevice extends Device {
       final Uri observatoryUri = await observatoryDiscovery.uri;
       onAttached(package, buildMode, process);
       return LaunchResult.succeeded(observatoryUri: observatoryUri);
-    } on Exception catch (error) {
+    } catch (error) {
       globals.printError('Error waiting for a debug connection: $error');
       return LaunchResult.failed();
     } finally {

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -238,7 +238,7 @@ class ServiceProtocolDevFSOperations implements DevFSOperations {
     List<int> bytes;
     try {
       bytes = await content.contentsAsBytes();
-    } on Exception catch (e) {
+    } catch (e) {
       return e;
     }
     final String fileContents = base64.encode(bytes);
@@ -251,7 +251,7 @@ class ServiceProtocolDevFSOperations implements DevFSOperations {
           'fileContents': fileContents,
         },
       );
-    } on Exception catch (error) {
+    } catch (error) {
       globals.printTrace('DevFS: Failed to write $deviceUri: $error');
     }
   }
@@ -319,7 +319,7 @@ class _DevFSHttpWriter {
             onError: (dynamic error) { globals.printTrace('error: $error'); },
             cancelOnError: true);
         break;
-      } on Exception catch (error, trace) {
+      } catch (error, trace) {
         if (!_completer.isCompleted) {
           globals.printTrace('Error writing "$deviceUri" to DevFS: $error');
           if (retry > 0) {
@@ -527,7 +527,7 @@ class DevFS {
       } on SocketException catch (socketException, stackTrace) {
         globals.printTrace('DevFS sync failed. Lost connection to device: $socketException');
         throw DevFSException('Lost connection to device.', socketException, stackTrace);
-      } on Exception catch (exception, stackTrace) {
+      } catch (exception, stackTrace) {
         globals.printError('Could not update files on device: $exception');
         throw DevFSException('Sync failed', exception, stackTrace);
       }

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -187,7 +187,7 @@ class Doctor {
       ValidationResult result;
       try {
         result = await asyncGuard<ValidationResult>(() => validator.validate());
-      } on Exception catch (exception) {
+      } catch (exception) {
         // We're generating a summary, so drop the stack trace.
         result = ValidationResult.crash(exception);
       }
@@ -269,10 +269,10 @@ class Doctor {
       ValidationResult result;
       try {
         result = await validatorTask.result;
-        status.stop();
-      } on Exception catch (exception, stackTrace) {
+      } catch (exception, stackTrace) {
         result = ValidationResult.crash(exception, stackTrace);
-        status.cancel();
+      } finally {
+        status.stop();
       }
 
       switch (result.type) {
@@ -426,7 +426,7 @@ class GroupedValidator extends DoctorValidator {
       _currentSlowWarning = subValidator.validator.slowWarning;
       try {
         results.add(await subValidator.result);
-      } on Exception catch (exception, stackTrace) {
+      } catch (exception, stackTrace) {
         results.add(ValidationResult.crash(exception, stackTrace));
       }
     }
@@ -656,7 +656,7 @@ bool _genSnapshotRuns(String genSnapshotPath) {
   const int kExpectedExitCode = 255;
   try {
     return processUtils.runSync(<String>[genSnapshotPath]).exitCode == kExpectedExitCode;
-  } on Exception {
+  } catch (error) {
     return false;
   }
 }
@@ -784,7 +784,7 @@ class IntelliJValidatorOnLinuxAndWindows extends IntelliJValidator {
           String installPath;
           try {
             installPath = globals.fs.file(globals.fs.path.join(dir.path, 'system', '.home')).readAsStringSync();
-          } on Exception {
+          } catch (e) {
             // ignored
           }
           if (installPath != null && globals.fs.isDirectorySync(installPath)) {

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -271,7 +271,7 @@ class FuchsiaDevice extends Device {
         packageRepo.deleteSync(recursive: true);
       }
       packageRepo.createSync(recursive: true);
-    } on Exception catch (e) {
+    } catch (e) {
       globals.printError('Failed to create Fuchisa package repo directory '
                  'at ${packageRepo.path}: $e');
       return LaunchResult.failed();
@@ -384,7 +384,7 @@ class FuchsiaDevice extends Device {
       globals.printTrace("Removing the tool's package repo: at ${packageRepo.path}");
       try {
         packageRepo.deleteSync(recursive: true);
-      } on Exception catch (e) {
+      } catch (e) {
         globals.printError('Failed to remove Fuchsia package repo directory '
                    'at ${packageRepo.path}: $e.');
       }
@@ -467,9 +467,9 @@ class FuchsiaDevice extends Device {
             'Failed to delete screenshot.ppm from the device:\n$deleteResult'
           );
         }
-      } on Exception catch (e) {
+      } catch (_) {
         globals.printError(
-          'Failed to delete screenshot.ppm from the device: $e'
+          'Failed to delete screenshot.ppm from the device'
         );
       }
     }

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
@@ -92,7 +92,7 @@ class FuchsiaSdk {
             .transform(const LineSplitter()));
       });
       return controller.stream;
-    } on Exception catch (exception) {
+    } catch (exception) {
       globals.printTrace('$exception');
     }
     return const Stream<String>.empty();

--- a/packages/flutter_tools/lib/src/intellij/intellij.dart
+++ b/packages/flutter_tools/lib/src/intellij/intellij.dart
@@ -67,7 +67,7 @@ class IntelliJPlugins {
       final int start = content.indexOf(versionStartTag);
       final int end = content.indexOf('</version>', start);
       return content.substring(start + versionStartTag.length, end);
-    } on Exception {
+    } catch (_) {
       return null;
     }
   }

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -448,7 +448,7 @@ String decodeSyslog(String line) {
       }
     }
     return utf8.decode(out);
-  } on Exception {
+  } catch (_) {
     // Unable to decode line: return as-is.
     return line;
   }

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -291,7 +291,7 @@ class IOSSimulator extends Device {
       final IOSApp iosApp = app;
       await SimControl.instance.install(id, iosApp.simulatorBundlePath);
       return true;
-    } on Exception {
+    } catch (e) {
       return false;
     }
   }
@@ -301,7 +301,7 @@ class IOSSimulator extends Device {
     try {
       await SimControl.instance.uninstall(id, app.id);
       return true;
-    } on Exception {
+    } catch (e) {
       return false;
     }
   }
@@ -395,7 +395,7 @@ class IOSSimulator extends Device {
       final String bundleIdentifier = globals.plistParser.getValueFromFile(plistPath, PlistParser.kCFBundleIdentifierKey);
 
       await SimControl.instance.launch(id, bundleIdentifier, args);
-    } on Exception catch (error) {
+    } catch (error) {
       globals.printError('$error');
       return LaunchResult.failed();
     }
@@ -411,7 +411,7 @@ class IOSSimulator extends Device {
     try {
       final Uri deviceUri = await observatoryDiscovery.uri;
       return LaunchResult.succeeded(observatoryUri: deviceUri);
-    } on Exception catch (error) {
+    } catch (error) {
       globals.printError('Error waiting for a debug connection: $error');
       return LaunchResult.failed();
     } finally {

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -339,7 +339,7 @@ class XcodeProjectInterpreter {
       );
       final String out = result.stdout.trim();
       return parseXcodeBuildSettings(out);
-    } on Exception catch (error) {
+    } catch(error) {
       if (error is ProcessException && error.toString().contains('timed out')) {
         BuildEvent('xcode-show-build-settings-timeout',
           command: showBuildSettingsCommand.join(' '),

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -406,15 +406,11 @@ class XCDevice {
       final String architecture = deviceProperties['architecture'] as String;
       try {
         cpuArchitecture = getIOSArchForName(architecture);
-      } on Exception {
-        // Fallback to default iOS architecture. Future-proof against a
-        // theoretical version of Xcode that changes this string to something
-        // slightly different like "ARM64".
+      } catch (error) {
+        // Fallback to default iOS architecture. Future-proof against a theoretical version
+        // of Xcode that changes this string to something slightly different like "ARM64".
         cpuArchitecture ??= defaultIOSArchs.first;
-        _logger.printError(
-          'Unknown architecture $architecture, defaulting to '
-          '${getNameForDarwinArch(cpuArchitecture)}',
-        );
+        _logger.printError('Unknown architecture $architecture, defaulting to ${getNameForDarwinArch(cpuArchitecture)}');
       }
     }
     return cpuArchitecture;

--- a/packages/flutter_tools/lib/src/reporting/crash_reporting.dart
+++ b/packages/flutter_tools/lib/src/reporting/crash_reporting.dart
@@ -126,9 +126,7 @@ class CrashReportSender {
       } else {
         globals.printError('Failed to send crash report. Server responded with HTTP status code ${resp.statusCode}');
       }
-    // Catch all exceptions to print the message that makes clear that the
-    // crash logger crashed.
-    } catch (sendError, sendStackTrace) { // ignore: avoid_catches_without_on_clauses
+    } catch (sendError, sendStackTrace) {
       if (sendError is SocketException || sendError is HttpException) {
         globals.printError('Failed to send crash report due to a network error: $sendError');
       } else {

--- a/packages/flutter_tools/lib/src/reporting/events.dart
+++ b/packages/flutter_tools/lib/src/reporting/events.dart
@@ -195,7 +195,7 @@ class CommandResultEvent extends UsageEvent {
         label: parameter,
         value: maxRss,
       );
-    } on Exception catch (error) {
+    } catch (error) {
       // If grabbing the maxRss fails for some reason, just don't send an event.
       globals.printTrace('Querying maxRss failed with error: $error');
     }

--- a/packages/flutter_tools/lib/src/reporting/github_template.dart
+++ b/packages/flutter_tools/lib/src/reporting/github_template.dart
@@ -136,7 +136,7 @@ ${_projectMetadataInformation()}
       } else {
         globals.printTrace('Failed to shorten GitHub template URL. Server responded with HTTP status code ${response.statusCode}');
       }
-    } on Exception catch (sendError) {
+    } catch (sendError) {
       globals.printTrace('Failed to shorten GitHub template URL: $sendError');
     }
 

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -873,7 +873,7 @@ abstract class ResidentRunner {
           for (final FlutterView view in device.views) {
             await view.uiIsolate.flutterDebugAllowBanner(false);
           }
-        } on Exception catch (error) {
+        } catch (error) {
           status.cancel();
           globals.printError('Error communicating with Flutter on the device: $error');
           return;
@@ -887,7 +887,7 @@ abstract class ResidentRunner {
             for (final FlutterView view in device.views) {
               await view.uiIsolate.flutterDebugAllowBanner(true);
             }
-          } on Exception catch (error) {
+          } catch (error) {
             status.cancel();
             globals.printError('Error communicating with Flutter on the device: $error');
             return;
@@ -899,7 +899,7 @@ abstract class ResidentRunner {
       globals.printStatus(
         'Screenshot written to ${globals.fs.path.relative(outputFile.path)} (${sizeKB}kB).',
       );
-    } on Exception catch (error) {
+    } catch (error) {
       status.cancel();
       globals.printError('Error taking screenshot: $error');
     }
@@ -1301,8 +1301,7 @@ class TerminalHandler {
     try {
       lastReceivedCommand = command;
       await _commonTerminalInputHandler(command);
-    // Catch all exception since this is doing cleanup and rethrowing.
-    } catch (error, st) { // ignore: avoid_catches_without_on_clauses
+    } catch (error, st) {
       // Don't print stack traces for known error types.
       if (error is! ToolExit) {
         globals.printError('$error\n$st');

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -131,7 +131,7 @@ class ColdRunner extends ResidentRunner {
     _didAttach = true;
     try {
       await connectToServiceProtocol();
-    } on Exception catch (error) {
+    } catch (error) {
       globals.printError('Error connecting to the service protocol: $error');
       // https://github.com/flutter/flutter/issues/33050
       // TODO(blasten): Remove this check once https://issuetracker.google.com/issues/132325318 has been fixed.

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -186,7 +186,7 @@ class HotRunner extends ResidentRunner {
         final Map<String, dynamic> firstReport = reports.first;
         await device.updateReloadStatus(validateReloadReport(firstReport, printErrors: false));
       }
-    } on Exception catch (error) {
+    } catch (error) {
       return OperationResult(1, error.toString());
     }
 
@@ -215,25 +215,14 @@ class HotRunner extends ResidentRunner {
         compileExpression: _compileExpressionService,
         reloadMethod: reloadMethod,
       );
-    // Catches all exceptions, non-Exception objects are rethrown.
-    } catch (error) { // ignore: avoid_catches_without_on_clauses
-      if (error is! Exception && error is! String) {
-        rethrow;
-      }
+    } catch (error) {
       globals.printError('Error connecting to the service protocol: $error');
       // https://github.com/flutter/flutter/issues/33050
-      // TODO(blasten): Remove this check once
-      // https://issuetracker.google.com/issues/132325318 has been fixed.
+      // TODO(blasten): Remove this check once https://issuetracker.google.com/issues/132325318 has been fixed.
       if (await hasDeviceRunningAndroidQ(flutterDevices) &&
           error.toString().contains(kAndroidQHttpConnectionClosedExp)) {
-        globals.printStatus(
-          '🔨 If you are using an emulator running Android Q Beta, '
-          'consider using an emulator running API level 29 or lower.',
-        );
-        globals.printStatus(
-          'Learn more about the status of this issue on '
-          'https://issuetracker.google.com/issues/132325318.',
-        );
+        globals.printStatus('🔨 If you are using an emulator running Android Q Beta, consider using an emulator running API level 29 or lower.');
+        globals.printStatus('Learn more about the status of this issue on https://issuetracker.google.com/issues/132325318.');
       }
       return 2;
     }
@@ -253,7 +242,7 @@ class HotRunner extends ResidentRunner {
           ),
         );
       }
-    } on Exception catch (error) {
+    } catch (error) {
       globals.printError('Error initializing DevFS: $error');
       return 3;
     }
@@ -883,7 +872,7 @@ class HotRunner extends ResidentRunner {
         return OperationResult(errorCode, errorMessage);
       }
       return OperationResult(errorCode, '$errorMessage (error code: $errorCode)');
-    } on Exception catch (error, stackTrace) {
+    } catch (error, stackTrace) {
       globals.printTrace('Hot reload failed: $error\n$stackTrace');
       return OperationResult(1, '$error');
     }
@@ -947,7 +936,7 @@ class HotRunner extends ResidentRunner {
         () async {
           try {
             await view.uiIsolate.flutterReassemble();
-          } on Exception catch (error) {
+          } catch (error) {
             failedReassemble = true;
             globals.printError('Reassembling ${view.uiIsolate.name} failed: $error');
             return;

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -8,7 +8,6 @@ import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:completion/completion.dart';
 import 'package:file/file.dart';
-import 'package:meta/meta.dart';
 
 import '../artifacts.dart';
 import '../base/common.dart';
@@ -190,7 +189,7 @@ class FlutterCommandRunner extends CommandRunner<void> {
       if (script.contains('flutter/examples/')) {
         return script.substring(0, script.indexOf('flutter/examples/') + 8);
       }
-    } on Exception catch (error) {
+    } catch (error) {
       // we don't have a logger at the time this is run
       // (which is why we don't use printTrace here)
       print(userMessages.runnerNoRoot('$error'));
@@ -422,7 +421,6 @@ class FlutterCommandRunner extends CommandRunner<void> {
     return EngineBuildPaths(targetEngine: engineBuildPath, hostEngine: engineHostBuildPath);
   }
 
-  @visibleForTesting
   static void initFlutterRoot() {
     Cache.flutterRoot ??= defaultFlutterRoot;
   }

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -313,7 +313,7 @@ class FlutterPlatform extends PlatformPlugin {
       final RunnerSuiteController controller = deserializeSuite(path, platform,
         suiteConfig, const PluginEnvironment(), channel, message);
       return await controller.suite;
-    } on Exception catch (err) {
+    } catch (err) {
       /// Rethrow a less confusing error if it is a test incompatibility.
       if (err.toString().contains("type 'Declarer' is not a subtype of type 'Declarer'")) {
         throw UnsupportedError('Package incompatibility between flutter and test packages:\n'
@@ -667,7 +667,7 @@ class FlutterPlatform extends PlatformPlugin {
           }
           break;
       }
-    } on Exception catch (error, stack) {
+    } catch (error, stack) {
       globals.printTrace('test $ourTestCount: error caught during test; ${controllerSinkClosed ? "reporting to console" : "sending to test framework"}');
       if (!controllerSinkClosed) {
         controller.sink.addError(error, stack);
@@ -681,7 +681,7 @@ class FlutterPlatform extends PlatformPlugin {
       for (final Finalizer finalizer in finalizers.reversed) {
         try {
           await finalizer();
-        } on Exception catch (error, stack) {
+        } catch (error, stack) {
           globals.printTrace('test $ourTestCount: error while cleaning up; ${controllerSinkClosed ? "reporting to console" : "sending to test framework"}');
           if (!controllerSinkClosed) {
             controller.sink.addError(error, stack);
@@ -873,7 +873,7 @@ class FlutterPlatform extends PlatformPlugin {
               if (reportObservatoryUri != null) {
                 reportObservatoryUri(uri);
               }
-            } on Exception catch (error) {
+            } catch (error) {
               globals.printError('Could not parse shell observatory port message: $error');
             }
           } else if (line != null) {

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -735,8 +735,7 @@ class BrowserManager {
 
         _controllers.add(controller);
         return await controller.suite;
-      // Not limiting to catching Exception because the exception is rethrown.
-      } catch (_) { // ignore: avoid_catches_without_on_clauses
+      } catch (_) {
         closeIframe();
         rethrow;
       }
@@ -990,7 +989,7 @@ void main() async {
         try {
           bool success = await goldenFileComparator.compare(bytes, goldenKey);
           print(jsonEncode({'success': success}));
-        } on Exception catch (ex) {
+        } catch (ex) {
           print(jsonEncode({'success': false, 'message': '\$ex'}));
         }
       }

--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -194,7 +194,7 @@ class FlutterTesterDevice extends Device {
 
       final Uri observatoryUri = await observatoryDiscovery.uri;
       return LaunchResult.succeeded(observatoryUri: observatoryUri);
-    } on Exception catch (error) {
+    } catch (error) {
       globals.printError('Failed to launch $package: $error');
       return LaunchResult.failed();
     }

--- a/packages/flutter_tools/lib/src/tracing.dart
+++ b/packages/flutter_tools/lib/src/tracing.dart
@@ -60,8 +60,7 @@ class Tracing {
         if (!done) {
           await whenFirstFrameRendered.future;
         }
-      // The exception is rethrown, so don't catch only Exceptions.
-      } catch (exception) { // ignore: avoid_catches_without_on_clauses
+      } catch (exception) {
         status.cancel();
         rethrow;
       }

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -528,7 +528,7 @@ class VersionCheckStamp {
         } else {
           globals.printTrace('Warning: expected version stamp to be a Map but found: $jsonObject');
         }
-      } on Exception catch (error, stackTrace) {
+      } catch (error, stackTrace) {
         // Do not crash if JSON is malformed.
         globals.printTrace('${error.runtimeType}: $error\n$stackTrace');
       }

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -145,7 +145,7 @@ class VMService {
           return <String, String>{'type': 'Success'};
         } on rpc.RpcException {
           rethrow;
-        } on Exception catch (e, st) {
+        } catch (e, st) {
           throw rpc.RpcException(rpc_error_code.SERVER_ERROR,
               'Error during Sources Reload: $e\n$st');
         }
@@ -189,7 +189,7 @@ class VMService {
           return <String, String>{'type': 'Success'};
         } on rpc.RpcException {
           rethrow;
-        } on Exception catch (e, st) {
+        } catch (e, st) {
           throw rpc.RpcException(rpc_error_code.SERVER_ERROR,
               'Error during Sources Reload: $e\n$st');
         }
@@ -213,7 +213,7 @@ class VMService {
           return <String, String>{'type': 'Success'};
         } on rpc.RpcException {
           rethrow;
-        } on Exception catch (e, st) {
+        } catch (e, st) {
           throw rpc.RpcException(rpc_error_code.SERVER_ERROR,
               'Error during Hot Restart: $e\n$st');
         }
@@ -266,7 +266,7 @@ class VMService {
             'result': <String, dynamic> {'kernelBytes': kernelBytesBase64}};
         } on rpc.RpcException {
           rethrow;
-        } on Exception catch (e, st) {
+        } catch (e, st) {
           throw rpc.RpcException(rpc_error_code.SERVER_ERROR,
               'Error during expression compilation: $e\n$st');
         }
@@ -625,8 +625,7 @@ abstract class ServiceObject {
           updateFromMap(response);
           completer.complete(this);
         }
-      // Catches all exceptions to propagate to the completer.
-      } catch (e, st) { // ignore: avoid_catches_without_on_clauses
+      } catch (e, st) {
         completer.completeError(e, st);
       }
       _inProgressReload = null;

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -211,7 +211,7 @@ class ChromeLauncher {
     if (!skipCheck) {
       try {
         await chrome.chromeConnection.getTabs();
-      } on Exception catch (e) {
+      } catch (e) {
         await chrome.close();
         throwToolExit(
             'Unable to connect to Chrome debug port: ${chrome.debugPort}\n $e');
@@ -235,7 +235,7 @@ class ChromeLauncher {
       final HttpClientResponse response = await request.close();
       final List<dynamic> jsonObject = await json.fuse(utf8).decoder.bind(response).single as List<dynamic>;
       return base.resolve(jsonObject.first['devtoolsFrontendUrl'] as String);
-    } on Exception {
+    } catch (_) {
       // If we fail to talk to the remote debugger protocol, give up and return
       // the raw URL rather than crashing.
       return base;

--- a/packages/flutter_tools/lib/src/web/compile.dart
+++ b/packages/flutter_tools/lib/src/web/compile.dart
@@ -66,7 +66,7 @@ Future<void> buildWeb(
       }
       throwToolExit('Failed to compile application for the Web.');
     }
-  } on Exception catch (err) {
+  } catch (err) {
     throwToolExit(err.toString());
   } finally {
     status.stop();

--- a/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
@@ -7,7 +7,6 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/assemble.dart';
-import 'package:flutter_tools/src/runner/flutter_command_runner.dart';
 import 'package:mockito/mockito.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 
@@ -16,7 +15,6 @@ import '../../src/context.dart';
 import '../../src/testbed.dart';
 
 void main() {
-  FlutterCommandRunner.initFlutterRoot();
   Cache.disableLocking();
   final Testbed testbed = Testbed(overrides: <Type, Generator>{
     BuildSystem: ()  => MockBuildSystem(),

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -76,7 +76,7 @@ void main() {
           '--show-test-device',
         ]);
         fail('Expect exception');
-      } on Exception catch (e) {
+      } catch (e) {
         expect(e.toString(), isNot(contains('--fast-start is not supported with --use-application-binary')));
       }
     }, overrides: <Type, Generator>{
@@ -102,7 +102,7 @@ void main() {
           '--no-pub',
         ]);
         fail('Expect exception');
-      } on Exception catch (e) {
+      } catch (e) {
         expect(e, isInstanceOf<ToolExit>());
       }
       final BufferLogger bufferLogger = globals.logger as BufferLogger;
@@ -127,7 +127,7 @@ void main() {
           '--no-pub',
         ]);
         fail('Expect exception');
-      } on Exception catch (e) {
+      } catch (e) {
         expect(e, isInstanceOf<ToolExit>());
         expect(e.toString(), contains('No pubspec.yaml file found'));
       }
@@ -221,8 +221,8 @@ void main() {
         } on ToolExit catch (e) {
           // We expect a ToolExit because no devices are attached
           expect(e.message, null);
-        } on Exception catch (e) {
-          fail('ToolExit expected, got $e');
+        } catch (e) {
+          fail('ToolExit expected');
         }
 
         verifyInOrder(<void>[
@@ -293,8 +293,8 @@ void main() {
         } on ToolExit catch (e) {
           // We expect a ToolExit because app does not start
           expect(e.message, null);
-        } on Exception catch (e) {
-          fail('ToolExit expected, got $e');
+        } catch (e) {
+          fail('ToolExit expected');
         }
         final List<dynamic> captures = verify(mockUsage.sendCommand(
           captureAny,

--- a/packages/flutter_tools/test/commands.shard/hermetic/version_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/version_test.dart
@@ -163,7 +163,7 @@ void main() {
       try {
         await command.getTags();
         fail('ToolExit expected');
-      } on Exception catch (e) {
+      } catch(e) {
         expect(e, isA<ToolExit>());
       }
     }, overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/general.shard/android/android_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_test.dart
@@ -584,9 +584,7 @@ flutter:
       final AndroidDevice device = AndroidDevice('emulator-5555');
       expect(await device.emulatorId, isNull);
     }, overrides: <Type, Generator>{
-      AndroidConsoleSocketFactory: () {
-        return (String host, int port) => throw Exception('Fake socket error');
-      },
+      AndroidConsoleSocketFactory: () => (String host, int port) => throw 'Fake socket error',
       ProcessManager: () => mockProcessManager,
     });
 

--- a/packages/flutter_tools/test/general.shard/android/android_sdk_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_sdk_test.dart
@@ -80,13 +80,6 @@ void main() {
       when(globals.processManager.runSync(<String>[sdk.sdkManagerPath, '--version'],
           environment: argThat(isNotNull,  named: 'environment')))
           .thenReturn(ProcessResult(1, 0, '26.1.1\n', ''));
-      if (globals.platform.isMacOS) {
-        when(globals.processManager.runSync(
-          <String>['/usr/libexec/java_home'],
-          workingDirectory: anyNamed('workingDirectory'),
-          environment: anyNamed('environment'),
-        )).thenReturn(ProcessResult(0, 0, '', ''));
-      }
       expect(sdk.sdkManagerVersion, '26.1.1');
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
@@ -119,13 +112,6 @@ void main() {
       when(globals.processManager.runSync(<String>[sdk.sdkManagerPath, '--version'],
           environment: argThat(isNotNull,  named: 'environment')))
           .thenReturn(ProcessResult(1, 1, '26.1.1\n', 'Mystery error'));
-      if (globals.platform.isMacOS) {
-        when(globals.processManager.runSync(
-          <String>['/usr/libexec/java_home'],
-          workingDirectory: anyNamed('workingDirectory'),
-          environment: anyNamed('environment'),
-        )).thenReturn(ProcessResult(0, 0, '', ''));
-      }
       expect(sdk.sdkManagerVersion, isNull);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,

--- a/packages/flutter_tools/test/general.shard/base/async_guard_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/async_guard_test.dart
@@ -197,7 +197,7 @@ void main() {
         );
         try {
           await f;
-        } on String {
+        } catch (e) {
           caughtByHandler = true;
         }
         if (!completer.isCompleted) {
@@ -235,7 +235,7 @@ void main() {
         );
         try {
           await f;
-        } on String {
+        } catch (e) {
           caughtByHandler = true;
         }
         if (!completer.isCompleted) {
@@ -275,7 +275,7 @@ void main() {
         );
         try {
           await f;
-        } on String {
+        } catch (e) {
           caughtByHandler = true;
         }
         if (!completer.isCompleted) {

--- a/packages/flutter_tools/test/general.shard/base/fingerprint_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/fingerprint_test.dart
@@ -249,7 +249,7 @@ void main() {
         globals.fs.file('a.dart').createSync();
         expect(
           () => Fingerprint.fromBuildInputs(<String, String>{}, <String>['a.dart', 'b.dart']),
-          throwsException,
+          throwsArgumentError,
         );
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
@@ -328,7 +328,7 @@ void main() {
           'properties': <String, String>{},
           'files': <String, String>{},
         });
-        expect(() => Fingerprint.fromJson(jsonString), throwsException);
+        expect(() => Fingerprint.fromJson(jsonString), throwsArgumentError);
       }, overrides: <Type, Generator>{
         FlutterVersion: () => mockVersion,
       });
@@ -338,7 +338,7 @@ void main() {
           'properties': <String, String>{},
           'files': <String, String>{},
         });
-        expect(() => Fingerprint.fromJson(jsonString), throwsException);
+        expect(() => Fingerprint.fromJson(jsonString), throwsArgumentError);
       }, overrides: <Type, Generator>{
         FlutterVersion: () => mockVersion,
       });

--- a/packages/flutter_tools/test/general.shard/base/signals_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/signals_test.dart
@@ -61,9 +61,8 @@ void main() {
     });
 
     testUsingContext('signal handler error goes on error stream', () async {
-      final Exception exn = Exception('Error');
       signals.addHandler(signalUnderTest, (ProcessSignal s) {
-        throw exn;
+        throw 'Error';
       });
 
       final Completer<void> completer = Completer<void>();
@@ -76,7 +75,7 @@ void main() {
       controller.add(mockSignal);
       await completer.future;
       await errSub.cancel();
-      expect(errList, contains(exn));
+      expect(errList, <Object>['Error']);
     }, overrides: <Type, Generator>{
       Signals: () => Signals(),
     });

--- a/packages/flutter_tools/test/general.shard/build_info_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_info_test.dart
@@ -91,6 +91,6 @@ void main() {
     expect(getIOSArchForName('arm64'), DarwinArch.arm64);
     expect(getIOSArchForName('arm64e'), DarwinArch.arm64);
     expect(getIOSArchForName('x86_64'), DarwinArch.x86_64);
-    expect(() => getIOSArchForName('bogus'), throwsException);
+    expect(() => getIOSArchForName('bogus'), throwsAssertionError);
   });
 }

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -231,7 +231,7 @@ void main() {
           null,
         });
         fail('Mock thrown exception expected');
-      } on Exception {
+      } catch (e) {
         verify(artifact1.update());
         // Don't continue when retrieval fails.
         verifyNever(artifact2.update());

--- a/packages/flutter_tools/test/general.shard/commands/build_apk_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_apk_test.dart
@@ -152,26 +152,6 @@ void main() {
         .thenAnswer((_) => Future<Process>.value(process));
       when(mockProcessManager.canRun(any)).thenReturn(false);
 
-      when(mockProcessManager.runSync(
-        argThat(contains(contains('gen_snapshot'))),
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).thenReturn(ProcessResult(0, 255, '', ''));
-
-      when(mockProcessManager.runSync(
-        <String>['/usr/bin/xcode-select', '--print-path'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).thenReturn(ProcessResult(0, 0, '', ''));
-
-      when(mockProcessManager.run(
-        <String>['which', 'pod'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).thenAnswer((_) {
-        return Future<ProcessResult>.value(ProcessResult(0, 0, '', ''));
-      });
-
       mockAndroidSdk = MockAndroidSdk();
       when(mockAndroidSdk.directory).thenReturn('irrelevant');
     });

--- a/packages/flutter_tools/test/general.shard/commands/build_appbundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_appbundle_test.dart
@@ -9,11 +9,12 @@ import 'package:flutter_tools/src/android/android_builder.dart';
 import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build_appbundle.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
 
@@ -133,26 +134,6 @@ void main() {
           environment: anyNamed('environment')))
         .thenAnswer((_) => Future<Process>.value(process));
       when(mockProcessManager.canRun(any)).thenReturn(false);
-
-      when(mockProcessManager.runSync(
-        argThat(contains(contains('gen_snapshot'))),
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).thenReturn(ProcessResult(0, 255, '', ''));
-
-      when(mockProcessManager.runSync(
-        <String>['/usr/bin/xcode-select', '--print-path'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).thenReturn(ProcessResult(0, 0, '', ''));
-
-      when(mockProcessManager.run(
-        <String>['which', 'pod'],
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment'),
-      )).thenAnswer((_) {
-        return Future<ProcessResult>.value(ProcessResult(0, 0, '', ''));
-      });
 
       mockAndroidSdk = MockAndroidSdk();
       when(mockAndroidSdk.validateSdkWellFormed()).thenReturn(const <String>[]);

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -327,7 +327,8 @@ void main() {
       try {
         await pub.get(context: PubContext.flutterTests, checkLastModified: true);
         expect(true, isFalse, reason: 'pub.get did not throw');
-      } on ToolExit catch (error) {
+      } catch (error) {
+        expect(error, isA<Exception>());
         expect(error.message, '/: unexpected concurrent modification of pubspec.yaml while running pub.');
       }
       expect(testLogger.statusText, 'Running "flutter pub get" in /...\n');

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -136,7 +136,7 @@ void main() {
       const int kFailedAttempts = 5;
       when(httpRequest.close()).thenAnswer((Invocation invocation) {
         if (nRequest++ < kFailedAttempts) {
-          throw Exception('Connection resert by peer');
+          throw 'Connection resert by peer';
         }
         return Future<HttpClientResponse>.value(httpClientResponse);
       });

--- a/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
@@ -46,17 +46,8 @@ void main() {
 
       Future<Map<String, String>> captureEnvironment() async {
         flutterPlatform.loadChannel('test1.dart', MockSuitePlatform());
-        when(mockProcessManager.start(
-          any,
-          environment: anyNamed('environment')),
-        ).thenAnswer((_) {
-          return Future<Process>.value(MockProcess());
-        });
         await untilCalled(mockProcessManager.start(any, environment: anyNamed('environment')));
-        final VerificationResult toVerify = verify(mockProcessManager.start(
-          any,
-          environment: captureAnyNamed('environment'),
-        ));
+        final VerificationResult toVerify = verify(mockProcessManager.start(any, environment: captureAnyNamed('environment')));
         expect(toVerify.captured, hasLength(1));
         expect(toVerify.captured.first, isA<Map<String, String>>());
         return toVerify.captured.first as Map<String, String>;
@@ -154,8 +145,6 @@ void main() {
 class MockSuitePlatform extends Mock implements SuitePlatform {}
 
 class MockProcessManager extends Mock implements ProcessManager {}
-
-class MockProcess extends Mock implements Process {}
 
 class MockPlatform extends Mock implements Platform {}
 

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
@@ -476,7 +476,7 @@ void main() {
 
       try {
         await device.takeScreenshot(globals.fs.file('file.ppm'));
-      } on Exception {
+      } catch (_) {
         assert(false);
       }
       expect(
@@ -534,8 +534,8 @@ void main() {
 
       try {
         await device.takeScreenshot(globals.fs.file('file.ppm'));
-      } on Exception catch (e) {
-        fail('Unexpected exception: $e');
+      } catch (_) {
+        assert(false);
       }
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,

--- a/packages/flutter_tools/test/general.shard/ios/code_signing_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/code_signing_test.dart
@@ -229,9 +229,9 @@ void main() {
       Map<String, String> signingConfigs;
       try {
         signingConfigs = await getCodeSigningIdentityDevelopmentTeam(iosApp: app);
-      } on Exception catch (e) {
+      } catch (e) {
         // This should not throw
-        fail('Code signing threw: $e');
+        expect(true, false);
       }
 
       expect(testLogger.statusText, contains('Apple Development: Profile 1 (1111AAAA11)'));

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -54,7 +54,7 @@ void main() {
       expect(portForwarder.forwardedPorts.length, 2);
       try {
         await portForwarder.dispose();
-      } on Exception catch (e) {
+      } catch (e) {
         fail('Encountered exception: $e');
       }
       expect(portForwarder.forwardedPorts.length, 0);

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -355,7 +355,7 @@ void main() {
           engineDir: 'engine/path',
         );
         fail('ToolExit expected');
-      } on Exception catch (e) {
+      } catch(e) {
         expect(e, isA<ToolExit>());
         verifyNever(mockProcessManager.run(
         argThat(containsAllInOrder(<String>['pod', 'install'])),
@@ -404,7 +404,7 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
           engineDir: 'engine/path',
         );
         fail('ToolExit expected');
-      } on Exception catch (e) {
+      } catch (e) {
         expect(e, isA<ToolExit>());
         expect(
           testLogger.errorText,

--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -528,7 +528,7 @@ class FlutterRunTestDriver extends FlutterTestDriver {
         // have already completed.
         _currentRunningAppId = (await started)['params']['appId'] as String;
         prematureExitGuard.complete();
-      } on Exception catch (error, stackTrace) {
+      } catch (error, stackTrace) {
         prematureExitGuard.completeError(error, stackTrace);
       }
     }());
@@ -732,7 +732,7 @@ class FlutterTestTestDriver extends FlutterTestDriver {
   Map<String, dynamic> _parseJsonResponse(String line) {
     try {
       return castStringKeyedMap(json.decode(line));
-    } on Exception {
+    } catch (e) {
       // Not valid JSON, so likely some other output.
       return null;
     }
@@ -771,7 +771,7 @@ Map<String, dynamic> parseFlutterResponse(String line) {
     try {
       final Map<String, dynamic> response = castStringKeyedMap(json.decode(line)[0]);
       return response;
-    } on Exception {
+    } catch (e) {
       // Not valid JSON, so likely some other output that was surrounded by [brackets]
       return null;
     }

--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -139,8 +139,7 @@ Future<void> expectToolExitLater(Future<dynamic> future, Matcher messageMatcher)
     fail('ToolExit expected, but nothing thrown');
   } on ToolExit catch(e) {
     expect(e.message, messageMatcher);
-  // Catch all exceptions to give a better test failure message.
-  } catch (e, trace) { // ignore: avoid_catches_without_on_clauses
+  } catch(e, trace) {
     fail('ToolExit expected, got $e\n$trace');
   }
 }

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -148,8 +148,7 @@ void testUsingContext(
                   return await testMethod();
                 },
               );
-            // This catch rethrows, so doesn't need to catch only Exception.
-            } catch (error) { // ignore: avoid_catches_without_on_clauses
+            } catch (error) {
               _printBufferedErrors(context);
               rethrow;
             }

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -398,8 +398,7 @@ class MemoryIOSink implements IOSink {
       (List<int> data) {
         try {
           add(data);
-        // Catches all exceptions to propagate them to the completer.
-        } catch (err, stack) { // ignore: avoid_catches_without_on_clauses
+        } catch (err, stack) {
           sub.cancel();
           completer.completeError(err, stack);
         }

--- a/packages/flutter_tools/tool/tool_coverage.dart
+++ b/packages/flutter_tools/tool/tool_coverage.dart
@@ -73,8 +73,7 @@ class VMPlatform extends PlatformPlugin {
     Isolate isolate;
     try {
       isolate = await _spawnIsolate(codePath, receivePort.sendPort);
-    // This catch rethrows, so doesn't need to catch only Exception.
-    } catch (error) { // ignore: avoid_catches_without_on_clauses
+    } catch (error) {
       receivePort.close();
       rethrow;
     }


### PR DESCRIPTION
Reverts flutter/flutter#51440

Reverting for device lab failures, for example `named_isolates_test` (and many others) fail with:

```
Task failed with the following reason:
ERROR: Command "/home/flutter/.cocoon/flutter/bin/flutter doctor" failed with exit code 1.
#0      fail (package:cocoon_agent/src/utils.dart:140:3)
#1      exec (package:cocoon_agent/src/utils.dart:341:5)
<asynchronous suspension>
#2      flutter (package:cocoon_agent/src/utils.dart:369:10)
#3      getFlutter (package:cocoon_agent/src/utils.dart:544:9)
<asynchronous suspension>
#4      getFlutterAt (package:cocoon_agent/src/utils.dart:278:9)
<asynchronous suspension>
#5      ContinuousIntegrationCommand.run.<anonymous closure> (package:cocoon_agent/src/commands/ci.dart:118:21)
<asynchronous suspension>
#6      _rootRun (dart:async/zone.dart:1124:13)
#7      _CustomZone.run (dart:async/zone.dart:1021:19)
#8      _runZoned (dart:async/zone.dart:1516:10)
#9      runZoned (dart:async/zone.dart:1500:12)
#10     ContinuousIntegrationCommand.run (package:cocoon_agent/src/commands/ci.dart:63:13)
<asynchronous suspension>
#11     main (file:///home/flutter/cocoon/agent/bin/agent.dart:63:19)
<asynchronous suspension>
#12     _startIsolate.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:303:32)
#13     _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:172:12)
```

Before relanding, I'll probably have to get cocoon to print the tool stderr when it fails.