### PR TITLE
Properly resolve cupertino theme data defaults for MaterialbasedCupertinoThemeData

### DIFF
--- a/packages/flutter/lib/src/cupertino/bottom_tab_bar.dart
+++ b/packages/flutter/lib/src/cupertino/bottom_tab_bar.dart
@@ -145,10 +145,8 @@ class CupertinoTabBar extends StatelessWidget implements PreferredSizeWidget {
     assert(debugCheckHasMediaQuery(context));
     final double bottomPadding = MediaQuery.of(context).padding.bottom;
 
-    final Color backgroundColor = CupertinoDynamicColor.resolve(
-      this.backgroundColor ?? CupertinoTheme.of(context).barBackgroundColor,
-      context,
-    );
+    final Color backgroundColor = CupertinoDynamicColor.maybeResolve(this.backgroundColor, context)
+      ?? CupertinoTheme.of(context).barBackgroundColor;
 
     BorderSide resolveBorderSide(BorderSide side) {
       return side == BorderSide.none

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -1825,7 +1825,7 @@ class MaterialBasedCupertinoThemeData extends CupertinoThemeData {
     required ThemeData materialTheme,
   }) : this._(
     materialTheme,
-    (materialTheme.cupertinoOverrideTheme ?? const CupertinoThemeData()).noDefault(),
+    materialTheme.cupertinoOverrideTheme?.noDefault() ?? const NoDefaultCupertinoThemeData(),
   );
 
   MaterialBasedCupertinoThemeData._(
@@ -1890,16 +1890,6 @@ class MaterialBasedCupertinoThemeData extends CupertinoThemeData {
         barBackgroundColor: barBackgroundColor,
         scaffoldBackgroundColor: scaffoldBackgroundColor,
       ),
-    );
-  }
-
-  @override
-  CupertinoThemeData resolveFrom(BuildContext context) {
-    // Only the cupertino override theme part will be resolved.
-    // If the color comes from the material theme it's not resolved.
-    return MaterialBasedCupertinoThemeData._(
-      _materialTheme,
-      _cupertinoOverrideTheme.resolveFrom(context),
     );
   }
 }

--- a/packages/flutter/test/cupertino/colors_test.dart
+++ b/packages/flutter/test/cupertino/colors_test.dart
@@ -553,30 +553,60 @@ void main() {
       expect(typedColor().value, dynamicColor.darkHighContrastElevatedColor.value);
     });
 
-    testWidgets('dynamic color does not work in a material theme', (WidgetTester tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          // This will create a MaterialBasedCupertinoThemeData with primaryColor set to `dynamicColor`.
-          theme: ThemeData(colorScheme: const ColorScheme.dark(primary: dynamicColor)),
-          home: MediaQuery(
-            data: const MediaQueryData(platformBrightness: Brightness.dark, highContrast: true),
-            child: CupertinoUserInterfaceLevel(
-              data: CupertinoUserInterfaceLevelData.elevated,
-              child: Builder(
-                builder: (BuildContext context) {
-                  color = CupertinoTheme.of(context).primaryColor;
-                  return const Placeholder();
-                }
+    testWidgets(
+      'Specs not specified in the cupertino override or the material theme'
+      "defaults to CupertinoThemeData's defaults",
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(colorScheme: const ColorScheme.dark()),
+            home: MediaQuery(
+              data: const MediaQueryData(platformBrightness: Brightness.dark, highContrast: true),
+              child: CupertinoUserInterfaceLevel(
+                data: CupertinoUserInterfaceLevelData.elevated,
+                child: Builder(
+                  builder: (BuildContext context) {
+                    color = CupertinoTheme.of(context).barBackgroundColor;
+                    return const Placeholder();
+                  }
+                ),
               ),
             ),
           ),
-        ),
-      );
+        );
 
-      // The color is not resolved.
-      expect(color, dynamicColor);
-      expect(color, isNot(dynamicColor.darkHighContrastElevatedColor));
-    });
+        // the default barBackgroundColor should be properly resolved.
+        expect(color, isSameColorAs(const Color(0xF01D1D1D)));
+        expect(color, isInstanceOf<CupertinoDynamicColor>());
+      },
+    );
+
+    testWidgets('default textTheme is derived from the right primary color',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(colorScheme: const ColorScheme.dark()),
+            home: MediaQuery(
+              data: const MediaQueryData(platformBrightness: Brightness.dark, highContrast: true),
+              child: CupertinoUserInterfaceLevel(
+                data: CupertinoUserInterfaceLevelData.elevated,
+                child: Builder(
+                  builder: (BuildContext context) {
+                    // The default actionTextStyle's color is the primary color
+                    // of the theme.
+                    color = CupertinoTheme.of(context).textTheme.actionTextStyle.color;
+                    return const Placeholder();
+                  }
+                ),
+              ),
+            ),
+          ),
+        );
+
+        // the default barBackgroundColor should be properly resolved.
+        expect(color, const ColorScheme.dark().primary);
+      },
+    );
   });
 }
 

