### PR TITLE
Add overrides for FileSystemUtils

### DIFF
--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -39,10 +39,12 @@ class MockPlistUtils extends Mock implements PlistParser {}
 
 void main() {
   FakePlatform osx;
+  FileSystemUtils fsUtils;
 
   setUp(() {
     osx = FakePlatform.fromPlatform(const LocalPlatform());
     osx.operatingSystem = 'macos';
+    fsUtils = FileSystemUtils(fileSystem: MemoryFileSystem(), platform: osx);
   });
 
   group('_IOSSimulatorDevicePortForwarder', () {
@@ -69,6 +71,7 @@ void main() {
       expect(IOSSimulator('123').logFilePath, '/foo/bar/Library/Logs/CoreSimulator/123/system.log');
     }, overrides: <Type, Generator>{
       Platform: () => osx,
+      FileSystemUtils: () => fsUtils,
     }, testOn: 'posix');
 
     testUsingContext('respects IOS_SIMULATOR_LOG_FILE_PATH', () {
@@ -77,6 +80,7 @@ void main() {
       expect(IOSSimulator('456').logFilePath, '/baz/qux/456/system.log');
     }, overrides: <Type, Generator>{
       Platform: () => osx,
+      FileSystemUtils: () => fsUtils,
     });
   });
 

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -40,11 +40,13 @@ class MockPlistUtils extends Mock implements PlistParser {}
 void main() {
   FakePlatform osx;
   FileSystemUtils fsUtils;
+  MemoryFileSystem fileSystem;
 
   setUp(() {
     osx = FakePlatform.fromPlatform(const LocalPlatform());
     osx.operatingSystem = 'macos';
-    fsUtils = FileSystemUtils(fileSystem: MemoryFileSystem(), platform: osx);
+    fileSystem = MemoryFileSystem();
+    fsUtils = FileSystemUtils(fileSystem: fileSystem, platform: osx);
   });
 
   group('_IOSSimulatorDevicePortForwarder', () {
@@ -62,6 +64,8 @@ void main() {
       expect(portForwarder.forwardedPorts.length, 0);
     }, overrides: <Type, Generator>{
       Platform: () => osx,
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
     }, testOn: 'posix');
   });
 
@@ -72,6 +76,8 @@ void main() {
     }, overrides: <Type, Generator>{
       Platform: () => osx,
       FileSystemUtils: () => fsUtils,
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
     }, testOn: 'posix');
 
     testUsingContext('respects IOS_SIMULATOR_LOG_FILE_PATH', () {
@@ -81,6 +87,8 @@ void main() {
     }, overrides: <Type, Generator>{
       Platform: () => osx,
       FileSystemUtils: () => fsUtils,
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
     });
   });
 
@@ -159,54 +167,72 @@ void main() {
       expect(IOSSimulator('x', name: 'Apple TV').isSupported(), false);
     }, overrides: <Type, Generator>{
       Platform: () => osx,
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
     });
 
     testUsingContext('Apple Watch is unsupported', () {
       expect(IOSSimulator('x', name: 'Apple Watch').isSupported(), false);
     }, overrides: <Type, Generator>{
       Platform: () => osx,
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
     });
 
     testUsingContext('iPad 2 is supported', () {
       expect(IOSSimulator('x', name: 'iPad 2').isSupported(), true);
     }, overrides: <Type, Generator>{
       Platform: () => osx,
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
     });
 
     testUsingContext('iPad Retina is supported', () {
       expect(IOSSimulator('x', name: 'iPad Retina').isSupported(), true);
     }, overrides: <Type, Generator>{
       Platform: () => osx,
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
     });
 
     testUsingContext('iPhone 5 is supported', () {
       expect(IOSSimulator('x', name: 'iPhone 5').isSupported(), true);
     }, overrides: <Type, Generator>{
       Platform: () => osx,
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
     });
 
     testUsingContext('iPhone 5s is supported', () {
       expect(IOSSimulator('x', name: 'iPhone 5s').isSupported(), true);
     }, overrides: <Type, Generator>{
       Platform: () => osx,
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
     });
 
     testUsingContext('iPhone SE is supported', () {
       expect(IOSSimulator('x', name: 'iPhone SE').isSupported(), true);
     }, overrides: <Type, Generator>{
       Platform: () => osx,
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
     });
 
     testUsingContext('iPhone 7 Plus is supported', () {
       expect(IOSSimulator('x', name: 'iPhone 7 Plus').isSupported(), true);
     }, overrides: <Type, Generator>{
       Platform: () => osx,
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
     });
 
     testUsingContext('iPhone X is supported', () {
       expect(IOSSimulator('x', name: 'iPhone X').isSupported(), true);
     }, overrides: <Type, Generator>{
       Platform: () => osx,
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
     });
   });
 
