### PR TITLE
[flutter_tool] Use unzip -t instead of zip -T to verify zip files

### DIFF
--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -223,7 +223,7 @@ class _PosixUtils extends OperatingSystemUtils {
 
   @override
   bool verifyZip(File zipFile) =>
-    _processUtils.exitsHappySync(<String>['zip', '-T', zipFile.path]);
+    _processUtils.exitsHappySync(<String>['unzip', '-t', '-qq', zipFile.path]);
 
   // tar -xzf tarball -C dest
   @override


### PR DESCRIPTION
## Description

This PR uses `unzip -t` instead of `zip -T` to verify zip files. Some users don't have zip installed.

## Related Issues

https://github.com/flutter/flutter/issues/52272

## Tests

There is no change in functionality.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
