### PR TITLE
Keep render tree and element tree in sync when re-used elements move in a MultiChildRenderObjectElement's child list

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -5389,7 +5389,7 @@ abstract class RenderObjectElement extends Element {
   /// linked list (as is done by the [ContainerRenderObjectMixin]) this can
   /// be implemented by re-inserting the child [RenderObject] into the
   /// list after the [RenderObject] associated with the [Element] provided as
-  /// [IndexedSlot.value] in the [slot] value.
+  /// [IndexedSlot.value] in the [slot] object.
   ///
   /// Simply using the previous sibling as a [slot] is not enough, though, because
   /// child [RenderObject]s are only moved around when the [slot] of their
@@ -5403,7 +5403,7 @@ abstract class RenderObjectElement extends Element {
   /// be assigned to its [RenderObjectElement] whenever its index in its
   /// parent's child list changes. Using an [IndexedSlot<Element>] achieves
   /// exactly that and also ensures that the underlying parent [RenderObject]
-  /// knows where a child needs to move to in a linked list by providing its
+  /// knows where a child needs to move to in a linked list by providing its new
   /// previous sibling.
   @protected
   List<Element> updateChildren(List<Element> oldChildren, List<Widget> newWidgets, { Set<Element> forgottenChildren }) {

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -5812,10 +5812,10 @@ class SingleChildRenderObjectElement extends RenderObjectElement {
 ///
 /// See also:
 ///
-/// * [IndexedSlot], which are used as [Element.slot]s for the children of a
+/// * [IndexedSlot], which is used as [Element.slot]s for the children of a
 ///   [MultiChildRenderObjectElement].
 /// * [RenderObjectElement.updateChildren], which discusses why [IndexedSlot]
-///   are used for the slots of the children.
+///   is used for the slots of the children.
 class MultiChildRenderObjectElement extends RenderObjectElement {
   /// Creates an element that uses the given widget as its configuration.
   MultiChildRenderObjectElement(MultiChildRenderObjectWidget widget)
@@ -5934,7 +5934,8 @@ FlutterErrorDetails _debugReportException(
   return details;
 }
 
-/// Used by [MultiChildRenderObjectElement] for the [Element.slot] value.
+/// A value for [Element.slot] used for children of
+/// [MultiChildRenderObjectElement]s.
 ///
 /// A slot for a [MultiChildRenderObjectElement] consists of an [index]
 /// identifying where the child occupying this slot is located in the

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -5400,7 +5400,7 @@ abstract class RenderObjectElement extends Element {
   /// continues to have e3 as a previous sibling even though its index in the list
   /// has changed and its [RenderObject] needs to move to come before e2's
   /// [RenderObject]. In order to trigger this move, a new [slot] value needs to
-  /// be assigned to its [RenderObjectElement] whenever its index in its
+  /// be assigned to its [Element] whenever its index in its
   /// parent's child list changes. Using an [IndexedSlot<Element>] achieves
   /// exactly that and also ensures that the underlying parent [RenderObject]
   /// knows where a child needs to move to in a linked list by providing its new

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -5960,6 +5960,8 @@ class IndexedSlot<T> {
 
   @override
   bool operator ==(Object other) {
+    if (other.runtimeType != runtimeType)
+      return false;
     return other is IndexedSlot
         && index == other.index
         && value == other.value;

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -5376,8 +5376,33 @@ abstract class RenderObjectElement extends Element {
   /// acts as if the child was not in `oldChildren`.
   ///
   /// This function is a convenience wrapper around [updateChild], which updates
-  /// each individual child. When calling [updateChild], this function uses the
-  /// previous element as the `newSlot` argument.
+  /// each individual child. When calling [updateChild], this function uses an
+  /// [IndexedSlot<Element>] as the value for the `newSlot` argument.
+  /// [IndexedSlot.index] is set to the index that the currently processed
+  /// `child` corresponds to in the `newWidgets` list and [IndexedSlot.value] is
+  /// set to the [Element] of the previous widget in that list (or null if it is
+  /// the first child). When the [slot] value of an [Element] changes, its
+  /// associated [renderObject] needs to move to a new position in the child
+  /// list of its parents. If that [RenderObject] organizes its children in a
+  /// linked list (as is done by the [ContainerRenderObjectMixin]) this can
+  /// be implemented by re-inserting the child [RenderObject] into the
+  /// list after the [RenderObject] associated with the [Element] provided as
+  /// [IndexedSlot.value] in the [slot] value.
+  ///
+  /// Simply using the previous child as a [slot] is not enough, though, because
+  /// child [RenderObject]s are only moved around when the [slot] of their
+  /// associated [RenderObjectElement]s is updated. When the order of child
+  /// [Element]s is changed, some elements in the list may move to a new index
+  /// but still have the same previous sibling. For example, when
+  /// `[e1, e2, e3, e4]` is changed to `[e1, e3, e4, e2]` the element e4
+  /// continues to have e3 as a previous child even though its index in the list
+  /// has changed and its [RenderObject] needs to move to come before e2's
+  /// [RenderObject]. In order to trigger this move, a new [slot] value needs to
+  /// be assigned to its [RenderObjectElement] whenever its index in its
+  /// parent's child list changes. Using an [IndexedSlot<Element>] achieves
+  /// exactly that and also ensures that the underlying parent [RenderObject]
+  /// knows where a child needs to move to in a linked list by providing its
+  /// previous sibling.
   @protected
   List<Element> updateChildren(List<Element> oldChildren, List<Widget> newWidgets, { Set<Element> forgottenChildren }) {
     assert(oldChildren != null);
@@ -5609,10 +5634,12 @@ abstract class RenderObjectElement extends Element {
 
   /// Insert the given child into [renderObject] at the given slot.
   ///
+  /// {@template flutter.widgets.slots}
   /// The semantics of `slot` are determined by this element. For example, if
   /// this element has a single child, the slot should always be null. If this
-  /// element has a list of children, the previous sibling is a convenient value
-  /// for the slot.
+  /// element has a list of children, the previous sibling element wrapped in an
+  /// [IndexedSlot] is a convenient value for the slot.
+  /// {@endtemplate}
   @protected
   void insertChildRenderObject(covariant RenderObject child, covariant dynamic slot);
 
@@ -5620,10 +5647,7 @@ abstract class RenderObjectElement extends Element {
   ///
   /// The given child is guaranteed to have [renderObject] as its parent.
   ///
-  /// The semantics of `slot` are determined by this element. For example, if
-  /// this element has a single child, the slot should always be null. If this
-  /// element has a list of children, the previous sibling is a convenient value
-  /// for the slot.
+  /// {@macro flutter.widgets.slots}
   ///
   /// This method is only ever called if [updateChild] can end up being called
   /// with an existing [Element] child and a `slot` that differs from the slot
@@ -5783,6 +5807,13 @@ class SingleChildRenderObjectElement extends RenderObjectElement {
 /// RenderObjects use the [ContainerRenderObjectMixin] mixin with a parent data
 /// type that implements [ContainerParentDataMixin<RenderObject>]. Such widgets
 /// are expected to inherit from [MultiChildRenderObjectWidget].
+///
+/// See also:
+///
+/// * [IndexedSlot], which are used as [Element.slot]s for the children of a
+///   [MultiChildRenderObjectElement].
+/// * [RenderObjectElement.updateChildren], which discusses why [IndexedSlot]
+///   are used for the slots of the children.
 class MultiChildRenderObjectElement extends RenderObjectElement {
   /// Creates an element that uses the given widget as its configuration.
   MultiChildRenderObjectElement(MultiChildRenderObjectWidget widget)
@@ -5901,13 +5932,18 @@ FlutterErrorDetails _debugReportException(
   return details;
 }
 
-/// Object used by [MultiChildRenderObjectElement] for the [Element.slot] value.
+/// Used by [MultiChildRenderObjectElement] for the [Element.slot] value.
 ///
 /// A slot for a [MultiChildRenderObjectElement] consists of an [index]
 /// identifying where the child occupying this slot is located in the
 /// [MultiChildRenderObjectElement]'s child list and an arbitrary [value] that
 /// can further define where the child occupying this slot fits in its
 /// parent's child list.
+///
+/// See also:
+///
+///  * [RenderObjectElement.updateChildren], which discusses why this class is
+///    used as slot values for the children of a [MultiChildRenderObjectElement].
 @immutable
 class IndexedSlot<T> {
   /// Creates an [IndexedSlot] with the provided [index] and slot [value].

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -5381,7 +5381,9 @@ abstract class RenderObjectElement extends Element {
   /// [IndexedSlot.index] is set to the index that the currently processed
   /// `child` corresponds to in the `newWidgets` list and [IndexedSlot.value] is
   /// set to the [Element] of the previous widget in that list (or null if it is
-  /// the first child). When the [slot] value of an [Element] changes, its
+  /// the first child).
+  ///
+  /// When the [slot] value of an [Element] changes, its
   /// associated [renderObject] needs to move to a new position in the child
   /// list of its parents. If that [RenderObject] organizes its children in a
   /// linked list (as is done by the [ContainerRenderObjectMixin]) this can

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -5389,13 +5389,13 @@ abstract class RenderObjectElement extends Element {
   /// list after the [RenderObject] associated with the [Element] provided as
   /// [IndexedSlot.value] in the [slot] value.
   ///
-  /// Simply using the previous child as a [slot] is not enough, though, because
+  /// Simply using the previous sibling as a [slot] is not enough, though, because
   /// child [RenderObject]s are only moved around when the [slot] of their
   /// associated [RenderObjectElement]s is updated. When the order of child
   /// [Element]s is changed, some elements in the list may move to a new index
   /// but still have the same previous sibling. For example, when
   /// `[e1, e2, e3, e4]` is changed to `[e1, e3, e4, e2]` the element e4
-  /// continues to have e3 as a previous child even though its index in the list
+  /// continues to have e3 as a previous sibling even though its index in the list
   /// has changed and its [RenderObject] needs to move to come before e2's
   /// [RenderObject]. In order to trigger this move, a new [slot] value needs to
   /// be assigned to its [RenderObjectElement] whenever its index in its

--- a/packages/flutter/lib/src/widgets/table.dart
+++ b/packages/flutter/lib/src/widgets/table.dart
@@ -266,7 +266,7 @@ class _TableElement extends RenderObjectElement {
   }
 
   @override
-  void insertChildRenderObject(RenderObject child, Element slot) {
+  void insertChildRenderObject(RenderObject child, IndexedSlot<Element> slot) {
     renderObject.setupParentData(child);
   }
 

--- a/packages/flutter/test/widgets/multichildobject_with_keys.dart
+++ b/packages/flutter/test/widgets/multichildobject_with_keys.dart
@@ -1,0 +1,72 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('MultiChildRenderObjectElement control test', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/48855.
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Column(
+          children: const <Widget>[
+            Text('0', key: ValueKey<int>(0)),
+            Text('1', key: ValueKey<int>(1)),
+            Text('2', key: ValueKey<int>(2)),
+            Text('3', key: ValueKey<int>(3)),
+            Text('4', key: ValueKey<int>(4)),
+            Text('5', key: ValueKey<int>(5)),
+            Text('6', key: ValueKey<int>(6)),
+            Text('7', key: ValueKey<int>(7)),
+            Text('8', key: ValueKey<int>(8)),
+          ],
+        ),
+      ),
+    );
+
+    expect(
+      _getChildOrder(tester.renderObject<RenderFlex>(find.byType(Column))),
+      <String>['0', '1', '2', '3', '4', '5', '6', '7', '8'],
+    );
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Column(
+          children: const <Widget>[
+            Text('0', key: ValueKey<int>(0)),
+            Text('6', key: ValueKey<int>(6)),
+            Text('7', key: ValueKey<int>(7)),
+            Text('8', key: ValueKey<int>(8)),
+            Text('1', key: ValueKey<int>(1)),
+            Text('2', key: ValueKey<int>(2)),
+            Text('3', key: ValueKey<int>(3)),
+            Text('4', key: ValueKey<int>(4)),
+            Text('5', key: ValueKey<int>(5)),
+          ],
+        ),
+      ),
+    );
+
+    expect(
+      _getChildOrder(tester.renderObject<RenderFlex>(find.byType(Column))),
+      <String>['0', '6', '7', '8', '1', '2', '3', '4', '5'],
+    );
+  });
+}
+
+// Do not use tester.renderObjectList(find.byType(RenderParagraph). That returns
+// the RenderObjects in the order of their associated RenderObjectWidgets. The
+// point of this test is to assert the children order in the render tree, though.
+List<String> _getChildOrder(RenderFlex flex) {
+  final List<String> childOrder = <String>[];
+  flex.visitChildren((RenderObject child) {
+    childOrder.add(((child as RenderParagraph).text as TextSpan).text);
+  });
+  return childOrder;
+}

--- a/packages/flutter/test/widgets/multichildobject_with_keys_test.dart
+++ b/packages/flutter/test/widgets/multichildobject_with_keys_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('MultiChildRenderObjectElement control test', (WidgetTester tester) async {
+  testWidgets('Render and element tree stay in sync when keyed children move around', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/48855.
 
     await tester.pumpWidget(


### PR DESCRIPTION
## Description

Prior to this change the Element child list of an MultiChildRenderObjectElement and the RenderObject child list of its associated RenderObject could get out of sync when Elements move around in the child list. See https://github.com/flutter/flutter/issues/48855#issuecomment-592261646 for a detailed description of the problem.

In a nutshell, we used to only change the slot of a child when its proceeding sibling changed. Updating a slot is what triggers moving the associated RenderObject to a new position. However, in situations involving keyed children as outlined in the bug linked above it is possible that we need to move a RenderObject to a new position in the child list even when its previous sibling hasn't changed.

This change fixes the problem by assigning a new slot value to all children that need their RenderObject moved to trigger the move.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/48855.

## Tests

I added the following tests:

* Render and element tree stay in sync when keyed children move around

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
