### PR TITLE
Migrate older Xcode projects off the legacy build system

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -24,6 +24,7 @@ import '../reporting/reporting.dart';
 import 'code_signing.dart';
 import 'migrations/ios_migrator.dart';
 import 'migrations/remove_framework_link_and_embedding_migration.dart';
+import 'migrations/xcode_build_system_migration.dart';
 import 'xcodeproj.dart';
 
 class IMobileDevice {
@@ -90,7 +91,8 @@ Future<XcodeBuildResult> buildXcodeProject({
   }
 
   final List<IOSMigrator> migrators = <IOSMigrator>[
-    RemoveFrameworkLinkAndEmbeddingMigration(app.project, globals.logger, globals.xcode, globals.flutterUsage)
+    RemoveFrameworkLinkAndEmbeddingMigration(app.project, globals.logger, globals.xcode, globals.flutterUsage),
+    XcodeBuildSystemMigration(app.project, globals.logger),
   ];
 
   final IOSMigration migration = IOSMigration(migrators);

--- a/packages/flutter_tools/lib/src/ios/migrations/ios_migrator.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/ios_migrator.dart
@@ -20,7 +20,10 @@ abstract class IOSMigrator {
   bool migrate();
 
   /// Return null if the line should be deleted.
-  String migrateLine(String line);
+  @protected
+  String migrateLine(String line) {
+    return line;
+  }
 
   @protected
   void processFileLines(File file) {

--- a/packages/flutter_tools/lib/src/ios/migrations/remove_framework_link_and_embedding_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/remove_framework_link_and_embedding_migration.dart
@@ -31,10 +31,6 @@ class RemoveFrameworkLinkAndEmbeddingMigration extends IOSMigrator {
   /// Inspect [project] for necessary migrations and rewrite files as needed.
   @override
   bool migrate() {
-    return _migrateXcodeProjectInfoFile();
-  }
-
-  bool _migrateXcodeProjectInfoFile() {
     if (!_xcodeProjectInfoFile.existsSync()) {
       logger.printTrace('Xcode project not found, skipping migration');
       return true;

--- a/packages/flutter_tools/lib/src/ios/migrations/remove_framework_link_and_embedding_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/remove_framework_link_and_embedding_migration.dart
@@ -10,9 +10,9 @@ import '../../project.dart';
 import '../../reporting/reporting.dart';
 import 'ios_migrator.dart';
 
-/// Xcode 11.4 requires linked and embedded frameworks to contain all targeted architectures before build phases are run.
-/// This caused issues switching between a real device and simulator due to architecture mismatch.
-/// Remove the linking and embedding logic from the Xcode project to give the tool more control over these.
+// Xcode 11.4 requires linked and embedded frameworks to contain all targeted architectures before build phases are run.
+// This caused issues switching between a real device and simulator due to architecture mismatch.
+// Remove the linking and embedding logic from the Xcode project to give the tool more control over these.
 class RemoveFrameworkLinkAndEmbeddingMigration extends IOSMigrator {
   RemoveFrameworkLinkAndEmbeddingMigration(
     IosProject project,
@@ -28,7 +28,6 @@ class RemoveFrameworkLinkAndEmbeddingMigration extends IOSMigrator {
   final Xcode _xcode;
   final Usage _usage;
 
-  /// Inspect [project] for necessary migrations and rewrite files as needed.
   @override
   bool migrate() {
     if (!_xcodeProjectInfoFile.existsSync()) {

--- a/packages/flutter_tools/lib/src/ios/migrations/xcode_build_system_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/xcode_build_system_migration.dart
@@ -30,13 +30,11 @@ class XcodeBuildSystemMigration extends IOSMigrator {
 
     // Only delete this file when it matches the original Flutter template.
     const String legacyBuildSettingsWorkspace = '''
-<?xml version="1.0" encoding="UTF-8"?>	
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">	
-<plist version="1.0">	
-<dict>	
-	<key>BuildSystemType</key>	
-	<string>Original</string>	
-</dict>	
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+</dict>
 </plist>''';
 
     // contains instead of equals to ignore newline file ending variance.

--- a/packages/flutter_tools/lib/src/ios/migrations/xcode_build_system_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/xcode_build_system_migration.dart
@@ -7,9 +7,9 @@ import '../../base/logger.dart';
 import '../../project.dart';
 import 'ios_migrator.dart';
 
-/// Xcode legacy build system no longer supported by Xcode.
-/// Set in https://github.com/flutter/flutter/pull/21901/.
-/// Removed in https://github.com/flutter/flutter/pull/33684.
+// Xcode legacy build system no longer supported by Xcode.
+// Set in https://github.com/flutter/flutter/pull/21901/.
+// Removed in https://github.com/flutter/flutter/pull/33684.
 class XcodeBuildSystemMigration extends IOSMigrator {
   XcodeBuildSystemMigration(
     IosProject project,

--- a/packages/flutter_tools/lib/src/ios/migrations/xcode_build_system_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/xcode_build_system_migration.dart
@@ -42,7 +42,7 @@ class XcodeBuildSystemMigration extends IOSMigrator {
       logger.printStatus('Legacy build system detected, removing ${_xcodeWorkspaceSharedSettings.path}');
       _xcodeWorkspaceSharedSettings.deleteSync();
     }
-    
+
     return true;
   }
 }

--- a/packages/flutter_tools/lib/src/ios/migrations/xcode_build_system_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/xcode_build_system_migration.dart
@@ -1,0 +1,50 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import '../../base/file_system.dart';
+import '../../base/logger.dart';
+import '../../project.dart';
+import 'ios_migrator.dart';
+
+/// Xcode legacy build system no longer supported by Xcode.
+/// Set in https://github.com/flutter/flutter/pull/21901/.
+/// Removed in https://github.com/flutter/flutter/pull/33684.
+class XcodeBuildSystemMigration extends IOSMigrator {
+  XcodeBuildSystemMigration(
+    IosProject project,
+    Logger logger,
+  ) : _xcodeWorkspaceSharedSettings = project.xcodeWorkspaceSharedSettings,
+      super(logger);
+
+  final File _xcodeWorkspaceSharedSettings;
+
+  @override
+  bool migrate() {
+    if (!_xcodeWorkspaceSharedSettings.existsSync()) {
+      logger.printTrace('Xcode workspace settings not found, skipping migration');
+      return true;
+    }
+
+    final String contents = _xcodeWorkspaceSharedSettings.readAsStringSync();
+
+    // Only delete this file when it matches the original Flutter template.
+    const String legacyBuildSettingsWorkspace = '''
+<?xml version="1.0" encoding="UTF-8"?>	
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">	
+<plist version="1.0">	
+<dict>	
+	<key>BuildSystemType</key>	
+	<string>Original</string>	
+</dict>	
+</plist>''';
+
+    // contains instead of equals to ignore newline file ending variance.
+    if (contents.contains(legacyBuildSettingsWorkspace)) {
+      logger.printStatus('Legacy build system detected, removing ${_xcodeWorkspaceSharedSettings.path}');
+      _xcodeWorkspaceSharedSettings.deleteSync();
+    }
+    
+    return true;
+  }
+}

--- a/packages/flutter_tools/test/general.shard/ios/ios_project_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_project_migration_test.dart
@@ -12,6 +12,7 @@ import 'package:platform/platform.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/ios/migrations/remove_framework_link_and_embedding_migration.dart';
+import 'package:flutter_tools/src/ios/migrations/xcode_build_system_migration.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
@@ -255,6 +256,84 @@ keep this 2
         );
         expect(() =>iosProjectMigration.migrate(), throwsToolExit(message: 'Your Xcode project requires migration'));
         verify(mockUsage.sendEvent('ios-migration', 'remove-frameworks', label: 'failure', value: null));
+      });
+    });
+
+    group('new Xcode build system', () {
+      MemoryFileSystem memoryFileSystem;
+      BufferLogger testLogger;
+      MockIosProject mockIosProject;
+      File xcodeWorkspaceSharedSettings;
+
+      setUp(() {
+        memoryFileSystem = MemoryFileSystem();
+        xcodeWorkspaceSharedSettings = memoryFileSystem.file('WorkspaceSettings.xcsettings');
+
+        testLogger = BufferLogger(
+          terminal: AnsiTerminal(
+            stdio: null,
+            platform: const LocalPlatform(),
+          ),
+          outputPreferences: OutputPreferences.test(),
+        );
+
+        mockIosProject = MockIosProject();
+        when(mockIosProject.xcodeWorkspaceSharedSettings).thenReturn(xcodeWorkspaceSharedSettings);
+      });
+
+      testWithoutContext('skipped if files are missing', () {
+        final XcodeBuildSystemMigration iosProjectMigration = XcodeBuildSystemMigration(
+          mockIosProject,
+          testLogger,
+        );
+        expect(iosProjectMigration.migrate(), isTrue);
+
+        expect(xcodeWorkspaceSharedSettings.existsSync(), isFalse);
+
+        expect(testLogger.traceText, contains('Xcode workspace settings not found, skipping migration'));
+        expect(testLogger.statusText, isEmpty);
+      });
+
+      testWithoutContext('skipped if nothing to upgrade', () {
+        const String contents = '''
+<?xml version="1.0" encoding="UTF-8"?>	
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">	
+<plist version="1.0">	
+<dict>	
+	<key>BuildSystemType</key>	
+	<string></string>	
+</dict>	
+</plist>''';
+        xcodeWorkspaceSharedSettings.writeAsStringSync(contents);
+
+        final XcodeBuildSystemMigration iosProjectMigration = XcodeBuildSystemMigration(
+          mockIosProject,
+          testLogger,
+        );
+        expect(iosProjectMigration.migrate(), isTrue);
+        expect(testLogger.statusText, isEmpty);
+      });
+
+      testWithoutContext('Xcode project is migrated', () {
+        const String contents = '''
+<?xml version="1.0" encoding="UTF-8"?>	
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">	
+<plist version="1.0">	
+<dict>	
+	<key>BuildSystemType</key>	
+	<string>Original</string>	
+</dict>	
+</plist>''';
+        xcodeWorkspaceSharedSettings.writeAsStringSync(contents);
+
+        final XcodeBuildSystemMigration iosProjectMigration = XcodeBuildSystemMigration(
+          mockIosProject,
+          testLogger,
+        );
+        expect(iosProjectMigration.migrate(), isTrue);
+        expect(xcodeWorkspaceSharedSettings.existsSync(), isFalse);
+
+        expect(testLogger.statusText, contains('Legacy build system detected, removing'));
       });
     });
   });

--- a/packages/flutter_tools/test/general.shard/ios/ios_project_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_project_migration_test.dart
@@ -316,13 +316,13 @@ keep this 2
 
       testWithoutContext('Xcode project is migrated', () {
         const String contents = '''
-<?xml version="1.0" encoding="UTF-8"?>	
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">	
-<plist version="1.0">	
-<dict>	
-	<key>BuildSystemType</key>	
-	<string>Original</string>	
-</dict>	
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+</dict>
 </plist>''';
         xcodeWorkspaceSharedSettings.writeAsStringSync(contents);
 

--- a/packages/flutter_tools/test/general.shard/ios/ios_project_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_project_migration_test.dart
@@ -287,7 +287,6 @@ keep this 2
           testLogger,
         );
         expect(iosProjectMigration.migrate(), isTrue);
-
         expect(xcodeWorkspaceSharedSettings.existsSync(), isFalse);
 
         expect(testLogger.traceText, contains('Xcode workspace settings not found, skipping migration'));
@@ -311,6 +310,7 @@ keep this 2
           testLogger,
         );
         expect(iosProjectMigration.migrate(), isTrue);
+        expect(xcodeWorkspaceSharedSettings.existsSync(), isTrue);
         expect(testLogger.statusText, isEmpty);
       });
 

--- a/packages/flutter_tools/test/general.shard/ios/ios_project_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_project_migration_test.dart
@@ -296,13 +296,13 @@ keep this 2
 
       testWithoutContext('skipped if nothing to upgrade', () {
         const String contents = '''
-<?xml version="1.0" encoding="UTF-8"?>	
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">	
-<plist version="1.0">	
-<dict>	
-	<key>BuildSystemType</key>	
-	<string></string>	
-</dict>	
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string></string>
+</dict>
 </plist>''';
         xcodeWorkspaceSharedSettings.writeAsStringSync(contents);
 


### PR DESCRIPTION
## Description

Legacy build system was introduced to work around https://github.com/flutter/flutter/issues/20685#issuecomment-542322890.  Legacy build system is now causing linker issues with plugins.  Remove the build system if they still have the default workspace settings.  Ignore the file if it's not quite the same because they already followed the manual migration instructions.

## Related Issues
Legacy build system introduced in https://github.com/flutter/flutter/pull/21901
Reverted in https://github.com/flutter/flutter/pull/33684

Fixes https://github.com/flutter/flutter/issues/51992.

Manually fixed in https://github.com/flutter/plugins/pull/2592 https://github.com/FirebaseExtended/flutterfire/pull/2152

## Tests

Added XcodeBuildSystemMigration tests.
Checked out plugin examples before they were manually fixed, confirmed with this change the workspace settings file were deleted.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*