### PR TITLE
Add timeout flag to devices command, pipe through discovery

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -62,7 +62,7 @@ class AndroidDevices extends PollingDeviceDiscovery {
   bool get canListAnything => androidWorkflow.canListDevices;
 
   @override
-  Future<List<Device>> pollingGetDevices() async => getAdbDevices();
+  Future<List<Device>> pollingGetDevices({ Duration timeout }) async => getAdbDevices();
 
   @override
   Future<List<String>> getDiagnostics() async => getAdbDeviceDiagnostics();

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -12,11 +12,35 @@ import '../globals.dart' as globals;
 import '../runner/flutter_command.dart';
 
 class DevicesCommand extends FlutterCommand {
+  DevicesCommand() {
+    argParser.addOption(
+      'timeout',
+      abbr: 't',
+      defaultsTo: null,
+      help: 'Time in seconds to wait for devices to attach. Longer timeouts may be necessary for networked devices.'
+    );
+  }
+
   @override
   final String name = 'devices';
 
   @override
   final String description = 'List all connected devices.';
+
+  Duration get timeout {
+    if (argResults['timeout'] == null) {
+      return null;
+    }
+    if (_timeout == null) {
+      final int timeoutSeconds = int.tryParse(stringArg('timeout'));
+      if (timeoutSeconds == null) {
+        throwToolExit( 'Could not parse -t/--timeout argument. It must be an integer.');
+      }
+      _timeout = Duration(seconds: timeoutSeconds);
+    }
+    return _timeout;
+  }
+  Duration _timeout;
 
   @override
   Future<FlutterCommandResult> runCommand() async {
@@ -27,14 +51,21 @@ class DevicesCommand extends FlutterCommand {
         exitCode: 1);
     }
 
-    final List<Device> devices = await deviceManager.getAllConnectedDevices();
+    final List<Device> devices = await deviceManager.refreshAllConnectedDevices(timeout: timeout);
 
     if (devices.isEmpty) {
-      globals.printStatus(
-        'No devices detected.\n\n'
-        "Run 'flutter emulators' to list and start any available device emulators.\n\n"
-        'Or, if you expected your device to be detected, please run "flutter doctor" to diagnose '
-        'potential issues, or visit https://flutter.dev/setup/ for troubleshooting tips.');
+      final StringBuffer status = StringBuffer('No devices detected.');
+      status.writeln();
+      status.writeln();
+      status.writeln('Run "flutter emulators" to list and start any available device emulators.');
+      status.writeln();
+      status.write('If you expected your device to be detected, please run "flutter doctor" to diagnose potential issues. ');
+      if (timeout == null) {
+        status.write('You may also try increasing the time to wait for connected devices with the --timeout flag. ');
+      }
+      status.write('Visit https://flutter.dev/setup/ for troubleshooting tips.');
+
+      globals.printStatus(status.toString());
       final List<String> diagnostics = await deviceManager.getDeviceDiagnostics();
       if (diagnostics.isNotEmpty) {
         globals.printStatus('');

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_dev_finder.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_dev_finder.dart
@@ -22,7 +22,7 @@ class FuchsiaDevFinder {
   /// Returns a list of attached devices as a list of strings with entries
   /// formatted as follows:
   /// 192.168.42.172 scare-cable-skip-joy
-  Future<List<String>> list() async {
+  Future<List<String>> list({ Duration timeout }) async {
     if (fuchsiaArtifacts.devFinder == null ||
         !fuchsiaArtifacts.devFinder.existsSync()) {
       throwToolExit('Fuchsia device-finder tool not found.');
@@ -31,6 +31,8 @@ class FuchsiaDevFinder {
       fuchsiaArtifacts.devFinder.path,
       'list',
       '-full',
+      if (timeout != null)
+        ...<String>['-timeout', '${timeout.inMilliseconds}ms']
     ];
     final RunResult result = await processUtils.run(command);
     if (result.exitCode != 0) {

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -145,11 +145,11 @@ class FuchsiaDevices extends PollingDeviceDiscovery {
   bool get canListAnything => fuchsiaWorkflow.canListDevices;
 
   @override
-  Future<List<Device>> pollingGetDevices() async {
+  Future<List<Device>> pollingGetDevices({ Duration timeout }) async {
     if (!fuchsiaWorkflow.canListDevices) {
       return <Device>[];
     }
-    final String text = await fuchsiaSdk.listDevices();
+    final String text = await fuchsiaSdk.listDevices(timeout: timeout);
     if (text == null || text.isEmpty) {
       return <Device>[];
     }

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
@@ -47,12 +47,12 @@ class FuchsiaSdk {
   /// Example output:
   ///    $ device-finder list -full
   ///    > 192.168.42.56 paper-pulp-bush-angel
-  Future<String> listDevices() async {
+  Future<String> listDevices({ Duration timeout }) async {
     if (fuchsiaArtifacts.devFinder == null ||
         !fuchsiaArtifacts.devFinder.existsSync()) {
       return null;
     }
-    final List<String> devices = await fuchsiaDevFinder.list();
+    final List<String> devices = await fuchsiaDevFinder.list(timeout: timeout);
     if (devices == null) {
       return null;
     }

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -38,7 +38,10 @@ class IOSDevices extends PollingDeviceDiscovery {
   bool get canListAnything => globals.iosWorkflow.canListDevices;
 
   @override
-  Future<List<Device>> pollingGetDevices() => IOSDevice.getAttachedDevices(globals.platform, globals.xcdevice);
+  Future<List<Device>> pollingGetDevices({ Duration timeout }) {
+    return IOSDevice.getAttachedDevices(
+        globals.platform, globals.xcdevice, timeout: timeout);
+  }
 
   @override
   Future<List<String>> getDiagnostics() => IOSDevice.getDiagnostics(globals.platform, globals.xcdevice);
@@ -109,12 +112,12 @@ class IOSDevice extends Device {
   @override
   bool get supportsStartPaused => false;
 
-  static Future<List<IOSDevice>> getAttachedDevices(Platform platform, XCDevice xcdevice) async {
+  static Future<List<IOSDevice>> getAttachedDevices(Platform platform, XCDevice xcdevice, { Duration timeout }) async {
     if (!platform.isMacOS) {
       throw UnsupportedError('Control of iOS devices or simulators only supported on macOS.');
     }
 
-    return await xcdevice.getAvailableTetheredIOSDevices();
+    return await xcdevice.getAvailableTetheredIOSDevices(timeout: timeout);
   }
 
   static Future<List<String>> getDiagnostics(Platform platform, XCDevice xcdevice) async {

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -43,7 +43,7 @@ class IOSSimulators extends PollingDeviceDiscovery {
   bool get canListAnything => globals.iosWorkflow.canListDevices;
 
   @override
-  Future<List<Device>> pollingGetDevices() async => _iosSimulatorUtils.getAttachedDevices();
+  Future<List<Device>> pollingGetDevices({ Duration timeout }) async => _iosSimulatorUtils.getAttachedDevices();
 }
 
 class IOSSimulatorUtils {

--- a/packages/flutter_tools/lib/src/linux/linux_device.dart
+++ b/packages/flutter_tools/lib/src/linux/linux_device.dart
@@ -76,7 +76,7 @@ class LinuxDevices extends PollingDeviceDiscovery {
   bool get canListAnything => _linuxWorkflow.canListDevices;
 
   @override
-  Future<List<Device>> pollingGetDevices() async {
+  Future<List<Device>> pollingGetDevices({ Duration timeout }) async {
     if (!canListAnything) {
       return const <Device>[];
     }

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -78,7 +78,7 @@ class MacOSDevices extends PollingDeviceDiscovery {
   bool get canListAnything => macOSWorkflow.canListDevices;
 
   @override
-  Future<List<Device>> pollingGetDevices() async {
+  Future<List<Device>> pollingGetDevices({ Duration timeout }) async {
     if (!canListAnything) {
       return const <Device>[];
     }

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -228,7 +228,10 @@ class XCDevice {
     return _xcdevicePath;
   }
 
-  Future<List<dynamic>> _getAllDevices({bool useCache = false}) async {
+  Future<List<dynamic>> _getAllDevices({
+    bool useCache = false,
+    @required Duration timeout
+  }) async {
     if (!isInstalled) {
       _logger.printTrace("Xcode not found. Run 'flutter doctor' for more information.");
       return null;
@@ -244,7 +247,7 @@ class XCDevice {
           'xcdevice',
           'list',
           '--timeout',
-          '1',
+          timeout.inSeconds.toString(),
         ],
         throwOnError: true,
       );
@@ -265,9 +268,9 @@ class XCDevice {
 
   List<dynamic> _cachedListResults;
 
-  /// List of devices available over USB.
-  Future<List<IOSDevice>> getAvailableTetheredIOSDevices() async {
-    final List<dynamic> allAvailableDevices = await _getAllDevices();
+  /// [timeout] defaults to 1 second.
+  Future<List<IOSDevice>> getAvailableTetheredIOSDevices({ Duration timeout }) async {
+    final List<dynamic> allAvailableDevices = await _getAllDevices(timeout: timeout ?? const Duration(seconds: 1));
 
     if (allAvailableDevices == null) {
       return const <IOSDevice>[];
@@ -501,7 +504,10 @@ class XCDevice {
 
   /// List of all devices reporting errors.
   Future<List<String>> getDiagnostics() async {
-    final List<dynamic> allAvailableDevices = await _getAllDevices(useCache: true);
+    final List<dynamic> allAvailableDevices = await _getAllDevices(
+      useCache: true,
+      timeout: const Duration(seconds: 1)
+    );
 
     if (allAvailableDevices == null) {
       return const <String>[];

--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -246,7 +246,7 @@ class FlutterTesterDevices extends PollingDeviceDiscovery {
   bool get supportsPlatform => true;
 
   @override
-  Future<List<Device>> pollingGetDevices() async {
+  Future<List<Device>> pollingGetDevices({ Duration timeout }) async {
     return showFlutterTesterDevice ? <Device>[_testerDevice] : <Device>[];
   }
 }

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -185,7 +185,7 @@ class WebDevices extends PollingDeviceDiscovery {
   bool get canListAnything => featureFlags.isWebEnabled;
 
   @override
-  Future<List<Device>> pollingGetDevices() async {
+  Future<List<Device>> pollingGetDevices({ Duration timeout }) async {
     return <Device>[
       if (_chromeIsAvailable)
         _webDevice,

--- a/packages/flutter_tools/lib/src/windows/windows_device.dart
+++ b/packages/flutter_tools/lib/src/windows/windows_device.dart
@@ -66,7 +66,7 @@ class WindowsDevices extends PollingDeviceDiscovery {
   bool get canListAnything => windowsWorkflow.canListDevices;
 
   @override
-  Future<List<Device>> pollingGetDevices() async {
+  Future<List<Device>> pollingGetDevices({ Duration timeout }) async {
     if (!canListAnything) {
       return const <Device>[];
     }

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
@@ -1344,7 +1344,7 @@ class FailingKernelCompiler implements FuchsiaKernelCompiler {
 
 class FakeFuchsiaDevFinder implements FuchsiaDevFinder {
   @override
-  Future<List<String>> list() async {
+  Future<List<String>> list({ Duration timeout }) async {
     return <String>['192.168.42.172 scare-cable-skip-joy'];
   }
 
@@ -1356,7 +1356,7 @@ class FakeFuchsiaDevFinder implements FuchsiaDevFinder {
 
 class FailingDevFinder implements FuchsiaDevFinder {
   @override
-  Future<List<String>> list() async {
+  Future<List<String>> list({ Duration timeout }) async {
     return null;
   }
 

--- a/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
@@ -13,20 +13,27 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/macos/application_package.dart';
 import 'package:flutter_tools/src/macos/macos_device.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/testbed.dart';
 
 void main() {
   group(MacOSDevice, () {
-    final MockPlatform notMac = MockPlatform();
     final MacOSDevice device = MacOSDevice();
     final MockProcessManager mockProcessManager = MockProcessManager();
+
+    final MockPlatform notMac = MockPlatform();
     when(notMac.isMacOS).thenReturn(false);
     when(notMac.environment).thenReturn(const <String, String>{});
+
+    final MockPlatform mockMacPlatform = MockPlatform();
+    when(mockMacPlatform.isMacOS).thenReturn(true);
+
     when(mockProcessManager.run(any)).thenAnswer((Invocation invocation) async {
       return ProcessResult(0, 1, '', '');
     });
@@ -46,6 +53,22 @@ void main() {
       expect(await MacOSDevices().devices, <Device>[]);
     }, overrides: <Type, Generator>{
       Platform: () => notMac,
+    });
+
+    testUsingContext('devices', () async {
+      expect(await MacOSDevices().devices, hasLength(1));
+    }, overrides: <Type, Generator>{
+      Platform: () => mockMacPlatform,
+      FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
+    });
+
+    testUsingContext('discoverDevices', () async {
+      // Timeout ignored.
+      final List<Device> devices = await MacOSDevices().discoverDevices(timeout: const Duration(seconds: 10));
+      expect(devices, hasLength(1));
+    }, overrides: <Type, Generator>{
+      Platform: () => mockMacPlatform,
+      FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
     });
 
     testUsingContext('isSupportedForProject is true with editable host app', () async {

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -359,6 +359,18 @@ void main() {
         Platform: () => macPlatform,
       });
 
+      testWithoutContext('uses timeout', () async {
+        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
+
+        when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
+          .thenReturn(ProcessResult(1, 0, '/path/to/xcdevice', ''));
+
+        when(processManager.run(any))
+          .thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 0, '[]', '')));
+        await xcdevice.getAvailableTetheredIOSDevices(timeout: const Duration(seconds: 20));
+        verify(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '20'])).called(1);
+      });
+
       testUsingContext('ignores "Preparing debugger support for iPhone" error', () async {
         when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
 

--- a/packages/flutter_tools/test/general.shard/tester/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/general.shard/tester/flutter_tester_test.dart
@@ -64,6 +64,15 @@ void main() {
       expect(device, isA<FlutterTesterDevice>());
       expect(device.id, 'flutter-tester');
     });
+
+    testUsingContext('discoverDevices', () async {
+      FlutterTesterDevices.showFlutterTesterDevice = true;
+      final FlutterTesterDevices discoverer = FlutterTesterDevices();
+
+      // Timeout ignored.
+      final List<Device> devices = await discoverer.discoverDevices(timeout: const Duration(seconds: 10));
+      expect(devices, hasLength(1));
+    });
   });
 
   group('FlutterTesterDevice', () {

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -219,6 +219,9 @@ class FakeDeviceManager implements DeviceManager {
   Future<List<Device>> getAllConnectedDevices() async => devices;
 
   @override
+  Future<List<Device>> refreshAllConnectedDevices({ Duration timeout }) async => devices;
+
+  @override
   Future<List<Device>> getDevicesById(String deviceId) async {
     return devices.where((Device device) => device.id == deviceId).toList();
   }

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -526,7 +526,12 @@ class MockPollingDeviceDiscovery extends PollingDeviceDiscovery {
   final StreamController<Device> _onRemovedController = StreamController<Device>.broadcast();
 
   @override
-  Future<List<Device>> pollingGetDevices() async => _devices;
+  Future<List<Device>> pollingGetDevices({ Duration timeout }) async {
+    lastPollingTimeout = timeout;
+    return _devices;
+  }
+
+  Duration lastPollingTimeout;
 
   @override
   bool get supportsPlatform => true;
@@ -534,14 +539,22 @@ class MockPollingDeviceDiscovery extends PollingDeviceDiscovery {
   @override
   bool get canListAnything => true;
 
-  void addDevice(MockAndroidDevice device) {
+  void addDevice(Device device) {
     _devices.add(device);
-
     _onAddedController.add(device);
   }
 
-  @override
-  Future<List<Device>> get devices async => _devices;
+  void _removeDevice(Device device) {
+    _devices.remove(device);
+    _onRemovedController.add(device);
+  }
+
+  void setDevices(List<Device> devices) {
+    while(_devices.isNotEmpty) {
+      _removeDevice(_devices.first);
+    }
+    devices.forEach(addDevice);
+  }
 
   @override
   Stream<Device> get onAdded => _onAddedController.stream;


### PR DESCRIPTION
## Description

Add a `--timeout` flag to `flutter devices` so device discovery can use a potentially longer timeout.  Use the timeout for finding iOS and Fuchsia devices.  This will be needed so users can discover networked iOS devices that require a longer timeout than the default.  

Also improves daemon polling behavior so the polling timeout can be piped down into the tools to override their default timeouts (like `device-finder` and `xcdevice`) instead of just killing the process.

## Related Issues

Next part of https://github.com/flutter/flutter/issues/15072.

## Tests

Added xcode_test, daemon_test, device_test, other device subclass tests.
There weren't any `device-finder` tests I could find.  Will test this manually.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*