### PR TITLE
[flutter_tools] fix coverage measurement to report on lib and not test

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -250,6 +250,7 @@ Future<void> _runToolCoverage() async {
       '--in=coverage',
       '--out=coverage/lcov.info',
       '--packages=.packages',
+      '--report-on=lib/'
     ],
     workingDirectory: toolRoot,
     outputMode: OutputMode.discard,

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -243,7 +243,14 @@ Future<void> _runToolCoverage() async {
     coverage: 'coverage',
   );
   await runCommand(pub,
-    <String>['run', 'coverage:format_coverage', '--lcov', '--in=coverage', '--out=coverage/lcov.info'],
+    <String>[
+      'run',
+      'coverage:format_coverage',
+      '--lcov',
+      '--in=coverage',
+      '--out=coverage/lcov.info',
+      '--packages=.packages',
+    ],
     workingDirectory: toolRoot,
     outputMode: OutputMode.discard,
   );


### PR DESCRIPTION
## Description

I needed to do a closer eyeball - we're currently reporting the test script's own coverage. Verified locally that lcov files are correct now