### PR TITLE
[flutter_tools] move stack_trace_mapper and require.js into memory files

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
@@ -510,14 +510,16 @@ class WebDevFS implements DevFS {
     if (bundleFirstUpload) {
       generator.addFileSystemRoot(outputDirectoryPath);
       final String entrypoint = globals.fs.path.basename(mainPath);
+      webAssetServer.writeFile('/require.js', requireJS.readAsStringSync());
+      webAssetServer.writeFile('/dart_stack_trace_mapper.js', stackTraceMapper.readAsStringSync());
       webAssetServer.writeFile('/$entrypoint', globals.fs.file(mainPath).readAsStringSync());
       webAssetServer.writeFile('/manifest.json', '{"info":"manifest not generated in run mode."}');
       webAssetServer.writeFile('/flutter_service_worker.js', '// Service worker not loaded in run mode.');
       webAssetServer.writeFile(
         '/main.dart.js',
         generateBootstrapScript(
-          requireUrl: _filePathToUriFragment(requireJS.path),
-          mapperUrl: _filePathToUriFragment(stackTraceMapper.path),
+          requireUrl: '/require.js',
+          mapperUrl: '/dart_stack_trace_mapper.js',
           entrypoint: '/$entrypoint.lib.js',
         ),
       );
@@ -602,19 +604,6 @@ class WebDevFS implements DevFS {
     'web',
     'dart_stack_trace_mapper.js',
   ));
-}
-
-String _filePathToUriFragment(String path) {
-  if (globals.platform.isWindows) {
-    final bool startWithSlash = path.startsWith('/');
-    final String partial =
-        globals.fs.path.split(path).skip(startWithSlash ? 2 : 1).join('/');
-    if (partial.startsWith('/')) {
-      return partial;
-    }
-    return '/$partial';
-  }
-  return path;
 }
 
 class ReleaseAssetServer {

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -367,6 +367,8 @@ void main() {
       invalidatedFiles: <Uri>[],
     );
 
+    expect(webDevFS.webAssetServer.getFile('/require.js'), isNotNull);
+    expect(webDevFS.webAssetServer.getFile('/dart_stack_trace_mapper.js'), isNotNull);
     expect(webDevFS.webAssetServer.getFile('/main.dart'), isNotNull);
     expect(webDevFS.webAssetServer.getFile('/manifest.json'), isNotNull);
     expect(webDevFS.webAssetServer.getFile('/flutter_service_worker.js'), isNotNull);


### PR DESCRIPTION
## Description

Can't repro the issue locally, but could be caused by wonky paths. Simplify this logic by pulling these files into the server directly.

https://github.com/flutter/flutter/issues/52174