### PR TITLE
Exit for missing Windows plugin projects

### DIFF
--- a/packages/flutter_tools/lib/src/windows/visual_studio_solution_utils.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio_solution_utils.dart
@@ -32,9 +32,13 @@ class _PluginProjectInfo {
   }) {
     name = plugin.name;
     final File projectFile = fileSystem.directory(plugin.path).childDirectory('windows').childFile('plugin.vcxproj');
+    try {
     guid = VisualStudioProject(projectFile, fileSystem: fileSystem).guid;
-    if (guid == null) {
+    } on FileSystemException {
       throwToolExit('Unable to find a plugin.vcxproj for plugin "$name"');
+    }
+    if (guid == null) {
+      throwToolExit('Unable to find a plugin.vcxproj ID for plugin "$name"');
     }
   }
 

--- a/packages/flutter_tools/test/general.shard/windows/visual_studio_solution_utils_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/visual_studio_solution_utils_test.dart
@@ -222,12 +222,14 @@ EndGlobal''');
 
     // Configures and returns a mock plugin with the given name and GUID in the
     // project's plugin symlink directory.
-    Plugin getMockPlugin(String name, String guid) {
+    Plugin getMockPlugin(String name, String guid, {bool createProject = true}) {
       final MockPlugin plugin = MockPlugin();
       when(plugin.platforms).thenReturn(<String, PluginPlatform>{project.pluginConfigKey: null});
       when(plugin.name).thenReturn(name);
       when(plugin.path).thenReturn(project.pluginSymlinkDirectory.childDirectory(name).path);
-      writeDummyPluginProject(name, guid);
+      if (createProject) {
+        writeDummyPluginProject(name, guid);
+      }
       return plugin;
     }
 
@@ -421,6 +423,16 @@ EndGlobal''');
       expect(RegExp(r'^([ \t]+\t|\t[ \t]+)EndProjectSection\s*$', multiLine: true).hasMatch(newSolutionContents), false);
       expect(RegExp(r'^([ \t]+\t|\t[ \t]+)GlobalSection\(\s*$', multiLine: true).hasMatch(newSolutionContents), false);
       expect(RegExp(r'^([ \t]+\t|\t[ \t]+)EndGlobalSection\s*$', multiLine: true).hasMatch(newSolutionContents), false);
+    });
+
+    test('A plugin without a project exits without crashing', () async {
+      writeSolutionWithoutPlugins();
+
+      final List<Plugin> plugins = <Plugin>[
+        getMockPlugin('plugin_a', pluginAGuid, createProject: false),
+      ];
+      expect(() => VisualStudioSolutionUtils(project: project, fileSystem: fs).updatePlugins(plugins),
+        throwsToolExit());
     });
   });
 }


### PR DESCRIPTION
## Description

Exit, rather than crash, if a Windows plugin is missing its project.

## Related Issues

Fixes #51743

## Tests

I added the following tests:
- Mock plugin without a project file.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
