### PR TITLE
Update dartdoc to 0.30.2

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -111,7 +111,7 @@ if [[ -d "$FLUTTER_PUB_CACHE" ]]; then
 fi
 
 # Install and activate dartdoc.
-"$PUB" global activate dartdoc 0.29.3
+"$PUB" global activate dartdoc 0.30.2 
 
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc.

--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -111,7 +111,7 @@ if [[ -d "$FLUTTER_PUB_CACHE" ]]; then
 fi
 
 # Install and activate dartdoc.
-"$PUB" global activate dartdoc 0.30.2 
+"$PUB" global activate dartdoc 0.30.2
 
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc.

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -136,6 +136,7 @@ Future<void> main(List<String> arguments) async {
     '--link-to-source-root', '../..',
     '--link-to-source-uri-template', 'https://github.com/flutter/flutter/blob/master/%f%#L%l%',
     '--inject-html',
+    '--use-base-href',
     '--header', 'styles.html',
     '--header', 'analytics.html',
     '--header', 'survey.html',


### PR DESCRIPTION
This fixes some search box problems for Flutter in 0.30.1, and adds the --use-base-href flag as the Flutter post-processing of Dartdoc output requires it (without it, last push broke the docs).  cc @jdkoren

Release notes:  https://github.com/dart-lang/dartdoc/releases/tag/v0.30.2

Screenshots of Flutter docs with this PR:

![Screen Shot 2020-03-05 at 9 10 15 AM](https://user-images.githubusercontent.com/14116827/76006906-0ba12d00-5ec2-11ea-8853-59cb3abcc1e6.png)
![Screen Shot 2020-03-05 at 9 10 55 AM](https://user-images.githubusercontent.com/14116827/76006909-0d6af080-5ec2-11ea-8327-3df93be2a523.png)
![Screen Shot 2020-03-05 at 9 11 30 AM](https://user-images.githubusercontent.com/14116827/76006912-0e9c1d80-5ec2-11ea-9b9a-5e3ce2e9b221.png)
![Screen Shot 2020-03-05 at 9 13 12 AM](https://user-images.githubusercontent.com/14116827/76006915-1065e100-5ec2-11ea-9b8e-5b5c440d8976.png)



