### PR TITLE
Bump recommended CocoaPods version to 1.8

### DIFF
--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -69,7 +69,7 @@ class CocoaPods {
   Future<String> _versionText;
 
   String get cocoaPodsMinimumVersion => '1.6.0';
-  String get cocoaPodsRecommendedVersion => '1.6.0';
+  String get cocoaPodsRecommendedVersion => '1.8.0';
 
   Future<bool> get isInstalled =>
       processUtils.exitsHappy(<String>['which', 'pod']);

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -68,7 +68,7 @@ void main() {
     projectUnderTest = FlutterProject.fromDirectory(fs.directory('project'));
     projectUnderTest.ios.xcodeProject.createSync(recursive: true);
     cocoaPodsUnderTest = CocoaPods();
-    pretendPodVersionIs('1.6.0');
+    pretendPodVersionIs('1.8.0');
     fs.file(fs.path.join(
       Cache.flutterRoot, 'packages', 'flutter_tools', 'templates', 'cocoapods', 'Podfile-ios-objc',
     ))
@@ -173,9 +173,17 @@ void main() {
       ProcessManager: () => mockProcessManager,
     });
 
-    testUsingContext('detects at recommended version', () async {
+    testUsingContext('detects below recommended version', () async {
       pretendPodIsInstalled();
       pretendPodVersionIs('1.6.0');
+      expect(await cocoaPodsUnderTest.evaluateCocoaPodsInstallation, CocoaPodsStatus.belowRecommendedVersion);
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+    });
+
+    testUsingContext('detects at recommended version', () async {
+      pretendPodIsInstalled();
+      pretendPodVersionIs('1.8.0');
       expect(await cocoaPodsUnderTest.evaluateCocoaPodsInstallation, CocoaPodsStatus.recommended);
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
@@ -183,7 +191,7 @@ void main() {
 
     testUsingContext('detects above recommended version', () async {
       pretendPodIsInstalled();
-      pretendPodVersionIs('1.6.1');
+      pretendPodVersionIs('1.8.1');
       expect(await cocoaPodsUnderTest.evaluateCocoaPodsInstallation, CocoaPodsStatus.recommended);
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,


### PR DESCRIPTION
## Description

CocoaPods introduced a CDN on 1.8 so the user [no longer has to run `pod setup`](https://github.com/flutter/flutter/pull/41491).  1.8 has been [out since September](https://github.com/CocoaPods/CocoaPods/blob/master/CHANGELOG.md#180-2019-09-23), so let's bump the minimum recommended version so users get a nudge to upgrade.  Minimum required version is still 1.6.0.  

Devicelab is already on higher version.

Error looks like:
<img width="1047" alt="Screen Shot 2020-03-05 at 6 36 57 PM" src="https://user-images.githubusercontent.com/682784/76044831-547fd280-5f10-11ea-96fd-93c060c60230.png">


## Related Issues

https://github.com/flutter/flutter/pull/41491
Fixes https://github.com/flutter/flutter/issues/25592

## Tests

Added recommended version test.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*