### PR TITLE
[flutter_tools] Hanlde OSError in places where we've seen it thrown

### DIFF
--- a/packages/flutter_tools/lib/src/base/io.dart
+++ b/packages/flutter_tools/lib/src/base/io.dart
@@ -78,6 +78,7 @@ export 'dart:io'
         IOSink,
         // Link              NO! Use `file_system.dart`
         // NetworkInterface  NO! Use `io.dart`
+        OSError,
         pid,
         // Platform          NO! use `platform.dart`
         Process,

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -319,7 +319,12 @@ class _DevFSHttpWriter {
             onError: (dynamic error) { globals.printTrace('error: $error'); },
             cancelOnError: true);
         break;
-      } on Exception catch (error, trace) {
+      } catch (error, trace) { // ignore: avoid_catches_without_on_clauses
+        // We treat OSError as an Exception.
+        // See: https://github.com/dart-lang/sdk/issues/40934
+        if (error is! Exception && error is! OSError) {
+          rethrow;
+        }
         if (!_completer.isCompleted) {
           globals.printTrace('Error writing "$deviceUri" to DevFS: $error');
           if (retry > 0) {

--- a/packages/flutter_tools/lib/src/mdns_discovery.dart
+++ b/packages/flutter_tools/lib/src/mdns_discovery.dart
@@ -58,10 +58,10 @@ class MDnsObservatoryDiscovery {
     try {
       await client.start();
       final List<PtrResourceRecord> pointerRecords = await client
-          .lookup<PtrResourceRecord>(
-            ResourceRecordQuery.serverPointer(dartObservatoryName),
-          )
-          .toList();
+        .lookup<PtrResourceRecord>(
+          ResourceRecordQuery.serverPointer(dartObservatoryName),
+        )
+        .toList();
       if (pointerRecords.isEmpty) {
         globals.printTrace('No pointer records found.');
         return null;
@@ -69,8 +69,8 @@ class MDnsObservatoryDiscovery {
       // We have no guarantee that we won't get multiple hits from the same
       // service on this.
       final Set<String> uniqueDomainNames = pointerRecords
-          .map<String>((PtrResourceRecord record) => record.domainName)
-          .toSet();
+        .map<String>((PtrResourceRecord record) => record.domainName)
+        .toSet();
 
       String domainName;
       if (applicationId != null) {
@@ -98,10 +98,10 @@ class MDnsObservatoryDiscovery {
       globals.printTrace('Checking for available port on $domainName');
       // Here, if we get more than one, it should just be a duplicate.
       final List<SrvResourceRecord> srv = await client
-          .lookup<SrvResourceRecord>(
-            ResourceRecordQuery.service(domainName),
-          )
-          .toList();
+        .lookup<SrvResourceRecord>(
+          ResourceRecordQuery.service(domainName),
+        )
+        .toList();
       if (srv.isEmpty) {
         return null;
       }
@@ -133,6 +133,11 @@ class MDnsObservatoryDiscovery {
         authCode += '/';
       }
       return MDnsObservatoryDiscoveryResult(srv.first.port, authCode);
+    } on OSError catch (e) {
+      // OSError is neither an Error nor and Exception, so we wrap it in a
+      // SocketException and rethrow.
+      // See: https://github.com/dart-lang/sdk/issues/40934
+      throw SocketException('mdns query failed', osError: e);
     } finally {
       client.stop();
     }

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -109,59 +109,66 @@ void main() {
       HttpOverrides.global = savedHttpOverrides;
     });
 
-    testUsingContext('retry uploads when failure', () async {
-      final File file = fs.file(fs.path.join(basePath, filePath));
-      await file.parent.create(recursive: true);
-      file.writeAsBytesSync(<int>[1, 2, 3]);
-      // simulate package
-      await _createPackage(fs, 'somepkg', 'somefile.txt');
+    final List<dynamic> exceptions = <dynamic>[
+      Exception('Connection resert by peer'),
+      const OSError('Connection reset by peer'),
+    ];
 
-      final RealMockVMService vmService = RealMockVMService();
-      final RealMockVM vm = RealMockVM();
-      final Map<String, dynamic> response =  <String, dynamic>{ 'uri': 'file://abc' };
-      when(vm.createDevFS(any)).thenAnswer((Invocation invocation) {
-        return Future<Map<String, dynamic>>.value(response);
+    for (final dynamic exception in exceptions) {
+      testUsingContext('retry uploads when failure: $exception', () async {
+        final File file = fs.file(fs.path.join(basePath, filePath));
+        await file.parent.create(recursive: true);
+        file.writeAsBytesSync(<int>[1, 2, 3]);
+        // simulate package
+        await _createPackage(fs, 'somepkg', 'somefile.txt');
+
+        final RealMockVMService vmService = RealMockVMService();
+        final RealMockVM vm = RealMockVM();
+        final Map<String, dynamic> response =  <String, dynamic>{ 'uri': 'file://abc' };
+        when(vm.createDevFS(any)).thenAnswer((Invocation invocation) {
+          return Future<Map<String, dynamic>>.value(response);
+        });
+        when(vmService.vm).thenReturn(vm);
+
+        reset(httpClient);
+
+        final MockHttpClientRequest httpRequest = MockHttpClientRequest();
+        when(httpRequest.headers).thenReturn(MockHttpHeaders());
+        when(httpClient.putUrl(any)).thenAnswer((Invocation invocation) {
+          return Future<HttpClientRequest>.value(httpRequest);
+        });
+        final MockHttpClientResponse httpClientResponse = MockHttpClientResponse();
+        int nRequest = 0;
+        const int kFailedAttempts = 5;
+        when(httpRequest.close()).thenAnswer((Invocation invocation) {
+          if (nRequest++ < kFailedAttempts) {
+            throw exception;
+          }
+          return Future<HttpClientResponse>.value(httpClientResponse);
+        });
+
+        final DevFS devFS = DevFS(vmService, 'test', tempDir);
+        await devFS.create();
+
+        final MockResidentCompiler residentCompiler = MockResidentCompiler();
+        final UpdateFSReport report = await devFS.update(
+          mainPath: 'lib/foo.txt',
+          generator: residentCompiler,
+          pathToReload: 'lib/foo.txt.dill',
+          trackWidgetCreation: false,
+          invalidatedFiles: <Uri>[],
+        );
+
+        expect(report.syncedBytes, 22);
+        expect(report.success, isTrue);
+        verify(httpClient.putUrl(any)).called(kFailedAttempts + 1);
+        verify(httpRequest.close()).called(kFailedAttempts + 1);
+      }, overrides: <Type, Generator>{
+        FileSystem: () => fs,
+        HttpClientFactory: () => () => httpClient,
+        ProcessManager: () => FakeProcessManager.any(),
       });
-      when(vmService.vm).thenReturn(vm);
-
-      reset(httpClient);
-
-      final MockHttpClientRequest httpRequest = MockHttpClientRequest();
-      when(httpRequest.headers).thenReturn(MockHttpHeaders());
-      when(httpClient.putUrl(any)).thenAnswer((Invocation invocation) {
-        return Future<HttpClientRequest>.value(httpRequest);
-      });
-      final MockHttpClientResponse httpClientResponse = MockHttpClientResponse();
-      int nRequest = 0;
-      const int kFailedAttempts = 5;
-      when(httpRequest.close()).thenAnswer((Invocation invocation) {
-        if (nRequest++ < kFailedAttempts) {
-          throw Exception('Connection resert by peer');
-        }
-        return Future<HttpClientResponse>.value(httpClientResponse);
-      });
-
-      final DevFS devFS = DevFS(vmService, 'test', tempDir);
-      await devFS.create();
-
-      final MockResidentCompiler residentCompiler = MockResidentCompiler();
-      final UpdateFSReport report = await devFS.update(
-        mainPath: 'lib/foo.txt',
-        generator: residentCompiler,
-        pathToReload: 'lib/foo.txt.dill',
-        trackWidgetCreation: false,
-        invalidatedFiles: <Uri>[],
-      );
-
-      expect(report.syncedBytes, 22);
-      expect(report.success, isTrue);
-      verify(httpClient.putUrl(any)).called(kFailedAttempts + 1);
-      verify(httpRequest.close()).called(kFailedAttempts + 1);
-    }, overrides: <Type, Generator>{
-      FileSystem: () => fs,
-      HttpClientFactory: () => () => httpClient,
-      ProcessManager: () => FakeProcessManager.any(),
-    });
+    }
   });
 
   group('devfs remote', () {

--- a/packages/flutter_tools/test/general.shard/mdns_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/mdns_discovery_test.dart
@@ -192,6 +192,21 @@ void main() {
       final int port = (await portDiscovery.query(applicationId: 'bar'))?.port;
       expect(port, isNull);
     });
+
+    testUsingContext('Throws SocketException when client throws OSError on start', () async {
+      final MDnsClient client = MockMDnsClient();
+      when(client.start()).thenAnswer((_) {
+        throw const OSError('Operation not suppoted on socket', 102);
+      });
+
+      final MDnsObservatoryDiscovery portDiscovery = MDnsObservatoryDiscovery(
+        mdnsClient: client,
+      );
+      expect(
+        () async => await portDiscovery.query(),
+        throwsA(isA<SocketException>()),
+      );
+    });
   });
 }
 


### PR DESCRIPTION
## Description

`OSError` rather than `SocketException` is thrown from certain socket operations. See https://github.com/dart-lang/sdk/issues/40934.

This PR handles `OSError` in a couple of places that we've seen it in crash logging.

## Related Issues

https://github.com/flutter/flutter/issues/52272

## Tests

I added the following tests:

Added tests to devfs_test.dart and mdns_discovery_test.dart.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
