### PR TITLE
Fix to DrawerController: Call the callback when drawer flung open.

### DIFF
--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -436,9 +436,13 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
       switch (Directionality.of(context)) {
         case TextDirection.rtl:
           _controller.fling(velocity: -visualVelocity);
+          if (widget.drawerCallback != null)
+            widget.drawerCallback(visualVelocity < 0.0);
           break;
         case TextDirection.ltr:
           _controller.fling(velocity: visualVelocity);
+          if (widget.drawerCallback != null)
+            widget.drawerCallback(visualVelocity > 0.0);
           break;
       }
     } else if (_controller.value < 0.5) {

--- a/packages/flutter/test/material/drawer_test.dart
+++ b/packages/flutter/test/material/drawer_test.dart
@@ -166,4 +166,53 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byType(Drawer), findsNothing);
   });
+
+  testWidgets('Open/close drawers by flinging', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          drawer: Drawer(
+            child: Container(
+              child: const Text('start drawer'),
+            ),
+          ),
+          endDrawer: Drawer(
+            child: Container(
+              child: const Text('end drawer'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // In the beginning, drawers are closed
+    final ScaffoldState state = tester.firstState(find.byType(Scaffold));
+    expect(state.isDrawerOpen, equals(false));
+    expect(state.isEndDrawerOpen, equals(false));
+    final Size size = tester.getSize(find.byType(Scaffold));
+
+    // A fling from the left opens the start drawer
+    await tester.flingFrom(Offset(0, size.height / 2), const Offset(80, 0), 500);
+    await tester.pumpAndSettle();
+    expect(state.isDrawerOpen, equals(true));
+    expect(state.isEndDrawerOpen, equals(false));
+
+    // Now, a fling from the right closes the drawer
+    await tester.flingFrom(Offset(size.width - 1, size.height / 2), const Offset(-80, 0), 500);
+    await tester.pumpAndSettle();
+    expect(state.isDrawerOpen, equals(false));
+    expect(state.isEndDrawerOpen, equals(false));
+
+    // Another fling from the right opens the end drawer
+    await tester.flingFrom(Offset(size.width - 1, size.height / 2), const Offset(-80, 0), 500);
+    await tester.pumpAndSettle();
+    expect(state.isDrawerOpen, equals(false));
+    expect(state.isEndDrawerOpen, equals(true));
+
+    // And a fling from the left closes it
+    await tester.flingFrom( Offset(0, size.height / 2), const Offset(80, 0), 500);
+    await tester.pumpAndSettle();
+    expect(state.isDrawerOpen, equals(false));
+    expect(state.isEndDrawerOpen, equals(false));
+  });
 }


### PR DESCRIPTION
## Description

DrawerController fails to call the drawer callback when a drawer is flung open, resulting in werid behavior - e.g. the user being able to open both drawers at the same time.

## Related Issues

This is a proposed fix for the issue #52592.
Fixes #52592

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
