### PR TITLE
[sdk] update default animation behavior of AnimationController

### DIFF
--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -237,7 +237,7 @@ class AnimationController extends Animation<double>
     this.debugLabel,
     this.lowerBound = 0.0,
     this.upperBound = 1.0,
-    this.animationBehavior = AnimationBehavior.normal,
+    this.animationBehavior = AnimationBehavior.preserve,
     @required TickerProvider vsync,
   }) : assert(lowerBound != null),
        assert(upperBound != null),

--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -763,7 +763,7 @@ void main() {
   group('AnimationBehavior', () {
     test('Default values for constructor', () {
       final AnimationController controller = AnimationController(vsync: const TestVSync());
-      expect(controller.animationBehavior, AnimationBehavior.normal);
+      expect(controller.animationBehavior, AnimationBehavior.preserve);
 
       final AnimationController repeating = AnimationController.unbounded(vsync: const TestVSync());
       expect(repeating.animationBehavior, AnimationBehavior.preserve);


### PR DESCRIPTION
## Description

It seems likely from several code snippets I've seen lately that this isn't being handled correctly, and likely won't be seen if incorrect since developers may not test code with animations disabled.

I think we should probably switch the default, then as needed update animation controllers to use `normal` where possible in the SDK