### PR TITLE
Revert "[flutter_tools] supports tree-shake-icons for web builds (#51…

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/icon_tree_shaker.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/icon_tree_shaker.dart
@@ -289,7 +289,7 @@ class IconTreeShaker {
     for (final Map<String, dynamic> iconDataMap in consts.constantInstances) {
       if ((iconDataMap['fontPackage'] ?? '') is! String || // Null is ok here.
            iconDataMap['fontFamily'] is! String ||
-           iconDataMap['codePoint'] is! num) {
+           iconDataMap['codePoint'] is! int) {
         throw IconTreeShakerException._(
           'Invalid ConstFinder result. Expected "fontPackage" to be a String, '
           '"fontFamily" to be a String, and "codePoint" to be an int, '
@@ -301,7 +301,7 @@ class IconTreeShaker {
         ? family
         : 'packages/$package/$family';
       result[key] ??= <int>[];
-      result[key].add((iconDataMap['codePoint'] as num).round());
+      result[key].add(iconDataMap['codePoint'] as int);
     }
     return result;
   }

--- a/packages/flutter_tools/lib/src/web/compile.dart
+++ b/packages/flutter_tools/lib/src/web/compile.dart
@@ -11,7 +11,6 @@ import '../base/logger.dart';
 import '../build_info.dart';
 import '../build_system/build_system.dart';
 import '../build_system/targets/dart.dart';
-import '../build_system/targets/icon_tree_shaker.dart';
 import '../build_system/targets/web.dart';
 import '../convert.dart';
 import '../globals.dart' as globals;
@@ -53,7 +52,8 @@ Future<void> buildWeb(
         kHasWebPlugins: hasWebPlugins.toString(),
         kDartDefines: jsonEncode(dartDefines),
         kCspMode: csp.toString(),
-        kIconTreeShakerFlag: buildInfo.treeShakeIcons.toString(),
+        // TODO(dnfield): Enable font subset. We need to get a kernel file to do
+        // that. https://github.com/flutter/flutter/issues/49730
       },
     ));
     if (!result.success) {


### PR DESCRIPTION
…808)"

This reverts commit aed961993dd67489f544d4aad867ed18b49b829f.

## Description

This breaks the web integration test:

```
Downloading Web SDK...                                              0.6s
Compiling lib/stack_trace.dart for the Web...                      10.6s
▌20:52:19▐ ELAPSED TIME: 12.208s for ../../../bin/flutter build web --profile -t lib/stack_trace.dart in dev/integration_tests/web
Launching Google Chrome 80.0.3987.87 
stderr: Fontconfig warning: "/etc/fonts/fonts.conf", line 100: unknown element "blank"
stderr: 
stderr: DevTools listening on ws://127.0.0.1:8081/devtools/browser/4bdccd96-71e8-4dc0-820d-e3ab9a9a9e49
stderr: [0305/205219.762184:WARNING:ipc_message_attachment_set.cc(49)] MessageAttachmentSet destroyed with unconsumed attachments: 0/1
stderr: [0305/205219.762221:ERROR:command_buffer_proxy_impl.cc(125)] ContextResult::kTransientFailure: Failed to send GpuChannelMsg_CreateCommandBuffer.
stderr: [0305/205219.964377:INFO:CONSOLE(3110)] "--- UNEXPECTED EXCEPTION ---
stderr: NoSuchMethodError: method not found: '_match' on null
stderr: TypeError: Cannot read property '_match' of null
stderr:     at Object.StackFrame__parseWebFrame (http://localhost:8080/main.dart.js:6630:18)
stderr:     at StaticClosure.StackFrame_fromStackTraceLine (http://localhost:8080/main.dart.js:6641:18)
stderr:     at MappedListIterable.elementAt$1 (http://localhost:8080/main.dart.js:8833:22)
stderr:     at ListIterator.moveNext$0 (http://localhost:8080/main.dart.js:8796:38)
stderr:     at SkipWhileIterator.moveNext$0 (http://localhost:8080/main.dart.js:8864:54)
stderr:     at Object.List_List$from (http://localhost:8080/main.dart.js:4398:49)
stderr:     at Object.StackFrame_fromStackString (http://localhost:8080/main.dart.js:6613:16)
stderr:     at Object.main (http://localhost:8080/main.dart.js:6703:28)
stderr:     at http://localhost:8080/main.dart.js:6757:17
stderr:     at _wrapJsFunctionForAsync_closure.$protected (http://localhost:8080/main.dart.js:3567:15)
stderr: --- TEST FAILED ---
stderr: ", source: http://localhost:8080/main.dart.js (3110)
--- UNEXPECTED EXCEPTION ---
NoSuchMethodError: method not found: '_match' on null
TypeError: Cannot read property '_match' of null
    at Object.StackFrame__parseWebFrame (http://localhost:8080/main.dart.js:6630:18)
    at StaticClosure.StackFrame_fromStackTraceLine (http://localhost:8080/main.dart.js:6641:18)
    at MappedListIterable.elementAt$1 (http://localhost:8080/main.dart.js:8833:22)
    at ListIterator.moveNext$0 (http://localhost:8080/main.dart.js:8796:38)
    at SkipWhileIterator.moveNext$0 (http://localhost:8080/main.dart.js:8864:54)
    at Object.List_List$from (http://localhost:8080/main.dart.js:4398:49)
    at Object.StackFrame_fromStackString (http://localhost:8080/main.dart.js:6613:16)
    at Object.main (http://localhost:8080/main.dart.js:6703:28)
    at http://localhost:8080/main.dart.js:6757:17
    at _wrapJsFunctionForAsync_closure.$protected (http://localhost:8080/main.dart.js:3567:15)
--- TEST FAILED ---
Web stack trace integration test failed.
```