### PR TITLE
Custom onPressed behavior for CloseButton widget

### DIFF
--- a/packages/flutter/lib/src/material/back_button.dart
+++ b/packages/flutter/lib/src/material/back_button.dart
@@ -130,13 +130,23 @@ class BackButton extends StatelessWidget {
 ///  * [IconButton], to create other material design icon buttons.
 class CloseButton extends StatelessWidget {
   /// Creates a Material Design close button.
-  const CloseButton({ Key key, this.color }) : super(key: key);
+  const CloseButton({ Key key, this.color, this.onPressed }) : super(key: key);
 
   /// The color to use for the icon.
   ///
   /// Defaults to the [IconThemeData.color] specified in the ambient [IconTheme],
   /// which usually matches the ambient [Theme]'s [ThemeData.iconTheme].
   final Color color;
+
+  /// An override callback to perform instead of the default behavior which is
+  /// to pop the [Navigator].
+  ///
+  /// It can, for instance, be used to pop the platform's navigation stack
+  /// via [SytemNavigator] instead of Flutter's [Navigator] in add-to-app
+  /// situations.
+  ///
+  /// Defaults to null.
+  final VoidCallback onPressed;
 
   @override
   Widget build(BuildContext context) {
@@ -146,7 +156,11 @@ class CloseButton extends StatelessWidget {
       color: color,
       tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
       onPressed: () {
-        Navigator.maybePop(context);
+        if (onPressed != null) {
+          onPressed();
+        } else {
+          Navigator.maybePop(context);
+        }
       },
     );
   }

--- a/packages/flutter/test/material/back_button_test.dart
+++ b/packages/flutter/test/material/back_button_test.dart
@@ -35,7 +35,7 @@ void main() {
   });
 
   testWidgets('BackButton onPressed overrides default pop behavior', (WidgetTester tester) async {
-    bool backPressed = false;
+    bool customCallbackWasCalled = false;
     await tester.pumpWidget(
       MaterialApp(
         home: const Material(child: Text('Home')),
@@ -43,7 +43,7 @@ void main() {
           '/next': (BuildContext context) {
             return Material(
               child: Center(
-                child: BackButton(onPressed: () => backPressed = true),
+                child: BackButton(onPressed: () => customCallbackWasCalled = true),
               ),
             );
           },
@@ -55,6 +55,8 @@ void main() {
 
     await tester.pumpAndSettle();
 
+    expect(find.text('Home'), findsNothing); // Start off on the second page.
+    expect(customCallbackWasCalled, false); // customCallbackWasCalled should still be false.
     await tester.tap(find.byType(BackButton));
 
     await tester.pumpAndSettle();
@@ -62,7 +64,7 @@ void main() {
     // We're still on the second page.
     expect(find.text('Home'), findsNothing);
     // But the custom callback is called.
-    expect(backPressed, true);
+    expect(customCallbackWasCalled, true);
   });
 
   testWidgets('BackButton icon', (WidgetTester tester) async {
@@ -182,7 +184,7 @@ void main() {
   });
 
   testWidgets('CloseButton onPressed overrides default pop behavior', (WidgetTester tester) async {
-    bool closePressed = false;
+    bool customCallbackWasCalled = false;
     await tester.pumpWidget(
       MaterialApp(
         home: const Material(child: Text('Home')),
@@ -190,7 +192,7 @@ void main() {
           '/next': (BuildContext context) {
             return Material(
               child: Center(
-                child: CloseButton(onPressed: () => closePressed = true),
+                child: CloseButton(onPressed: () => customCallbackWasCalled = true),
               ),
             );
           },
@@ -201,14 +203,15 @@ void main() {
     tester.state<NavigatorState>(find.byType(Navigator)).pushNamed('/next');
 
     await tester.pumpAndSettle();
-
+    expect(find.text('Home'), findsNothing); // Start off on the second page.
+    expect(customCallbackWasCalled, false); // customCallbackWasCalled should still be false.
     await tester.tap(find.byType(CloseButton));
 
     await tester.pumpAndSettle();
 
     // We're still on the second page.
     expect(find.text('Home'), findsNothing);
-    // But the custom callback is called.
-    expect(closePressed, true);
+    // The custom callback is called, setting customCallbackWasCalled to true.
+    expect(customCallbackWasCalled, true);
   });
 }

--- a/packages/flutter/test/material/back_button_test.dart
+++ b/packages/flutter/test/material/back_button_test.dart
@@ -180,4 +180,35 @@ void main() {
     ));
     expect(iconText.text.style.color, Colors.red);
   });
+
+  testWidgets('CloseButton onPressed overrides default pop behavior', (WidgetTester tester) async {
+    bool closePressed = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: const Material(child: Text('Home')),
+        routes: <String, WidgetBuilder>{
+          '/next': (BuildContext context) {
+            return Material(
+              child: Center(
+                child: CloseButton(onPressed: () => closePressed = true),
+              ),
+            );
+          },
+        },
+      ),
+    );
+
+    tester.state<NavigatorState>(find.byType(Navigator)).pushNamed('/next');
+
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(CloseButton));
+
+    await tester.pumpAndSettle();
+
+    // We're still on the second page.
+    expect(find.text('Home'), findsNothing);
+    // But the custom callback is called.
+    expect(closePressed, true);
+  });
 }


### PR DESCRIPTION
## Description

In our application we want to display a close icon in AppBar with customized behavior.
backButton has onPressed parameter in initializer to enable override of default navigator pop behavior. closeButton should also be able to set it. This PR proposes a fix to it.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/51924

## Tests

I added the following tests:

CloseButton onPressed overrides default pop behavior

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
