### PR TITLE
[flutter_tools] support coverage and machine together

### DIFF
--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -208,24 +208,21 @@ class TestCommand extends FlutterCommand {
       ];
     }
 
+    final bool machine = boolArg('machine');
     CoverageCollector collector;
     if (boolArg('coverage') || boolArg('merge-coverage')) {
       final String projectName = FlutterProject.current().manifest.appName;
       collector = CoverageCollector(
+        verbose: !machine,
         libraryPredicate: (String libraryName) => libraryName.contains(projectName),
       );
     }
 
-    final bool machine = boolArg('machine');
-    if (collector != null && machine) {
-      throwToolExit("The test command doesn't support --machine and coverage together");
-    }
-
     TestWatcher watcher;
-    if (collector != null) {
+    if (machine) {
+      watcher = EventPrinter(parent: collector);
+    } else if (collector != null) {
       watcher = collector;
-    } else if (machine) {
-      watcher = EventPrinter();
     }
 
     Cache.releaseLockEarly();

--- a/packages/flutter_tools/lib/src/test/event_printer.dart
+++ b/packages/flutter_tools/lib/src/test/event_printer.dart
@@ -8,14 +8,18 @@ import 'watcher.dart';
 
 /// Prints JSON events when running a test in --machine mode.
 class EventPrinter extends TestWatcher {
-  EventPrinter({StringSink out}) : _out = out ?? globals.stdio.stdout;
+  EventPrinter({StringSink out, TestWatcher parent})
+    : _out = out ?? globals.stdio.stdout,
+      _parent = parent;
 
   final StringSink _out;
+  final TestWatcher _parent;
 
   @override
   void handleStartedProcess(ProcessEvent event) {
     _sendEvent('test.startedProcess',
         <String, dynamic>{'observatoryUri': event.observatoryUri.toString()});
+    _parent?.handleStartedProcess(event);
   }
 
   void _sendEvent(String name, [ dynamic params ]) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:args/command_runner.dart';
 import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
@@ -48,6 +49,28 @@ void main() {
       fakePackageTest.lastArgs,
       contains('--test-randomize-ordering-seed=random'),
     );
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fs,
+    ProcessManager: () => FakeProcessManager.any(),
+    Cache: () => FakeCache(),
+  });
+
+  testUsingContext('Supports coverage and machine', () async {
+    final FakePackageTest fakePackageTest = FakePackageTest();
+
+    final TestCommand testCommand = TestCommand(testWrapper: fakePackageTest);
+    final CommandRunner<void> commandRunner =
+        createTestCommandRunner(testCommand);
+
+    expect(() => commandRunner.run(const <String>[
+      'test',
+      '--no-pub',
+      '--machine',
+      '--coverage',
+      '--',
+      'test/fake_test.dart',
+    ]), throwsA(isA<ToolExit>()
+      .having((ToolExit toolExit) => toolExit.message, 'message', isNull)));
   }, overrides: <Type, Generator>{
     FileSystem: () => fs,
     ProcessManager: () => FakeProcessManager.any(),


### PR DESCRIPTION
## Description

Create a parent/delegate property of the machine test watcher so that it can still call coverage methods. Prevent extra logging in machine mode.

Fixes https://github.com/flutter/flutter/issues/30108