### PR TITLE
When sending to device, use gzip compression level 1 instead of the default (6)

### DIFF
--- a/packages/flutter_tools/lib/src/base/io.dart
+++ b/packages/flutter_tools/lib/src/base/io.dart
@@ -61,6 +61,7 @@ export 'dart:io'
         // File,              NO! Use `file_system.dart`
         // FileSystemEntity,  NO! Use `file_system.dart`
         gzip,
+        GZipCodec,
         HandshakeException,
         HttpClient,
         HttpClientRequest,

--- a/packages/flutter_tools/lib/src/base/io.dart
+++ b/packages/flutter_tools/lib/src/base/io.dart
@@ -60,7 +60,6 @@ export 'dart:io'
         exitCode,
         // File,              NO! Use `file_system.dart`
         // FileSystemEntity,  NO! Use `file_system.dart`
-        gzip,
         GZipCodec,
         HandshakeException,
         HttpClient,

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -31,6 +31,8 @@ DevFSConfig get devFSConfig => context.get<DevFSConfig>();
 
 /// Common superclass for content copied to the device.
 abstract class DevFSContent {
+  static final GZipCodec gzip = GZipCodec(level: 1);
+
   /// Return true if this is the first time this method is called
   /// or if the entry has been modified since this method was last called.
   bool get isModified;
@@ -47,11 +49,6 @@ abstract class DevFSContent {
   Stream<List<int>> contentsAsStream();
 
   Stream<List<int>> contentsAsCompressedStream() {
-    return contentsAsStream().cast<List<int>>().transform<List<int>>(gzip.encoder);
-  }
-
-  Stream<List<int>> contentsAsGzip1CompressedStream() {
-    final GZipCodec gzip = GZipCodec(level: 1);
     return contentsAsStream().cast<List<int>>().transform<List<int>>(gzip.encoder);
   }
 
@@ -317,7 +314,7 @@ class _DevFSHttpWriter {
         request.headers.removeAll(HttpHeaders.acceptEncodingHeader);
         request.headers.add('dev_fs_name', fsName);
         request.headers.add('dev_fs_uri_b64', base64.encode(utf8.encode('$deviceUri')));
-        final Stream<List<int>> contents = content.contentsAsGzip1CompressedStream();
+        final Stream<List<int>> contents = content.contentsAsCompressedStream();
         await request.addStream(contents);
         final HttpClientResponse response = await request.close();
         response.listen((_) => null,

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -50,6 +50,11 @@ abstract class DevFSContent {
     return contentsAsStream().cast<List<int>>().transform<List<int>>(gzip.encoder);
   }
 
+  Stream<List<int>> contentsAsGzip1CompressedStream() {
+    final GZipCodec gzip = GZipCodec(level: 1);
+    return contentsAsStream().cast<List<int>>().transform<List<int>>(gzip.encoder);
+  }
+
   /// Return the list of files this content depends on.
   List<String> get fileDependencies => <String>[];
 }
@@ -312,7 +317,7 @@ class _DevFSHttpWriter {
         request.headers.removeAll(HttpHeaders.acceptEncodingHeader);
         request.headers.add('dev_fs_name', fsName);
         request.headers.add('dev_fs_uri_b64', base64.encode(utf8.encode('$deviceUri')));
-        final Stream<List<int>> contents = content.contentsAsCompressedStream();
+        final Stream<List<int>> contents = content.contentsAsGzip1CompressedStream();
         await request.addStream(contents);
         final HttpClientResponse response = await request.close();
         response.listen((_) => null,


### PR DESCRIPTION
## Description

When sending files to the device it is first compressed with gzip in an effort to make the whole thing go faster.
As detailed here: https://github.com/dart-lang/sdk/issues/41048 gzip encoding is pretty slow, and in all but cases where the transfer speed is very slow, it would be better to spend less time compressing, even if it means sending more data.

This change - tested on flutter gallery on an android emulator on my google issue desktop - has the following characteristics:

Before this change the time spend transferring to device (via this mechanism) was (timings in ms):

Initial transfer | 13.5 MB partial dill transfer
-- | --
1551 | 474
1567 | 476
1679 | 484
1632 | 470
1526 | 517

(Note for reproduction: The 13.4 MB partial dill file is the dill generated when changing package flutters "lib/src/widgets/text.dart".)

After this change the times are:


Initial transfer | 13.5 MB partial dill transfer
-- | --
1580 | 182
1510 | 187
1493 | 184
1443 | 172
1422 | 182

For the initial transfer that's (difference at 95.0% confidence): -101.4 +/- 91.0318 (-6.37335% +/- 5.72167%) ---- i.e. almost unchanged.

For the partial dill that's (difference at 95.0% confidence): -302.8 +/- 20.4702 (-62.5361% +/- 4.22764%) ---- i.e. at lot faster.


Digging into why the initial transfer is almost not different:
* The dill isn't included in this, only assets (222 of them) - the dill is likely part of the apk that's installed via adb
* The average (uncompressed file size) is ~161 KB; the median is ~59 KB
* The compressed (original) output size is ~31.76 MB; the compressed (changed) output size is ~31.91 MB (~152 KB more)
* It does this in parallel (it seems 6 at a time): Compressing it single-threaded would take (original) 6.2 seconds; (changed) 6.0 seconds (~0.2 seconds less)
* Combined, it is probably ~33 ms faster (200 ms / 6 "threads") to compress with the changed scheme, but it has to send ~150 KB more.

The change for the partial dill file is consistent with the calculations on https://github.com/dart-lang/sdk/issues/41048

Note (and again): This was tested on an emulator, a real device connected via either usb2, usb3, wifi or whatever else will probably behave differently. From the above though, I think the conclusion can be that it doesn't matter for the initial transfer, and unless the transfer speed is very slow, this change is for the better (I get that saving these 300 ms is not changing the fact that compiling the 13.5 MB file takes several seconds, but shaving of 300 ms is still something like an overall improvement of ~8% for the entire hot-reload).

## Related Issues

https://github.com/dart-lang/sdk/issues/41048
https://github.com/dart-lang/sdk/issues/34001

## Tests

No tests have been added or changed.
