### PR TITLE
[flutter_tools] Handle StateError in ProtocolDiscovery.uri

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -627,11 +627,16 @@ class AndroidDevice extends Device {
     // TODO(danrubel): Waiting for observatory services can be made common across all devices.
     try {
       Uri observatoryUri;
-
       if (debuggingOptions.buildInfo.isDebug || debuggingOptions.buildInfo.isProfile) {
         observatoryUri = await observatoryDiscovery.uri;
+        if (observatoryUri == null) {
+          globals.printError(
+            'Error waiting for a debug connection: '
+            'The log reader stopped unexpectedly',
+          );
+          return LaunchResult.failed();
+        }
       }
-
       return LaunchResult.succeeded(observatoryUri: observatoryUri);
     } on Exception catch (error) {
       globals.printError('Error waiting for a debug connection: $error');

--- a/packages/flutter_tools/lib/src/desktop_device.dart
+++ b/packages/flutter_tools/lib/src/desktop_device.dart
@@ -114,14 +114,20 @@ abstract class DesktopDevice extends Device {
     );
     try {
       final Uri observatoryUri = await observatoryDiscovery.uri;
-      onAttached(package, buildMode, process);
-      return LaunchResult.succeeded(observatoryUri: observatoryUri);
+      if (observatoryUri != null) {
+        onAttached(package, buildMode, process);
+        return LaunchResult.succeeded(observatoryUri: observatoryUri);
+      }
+      globals.printError(
+        'Error waiting for a debug connection: '
+        'The log reader stopped unexpectedly.',
+      );
     } on Exception catch (error) {
       globals.printError('Error waiting for a debug connection: $error');
-      return LaunchResult.failed();
     } finally {
       await observatoryDiscovery.cancel();
     }
+    return LaunchResult.failed();
   }
 
   @override

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -445,13 +445,19 @@ class IOSSimulator extends Device {
 
     try {
       final Uri deviceUri = await observatoryDiscovery.uri;
-      return LaunchResult.succeeded(observatoryUri: deviceUri);
+      if (deviceUri != null) {
+        return LaunchResult.succeeded(observatoryUri: deviceUri);
+      }
+      globals.printError(
+        'Error waiting for a debug connection: '
+        'The log reader failed unexpectedly',
+      );
     } on Exception catch (error) {
       globals.printError('Error waiting for a debug connection: $error');
-      return LaunchResult.failed();
     } finally {
-      await observatoryDiscovery.cancel();
+      await observatoryDiscovery?.cancel();
     }
+    return LaunchResult.failed();
   }
 
   Future<void> _setupUpdatedApplicationBundle(covariant BuildableIOSApp app, BuildInfo buildInfo, String mainPath) async {

--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -64,10 +64,17 @@ class ProtocolDiscovery {
   _BufferedStreamController<Uri> _uriStreamController;
 
   /// The discovered service URL.
+  ///
+  /// Returns null if the log reader shuts down before any uri is found.
+  ///
   /// Use [uris] instead.
   // TODO(egarciad): replace `uri` for `uris`.
-  Future<Uri> get uri {
-    return uris.first;
+  Future<Uri> get uri async {
+    try {
+      return await uris.first;
+    } on StateError {
+      return null;
+    }
   }
 
   /// The discovered service URLs.

--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -157,6 +157,7 @@ class FlutterTesterDevice extends Device {
 
     command.add(applicationKernelFilePath);
 
+    ProtocolDiscovery observatoryDiscovery;
     try {
       globals.printTrace(command.join(' '));
 
@@ -185,7 +186,7 @@ class FlutterTesterDevice extends Device {
         return LaunchResult.succeeded();
       }
 
-      final ProtocolDiscovery observatoryDiscovery = ProtocolDiscovery.observatory(
+      observatoryDiscovery = ProtocolDiscovery.observatory(
         getLogReader(),
         hostPort: debuggingOptions.hostVmServicePort,
         devicePort: debuggingOptions.deviceVmServicePort,
@@ -193,11 +194,19 @@ class FlutterTesterDevice extends Device {
       );
 
       final Uri observatoryUri = await observatoryDiscovery.uri;
-      return LaunchResult.succeeded(observatoryUri: observatoryUri);
+      if (observatoryUri != null) {
+        return LaunchResult.succeeded(observatoryUri: observatoryUri);
+      }
+      globals.printError(
+        'Failed to launch $package: '
+        'The log reader failed unexpectedly.',
+      );
     } on Exception catch (error) {
       globals.printError('Failed to launch $package: $error');
-      return LaunchResult.failed();
+    } finally {
+      await observatoryDiscovery?.cancel();
     }
+    return LaunchResult.failed();
   }
 
   @override

--- a/packages/flutter_tools/test/general.shard/protocol_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/protocol_discovery_test.dart
@@ -112,6 +112,14 @@ void main() {
         expect(discoverer.uri, throwsA(isFormatException));
       });
 
+      testUsingContext('uri is null when the log reader closes early', () async {
+        initialize();
+        final Future<Uri> uriFuture = discoverer.uri;
+        await logReader.dispose();
+
+        expect(await uriFuture, isNull);
+      });
+
       testUsingContext('uri waits for correct log line', () async {
         initialize();
         final Future<Uri> uriFuture = discoverer.uri;


### PR DESCRIPTION
## Description

Previously, when a log reader stopped before finding a vmservice uri, `ProtocolDiscovery.uri` would throw a `StateError`. This change catches the `StateError` and instead returns `null`.

## Related Issues

https://github.com/flutter/flutter/issues/52272

## Tests

I added the following tests:

Added a test to protocol_discovery_test.dart

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
