### PR TITLE
[flutter_tools] ensure --track-widget-creation is not enabled for build aot

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -25,7 +25,7 @@ class BuildCommand extends FlutterCommand {
     addSubcommand(BuildAarCommand());
     addSubcommand(BuildApkCommand(verboseHelp: verboseHelp));
     addSubcommand(BuildAppBundleCommand(verboseHelp: verboseHelp));
-    addSubcommand(BuildAotCommand(verboseHelp: verboseHelp));
+    addSubcommand(BuildAotCommand());
     addSubcommand(BuildIOSCommand());
     addSubcommand(BuildIOSFrameworkCommand(
       aotBuilder: AotBuilder(),

--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -14,7 +14,7 @@ import 'build.dart';
 
 /// Builds AOT snapshots into platform specific library containers.
 class BuildAotCommand extends BuildSubCommand with TargetPlatformBasedDevelopmentArtifacts {
-  BuildAotCommand({bool verboseHelp = false, this.aotBuilder}) {
+  BuildAotCommand({this.aotBuilder}) {
     addTreeShakeIconsFlag();
     usesTargetOption();
     addBuildModeFlags();
@@ -51,10 +51,6 @@ class BuildAotCommand extends BuildSubCommand with TargetPlatformBasedDevelopmen
         help: 'Build the AOT bundle with bitcode. Requires a compatible bitcode engine.',
         hide: true,
       );
-    // --track-widget-creation is exposed as a flag here to deal with build
-    // invalidation issues, but it is ignored -- there are no plans to support
-    // it for AOT mode.
-    usesTrackWidgetCreation(hasEffect: false, verboseHelp: verboseHelp);
   }
 
   AotBuilder aotBuilder;


### PR DESCRIPTION
## Description

Since the flag defaulted to on, it was being passed to the compiler increasing code size. Not severe since this command is currently only used for benchmarking