### PR TITLE
Revert "Write FLUTTER_BUILD_MODE when using a local engine"

### DIFF
--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -209,20 +209,9 @@ List<String> _xcodeBuildSettingsLines({
 
   if (globals.artifacts is LocalEngineArtifacts) {
     final LocalEngineArtifacts localEngineArtifacts = globals.artifacts as LocalEngineArtifacts;
-    final String engineOutPath = globals.fs.path.basename(localEngineArtifacts.engineOutPath);
-    String engineBuildMode = 'release';
-    if (engineOutPath.toLowerCase().contains('debug')) {
-      engineBuildMode = 'debug';
-    } else if (engineOutPath.toLowerCase().contains('profile')) {
-      engineBuildMode = 'profile';
-    }
+    final String engineOutPath = localEngineArtifacts.engineOutPath;
     xcodeBuildSettings.add('FLUTTER_ENGINE=${globals.fs.path.dirname(globals.fs.path.dirname(engineOutPath))}');
-    xcodeBuildSettings.add('LOCAL_ENGINE=$engineOutPath');
-    // Only write this or local engines, where it is supposed to be sticky to
-    // match the engine configuration. Avoid writing it otherwise so that it
-    // does not stick the user with the wrong build mode, particularly for
-    // existing app use cases.
-    xcodeBuildSettings.add('FLUTTER_BUILD_MODE=$engineBuildMode');
+    xcodeBuildSettings.add('LOCAL_ENGINE=${globals.fs.path.basename(engineOutPath)}');
 
     // Tell Xcode not to build universal binaries for local engines, which are
     // single-architecture.

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -433,24 +433,22 @@ Information about project "Runner":
   });
 
   group('updateGeneratedXcodeProperties', () {
-    MockLocalEngineArtifacts mockEngineArtifacts;
-    MockArtifacts mockArtifacts;
+    MockLocalEngineArtifacts mockArtifacts;
     MockProcessManager mockProcessManager;
     FakePlatform macOS;
     FileSystem fs;
 
     setUp(() {
       fs = MemoryFileSystem();
-      mockEngineArtifacts = MockLocalEngineArtifacts();
-      mockArtifacts = MockArtifacts();
+      mockArtifacts = MockLocalEngineArtifacts();
       mockProcessManager = MockProcessManager();
       macOS = fakePlatform('macos');
       fs.file(xcodebuild).createSync(recursive: true);
     });
 
-    void testUsingOsxContext(String description, dynamic testMethod(), {bool isLocalEngine = true}) {
+    void testUsingOsxContext(String description, dynamic testMethod()) {
       testUsingContext(description, testMethod, overrides: <Type, Generator>{
-        Artifacts: () => isLocalEngine ? mockEngineArtifacts : mockArtifacts,
+        Artifacts: () => mockArtifacts,
         Platform: () => macOS,
         FileSystem: () => fs,
         ProcessManager: () => mockProcessManager,
@@ -509,9 +507,9 @@ Information about project "Runner":
     });
 
     testUsingOsxContext('sets ARCHS=armv7 when armv7 local engine is set', () async {
-      when(mockEngineArtifacts.getArtifactPath(Artifact.flutterFramework,
+      when(mockArtifacts.getArtifactPath(Artifact.flutterFramework,
           platform: TargetPlatform.ios, mode: anyNamed('mode'))).thenReturn('engine');
-      when(mockEngineArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile_arm'));
+      when(mockArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile_arm'));
 
       const BuildInfo buildInfo = BuildInfo(BuildMode.debug, null, treeShakeIcons: false);
       final FlutterProject project = FlutterProject.fromPath('path/to/project');
@@ -533,59 +531,10 @@ Information about project "Runner":
       expect(buildPhaseScriptContents.contains('ARCHS=armv7'), isTrue);
     });
 
-    testUsingOsxContext('sets FLUTTER_BUILD_MODE local engine is set', () async {
-      when(mockEngineArtifacts.getArtifactPath(Artifact.flutterFramework,
-          platform: TargetPlatform.ios, mode: anyNamed('mode'))).thenReturn('engine');
-      when(mockEngineArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile_arm'));
-
-      const BuildInfo buildInfo = BuildInfo(BuildMode.profile, null, treeShakeIcons: false);
-      final FlutterProject project = FlutterProject.fromPath('path/to/project');
-      await updateGeneratedXcodeProperties(
-        project: project,
-        buildInfo: buildInfo,
-      );
-
-      final File config = fs.file('path/to/project/ios/Flutter/Generated.xcconfig');
-      expect(config.existsSync(), isTrue);
-
-      final String contents = config.readAsStringSync();
-      expect(contents, contains('FLUTTER_BUILD_MODE=profile'));
-
-      final File buildPhaseScript = fs.file('path/to/project/ios/Flutter/flutter_export_environment.sh');
-      expect(buildPhaseScript.existsSync(), isTrue);
-
-      final String buildPhaseScriptContents = buildPhaseScript.readAsStringSync();
-      expect(buildPhaseScriptContents, contains('FLUTTER_BUILD_MODE=profile'));
-    });
-
-    testUsingOsxContext('does not set FLUTTER_BUILD_MODE without local engine', () async {
+    testUsingOsxContext('sets TRACK_WIDGET_CREATION=true when trackWidgetCreation is true', () async {
       when(mockArtifacts.getArtifactPath(Artifact.flutterFramework,
           platform: TargetPlatform.ios, mode: anyNamed('mode'))).thenReturn('engine');
-
-      const BuildInfo buildInfo = BuildInfo(BuildMode.profile, null, treeShakeIcons: false);
-      final FlutterProject project = FlutterProject.fromPath('path/to/project');
-      await updateGeneratedXcodeProperties(
-        project: project,
-        buildInfo: buildInfo,
-      );
-
-      final File config = fs.file('path/to/project/ios/Flutter/Generated.xcconfig');
-      expect(config.existsSync(), isTrue);
-
-      final String contents = config.readAsStringSync();
-      expect(contents, isNot(contains('FLUTTER_BUILD_MODE=')));
-
-      final File buildPhaseScript = fs.file('path/to/project/ios/Flutter/flutter_export_environment.sh');
-      expect(buildPhaseScript.existsSync(), isTrue);
-
-      final String buildPhaseScriptContents = buildPhaseScript.readAsStringSync();
-      expect(buildPhaseScriptContents, isNot(contains('FLUTTER_BUILD_MODE=')));
-    }, isLocalEngine: false);
-
-    testUsingOsxContext('sets TRACK_WIDGET_CREATION=true when trackWidgetCreation is true', () async {
-      when(mockEngineArtifacts.getArtifactPath(Artifact.flutterFramework,
-          platform: TargetPlatform.ios, mode: anyNamed('mode'))).thenReturn('engine');
-      when(mockEngineArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile_arm'));
+      when(mockArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile_arm'));
       const BuildInfo buildInfo = BuildInfo(BuildMode.debug, null, trackWidgetCreation: true, treeShakeIcons: false);
       final FlutterProject project = FlutterProject.fromPath('path/to/project');
       await updateGeneratedXcodeProperties(
@@ -607,9 +556,9 @@ Information about project "Runner":
     });
 
     testUsingOsxContext('does not set TRACK_WIDGET_CREATION when trackWidgetCreation is false', () async {
-      when(mockEngineArtifacts.getArtifactPath(Artifact.flutterFramework,
+      when(mockArtifacts.getArtifactPath(Artifact.flutterFramework,
           platform: TargetPlatform.ios, mode: anyNamed('mode'))).thenReturn('engine');
-      when(mockEngineArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile_arm'));
+      when(mockArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile_arm'));
       const BuildInfo buildInfo = BuildInfo(BuildMode.debug, null, treeShakeIcons: false);
       final FlutterProject project = FlutterProject.fromPath('path/to/project');
       await updateGeneratedXcodeProperties(
@@ -631,9 +580,9 @@ Information about project "Runner":
     });
 
     testUsingOsxContext('sets ARCHS=armv7 when armv7 local engine is set', () async {
-      when(mockEngineArtifacts.getArtifactPath(Artifact.flutterFramework,
+      when(mockArtifacts.getArtifactPath(Artifact.flutterFramework,
           platform: TargetPlatform.ios, mode: anyNamed('mode'))).thenReturn('engine');
-      when(mockEngineArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile'));
+      when(mockArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile'));
       const BuildInfo buildInfo = BuildInfo(BuildMode.debug, null, treeShakeIcons: false);
 
       final FlutterProject project = FlutterProject.fromPath('path/to/project');
@@ -664,9 +613,9 @@ Information about project "Runner":
       String expectedBuildName,
       String expectedBuildNumber,
     }) async {
-      when(mockEngineArtifacts.getArtifactPath(Artifact.flutterFramework,
+      when(mockArtifacts.getArtifactPath(Artifact.flutterFramework,
           platform: TargetPlatform.ios, mode: anyNamed('mode'))).thenReturn('engine');
-      when(mockEngineArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios'));
+      when(mockArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios'));
 
       final File manifestFile = fs.file('path/to/project/pubspec.yaml');
       manifestFile.createSync(recursive: true);
@@ -860,4 +809,3 @@ class MockAnsiTerminal extends Mock implements AnsiTerminal {
   @override
   bool get supportsColor => false;
 }
-class MockArtifacts extends Mock implements Artifacts {}


### PR DESCRIPTION
Reverts flutter/flutter#51687

Reverting for analyzer failures:
```
Analyzing 3 directories...                                      
  error • Missing type arguments for calling generic function type 'PostExpectation<T> Function<T>(T)' • packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart:463:7 • implicit_dynamic_invoke
  error • The getter 'engineOutPath' isn't defined for the type 'MockArtifacts' • packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart:463:26 • undefined_getter
  error • Missing type arguments for calling generic function type 'PostExpectation<T> Function<T>(T)' • packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart:488:7 • implicit_dynamic_invoke
  error • The getter 'engineOutPath' isn't defined for the type 'MockArtifacts' • packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart:488:26 • undefined_getter
4 issues found. (ran in 327.3s)
```