### PR TITLE
Bitcode strip embedded iOS frameworks

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -397,9 +397,9 @@ tasks:
 
   # iOS on-device tests
 
-  ios_obfuscate_test:
+  ios_content_validation_test:
     description: >
-      Builds an obfuscated APK and verifies a dart identifier cannot be found
+      Builds an obfuscated app and verifies contents and structure
     stage: devicelab
     flaky: true
     required_agent_capabilities: ["mac/ios"]


### PR DESCRIPTION
## Description

https://github.com/flutter/flutter/pull/51453 moved embedding logic from Xcode into the tool to give more flexibility.  When Xcode copies frameworks for build (not archive), it strips bitcode to reduce the size of the generated app.  It also doesn't copy Modules or Headers since the app only needs this for linking and not at runtime.  Copy both of these behaviors into xcode_backend (and someday the assemble dart scripts).

The archive size is no different before and after https://github.com/flutter/flutter/pull/51453, but reducing the release app binary is still nice to do for the sake of developer installation time.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/51904.
I don't think this will completely get us back to the previous binary size, but it will be much closer.  However that test should be re-baselined for this change.  The real fix is to change that test to archive instead of release building, since release building and zippping is a very poor proxy for final release binary size.  See https://github.com/flutter/flutter/issues/40471.

## Tests

Renamed and expanded the purpose of ios_obfuscate_test.

I also tested by turning on bitcode on in the hello_world project and confirming the App Store Connect distribution options still had the "Include bitcode" checkbox enabled (this means all embedded content contained bitcode).

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*