### PR TITLE
Fetch tags for version command

### DIFF
--- a/packages/flutter_tools/lib/src/commands/version.dart
+++ b/packages/flutter_tools/lib/src/commands/version.dart
@@ -41,6 +41,7 @@ class VersionCommand extends FlutterCommand {
   Version minSupportedVersion = Version.parse('1.2.1');
 
   Future<List<String>> getTags() async {
+    globals.flutterVersion.fetchTagsAndUpdate();
     RunResult runResult;
     try {
       runResult = await processUtils.run(

--- a/packages/flutter_tools/test/commands.shard/hermetic/version_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/version_test.dart
@@ -23,6 +23,7 @@ import '../../src/mocks.dart' show MockProcess;
 void main() {
   group('version', () {
     MockStdio mockStdio;
+    MockVersion mockVersion;
 
     setUpAll(() {
       Cache.disableLocking();
@@ -30,6 +31,7 @@ void main() {
 
     setUp(() {
       mockStdio = MockStdio();
+      mockVersion = MockVersion();
       when(mockStdio.stdinHasTerminal).thenReturn(false);
       when(mockStdio.hasTerminal).thenReturn(false);
     });
@@ -44,6 +46,7 @@ void main() {
     }, overrides: <Type, Generator>{
       ProcessManager: () => MockProcessManager(),
       Stdio: () => mockStdio,
+      FlutterVersion: () => mockVersion,
     });
 
     testUsingContext('version switch prompt is accepted', () async {
@@ -65,6 +68,7 @@ void main() {
       ProcessManager: () => MockProcessManager(),
       Stdio: () => mockStdio,
       AnsiTerminal: () => MockTerminal(),
+      FlutterVersion: () => mockVersion,
     });
 
     testUsingContext('version switch prompt is declined', () async {
@@ -86,6 +90,7 @@ void main() {
       ProcessManager: () => MockProcessManager(),
       Stdio: () => mockStdio,
       AnsiTerminal: () => MockTerminal(),
+      FlutterVersion: () => mockVersion,
     });
 
     testUsingContext('version switch, latest commit query fails', () async {
@@ -100,6 +105,7 @@ void main() {
     }, overrides: <Type, Generator>{
       ProcessManager: () => MockProcessManager(latestCommitFails: true),
       Stdio: () => mockStdio,
+      FlutterVersion: () => mockVersion,
     });
 
     testUsingContext('latest commit is parsable when query fails', () {
@@ -111,6 +117,7 @@ void main() {
     }, overrides: <Type, Generator>{
       ProcessManager: () => MockProcessManager(latestCommitFails: true),
       Stdio: () => mockStdio,
+      FlutterVersion: () => mockVersion,
     });
 
     testUsingContext('switch to not supported version without force', () async {
@@ -125,6 +132,7 @@ void main() {
     }, overrides: <Type, Generator>{
       ProcessManager: () => MockProcessManager(),
       Stdio: () => mockStdio,
+      FlutterVersion: () => mockVersion,
     });
 
     testUsingContext('switch to not supported version with force', () async {
@@ -140,6 +148,7 @@ void main() {
     }, overrides: <Type, Generator>{
       ProcessManager: () => MockProcessManager(),
       Stdio: () => mockStdio,
+      FlutterVersion: () => mockVersion,
     });
 
     testUsingContext('tool exit on confusing version', () async {
@@ -156,6 +165,7 @@ void main() {
     }, overrides: <Type, Generator>{
       ProcessManager: () => MockProcessManager(),
       Stdio: () => mockStdio,
+      FlutterVersion: () => mockVersion,
     });
 
     testUsingContext("exit tool if can't get the tags", () async {
@@ -169,6 +179,7 @@ void main() {
     }, overrides: <Type, Generator>{
       ProcessManager: () => MockProcessManager(failGitTag: true),
       Stdio: () => mockStdio,
+      FlutterVersion: () => mockVersion,
     });
 
     testUsingContext('Does not run pub when outside a project', () async {
@@ -180,10 +191,24 @@ void main() {
     }, overrides: <Type, Generator>{
       ProcessManager: () => MockProcessManager(),
       Stdio: () => mockStdio,
+      FlutterVersion: () => mockVersion,
+    });
+
+    testUsingContext('Fetches upstream tags', () async {
+      final VersionCommand command = VersionCommand();
+      await createTestCommandRunner(command).run(<String>[
+        'version',
+      ]);
+      verify(mockVersion.fetchTagsAndUpdate()).called(1);
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => MockProcessManager(),
+      Stdio: () => mockStdio,
+      FlutterVersion: () => mockVersion,
     });
   });
 }
 
+class MockVersion extends Mock implements FlutterVersion {}
 class MockTerminal extends Mock implements AnsiTerminal {}
 class MockStdio extends Mock implements Stdio {}
 class MockProcessManager extends Mock implements ProcessManager {


### PR DESCRIPTION
## Description

Fetch upstream tags as part of the `version` command. 

## Related Issues

Fixes reported issues in  #14230 
See also #52062 

## Tests

I added the following tests:

Assert that `flutter version` calls the `fetchAndUpdateTags` on the global `flutterVersion`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
