### PR TITLE
[flutter_tools] Handle errors on the std{out,err}.done future

### DIFF
--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -175,7 +175,7 @@ Future<T> runInContext<T>(
       ShutdownHooks: () => ShutdownHooks(logger: globals.logger),
       Signals: () => Signals(),
       SimControl: () => SimControl(),
-      Stdio: () => const Stdio(),
+      Stdio: () => Stdio(),
       SystemClock: () => const SystemClock(),
       TimeoutConfiguration: () => const TimeoutConfiguration(),
       Usage: () => Usage(

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -150,14 +150,16 @@ final AnsiTerminal _defaultAnsiTerminal = AnsiTerminal(
 );
 
 /// The global Stdio wrapper.
-Stdio get stdio => context.get<Stdio>() ?? const Stdio();
+Stdio get stdio => context.get<Stdio>() ?? (_stdioInstance ??= Stdio());
+Stdio _stdioInstance;
 
-PlistParser get plistParser => context.get<PlistParser>() ?? (_defaultInstance ??= PlistParser(
-  fileSystem: fs,
-  processManager: processManager,
-  logger: logger,
+PlistParser get plistParser => context.get<PlistParser>() ?? (
+  _plistInstance ??= PlistParser(
+    fileSystem: fs,
+    processManager: processManager,
+    logger: logger,
 ));
-PlistParser _defaultInstance;
+PlistParser _plistInstance;
 
 /// The [ChromeLauncher] instance.
 ChromeLauncher get chromeLauncher => context.get<ChromeLauncher>();

--- a/packages/flutter_tools/test/general.shard/crash_reporting_test.dart
+++ b/packages/flutter_tools/test/general.shard/crash_reporting_test.dart
@@ -56,7 +56,7 @@ void main() {
 
       await verifyCrashReportSent(requestInfo);
     }, overrides: <Type, Generator>{
-      Stdio: () => const _NoStderr(),
+      Stdio: () => _NoStderr(),
     });
 
     testUsingContext('should print an explanatory message when there is a SocketException', () async {
@@ -77,7 +77,7 @@ void main() {
       expect(await exitCodeCompleter.future, 1);
       expect(testLogger.errorText, contains('Failed to send crash report due to a network error'));
     }, overrides: <Type, Generator>{
-      Stdio: () => const _NoStderr(),
+      Stdio: () => _NoStderr(),
     });
 
     testUsingContext('should print an explanatory message when there is an HttpException', () async {
@@ -98,7 +98,7 @@ void main() {
       expect(await exitCodeCompleter.future, 1);
       expect(testLogger.errorText, contains('Failed to send crash report due to a network error'));
     }, overrides: <Type, Generator>{
-      Stdio: () => const _NoStderr(),
+      Stdio: () => _NoStderr(),
     });
 
     testUsingContext('should send crash reports when async throws', () async {
@@ -120,7 +120,7 @@ void main() {
       expect(await exitCodeCompleter.future, 1);
       await verifyCrashReportSent(requestInfo);
     }, overrides: <Type, Generator>{
-      Stdio: () => const _NoStderr(),
+      Stdio: () => _NoStderr(),
     });
 
     testUsingContext('should send only one crash report when async throws many', () async {
@@ -151,7 +151,7 @@ void main() {
       await verifyCrashReportSent(requestInfo, crashes: 4);
     }, overrides: <Type, Generator>{
       DoctorValidatorsProvider: () => FakeDoctorValidatorsProvider(),
-      Stdio: () => const _NoStderr(),
+      Stdio: () => _NoStderr(),
     });
 
     testUsingContext('should not send a crash report if on a user-branch', () async {
@@ -183,7 +183,7 @@ void main() {
 
       expect(testLogger.traceText, isNot(contains('Crash report sent')));
     }, overrides: <Type, Generator>{
-      Stdio: () => const _NoStderr(),
+      Stdio: () => _NoStderr(),
     });
 
     testUsingContext('can override base URL', () async {
@@ -223,7 +223,7 @@ void main() {
         },
         script: Uri(scheme: 'data'),
       ),
-      Stdio: () => const _NoStderr(),
+      Stdio: () => _NoStderr(),
     });
   });
 }
@@ -400,7 +400,7 @@ class FakeDoctorValidatorsProvider implements DoctorValidatorsProvider {
 }
 
 class _NoStderr extends Stdio {
-  const _NoStderr();
+  _NoStderr();
 
   @override
   IOSink get stderr => const _NoopIOSink();

--- a/packages/flutter_tools/test/integration.shard/downgrade_upgrade_integration_test.dart
+++ b/packages/flutter_tools/test/integration.shard/downgrade_upgrade_integration_test.dart
@@ -16,12 +16,13 @@ const String _kInitialVersion = 'v1.9.1+hotfix.6';
 const String _kBranch = 'stable';
 const FileSystem fileSystem = LocalFileSystem();
 const ProcessManager processManager = LocalProcessManager();
+final Stdio stdio = Stdio();
 final ProcessUtils processUtils = ProcessUtils(processManager: processManager, logger: StdoutLogger(
   terminal: AnsiTerminal(
     platform: const LocalPlatform(),
-    stdio: const Stdio(),
+    stdio: stdio,
   ),
-  stdio: const Stdio(),
+  stdio: stdio,
   outputPreferences: OutputPreferences.test(wrapText: true),
   timeoutConfiguration: const TimeoutConfiguration(),
 ));


### PR DESCRIPTION
## Description

`stdout` and `stderr` can put errors on their respective `done` futures. This PR catches those errors to avoid the tool crashing on a write to `stdout` or `stderr`.

## Related Issues

Crash seen in crash logging.

## Tests

I added the following tests:

Added a test `logger_test.dart`

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
