### PR TITLE
[flutter_tools] remove LinuxWorkflow from injection and clean up tests

### DIFF
--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -40,7 +40,6 @@ import 'ios/ios_workflow.dart';
 import 'ios/mac.dart';
 import 'ios/simulators.dart';
 import 'ios/xcodeproj.dart';
-import 'linux/linux_workflow.dart';
 import 'macos/cocoapods.dart';
 import 'macos/cocoapods_validator.dart';
 import 'macos/macos_workflow.dart';
@@ -141,7 +140,6 @@ Future<T> runInContext<T>(
       IOSSimulatorUtils: () => IOSSimulatorUtils(),
       IOSWorkflow: () => const IOSWorkflow(),
       KernelCompilerFactory: () => const KernelCompilerFactory(),
-      LinuxWorkflow: () => const LinuxWorkflow(),
       Logger: () => globals.platform.isWindows
         ? WindowsStdoutLogger(
             terminal: globals.terminal,

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -15,6 +15,7 @@ import 'base/file_system.dart';
 import 'base/io.dart';
 import 'base/utils.dart';
 import 'build_info.dart';
+import 'features.dart';
 import 'fuchsia/fuchsia_device.dart';
 import 'globals.dart' as globals;
 import 'ios/devices.dart';
@@ -74,7 +75,10 @@ class DeviceManager {
     FuchsiaDevices(),
     FlutterTesterDevices(),
     MacOSDevices(),
-    LinuxDevices(),
+    LinuxDevices(
+      platform: globals.platform,
+      featureFlags: featureFlags,
+    ),
     WindowsDevices(),
     WebDevices(),
   ]);

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -20,6 +20,7 @@ import 'base/utils.dart';
 import 'base/version.dart';
 import 'cache.dart';
 import 'device.dart';
+import 'features.dart';
 import 'fuchsia/fuchsia_workflow.dart';
 import 'globals.dart' as globals;
 import 'intellij/intellij.dart';
@@ -67,6 +68,10 @@ class _DefaultDoctorValidatorsProvider implements DoctorValidatorsProvider {
       ...IntelliJValidator.installedValidators,
       ...VsCodeValidator.installedValidators,
     ];
+    final LinuxWorkflow linuxWorkflow = LinuxWorkflow(
+      platform: globals.platform,
+      featureFlags: featureFlags,
+    );
 
     _validators = <DoctorValidator>[
       FlutterValidator(),
@@ -113,6 +118,10 @@ class _DefaultDoctorValidatorsProvider implements DoctorValidatorsProvider {
         _workflows.add(fuchsiaWorkflow);
       }
 
+      final LinuxWorkflow linuxWorkflow = LinuxWorkflow(
+        platform: globals.platform,
+        featureFlags: featureFlags,
+      );
       if (linuxWorkflow.appliesToHostPlatform) {
         _workflows.add(linuxWorkflow);
       }

--- a/packages/flutter_tools/lib/src/linux/linux_device.dart
+++ b/packages/flutter_tools/lib/src/linux/linux_device.dart
@@ -2,10 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:meta/meta.dart';
+import 'package:platform/platform.dart';
+
 import '../build_info.dart';
 import '../desktop_device.dart';
 import '../device.dart';
-import '../globals.dart' as globals;
+import '../features.dart';
 import '../project.dart';
 import 'application_package.dart';
 import 'build_linux.dart';
@@ -53,13 +56,24 @@ class LinuxDevice extends DesktopDevice {
 }
 
 class LinuxDevices extends PollingDeviceDiscovery {
-  LinuxDevices() : super('linux devices');
+  LinuxDevices({
+    @required Platform platform,
+    @required FeatureFlags featureFlags,
+  }) : _platform = platform,
+       _linuxWorkflow = LinuxWorkflow(
+          platform: platform,
+          featureFlags: featureFlags,
+       ),
+       super('linux devices');
+
+  final Platform _platform;
+  final LinuxWorkflow _linuxWorkflow;
 
   @override
-  bool get supportsPlatform => globals.platform.isLinux;
+  bool get supportsPlatform => _platform.isLinux;
 
   @override
-  bool get canListAnything => linuxWorkflow.canListDevices;
+  bool get canListAnything => _linuxWorkflow.canListDevices;
 
   @override
   Future<List<Device>> pollingGetDevices() async {

--- a/packages/flutter_tools/lib/src/linux/linux_workflow.dart
+++ b/packages/flutter_tools/lib/src/linux/linux_workflow.dart
@@ -2,29 +2,34 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import '../base/context.dart';
+import 'package:meta/meta.dart';
+import 'package:platform/platform.dart';
+
 import '../doctor.dart';
 import '../features.dart';
-import '../globals.dart' as globals;
-
-/// The [WindowsWorkflow] instance.
-LinuxWorkflow get linuxWorkflow => context.get<LinuxWorkflow>();
 
 /// The windows-specific implementation of a [Workflow].
 ///
 /// This workflow requires the flutter-desktop-embedding as a sibling
 /// repository to the flutter repo.
 class LinuxWorkflow implements Workflow {
-  const LinuxWorkflow();
+  const LinuxWorkflow({
+    @required Platform platform,
+    @required FeatureFlags featureFlags,
+  }) : _platform = platform,
+       _featureFlags = featureFlags;
+
+  final Platform _platform;
+  final FeatureFlags _featureFlags;
 
   @override
-  bool get appliesToHostPlatform => globals.platform.isLinux && featureFlags.isLinuxEnabled;
+  bool get appliesToHostPlatform => _platform.isLinux && _featureFlags.isLinuxEnabled;
 
   @override
-  bool get canLaunchDevices => globals.platform.isLinux && featureFlags.isLinuxEnabled;
+  bool get canLaunchDevices => _platform.isLinux && _featureFlags.isLinuxEnabled;
 
   @override
-  bool get canListDevices => globals.platform.isLinux && featureFlags.isLinuxEnabled;
+  bool get canListDevices => _platform.isLinux && _featureFlags.isLinuxEnabled;
 
   @override
   bool get canListEmulators => false;

--- a/packages/flutter_tools/test/general.shard/linux/linux_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/linux/linux_device_test.dart
@@ -5,6 +5,7 @@
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/linux/application_package.dart';
 import 'package:flutter_tools/src/linux/linux_device.dart';
 import 'package:flutter_tools/src/device.dart';
@@ -36,9 +37,10 @@ void main() {
   });
 
   testUsingContext('LinuxDevice: no devices listed if platform unsupported', () async {
-    expect(await LinuxDevices().devices, <Device>[]);
-  }, overrides: <Type, Generator>{
-    Platform: () => notLinux,
+    expect(await LinuxDevices(
+      platform: notLinux,
+      featureFlags: featureFlags,
+    ).devices, <Device>[]);
   });
 
   testUsingContext('LinuxDevice.isSupportedForProject is true with editable host app', () async {

--- a/packages/flutter_tools/test/general.shard/linux/linux_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/linux/linux_workflow_test.dart
@@ -3,60 +3,60 @@
 // found in the LICENSE file.
 
 import 'package:flutter_tools/src/features.dart';
-import 'package:mockito/mockito.dart';
 import 'package:platform/platform.dart';
 
 import 'package:flutter_tools/src/linux/linux_workflow.dart';
 
 import '../../src/common.dart';
-import '../../src/context.dart';
 import '../../src/testbed.dart';
 
 void main() {
-  MockPlatform linux;
-  MockPlatform notLinux;
-  Testbed testbed;
+  final Platform linux = FakePlatform(
+    operatingSystem: 'linux',
+    environment: <String, String>{},
+  );
+  final Platform notLinux = FakePlatform(
+    operatingSystem: 'windows',
+    environment: <String, String>{},
+  );
+  final FeatureFlags enabledFlags = TestFeatureFlags(
+    isLinuxEnabled: true,
+  );
+  final FeatureFlags disabledFlags = TestFeatureFlags(isLinuxEnabled: false);
 
-  setUp(() {
-    linux = MockPlatform();
-    notLinux = MockPlatform();
-    when(linux.isLinux).thenReturn(true);
-    when(notLinux.isLinux).thenReturn(false);
-    testbed = Testbed(
-      overrides: <Type, Generator>{
-        Platform: () => linux,
-        FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
-      },
+  test('Applies to linux platform', () {
+    final LinuxWorkflow linuxWorkflow = LinuxWorkflow(
+      platform: linux,
+      featureFlags: enabledFlags,
     );
-  });
 
-  test('Applies to linux platform', () => testbed.run(() {
     expect(linuxWorkflow.appliesToHostPlatform, true);
     expect(linuxWorkflow.canLaunchDevices, true);
     expect(linuxWorkflow.canListDevices, true);
     expect(linuxWorkflow.canListEmulators, false);
-  }));
+  });
 
-  test('Does not apply to non-linux platform', () => testbed.run(() {
+  test('Does not apply to non-linux platform', () {
+    final LinuxWorkflow linuxWorkflow = LinuxWorkflow(
+      platform: notLinux,
+      featureFlags: enabledFlags,
+    );
+
     expect(linuxWorkflow.appliesToHostPlatform, false);
     expect(linuxWorkflow.canLaunchDevices, false);
     expect(linuxWorkflow.canListDevices, false);
     expect(linuxWorkflow.canListEmulators, false);
-  }, overrides: <Type, Generator>{
-    Platform: () => notLinux,
-  }));
+  });
 
-  test('Does not apply when feature is disabled', () => testbed.run(() {
+  test('Does not apply when feature is disabled', () {
+    final LinuxWorkflow linuxWorkflow = LinuxWorkflow(
+      platform: linux,
+      featureFlags: disabledFlags,
+    );
+
     expect(linuxWorkflow.appliesToHostPlatform, false);
     expect(linuxWorkflow.canLaunchDevices, false);
     expect(linuxWorkflow.canListDevices, false);
     expect(linuxWorkflow.canListEmulators, false);
-  }, overrides: <Type, Generator>{
-    FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: false),
-  }));
-}
-
-class MockPlatform extends Mock implements Platform {
-  @override
-  final Map<String, String> environment = <String, String>{};
+  });
 }

--- a/packages/flutter_tools/test/general.shard/linux/linux_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/linux/linux_workflow_test.dart
@@ -2,9 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter_tools/src/features.dart';
 import 'package:platform/platform.dart';
-
+import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/linux/linux_workflow.dart';
 
 import '../../src/common.dart';
@@ -24,7 +23,7 @@ void main() {
   );
   final FeatureFlags disabledFlags = TestFeatureFlags(isLinuxEnabled: false);
 
-  test('Applies to linux platform', () {
+  testWithoutContext('Applies to Linux platform', () {
     final LinuxWorkflow linuxWorkflow = LinuxWorkflow(
       platform: linux,
       featureFlags: enabledFlags,
@@ -36,7 +35,7 @@ void main() {
     expect(linuxWorkflow.canListEmulators, false);
   });
 
-  test('Does not apply to non-linux platform', () {
+  testWithoutContext('Does not apply to non-Linux platform', () {
     final LinuxWorkflow linuxWorkflow = LinuxWorkflow(
       platform: notLinux,
       featureFlags: enabledFlags,
@@ -48,7 +47,7 @@ void main() {
     expect(linuxWorkflow.canListEmulators, false);
   });
 
-  test('Does not apply when feature is disabled', () {
+  testWithoutContext('Does not apply when the Linux desktop feature is disabled', () {
     final LinuxWorkflow linuxWorkflow = LinuxWorkflow(
       platform: linux,
       featureFlags: disabledFlags,


### PR DESCRIPTION
## Description

- This is a fairly trivial class that doesn't need to be injected.
- Updates tests to use FakePlatform instead of a Mock.