### PR TITLE
[flutter_tools] always initialize the resident runner from dill

### DIFF
--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -75,6 +75,12 @@ class FlutterDevice {
     if (device.platformType == PlatformType.fuchsia) {
       targetModel = TargetModel.flutterRunner;
     }
+    // For both web and non-web platforms we initialize dill to/from
+    // a shared location for faster bootstrapping. If this process fails
+    // due to a kernel target or version mismatch, no error is reported
+    // and the compiler starts up as normal. Unexpected errors will print
+    // a warning message and dump some debug information which can be
+    // used to file a bug, but the compiler will still bootstrap correctly.
     if (targetPlatform == TargetPlatform.web_javascript) {
       generator = ResidentCompiler(
         globals.artifacts.getArtifactPath(Artifact.flutterWebSdk, mode: buildInfo.mode),
@@ -84,7 +90,6 @@ class FlutterDevice {
         // Override the filesystem scheme so that the frontend_server can find
         // the generated entrypoint code.
         fileSystemScheme: 'org-dartlang-app',
-        // initialize dill to/from a shared location for faster bootstrapping.
         initializeFromDill: globals.fs.path.join(getBuildDirectory(), 'cache.dill'),
         targetModel: TargetModel.dartdevc,
         experimentalFlags: experimentalFlags,
@@ -109,7 +114,6 @@ class FlutterDevice {
         targetModel: targetModel,
         experimentalFlags: experimentalFlags,
         dartDefines: buildInfo.dartDefines,
-        // initialize dill to/from a shared location for faster bootstrapping.
         initializeFromDill: globals.fs.path.join(getBuildDirectory(), 'cache.dill'),
       );
     }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -76,11 +76,11 @@ class FlutterDevice {
       targetModel = TargetModel.flutterRunner;
     }
     // For both web and non-web platforms we initialize dill to/from
-    // a shared location for faster bootstrapping. If this process fails
+    // a shared location for faster bootstrapping. If the compiler fails
     // due to a kernel target or version mismatch, no error is reported
     // and the compiler starts up as normal. Unexpected errors will print
     // a warning message and dump some debug information which can be
-    // used to file a bug, but the compiler will still bootstrap correctly.
+    // used to file a bug, but the compiler will still start up correctly.
     if (targetPlatform == TargetPlatform.web_javascript) {
       generator = ResidentCompiler(
         globals.artifacts.getArtifactPath(Artifact.flutterWebSdk, mode: buildInfo.mode),

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1012,8 +1012,11 @@ abstract class ResidentRunner {
   Future<void> preExit() async {
     // If _dillOutputPath is null, we created a temporary directory for the dill.
     if (_dillOutputPath == null && artifactDirectory.existsSync()) {
-      artifactDirectory.childFile('app.dill')
-        .copySync(globals.fs.path.join(getBuildDirectory(), 'cache.dill'));
+      final File outputDill = artifactDirectory.childFile('app.dill');
+      if (outputDill.existsSync()) {
+        artifactDirectory.childFile('app.dill')
+          .copySync(globals.fs.path.join(getBuildDirectory(), 'cache.dill'));
+      }
       artifactDirectory.deleteSync(recursive: true);
     }
   }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -84,6 +84,8 @@ class FlutterDevice {
         // Override the filesystem scheme so that the frontend_server can find
         // the generated entrypoint code.
         fileSystemScheme: 'org-dartlang-app',
+        // initialize dill to/from a shared location for faster bootstrapping.
+        initializeFromDill: globals.fs.path.join(getBuildDirectory(), 'cache.dill'),
         targetModel: TargetModel.dartdevc,
         experimentalFlags: experimentalFlags,
         platformDill: globals.fs.file(globals.artifacts
@@ -107,6 +109,8 @@ class FlutterDevice {
         targetModel: targetModel,
         experimentalFlags: experimentalFlags,
         dartDefines: buildInfo.dartDefines,
+        // initialize dill to/from a shared location for faster bootstrapping.
+        initializeFromDill: globals.fs.path.join(getBuildDirectory(), 'cache.dill'),
       );
     }
 
@@ -637,7 +641,6 @@ abstract class ResidentRunner {
   final bool ipv6;
   final String _dillOutputPath;
   /// The parent location of the incremental artifacts.
-  @visibleForTesting
   final Directory artifactDirectory;
   final String packagesFilePath;
   final String projectRootPath;
@@ -1009,6 +1012,8 @@ abstract class ResidentRunner {
   Future<void> preExit() async {
     // If _dillOutputPath is null, we created a temporary directory for the dill.
     if (_dillOutputPath == null && artifactDirectory.existsSync()) {
+      artifactDirectory.childFile('app.dill')
+        .copySync(globals.fs.path.join(getBuildDirectory(), 'cache.dill'));
       artifactDirectory.deleteSync(recursive: true);
     }
   }

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -366,6 +366,13 @@ void main() {
     expect(cacheDill.readAsStringSync(), 'hello');
   }));
 
+  test('ResidentRunner handles output dill missing during preExit', () => testbed.run(() async {
+    await residentRunner.preExit();
+    final File cacheDill = globals.fs.file(globals.fs.path.join(getBuildDirectory(), 'cache.dill'));
+
+    expect(cacheDill, isNot(exists));
+  }));
+
   test('ResidentRunner printHelpDetails', () => testbed.run(() {
     when(mockDevice.supportsHotRestart).thenReturn(true);
     when(mockDevice.supportsScreenshot).thenReturn(true);


### PR DESCRIPTION
## Description

Copy the output dill to a shared location `build/cache.dill` after running, and initialize new runners from this dill. Doesn't attempt to handle different build configurations or updates to dart, since this is a best effort only performance improvement.

Along with https://dart-review.googlesource.com/c/sdk/+/139313 , this change speeds up subsequent compiles of the flutter gallery (in web) from 14-16 seconds to 7-8 seconds.

https://github.com/flutter/flutter/issues/50616