### PR TITLE
Apply fetch tag logic to upgrade command, build ios framework.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -232,6 +232,7 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
   void produceFlutterPodspec(BuildMode mode, Directory modeDirectory, { bool force = false }) {
     final Status status = globals.logger.startProgress(' ├─Creating Flutter.podspec...', timeout: timeoutConfiguration.fastOperation);
     try {
+      _flutterVersion.fetchTagsAndUpdate();
       final GitTagVersion gitTagVersion = _flutterVersion.gitTagVersion;
       if (!force && (gitTagVersion.x == null || gitTagVersion.y == null || gitTagVersion.z == null || gitTagVersion.commits != 0)) {
         throwToolExit(

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -39,7 +39,7 @@ class UpgradeCommand extends FlutterCommand {
       ..addOption(
         'working-directory',
         hide: true,
-        help: 'Override the upgrade working directoy for integration testing.'
+        help: 'Override the upgrade working directory for integration testing.'
       );
   }
 
@@ -61,7 +61,6 @@ class UpgradeCommand extends FlutterCommand {
       force: boolArg('force'),
       continueFlow: boolArg('continue'),
       testFlow: stringArg('working-directory') != null,
-      gitTagVersion: GitTagVersion.determine(processUtils),
       flutterVersion: stringArg('working-directory') == null
         ? globals.flutterVersion
         : FlutterVersion(const SystemClock(), _commandRunner.workingDirectory),
@@ -78,13 +77,12 @@ class UpgradeCommandRunner {
     @required bool force,
     @required bool continueFlow,
     @required bool testFlow,
-    @required GitTagVersion gitTagVersion,
     @required FlutterVersion flutterVersion,
   }) async {
+    flutterVersion.fetchTagsAndUpdate();
     if (!continueFlow) {
       await runCommandFirstHalf(
         force: force,
-        gitTagVersion: gitTagVersion,
         flutterVersion: flutterVersion,
         testFlow: testFlow,
       );
@@ -96,11 +94,11 @@ class UpgradeCommandRunner {
 
   Future<void> runCommandFirstHalf({
     @required bool force,
-    @required GitTagVersion gitTagVersion,
     @required FlutterVersion flutterVersion,
     @required bool testFlow,
   }) async {
     await verifyUpstreamConfigured();
+    final GitTagVersion gitTagVersion = flutterVersion.gitTagVersion;
     if (!force && gitTagVersion == const GitTagVersion.unknown()) {
       // If the commit is a recognized branch and not master,
       // explain that we are avoiding potential damage.

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
@@ -46,6 +46,27 @@ void main() {
         ..createSync();
     });
 
+    testUsingContext('Fetches upstream tags', () async {
+      final File licenseFile = memoryFileSystem.file('license')..createSync(recursive: true);
+      when(mockCache.getLicenseFile()).thenReturn(licenseFile);
+
+      when(mockFlutterVersion.gitTagVersion).thenReturn(const GitTagVersion(1, 2, 3, 4, 0, 'deadbeef'));
+
+      final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
+        aotBuilder: MockAotBuilder(),
+        bundleBuilder: MockBundleBuilder(),
+        platform: fakePlatform,
+        flutterVersion: mockFlutterVersion,
+        cache: mockCache
+      );
+
+      command.produceFlutterPodspec(BuildMode.debug, outputDirectory);
+      verify(mockFlutterVersion.fetchTagsAndUpdate()).called(1);
+    }, overrides: <Type, Generator>{
+      FileSystem: () => memoryFileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
+    });
+
     group('podspec', () {
       const String storageBaseUrl = 'https://fake.googleapis.com';
       const String engineRevision = '0123456789abcdef';


### PR DESCRIPTION
Applies logic from #52141  to `upgrade` and `build ios-framework`.  Both of these depend on tags being correct to run properly.

This is expected to not regress benchmarks, since `analyze`, `run`, and other build commands that do not depend on tags are not affected.

/cc @zanderso @jonahwilliams @jmagman 