### PR TITLE
increase analyze-linux RAM allocation from 4gb -> 6gb

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -97,9 +97,10 @@ task:
       - which flutter
   matrix:
     - name: analyze-linux # linux-only
-      # environment:
+      environment:
         # Empirically, the analyze-linux shard runs surprisingly fast (under 15 minutes) with just 1
-        # CPU and 4G RAM as of October 2019. It fails with less than 4G though.
+        # CPU as of October 2019. It runs out of memory with less than 6G as of March 19, 2020.
+        MEMORY: 6G
       script:
         - dart --enable-asserts ./dev/bots/analyze.dart
 


### PR DESCRIPTION
## Description

This started flaking with OOMKilled (e.g. https://cirrus-ci.com/task/4794765682147328 & https://cirrus-ci.com/task/5829733212487680).