### PR TITLE
[flutter_tools] throw exception instead of string from startApp

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -459,7 +459,7 @@ class AppDomain extends Domain {
     String isolateFilter,
   }) async {
     if (await device.isLocalEmulator && !options.buildInfo.supportsEmulator) {
-      throw '${toTitleCase(options.buildInfo.friendlyModeName)} mode is not supported for emulators.';
+      throw Exception('${toTitleCase(options.buildInfo.friendlyModeName)} mode is not supported for emulators.');
     }
     // We change the current working directory for the duration of the `start` command.
     final Directory cwd = globals.fs.currentDirectory;

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -418,7 +418,8 @@ class RunCommand extends RunCommandBase {
           dillOutputPath: stringArg('output-dill'),
           ipv6: ipv6,
         );
-      } on Exception catch (error) {
+      } on Exception catch (error, st) {
+        print('caught: $error, $st');
         throwToolExit(error.toString());
       }
       final DateTime appStartedTime = systemClock.now();

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -418,8 +418,7 @@ class RunCommand extends RunCommandBase {
           dillOutputPath: stringArg('output-dill'),
           ipv6: ipv6,
         );
-      } on Exception catch (error, st) {
-        print('caught: $error, $st');
+      } on Exception catch (error) {
         throwToolExit(error.toString());
       }
       final DateTime appStartedTime = systemClock.now();

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/user_messages.dart';
 import 'package:flutter_tools/src/base/net.dart';
@@ -143,6 +144,7 @@ void main() {
       FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
       DeviceManager: () => MockDeviceManager(),
+      Stdio: () => MockStdio(),
     });
 
     testUsingContext('Walks upward looking for a pubspec.yaml and exits if missing', () async {

--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -101,7 +101,7 @@ Matcher throwsToolExit({ int exitCode, Pattern message }) {
     matcher = allOf(matcher, (ToolExit e) => e.exitCode == exitCode);
   }
   if (message != null) {
-    matcher = allOf(matcher, (ToolExit e) => e.message.contains(message));
+    matcher = allOf(matcher, (ToolExit e) => e.message?.contains(message) ?? false);
   }
   return throwsA(matcher);
 }


### PR DESCRIPTION
## Description

Update to throw exception and add test case. We were catching `on Exception`, so the string was slipping through - but this is still a fatal error so we need to exit.