### PR TITLE
Allow proper reordering in reverse ReorderableListView

### DIFF
--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -581,7 +581,9 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
         reverse: widget.reverse,
         child: _buildContainerForScrollDirection(
           children: <Widget>[
-            if (widget.reverse) _wrap(finalDropArea, widget.children.length, constraints),
+            // The finalDropArea must be at index 0 so that widget.onReorder
+            // gets called with the correct start and end index.
+            if (widget.reverse) _wrap(finalDropArea, 0, constraints),
             if (widget.header != null) widget.header,
             for (int i = 0; i < widget.children.length; i += 1) _wrap(widget.children[i], i, constraints),
             if (!widget.reverse) _wrap(finalDropArea, widget.children.length, constraints),

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -30,7 +30,12 @@ void main() {
       );
     }
 
-    Widget build({ Widget header, Axis scrollDirection = Axis.vertical, TextDirection textDirection = TextDirection.ltr }) {
+    Widget build({
+      Widget header,
+      Axis scrollDirection = Axis.vertical,
+      TextDirection textDirection = TextDirection.ltr,
+      bool reverse = false,
+      }) {
       return MaterialApp(
         home: Directionality(
           textDirection: textDirection,
@@ -38,6 +43,7 @@ void main() {
             height: itemHeight * 10,
             width: itemHeight * 10,
             child: ReorderableListView(
+              reverse: reverse,
               header: header,
               children: listItems.map<Widget>(listItemToWidget).toList(),
               scrollDirection: scrollDirection,
@@ -957,7 +963,20 @@ void main() {
           handle.dispose();
         });
       });
+    });
 
+    testWidgets('allows reordering from the very bottom to the very top in reverse', (WidgetTester tester) async {
+      // Test for https://github.com/flutter/flutter/issues/51359 to avoid a regression.
+      // To replicate the bugs behaviour we need to drag an item into the finalDropArea. 
+      // The finalDropArea is _ReorderableListContentState._defaultDropAreaExtent (= 100) wide/high
+      await tester.pumpWidget(build(reverse: true));
+      expect(listItems, orderedEquals(originalListItems));
+      await longPressDrag(
+        tester,
+        tester.getCenter(find.text('Item 4')),
+        tester.getCenter(find.text('Item 1')) - const Offset(0, 100),
+      );
+      expect(listItems, orderedEquals(<String>['Item 4', 'Item 1', 'Item 2', 'Item 3']));
     });
 
     testWidgets('ReorderableListView can be reversed', (WidgetTester tester) async {

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -967,7 +967,7 @@ void main() {
 
     testWidgets('allows reordering from the very bottom to the very top in reverse', (WidgetTester tester) async {
       // Test for https://github.com/flutter/flutter/issues/51359 to avoid a regression.
-      // To replicate the bugs behaviour we need to drag an item into the finalDropArea. 
+      // To replicate the bugs behaviour we need to drag an item into the finalDropArea.
       // The finalDropArea is _ReorderableListContentState._defaultDropAreaExtent (= 100) wide/high
       await tester.pumpWidget(build(reverse: true));
       expect(listItems, orderedEquals(originalListItems));


### PR DESCRIPTION
## Description

Fixes #51359

In the current implementation of the reversed ReorderableListView a listelement gets reordered to the end of the list, if it gets dragged before the first element. I've fixed this and the element gets reordered to the start of the list.

Previously:
The Flutter logo is used as the lists header. Everything which doesn't get dragged above the header is reordered fine but everything above is reordered to the end of the list. The header itself does not affect this behaviour. It's just used to better illustrate the problem.
![reverse_reorderable](https://user-images.githubusercontent.com/1270149/75770799-f81e8680-5d48-11ea-804a-239a6bb4ab09.gif)

After this fix:
![reverse_reorderable_fixed](https://user-images.githubusercontent.com/1270149/75770803-fbb20d80-5d48-11ea-9be5-9c2bb5c6ebb5.gif)

## Related Issues

Fixes #51359

## Tests

I added the following tests:

- I've added a test to make sure it gets properly reordered.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
