### PR TITLE
Fix a11y scrolling for reversed lists

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -447,14 +447,22 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
   void _updateSemanticActions() {
     SemanticsAction forward;
     SemanticsAction backward;
-    switch (axis) {
-      case Axis.vertical:
+    switch (axisDirection) {
+      case AxisDirection.up:
+        forward = SemanticsAction.scrollDown;
+        backward = SemanticsAction.scrollUp;
+        break;
+      case AxisDirection.right:
+        forward = SemanticsAction.scrollLeft;
+        backward = SemanticsAction.scrollRight;
+        break;
+      case AxisDirection.down:
         forward = SemanticsAction.scrollUp;
         backward = SemanticsAction.scrollDown;
         break;
-      case Axis.horizontal:
-        forward = SemanticsAction.scrollLeft;
-        backward = SemanticsAction.scrollRight;
+      case AxisDirection.left:
+        forward = SemanticsAction.scrollRight;
+        backward = SemanticsAction.scrollLeft;
         break;
     }
 

--- a/packages/flutter/test/widgets/list_view_semantics_test.dart
+++ b/packages/flutter/test/widgets/list_view_semantics_test.dart
@@ -10,6 +10,10 @@ import 'semantics_tester.dart';
 void main() {
   group('Available semantic scroll actions', () {
     // Regression tests for https://github.com/flutter/flutter/issues/52032.
+
+    const int itemCount = 10;
+    const double itemHeight = 150.0;
+
     testWidgets('forward vertical', (WidgetTester tester) async {
       final SemanticsTester semantics = SemanticsTester(tester);
       final ScrollController controller = ScrollController();
@@ -19,10 +23,10 @@ void main() {
           textDirection: TextDirection.ltr,
           child: ListView.builder(
             controller: controller,
-            itemCount: 10,
+            itemCount: itemCount,
             itemBuilder: (BuildContext context, int index) {
               return SizedBox(
-                height: 150,
+                height: itemHeight,
                 child: Text('Tile $index'),
               );
             },
@@ -33,7 +37,7 @@ void main() {
       expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.scrollUp]));
 
       // Jump to the end.
-      controller.jumpTo(10 * 150.0);
+      controller.jumpTo(itemCount * itemHeight);
       await tester.pumpAndSettle();
       expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.scrollDown]));
 
@@ -50,10 +54,10 @@ void main() {
           child: ListView.builder(
             reverse: true,
             controller: controller,
-            itemCount: 10,
+            itemCount: itemCount,
             itemBuilder: (BuildContext context, int index) {
               return SizedBox(
-                height: 150,
+                height: itemHeight,
                 child: Text('Tile $index'),
               );
             },
@@ -64,7 +68,7 @@ void main() {
       expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.scrollDown]));
 
       // Jump to the end.
-      controller.jumpTo(10 * 150.0);
+      controller.jumpTo(itemCount * itemHeight);
       await tester.pumpAndSettle();
       expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.scrollUp]));
 
@@ -81,10 +85,10 @@ void main() {
           child: ListView.builder(
             scrollDirection: Axis.horizontal,
             controller: controller,
-            itemCount: 10,
+            itemCount: itemCount,
             itemBuilder: (BuildContext context, int index) {
               return SizedBox(
-                height: 150,
+                height: itemHeight,
                 child: Text('Tile $index'),
               );
             },
@@ -95,7 +99,7 @@ void main() {
       expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.scrollLeft]));
 
       // Jump to the end.
-      controller.jumpTo(10 * 150.0);
+      controller.jumpTo(itemCount * itemHeight);
       await tester.pumpAndSettle();
       expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.scrollRight]));
 
@@ -113,10 +117,10 @@ void main() {
             scrollDirection: Axis.horizontal,
             reverse: true,
             controller: controller,
-            itemCount: 10,
+            itemCount: itemCount,
             itemBuilder: (BuildContext context, int index) {
               return SizedBox(
-                height: 150,
+                height: itemHeight,
                 child: Text('Tile $index'),
               );
             },
@@ -127,7 +131,7 @@ void main() {
       expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.scrollRight]));
 
       // Jump to the end.
