### PR TITLE
[DataTable] Hide arrow padding when not sorting

### DIFF
--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -516,18 +516,23 @@ class DataTable extends StatelessWidget {
     bool sorted,
     bool ascending,
   }) {
-    if (onSort != null) {
-      final Widget arrow = _SortArrow(
-        visible: sorted,
-        down: sorted ? ascending : null,
-        duration: _sortArrowAnimationDuration,
-      );
-      const Widget arrowPadding = SizedBox(width: _sortArrowPadding);
-      label = Row(
-        textDirection: numeric ? TextDirection.rtl : null,
-        children: <Widget>[ label, arrowPadding, arrow ],
-      );
+    List<Widget> arrowWithPadding() {
+      return onSort == null ? const <Widget>[] : <Widget>[
+        _SortArrow(
+          visible: sorted,
+          down: sorted ? ascending : null,
+          duration: _sortArrowAnimationDuration,
+        ),
+        const SizedBox(width: _sortArrowPadding),
+      ];
     }
+    label = Row(
+      textDirection: numeric ? TextDirection.rtl : null,
+      children: <Widget>[
+        label,
+        ...arrowWithPadding(),
+      ],
+    );
     label = Container(
       padding: padding,
       height: headingRowHeight,
@@ -702,7 +707,7 @@ class DataTable extends StatelessWidget {
         label: column.label,
         tooltip: column.tooltip,
         numeric: column.numeric,
-        onSort: () => column.onSort != null ? column.onSort(dataColumnIndex, sortColumnIndex != dataColumnIndex || !sortAscending) : null,
+        onSort: column.onSort != null ? () => column.onSort(dataColumnIndex, sortColumnIndex != dataColumnIndex || !sortAscending) : null,
         sorted: dataColumnIndex == sortColumnIndex,
         ascending: sortAscending,
       );

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -562,7 +562,9 @@ class DataTable extends StatelessWidget {
         child: label,
       );
     }
-    if (onSort != null) {
+    // TODO(dkwingsmt): Change the condition to `if (onSort != null)` when
+    // https://github.com/flutter/flutter/issues/51152 is fixed
+    if (true) {
       label = InkWell(
         onTap: onSort,
         child: label,

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -562,14 +562,12 @@ class DataTable extends StatelessWidget {
         child: label,
       );
     }
-    // TODO(dkwingsmt): Change the condition to `if (onSort != null)` when
-    // https://github.com/flutter/flutter/issues/51152 is fixed
-    if (true) {
-      label = InkWell(
-        onTap: onSort,
-        child: label,
-      );
-    }
+    // TODO(dkwingsmt): Only wrap Inkwell if onSort != null. Blocked by
+    // https://github.com/flutter/flutter/issues/51152
+    label = InkWell(
+      onTap: onSort,
+      child: label,
+    );
     return label;
   }
 

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -47,6 +47,10 @@ class DataColumn {
   /// [Icon] (typically using size 18), or a [Row] with an icon and
   /// some text.
   ///
+  /// By default, this widget will only occupy the minimal space. If you want
+  /// it to take the entire remaining space, e.g. when you want to use [Center],
+  /// you can wrap it with an [Expanded].
+  ///
   /// The label should not include the sort indicator.
   final Widget label;
 

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -1030,7 +1030,8 @@ void main() {
     expect(tester.renderObject(find.text('column1')).attached, true);
     expect(tester.renderObject(find.text('column2')).attached, true);
 
-    // Wait for the tooltip timer
+    // Wait for the tooltip timer to expire to prevent it scheduling a new frame
+    // after the view is destroyed, which causes exceptions.
     await tester.pumpAndSettle(const Duration(seconds: 1));
   });
 }

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -918,4 +918,67 @@ void main() {
     boxDecoration = tableRow.decoration as BoxDecoration;
     expect(boxDecoration.border.bottom.width, thickness);
   });
+
+  testWidgets('DataTable column heading cell - no sort', (WidgetTester tester) async {
+    Widget buildTable({ int sortColumnIndex, bool sortEnabled = true }) {
+      return DataTable(
+        sortColumnIndex: sortColumnIndex,
+        columns: <DataColumn>[
+          DataColumn(
+            label: const Expanded(child: Center(child: Text('Name'))),
+            tooltip: 'Name',
+            onSort: sortEnabled ? (_, __) {} : null,
+          ),
+        ],
+        rows: const <DataRow>[
+          DataRow(
+            cells: <DataCell>[
+              DataCell(Text('A long desert name')),
+            ],
+          ),
+        ]
+      );
+    }
+
+    await tester.pumpWidget(MaterialApp(
+      home: Material(child: buildTable(
+        sortEnabled: false,
+      )),
+    ));
+
+    {
+      final Finder nameText = find.text('Name');
+      expect(nameText, findsOneWidget);
+      final Finder nameCell = find.ancestor(of: find.text('Name'), matching: find.byType(Container)).first;
+      expect(tester.getCenter(nameText), equals(tester.getCenter(nameCell)));
+      expect(find.descendant(of: nameCell, matching: find.byType(Icon)), findsNothing);
+    }
+
+    await tester.pumpWidget(MaterialApp(
+      home: Material(child: buildTable(
+        sortEnabled: true,
+      )),
+    ));
+
+    {
+      final Finder nameText = find.text('Name');
+      expect(nameText, findsOneWidget);
+      final Finder nameCell = find.ancestor(of: find.text('Name'), matching: find.byType(Container)).first;
+      expect(find.descendant(of: nameCell, matching: find.byType(Icon)), findsOneWidget);
+    }
+
+    await tester.pumpWidget(MaterialApp(
+      home: Material(child: buildTable(
+        sortEnabled: false,
+      )),
+    ));
+
+    {
+      final Finder nameText = find.text('Name');
+      expect(nameText, findsOneWidget);
+      final Finder nameCell = find.ancestor(of: find.text('Name'), matching: find.byType(Container)).first;
+      expect(tester.getCenter(nameText), equals(tester.getCenter(nameCell)));
+      expect(find.descendant(of: nameCell, matching: find.byType(Icon)), findsNothing);
+    }
+  });
 }

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -920,7 +920,7 @@ void main() {
     expect(boxDecoration.border.bottom.width, thickness);
   });
 
