### PR TITLE
[flutter_tools] support run -d chrome test scripts

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -590,7 +590,8 @@ Future<void> _runWebUnitTests() async {
 Future<void> _runWebIntegrationTests() async {
   await _runWebStackTraceTest('profile');
   await _runWebStackTraceTest('release');
-  await _runWebDebugStackTraceTest();
+  await _runWebDebugTest('lib/stack_trace.dart');
+  await _runWebDebugTest('test/test.dart');
 }
 
 Future<void> _runWebStackTraceTest(String buildMode) async {
@@ -636,7 +637,7 @@ Future<void> _runWebStackTraceTest(String buildMode) async {
 /// Debug mode is special because `flutter build web` doesn't build in debug mode.
 ///
 /// Instead, we use `flutter run --debug` and sniff out the standard output.
-Future<void> _runWebDebugStackTraceTest() async {
+Future<void> _runWebDebugTest(String target) async {
   final String testAppDirectory = path.join(flutterRoot, 'dev', 'integration_tests', 'web');
   final CapturedOutput output = CapturedOutput();
   bool success = false;
@@ -648,7 +649,8 @@ Future<void> _runWebDebugStackTraceTest() async {
       '-d',
       'chrome',
       '--web-run-headless',
-      'lib/stack_trace.dart',
+      '-t',
+      target,
     ],
     output: output,
     outputMode: OutputMode.capture,

--- a/dev/integration_tests/web/lib/a.dart
+++ b/dev/integration_tests/web/lib/a.dart
@@ -1,0 +1,5 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+const String message = 'a';

--- a/dev/integration_tests/web/lib/b.dart
+++ b/dev/integration_tests/web/lib/b.dart
@@ -1,0 +1,5 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+const String message = 'b';

--- a/dev/integration_tests/web/lib/c.dart
+++ b/dev/integration_tests/web/lib/c.dart
@@ -1,0 +1,5 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+const String message = 'c';

--- a/dev/integration_tests/web/lib/d.dart
+++ b/dev/integration_tests/web/lib/d.dart
@@ -1,0 +1,5 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+const String message = 'd';

--- a/dev/integration_tests/web/test/test.dart
+++ b/dev/integration_tests/web/test/test.dart
@@ -1,0 +1,25 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:html' as html;
+
+import 'package:web_integration/a.dart'
+  if (dart.library.io) 'package:web_integration/b.dart' as message1;
+import 'package:web_integration/c.dart'
+  if (dart.library.html) 'package:web_integration/d.dart' as message2;
+
+void main() {
+  String message;
+  if (message1.message == 'a' && message2.message == 'd')  {
+    message = '--- TEST SUCCEEDED ---';
+  } else {
+    message = '--- TEST FAILED ---';
+  }
+  print(message);
+  html.HttpRequest.request(
+    '/test-result',
+    method: 'POST',
+    sendData: message,
+  );
+}

--- a/dev/integration_tests/web/test/test.dart
+++ b/dev/integration_tests/web/test/test.dart
@@ -2,24 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:html' as html;
-
 import 'package:web_integration/a.dart'
   if (dart.library.io) 'package:web_integration/b.dart' as message1;
 import 'package:web_integration/c.dart'
   if (dart.library.html) 'package:web_integration/d.dart' as message2;
 
 void main() {
-  String message;
   if (message1.message == 'a' && message2.message == 'd')  {
-    message = '--- TEST SUCCEEDED ---';
+    print('--- TEST SUCCEEDED ---');
   } else {
-    message = '--- TEST FAILED ---';
+    print('--- TEST FAILED ---');
   }
-  print(message);
-  html.HttpRequest.request(
-    '/test-result',
-    method: 'POST',
-    sendData: message,
-  );
 }

--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -573,7 +573,13 @@ class _ResidentWebRunner extends ResidentWebRunner {
         .childFile('generated_plugin_registrant.dart')
         .absolute.path;
       final Uri generatedImport = packageUriMapper.map(generatedPath);
-      final String importedEntrypoint = packageUriMapper.map(main).toString() ?? 'file://$main';
+      String importedEntrypoint = packageUriMapper.map(main)?.toString();
+      // Special handling for entrypoints that are not under lib, such as test scripts.
+      if (importedEntrypoint == null) {
+        final String parent = globals.fs.file(main).parent.path;
+        flutterDevices.first.generator.addFileSystemRoot(parent);
+        importedEntrypoint = 'org-dartlang-app:///${globals.fs.path.basename(main)}';
+      }
 
       final String entrypoint = <String>[
         'import "$importedEntrypoint" as entrypoint;',

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -427,9 +427,8 @@ void main() {
     Usage: () => MockFlutterUsage(),
   }));
 
-  test('web resident runner iss debuggable', () => testbed.run(() {
+  test('web resident runner is debuggable', () => testbed.run(() {
     expect(residentWebRunner.debuggingEnabled, true);
-  }, overrides: <Type, Generator>{
   }));
 
   test('Exits when initial compile fails', () => testbed.run(() async {


### PR DESCRIPTION
## Description

Fixes https://github.com/flutter/flutter/issues/49838

Allow debug mode web applications to run test scripts and other files not under `lib/`. Adds an integration test for this, as well as for conditional imports.