### PR TITLE
Tap gesture no longer add pointer after resetting

### DIFF
--- a/packages/flutter/lib/src/gestures/tap.dart
+++ b/packages/flutter/lib/src/gestures/tap.dart
@@ -204,8 +204,8 @@ abstract class BaseTapGestureRecognizer extends PrimaryPointerGestureRecognizer 
   @override
   @protected
   void startTrackingPointer(int pointer, [Matrix4 transform]) {
-    // If the recognizer is tracked, it can be accepted and called [onTap],
-    // which is never expected to happen if `_down` is null.
+    // The recognizer should never track any pointers when `_down` is null,
+    // because calling `_checkDown` in this state will throw exception.
     assert(_down != null);
     super.startTrackingPointer(pointer, transform);
   }

--- a/packages/flutter/lib/src/gestures/tap.dart
+++ b/packages/flutter/lib/src/gestures/tap.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:vector_math/vector_math_64.dart' show Matrix4;
 import 'package:flutter/foundation.dart';
 
 import 'arena.dart';
@@ -183,13 +184,30 @@ abstract class BaseTapGestureRecognizer extends PrimaryPointerGestureRecognizer 
 
   @override
   void addAllowedPointer(PointerDownEvent event) {
+    assert(event != null);
     if (state == GestureRecognizerState.ready) {
       // `_down` must be assigned in this method instead of `handlePrimaryPointer`,
       // because `acceptGesture` might be called before `handlePrimaryPointer`,
       // which relies on `_down` to call `handleTapDown`.
       _down = event;
     }
-    super.addAllowedPointer(event);
+    if (_down != null) {
+      // This happens when this tap gesture has been rejected while the pointer
+      // is down (i.e. due to movement), when another allowed pointer is added,
+      // in which case all pointers are simply ignored. The `_down` being null
+      // means that _reset() has been called, since it is always set at the
+      // first allowed down event and will not be cleared except for reset(),
+      super.addAllowedPointer(event);
+    }
+  }
+
+  @override
+  @protected
+  void startTrackingPointer(int pointer, [Matrix4 transform]) {
+    // If the recognizer is tracked, it can be accepted and called [onTap],
+    // which is never expected to happen if `_down` is null.
+    assert(_down != null);
+    super.startTrackingPointer(pointer, transform);
   }
 
   @override

--- a/packages/flutter/test/gestures/tap_test.dart
+++ b/packages/flutter/test/gestures/tap_test.dart
@@ -4,8 +4,8 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter_test/flutter_test.dart';
 
-import '../flutter_test_alternative.dart';
 import 'gesture_tester.dart';
 
 class TestGestureArenaMember extends GestureArenaMember {
@@ -903,5 +903,39 @@ void main() {
       GestureBinding.instance.gestureArena.sweep(down5.pointer);
       expect(recognized, <String>['secondaryCancel']);
     });
+  });
+
+  testGesture('A second tap after rejection is ignored', (GestureTester tester) {
+    bool didTap = false;
+
+    final TapGestureRecognizer tap = TapGestureRecognizer()
+      ..onTap = () {
+        didTap = true;
+      };
+    // Add drag recognizer for competition
+    final HorizontalDragGestureRecognizer drag = HorizontalDragGestureRecognizer()
+      ..onStart = (_) {};
+
+    final TestPointer pointer1 = TestPointer(1);
+
+    final PointerDownEvent down = pointer1.down(const Offset(0.0, 0.0));
+    drag.addPointer(down);
+    tap.addPointer(down);
+
+    tester.closeArena(1);
+
+    // One-finger moves, canceling the tap
+    tester.route(down);
+    tester.route(pointer1.move(const Offset(50.0, 0)));
+
+    // Add another finger
+    final TestPointer pointer2 = TestPointer(2);
+    final PointerDownEvent down2 = pointer2.down(const Offset(10.0, 20.0));
+    drag.addPointer(down2);
+    tap.addPointer(down2);
+    tester.closeArena(2);
+    tester.route(down2);
+
+    expect(didTap, isFalse);
   });
 }


### PR DESCRIPTION
## Description

Sometimes a tap gesture recognizer can receive pointers after it resets. This will happen if the first pointer rejects the gesture but is still down (i.e. due to movement), before the second pointer joins. The problem with this sequence is that the 2nd pointer will be tracked even though the recognizer has already been reset to a malfunctioning state (i.e. `_down` is null).

This PR changes so that `TapGestureRecognizer` no longer adds the pointer in such cases, which is identified by testing if `_down` is null. This is reliable because `_down` is always and only set at the first allowed pointer, and is not reset except for `_reset()`.

This PR also adds an assertion to make sure `TapGestureRecognizer.startTrackingPointer` is never called when `_down` is null, allowing us to detect this problem (if any in the future) earlier.

## Related Issues

- Might be a fix to https://github.com/flutter/flutter/issues/52256

## Tests

I added the following tests:

- A second tap after rejection is ignored

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