-  testWidgets('DataTable column heading cell - no sort', (WidgetTester tester) async {
+  testWidgets('DataTable column heading cell - with and without sorting', (WidgetTester tester) async {
     Widget buildTable({ int sortColumnIndex, bool sortEnabled = true }) {
       return DataTable(
         sortColumnIndex: sortColumnIndex,
@@ -941,6 +941,7 @@ void main() {
       );
     }
 
+    // Start with without sorting
     await tester.pumpWidget(MaterialApp(
       home: Material(child: buildTable(
         sortEnabled: false,
@@ -955,6 +956,7 @@ void main() {
       expect(find.descendant(of: nameCell, matching: find.byType(Icon)), findsNothing);
     }
 
+    // Turn on sorting
     await tester.pumpWidget(MaterialApp(
       home: Material(child: buildTable(
         sortEnabled: true,
@@ -968,6 +970,7 @@ void main() {
       expect(find.descendant(of: nameCell, matching: find.byType(Icon)), findsOneWidget);
     }
 
+    // Turn off sorting again
     await tester.pumpWidget(MaterialApp(
       home: Material(child: buildTable(
         sortEnabled: false,


### PR DESCRIPTION
## Description

This PR fixes the problem that the arrow padding still displays when `DataColumn.onSort` is null, thus allowing the label to be truly centered.

This continues the work of https://github.com/flutter/flutter/pull/43735 by @andermoran.

## Related Issues

- Affected by https://github.com/flutter/flutter/issues/51152. A workaround is used with a regression test

## Tests

I added the following tests:

- DataTable column heading cell - no sort
- DataTable correctly renders with a mouse

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
