### PR TITLE
Fix outline button solid path when BorderSize.width is used

### DIFF
--- a/packages/flutter/lib/src/material/outline_button.dart
+++ b/packages/flutter/lib/src/material/outline_button.dart
@@ -547,7 +547,7 @@ class _OutlineBorder extends ShapeBorder implements MaterialStateProperty<ShapeB
       case BorderStyle.none:
         break;
       case BorderStyle.solid:
-        canvas.drawPath(shape.getOuterPath(rect, textDirection: textDirection), side.toPaint());
+        canvas.drawPath(shape.getOuterPath(rect.deflate(side.width / 2.0), textDirection: textDirection), side.toPaint());
     }
   }
 

--- a/packages/flutter/test/material/outline_button_test.dart
+++ b/packages/flutter/test/material/outline_button_test.dart
@@ -783,7 +783,7 @@ void main() {
             alignment: Alignment.topLeft,
             child: OutlineButton(
               key: buttonKey,
-              borderSide: BorderSide(
+              borderSide: const BorderSide(
                   color: Colors.black12,
                   width: thickness),
               onPressed: () {},

--- a/packages/flutter/test/material/outline_button_test.dart
+++ b/packages/flutter/test/material/outline_button_test.dart
@@ -772,6 +772,39 @@ void main() {
     );
   });
 
+  testWidgets('OutlineButton uses borderSide width to paint', (WidgetTester tester) async {
+    final GlobalKey buttonKey = GlobalKey();
+    const double thickness = 12.5;
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Material(
+          child: Align(
+            alignment: Alignment.topLeft,
+            child: OutlineButton(
+              key: buttonKey,
+              borderSide: BorderSide(
+                  color: Colors.black12,
+                  width: thickness),
+              onPressed: () {},
+              child: const SizedBox(
+                  width: 120,
+                  height: 50,
+                  child: Text('ABC'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Finder outlineButton = find.byType(OutlineButton);
+    expect(outlineButton, paints..path(
+      includes: const <Offset>[Offset(60, thickness / 2.0)],
+      excludes: const <Offset>[Offset(60, thickness / 3.0)],
+    ));
+  });
+
   testWidgets('OutlineButton contributes semantics', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
     await tester.pumpWidget(

--- a/packages/flutter/test/rendering/mock_canvas.dart
+++ b/packages/flutter/test/rendering/mock_canvas.dart
@@ -1161,13 +1161,15 @@ class _PathPaintPredicate extends _DrawCommandPaintPredicate {
     if (includes != null) {
       for (final Offset offset in includes) {
         if (!pathArgument.contains(offset))
-          throw 'It called $methodName with a path that unexpectedly did not contain $offset.';
+          throw 'It called $methodName with a path that unexpectedly did not '
+              'contain $offset. Path bounds = ${pathArgument.getBounds()}';
       }
     }
     if (excludes != null) {
       for (final Offset offset in excludes) {
         if (pathArgument.contains(offset))
-          throw 'It called $methodName with a path that unexpectedly contained $offset.';
+          throw 'It called $methodName with a path that unexpectedly '
+              'contained $offset. . Path bounds = ${pathArgument.getBounds()}';
       }
     }
   }


### PR DESCRIPTION
## Description

_OutlineBorder shape thickness was not correctly adjusting the outerpath bounds to paint at correct thickness. At very low values, this was causing the outline path from being clipped at subpixel causing https://github.com/flutter/flutter/issues/49287.

The problem was not visible on mobile since viewport width is even. Resizing a browser window to odd width and continuous resizing uncovered issue.

* This PR also updates paint matcher to provide path bounds when reporting an error for included/excluded Offsets to aid in debugging test failures.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/49287

## Tests

Added a test case to outline_button_test.dart to make sure we are stroking path at offset+=thickness/2.0.

## Breaking change

OutlineButton(s) were clipping half of stroke width before this change. So visually the border will render 0.5pixels larger in most use cases.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.