@@ -228,6 +254,8 @@ void main() {
     });
   }, overrides: <Type, Generator>{
     BuildSystem: () => MockBuildSystem(),
+    FileSystem: () => fileSystem,
+    ProcessManager: () => FakeProcessManager.any(),
   });
 
   group('Simulator screenshot', () {
@@ -255,7 +283,11 @@ void main() {
         when(mockXcode.minorVersion).thenReturn(1);
         expect(deviceUnderTest.supportsScreenshot, false);
       },
-      overrides: <Type, Generator>{Xcode: () => mockXcode},
+      overrides: <Type, Generator>{
+        Xcode: () => mockXcode,
+        FileSystem: () => fileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+      },
     );
 
     testUsingContext(
@@ -285,6 +317,7 @@ void main() {
         // Test a real one. Screenshot doesn't require instance states.
         SimControl: () => SimControl(),
         Xcode: () => mockXcode,
+        FileSystem: () => fileSystem,
       },
     );
   });
@@ -308,6 +341,7 @@ void main() {
     },
     overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
+      FileSystem: () => fileSystem,
     });
 
     testUsingContext('uses /usr/bin/log on iOS 11 and above', () async {
@@ -320,6 +354,7 @@ void main() {
     },
     overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
+      FileSystem: () => fileSystem,
     });
   });
 
@@ -342,6 +377,7 @@ void main() {
     },
     overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
+      FileSystem: () => fileSystem,
     });
 
     testUsingContext('uses /usr/bin/log on iOS 11 and above', () async {
@@ -351,6 +387,7 @@ void main() {
     },
     overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
+      FileSystem: () => fileSystem,
     });
   });
 
@@ -396,6 +433,7 @@ void main() {
       ]);
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
+      FileSystem: () => fileSystem,
     });
   });
 
@@ -473,6 +511,7 @@ void main() {
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
       SimControl: () => simControl,
+      FileSystem: () => fileSystem,
     });
 
     testUsingContext('getDevices handles bad simctl output', () async {
@@ -484,6 +523,7 @@ void main() {
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
       SimControl: () => simControl,
+      FileSystem: () => fileSystem,
     });
 
     testUsingContext('sdkMajorVersion defaults to 11 when sdkNameAndVersion is junk', () async {
@@ -515,6 +555,8 @@ void main() {
     }, overrides: <Type, Generator>{
       SimControl: () => simControl,
       PlistParser: () => MockPlistUtils(),
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
     });
   });
 
@@ -544,8 +586,8 @@ flutter:
 
     expect(IOSSimulator('test').isSupportedForProject(flutterProject), true);
   }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(),
     ProcessManager: () => FakeProcessManager.any(),
+    FileSystem: () => fileSystem,
   });
 
   testUsingContext('IOSDevice.isSupportedForProject is false with no host app and no module', () async {
@@ -555,7 +597,7 @@ flutter:
 
     expect(IOSSimulator('test').isSupportedForProject(flutterProject), false);
   }, overrides: <Type, Generator>{
-    FileSystem: () => MemoryFileSystem(),
+    FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),
   });
 }


### PR DESCRIPTION
In some orderings, the context's FileSystemUtils was picking up the _actual_ platform instead of the fake platform.  See https://cirrus-ci.com/task/4530993889542144?command=main#L2934