### PR TITLE
[flutter_tools] support new SDK structure for sdkmanager

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -289,8 +289,8 @@ class AndroidSdk {
   /// sdkmanager. The [licensesAvailable] property should be used to determine
   /// whether the licenses are at least possibly accepted.
   bool get platformToolsAvailable =>
-    globals.fs.directory(globals.fs.path.join(directory, 'platform-tools')).existsSync()  ||
-    globals.fs.directory(globals.fs.path.join(directory, 'cmdline-tools')).existsSync();
+    globals.fs.directory(globals.fs.path.join(directory, 'cmdline-tools')).existsSync() ||
+    globals.fs.directory(globals.fs.path.join(directory, 'platform-tools')).existsSync();
 
   /// Whether the `licenses` directory exists in the Android SDK.
   ///
@@ -549,11 +549,13 @@ class AndroidSdk {
 
   /// Returns the filesystem path of the Android SDK manager tool or null if not found.
   String get sdkManagerPath {
-    final File oldPath = globals.fs.file(globals.fs.path.join(directory, 'tools', 'bin', 'sdkmanager'));
-    if (oldPath.existsSync()) {
-      return oldPath.path;
+    final File cmdlineTool = globals.fs.file(
+      globals.fs.path.join(directory, 'cmdline-tools', 'latest', 'bin', 'sdkmanager')
+    );
+    if (cmdlineTool.existsSync()) {
+      return cmdlineTool.path;
     }
-    return globals.fs.path.join(directory, 'cmdline-tools', 'latest', 'bin', 'sdkmanager');
+    return globals.fs.path.join(directory, 'tools', 'bin', 'sdkmanager');
   }
 
   /// First try Java bundled with Android Studio, then sniff JAVA_HOME, then fallback to PATH.

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -282,13 +282,15 @@ class AndroidSdk {
   List<AndroidSdkVersion> _sdkVersions;
   AndroidSdkVersion _latestVersion;
 
-  /// Whether the `platform-tools` directory exists in the Android SDK.
+  /// Whether the `platform-tools` or `cmdline-tools` directory exists in the Android SDK.
   ///
   /// It is possible to have an Android SDK folder that is missing this with
   /// the expectation that it will be downloaded later, e.g. by gradle or the
   /// sdkmanager. The [licensesAvailable] property should be used to determine
   /// whether the licenses are at least possibly accepted.
-  bool get platformToolsAvailable => globals.fs.directory(globals.fs.path.join(directory, 'platform-tools')).existsSync();
+  bool get platformToolsAvailable =>
+    globals.fs.directory(globals.fs.path.join(directory, 'platform-tools')).existsSync()  ||
+    globals.fs.directory(globals.fs.path.join(directory, 'cmdline-tools')).existsSync();
 
   /// Whether the `licenses` directory exists in the Android SDK.
   ///
@@ -547,7 +549,11 @@ class AndroidSdk {
 
   /// Returns the filesystem path of the Android SDK manager tool or null if not found.
   String get sdkManagerPath {
-    return globals.fs.path.join(directory, 'tools', 'bin', 'sdkmanager');
+    final File oldPath = globals.fs.file(globals.fs.path.join(directory, 'tools', 'bin', 'sdkmanager'));
+    if (oldPath.existsSync()) {
+      return oldPath.path;
+    }
+    return globals.fs.path.join(directory, 'cmdline-tools', 'latest', 'bin', 'sdkmanager');
   }
 
   /// First try Java bundled with Android Studio, then sniff JAVA_HOME, then fallback to PATH.

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -547,7 +547,10 @@ class AndroidSdk {
     _latestVersion = _sdkVersions.isEmpty ? null : _sdkVersions.last;
   }
 
-  /// Returns the filesystem path of the Android SDK manager tool or null if not found.
+  /// Returns the filesystem path of the Android SDK manager tool.
+  ///
+  /// The sdkmanager was previously in the tools directory but this component
+  /// was marked as obsolete in 3.6.
   String get sdkManagerPath {
     final File cmdlineTool = globals.fs.file(
       globals.fs.path.join(directory, 'cmdline-tools', 'latest', 'bin', 'sdkmanager')

--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -359,12 +359,6 @@ class AndroidLicenseValidator extends DoctorValidator {
       throwToolExit(userMessages.androidMissingSdkManager(androidSdk.sdkManagerPath));
     }
 
-    final Version sdkManagerVersion = Version.parse(androidSdk.sdkManagerVersion);
-    if (sdkManagerVersion == null || sdkManagerVersion.major < 26) {
-      // SDK manager is found, but needs to be updated.
-      throwToolExit(userMessages.androidSdkManagerOutdated(androidSdk.sdkManagerPath));
-    }
-
     try {
       final Process process = await processUtils.start(
         <String>[androidSdk.sdkManagerPath, '--licenses'],

--- a/packages/flutter_tools/test/general.shard/android/android_sdk_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_sdk_test.dart
@@ -60,11 +60,27 @@ void main() {
       ProcessManager: () => FakeProcessManager.any(),
     });
 
-    testUsingContext('returns sdkmanager path', () {
+    testUsingContext('returns sdkmanager path under cmdline tools', () {
       sdkDir = MockAndroidSdk.createSdkDirectory();
       globals.config.setValue('android-sdk', sdkDir.path);
 
       final AndroidSdk sdk = AndroidSdk.locateAndroidSdk();
+      globals.fs.file(
+        globals.fs.path.join(sdk.directory, 'cmdline-tools', 'latest', 'bin', 'sdkmanager')
+      ).createSync(recursive: true);
+
+      expect(sdk.sdkManagerPath, globals.fs.path.join(sdk.directory, 'cmdline-tools', 'latest', 'bin', 'sdkmanager'));
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager.any(),
+    });
+
+    testUsingContext('returns sdkmanager path under tools if cmdline doesnt exist', () {
+      sdkDir = MockAndroidSdk.createSdkDirectory();
+      globals.config.setValue('android-sdk', sdkDir.path);
+
+      final AndroidSdk sdk = AndroidSdk.locateAndroidSdk();
+
       expect(sdk.sdkManagerPath, globals.fs.path.join(sdk.directory, 'tools', 'bin', 'sdkmanager'));
     }, overrides: <Type, Generator>{
       FileSystem: () => fs,

--- a/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
@@ -169,32 +169,6 @@ void main() {
     Stdio: () => stdio,
   }));
 
-  testUsingContext('runLicenseManager errors for version < 26', () async {
-    when(sdk.sdkManagerPath).thenReturn('/foo/bar/sdkmanager');
-    when(sdk.sdkManagerVersion).thenReturn('25.0.0');
-
-    expect(AndroidLicenseValidator.runLicenseManager(), throwsToolExit(message: 'To update, run'));
-  }, overrides: Map<Type, Generator>.unmodifiable(<Type, Generator>{
-    AndroidSdk: () => sdk,
-    FileSystem: () => fs,
-    ProcessManager: () => processManager,
-    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
-    Stdio: () => stdio,
-  }));
-
-  testUsingContext('runLicenseManager errors correctly for null version', () async {
-    when(sdk.sdkManagerPath).thenReturn('/foo/bar/sdkmanager');
-    when(sdk.sdkManagerVersion).thenReturn(null);
-
-    expect(AndroidLicenseValidator.runLicenseManager(), throwsToolExit(message: 'To update, run'));
-  }, overrides: Map<Type, Generator>.unmodifiable(<Type, Generator>{
-    AndroidSdk: () => sdk,
-    FileSystem: () => fs,
-    ProcessManager: () => processManager,
-    Platform: () => FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
-    Stdio: () => stdio,
-  }));
-
   testUsingContext('runLicenseManager errors when sdkmanager is not found', () async {
     when(sdk.sdkManagerPath).thenReturn('/foo/bar/sdkmanager');
     processManager.canRunSucceeds = false;


### PR DESCRIPTION
## Description

Teach the android SDK class about the cmdline tools, which accept licenses instead of the obsolete platform tools.


We're not currently able to accept android licenses in the latest SDK. We also need to update our documentation to explain which component to download.


 https://github.com/flutter/flutter/issues/51712