### PR TITLE
Update iOS project migration help URL

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -458,7 +458,7 @@ Future<void> diagnoseXcodeBuildFailure(XcodeBuildResult result) async {
       && result.stdout?.contains('but the linked and embedded framework') == true
       && result.stdout?.contains('was built for iOS') == true) {
     globals.printError('');
-    globals.printError('Your Xcode project requires migration. See https://github.com/flutter/flutter/issues/50568 for details.');
+    globals.printError('Your Xcode project requires migration. See https://flutter.dev/docs/development/ios-project-migration for details.');
     globals.printError('');
     globals.printError('You can temporarily work around this issue by running:');
     globals.printError('  rm -rf ios/Flutter/App.framework');

--- a/packages/flutter_tools/lib/src/ios/migrations/remove_framework_link_and_embedding_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/remove_framework_link_and_embedding_migration.dart
@@ -102,7 +102,7 @@ class RemoveFrameworkLinkAndEmbeddingMigration extends IOSMigrator {
       // Print scary message if the user is on Xcode 11.4 or greater, or if Xcode isn't installed.
       final bool xcodeIsInstalled = _xcode.isInstalled;
       if(!xcodeIsInstalled || (_xcode.majorVersion > 11 || (_xcode.majorVersion == 11 && _xcode.minorVersion >= 4))) {
-        logger.printError('Your Xcode project requires migration. See https://github.com/flutter/flutter/issues/50568 for details.');
+        logger.printError('Your Xcode project requires migration. See https://flutter.dev/docs/development/ios-project-migration for details.');
         return false;
       }
     }


### PR DESCRIPTION
## Description

Update migration failure URL from GitHub issue to new website documentation.

## Related Issues

https://github.com/flutter/website/issues/3741
https://github.com/flutter/flutter/issues/50568

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*