### PR TITLE
Fix for negative padding from a curve in AnimatedPadding.

### DIFF
--- a/packages/flutter/lib/src/painting/edge_insets.dart
+++ b/packages/flutter/lib/src/painting/edge_insets.dart
@@ -503,6 +503,16 @@ class EdgeInsets extends EdgeInsetsGeometry {
     return super.add(other);
   }
 
+  @override
+  EdgeInsetsGeometry clamp(EdgeInsetsGeometry min, EdgeInsetsGeometry max) {
+    return EdgeInsets.fromLTRB(
+      _left.clamp(min._left, max._left) as double,
+      _top.clamp(min._top, max._top) as double,
+      _right.clamp(min._right, max._right) as double,
+      _bottom.clamp(min._bottom, max._bottom) as double,
+    );
+  }
+
   /// Returns the difference between two [EdgeInsets].
   EdgeInsets operator -(EdgeInsets other) {
     return EdgeInsets.fromLTRB(

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -834,7 +834,9 @@ class _AnimatedPaddingState extends AnimatedWidgetBaseState<AnimatedPadding> {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: _padding.evaluate(animation),
+      padding: _padding
+        .evaluate(animation)
+        .clamp(EdgeInsets.zero, EdgeInsetsGeometry.infinity),
       child: widget.child,
     );
   }

--- a/packages/flutter/test/widgets/animated_padding_test.dart
+++ b/packages/flutter/test/widgets/animated_padding_test.dart
@@ -58,4 +58,44 @@ void main() {
     expect(tester.getSize(find.byKey(target)), const Size(700.0, 600.0));
     expect(tester.getTopRight(find.byKey(target)), const Offset(700.0, 0.0));
   });
+
+  testWidgets('AnimatedPadding animated padding clamped to positive values', (WidgetTester tester) async {
+    final Key target = UniqueKey();
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.rtl,
+        child: AnimatedPadding(
+          curve: Curves.easeInOutBack, // will cause negative padding during overshoot
+          duration: const Duration(milliseconds: 200),
+          padding: const EdgeInsets.only(right: 50.0),
+          child: SizedBox.expand(key: target),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byKey(target)), const Size(750.0, 600.0));
+    expect(tester.getTopRight(find.byKey(target)), const Offset(750.0, 0.0));
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.rtl,
+        child: AnimatedPadding(
+          curve: Curves.easeInOutBack,
+          duration: const Duration(milliseconds: 200),
+          padding: const EdgeInsets.only(right: 0.0),
+          child: SizedBox.expand(key: target),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byKey(target)), const Size(750.0, 600.0));
+    expect(tester.getTopRight(find.byKey(target)), const Offset(750.0, 0.0));
+
+    await tester.pump(const Duration(milliseconds: 128));
+    // Curve would have made the padding negative a this point if it is not clamped.
+    expect(tester.getSize(find.byKey(target)), const Size(800.0, 600.0));
+    expect(tester.getTopRight(find.byKey(target)), const Offset(800.0, 0.0));
+  });
+
 }


### PR DESCRIPTION
## Description

If the curve for AnimatedPadding causing the padding to go negative, it will throw an exception. This PR clamps the padding from the curve to always be positive.

## Related Issues

Fixes: #51248

## Tests

I added the following tests:

* A new test to check the animation hitting a negative.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them?.

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
