### PR TITLE
[flutter_tools] cache result of BotDetector in persistent tool state

### DIFF
--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -35,8 +35,6 @@ Future<int> run(
   String flutterVersion,
   Map<Type, Generator> overrides,
 }) async {
-  reportCrashes ??= !await globals.isRunningOnBot;
-
   if (muteCommandLogging) {
     // Remove the verbose option; for help and doctor, users don't need to see
     // verbose logs.
@@ -48,6 +46,8 @@ Future<int> run(
   commands.forEach(runner.addCommand);
 
   return runInContext<int>(() async {
+    reportCrashes ??= !await globals.isRunningOnBot;
+
     // Initialize the system locale.
     final String systemLocale = await intl_standalone.findSystemLocale();
     intl.Intl.defaultLocale = intl.Intl.verifiedLocale(

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -80,6 +80,7 @@ XCDevice get xcdevice => context.get<XCDevice>();
 final BotDetector _defaultBotDetector = BotDetector(
   httpClientFactory: context.get<HttpClientFactory>() ?? () => HttpClient(),
   platform: platform,
+  persistentToolState: persistentToolState,
 );
 
 BotDetector get botDetector => context.get<BotDetector>() ?? _defaultBotDetector;

--- a/packages/flutter_tools/lib/src/persistent_tool_state.dart
+++ b/packages/flutter_tools/lib/src/persistent_tool_state.dart
@@ -46,6 +46,9 @@ abstract class PersistentToolState {
 
   /// Update the last active version for a given [channel].
   void updateLastActiveVersion(String fullGitHash, Channel channel);
+
+  /// Whether this client was already determined to be or not be a bot.
+  bool isBot;
 }
 
 class _DefaultPersistentToolState implements PersistentToolState {
@@ -78,6 +81,7 @@ class _DefaultPersistentToolState implements PersistentToolState {
     Channel.beta: 'last-active-beta-version',
     Channel.stable: 'last-active-stable-version'
   };
+  static const String _kAzureBot = 'azure-bot';
 
   final Config _config;
 
@@ -108,4 +112,10 @@ class _DefaultPersistentToolState implements PersistentToolState {
   String _versionKeyFor(Channel channel) {
     return _lastActiveVersionKeys[channel];
   }
+
+  @override
+  bool get isBot => _config.getValue(_kAzureBot) as bool;
+
+  @override
+  set isBot(bool value) => _config.setValue(_kAzureBot, value);
 }

--- a/packages/flutter_tools/lib/src/persistent_tool_state.dart
+++ b/packages/flutter_tools/lib/src/persistent_tool_state.dart
@@ -48,7 +48,7 @@ abstract class PersistentToolState {
   void updateLastActiveVersion(String fullGitHash, Channel channel);
 
   /// Whether this client was already determined to be or not be a bot.
-  bool isBot;
+  bool isRunningOnBot;
 }
 
 class _DefaultPersistentToolState implements PersistentToolState {
@@ -114,8 +114,8 @@ class _DefaultPersistentToolState implements PersistentToolState {
   }
 
   @override
-  bool get isBot => _config.getValue(_kAzureBot) as bool;
+  bool get isRunningOnBot => _config.getValue(_kAzureBot) as bool;
 
   @override
-  set isBot(bool value) => _config.setValue(_kAzureBot, value);
+  set isRunningOnBot(bool value) => _config.setValue(_kAzureBot, value);
 }

--- a/packages/flutter_tools/lib/src/persistent_tool_state.dart
+++ b/packages/flutter_tools/lib/src/persistent_tool_state.dart
@@ -81,7 +81,7 @@ class _DefaultPersistentToolState implements PersistentToolState {
     Channel.beta: 'last-active-beta-version',
     Channel.stable: 'last-active-stable-version'
   };
-  static const String _kAzureBot = 'azure-bot';
+  static const String _kBotKey = 'is-bot';
 
   final Config _config;
 
@@ -114,8 +114,8 @@ class _DefaultPersistentToolState implements PersistentToolState {
   }
 
   @override
-  bool get isRunningOnBot => _config.getValue(_kAzureBot) as bool;
+  bool get isRunningOnBot => _config.getValue(_kBotKey) as bool;
 
   @override
-  set isRunningOnBot(bool value) => _config.setValue(_kAzureBot, value);
+  set isRunningOnBot(bool value) => _config.setValue(_kBotKey, value);
 }

--- a/packages/flutter_tools/test/general.shard/base/bot_detector_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/bot_detector_test.dart
@@ -82,7 +82,7 @@ void main() {
         when(mockHttpClientRequest.headers).thenReturn(mockHttpHeaders);
 
         expect(await botDetector.isRunningOnBot, isTrue);
-        expect(persistentToolState.isRunningOnBot, isFalse);
+        expect(persistentToolState.isRunningOnBot, isTrue);
       });
 
       testWithoutContext('caches azure bot detection results across instances', () async {
@@ -104,7 +104,7 @@ void main() {
         fakePlatform.environment['BORG_ALLOC_DIR'] = 'true';
 
         expect(await botDetector.isRunningOnBot, isTrue);
-        expect(persistentToolState.isRunningOnBot, isFalse);
+        expect(persistentToolState.isRunningOnBot, isTrue);
       });
     });
   });


### PR DESCRIPTION
## Description

The Azure bot detection can take up to a second to determine if a client is/isn't a bot. To prevent this from slowing down all flutter commands, we can cache the results in the persistent tool state - since we don't expect the same client id to ever become a bot or stop being a bot

Fixes https://github.com/flutter/flutter/issues/52065