### PR TITLE
Improve text formatter repeat filter logic

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1645,15 +1645,21 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     // Check if the new value is the same as the current local value, or is the same
     // as the post-formatting value of the previous pass.
     final bool textChanged = _value?.text != value?.text;
-    final bool isRepeat = value == _lastFormattedUnmodifiedTextEditingValue;
-    if (!isRepeat) {
-      if (textChanged && widget.inputFormatters != null && widget.inputFormatters.isNotEmpty) {
-        for (final TextInputFormatter formatter in widget.inputFormatters) {
-          value = formatter.formatEditUpdate(_value, value);
-        }
+    final bool isRepeatText = value?.text == _lastFormattedUnmodifiedTextEditingValue?.text;
+    final bool isRepeatSelection = value?.selection == _lastFormattedUnmodifiedTextEditingValue?.selection;
+    // Only format when the text has changed and there are available formatters.
+    if (!isRepeatText && textChanged && widget.inputFormatters != null && widget.inputFormatters.isNotEmpty) {
+      for (final TextInputFormatter formatter in widget.inputFormatters) {
+        value = formatter.formatEditUpdate(_value, value);
       }
+    }
+    // If the text has changed or the selection has changed, we should update the
+    // locally stored TextEditingValue to the new one.
+    if (!isRepeatText || !isRepeatSelection) {
       _value = value;
     }
+    // Always attempt to send the value. If the value has changed, then it will send,
+    // otherwise, it will short-circuit.
     _updateRemoteEditingValueIfNeeded();
 
     if (textChanged && widget.onChanged != null)

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1651,6 +1651,8 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         value = formatter.formatEditUpdate(_value, value);
       _value = value;
       _updateRemoteEditingValueIfNeeded();
+    } else if (isRepeat) {
+      _updateRemoteEditingValueIfNeeded();
     } else {
       _value = value;
     }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1645,19 +1645,17 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     // Check if the new value is the same as the current local value, or is the same
     // as the post-formatting value of the previous pass.
     final bool textChanged = _value?.text != value?.text;
-    final bool isRepeat = value?.text == _lastFormattedUnmodifiedTextEditingValue?.text;
-    if (textChanged && !isRepeat && widget.inputFormatters != null && widget.inputFormatters.isNotEmpty) {
-      for (final TextInputFormatter formatter in widget.inputFormatters)
-        value = formatter.formatEditUpdate(_value, value);
-      _value = value;
-      _updateRemoteEditingValueIfNeeded();
-    } else if (isRepeat) {
-      // Clear out the unformatted remote value with the already-known
-      // post-format value.
-      _updateRemoteEditingValueIfNeeded();
-    } else {
+    final bool isRepeat = value == _lastFormattedUnmodifiedTextEditingValue;
+    if (!isRepeat) {
+      if (textChanged && widget.inputFormatters != null && widget.inputFormatters.isNotEmpty) {
+        for (final TextInputFormatter formatter in widget.inputFormatters) {
+          value = formatter.formatEditUpdate(_value, value);
+        }
+      }
       _value = value;
     }
+    _updateRemoteEditingValueIfNeeded();
+
     if (textChanged && widget.onChanged != null)
       widget.onChanged(value.text);
     _lastFormattedUnmodifiedTextEditingValue = _receivedRemoteTextEditingValue;

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1652,6 +1652,8 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       _value = value;
       _updateRemoteEditingValueIfNeeded();
     } else if (isRepeat) {
+      // Clear out the unformatted remote value with the already-known
+      // post-format value.
       _updateRemoteEditingValueIfNeeded();
     } else {
       _value = value;


### PR DESCRIPTION
## Description

The checking for repeated calls of formatter has caused us to no longer update the remote value when a repeat format case is hit. This makes sure we clear out the unformatted remote value with the already know post-format value.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/51180

Related to https://github.com/flutter/flutter/pull/51964. This is expected to land first.

## Tests

Added tests to verify the new repeat filtering behavior.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