--- a/packages/flutter/test/cupertino/theme_test.dart
+++ b/packages/flutter/test/cupertino/theme_test.dart
@@ -295,8 +295,8 @@ void main() {
       );
 
       setState(() { brightness = Brightness.light; });
-      // Changes the platform brightness. Since the builder widget is not
-      // depending on any dynamic colors, it shouldn't rebuild.
+      // Changes the platform brightness. Since "leafWidget" does not depend on
+      // any dynamic colors, it shouldn't rebuild.
       await tester.pump();
 
       expect(buildCount, 1);

--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -448,6 +448,7 @@ void main() {
       expect(theme.primaryColor, Colors.blue);
       expect(theme.scaffoldBackgroundColor, Colors.grey[50]);
       expect(theme.primaryContrastingColor, Colors.white);
+      expect(theme.barBackgroundColor, isSameColorAs(const Color(0xF0F9F9F9)));
       expect(theme.textTheme.textStyle.fontFamily, '.SF Pro Text');
       expect(theme.textTheme.textStyle.fontSize, 17.0);
     });
@@ -459,6 +460,7 @@ void main() {
       expect(theme.primaryColor, Colors.blue);
       expect(theme.primaryContrastingColor, Colors.white);
       expect(theme.scaffoldBackgroundColor, Colors.grey[850]);
+      expect(theme.barBackgroundColor, isSameColorAs(const Color(0xF01D1D1D)));
       expect(theme.textTheme.textStyle.fontFamily, '.SF Pro Text');
       expect(theme.textTheme.textStyle.fontSize, 17.0);
     });

--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -451,6 +451,7 @@ void main() {
       expect(theme.barBackgroundColor, isSameColorAs(const Color(0xF0F9F9F9)));
       expect(theme.textTheme.textStyle.fontFamily, '.SF Pro Text');
       expect(theme.textTheme.textStyle.fontSize, 17.0);
+      expect(theme.textTheme.textStyle.color, isSameColorAs(CupertinoColors.label.color));
     });
 
     testWidgets('Dark theme has defaults', (WidgetTester tester) async {
@@ -463,6 +464,7 @@ void main() {
       expect(theme.barBackgroundColor, isSameColorAs(const Color(0xF01D1D1D)));
       expect(theme.textTheme.textStyle.fontFamily, '.SF Pro Text');
       expect(theme.textTheme.textStyle.fontSize, 17.0);
+      expect(theme.textTheme.textStyle.color, isSameColorAs(CupertinoColors.label.darkColor));
     });
 
     testWidgets('MaterialTheme overrides the brightness', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

Captures the provided `BuildContext` so that the colors can be resolved lazily at a later point in time. Currently `CupertinoThemeData` eagerly resolves all its attributes in `CupertinoTheme.of`, causing the calling widget (i.e., `BuildContext`) to declare dependencies on more `InheritedWidget`s than necessary. 
It could be problematic if a `_CupertinoDynamicThemeData` is passed to a descendant widget or render objects. 

## Related Issues

Fixes https://github.com/flutter/flutter/issues/51899

## Tests

- Updated "Default theme has defaults" to cover `barBackgroundColor`


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.