### PR TITLE
Skip iOS project migration when script is already embedding frameworks

### DIFF
--- a/packages/flutter_tools/lib/src/ios/migrations/remove_framework_link_and_embedding_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/remove_framework_link_and_embedding_migration.dart
@@ -87,7 +87,7 @@ class RemoveFrameworkLinkAndEmbeddingMigration extends IOSMigrator {
 
       // Embed and thin frameworks in a script instead of using Xcode's link / embed build phases.
       const String thinBinaryScript = 'xcode_backend.sh\\" thin';
-      if (line.contains(thinBinaryScript)) {
+      if (line.contains(thinBinaryScript) && !line.contains(' embed')) {
         return line.replaceFirst(thinBinaryScript, 'xcode_backend.sh\\" embed_and_thin');
       }
 

--- a/packages/flutter_tools/test/general.shard/ios/ios_project_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_project_migration_test.dart
@@ -72,6 +72,22 @@ void main () {
       expect(testLogger.statusText, isEmpty);
     });
 
+    testWithoutContext('skips migrating script with embed', () {
+      const String contents = '''
+shellScript = "/bin/sh \"\$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\\" embed\\n/bin/sh \"\$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\\" thin\n";
+			''';
+      xcodeProjectInfoFile.writeAsStringSync(contents);
+
+      final RemoveFrameworkLinkAndEmbeddingMigration iosProjectMigration = RemoveFrameworkLinkAndEmbeddingMigration(
+        mockIosProject,
+        testLogger,
+        mockXcode,
+      );
+      expect(iosProjectMigration.migrate(), isTrue);
+      expect(xcodeProjectInfoFile.readAsStringSync(), contents);
+      expect(testLogger.statusText, isEmpty);
+    });
+
     testWithoutContext('Xcode project is migrated', () {
       xcodeProjectInfoFile.writeAsStringSync('''
 prefix 3B80C3941E831B6300D905FE


### PR DESCRIPTION
## Description

https://github.com/flutter/website/pull/3763 documentation will suggest changing Thin script to:
```
/bin/sh "$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh" embed
/bin/sh "$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh" thin
```
as a workaround in case they are not on master and don't have the embed_and_thin command.  Don't migrate if the user makes this change manually.

## Tests

Added ios_project_migration_test

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*