### PR TITLE
Reland "Improve text formatter repeat filter logic (#52055)"

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1645,15 +1645,21 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     // Check if the new value is the same as the current local value, or is the same
     // as the post-formatting value of the previous pass.
     final bool textChanged = _value?.text != value?.text;
-    final bool isRepeat = value == _lastFormattedUnmodifiedTextEditingValue;
-    if (!isRepeat) {
-      if (textChanged && widget.inputFormatters != null && widget.inputFormatters.isNotEmpty) {
-        for (final TextInputFormatter formatter in widget.inputFormatters) {
-          value = formatter.formatEditUpdate(_value, value);
-        }
+    final bool isRepeatText = value?.text == _lastFormattedUnmodifiedTextEditingValue?.text;
+    final bool isRepeatSelection = value?.selection == _lastFormattedUnmodifiedTextEditingValue?.selection;
+    // Only format when the text has changed and there are available formatters.
+    if (!isRepeatText && textChanged && widget.inputFormatters != null && widget.inputFormatters.isNotEmpty) {
+      for (final TextInputFormatter formatter in widget.inputFormatters) {
+        value = formatter.formatEditUpdate(_value, value);
       }
+    }
+    // If the text has changed or the selection has changed, we should update the
+    // locally stored TextEditingValue to the new one.
+    if (!isRepeatText || !isRepeatSelection) {
       _value = value;
     }
+    // Always attempt to send the value. If the value has changed, then it will send,
+    // otherwise, it will short-circuit.
     _updateRemoteEditingValueIfNeeded();
 
     if (textChanged && widget.onChanged != null)

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1651,6 +1651,8 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         value = formatter.formatEditUpdate(_value, value);
       _value = value;
       _updateRemoteEditingValueIfNeeded();
+    } else if (isRepeat) {
+      _updateRemoteEditingValueIfNeeded();
     } else {
       _value = value;
     }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1645,19 +1645,17 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     // Check if the new value is the same as the current local value, or is the same
     // as the post-formatting value of the previous pass.
     final bool textChanged = _value?.text != value?.text;
-    final bool isRepeat = value?.text == _lastFormattedUnmodifiedTextEditingValue?.text;
-    if (textChanged && !isRepeat && widget.inputFormatters != null && widget.inputFormatters.isNotEmpty) {
-      for (final TextInputFormatter formatter in widget.inputFormatters)
-        value = formatter.formatEditUpdate(_value, value);
-      _value = value;
-      _updateRemoteEditingValueIfNeeded();
-    } else if (isRepeat) {
-      // Clear out the unformatted remote value with the already-known
-      // post-format value.
-      _updateRemoteEditingValueIfNeeded();
-    } else {
+    final bool isRepeat = value == _lastFormattedUnmodifiedTextEditingValue;
+    if (!isRepeat) {
+      if (textChanged && widget.inputFormatters != null && widget.inputFormatters.isNotEmpty) {
+        for (final TextInputFormatter formatter in widget.inputFormatters) {
+          value = formatter.formatEditUpdate(_value, value);
+        }
+      }
       _value = value;
     }
+    _updateRemoteEditingValueIfNeeded();
+
     if (textChanged && widget.onChanged != null)
       widget.onChanged(value.text);
     _lastFormattedUnmodifiedTextEditingValue = _receivedRemoteTextEditingValue;

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1226,7 +1226,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   // that the formatter ran on and is used to prevent double-formatting.
   TextEditingValue _lastFormattedUnmodifiedTextEditingValue;
   // _lastFormattedValue tracks the last post-format value, so that it can be
-  // without rerunning the formatter when the input value is repeated.
+  // reused without rerunning the formatter when the input value is repeated.
   TextEditingValue _lastFormattedValue;
   // _receivedRemoteTextEditingValue is the direct value last passed in
   // updateEditingValue. This value does not get updated with the formatted

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1225,6 +1225,9 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   // _lastFormattedUnmodifiedTextEditingValue tracks the last value
   // that the formatter ran on and is used to prevent double-formatting.
   TextEditingValue _lastFormattedUnmodifiedTextEditingValue;
+  // _lastFormattedValue tracks the last post-format value, so that it can be
+  // without rerunning the formatter when the input value is repeated.
+  TextEditingValue _lastFormattedValue;
   // _receivedRemoteTextEditingValue is the direct value last passed in
   // updateEditingValue. This value does not get updated with the formatted
   // version.
@@ -1652,11 +1655,14 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       for (final TextInputFormatter formatter in widget.inputFormatters) {
         value = formatter.formatEditUpdate(_value, value);
       }
+      _lastFormattedValue = value;
     }
     // If the text has changed or the selection has changed, we should update the
     // locally stored TextEditingValue to the new one.
     if (!isRepeatText || !isRepeatSelection) {
       _value = value;
+    } else if (textChanged && _lastFormattedValue != null) {
+      _value = _lastFormattedValue;
     }
     // Always attempt to send the value. If the value has changed, then it will send,
     // otherwise, it will short-circuit.

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1652,6 +1652,8 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       _value = value;
       _updateRemoteEditingValueIfNeeded();
     } else if (isRepeat) {
+      // Clear out the unformatted remote value with the already-known
+      // post-format value.
       _updateRemoteEditingValueIfNeeded();
     } else {
       _value = value;

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4273,14 +4273,23 @@ void main() {
     expect(tester.testTextInput.editingState['text'], equals(''));
     expect(state.wantKeepAlive, true);
 
+    expect(formatter.formatCallCount, 0);
     state.updateEditingValue(const TextEditingValue(text: '01'));
+    expect(formatter.formatCallCount, 1);
     state.updateEditingValue(const TextEditingValue(text: '012'));
+    expect(formatter.formatCallCount, 2);
     state.updateEditingValue(const TextEditingValue(text: '0123')); // Text change causes reformat
+    expect(formatter.formatCallCount, 3);
     state.updateEditingValue(const TextEditingValue(text: '0123')); // Repeat, does not format
+    expect(formatter.formatCallCount, 3);
     state.updateEditingValue(const TextEditingValue(text: '0123')); // Repeat, does not format
+    expect(formatter.formatCallCount, 3);
     state.updateEditingValue(const TextEditingValue(text: '0123', selection: TextSelection.collapsed(offset: 2))); // Selection change does not reformat
+    expect(formatter.formatCallCount, 3);
     state.updateEditingValue(const TextEditingValue(text: '0123', selection: TextSelection.collapsed(offset: 2))); // Repeat, does not format
+    expect(formatter.formatCallCount, 3);
     state.updateEditingValue(const TextEditingValue(text: '0123', selection: TextSelection.collapsed(offset: 2))); // Repeat, does not format
+    expect(formatter.formatCallCount, 3);
 
     const List<String> referenceLog = <String>[
       '[1]: , 01',
@@ -4296,9 +4305,9 @@ void main() {
 }
 
 class MockTextFormatter extends TextInputFormatter {
-  MockTextFormatter() : _counter = 0, log = <String>[];
+  MockTextFormatter() : formatCallCount = 0, log = <String>[];
 
-  int _counter;
+  int formatCallCount;
   List<String> log;
 
   @override
@@ -4306,8 +4315,8 @@ class MockTextFormatter extends TextInputFormatter {
     TextEditingValue oldValue,
     TextEditingValue newValue,
   ) {
-    _counter++;
-    log.add('[$_counter]: ${oldValue.text}, ${newValue.text}');
+    formatCallCount++;
+    log.add('[$formatCallCount]: ${oldValue.text}, ${newValue.text}');
     TextEditingValue finalValue;
     if (newValue.text.length < oldValue.text.length) {
       finalValue = _handleTextDeletion(oldValue, newValue);
@@ -4320,14 +4329,14 @@ class MockTextFormatter extends TextInputFormatter {
 
   TextEditingValue _handleTextDeletion(
       TextEditingValue oldValue, TextEditingValue newValue) {
-    final String result = 'a' * (_counter - 2);
-    log.add('[$_counter]: deleting $result');
+    final String result = 'a' * (formatCallCount - 2);
+    log.add('[$formatCallCount]: deleting $result');
     return TextEditingValue(text: result);
   }
 
   TextEditingValue _formatText(TextEditingValue value) {
-    final String result = 'a' * _counter * 2;
-    log.add('[$_counter]: normal $result');
+    final String result = 'a' * formatCallCount * 2;
+    log.add('[$formatCallCount]: normal $result');
     return TextEditingValue(text: result);
   }
 }


### PR DESCRIPTION
## Description

This relands #52055 with required fixes to pass Google3 tests.

Specifically, now cache the post-format value for re-use.

Fixes https://github.com/flutter/flutter/issues/51180