### PR TITLE
Reland "Enable iOS platform views for Flutter Gallery"

### DIFF
--- a/examples/flutter_gallery/ios/Runner/Info.plist
+++ b/examples/flutter_gallery/ios/Runner/Info.plist
@@ -43,5 +43,7 @@
 	<false/>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>io.flutter.embedded_views_preview</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Reverts flutter/flutter#45130

This should fix https://github.com/flutter/flutter/issues/49300

This revert/reland should not affect any production according to https://github.com/flutter/flutter/pull/45130#issuecomment-571336375

TBR: @amirh @tvolkert @flar @cbracken 