### PR TITLE
Fix _DatePickerDialog for landscape orientation [small change]

### DIFF
--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -1026,23 +1026,26 @@ class _DatePickerDialogState extends State<_DatePickerDialog> {
             case Orientation.landscape:
               return Container(
                 color: theme.dialogBackgroundColor,
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: <Widget>[
-                    Flexible(child: header),
-                    Flexible(
-                      flex: 2, // have the picker take up 2/3 of the dialog width
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: <Widget>[
-                          Flexible(child: picker),
-                          actions,
-                        ],
+                child: IntrinsicHeight(
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: <Widget>[
+                      Flexible(child: header),
+                      Flexible(
+                        flex: 2,
+                        // have the picker take up 2/3 of the dialog width
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: <Widget>[
+                            Flexible(child: picker),
+                            actions,
+                          ],
+                        ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               );
           }


### PR DESCRIPTION
## Description

This is a small change.

The date picker was stretched vertically when in landscape and on larger screens it didn't look good. Now it wraps it's height to min.

**BEFORE:**
<img src="https://user-images.githubusercontent.com/5168594/75446972-65c25f80-59a3-11ea-8156-3a68c96e69f3.png" width="400" /> <img src="https://user-images.githubusercontent.com/5168594/75446965-63f89c00-59a3-11ea-9192-007b0a0d7e4c.png" width="250" />

**AFTER:**
<img src="https://user-images.githubusercontent.com/5168594/75446988-6955e680-59a3-11ea-9aa6-fe3ef99f52a6.png" width="400" /> <img src="https://user-images.githubusercontent.com/5168594/75446984-68bd5000-59a3-11ea-8dd0-b9753ca9ead2.png" width="250" />

Example code:
```dart

void main() => runApp(MyApp());

class MyApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Flutter Demo',
      theme: ThemeData(
        primarySwatch: Colors.blue,
      ),
      home: MyHomePage(),
    );
  }
}

class MyHomePage extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: Text('Date Picker Demo'),
      ),
      floatingActionButton: FloatingActionButton(
        child: Icon(Icons.date_range),
        onPressed: () => _showPicker(context),
      ),
    );
  }

  void _showPicker(BuildContext context) {
    final now = DateTime.now();
    showDatePicker(
      context: context,
      initialDate: now,
      firstDate: now,
      lastDate: now.add(Duration(days: 100)),
    );
  }
}
```

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*
