### PR TITLE
[flutter-tools] see if its a timing issue

### DIFF
--- a/packages/flutter_tools/test/integration.shard/hot_reload_test.dart
+++ b/packages/flutter_tools/test/integration.shard/hot_reload_test.dart
@@ -125,7 +125,6 @@ void main() {
 
   test("hot reload doesn't reassemble if paused", () async {
     final Completer<void> sawTick1 = Completer<void>();
-    final Completer<void> sawTick3 = Completer<void>();
     final Completer<void> sawDebuggerPausedMessage1 = Completer<void>();
     final Completer<void> sawDebuggerPausedMessage2 = Completer<void>();
     final StreamSubscription<String> subscription = _flutter.stdout.listen(
@@ -146,12 +145,14 @@ void main() {
       },
     );
     await _flutter.run(withDebugger: true);
+    await Future<void>.delayed(const Duration(seconds: 1));
     await sawTick1.future;
     await _flutter.addBreakpoint(
       _project.buildBreakpointUri,
       _project.buildBreakpointLine,
     );
     bool reloaded = false;
+    await Future<void>.delayed(const Duration(seconds: 1));
     final Future<void> reloadFuture = _flutter.hotReload().then((void value) { reloaded = true; });
     final Isolate isolate = await _flutter.waitForPause();
     expect(isolate.pauseEvent.kind, equals(EventKind.kPauseBreakpoint));
@@ -160,7 +161,6 @@ void main() {
     await reloadFuture; // this is the one where it times out because you're in the debugger
     expect(reloaded, isTrue);
     await _flutter.hotReload(); // now we're already paused
-    expect(sawTick3.isCompleted, isFalse);
     await sawDebuggerPausedMessage2.future; // so we just get told that nothing is going to happen
     await _flutter.resume();
     await subscription.cancel();


### PR DESCRIPTION
## Description

If the add breakpoint or reload command requests return before the operation is actually complete, a timing issue could cause the test to get stuck. Try adding a delay to see if that reduces flakiness.

https://github.com/flutter/flutter/issues/52028