### PR TITLE
Teach flutter to build itself

### DIFF
--- a/bin/flutter
+++ b/bin/flutter
@@ -16,6 +16,17 @@ set -e
 
 unset CDPATH
 
+# Check for build self command
+BUILD_SELF=false
+if [[ $1 == build && $2 == self ]]; then
+  if [[ $# == 2 ]]; then
+    BUILD_SELF=true
+  else
+    echo "$(basename -- $0) $@: '$1 $2' does not support any additional parameters."
+    exit 1
+  fi
+fi
+
 function follow_links() {
   cd -P "${1%/*}"
   local file="$PWD/${1##*/}"
@@ -104,11 +115,12 @@ function upgrade_flutter () {
   local revision="$(cd "$FLUTTER_ROOT"; git rev-parse HEAD)"
 
   # Invalidate cache if:
+  #  * BUILD_SELF if true, or
   #  * SNAPSHOT_PATH is not a file, or
   #  * STAMP_PATH is not a file with nonzero size, or
   #  * Contents of STAMP_PATH is not our local git HEAD revision, or
   #  * pubspec.yaml last modified after pubspec.lock
-  if [[ ! -f "$SNAPSHOT_PATH" || ! -s "$STAMP_PATH" || "$(cat "$STAMP_PATH")" != "$revision" || "$FLUTTER_TOOLS_DIR/pubspec.yaml" -nt "$FLUTTER_TOOLS_DIR/pubspec.lock" ]]; then
+  if [[ "$BUILD_SELF" == "true" || ! -f "$SNAPSHOT_PATH" || ! -s "$STAMP_PATH" || "$(cat "$STAMP_PATH")" != "$revision" || "$FLUTTER_TOOLS_DIR/pubspec.yaml" -nt "$FLUTTER_TOOLS_DIR/pubspec.lock" ]]; then
     rm -f "$FLUTTER_ROOT/version"
     touch "$FLUTTER_ROOT/bin/cache/.dartignore"
     "$FLUTTER_ROOT/bin/internal/update_dart_sdk.sh"
@@ -189,4 +201,6 @@ fi
 
 # FLUTTER_TOOL_ARGS isn't quoted below, because it is meant to be considered as
 # separate space-separated args.
-"$DART" --packages="$FLUTTER_TOOLS_DIR/.packages" $FLUTTER_TOOL_ARGS "$SNAPSHOT_PATH" "$@"
+if [[ $BUILD_SELF == false ]]; then
+  "$DART" --packages="$FLUTTER_TOOLS_DIR/.packages" $FLUTTER_TOOL_ARGS "$SNAPSHOT_PATH" "$@"
+fi

--- a/packages/flutter_tools/README.md
+++ b/packages/flutter_tools/README.md
@@ -86,8 +86,7 @@ This is what we do in the continuous integration bots.
 
 ### Forcing snapshot regeneration
 
-To force the Flutter Tools snapshot to be regenerated, delete the following
-files:
+To force the Flutter Tools snapshot to be regenerated, run:
 ```shell
-$ rm ../../bin/cache/flutter_tools.stamp ../../bin/cache/flutter_tools.snapshot
+$ flutter build self
 ```

--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -8,6 +8,7 @@ import '../aot.dart';
 import '../bundle.dart';
 import '../commands/build_linux.dart';
 import '../commands/build_macos.dart';
+import '../commands/build_self.dart';
 import '../commands/build_windows.dart';
 import '../runner/flutter_command.dart';
 import 'build_aar.dart';
@@ -35,6 +36,7 @@ class BuildCommand extends FlutterCommand {
     addSubcommand(BuildWebCommand());
     addSubcommand(BuildMacosCommand());
     addSubcommand(BuildLinuxCommand());
+    addSubcommand(BuildSelfCommand());
     addSubcommand(BuildWindowsCommand());
     addSubcommand(BuildFuchsiaCommand(verboseHelp: verboseHelp));
   }

--- a/packages/flutter_tools/lib/src/commands/build_self.dart
+++ b/packages/flutter_tools/lib/src/commands/build_self.dart
@@ -1,0 +1,23 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import '../runner/flutter_command.dart' show FlutterCommandResult;
+import 'build.dart';
+
+/// Document the "build self" command which is actually performed by
+/// code in <flutter src root>/bin/flutter.
+class BuildSelfCommand extends BuildSubCommand {
+  @override
+  final String name = 'self';
+
+  @override
+  String get description => 'build the flutter tool itself.';
+
+  @override
+  Future<FlutterCommandResult> runCommand() async {
+    return FlutterCommandResult.success();
+  }
+}


### PR DESCRIPTION
## Description

Instead of having to delete <flutter src root>/bin/cache/flutter_tools.*
to have flutter rebuild itself add support for "flutter build self".

## Related Issues

None

## Tests

I'm not sure how this should be tested. I'll be glad to add some
if someone can point me to some examples.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [x] Yes, but these are the same failures I see without this PR:

 (py38) wink@wink-desktop:~/prgs/flutter/flutter (Teach-flutter-to-build-itself)
 $ cat ../pub.run.test.Teach-flutter-to-build-itself.E.txt
 00:42 +127 -1: test/commands.shard/hermetic/shell_completion_test.dart: shell_completion generates bash initialization script to stdout [E]
 00:42 +128 -2: test/commands.shard/hermetic/shell_completion_test.dart: shell_completion generates bash initialization script to stdout with arg [E]
 00:42 +128 -3: test/commands.shard/hermetic/shell_completion_test.dart: shell_completion generates bash initialization script to output file [E]
 00:42 +129 -4: test/commands.shard/hermetic/shell_completion_test.dart: shell_completion won't overwrite existing output file  [E]
 00:42 +129 -5: test/commands.shard/hermetic/shell_completion_test.dart: shell_completion will overwrite existing output file if given --overwrite [E]
 01:46 +286 -6: test/commands.shard/permeable/packages_test.dart: packages test/pub test without bot [E]
 01:46 +286 -7: test/commands.shard/permeable/packages_test.dart: packages test/pub test with bot [E]
 01:46 +286 -8: test/commands.shard/permeable/packages_test.dart: packages test/pub run [E]
 05:44 +706 -9: test/general.shard/android/gradle_errors_test.dart: flavor undefined handler - with flavor [E]
 05:44 +706 -10: test/general.shard/android/gradle_errors_test.dart: flavor undefined handler - without flavor [E]
 16:46 +2087 ~11 -11: test/commands.shard/permeable/packages_test.dart: packages test/pub pub publish [E]
 31:46 +2087 ~11 -12: test/commands.shard/permeable/packages_test.dart: packages test/pub pub publish input fails [E]
 31:46 +2087 ~11 -13: test/commands.shard/permeable/packages_test.dart: packages test/pub publish [E]
 31:46 +2087 ~11 -14: test/commands.shard/permeable/packages_test.dart: packages test/pub packages publish [E]
 31:46 +2087 ~11 -15: test/commands.shard/permeable/packages_test.dart: packages test/pub deps [E]
 31:46 +2087 ~11 -16: test/commands.shard/permeable/packages_test.dart: packages test/pub cache [E]
 31:46 +2087 ~11 -17: test/commands.shard/permeable/packages_test.dart: packages test/pub version [E]
 31:46 +2087 ~11 -18: test/commands.shard/permeable/packages_test.dart: packages test/pub uploader [E]
 31:46 +2087 ~11 -19: test/commands.shard/permeable/packages_test.dart: packages test/pub global [E]


<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
