### PR TITLE
Make --androidx flag a noop in flutter create

### DIFF
--- a/dev/devicelab/bin/tasks/gradle_jetifier_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_jetifier_test.dart
@@ -34,7 +34,6 @@ Future<void> main() async {
           'create',
           options: <String>[
             '--org', 'io.flutter.devicelab',
-            '--androidx',
             'hello',
           ],
         );

--- a/dev/devicelab/bin/tasks/gradle_plugin_dependencies_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_dependencies_test.dart
@@ -35,7 +35,6 @@ Future<void> main() async {
           'create',
           options: <String>[
             '--org', 'io.flutter.devicelab',
-            '--androidx',
             'hello',
           ],
         );

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -139,12 +139,6 @@ class CreateCommand extends FlutterCommand {
       defaultsTo: 'kotlin',
       allowed: <String>['java', 'kotlin'],
     );
-    argParser.addFlag(
-      'androidx',
-      negatable: true,
-      defaultsTo: true,
-      help: 'Generate a project using the AndroidX support libraries',
-    );
   }
 
   @override
@@ -394,7 +388,6 @@ class CreateCommand extends FlutterCommand {
       flutterRoot: flutterRoot,
       renderDriverTest: boolArg('with-driver-test'),
       withPluginHook: generatePlugin,
-      androidX: boolArg('androidx'),
       androidLanguage: stringArg('android-language'),
       iosLanguage: stringArg('ios-language'),
       web: featureFlags.isWebEnabled,
@@ -404,7 +397,7 @@ class CreateCommand extends FlutterCommand {
 
     final String relativeDirPath = globals.fs.path.relative(projectDirPath);
     if (!projectDir.existsSync() || projectDir.listSync().isEmpty) {
-      globals.printStatus('Creating project $relativeDirPath... androidx: ${boolArg('androidx')}');
+      globals.printStatus('Creating project $relativeDirPath...');
     } else {
       if (sampleCode != null && !overwrite) {
         throwToolExit('Will not overwrite existing project in $relativeDirPath: '
@@ -612,7 +605,6 @@ To edit platform code in an IDE see https://flutter.dev/developing-packages/#edi
     String projectName,
     String projectDescription,
     String androidLanguage,
-    bool androidX,
     String iosLanguage,
     String flutterRoot,
     bool renderDriverTest = false,
@@ -637,7 +629,6 @@ To edit platform code in an IDE see https://flutter.dev/developing-packages/#edi
       'macosIdentifier': appleIdentifier,
       'description': projectDescription,
       'dartSdk': '$flutterRoot/bin/cache/dart-sdk',
-      'androidX': androidX,
       'useAndroidEmbeddingV2': featureFlags.isAndroidEmbeddingV2Enabled,
       'androidMinApiLevel': android.minApiLevel,
       'androidSdkVersion': android_sdk.minimumAndroidSdkVersion,

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -142,8 +142,6 @@ class CreateCommand extends FlutterCommand {
     // TODO(egarciad): Remove this flag. https://github.com/flutter/flutter/issues/52363
     argParser.addFlag(
       'androidx',
-      negatable: true,
-      defaultsTo: true,
       hide: true,
       help: 'Noop flag. (settings this flag to false has no effect)',
     );

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -143,7 +143,8 @@ class CreateCommand extends FlutterCommand {
     argParser.addFlag(
       'androidx',
       hide: true,
-      help: 'Noop flag. (settings this flag to false has no effect)',
+      negatable: true,
+      help: 'Deprecated. Setting this flag has no effect.',
     );
   }
 

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -139,6 +139,14 @@ class CreateCommand extends FlutterCommand {
       defaultsTo: 'kotlin',
       allowed: <String>['java', 'kotlin'],
     );
+    // TODO(egarciad): Remove this flag. https://github.com/flutter/flutter/issues/52363
+    argParser.addFlag(
+      'androidx',
+      negatable: true,
+      defaultsTo: true,
+      hide: true,
+      help: 'Noop flag. (settings this flag to false has no effect)',
+    );
   }
 
   @override

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -527,14 +527,9 @@ public final class GeneratedPluginRegistrant {
 const String _androidPluginRegistryTemplateNewEmbedding = '''
 package io.flutter.plugins;
 
-{{#androidX}}
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
-{{/androidX}}
-{{^androidX}}
-import android.support.annotation.Keep;
-import android.support.annotation.NonNull;
-{{/androidX}}
+
 import io.flutter.embedding.engine.FlutterEngine;
 {{#needsShim}}
 import io.flutter.embedding.engine.plugins.shim.ShimPluginRegistry;

--- a/packages/flutter_tools/templates/app/android.tmpl/gradle.properties.tmpl
+++ b/packages/flutter_tools/templates/app/android.tmpl/gradle.properties.tmpl
@@ -1,6 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
 android.enableR8=true
-{{#androidX}}
 android.useAndroidX=true
 android.enableJetifier=true
-{{/androidX}}

--- a/packages/flutter_tools/templates/module/android/gradle/gradle.properties.tmpl
+++ b/packages/flutter_tools/templates/module/android/gradle/gradle.properties.tmpl
@@ -1,6 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
 android.enableR8=true
-{{#androidX}}
 android.useAndroidX=true
 android.enableJetifier=true
-{{/androidX}}

--- a/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/build.gradle.tmpl
@@ -34,13 +34,6 @@ buildDir = new File(rootProject.projectDir, "../build/host")
 dependencies {
     implementation project(':flutter')
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    {{#androidX}}
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    {{/androidX}}
-    {{^androidX}}
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
-    implementation 'com.android.support:design:28.0.0'
-    {{/androidX}}
 }

--- a/packages/flutter_tools/templates/module/android/library/Flutter.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/library/Flutter.tmpl/build.gradle.tmpl
@@ -45,11 +45,5 @@ flutter {
 }
 
 dependencies {
-    {{#androidX}}
     implementation 'androidx.appcompat:appcompat:1.0.2'
-    {{/androidX}}
-    {{^androidX}}
-    implementation 'com.android.support:support-v13:27.1.1'
-    implementation 'com.android.support:support-annotations:27.1.1'
-    {{/androidX}}
 }

--- a/packages/flutter_tools/templates/module/android/library/Flutter.tmpl/src/main/java/io/flutter/facade/Flutter.java.tmpl
+++ b/packages/flutter_tools/templates/module/android/library/Flutter.tmpl/src/main/java/io/flutter/facade/Flutter.java.tmpl
@@ -4,18 +4,11 @@ import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
 
-{{#androidX}}
 import androidx.annotation.NonNull;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleObserver;
 import androidx.lifecycle.OnLifecycleEvent;
-{{/androidX}}
-{{^androidX}}
-import android.arch.lifecycle.Lifecycle;
-import android.arch.lifecycle.LifecycleObserver;
-import android.arch.lifecycle.OnLifecycleEvent;
-import android.support.annotation.NonNull;
-{{/androidX}}
+
 import io.flutter.plugin.common.BasicMessageChannel;
 import io.flutter.plugin.common.StringCodec;
 import io.flutter.plugins.GeneratedPluginRegistrant;

--- a/packages/flutter_tools/templates/module/android/library/Flutter.tmpl/src/main/java/io/flutter/facade/FlutterFragment.java.tmpl
+++ b/packages/flutter_tools/templates/module/android/library/Flutter.tmpl/src/main/java/io/flutter/facade/FlutterFragment.java.tmpl
@@ -6,14 +6,9 @@ import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
-{{#androidX}}
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
-{{/androidX}}
-{{^androidX}}
-import android.support.annotation.NonNull;
-import android.support.v4.app.Fragment;
-{{/androidX}}
+
 import io.flutter.view.FlutterView;
 
 /**

--- a/packages/flutter_tools/templates/module/common/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/module/common/pubspec.yaml.tmpl
@@ -85,6 +85,6 @@ flutter:
   # They also do not have any bearing on your native host application's
   # identifiers, which may be completely independent or the same as these.
   module:
-    androidX: {{androidX}}
+    androidX: true
     androidPackage: {{androidIdentifier}}
     iosBundleIdentifier: {{iosIdentifier}}

--- a/packages/flutter_tools/templates/plugin/android-java.tmpl/src/main/java/androidIdentifier/pluginClass.java.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-java.tmpl/src/main/java/androidIdentifier/pluginClass.java.tmpl
@@ -1,12 +1,8 @@
 package {{androidIdentifier}};
 
 {{#useAndroidEmbeddingV2}}
-{{#androidX}}
 import androidx.annotation.NonNull;
-{{/androidX}}
-{{^androidX}}
-import android.support.annotation.NonNull;
-{{/androidX}}
+
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;

--- a/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/src/main/kotlin/androidIdentifier/pluginClass.kt.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/src/main/kotlin/androidIdentifier/pluginClass.kt.tmpl
@@ -1,12 +1,8 @@
 package {{androidIdentifier}}
 
 {{#useAndroidEmbeddingV2}}
-{{#androidX}}
 import androidx.annotation.NonNull;
-{{/androidX}}
-{{^androidX}}
-import android.support.annotation.NonNull;
-{{/androidX}}
+
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel

--- a/packages/flutter_tools/templates/plugin/android.tmpl/gradle.properties.tmpl
+++ b/packages/flutter_tools/templates/plugin/android.tmpl/gradle.properties.tmpl
@@ -1,6 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
 android.enableR8=true
-{{#androidX}}
 android.useAndroidX=true
 android.enableJetifier=true
-{{/androidX}}

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -488,27 +488,6 @@ void main() {
     expect(actualContents.contains('useAndroidX'), true);
   });
 
-  testUsingContext('non androidx app project', () async {
-    Cache.flutterRoot = '../..';
-    when(mockFlutterVersion.frameworkRevision).thenReturn(frameworkRevision);
-    when(mockFlutterVersion.channel).thenReturn(frameworkChannel);
-
-    final CreateCommand command = CreateCommand();
-    final CommandRunner<void> runner = createTestCommandRunner(command);
-
-    await runner.run(<String>['create', '--no-pub', '--no-androidx', projectDir.path]);
-
-    void expectExists(String relPath) {
-      expect(globals.fs.isFileSync('${projectDir.path}/$relPath'), true);
-    }
-
-    expectExists('android/gradle.properties');
-
-    final String actualContents = await globals.fs.file(projectDir.path + '/android/gradle.properties').readAsString();
-
-    expect(actualContents.contains('useAndroidX'), false);
-  });
-
   testUsingContext('androidx is used by default in a module project', () async {
     Cache.flutterRoot = '../..';
     when(mockFlutterVersion.frameworkRevision).thenReturn(frameworkRevision);
@@ -523,23 +502,6 @@ void main() {
     expect(
       project.usesAndroidX,
       true,
-    );
-  });
-
-  testUsingContext('non androidx module', () async {
-    Cache.flutterRoot = '../..';
-    when(mockFlutterVersion.frameworkRevision).thenReturn(frameworkRevision);
-    when(mockFlutterVersion.channel).thenReturn(frameworkChannel);
-
-    final CreateCommand command = CreateCommand();
-    final CommandRunner<void> runner = createTestCommandRunner(command);
-
-    await runner.run(<String>['create', '--template=module', '--no-pub', '--no-androidx', projectDir.path]);
-
-    final FlutterProject project = FlutterProject.fromDirectory(projectDir);
-    expect(
-      project.usesAndroidX,
-      false,
     );
   });
 
@@ -562,27 +524,6 @@ void main() {
     final String actualContents = await globals.fs.file(projectDir.path + '/android/gradle.properties').readAsString();
 
     expect(actualContents.contains('useAndroidX'), true);
-  });
-
-  testUsingContext('non androidx plugin project', () async {
-    Cache.flutterRoot = '../..';
-    when(mockFlutterVersion.frameworkRevision).thenReturn(frameworkRevision);
-    when(mockFlutterVersion.channel).thenReturn(frameworkChannel);
-
-    final CreateCommand command = CreateCommand();
-    final CommandRunner<void> runner = createTestCommandRunner(command);
-
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--no-androidx', projectDir.path]);
-
-    void expectExists(String relPath) {
-      expect(globals.fs.isFileSync('${projectDir.path}/$relPath'), true);
-    }
-
-    expectExists('android/gradle.properties');
-
-    final String actualContents = await globals.fs.file(projectDir.path + '/android/gradle.properties').readAsString();
-
-    expect(actualContents.contains('useAndroidX'), false);
   });
 
   testUsingContext('app supports Linux if requested', () async {

--- a/packages/flutter_tools/test/general.shard/commands/build_apk_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_apk_test.dart
@@ -366,7 +366,13 @@ void main() {
 
     testUsingContext("reports when the app isn't using AndroidX", () async {
       final String projectPath = await createProject(tempDir,
-          arguments: <String>['--no-pub', '--no-androidx', '--template=app']);
+          arguments: <String>['--no-pub', '--template=app']);
+      // Simulate a non-androidx project.
+      tempDir
+        .childDirectory('flutter_project')
+        .childDirectory('android')
+        .childFile('gradle.properties')
+        .writeAsStringSync('android.useAndroidX=false');
 
       when(mockProcessManager.start(
         <String>[

--- a/packages/flutter_tools/test/general.shard/commands/build_appbundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_appbundle_test.dart
@@ -324,7 +324,13 @@ void main() {
 
     testUsingContext("reports when the app isn't using AndroidX", () async {
       final String projectPath = await createProject(tempDir,
-          arguments: <String>['--no-pub', '--no-androidx', '--template=app']);
+          arguments: <String>['--no-pub', '--template=app']);
+      // Simulate a non-androidx project.
+      tempDir
+        .childDirectory('flutter_project')
+        .childDirectory('android')
+        .childFile('gradle.properties')
+        .writeAsStringSync('android.useAndroidX=false');
 
       when(mockProcessManager.start(
         <String>[


### PR DESCRIPTION
## Description

Make androidx flag a noop in `flutter create`. This means that there won't be a way to create a non-androidx project from flutter create.

## Related Issues

https://github.com/flutter/flutter/issues/39283

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
