### PR TITLE
Fix paths causing test failures

### DIFF
--- a/dev/devicelab/bin/tasks/time_to_development_benchmark__android.dart
+++ b/dev/devicelab/bin/tasks/time_to_development_benchmark__android.dart
@@ -15,7 +15,7 @@ Future<void> main() async {
 }
 
 final Directory flutterGalleryDir =
-    dir(path.join(flutterDirectory.path, flutterRoot, 'dev', 'integration_tests', 'flutter_gallery'));
+    dir(path.join(flutterDirectory.path, 'dev', 'integration_tests', 'flutter_gallery'));
 final Directory editedFlutterGalleryDir =
     dir(path.join(Directory.systemTemp.path, 'edited_flutter_gallery'));
 

--- a/dev/devicelab/bin/tasks/time_to_development_benchmark__android.dart
+++ b/dev/devicelab/bin/tasks/time_to_development_benchmark__android.dart
@@ -15,7 +15,7 @@ Future<void> main() async {
 }
 
 final Directory flutterGalleryDir =
-    dir(path.join(flutterDirectory.path, 'examples', 'flutter_gallery'));
+    dir(path.join(flutterDirectory.path, flutterRoot, 'dev', 'integration_tests', 'flutter_gallery'));
 final Directory editedFlutterGalleryDir =
     dir(path.join(Directory.systemTemp.path, 'edited_flutter_gallery'));
 

--- a/dev/integration_tests/flutter_gallery/ios/fastlane/Fastfile
+++ b/dev/integration_tests/flutter_gallery/ios/fastlane/Fastfile
@@ -29,7 +29,7 @@ platform :ios do
     setup_travis
 
     # Relative to this file.
-    raw_version = File.read('../../../../version')
+    raw_version = File.read('../../../../../version')
     puts "Building and deploying version #{raw_version}..."
 
     update_app_identifier(


### PR DESCRIPTION
Fix build error caused by https://github.com/flutter/flutter/pull/52532

- time_to_development_benchmark__android
- deploy_gallery-macos

```console
[02:49:38]: 
Error in your Fastfile at line 32
[02:49:38]: 
    30:	
[02:49:38]: 
    31:	    # Relative to this file.
[02:49:38]: 
 => 32:	    raw_version = File.read('../../../../version')
[02:49:38]: 
    33:	    puts "Building and deploying version #{raw_version}..."
[02:49:38]: 
    34:	
[02:49:38]: 
No such file or directory @ rb_sysopen - ../../../../version
```

