### PR TITLE
Remove target platform override on the gallery.

### DIFF
--- a/examples/flutter_gallery/lib/main.dart
+++ b/examples/flutter_gallery/lib/main.dart
@@ -5,26 +5,8 @@
 // Thanks for checking out Flutter!
 // Like what you see? Tweet us @FlutterDev
 
-import 'dart:io';
-
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'gallery/app.dart';
 
-// Sets a platform override for desktop to avoid exceptions. See
-// https://flutter.dev/desktop#target-platform-override for more info.
-// TODO(gspencergoog): Remove once TargetPlatform includes all desktop platforms.
-// This is only included in the Gallery because Flutter's testing infrastructure
-// uses the Gallery for various tests, and this allows us to test on desktop
-// platforms that aren't yet supported in TargetPlatform.
-void _enablePlatformOverrideForDesktop() {
-  if (!kIsWeb && (Platform.isWindows || Platform.isLinux)) {
-    debugDefaultTargetPlatformOverride = TargetPlatform.fuchsia;
-  }
-}
-
-void main() {
-  _enablePlatformOverrideForDesktop();
-  runApp(const GalleryApp());
-}
+void main() => runApp(const GalleryApp());


### PR DESCRIPTION
## Description

Remove a target platform override that is no longer needed (I missed this in #51519).

## Tests

- No tests were harmed in the making of this PR (removed code doesn't need a test).

## Breaking Change

- [X] No, this is *not* a breaking change.