-      controller.jumpTo(10 * 150.0);
+      controller.jumpTo(itemCount * itemHeight);
       await tester.pumpAndSettle();
       expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.scrollLeft]));
 

--- a/packages/flutter/test/widgets/list_view_semantics_test.dart
+++ b/packages/flutter/test/widgets/list_view_semantics_test.dart
@@ -1,0 +1,137 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+
+import 'semantics_tester.dart';
+
+void main() {
+  group('Available semantic scroll actions', () {
+    // Regression tests for https://github.com/flutter/flutter/issues/52032.
+    testWidgets('forward vertical', (WidgetTester tester) async {
+      final SemanticsTester semantics = SemanticsTester(tester);
+      final ScrollController controller = ScrollController();
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: ListView.builder(
+            controller: controller,
+            itemCount: 10,
+            itemBuilder: (BuildContext context, int index) {
+              return SizedBox(
+                height: 150,
+                child: Text('Tile $index'),
+              );
+            },
+          ),
+        ),
+      );
+
+      expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.scrollUp]));
+
+      // Jump to the end.
+      controller.jumpTo(10 * 150.0);
+      await tester.pumpAndSettle();
+      expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.scrollDown]));
+
+      semantics.dispose();
+    });
+
+    testWidgets('reverse vertical', (WidgetTester tester) async {
+      final SemanticsTester semantics = SemanticsTester(tester);
+      final ScrollController controller = ScrollController();
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: ListView.builder(
+            reverse: true,
+            controller: controller,
+            itemCount: 10,
+            itemBuilder: (BuildContext context, int index) {
+              return SizedBox(
+                height: 150,
+                child: Text('Tile $index'),
+              );
+            },
+          ),
+        ),
+      );
+
+      expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.scrollDown]));
+
+      // Jump to the end.
+      controller.jumpTo(10 * 150.0);
+      await tester.pumpAndSettle();
+      expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.scrollUp]));
+
+      semantics.dispose();
+    });
+
+    testWidgets('forward horizontal', (WidgetTester tester) async {
+      final SemanticsTester semantics = SemanticsTester(tester);
+      final ScrollController controller = ScrollController();
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: ListView.builder(
+            scrollDirection: Axis.horizontal,
+            controller: controller,
+            itemCount: 10,
+            itemBuilder: (BuildContext context, int index) {
+              return SizedBox(
+                height: 150,
+                child: Text('Tile $index'),
+              );
+            },
+          ),
+        ),
+      );
+
+      expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.scrollLeft]));
+
+      // Jump to the end.
+      controller.jumpTo(10 * 150.0);
+      await tester.pumpAndSettle();
+      expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.scrollRight]));
+
+      semantics.dispose();
+    });
+
+    testWidgets('reverse horizontal', (WidgetTester tester) async {
+      final SemanticsTester semantics = SemanticsTester(tester);
+      final ScrollController controller = ScrollController();
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: ListView.builder(
+            scrollDirection: Axis.horizontal,
+            reverse: true,
+            controller: controller,
+            itemCount: 10,
+            itemBuilder: (BuildContext context, int index) {
+              return SizedBox(
+                height: 150,
+                child: Text('Tile $index'),
+              );
+            },
+          ),
+        ),
+      );
+
+      expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.scrollRight]));
+
+      // Jump to the end.
+      controller.jumpTo(10 * 150.0);
+      await tester.pumpAndSettle();
+      expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.scrollLeft]));
+
+      semantics.dispose();
+    });
+  });
+}


### PR DESCRIPTION
## Description

Prior to this change the semantics tree contained incorrect information about the available scroll actions for reversed lists. This was breaking a11y focus traversal because when scrolled to the end of a list instead of moving a11y focus outside of the list Android thought there are more items in the list and tried to scroll the list instead to expose those (non-existing) items.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/52032.

## Tests

I added the following tests:

* Available semantic scroll actions (forward, vertical)
* Available semantic scroll actions (reverse, vertical)
* Available semantic scroll actions (forward, horizontal)
* Available semantic scroll actions (reverse, horizontal)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
