### PR TITLE
Do not check the executable status of gen_snapshot if it has not yet been downloaded

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -639,7 +639,8 @@ class FlutterValidator extends DoctorValidator {
       globals.artifacts.getArtifactPath(Artifact.genSnapshot);
 
     // Check that the binaries we downloaded for this platform actually run on it.
-    if (!_genSnapshotRuns(genSnapshotPath)) {
+    if (globals.fs.file(genSnapshotPath).existsSync()
+        && !_genSnapshotRuns(genSnapshotPath)) {
       final StringBuffer buf = StringBuffer();
       buf.writeln(userMessages.flutterBinariesDoNotRun);
       if (globals.platform.isLinux) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
@@ -529,6 +529,16 @@ void main() {
       Platform: _kNoColorOutputPlatform,
     });
 
+    testUsingContext('gen_snapshot binary not available', () async {
+        expect(await FlutterValidatorDoctor().diagnose(verbose: false), isTrue);
+        // gen_snapshot is downloaded on demand, and the doctor should not
+        // fail if the gen_snapshot binary is not present.
+        expect(testLogger.statusText, contains('No issues found!'));
+    }, overrides: <Type, Generator>{
+      FileSystem: () => MemoryFileSystem(),
+      ProcessManager: () => FakeProcessManager.any(),
+    });
+
     testUsingContext('version checking does not work', () async {
       final VersionCheckError versionCheckError = VersionCheckError('version error');
 


### PR DESCRIPTION
This will happen if you do a "git clean" of the Flutter framework tree
and then run "flutter create".  Currently the tool will throw an exception
because "create" runs the doctor but does not download the gen_snapshot
artifact.