### PR TITLE
[flutter_tools] pin exact build_runner version

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/build_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/build_runner.dart
@@ -96,7 +96,7 @@ class BuildRunner extends CodeGenerator {
           }
         }
       }
-      stringBuffer.writeln('  build_runner: ^$kMinimumBuildRunnerVersion');
+      stringBuffer.writeln('  build_runner: $kMinimumBuildRunnerVersion');
       stringBuffer.writeln('  build_daemon: $kSupportedBuildDaemonVersion');
       syntheticPubspec.writeAsStringSync(stringBuffer.toString());
 


### PR DESCRIPTION
## Description

BR 1.8.0 has some behavior changes we still need to deal with in the tool. Pin the version to green the build.