### PR TITLE
fix issue with multiple java runtimes on macOS

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -583,14 +583,13 @@ class AndroidSdk {
     if (platform.isMacOS) {
       try {
         final String javaHomeOutput = processUtils.runSync(
-          <String>['/usr/libexec/java_home'],
+          <String>['/usr/libexec/java_home', '-v', '1.8'],
           throwOnError: true,
           hideStdout: true,
         ).stdout.trim();
         if (javaHomeOutput != null) {
-          final List<String> javaHomeOutputSplit = javaHomeOutput.split('\n');
-          if ((javaHomeOutputSplit != null) && (javaHomeOutputSplit.isNotEmpty)) {
-            final String javaHome = javaHomeOutputSplit[0].trim();
+          if ((javaHomeOutput != null) && (javaHomeOutput.isNotEmpty)) {
+            final String javaHome = javaHomeOutput.split('\n').last.trim();
             return fileSystem.path.join(javaHome, 'bin', 'java');
           }
         }

--- a/packages/flutter_tools/test/general.shard/android/android_sdk_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_sdk_test.dart
@@ -98,7 +98,7 @@ void main() {
           .thenReturn(ProcessResult(1, 0, '26.1.1\n', ''));
       if (globals.platform.isMacOS) {
         when(globals.processManager.runSync(
-          <String>['/usr/libexec/java_home'],
+          <String>['/usr/libexec/java_home', '-v', '1.8'],
           workingDirectory: anyNamed('workingDirectory'),
           environment: anyNamed('environment'),
         )).thenReturn(ProcessResult(0, 0, '', ''));
@@ -137,7 +137,7 @@ void main() {
           .thenReturn(ProcessResult(1, 1, '26.1.1\n', 'Mystery error'));
       if (globals.platform.isMacOS) {
         when(globals.processManager.runSync(
-          <String>['/usr/libexec/java_home'],
+          <String>['/usr/libexec/java_home', '-v', '1.8'],
           workingDirectory: anyNamed('workingDirectory'),
           environment: anyNamed('environment'),
         )).thenReturn(ProcessResult(0, 0, '', ''));


### PR DESCRIPTION
## Description

Flutter developers on macOS with multiple JVM installations encounter an issue where flutter reports an installation error with the installed Android SDK.

I found out that this was due to how Flutter looks for the JDK on macOS.

Below is a screenshot of what the error looks like, and the results after this fix.

![image](https://user-images.githubusercontent.com/44836329/76535665-826a9700-647b-11ea-8f0a-1aec99c20c11.png)

![image](https://user-images.githubusercontent.com/44836329/76537356-f1e18600-647d-11ea-8d37-c6f26621b5b5.png)

## Related Issues

*Replace this paragraph with a list of issues related to this PR from our [issue database]. Indicate, which of these issues are resolved or fixed by this PR. There should be at least one issue listed here.*

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behaviour with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
