### PR TITLE
Fix `_checkPodCondition` not handling `CocoaPodsStatus.brokenInstall`

### DIFF
--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -143,13 +143,14 @@ class CocoaPods {
       throwToolExit('Podfile missing');
     }
     bool podsProcessed = false;
-    if (await _checkPodCondition()) {
-      if (_shouldRunPodInstall(xcodeProject, dependenciesChanged)) {
-        await _runPodInstall(xcodeProject, engineDir);
-        podsProcessed = true;
+    if (_shouldRunPodInstall(xcodeProject, dependenciesChanged)) {
+      if (!await _checkPodCondition()) {
+        throwToolExit('CocoaPods not installed or not in valid state.');
       }
-      _warnIfPodfileOutOfDate(xcodeProject);
+      await _runPodInstall(xcodeProject, engineDir);
+      podsProcessed = true;
     }
+    _warnIfPodfileOutOfDate(xcodeProject);
     return podsProcessed;
   }
 

--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -166,6 +166,15 @@ class CocoaPods {
           emphasis: true,
         );
         return false;
+      case CocoaPodsStatus.brokenInstall:
+        globals.printError(
+          'Warning: CocoaPods is installed but broken. Skipping pod install.\n'
+          '$brokenCocoaPodsConsequence\n'
+          'To re-install:\n'
+          '$cocoaPodsUpgradeInstructions\n',
+          emphasis: true,
+        );
+        return false;
       case CocoaPodsStatus.unknownVersion:
         globals.printError(
           'Warning: Unknown CocoaPods version installed.\n'
@@ -193,7 +202,7 @@ class CocoaPods {
           emphasis: true,
         );
         break;
-      default:
+      case CocoaPodsStatus.recommended:
         break;
     }
     if (!await isCocoaPodsInitialized) {

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -322,7 +322,7 @@ void main() {
       podsIsInHomeDir();
     });
 
-    testUsingContext('prints error, if CocoaPods is not installed', () async {
+    testUsingContext('throwsToolExit if CocoaPods is not installed', () async {
       pretendPodIsNotInstalled();
       projectUnderTest.ios.podfile.createSync();
       final Function invokeProcessPods = () async => await cocoaPodsUnderTest.processPods(
@@ -340,7 +340,7 @@ void main() {
       ProcessManager: () => mockProcessManager,
     });
 
-    testUsingContext('prints error if CocoaPods install is broken', () async {
+    testUsingContext('throwsToolExit if CocoaPods install is broken', () async {
       pretendPodIsBroken();
       projectUnderTest.ios.podfile.createSync();
       final Function invokeProcessPods = () async => await cocoaPodsUnderTest.processPods(

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -342,7 +342,7 @@ void main() {
       ProcessManager: () => mockProcessManager,
     });
 
-    testUsingContext('prints error, if CocoaPods install is broken', () async {
+    testUsingContext('prints error if CocoaPods install is broken', () async {
       pretendPodIsBroken();
       projectUnderTest.ios.podfile.createSync();
       final bool didInstall = await cocoaPodsUnderTest.processPods(
@@ -354,8 +354,8 @@ void main() {
         workingDirectory: anyNamed('workingDirectory'),
         environment: anyNamed('environment'),
       ));
-      //expect(testLogger.errorText, contains('not installed'));
-      //expect(testLogger.errorText, contains('Skipping pod install'));
+      expect(testLogger.errorText, contains('is installed but broken'));
+      expect(testLogger.errorText, contains('Skipping pod install'));
       expect(didInstall, isFalse);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -325,18 +325,16 @@ void main() {
     testUsingContext('prints error, if CocoaPods is not installed', () async {
       pretendPodIsNotInstalled();
       projectUnderTest.ios.podfile.createSync();
-      final bool didInstall = await cocoaPodsUnderTest.processPods(
+      final Function invokeProcessPods = () async => await cocoaPodsUnderTest.processPods(
         xcodeProject: projectUnderTest.ios,
         engineDir: 'engine/path',
       );
+      expect(invokeProcessPods, throwsToolExit());
       verifyNever(mockProcessManager.run(
       argThat(containsAllInOrder(<String>['pod', 'install'])),
         workingDirectory: anyNamed('workingDirectory'),
         environment: anyNamed('environment'),
       ));
-      expect(testLogger.errorText, contains('not installed'));
-      expect(testLogger.errorText, contains('Skipping pod install'));
-      expect(didInstall, isFalse);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
       ProcessManager: () => mockProcessManager,
@@ -345,18 +343,16 @@ void main() {
     testUsingContext('prints error if CocoaPods install is broken', () async {
       pretendPodIsBroken();
       projectUnderTest.ios.podfile.createSync();
-      final bool didInstall = await cocoaPodsUnderTest.processPods(
+      final Function invokeProcessPods = () async => await cocoaPodsUnderTest.processPods(
         xcodeProject: projectUnderTest.ios,
         engineDir: 'engine/path',
       );
+      expect(invokeProcessPods, throwsToolExit());
       verifyNever(mockProcessManager.run(
       argThat(containsAllInOrder(<String>['pod', 'install'])),
         workingDirectory: anyNamed('workingDirectory'),
         environment: anyNamed('environment'),
       ));
-      expect(testLogger.errorText, contains('is installed but broken'));
-      expect(testLogger.errorText, contains('Skipping pod install'));
-      expect(didInstall, isFalse);
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,
       ProcessManager: () => mockProcessManager,


### PR DESCRIPTION
## Description

As seen in https://github.com/flutter/flutter/issues/42782, if cocoapods is installed but broken, the verification check fails before invoking pod install during the `processPods()` flow. The reason the verification check fails is because `_checkPodCondition` has a `switch`-`case` that handles `CocoaPodsStatus` values from `evaluateCocoaPodsInstallation`, but it failed to handle `CocoaPodsStatus.brokenInstall` and had a no-op `default` value (thus not triggering the analyzer warning to handle all elements of an enum). Fixed by removing the `default` and handling all cases.

In addition, I made the case of cocoapods being required but not in a valid state a toolexit; the previous behavior was to log the error but continue execution, until later when the app build would fail.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/42782

## Tests

I added a new test verifying that `pod install` would not be invoked and a warning emitted if cocoapods are present but in a broken state.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.