### PR TITLE
add usbmuxd

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -1274,6 +1274,9 @@ class IosUsbArtifacts extends CachedArtifact {
       'idevicescreenshot',
       'idevicesyslog',
     ],
+    'usbmuxd': <String>[
+      'iproxy',
+    ],
   };
 
   @override

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -436,6 +436,24 @@ void main() {
       ProcessManager: () => FakeProcessManager.any(),
     });
 
+    testUsingContext('verifies iproxy for usbmuxd in isUpToDateInner', () async {
+      final IosUsbArtifacts iosUsbArtifacts = IosUsbArtifacts('usbmuxd', mockCache);
+      when(mockCache.getArtifactDirectory(any)).thenReturn(globals.fs.currentDirectory);
+      iosUsbArtifacts.location.createSync();
+      final File iproxy = iosUsbArtifacts.location.childFile('iproxy')
+        ..createSync();
+
+      expect(iosUsbArtifacts.isUpToDateInner(), true);
+
+      iproxy.deleteSync();
+
+      expect(iosUsbArtifacts.isUpToDateInner(), false);
+    }, overrides: <Type, Generator>{
+      Cache: () => mockCache,
+      FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager.any(),
+    });
+
     testUsingContext('Does not verify executables for openssl in isUpToDateInner', () async {
       final IosUsbArtifacts iosUsbArtifacts = IosUsbArtifacts('openssl', mockCache);
       when(mockCache.getArtifactDirectory(any)).thenReturn(globals.fs.currentDirectory);


### PR DESCRIPTION
## Description

This is an extension of https://github.com/flutter/flutter/pull/43767 to include `iproxy`, which is showing in crash logs. I tried to copy invocations directly from crash reporting, but I was not able to reproduce locally. I suspect to actually track this down/fix this, we'll need to implement a wrapper around cache artifacts that ensures they exist/tries to redownload before executing. Filed https://github.com/flutter/flutter/issues/52499 to track.

## Related Issues

Attempt to mitigate (but not fix) https://github.com/flutter/flutter/issues/46892.

## Tests

Added a test verifying `isUpToDateInner()` verifies `iproxy`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*