### PR TITLE
Mark devicelab tests as no longer flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -131,7 +131,6 @@ tasks:
       Run flutter web on the devicelab and hot restart.
     stage: devicelab_win
     required_agent_capabilities: ["windows/android"]
-    flaky: true
 
   # Android on-device tests
 
@@ -226,7 +225,6 @@ tasks:
       Checks that `flutter run --release` does not crash.
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
-    flaky: true # https://github.com/flutter/flutter/issues/45416.
 
   platform_interaction_test:
     description: >
@@ -329,7 +327,6 @@ tasks:
     description: >
       Builds an obfuscated APK and verifies a dart identifier cannot be found
     stage: devicelab
-    flaky: true
     required_agent_capabilities: ["linux/android"]
 
   complex_layout_semantics_perf:
@@ -407,7 +404,6 @@ tasks:
     description: >
       Builds an obfuscated app and verifies contents and structure
     stage: devicelab
-    flaky: true
     required_agent_capabilities: ["mac/ios"]
 
   tiles_scroll_perf_ios__timeline_summary:
@@ -573,7 +569,6 @@ tasks:
       Run flutter web on the devicelab and hot restart.
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
-    flaky: true # marked as flaky while infra is under heavy development
 
   build_benchmark_ios:
     description: >
@@ -727,7 +722,6 @@ tasks:
       placeholder.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
-    flaky: true
 
   analyzer_benchmark:
     description: >


### PR DESCRIPTION
## Description

All these tests have consistently passed recently.

## Related Issues

https://github.com/flutter/flutter/pull/45417
https://github.com/flutter/flutter/pull/50509
https://github.com/flutter/flutter/pull/43691
https://github.com/flutter/flutter/pull/50987

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*