### PR TITLE
Remove bad assert

### DIFF
--- a/packages/flutter/lib/src/painting/image_cache.dart
+++ b/packages/flutter/lib/src/painting/image_cache.dart
@@ -393,7 +393,6 @@ class ImageCache {
 
       final _CachedImage image = _CachedImage(result, imageSize);
       if (!_liveImages.containsKey(key)) {
-        assert(syncCall);
         result.addOnLastListenerRemovedCallback(() {
           _liveImages.remove(key);
         });


### PR DESCRIPTION
I added this assert with the idea that this should only happen for an image that's loaded synchronously, and thus loads before we get to line 360 where we put it into the cache.

It seems like it can also happen if someone calls `clearLiveImages` _before the listener completes on the pending image, but after the listener has been added_.  In this case it's not a sync call.  This seems to be reproducing for some people internally when hot reloading.
@jamesderlin @goderbauer 