### PR TITLE
[flutter_tools] Fallback discovery: Don't crash when an Isolate has no root library

### DIFF
--- a/packages/flutter_tools/lib/src/ios/fallback_discovery.dart
+++ b/packages/flutter_tools/lib/src/ios/fallback_discovery.dart
@@ -167,7 +167,7 @@ class FallbackDiscovery {
             throw Exception('Expected Isolate but found Sentinel: $isolateResponse');
           }
           final LibraryRef library = (isolateResponse as Isolate).rootLib;
-          if (library.uri.startsWith('package:$packageName')) {
+          if (library != null && library.uri.startsWith('package:$packageName')) {
             UsageEvent(
               _kEventName,
               'success',

--- a/packages/flutter_tools/test/general.shard/ios/fallback_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/fallback_discovery_test.dart
@@ -67,6 +67,31 @@ void main() {
     ), Uri.parse('http://localhost:1'));
   });
 
+  testUsingContext('Selects assumed port when another isolate has no root library', () async {
+    when(mockVmService.getVM()).thenAnswer((Invocation invocation) async {
+      return VM()..isolates = <IsolateRef>[
+        IsolateRef()..id = '1',
+        IsolateRef()..id = '2',
+      ];
+    });
+    when(mockVmService.getIsolate('1')).thenAnswer((Invocation invocation) async {
+      return Isolate()
+        ..rootLib = null;
+    });
+    when(mockVmService.getIsolate('2')).thenAnswer((Invocation invocation) async {
+      return Isolate()
+        ..rootLib = (LibraryRef()..uri = 'package:hello/main.dart');
+    });
+    expect(await fallbackDiscovery.discover(
+      assumedDevicePort: 23,
+      deivce: null,
+      hostVmservicePort: 1,
+      packageId: null,
+      usesIpv6: false,
+      packageName: 'hello',
+    ), Uri.parse('http://localhost:1'));
+  });
+
   testUsingContext('Selects mdns discovery if VM service connecton fails due to Sentinel', () async {
     when(mockVmService.getVM()).thenAnswer((Invocation invocation) async {
       return VM()..isolates = <IsolateRef>[


### PR DESCRIPTION
## Description

From crash logging, the vm service may hand us an isolate with no root library filled in. In this case, rather than crash, this PR continues with the search/retry logic.

## Related Issues

https://github.com/flutter/flutter/issues/52272

## Tests

I added the following tests:

Added a test to fallback_discovery_test.dart.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
