### PR TITLE
[flutter_tools] Make AndroidConsole check for next line

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_console.dart
+++ b/packages/flutter_tools/lib/src/android/android_console.dart
@@ -42,21 +42,29 @@ class AndroidConsole {
   }
 
   Future<String> getAvdName() async {
+    if (_queue == null) {
+      return null;
+    }
     _write('avd name\n');
     return _readResponse();
   }
 
   void destroy() {
-    if (_socket != null) {
-      _socket.destroy();
-      _socket = null;
-      _queue = null;
-    }
+    _socket?.destroy();
+    _socket = null;
+    _queue = null;
   }
 
   Future<String> _readResponse() async {
+    if (_queue == null) {
+      return null;
+    }
     final StringBuffer output = StringBuffer();
     while (true) {
+      if (!await _queue.hasNext) {
+        destroy();
+        return null;
+      }
       final String text = await _queue.next;
       final String trimmedText = text.trim();
       if (trimmedText == 'OK') {
@@ -72,6 +80,6 @@ class AndroidConsole {
   }
 
   void _write(String text) {
-    _socket.add(ascii.encode(text));
+    _socket?.add(ascii.encode(text));
   }
 }


### PR DESCRIPTION
## Description

This PR makes `AndroidConsole` check that the underlying socket is not closed before trying to read the next line. This prevents a `StateError` from being thrown.

## Related Issues

https://github.com/flutter/flutter/issues/52272

## Tests

I added the following tests:

Added a test to android_device_test.dart

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
