### PR TITLE
Fall back to environment SDKROOT passed from Xcode

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -225,7 +225,7 @@ class AOTSnapshotter {
     final String assemblyO = globals.fs.path.join(outputPath, 'snapshot_assembly.o');
     List<String> isysrootArgs;
     if (isIOS) {
-      final String iPhoneSDKLocation = await globals.xcode.sdkLocation(SdkType.iPhone);
+      final String iPhoneSDKLocation = await globals.xcode.sdkLocation(SdkType.iPhone, globals.platform.environment);
       if (iPhoneSDKLocation != null) {
         isysrootArgs = <String>['-isysroot', iPhoneSDKLocation];
       }

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -412,7 +412,7 @@ Future<RunResult> createStubAppFramework(File outputFile, SdkType sdk, { bool in
       '-Xlinker', '-rpath', '-Xlinker', '@executable_path/Frameworks',
       '-Xlinker', '-rpath', '-Xlinker', '@loader_path/Frameworks',
       '-install_name', '@rpath/App.framework/App',
-      '-isysroot', await globals.xcode.sdkLocation(sdk),
+      '-isysroot', await globals.xcode.sdkLocation(sdk, globals.platform.environment),
       '-o', outputFile.path,
     ]);
   } finally {

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -165,14 +165,17 @@ class Xcode {
     );
   }
 
-  Future<String> sdkLocation(SdkType sdk) async {
+  Future<String> sdkLocation(SdkType sdk, Map<String, String> environment) async {
+    // If this is run an Xcode script build phase, the SDKROOT is already exported.
+    if (environment.containsKey('SDKROOT')) {
+      return environment['SDKROOT'];
+    }
     assert(sdk != null);
     final RunResult runResult = await _processUtils.run(
       <String>['xcrun', '--sdk', getNameForSdk(sdk), '--show-sdk-path'],
-      throwOnError: true,
     );
     if (runResult.exitCode != 0) {
-      throwToolExit('Could not find iPhone SDK location: ${runResult.stderr}');
+      throwToolExit('Could not find SDK location: ${runResult.stderr}');
     }
     return runResult.stdout.trim();
   }

--- a/packages/flutter_tools/test/general.shard/base/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/build_test.dart
@@ -240,7 +240,7 @@ void main() {
       mockAndroidSdk = MockAndroidSdk();
       mockArtifacts = MockArtifacts();
       mockXcode = MockXcode();
-      when(mockXcode.sdkLocation(any)).thenAnswer((_) => Future<String>.value(kSDKPath));
+      when(mockXcode.sdkLocation(any, any)).thenAnswer((_) => Future<String>.value(kSDKPath));
 
       for (final BuildMode mode in BuildMode.values) {
         when(mockArtifacts.getArtifactPath(Artifact.snapshotDart,

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -178,6 +178,36 @@ void main() {
       expect(getNameForSdk(SdkType.iPhoneSimulator), 'iphonesimulator');
       expect(getNameForSdk(SdkType.macOS), 'macosx');
     });
+
+    group('SDK location', () {
+      const String sdkroot = 'Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS13.2.sdk';
+
+      testWithoutContext('environment', () async {
+        expect(await xcode.sdkLocation(SdkType.iPhone, <String, String>{'SDKROOT': sdkroot}), sdkroot);
+      });
+
+      testWithoutContext('--show-sdk-path iphoneos', () async {
+        when(processManager.run(<String>['xcrun', '--sdk', 'iphoneos', '--show-sdk-path'])).thenAnswer((_) =>
+        Future<ProcessResult>.value(ProcessResult(1, 0, sdkroot, '')));
+
+        expect(await xcode.sdkLocation(SdkType.iPhone, <String, String>{}), sdkroot);
+      });
+
+      testWithoutContext('--show-sdk-path macosx', () async {
+        when(processManager.run(<String>['xcrun', '--sdk', 'macosx', '--show-sdk-path'])).thenAnswer((_) =>
+        Future<ProcessResult>.value(ProcessResult(1, 0, sdkroot, '')));
+
+        expect(await xcode.sdkLocation(SdkType.macOS, <String, String>{}), sdkroot);
+      });
+
+      testWithoutContext('--show-sdk-path fails', () async {
+        when(processManager.run(<String>['xcrun', '--sdk', 'iphoneos', '--show-sdk-path'])).thenAnswer((_) =>
+        Future<ProcessResult>.value(ProcessResult(1, 1, '', 'xcrun: error:')));
+
+        expect(() async => await xcode.sdkLocation(SdkType.iPhone, <String, String>{}),
+          throwsToolExit(message: 'Could not find SDK location'));
+      });
+    });
   });
 
   group('xcdevice', () {


### PR DESCRIPTION
## Description

This was doing redundant work when `build`ing from Xcode since the build settings are already exported in the env.  Saves ~600ms on my machine on the first run (subsequently cached by `xcrun`).

## Related Issues

Fixes https://github.com/flutter/flutter/issues/46137

## Tests

Added SDK root tests.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*