### PR TITLE
[flutter_tools] support toggling CanvasKit rendering on with 'k'

### DIFF
--- a/packages/flutter_tools/lib/src/base/command_help.dart
+++ b/packages/flutter_tools/lib/src/base/command_help.dart
@@ -153,6 +153,12 @@ class CommandHelp {
     'Toggle elevation checker.',
   );
 
+  CommandHelpOption _k;
+  CommandHelpOption get k => _k ??= _makeOption(
+    'k',
+    'Toggle CanvasKit rendering.',
+  );
+
   CommandHelpOption _makeOption(String key, String description, [
     String inParenthesis = '',
   ]) {

--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -711,6 +711,16 @@ class _ResidentWebRunner extends ResidentWebRunner {
   }
 
   @override
+  bool get supportsCanvasKit => supportsServiceProtocol;
+
+  @override
+  Future<void> toggleCanvaskit() async {
+    final WebDevFS webDevFS = device.devFS as WebDevFS;
+    webDevFS.webAssetServer.canvasKitRendering = !webDevFS.webAssetServer.canvasKitRendering;
+    await _wipConnection?.sendCommand('Page.reload');
+  }
+
+  @override
   Future<void> exitApp() async {
     await device.exitApps();
     appFinished();

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -665,6 +665,7 @@ abstract class ResidentRunner {
   bool get isRunningProfile => debuggingOptions.buildInfo.isProfile;
   bool get isRunningRelease => debuggingOptions.buildInfo.isRelease;
   bool get supportsServiceProtocol => isRunningDebug || isRunningProfile;
+  bool get supportsCanvasKit => false;
 
   // Returns the Uri of the first connected device for mobile,
   // and only connected device for web.
@@ -722,6 +723,13 @@ abstract class ResidentRunner {
     final String mode = isRunningProfile ? 'profile' :
         isRunningRelease ? 'release' : 'this';
     throw '${fullRestart ? 'Restart' : 'Reload'} is not supported in $mode mode';
+  }
+
+  /// Toggle whether canvaskit is being used for rendering.
+  ///
+  /// Only supported on the web.
+  Future<void> toggleCanvaskit() {
+    throw Exception('Canvaskit not supported by this runner.');
   }
 
   /// The resident runner API for interaction with the reloadMethod vmservice
@@ -1043,6 +1051,9 @@ abstract class ResidentRunner {
         commandHelp.S.print();
         commandHelp.U.print();
       }
+      if (supportsCanvasKit){
+        commandHelp.k.print();
+      }
       // `P` should precede `a`
       commandHelp.P.print();
       commandHelp.a.print();
@@ -1179,6 +1190,12 @@ class TerminalHandler {
       case 'I':
         if (residentRunner.supportsServiceProtocol) {
           await residentRunner.debugToggleWidgetInspector();
+          return true;
+        }
+        return false;
+      case 'k':
+        if (residentRunner.supportsCanvasKit) {
+          await residentRunner.toggleCanvaskit();
           return true;
         }
         return false;

--- a/packages/flutter_tools/test/general.shard/base/command_help_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/command_help_test.dart
@@ -59,6 +59,7 @@ void _testMessageLength({
   expect(commandHelp.d.toString().length, lessThanOrEqualTo(expectedWidth));
   expect(commandHelp.h.toString().length, lessThanOrEqualTo(expectedWidth));
   expect(commandHelp.i.toString().length, lessThanOrEqualTo(expectedWidth));
+  expect(commandHelp.k.toString().length, lessThanOrEqualTo(expectedWidth));
   expect(commandHelp.o.toString().length, lessThanOrEqualTo(expectedWidth));
   expect(commandHelp.p.toString().length, lessThanOrEqualTo(expectedWidth));
   expect(commandHelp.q.toString().length, lessThanOrEqualTo(expectedWidth));

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -368,6 +368,8 @@ void main() {
     expect(residentRunner.supportsServiceProtocol, true);
     // isRunningDebug
     expect(residentRunner.isRunningDebug, true);
+    // does not support CanvasKit
+    expect(residentRunner.supportsCanvasKit, false);
     // commands
     expect(testLogger.statusText, equals(
         <dynamic>[
@@ -393,6 +395,11 @@ void main() {
           ''
         ].join('\n')
     ));
+  }));
+
+  test('ResidentRunner does not support CanvasKit', () => testbed.run(() async {
+    expect(() => residentRunner.toggleCanvaskit(),
+      throwsA(isA<Exception>()));
   }));
 
   test('ResidentRunner can take screenshot on debug device', () => testbed.run(() async {

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -425,6 +425,18 @@ void main() {
     expect(residentWebRunner.debuggingEnabled, true);
   }));
 
+  test('web resident runner can toggle CanvasKit', () => testbed.run(() async {
+    final WebAssetServer webAssetServer = WebAssetServer(null, null, null);
+    when(mockWebDevFS.webAssetServer).thenReturn(webAssetServer);
+
+    expect(residentWebRunner.supportsCanvasKit, true);
+    expect(webAssetServer.canvasKitRendering, false);
+
+    await residentWebRunner.toggleCanvaskit();
+
+    expect(webAssetServer.canvasKitRendering, true);
+  }));
+
   test('Exits when initial compile fails', () => testbed.run(() async {
     _setupMocks();
     when(mockWebDevFS.update(

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -357,6 +357,15 @@ void main() {
     webDevFS.webAssetServer.dartSdk
       ..createSync(recursive: true)
       ..writeAsStringSync('HELLO');
+    webDevFS.webAssetServer.dartSdkSourcemap
+      ..createSync(recursive: true)
+      ..writeAsStringSync('THERE');
+    webDevFS.webAssetServer.canvasKitDartSdk
+      ..createSync(recursive: true)
+      ..writeAsStringSync('OL');
+    webDevFS.webAssetServer.canvasKitDartSdkSourcemap
+      ..createSync(recursive: true)
+      ..writeAsStringSync('CHUM');
     webDevFS.webAssetServer.dartSdkSourcemap.createSync(recursive: true);
 
     await webDevFS.update(
@@ -373,12 +382,18 @@ void main() {
     expect(webDevFS.webAssetServer.getFile('/manifest.json'), isNotNull);
     expect(webDevFS.webAssetServer.getFile('/flutter_service_worker.js'), isNotNull);
     expect(await webDevFS.webAssetServer.dartSourceContents('/dart_sdk.js'), 'HELLO');
+    expect(await webDevFS.webAssetServer.dartSourceContents('/dart_sdk.js.map'), 'THERE');
 
     // Update to the SDK.
     webDevFS.webAssetServer.dartSdk.writeAsStringSync('BELLOW');
 
     // New SDK should be visible..
     expect(await webDevFS.webAssetServer.dartSourceContents('/dart_sdk.js'), 'BELLOW');
+
+    // Toggle CanvasKit
+    webDevFS.webAssetServer.canvasKitRendering = true;
+    expect(await webDevFS.webAssetServer.dartSourceContents('/dart_sdk.js'), 'OL');
+    expect(await webDevFS.webAssetServer.dartSourceContents('/dart_sdk.js.map'), 'CHUM');
 
     await webDevFS.destroy();
   }));


### PR DESCRIPTION
## Description

Adds the ability to toggle a debug build of Flutter for the Web between the html and CanvasKit backends with "k". Requires a slightly newer engine revision (soon).

Currently this is done as a full page refresh. Its not clear if we could use the hot restart functionality to invalidate the dart sdk, since the dart sdk itself tracks state for hot restarts.