### PR TITLE
[flutter_tools] attempt to fix a List.first crasher in web loading

### DIFF
--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -234,6 +234,9 @@ class ChromeLauncher {
       final HttpClientRequest request = await client.getUrl(base.resolve('/json/list'));
       final HttpClientResponse response = await request.close();
       final List<dynamic> jsonObject = await json.fuse(utf8).decoder.bind(response).single as List<dynamic>;
+      if (jsonObject == null || jsonObject.isEmpty) {
+        return base;
+      }
       return base.resolve(jsonObject.first['devtoolsFrontendUrl'] as String);
     } on Exception {
       // If we fail to talk to the remote debugger protocol, give up and return


### PR DESCRIPTION
## Description

Crash is caused by bad .first call?

```
  Failed to load "/tmp/flutter sdk/packages/flutter/test/cupertino/button_test.dart": Bad state: No element
  dart:core-patch/growable_array.dart 219:5                     List.first
  package:flutter_tools/src/web/chrome.dart 237:38              ChromeLauncher._getRemoteDebuggerUrl
  ===== asynchronous gap ===========================
  dart:async/future.dart 276:45                                 new Future.error
  package:test_core/src/runner/loader.dart 246:26               Loader.loadFile.<fn>
  ===== asynchronous gap ===========================
  dart:async/zone.dart 1064:19                                  _CustomZone.registerBinaryCallback
  dart:async-patch/async_patch.dart 84:23                       _asyncErrorWrapperHelper
  package:test_core/src/runner/loader.dart                      Loader.loadFile.<fn>
  package:test_core/src/runner/load_suite.dart 98:31            new LoadSuite.<fn>.<fn>
  package:test_core/src/runner/load_suite.dart 108:8            new LoadSuite.<fn>
  package:test_api/src/backend/invoker.dart 400:25              Invoker._onRun.<fn>.<fn>.<fn>.<fn>
  dart:async/future.dart 176:37                                 new Future.<fn>
```