### PR TITLE
[flutter_tools] configure dwds to not serve devtools

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
@@ -91,6 +91,7 @@ class WebAssetServer implements AssetReader {
         },
         urlEncoder: urlTunneller,
         enableDebugging: true,
+        serveDevTools: false,
         logWriter: (Level logLevel, String message) => globals.printTrace(message)
       );
       shelf.Pipeline pipeline = const shelf.Pipeline();


### PR DESCRIPTION
## Description

This isn't necessary for any current functionality. Fixes https://github.com/flutter/flutter/issues/52269