### PR TITLE
More fixes for randomizing test order

### DIFF
--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -206,7 +206,7 @@ void main() {
   });
 
   group('PrebuiltIOSApp', () {
-    final MockOperatingSystemUtils os = MockOperatingSystemUtils();
+    MockOperatingSystemUtils os;
     final Map<Type, Generator> overrides = <Type, Generator>{
       FileSystem: () => MemoryFileSystem(),
       ProcessManager: () => FakeProcessManager.any(),
@@ -214,6 +214,10 @@ void main() {
       Platform: _kNoColorTerminalPlatform,
       OperatingSystemUtils: () => os,
     };
+
+    setUp(() {
+      os = MockOperatingSystemUtils();
+    });
 
     testUsingContext('Error on non-existing file', () {
       final PrebuiltIOSApp iosApp =


### PR DESCRIPTION
More fixes for #47963

- Reset a shared mock between tests
- Don't depend on order of creation of temp directories in memory FS