### PR TITLE
Revert "Step 3 of 4: Make AlertDialog scrollable by default"

### DIFF
--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -259,7 +259,7 @@ class AlertDialog extends StatelessWidget {
     this.insetPadding = _defaultInsetPadding,
     this.clipBehavior = Clip.none,
     this.shape,
-    this.scrollable = true,
+    this.scrollable = false,
   }) : assert(contentPadding != null),
        assert(clipBehavior != null),
        super(key: key);

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -1100,6 +1100,7 @@ void main() {
           color: Colors.green,
           height: 1000,
         ),
+        scrollable: true,
       );
       await tester.pumpWidget(_buildAppWithDialog(dialog));
       await tester.tap(find.text('X'));
@@ -1119,6 +1120,7 @@ void main() {
           color: Colors.orange,
           height: 1000,
         ),
+        scrollable: true,
       );
       await tester.pumpWidget(_buildAppWithDialog(dialog));
       await tester.tap(find.text('X'));
@@ -1144,6 +1146,7 @@ void main() {
           color: Colors.orange,
           height: 400,
         ),
+        scrollable: true,
       );
       await tester.pumpWidget(_buildAppWithDialog(dialog));
       await tester.tap(find.text('X'));


### PR DESCRIPTION
Reverts flutter/flutter#49848

Breaks a [customer test](https://cirrus-ci.com/task/4611580847456256?command=main#L119), so I'm reverting until that's been resolved. Will land on red to get tree green.