### PR TITLE
Android SDK test fixes

### DIFF
--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -1067,6 +1067,8 @@ plugin1=${plugin1.path}
       mockProcessManager = MockProcessManager();
       android = fakePlatform('android');
 
+      when(mockAndroidSdk.directory).thenReturn('irrelevant');
+
       final Directory rootDirectory = fileSystem.currentDirectory;
       cache = Cache(
         rootOverride: rootDirectory,
@@ -2653,5 +2655,4 @@ class MockFlutterProject extends Mock implements FlutterProject {}
 class MockLocalEngineArtifacts extends Mock implements LocalEngineArtifacts {}
 class MockProcessManager extends Mock implements ProcessManager {}
 class MockXcodeProjectInterpreter extends Mock implements XcodeProjectInterpreter {}
-class MockitoAndroidSdk extends Mock implements AndroidSdk {}
 class MockUsage extends Mock implements Usage {}

--- a/packages/flutter_tools/test/general.shard/commands/build_appbundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_appbundle_test.dart
@@ -155,6 +155,8 @@ void main() {
       });
 
       mockAndroidSdk = MockAndroidSdk();
+      when(mockAndroidSdk.licensesAvailable).thenReturn(true);
+      when(mockAndroidSdk.platformToolsAvailable).thenReturn(true);
       when(mockAndroidSdk.validateSdkWellFormed()).thenReturn(const <String>[]);
       when(mockAndroidSdk.directory).thenReturn('irrelevant');
     });


### PR DESCRIPTION
Two more fixes for #47963 

The Android SDK wasn't being set up properly in these cases.  In the gradle_test, on Windows, the `path` to be escaped was null, which caused a test failure if the test was run in such an order where the root directory wasn't set up ahead of time.

In the appbundle test, certain run orders didn't properly set booleans needed on the Android SDK object.

See https://api.cirrus-ci.com/v1/task/5566268459712512/logs/main.log for failures.