### PR TITLE
Enables log reader on iOS Simulator to (rudimentary) process multiline messages

### DIFF
--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -659,6 +659,10 @@ class _IOSSimulatorLogReader extends DeviceLogReader {
 
   static final RegExp _flutterRunnerRegex = RegExp(r' FlutterRunner\[\d+\] ');
 
+  // Remember what we did with the last line, in case we need to process
+  // a multiline record
+  bool _lastLineMatched = false;
+
   String _filterDeviceLine(String string) {
     final Match match = _mapRegex.matchAsPrefix(string);
     if (match != null) {
@@ -710,6 +714,11 @@ class _IOSSimulatorLogReader extends DeviceLogReader {
       return null;
     }
 
+    // Starts with space(s) - continuation of the multiline message
+    if (RegExp(r'\s*').matchAsPrefix(string) != null && !_lastLineMatched) {
+      return null;
+    }
+
     return string;
   }
 
@@ -731,6 +740,9 @@ class _IOSSimulatorLogReader extends DeviceLogReader {
       _lastLine = _filterDeviceLine(line);
       if (_lastLine != null) {
         _linesController.add(_lastLine);
+        _lastLineMatched = true;
+      } else {
+        _lastLineMatched = false;
       }
     }
   }

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -715,7 +715,7 @@ class _IOSSimulatorLogReader extends DeviceLogReader {
     }
 
     // Starts with space(s) - continuation of the multiline message
-    if (RegExp(r'\s*').matchAsPrefix(string) != null && !_lastLineMatched) {
+    if (RegExp(r'\s+').matchAsPrefix(string) != null && !_lastLineMatched) {
       return null;
     }
 

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -565,6 +565,62 @@ void main() {
       ProcessManager: () => mockProcessManager,
       FileSystem: () => fileSystem,
     });
+
+    testUsingContext('log reader handles multiline messages', () async {
+      when(mockProcessManager.start(any, environment: null, workingDirectory: null))
+        .thenAnswer((Invocation invocation) {
+          final Process mockProcess = MockProcess();
+          when(mockProcess.stdout)
+            .thenAnswer((Invocation invocation) {
+              // Messages from 2017 should pass through, 2020 message should not
+              return Stream<List<int>>.fromIterable(<List<int>>['''
+2017-09-13 15:26:57.228948-0700  localhost Runner[37195]: (Flutter) Single line message
+2017-09-13 15:26:57.228948-0700  localhost Runner[37195]: (Flutter) Multi line message
+  continues...
+  continues...
+2020-03-11 15:58:28.207175-0700  localhost Runner[72166]: (libnetwork.dylib) [com.apple.network:] [28 www.googleapis.com:443 stream, pid: 72166, tls] cancelled
+	[28.1 64A98447-EABF-4983-A387-7DB9D0C1785F 10.0.1.200.57912<->172.217.6.74:443]
+	Connected Path: satisfied (Path is satisfied), interface: en18
+	Duration: 0.271s, DNS @0.000s took 0.001s, TCP @0.002s took 0.019s, TLS took 0.046s
+	bytes in/out: 4468/1933, packets in/out: 11/10, rtt: 0.016s, retransmitted packets: 0, out-of-order packets: 0
+2017-09-13 15:36:57.228948-0700  localhost Runner[37195]: (Flutter) Multi line message again
+  and it goes...
+  and goes...
+'''
+                .codeUnits]);
+            });
+          when(mockProcess.stderr)
+              .thenAnswer((Invocation invocation) => const Stream<List<int>>.empty());
+          // Delay return of exitCode until after stdout stream data, since it terminates the logger.
+          when(mockProcess.exitCode)
+              .thenAnswer((Invocation invocation) => Future<int>.delayed(Duration.zero, () => 0));
+          return Future<Process>.value(mockProcess);
+        });
+
+      final IOSSimulator device = IOSSimulator(
+        '123456',
+        simulatorCategory: 'iOS 11.0',
+        simControl: mockSimControl,
+        xcode: mockXcode,
+      );
+      final DeviceLogReader logReader = device.getLogReader(
+        app: await BuildableIOSApp.fromProject(mockIosProject),
+      );
+
+      final List<String> lines = await logReader.logLines.toList();
+      expect(lines, <String>[
+        'Single line message',
+        'Multi line message',
+        '  continues...',
+        '  continues...',
+        'Multi line message again',
+        '  and it goes...',
+        '  and goes...',
+      ]);
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+      FileSystem: () => fileSystem,
+    });
   });
 
   group('SimControl', () {

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -586,6 +586,7 @@ void main() {
 2017-09-13 15:36:57.228948-0700  localhost Runner[37195]: (Flutter) Multi line message again
   and it goes...
   and goes...
+2017-09-13 15:36:57.228948-0700  localhost Runner[37195]: (Flutter) Single line message, not the part of the above
 '''
                 .codeUnits]);
             });
@@ -616,6 +617,7 @@ void main() {
         'Multi line message again',
         '  and it goes...',
         '  and goes...',
+        'Single line message, not the part of the above'
       ]);
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,


### PR DESCRIPTION
Fixes https://github.com/FirebaseExtended/flutterfire/issues/1130

## Description

Current implementation of log reader for iOS Simulator doesn't handle multiline messages well. If the first line of the message is filtered out the remaining still pass through and this cause issues. https://github.com/FirebaseExtended/flutterfire/issues/1130 in particular.

## Related Issues

* https://github.com/FirebaseExtended/flutterfire/issues/1130

## Tests

I added the following tests:

* `log reader handles multiline messages`
    Verifies that log reader reads single line and multi line messages, then skips the multi line message in its entirety that should be skipped and then reads the multi line message again.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
   * TBH a few totally unrelated tests failed, but they have absolutely nothing to do with my changes. Broken master?
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
