### PR TITLE
[flutter_tools] add status logs to determine where test is getting stuck

### DIFF
--- a/packages/flutter_tools/test/integration.shard/hot_reload_test.dart
+++ b/packages/flutter_tools/test/integration.shard/hot_reload_test.dart
@@ -107,14 +107,19 @@ void main() {
     );
     bool reloaded = false;
     final Future<void> reloadFuture = _flutter.hotReload().then((void value) { reloaded = true; });
+    print('waiting for pause...');
     isolate = await _flutter.waitForPause();
     expect(isolate.pauseEvent.kind, equals(EventKind.kPauseBreakpoint));
+    print('waiting for debugger message...');
     await sawDebuggerPausedMessage.future;
     expect(reloaded, isFalse);
+    print('waiting for resume...');
     await _flutter.resume();
+    print('waiting for reload future...');
     await reloadFuture;
     expect(reloaded, isTrue);
     reloaded = false;
+    print('subscription cancel...');
     await subscription.cancel();
   });
 


### PR DESCRIPTION
## Description

This test has been flaking more recently, see https://cirrus-ci.com/task/5615992101404672?command=main#L253 . Add status logs to determine where it is getting stuck, since this doesn't reproduce locally.