### PR TITLE
Improve page.dart documentation

### DIFF
--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -20,8 +20,10 @@ import 'theme.dart';
 /// in environments with a right-to-left reading direction.)
 ///
 /// By default, when a modal route is replaced by another, the previous route
-/// remains in memory. To free all the resources when this is not necessary, set
-/// [maintainState] to false.
+/// remains in memory. To free resources when this is not necessary, set
+/// [maintainState] to false. When [maintainState] is false, it stills maintains
+/// the first, and only the first, route in memory. Use [Navigator.pushReplacement]
+/// to free every route from memory.
 ///
 /// The `fullscreenDialog` property specifies whether the incoming page is a
 /// fullscreen modal dialog. On iOS, those pages animate from the bottom to the


### PR DESCRIPTION
## Description
Possible documentation fix for: https://github.com/flutter/flutter/issues/44836
I'm open to discussions.

## Related Issues

> Today I spent a lot of time trying to figure out why maintainState = false was maintaining the state. Basically, if I open 5 widgets, mainTainState = true maintains all five, mainTainState = false maintains only the first and last, and Navigator.pushReplacement only the last.
> 
> The issue is that maintainState (from MaterialPageRoute) explicitly says...

https://github.com/flutter/flutter/issues/44836