### PR TITLE
[flutter_tools] handle null value from SDK version checks

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -317,9 +317,11 @@ class AndroidDevice extends Device {
         throwOnError: true,
       );
 
+      // This has been reported to return null on some devices. In this case,
+      // assume the lowest supported API to still allow Flutter to run.
       // Sample output: '22'
-      final String sdkVersion = await _getProperty('ro.build.version.sdk');
-
+      final String sdkVersion = await _getProperty('ro.build.version.sdk')
+        ?? minApiLevel.toString();
 
       final int sdkVersionParsed = int.tryParse(sdkVersion);
       if (sdkVersionParsed == null) {

--- a/packages/flutter_tools/test/general.shard/android/android_install_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_install_test.dart
@@ -1,0 +1,133 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/android/android_device.dart';
+import 'package:flutter_tools/src/android/android_sdk.dart';
+import 'package:flutter_tools/src/application_package.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:mockito/mockito.dart';
+
+import '../../src/common.dart';
+import '../../src/context.dart';
+
+const FakeCommand kAdbVersionCommand = FakeCommand(
+  command: <String>['adb', 'version'],
+  stdout: 'Android Debug Bridge version 1.0.39',
+);
+const FakeCommand kAdbStartServerCommand = FakeCommand(
+  command: <String>['adb', 'start-server']
+);
+const FakeCommand kInstallCommand = FakeCommand(
+  command: <String>['adb', '-s', '1234', 'install', '-t', '-r', 'app.apk'],
+);
+const FakeCommand kStoreShaCommand = FakeCommand(
+  command: <String>['adb', '-s', '1234', 'shell', 'echo', '-n', '', '>', '/data/local/tmp/sky.app.sha1']
+);
+
+void main() {
+  testUsingContext('Cannot install app on API level below 16', () async {
+    final File apk = globals.fs.file('app.apk')..createSync();
+    final AndroidApk androidApk = AndroidApk(
+      file: apk,
+      id: 'app',
+      versionCode: 22,
+      launchActivity: 'Main',
+    );
+    final AndroidDevice androidDevice = AndroidDevice('1234');
+    when(globals.androidSdk.adbPath).thenReturn('adb');
+    final FakeProcessManager processManager = globals.processManager as FakeProcessManager;
+
+    expect(await androidDevice.installApp(androidApk), false);
+    expect(processManager.hasRemainingExpectations, false);
+  }, overrides: <Type, Generator>{
+    ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
+      kAdbVersionCommand,
+      kAdbStartServerCommand,
+      const FakeCommand(
+        command: <String>['adb', '-s', '1234', 'shell', 'getprop'],
+        stdout: '[ro.build.version.sdk]: [11]',
+      ),
+    ]),
+    FileSystem: () => MemoryFileSystem.test(),
+    AndroidSdk: () => MockAndroidSdk(),
+  });
+
+  testUsingContext('Cannot install app if APK file is missing', () async {
+    final File apk = globals.fs.file('app.apk');
+    final AndroidApk androidApk = AndroidApk(
+      file: apk,
+      id: 'app',
+      versionCode: 22,
+      launchActivity: 'Main',
+    );
+    final AndroidDevice androidDevice = AndroidDevice('1234');
+
+    expect(await androidDevice.installApp(androidApk), false);
+  }, overrides: <Type, Generator>{
+    ProcessManager: () => FakeProcessManager.list(<FakeCommand>[]),
+    FileSystem: () => MemoryFileSystem.test(),
+    AndroidSdk: () => MockAndroidSdk(),
+  });
+
+  testUsingContext('Can install app on API level 16 or greater', () async {
+    final File apk = globals.fs.file('app.apk')..createSync();
+    final AndroidApk androidApk = AndroidApk(
+      file: apk,
+      id: 'app',
+      versionCode: 22,
+      launchActivity: 'Main',
+    );
+    final AndroidDevice androidDevice = AndroidDevice('1234');
+    when(globals.androidSdk.adbPath).thenReturn('adb');
+    final FakeProcessManager processManager = globals.processManager as FakeProcessManager;
+
+    expect(await androidDevice.installApp(androidApk), true);
+    expect(processManager.hasRemainingExpectations, false);
+  }, overrides: <Type, Generator>{
+    ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
+      kAdbVersionCommand,
+      kAdbStartServerCommand,
+      const FakeCommand(
+        command: <String>['adb', '-s', '1234', 'shell', 'getprop'],
+        stdout: '[ro.build.version.sdk]: [16]',
+      ),
+      kInstallCommand,
+      kStoreShaCommand,
+    ]),
+    FileSystem: () => MemoryFileSystem.test(),
+    AndroidSdk: () => MockAndroidSdk(),
+  });
+
+  testUsingContext('Defaults to API level 16 if adb returns a null response', () async {
+    final File apk = globals.fs.file('app.apk')..createSync();
+    final AndroidApk androidApk = AndroidApk(
+      file: apk,
+      id: 'app',
+      versionCode: 22,
+      launchActivity: 'Main',
+    );
+    final AndroidDevice androidDevice = AndroidDevice('1234');
+    when(globals.androidSdk.adbPath).thenReturn('adb');
+    final FakeProcessManager processManager = globals.processManager as FakeProcessManager;
+
+    expect(await androidDevice.installApp(androidApk), true);
+    expect(processManager.hasRemainingExpectations, false);
+  }, overrides: <Type, Generator>{
+    ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
+      kAdbVersionCommand,
+      kAdbStartServerCommand,
+      const FakeCommand(
+        command: <String>['adb', '-s', '1234', 'shell', 'getprop'],
+      ),
+      kInstallCommand,
+      kStoreShaCommand,
+    ]),
+    FileSystem: () => MemoryFileSystem.test(),
+    AndroidSdk: () => MockAndroidSdk(),
+  });
+}
+
+class MockAndroidSdk extends Mock implements AndroidSdk {}


### PR DESCRIPTION
## Description

When the AndroidDevice checks for the current API version, it isn't handling a null response. While we can refuse to run on API levels that are unsupported, we should probably assume that a null response = lowest possible API level and allow these to run.

I didn't find any tests that broke from my change  so I added some, though I did not refactor the globals since that would be a much larger change (and conflict with my pending adb log fix).

https://github.com/flutter/flutter/issues/52272