### PR TITLE
Add explicit casts to for-in-dynamic.

### DIFF
--- a/packages/flutter_driver/lib/src/common/wait.dart
+++ b/packages/flutter_driver/lib/src/common/wait.dart
@@ -251,7 +251,7 @@ class CombinedCondition extends SerializableWaitCondition {
     }
 
     final List<SerializableWaitCondition> conditions = <SerializableWaitCondition>[];
-    for (final Map<String, dynamic> condition in json.decode(jsonMap['conditions'])) {
+    for (final Map<String, dynamic> condition in (json.decode(jsonMap['conditions']) as List<dynamic>).cast<Map<String, dynamic>>()) {
       conditions.add(_deserialize(condition.cast<String, String>()));
     }
     return CombinedCondition(conditions);

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -335,7 +335,7 @@ List<_Asset> _getMaterialAssets(String fontSet) {
   final List<_Asset> result = <_Asset>[];
 
   for (final Map<String, dynamic> family in _getMaterialFonts(fontSet)) {
-    for (final Map<dynamic, dynamic> font in family['fonts']) {
+    for (final Map<dynamic, dynamic> font in (family['fonts'] as List<dynamic>).cast<Map<dynamic, dynamic>>()) {
       final Uri entryUri = globals.fs.path.toUri(font['asset'] as String);
       result.add(_Asset(
         baseDir: globals.fs.path.join(Cache.flutterRoot, 'bin', 'cache', 'artifacts', 'material_fonts'),

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -597,7 +597,7 @@ class HotRunner extends ResidentRunner {
     if (!(reloadReport['success'] as bool)) {
       if (printErrors) {
         globals.printError('Hot reload was rejected:');
-        for (final Map<String, dynamic> notice in reloadReport['details']['notices']) {
+        for (final Map<String, dynamic> notice in (reloadReport['details']['notices'] as List<dynamic>).cast<Map<String, dynamic>>()) {
           globals.printError('${notice['message']}');
         }
       }

--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -206,7 +206,7 @@ Future<Map<String, dynamic>> _getAllCoverage(VMService service, bool Function(St
     if (scriptList['scripts'] == null) {
       continue;
     }
-    for (final Map<String, dynamic> script in scriptList['scripts']) {
+    for (final Map<String, dynamic> script in (scriptList['scripts'] as List<dynamic>).cast<Map<String, dynamic>>()) {
       if (!libraryPredicate(script['uri'] as String)) {
         continue;
       }
@@ -247,7 +247,7 @@ void _buildCoverageMap(
   final Map<String, Map<int, int>> hitMaps = <String, Map<int, int>>{};
   for (final String scriptId in scripts.keys) {
     final Map<String, dynamic> sourceReport = sourceReports[scriptId];
-    for (final Map<String, dynamic> range in sourceReport['ranges']) {
+    for (final Map<String, dynamic> range in (sourceReport['ranges'] as List<dynamic>).cast<Map<String, dynamic>>()) {
       final Map<String, dynamic> coverage = castStringKeyedMap(range['coverage']);
       // Coverage reports may sometimes be null for a Script.
       if (coverage == null) {

--- a/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/dart/dart_vm.dart
@@ -170,7 +170,7 @@ class DartVm {
     final Map<String, dynamic> jsonVmRef =
         await invokeRpc('getVM', timeout: timeout);
     final List<IsolateRef> result = <IsolateRef>[];
-    for (final Map<String, dynamic> jsonIsolate in jsonVmRef['isolates']) {
+    for (final Map<String, dynamic> jsonIsolate in (jsonVmRef['isolates'] as List<dynamic>).cast<Map<String, dynamic>>()) {
       final String name = jsonIsolate['name'] as String;
       if (pattern.matchAsPrefix(name) != null) {
         _log.fine('Found Isolate matching "$pattern": "$name"');
@@ -213,7 +213,7 @@ class DartVm {
     final List<FlutterView> views = <FlutterView>[];
     final Map<String, dynamic> rpcResponse =
         await invokeRpc('_flutter.listViews', timeout: timeout);
-    for (final Map<String, dynamic> jsonView in rpcResponse['views']) {
+    for (final Map<String, dynamic> jsonView in (rpcResponse['views'] as List<dynamic>).cast<Map<String, dynamic>>()) {
       final FlutterView flutterView = FlutterView._fromJson(jsonView);
       if (flutterView != null) {
         views.add(flutterView);


### PR DESCRIPTION
According to the language specification, `for (D id in e) S;` is treated as the following code:
```dart
T id1 = e;
var id2 = id1.iterator;
while (id2.moveNext()) {
  D id = id2.current;
  S;
}
```

So, it should cause the same `implicit-cast` error as for `T id1 = e;`.

https://dart-review.googlesource.com/c/sdk/+/137681 tried to update analyzer to do this, but found several issues in Flutter codebase.