### PR TITLE
Increase the timeout for the cull_opacity_perf_test to 45 seconds

### DIFF
--- a/dev/benchmarks/macrobenchmarks/test_driver/cull_opacity_perf_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/cull_opacity_perf_test.dart
@@ -12,5 +12,6 @@ void main() {
     kCullOpacityRouteName,
     pageDelay: const Duration(seconds: 1),
     duration: const Duration(seconds: 10),
+    timeout: const Duration(seconds: 45),
   );
 }

--- a/dev/benchmarks/macrobenchmarks/test_driver/util.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/util.dart
@@ -12,6 +12,7 @@ void macroPerfTest(
     String routeName,
     { Duration pageDelay,
       Duration duration = const Duration(seconds: 3),
+      Duration timeout = const Duration(seconds: 30),
       Future<void> driverOps(FlutterDriver driver),
       Future<void> setupOps(FlutterDriver driver),
     }) {
@@ -52,5 +53,5 @@ void macroPerfTest(
     summary.writeTimelineToFile(testName, pretty: true);
 
     driver.close();
-  });
+  }, timeout: Timeout(timeout));
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/51795