### PR TITLE
web tests: run no more than one `RunnerSuite` at a time

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,9 +4,9 @@
 web_shard_template: &WEB_SHARD_TEMPLATE
   only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_tools/lib/src/test/**', 'packages/flutter_web_plugins/**', 'bin/internal/**') || $CIRRUS_PR == ''"
   environment:
-    # As of October 2019, the Web shards needed more than 6G of RAM.
-    CPU: 2
-    MEMORY: 8G
+    # As of March 2020, the Web shards needed 16G of RAM and 4 CPUs to run all framework tests with goldens without flaking.
+    CPU: 4
+    MEMORY: 16G
     CHROME_NO_SANDBOX: true
     GOLD_SERVICE_ACCOUNT: ENCRYPTED[3afeea5ac7201151c3d0dc9648862f0462b5e4f55dc600ca8b692319622f7c3eda3d577b1b16cc2ef0311b7314c1c095]
   script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -194,28 +194,104 @@ task:
     #   script:
     #     - dart --enable-asserts ./dev/bots/test.dart
 
-    - name: web_tests-0-linux
+    ### RUN 1
+    - name: web_tests1-0-linux
       << : *WEB_SHARD_TEMPLATE
 
-    - name: web_tests-1-linux
+    - name: web_tests1-1-linux
       << : *WEB_SHARD_TEMPLATE
 
-    - name: web_tests-2-linux
+    - name: web_tests1-2-linux
       << : *WEB_SHARD_TEMPLATE
 
-    - name: web_tests-3-linux
+    - name: web_tests1-3-linux
       << : *WEB_SHARD_TEMPLATE
 
-    - name: web_tests-4-linux
+    - name: web_tests1-4-linux
       << : *WEB_SHARD_TEMPLATE
 
-    - name: web_tests-5-linux
+    - name: web_tests1-5-linux
       << : *WEB_SHARD_TEMPLATE
 
-    - name: web_tests-6-linux
+    - name: web_tests1-6-linux
       << : *WEB_SHARD_TEMPLATE
 
-    - name: web_tests-7_last-linux # last Web shard must end with _last
+    - name: web_tests1-7_last-linux # last Web shard must end with _last
+      << : *WEB_SHARD_TEMPLATE
+
+    ### RUN 2
+    - name: web_tests2-0-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests2-1-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests2-2-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests2-3-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests2-4-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests2-5-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests2-6-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests2-7_last-linux # last Web shard must end with _last
+      << : *WEB_SHARD_TEMPLATE
+
+    ### RUN 3
+    - name: web_tests3-0-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests3-1-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests3-2-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests3-3-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests3-4-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests3-5-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests3-6-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests3-7_last-linux # last Web shard must end with _last
+      << : *WEB_SHARD_TEMPLATE
+
+    ### RUN 4
+    - name: web_tests4-0-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests4-1-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests4-2-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests4-3-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests4-4-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests4-5-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests4-6-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests4-7_last-linux # last Web shard must end with _last
       << : *WEB_SHARD_TEMPLATE
 
     # - name: build_tests-linux

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -294,6 +294,106 @@ task:
     - name: web_tests4-7_last-linux # last Web shard must end with _last
       << : *WEB_SHARD_TEMPLATE
 
+    ### RUN 5
+    - name: web_tests5-0-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests5-1-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests5-2-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests5-3-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests5-4-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests5-5-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests5-6-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests5-7_last-linux # last Web shard must end with _last
+      << : *WEB_SHARD_TEMPLATE
+
+    ### RUN 6
+    - name: web_tests6-0-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests6-1-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests6-2-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests6-3-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests6-4-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests6-5-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests6-6-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests6-7_last-linux # last Web shard must end with _last
+      << : *WEB_SHARD_TEMPLATE
+
+    ### RUN 7
+    - name: web_tests7-0-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests7-1-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests7-2-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests7-3-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests7-4-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests7-5-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests7-6-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests7-7_last-linux # last Web shard must end with _last
+      << : *WEB_SHARD_TEMPLATE
+
+    ### RUN 8
+    - name: web_tests9-0-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests9-1-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests9-2-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests9-3-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests9-4-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests9-5-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests9-6-linux
+      << : *WEB_SHARD_TEMPLATE
+
+    - name: web_tests9-7_last-linux # last Web shard must end with _last
+      << : *WEB_SHARD_TEMPLATE
+
     # - name: build_tests-linux
     #   environment:
     #     # With 1 CPU and 4G of RAM, as of October 2019, build_tests-linux would get OOM-killed.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,3 +1,4 @@
+# re-run 1
 # CIRRUS CONFIGURATION FILE
 # https://cirrus-ci.org/guide/writing-tasks/
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -96,103 +96,103 @@ task:
       - date
       - which flutter
   matrix:
-    - name: analyze-linux # linux-only
-      # environment:
-        # Empirically, the analyze-linux shard runs surprisingly fast (under 15 minutes) with just 1
-        # CPU and 4G RAM as of October 2019. It fails with less than 4G though.
-      script:
-        - dart --enable-asserts ./dev/bots/analyze.dart
+    # - name: analyze-linux # linux-only
+    #   # environment:
+    #     # Empirically, the analyze-linux shard runs surprisingly fast (under 15 minutes) with just 1
+    #     # CPU and 4G RAM as of October 2019. It fails with less than 4G though.
+    #   script:
+    #     - dart --enable-asserts ./dev/bots/analyze.dart
 
-    - name: fuchsia_precache-linux # linux-only
-      only_if: "changesInclude('.cirrus.yml', 'bin/internal/engine.version')"
-      script:
-        - flutter precache --fuchsia --no-android --no-ios
-        - flutter precache --flutter_runner --no-android --no-ios
+    # - name: fuchsia_precache-linux # linux-only
+    #   only_if: "changesInclude('.cirrus.yml', 'bin/internal/engine.version')"
+    #   script:
+    #     - flutter precache --fuchsia --no-android --no-ios
+    #     - flutter precache --flutter_runner --no-android --no-ios
 
-    - name: framework_tests-widgets-linux
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_tools/lib/src/test/**', 'bin/internal/**') || $CIRRUS_PR == ''"
-      environment:
-        # We use 3 CPUs because that's the minimum required to get framework_tests-widgets-linux
-        # running fast enough that it is not the long pole, as of OCtober 2019.
-        CPU: 3
-        GOLD_SERVICE_ACCOUNT: ENCRYPTED[3afeea5ac7201151c3d0dc9648862f0462b5e4f55dc600ca8b692319622f7c3eda3d577b1b16cc2ef0311b7314c1c095]
-      script:
-        - dart --enable-asserts ./dev/bots/test.dart
+    # - name: framework_tests-widgets-linux
+    #   only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_tools/lib/src/test/**', 'bin/internal/**') || $CIRRUS_PR == ''"
+    #   environment:
+    #     # We use 3 CPUs because that's the minimum required to get framework_tests-widgets-linux
+    #     # running fast enough that it is not the long pole, as of OCtober 2019.
+    #     CPU: 3
+    #     GOLD_SERVICE_ACCOUNT: ENCRYPTED[3afeea5ac7201151c3d0dc9648862f0462b5e4f55dc600ca8b692319622f7c3eda3d577b1b16cc2ef0311b7314c1c095]
+    #   script:
+    #     - dart --enable-asserts ./dev/bots/test.dart
 
-    - name: framework_tests-libraries-linux
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_tools/lib/src/test/**', 'bin/internal/**') || $CIRRUS_PR == ''"
-      environment:
-        # We use 3 CPUs because that's the minimum required to get the
-        # framework_tests-libraries-linux shard running fast enough that it is not the long pole, as
-        # of October 2019.
-        CPU: 3
-        GOLD_SERVICE_ACCOUNT: ENCRYPTED[3afeea5ac7201151c3d0dc9648862f0462b5e4f55dc600ca8b692319622f7c3eda3d577b1b16cc2ef0311b7314c1c095]
-      script:
-        - dart --enable-asserts ./dev/bots/test.dart
+    # - name: framework_tests-libraries-linux
+    #   only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_tools/lib/src/test/**', 'bin/internal/**') || $CIRRUS_PR == ''"
+    #   environment:
+    #     # We use 3 CPUs because that's the minimum required to get the
+    #     # framework_tests-libraries-linux shard running fast enough that it is not the long pole, as
+    #     # of October 2019.
+    #     CPU: 3
+    #     GOLD_SERVICE_ACCOUNT: ENCRYPTED[3afeea5ac7201151c3d0dc9648862f0462b5e4f55dc600ca8b692319622f7c3eda3d577b1b16cc2ef0311b7314c1c095]
+    #   script:
+    #     - dart --enable-asserts ./dev/bots/test.dart
 
-    - name: framework_tests-misc-linux
-      # this includes the tests for directories in dev/
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_goldens/**', 'packages/flutter_test/**', 'packages/flutter_tools/lib/src/test/**', 'bin/internal/**') || $CIRRUS_PR == ''"
-      environment:
-        # We use 3 CPUs because that's the minimum required to get framework_tests-misc-linux
-        # running fast enough that it is not the long pole, as of October 2019.
-        CPU: 3
-      script:
-        - dart --enable-asserts ./dev/bots/test.dart
+    # - name: framework_tests-misc-linux
+    #   # this includes the tests for directories in dev/
+    #   only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_goldens/**', 'packages/flutter_test/**', 'packages/flutter_tools/lib/src/test/**', 'bin/internal/**') || $CIRRUS_PR == ''"
+    #   environment:
+    #     # We use 3 CPUs because that's the minimum required to get framework_tests-misc-linux
+    #     # running fast enough that it is not the long pole, as of October 2019.
+    #     CPU: 3
+    #   script:
+    #     - dart --enable-asserts ./dev/bots/test.dart
 
-    - name: tool_tests-general-linux
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter_tools/**', 'bin/internal/**') || $CIRRUS_PR == ''"
-      environment:
-        # As of November 2019, the tool_tests-general-linux shard got faster with more CPUs up to 4
-        # CPUs, and needed at least 10G of RAM to not run out of memory.
-        CPU: 4
-        MEMORY: 10G
-      script:
-        - dart --enable-asserts ./dev/bots/test.dart
+    # - name: tool_tests-general-linux
+    #   only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter_tools/**', 'bin/internal/**') || $CIRRUS_PR == ''"
+    #   environment:
+    #     # As of November 2019, the tool_tests-general-linux shard got faster with more CPUs up to 4
+    #     # CPUs, and needed at least 10G of RAM to not run out of memory.
+    #     CPU: 4
+    #     MEMORY: 10G
+    #   script:
+    #     - dart --enable-asserts ./dev/bots/test.dart
 
-    - name: tool_tests-commands-linux
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter_tools/**', 'bin/internal/**') || $CIRRUS_PR == ''"
-      environment:
-        # As of October 2019, the tool_tests-commands-linux shard got faster with more CPUs up to 6
-        # CPUs, and needed at least 8G of RAM to not run out of memory.
-        # Increased to 10GB on 19th Nov 2019 due to significant number of OOMKilled failures on PR builds.
-        CPU: 6
-        MEMORY: 10G
-      script:
-        - dart --enable-asserts ./dev/bots/test.dart
+    # - name: tool_tests-commands-linux
+    #   only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter_tools/**', 'bin/internal/**') || $CIRRUS_PR == ''"
+    #   environment:
+    #     # As of October 2019, the tool_tests-commands-linux shard got faster with more CPUs up to 6
+    #     # CPUs, and needed at least 8G of RAM to not run out of memory.
+    #     # Increased to 10GB on 19th Nov 2019 due to significant number of OOMKilled failures on PR builds.
+    #     CPU: 6
+    #     MEMORY: 10G
+    #   script:
+    #     - dart --enable-asserts ./dev/bots/test.dart
 
-    - name: tool_tests-integration-linux
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter_tools/**', 'bin/internal/**') || $CIRRUS_PR == ''"
-      environment:
-        # As of October 2019, the tool_tests-integration-linux shard got faster with more CPUs up to
-        # 6 CPUs, and needed at least 8G of RAM to not run out of memory.
-        CPU: 6
-        MEMORY: 8G
-      script:
-        - dart --enable-asserts ./dev/bots/test.dart
+    # - name: tool_tests-integration-linux
+    #   only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter_tools/**', 'bin/internal/**') || $CIRRUS_PR == ''"
+    #   environment:
+    #     # As of October 2019, the tool_tests-integration-linux shard got faster with more CPUs up to
+    #     # 6 CPUs, and needed at least 8G of RAM to not run out of memory.
+    #     CPU: 6
+    #     MEMORY: 8G
+    #   script:
+    #     - dart --enable-asserts ./dev/bots/test.dart
 
-    - name: tool_coverage-linux # linux-only
-      only_if: "$CIRRUS_BRANCH == 'master'"
-      environment:
-        # As of February 2020, the tool_coverage-linux shard needed at least 24G of RAM to run without
-        # getting OOM-killed, and even 8 CPUs took 25 minutes.
-        CPU: 8
-        MEMORY: 24G
-        CODECOV_TOKEN: ENCRYPTED[7c76a7f8c9264f3b7f3fd63fcf186f93c62c4dfe43ec288861c2f506d456681032b89efe7b7a139c82156350ca2c752c]
-      script:
-        - dart --enable-asserts ./dev/bots/test.dart
-        - bash <(curl -s https://codecov.io/bash) -c -f packages/flutter_tools/coverage/lcov.info -F flutter_tool
+    # - name: tool_coverage-linux # linux-only
+    #   only_if: "$CIRRUS_BRANCH == 'master'"
+    #   environment:
+    #     # As of February 2020, the tool_coverage-linux shard needed at least 24G of RAM to run without
+    #     # getting OOM-killed, and even 8 CPUs took 25 minutes.
+    #     CPU: 8
+    #     MEMORY: 24G
+    #     CODECOV_TOKEN: ENCRYPTED[7c76a7f8c9264f3b7f3fd63fcf186f93c62c4dfe43ec288861c2f506d456681032b89efe7b7a139c82156350ca2c752c]
+    #   script:
+    #     - dart --enable-asserts ./dev/bots/test.dart
+    #     - bash <(curl -s https://codecov.io/bash) -c -f packages/flutter_tools/coverage/lcov.info -F flutter_tool
 
-    - name: web_integration_tests
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_tools/**', 'packages/flutter_web_plugins/**', 'bin/internal/**') || $CIRRUS_PR == ''"
-      environment:
-        # As of October 2019, the Web shards needed more than 6G of RAM.
-        CPU: 2
-        MEMORY: 8G
-        CHROME_NO_SANDBOX: true
-        GOLD_SERVICE_ACCOUNT: ENCRYPTED[3afeea5ac7201151c3d0dc9648862f0462b5e4f55dc600ca8b692319622f7c3eda3d577b1b16cc2ef0311b7314c1c095]
-      script:
-        - dart --enable-asserts ./dev/bots/test.dart
+    # - name: web_integration_tests
+    #   only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_tools/**', 'packages/flutter_web_plugins/**', 'bin/internal/**') || $CIRRUS_PR == ''"
+    #   environment:
+    #     # As of October 2019, the Web shards needed more than 6G of RAM.
+    #     CPU: 2
+    #     MEMORY: 8G
+    #     CHROME_NO_SANDBOX: true
+    #     GOLD_SERVICE_ACCOUNT: ENCRYPTED[3afeea5ac7201151c3d0dc9648862f0462b5e4f55dc600ca8b692319622f7c3eda3d577b1b16cc2ef0311b7314c1c095]
+    #   script:
+    #     - dart --enable-asserts ./dev/bots/test.dart
 
     - name: web_tests-0-linux
       << : *WEB_SHARD_TEMPLATE
@@ -218,407 +218,407 @@ task:
     - name: web_tests-7_last-linux # last Web shard must end with _last
       << : *WEB_SHARD_TEMPLATE
 
-    - name: build_tests-linux
-      environment:
-        # With 1 CPU and 4G of RAM, as of October 2019, build_tests-linux would get OOM-killed.
-        # Increasing the RAM to 12G allowed it to finish in about 30 minutes, any extra CPU (tried 2
-        # and 4) reduced that to just over 20 minutes. 6G was enough not to get OOM-killed.
-        CPU: 2
-        MEMORY: 6G
-      script:
-        - dart --enable-asserts ./dev/bots/test.dart
+    # - name: build_tests-linux
+    #   environment:
+    #     # With 1 CPU and 4G of RAM, as of October 2019, build_tests-linux would get OOM-killed.
+    #     # Increasing the RAM to 12G allowed it to finish in about 30 minutes, any extra CPU (tried 2
+    #     # and 4) reduced that to just over 20 minutes. 6G was enough not to get OOM-killed.
+    #     CPU: 2
+    #     MEMORY: 6G
+    #   script:
+    #     - dart --enable-asserts ./dev/bots/test.dart
 
-    - name: hostonly_devicelab_tests-0-linux
-      << : *LINUX_SHARD_TEMPLATE
+    # - name: hostonly_devicelab_tests-0-linux
+    #   << : *LINUX_SHARD_TEMPLATE
 
-    - name: hostonly_devicelab_tests-1-linux
-      << : *LINUX_SHARD_TEMPLATE
+    # - name: hostonly_devicelab_tests-1-linux
+    #   << : *LINUX_SHARD_TEMPLATE
 
-    - name: hostonly_devicelab_tests-2-linux
-      << : *LINUX_SHARD_TEMPLATE
+    # - name: hostonly_devicelab_tests-2-linux
+    #   << : *LINUX_SHARD_TEMPLATE
 
-    - name: hostonly_devicelab_tests-3_last-linux
-      << : *LINUX_SHARD_TEMPLATE
+    # - name: hostonly_devicelab_tests-3_last-linux
+    #   << : *LINUX_SHARD_TEMPLATE
 
-    # TODO(ianh): name: add_to_app_tests-linux
+    # # TODO(ianh): name: add_to_app_tests-linux
 
-    - name: docs-linux # linux-only
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_drive/**', 'packages/flutter_localizations/**', 'packages/flutter_goldens/**', 'bin/internal/**') || $CIRRUS_PR == ''"
-      environment:
-        # Empirically, as of October 2019, the docs-linux shard took about 30 minutes when run with
-        # 1 CPU and 4G of RAM. 2 CPUs reduced that to 20 minutes, more CPUs did not improve matters.
-        CPU: 2
-        # For uploading master docs to Firebase master branch staging site
-        FIREBASE_MASTER_TOKEN: ENCRYPTED[eb768d18798fdc5abfe09b224e1724c4d82831d715ccf90df2c79d618c317216cbd99493278361f6fe7948b409b603f0]
-        # For uploading beta docs to Firebase public live site
-        FIREBASE_PUBLIC_TOKEN: ENCRYPTED[37e8b82f167864cae9a3f4d2cf3f37dea331d9375c295327c45de524f6c588fa6f6d63e5784f10f6d43ce29689f36c92]
-      script:
-        - ./dev/bots/docs.sh
+    # - name: docs-linux # linux-only
+    #   only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_drive/**', 'packages/flutter_localizations/**', 'packages/flutter_goldens/**', 'bin/internal/**') || $CIRRUS_PR == ''"
+    #   environment:
+    #     # Empirically, as of October 2019, the docs-linux shard took about 30 minutes when run with
+    #     # 1 CPU and 4G of RAM. 2 CPUs reduced that to 20 minutes, more CPUs did not improve matters.
+    #     CPU: 2
+    #     # For uploading master docs to Firebase master branch staging site
+    #     FIREBASE_MASTER_TOKEN: ENCRYPTED[eb768d18798fdc5abfe09b224e1724c4d82831d715ccf90df2c79d618c317216cbd99493278361f6fe7948b409b603f0]
+    #     # For uploading beta docs to Firebase public live site
+    #     FIREBASE_PUBLIC_TOKEN: ENCRYPTED[37e8b82f167864cae9a3f4d2cf3f37dea331d9375c295327c45de524f6c588fa6f6d63e5784f10f6d43ce29689f36c92]
+    #   script:
+    #     - ./dev/bots/docs.sh
 
-    - name: customer_testing-linux
-      # environment:
-        # Empirically, this shard runs fine at 1 CPU and 4G RAM as of October 2019. We will probably
-        # want to grow this container when we invite people to add their tests in large numbers.
-      script:
-        - rm -rf bin/cache/pkg/tests
-        - git clone https://github.com/flutter/tests.git bin/cache/pkg/tests
-        - dart --enable-asserts dev/customer_testing/run_tests.dart --skip-on-fetch-failure --skip-template bin/cache/pkg/tests/registry/*.test
+    # - name: customer_testing-linux
+    #   # environment:
+    #     # Empirically, this shard runs fine at 1 CPU and 4G RAM as of October 2019. We will probably
+    #     # want to grow this container when we invite people to add their tests in large numbers.
+    #   script:
+    #     - rm -rf bin/cache/pkg/tests
+    #     - git clone https://github.com/flutter/tests.git bin/cache/pkg/tests
+    #     - dart --enable-asserts dev/customer_testing/run_tests.dart --skip-on-fetch-failure --skip-template bin/cache/pkg/tests/registry/*.test
 
-    - name: firebase_test_lab_tests-linux # linux-only
-      environment:
-        # Empirically, this shard runs in 20-25 minutes with just one CPU and 4G of RAM, as of
-        # October 2019. It does not seem to be sensitive to the number of CPUs or amount of RAM;
-        # doubling CPUs had no effect (mere seconds under 20 minutes), increasing RAM to 24G left it
-        # on the high end of the 20-25 minute range. (This makes sense, as it's just driving the
-        # Firebase test lab remotely.) Less than 4G of RAM made it go OOM.
-        CLOUDSDK_CORE_DISABLE_PROMPTS: 1
-        GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[1c140257edc48f5578fa5a0e5038b84c8e53270c405efa5a8e35ea303a4e0d135853989f448f72136206de854d17fbec]
-      script:
-        - ./dev/bots/firebase_testlab.sh
+    # - name: firebase_test_lab_tests-linux # linux-only
+    #   environment:
+    #     # Empirically, this shard runs in 20-25 minutes with just one CPU and 4G of RAM, as of
+    #     # October 2019. It does not seem to be sensitive to the number of CPUs or amount of RAM;
+    #     # doubling CPUs had no effect (mere seconds under 20 minutes), increasing RAM to 24G left it
+    #     # on the high end of the 20-25 minute range. (This makes sense, as it's just driving the
+    #     # Firebase test lab remotely.) Less than 4G of RAM made it go OOM.
+    #     CLOUDSDK_CORE_DISABLE_PROMPTS: 1
+    #     GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[1c140257edc48f5578fa5a0e5038b84c8e53270c405efa5a8e35ea303a4e0d135853989f448f72136206de854d17fbec]
+    #   script:
+    #     - ./dev/bots/firebase_testlab.sh
 
-    - name: web_smoke_test
-      only_if: "changesInclude('.cirrus.yml', 'examples/hello_world/**' ,'dev/**', 'packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_tools/lib/src/test/**', 'packages/flutter_web_plugins/**', 'bin/internal/**') || $CIRRUS_PR == ''"
-      environment:
-        # Tests Hello World with Flutter Web Engine using Flutter Driver. Should not need more resources.
-        CPU: 2
-        MEMORY: 2G
-        CHROME_NO_SANDBOX: true
-      script:
-        - flutter config --enable-web
-        - git clone https://github.com/flutter/web_installers.git
-        - cd web_installers/packages/web_drivers/
-        - pub get
-        - dart lib/web_driver_installer.dart &
-        - sleep 20
-        - chromedriver/chromedriver --port=4444 &
-        - sleep 5
-        - cd ../../../examples/hello_world/
-        - flutter drive --target=test_driver/smoke_web_engine.dart -d web-server --profile --browser-name=chrome
+    # - name: web_smoke_test
+    #   only_if: "changesInclude('.cirrus.yml', 'examples/hello_world/**' ,'dev/**', 'packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_tools/lib/src/test/**', 'packages/flutter_web_plugins/**', 'bin/internal/**') || $CIRRUS_PR == ''"
+    #   environment:
+    #     # Tests Hello World with Flutter Web Engine using Flutter Driver. Should not need more resources.
+    #     CPU: 2
+    #     MEMORY: 2G
+    #     CHROME_NO_SANDBOX: true
+    #   script:
+    #     - flutter config --enable-web
+    #     - git clone https://github.com/flutter/web_installers.git
+    #     - cd web_installers/packages/web_drivers/
+    #     - pub get
+    #     - dart lib/web_driver_installer.dart &
+    #     - sleep 20
+    #     - chromedriver/chromedriver --port=4444 &
+    #     - sleep 5
+    #     - cd ../../../examples/hello_world/
+    #     - flutter drive --target=test_driver/smoke_web_engine.dart -d web-server --profile --browser-name=chrome
 
-    - name: deploy_gallery-linux # linux- and macos- only
-      # Do not add more tasks here. Nothing is currently deployed from master branch, so it is safe to run
-      # even if a test has failed. The behavior of failing dependencies is non-ideal for infra health.
-      # See also: https://github.com/flutter/flutter/pull/49454
-      depends_on:
-        - analyze-linux
-      environment:
-        # As of October 2019, 1 CPU and 4G of RAM let deploy_gallery-linux finish in about 15
-        # minutes, once it got started.
-        GOOGLE_DEVELOPER_SERVICE_ACCOUNT_ACTOR_FASTLANE: ENCRYPTED[d9ac1462c3c556fc2f8165c9d5566a16497d8ebc38a50357f7f3abf136b7f83e1d1d76dde36fee356cb0f9ebf7a89346]
-        ANDROID_GALLERY_UPLOAD_KEY: ENCRYPTED[0f2aca35f05b26add5d9edea2a7449341269a2b7e22d5c667f876996e2e8bc44ff1369431ebf73b7c5581fd95d0e5902]
-      script:
-        - ./dev/bots/deploy_gallery.sh
+    # - name: deploy_gallery-linux # linux- and macos- only
+    #   # Do not add more tasks here. Nothing is currently deployed from master branch, so it is safe to run
+    #   # even if a test has failed. The behavior of failing dependencies is non-ideal for infra health.
+    #   # See also: https://github.com/flutter/flutter/pull/49454
+    #   depends_on:
+    #     - analyze-linux
+    #   environment:
+    #     # As of October 2019, 1 CPU and 4G of RAM let deploy_gallery-linux finish in about 15
+    #     # minutes, once it got started.
+    #     GOOGLE_DEVELOPER_SERVICE_ACCOUNT_ACTOR_FASTLANE: ENCRYPTED[d9ac1462c3c556fc2f8165c9d5566a16497d8ebc38a50357f7f3abf136b7f83e1d1d76dde36fee356cb0f9ebf7a89346]
+    #     ANDROID_GALLERY_UPLOAD_KEY: ENCRYPTED[0f2aca35f05b26add5d9edea2a7449341269a2b7e22d5c667f876996e2e8bc44ff1369431ebf73b7c5581fd95d0e5902]
+    #   script:
+    #     - ./dev/bots/deploy_gallery.sh
 
 # WINDOWS SHARDS
-task:
-  windows_container:
-    image: cirrusci/android-sdk:28-windowsservercore-2019
-    os_version: 2019
-    cpu: $CPU
-    memory: $MEMORY
-  environment:
-    CPU: 1 # 1-8 without compute credits, 1-30 with
-    MEMORY: 2G # 256M-24G without compute credits, 256M-90G with
-    CIRRUS_WORKING_DIR: "C:\\Windows\\Temp\\$FLUTTER_SDK_PATH_WITH_SPACE"
-    PATH: "$CIRRUS_WORKING_DIR/bin;$CIRRUS_WORKING_DIR/bin/cache/dart-sdk/bin;$PATH"
-  pub_cache:
-    folder: $APPDATA\Pub\Cache
-    fingerprint_script:
-      - ps: $Environment:OS; Get-ChildItem -Path "$Environment:CIRRUS_WORKING_DIR" pubspec.yaml -Recurse | Select-String -Pattern "PUBSPEC CHECKSUM" -SimpleMatch
-    reupload_on_changes: false
-  flutter_pkg_cache:
-    folder: bin\cache\pkg
-    fingerprint_script: echo %OS% & type bin\internal\*.version
-    reupload_on_changes: false
-  artifacts_cache:
-    folder: bin\cache\artifacts
-    fingerprint_script: echo %OS% & type bin\internal\*.version
-    reupload_on_changes: false
-  setup_script:
-    - git clean -xffd --exclude=bin/cache/ # git wants forward slash path separators, even on Windows.
-    - git fetch origin
-    - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
-    - flutter config --no-analytics
-    - flutter doctor -v
-    - flutter update-packages
-    - git fetch origin master
-  matrix:
-    - name: framework_tests-widgets-windows
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_tools/lib/src/test/**', 'bin/internal/**') || $CIRRUS_PR == ''"
-      environment:
-        # As of December 2019, framework_tests-widgets-windows needs 4 CPUs to pass reliably.
-        # With a min of 4 CPUs and 4 GB of RAM, it ran in about 50 minutes. Increasing to 8 CPUs and
-        # 8 GB RAM sped that up to ~25 minutes, and increasing either beyond that yielded no
-        # further speed increase. Cirrus requires >= 8GM RAM for 8 CPUs.
-        CPU: 8
-        MEMORY: 8G
-        GOLDCTL: "C:\\Windows\\Temp\\depot_tools\\goldctl.exe"
-        GOLD_SERVICE_ACCOUNT: ENCRYPTED[3afeea5ac7201151c3d0dc9648862f0462b5e4f55dc600ca8b692319622f7c3eda3d577b1b16cc2ef0311b7314c1c095]
-      script:
-        - powershell dev\bots\download_goldctl.ps1
-        - dart --enable-asserts dev\bots\test.dart
+# task:
+#   windows_container:
+#     image: cirrusci/android-sdk:28-windowsservercore-2019
+#     os_version: 2019
+#     cpu: $CPU
+#     memory: $MEMORY
+#   environment:
+#     CPU: 1 # 1-8 without compute credits, 1-30 with
+#     MEMORY: 2G # 256M-24G without compute credits, 256M-90G with
+#     CIRRUS_WORKING_DIR: "C:\\Windows\\Temp\\$FLUTTER_SDK_PATH_WITH_SPACE"
+#     PATH: "$CIRRUS_WORKING_DIR/bin;$CIRRUS_WORKING_DIR/bin/cache/dart-sdk/bin;$PATH"
+#   pub_cache:
+#     folder: $APPDATA\Pub\Cache
+#     fingerprint_script:
+#       - ps: $Environment:OS; Get-ChildItem -Path "$Environment:CIRRUS_WORKING_DIR" pubspec.yaml -Recurse | Select-String -Pattern "PUBSPEC CHECKSUM" -SimpleMatch
+#     reupload_on_changes: false
+#   flutter_pkg_cache:
+#     folder: bin\cache\pkg
+#     fingerprint_script: echo %OS% & type bin\internal\*.version
+#     reupload_on_changes: false
+#   artifacts_cache:
+#     folder: bin\cache\artifacts
+#     fingerprint_script: echo %OS% & type bin\internal\*.version
+#     reupload_on_changes: false
+#   setup_script:
+#     - git clean -xffd --exclude=bin/cache/ # git wants forward slash path separators, even on Windows.
+#     - git fetch origin
+#     - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
+#     - flutter config --no-analytics
+#     - flutter doctor -v
+#     - flutter update-packages
+#     - git fetch origin master
+#   matrix:
+#     - name: framework_tests-widgets-windows
+#       only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_tools/lib/src/test/**', 'bin/internal/**') || $CIRRUS_PR == ''"
+#       environment:
+#         # As of December 2019, framework_tests-widgets-windows needs 4 CPUs to pass reliably.
+#         # With a min of 4 CPUs and 4 GB of RAM, it ran in about 50 minutes. Increasing to 8 CPUs and
+#         # 8 GB RAM sped that up to ~25 minutes, and increasing either beyond that yielded no
+#         # further speed increase. Cirrus requires >= 8GM RAM for 8 CPUs.
+#         CPU: 8
+#         MEMORY: 8G
+#         GOLDCTL: "C:\\Windows\\Temp\\depot_tools\\goldctl.exe"
+#         GOLD_SERVICE_ACCOUNT: ENCRYPTED[3afeea5ac7201151c3d0dc9648862f0462b5e4f55dc600ca8b692319622f7c3eda3d577b1b16cc2ef0311b7314c1c095]
+#       script:
+#         - powershell dev\bots\download_goldctl.ps1
+#         - dart --enable-asserts dev\bots\test.dart
 
-    - name: framework_tests-libraries-windows
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_tools/lib/src/test/**', 'bin/internal/**') || $CIRRUS_PR == ''"
-      environment:
-        # As of December 2019, the framework_tests-libraries-windows shard needed 2 CPUs to pass.
-        # With a min of 2 CPUs and 2 GB RAM, it ran in about 60 minutes. Increasing to 8 CPUs made
-        # it run in ~20 minutes, and Cirrus requires 8 CPUs to have at least 8 GB RAM. Increasing
-        # beyond this yielded no gains.
-        CPU: 8
-        MEMORY: 8G
-        GOLDCTL: "C:\\Windows\\Temp\\depot_tools\\goldctl.exe"
-        GOLD_SERVICE_ACCOUNT: ENCRYPTED[3afeea5ac7201151c3d0dc9648862f0462b5e4f55dc600ca8b692319622f7c3eda3d577b1b16cc2ef0311b7314c1c095]
-      script:
-        - powershell dev\bots\download_goldctl.ps1
-        - dart --enable-asserts dev\bots\test.dart
+#     - name: framework_tests-libraries-windows
+#       only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_tools/lib/src/test/**', 'bin/internal/**') || $CIRRUS_PR == ''"
+#       environment:
+#         # As of December 2019, the framework_tests-libraries-windows shard needed 2 CPUs to pass.
+#         # With a min of 2 CPUs and 2 GB RAM, it ran in about 60 minutes. Increasing to 8 CPUs made
+#         # it run in ~20 minutes, and Cirrus requires 8 CPUs to have at least 8 GB RAM. Increasing
+#         # beyond this yielded no gains.
+#         CPU: 8
+#         MEMORY: 8G
+#         GOLDCTL: "C:\\Windows\\Temp\\depot_tools\\goldctl.exe"
+#         GOLD_SERVICE_ACCOUNT: ENCRYPTED[3afeea5ac7201151c3d0dc9648862f0462b5e4f55dc600ca8b692319622f7c3eda3d577b1b16cc2ef0311b7314c1c095]
+#       script:
+#         - powershell dev\bots\download_goldctl.ps1
+#         - dart --enable-asserts dev\bots\test.dart
 
-    - name: framework_tests-misc-windows
-      # this includes the tests for directories in dev/
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_goldens/**', 'packages/flutter_test/**', 'packages/flutter_tools/lib/src/test/**', 'bin/internal/**') || $CIRRUS_PR == ''"
-      environment:
-        # As of December 2019, the framework_tests-misc-windows shard needed 2 CPUs and 3 GB RAM
-        # to pass (taking ~40 minutes). Increasing to 4 CPUs (necessitating 4 GB RAM per Cirrus)
-        # sped that up to ~30 minutes, with further overprovisioning yielding no further gain.
-        CPU: 4
-        MEMORY: 4G
-      script:
-        - dart --enable-asserts dev\bots\test.dart
+#     - name: framework_tests-misc-windows
+#       # this includes the tests for directories in dev/
+#       only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_goldens/**', 'packages/flutter_test/**', 'packages/flutter_tools/lib/src/test/**', 'bin/internal/**') || $CIRRUS_PR == ''"
+#       environment:
+#         # As of December 2019, the framework_tests-misc-windows shard needed 2 CPUs and 3 GB RAM
+#         # to pass (taking ~40 minutes). Increasing to 4 CPUs (necessitating 4 GB RAM per Cirrus)
+#         # sped that up to ~30 minutes, with further overprovisioning yielding no further gain.
+#         CPU: 4
+#         MEMORY: 4G
+#       script:
+#         - dart --enable-asserts dev\bots\test.dart
 
-    - name: tool_tests-general-windows
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter_tools/**', 'bin/internal/**') || $CIRRUS_PR == ''"
-      environment:
-        # As of December 2019, the tool_tests-general-windows shard required 2 CPUs and 8 GB RAM to
-        # pass. Raising that to 4 CPUs sped it up to ~30 minutes, with further provisioning yielding
-        # no gain.
-        CPU: 4
-        MEMORY: 8G
-      script:
-        - dart --enable-asserts ./dev/bots/test.dart
+#     - name: tool_tests-general-windows
+#       only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter_tools/**', 'bin/internal/**') || $CIRRUS_PR == ''"
+#       environment:
+#         # As of December 2019, the tool_tests-general-windows shard required 2 CPUs and 8 GB RAM to
+#         # pass. Raising that to 4 CPUs sped it up to ~30 minutes, with further provisioning yielding
+#         # no gain.
+#         CPU: 4
+#         MEMORY: 8G
+#       script:
+#         - dart --enable-asserts ./dev/bots/test.dart
 
-    - name: tool_tests-commands-windows
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter_tools/**', 'bin/internal/**') || $CIRRUS_PR == ''"
-      environment:
-        # As of December 2019, the tool_tests-commands-windows shard needed 4 CPUs and 8 GB RAM to
-        # reliably pass and not be the long pole, running in about 25 minutes. Bumping beyond these
-        # numbers yielded no extra gain.
-        CPU: 4
-        MEMORY: 8G
-      script:
-        - dart --enable-asserts ./dev/bots/test.dart
+#     - name: tool_tests-commands-windows
+#       only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter_tools/**', 'bin/internal/**') || $CIRRUS_PR == ''"
+#       environment:
+#         # As of December 2019, the tool_tests-commands-windows shard needed 4 CPUs and 8 GB RAM to
+#         # reliably pass and not be the long pole, running in about 25 minutes. Bumping beyond these
+#         # numbers yielded no extra gain.
+#         CPU: 4
+#         MEMORY: 8G
+#       script:
+#         - dart --enable-asserts ./dev/bots/test.dart
 
-    - name: tool_tests-integration-windows
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter_tools/**', 'bin/internal/**') || $CIRRUS_PR == ''"
-      environment:
-        # As of December 2019, the tool_tests-integration-windows shard required 6 GB RAM to pass.
-        # Emperically, 4 CPUs and 10 GB RAM yielded optimal results (~22 minutes); bumping beyond
-        # these amounts yielded no extra gain.
-        CPU: 4
-        MEMORY: 10G
-      script:
-        - dart --enable-asserts ./dev/bots/test.dart
+#     - name: tool_tests-integration-windows
+#       only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter_tools/**', 'bin/internal/**') || $CIRRUS_PR == ''"
+#       environment:
+#         # As of December 2019, the tool_tests-integration-windows shard required 6 GB RAM to pass.
+#         # Emperically, 4 CPUs and 10 GB RAM yielded optimal results (~22 minutes); bumping beyond
+#         # these amounts yielded no extra gain.
+#         CPU: 4
+#         MEMORY: 10G
+#       script:
+#         - dart --enable-asserts ./dev/bots/test.dart
 
-    # TODO(ianh): Enable Web tests on Windows
+#     # TODO(ianh): Enable Web tests on Windows
 
-    - name: build_tests-windows
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || $CIRRUS_PR == ''" # https://github.com/flutter/flutter/issues/41941
-      environment:
-        # As of December 2019, the build_tests-windows shard requires 6 GB RAM to pass.
-        # Emperically, using 6 CPUs and 10 GB RAM yielded optimal results (~33 minutes);
-        # bumping beyond these limits yielded no extra gain.
-        CPU: 6
-        MEMORY: 10G
-      script:
-        - dart --enable-asserts dev\bots\test.dart
+#     - name: build_tests-windows
+#       only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || $CIRRUS_PR == ''" # https://github.com/flutter/flutter/issues/41941
+#       environment:
+#         # As of December 2019, the build_tests-windows shard requires 6 GB RAM to pass.
+#         # Emperically, using 6 CPUs and 10 GB RAM yielded optimal results (~33 minutes);
+#         # bumping beyond these limits yielded no extra gain.
+#         CPU: 6
+#         MEMORY: 10G
+#       script:
+#         - dart --enable-asserts dev\bots\test.dart
 
-    - name: hostonly_devicelab_tests-0-windows
-      << : *WINDOWS_SHARD_TEMPLATE
-      environment:
-        # As of December 2019, the hostonly_devicelab_tests-0-windows shard needs at least 6G RAM to
-        # succeed. The shard got faster with more CPUs up to 6 CPUs and more RAM up to 8 GB
-        # (running in about 30 minutes).
-        CPU: 6
-        MEMORY: 8G
+#     - name: hostonly_devicelab_tests-0-windows
+#       << : *WINDOWS_SHARD_TEMPLATE
+#       environment:
+#         # As of December 2019, the hostonly_devicelab_tests-0-windows shard needs at least 6G RAM to
+#         # succeed. The shard got faster with more CPUs up to 6 CPUs and more RAM up to 8 GB
+#         # (running in about 30 minutes).
+#         CPU: 6
+#         MEMORY: 8G
 
-    - name: hostonly_devicelab_tests-1-windows
-      << : *WINDOWS_SHARD_TEMPLATE
-      environment:
-        # As of December 2019, the hostonly_devicelab_tests-1-windows shard requires 4 GB RAM to
-        # succeed. The optimal configuration was 4 CPUs and 6 GB RAM, running in ~26 minutes.
-        # Less CPU or RAM ran slower, and more CPU or RAM yielded no extra gain.
-        CPU: 4
-        MEMORY: 6G
+#     - name: hostonly_devicelab_tests-1-windows
+#       << : *WINDOWS_SHARD_TEMPLATE
+#       environment:
+#         # As of December 2019, the hostonly_devicelab_tests-1-windows shard requires 4 GB RAM to
+#         # succeed. The optimal configuration was 4 CPUs and 6 GB RAM, running in ~26 minutes.
+#         # Less CPU or RAM ran slower, and more CPU or RAM yielded no extra gain.
+#         CPU: 4
+#         MEMORY: 6G
 
-    - name: hostonly_devicelab_tests-2-windows
-      << : *WINDOWS_SHARD_TEMPLATE
-      environment:
-        # As of December 2019, the hostonly_devicelab_tests-2-windows shard required 2 GB RAM to
-        # succeed. The optimal configuration was 4 CPUs and 8 GB RAM, running in ~33 minutes.
-        # Less CPU or RAM ran slower, and more CPU or RAM yielded no extra gain.
-        CPU: 4
-        MEMORY: 8G
+#     - name: hostonly_devicelab_tests-2-windows
+#       << : *WINDOWS_SHARD_TEMPLATE
+#       environment:
+#         # As of December 2019, the hostonly_devicelab_tests-2-windows shard required 2 GB RAM to
+#         # succeed. The optimal configuration was 4 CPUs and 8 GB RAM, running in ~33 minutes.
+#         # Less CPU or RAM ran slower, and more CPU or RAM yielded no extra gain.
+#         CPU: 4
+#         MEMORY: 8G
 
-    - name: hostonly_devicelab_tests-3_last-windows
-      << : *WINDOWS_SHARD_TEMPLATE
-      environment:
-        # As of December 2019, the hostonly_devicelab_tests-3_last-windows shard required 6 GB RAM
-        # to succeed. The optimal configuration was 4 CPUs and 6 GB RAM, running in ~43 minutes.
-        # Less CPU or RAM ran slower, and more CPU or RAM yielded no extra gain.
-        CPU: 4
-        MEMORY: 6G
+#     - name: hostonly_devicelab_tests-3_last-windows
+#       << : *WINDOWS_SHARD_TEMPLATE
+#       environment:
+#         # As of December 2019, the hostonly_devicelab_tests-3_last-windows shard required 6 GB RAM
+#         # to succeed. The optimal configuration was 4 CPUs and 6 GB RAM, running in ~43 minutes.
+#         # Less CPU or RAM ran slower, and more CPU or RAM yielded no extra gain.
+#         CPU: 4
+#         MEMORY: 6G
 
-    # TODO(ianh): name: add_to_app_tests-windows
+#     # TODO(ianh): name: add_to_app_tests-windows
 
-    - name: customer_testing-windows
-      environment:
-        # As of December 2019, the customer_testing-windows shard got faster with more CPUs up to 4
-        # CPUs (which requires >=4G RAM), and needed at least 2G of RAM to not run out of memory.
-        CPU: 4
-        MEMORY: 4G
-      script:
-        - CMD /S /C "IF EXIST "bin\cache\pkg\tests\" RMDIR /S /Q bin\cache\pkg\tests"
-        - git clone https://github.com/flutter/tests.git bin\cache\pkg\tests
-        - dart --enable-asserts dev\customer_testing\run_tests.dart --skip-on-fetch-failure --skip-template bin/cache/pkg/tests/registry/*.test
+#     - name: customer_testing-windows
+#       environment:
+#         # As of December 2019, the customer_testing-windows shard got faster with more CPUs up to 4
+#         # CPUs (which requires >=4G RAM), and needed at least 2G of RAM to not run out of memory.
+#         CPU: 4
+#         MEMORY: 4G
+#       script:
+#         - CMD /S /C "IF EXIST "bin\cache\pkg\tests\" RMDIR /S /Q bin\cache\pkg\tests"
+#         - git clone https://github.com/flutter/tests.git bin\cache\pkg\tests
+#         - dart --enable-asserts dev\customer_testing\run_tests.dart --skip-on-fetch-failure --skip-template bin/cache/pkg/tests/registry/*.test
 
 # MACOS SHARDS
 # Mac doesn't use caches because they apparently take longer to populate and save
 # than just fetching the data in the first place.
-task:
-  osx_instance:
-    image: catalina-flutter # see https://cirrus-ci.org/guide/macOS/ for list of images (we should update regularly)
-    # cpu is always 2
-    # memory is always 8G
-  environment:
-    CIRRUS_WORKING_DIR: "/tmp/$FLUTTER_SDK_PATH_WITH_SPACE"
-    FLUTTER_FRAMEWORK_DIR: "$CIRRUS_WORKING_DIR/bin/cache/artifacts/engine/ios/"
-    PATH: "$CIRRUS_WORKING_DIR/bin:$CIRRUS_WORKING_DIR/bin/cache/dart-sdk/bin:$PATH"
-    COCOAPODS_DISABLE_STATS: true
-    CPU: 2
-    MEMORY: 8G
-  setup_script:
-    - date
-    - which flutter
-    - bundle --version
-    - bundle config set system 'true'
-    - sudo bundle install --gemfile=dev/ci/mac/Gemfile
-    - git clean -xffd --exclude=bin/cache/
-    - git fetch origin
-    - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
-    - flutter config --no-analytics
-    - flutter doctor -v
-    - flutter update-packages
-    - date
-    - which flutter
-  on_failure:
-    failure_script:
-      - date
-      - which flutter
-  matrix:
-    - name: framework_tests-widgets-macos
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_tools/lib/src/test/**', 'bin/internal/**') || $CIRRUS_PR == ''"
-      environment:
-        GOLDCTL: "$CIRRUS_WORKING_DIR/depot_tools/goldctl"
-        GOLD_SERVICE_ACCOUNT: ENCRYPTED[3afeea5ac7201151c3d0dc9648862f0462b5e4f55dc600ca8b692319622f7c3eda3d577b1b16cc2ef0311b7314c1c095]
-      script:
-        - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
-        - ./dev/bots/download_goldctl.sh
-        - dart --enable-asserts dev/bots/test.dart
+# task:
+#   osx_instance:
+#     image: catalina-flutter # see https://cirrus-ci.org/guide/macOS/ for list of images (we should update regularly)
+#     # cpu is always 2
+#     # memory is always 8G
+#   environment:
+#     CIRRUS_WORKING_DIR: "/tmp/$FLUTTER_SDK_PATH_WITH_SPACE"
+#     FLUTTER_FRAMEWORK_DIR: "$CIRRUS_WORKING_DIR/bin/cache/artifacts/engine/ios/"
+#     PATH: "$CIRRUS_WORKING_DIR/bin:$CIRRUS_WORKING_DIR/bin/cache/dart-sdk/bin:$PATH"
+#     COCOAPODS_DISABLE_STATS: true
+#     CPU: 2
+#     MEMORY: 8G
+#   setup_script:
+#     - date
+#     - which flutter
+#     - bundle --version
+#     - bundle config set system 'true'
+#     - sudo bundle install --gemfile=dev/ci/mac/Gemfile
+#     - git clean -xffd --exclude=bin/cache/
+#     - git fetch origin
+#     - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
+#     - flutter config --no-analytics
+#     - flutter doctor -v
+#     - flutter update-packages
+#     - date
+#     - which flutter
+#   on_failure:
+#     failure_script:
+#       - date
+#       - which flutter
+#   matrix:
+#     - name: framework_tests-widgets-macos
+#       only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_tools/lib/src/test/**', 'bin/internal/**') || $CIRRUS_PR == ''"
+#       environment:
+#         GOLDCTL: "$CIRRUS_WORKING_DIR/depot_tools/goldctl"
+#         GOLD_SERVICE_ACCOUNT: ENCRYPTED[3afeea5ac7201151c3d0dc9648862f0462b5e4f55dc600ca8b692319622f7c3eda3d577b1b16cc2ef0311b7314c1c095]
+#       script:
+#         - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
+#         - ./dev/bots/download_goldctl.sh
+#         - dart --enable-asserts dev/bots/test.dart
 
-    - name: framework_tests-libraries-macos
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_tools/lib/src/test/**', 'bin/internal/**') || $CIRRUS_PR == ''"
-      environment:
-        GOLDCTL: "$CIRRUS_WORKING_DIR/depot_tools/goldctl"
-        GOLD_SERVICE_ACCOUNT: ENCRYPTED[3afeea5ac7201151c3d0dc9648862f0462b5e4f55dc600ca8b692319622f7c3eda3d577b1b16cc2ef0311b7314c1c095]
-      script:
-        - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
-        - ./dev/bots/download_goldctl.sh
-        - dart --enable-asserts dev/bots/test.dart
+#     - name: framework_tests-libraries-macos
+#       only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_tools/lib/src/test/**', 'bin/internal/**') || $CIRRUS_PR == ''"
+#       environment:
+#         GOLDCTL: "$CIRRUS_WORKING_DIR/depot_tools/goldctl"
+#         GOLD_SERVICE_ACCOUNT: ENCRYPTED[3afeea5ac7201151c3d0dc9648862f0462b5e4f55dc600ca8b692319622f7c3eda3d577b1b16cc2ef0311b7314c1c095]
+#       script:
+#         - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
+#         - ./dev/bots/download_goldctl.sh
+#         - dart --enable-asserts dev/bots/test.dart
 
-    - name: framework_tests-misc-macos
-      # this includes the tests for directories in dev/
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_goldens/**', 'packages/flutter_test/**', 'packages/flutter_tools/lib/src/test/**', 'bin/internal/**') || $CIRRUS_PR == ''"
-      script:
-        - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
-        - dart --enable-asserts dev/bots/test.dart
+#     - name: framework_tests-misc-macos
+#       # this includes the tests for directories in dev/
+#       only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_goldens/**', 'packages/flutter_test/**', 'packages/flutter_tools/lib/src/test/**', 'bin/internal/**') || $CIRRUS_PR == ''"
+#       script:
+#         - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
+#         - dart --enable-asserts dev/bots/test.dart
 
-    - name: tool_tests-general-macos
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter_tools/**', 'bin/internal/**') || $CIRRUS_PR == ''"
-      script:
-        - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
-        - dart --enable-asserts ./dev/bots/test.dart
+#     - name: tool_tests-general-macos
+#       only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter_tools/**', 'bin/internal/**') || $CIRRUS_PR == ''"
+#       script:
+#         - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
+#         - dart --enable-asserts ./dev/bots/test.dart
 
-    - name: tool_tests-commands-macos
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter_tools/**', 'bin/internal/**') || $CIRRUS_PR == ''"
-      script:
-        - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
-        - dart --enable-asserts ./dev/bots/test.dart
+#     - name: tool_tests-commands-macos
+#       only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter_tools/**', 'bin/internal/**') || $CIRRUS_PR == ''"
+#       script:
+#         - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
+#         - dart --enable-asserts ./dev/bots/test.dart
 
-    - name: tool_tests-integration-macos
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter_tools/**', 'bin/internal/**') || $CIRRUS_PR == ''"
-      script:
-        - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
-        - dart --enable-asserts ./dev/bots/test.dart
+#     - name: tool_tests-integration-macos
+#       only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter_tools/**', 'bin/internal/**') || $CIRRUS_PR == ''"
+#       script:
+#         - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
+#         - dart --enable-asserts ./dev/bots/test.dart
 
-    # TODO(ianh): Enable Web tests on macOS.
+#     # TODO(ianh): Enable Web tests on macOS.
 
-    - name: build_tests-macos
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || $CIRRUS_PR == ''" # https://github.com/flutter/flutter/issues/41940
-      script:
-        - dart --enable-asserts ./dev/bots/test.dart
+#     - name: build_tests-macos
+#       only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || $CIRRUS_PR == ''" # https://github.com/flutter/flutter/issues/41940
+#       script:
+#         - dart --enable-asserts ./dev/bots/test.dart
 
-    - name: hostonly_devicelab_tests-0-macos
-      << : *MACOS_SHARD_TEMPLATE
+#     - name: hostonly_devicelab_tests-0-macos
+#       << : *MACOS_SHARD_TEMPLATE
 
-    - name: hostonly_devicelab_tests-1-macos
-      << : *MACOS_SHARD_TEMPLATE
+#     - name: hostonly_devicelab_tests-1-macos
+#       << : *MACOS_SHARD_TEMPLATE
 
-    - name: hostonly_devicelab_tests-2-macos
-      << : *MACOS_SHARD_TEMPLATE
+#     - name: hostonly_devicelab_tests-2-macos
+#       << : *MACOS_SHARD_TEMPLATE
 
-    - name: hostonly_devicelab_tests-3_last-macos
-      << : *MACOS_SHARD_TEMPLATE
+#     - name: hostonly_devicelab_tests-3_last-macos
+#       << : *MACOS_SHARD_TEMPLATE
 
-    - name: add_to_app_tests-macos
-      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || $CIRRUS_PR == ''" # https://github.com/flutter/flutter/issues/41940
-      skip: true # https://github.com/flutter/flutter/pull/42444
-      script:
-        - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
-        - dart --enable-asserts dev/bots/test.dart
+#     - name: add_to_app_tests-macos
+#       only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || $CIRRUS_PR == ''" # https://github.com/flutter/flutter/issues/41940
+#       skip: true # https://github.com/flutter/flutter/pull/42444
+#       script:
+#         - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
+#         - dart --enable-asserts dev/bots/test.dart
 
-    - name: customer_testing-macos
-      script:
-        - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
-        - rm -rf bin/cache/pkg/tests
-        - git clone https://github.com/flutter/tests.git bin/cache/pkg/tests
-        - dart --enable-asserts dev/customer_testing/run_tests.dart --skip-on-fetch-failure --skip-template bin/cache/pkg/tests/registry/*.test
+#     - name: customer_testing-macos
+#       script:
+#         - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
+#         - rm -rf bin/cache/pkg/tests
+#         - git clone https://github.com/flutter/tests.git bin/cache/pkg/tests
+#         - dart --enable-asserts dev/customer_testing/run_tests.dart --skip-on-fetch-failure --skip-template bin/cache/pkg/tests/registry/*.test
 
-    - name: deploy_gallery-macos # linux- and macos- only
-      # Do not add more tasks here. Nothing is currently deployed from master branch, so it is safe to run
-      # even if a test has failed. The behavior of failing dependencies is non-ideal for infra health.
-      # See also: https://github.com/flutter/flutter/pull/49454
-      depends_on:
-        - analyze-linux
-      environment:
-        # Apple Fastlane password.
-        FASTLANE_PASSWORD: ENCRYPTED[4b1f0b8d52874e9de965acd46c79743f3b81f3a513614179b9be7cf53dc8258753e257bdadb11a298ee455259df21865]
-        # Private repo for publishing certificates.
-        PUBLISHING_MATCH_CERTIFICATE_REPO: ENCRYPTED[3c0e78877d933fc80107aa6f3790fd1cf927250b852d6cb53202be696b4903ed8ca839b809626aaf18050bf7e436fab7]
-        PUBLISHING_MATCH_REPO_TOKEN: ENCRYPTED[3d1230b744c6ed6c788a91bec741b769401dbcd426b18f9af8080bfeefdfc21913ca4047980c5b5b7ce823f12e7b6b19]
-        # Apple Certificates Match Passphrase
-        MATCH_PASSWORD: ENCRYPTED[db07f252234397090e3ec59152d9ec1831f5ecd0ef97d247b1dca757bbb9ef9b7c832a39bce2caf1949ccdf097e59a73]
-      script:
-        - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
-        - ./dev/bots/deploy_gallery.sh
+#     - name: deploy_gallery-macos # linux- and macos- only
+#       # Do not add more tasks here. Nothing is currently deployed from master branch, so it is safe to run
+#       # even if a test has failed. The behavior of failing dependencies is non-ideal for infra health.
+#       # See also: https://github.com/flutter/flutter/pull/49454
+#       depends_on:
+#         - analyze-linux
+#       environment:
+#         # Apple Fastlane password.
+#         FASTLANE_PASSWORD: ENCRYPTED[4b1f0b8d52874e9de965acd46c79743f3b81f3a513614179b9be7cf53dc8258753e257bdadb11a298ee455259df21865]
+#         # Private repo for publishing certificates.
+#         PUBLISHING_MATCH_CERTIFICATE_REPO: ENCRYPTED[3c0e78877d933fc80107aa6f3790fd1cf927250b852d6cb53202be696b4903ed8ca839b809626aaf18050bf7e436fab7]
+#         PUBLISHING_MATCH_REPO_TOKEN: ENCRYPTED[3d1230b744c6ed6c788a91bec741b769401dbcd426b18f9af8080bfeefdfc21913ca4047980c5b5b7ce823f12e7b6b19]
+#         # Apple Certificates Match Passphrase
+#         MATCH_PASSWORD: ENCRYPTED[db07f252234397090e3ec59152d9ec1831f5ecd0ef97d247b1dca757bbb9ef9b7c832a39bce2caf1949ccdf097e59a73]
+#       script:
+#         - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
+#         - ./dev/bots/deploy_gallery.sh
 
-    - name: verify_binaries_codesigned-macos # macos-only
-      # TODO(fujino): remove this `only_if` after https://github.com/flutter/flutter/issues/44372
-      # Only run pre/post submit for release branches
-      only_if: "$CIRRUS_BASE_BRANCH == 'dev' || $CIRRUS_BRANCH == 'dev' || $CIRRUS_BASE_BRANCH == 'beta' || $CIRRUS_BRANCH == 'beta' || $CIRRUS_BASE_BRANCH == 'stable' || $CIRRUS_BRANCH == 'stable'"
-      depends_on:
-        - analyze-linux
-      script:
-        - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
-        - dart --enable-asserts ./dev/bots/codesign.dart
+#     - name: verify_binaries_codesigned-macos # macos-only
+#       # TODO(fujino): remove this `only_if` after https://github.com/flutter/flutter/issues/44372
+#       # Only run pre/post submit for release branches
+#       only_if: "$CIRRUS_BASE_BRANCH == 'dev' || $CIRRUS_BRANCH == 'dev' || $CIRRUS_BASE_BRANCH == 'beta' || $CIRRUS_BRANCH == 'beta' || $CIRRUS_BASE_BRANCH == 'stable' || $CIRRUS_BRANCH == 'stable'"
+#       depends_on:
+#         - analyze-linux
+#       script:
+#         - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
+#         - dart --enable-asserts ./dev/bots/codesign.dart
 
 docker_builder:
   # Only build a new docker image when we tag a release (for dev, beta, or
@@ -631,9 +631,9 @@ docker_builder:
     GCLOUD_CREDENTIALS: ENCRYPTED[f7c098d4dd7f5ee1bfee0bb7e944cce72efbe10e97ad6440ae72de4de6a1c24d23f421a2619c668e94377fb64b0bb3e6]
   # Do not add more tasks here. The behavior of failing dependencies is non-ideal for infra health.
   # See also: https://github.com/flutter/flutter/pull/49454
-  depends_on:
-    - docs-linux
-    - analyze-linux
+  # depends_on:
+  #   - docs-linux
+  #   - analyze-linux
   build_script:
     - cd "$CIRRUS_WORKING_DIR/dev/ci/docker_linux"
     - ./docker_build.sh

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -370,28 +370,28 @@ task:
       << : *WEB_SHARD_TEMPLATE
 
     ### RUN 8
-    - name: web_tests9-0-linux
+    - name: web_tests8-0-linux
       << : *WEB_SHARD_TEMPLATE
 
-    - name: web_tests9-1-linux
+    - name: web_tests8-1-linux
       << : *WEB_SHARD_TEMPLATE
 
-    - name: web_tests9-2-linux
+    - name: web_tests8-2-linux
       << : *WEB_SHARD_TEMPLATE
 
-    - name: web_tests9-3-linux
+    - name: web_tests8-3-linux
       << : *WEB_SHARD_TEMPLATE
 
-    - name: web_tests9-4-linux
+    - name: web_tests8-4-linux
       << : *WEB_SHARD_TEMPLATE
 
-    - name: web_tests9-5-linux
+    - name: web_tests8-5-linux
       << : *WEB_SHARD_TEMPLATE
 
-    - name: web_tests9-6-linux
+    - name: web_tests8-6-linux
       << : *WEB_SHARD_TEMPLATE
 
-    - name: web_tests9-7_last-linux # last Web shard must end with _last
+    - name: web_tests8-7_last-linux # last Web shard must end with _last
       << : *WEB_SHARD_TEMPLATE
 
     # - name: build_tests-linux

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -116,7 +116,10 @@ Future<void> main(List<String> args) async {
       'hostonly_devicelab_tests': _runHostOnlyDeviceLabTests,
       'tool_coverage': _runToolCoverage,
       'tool_tests': _runToolTests,
-      'web_tests': _runWebUnitTests,
+      'web_tests1': _runWebUnitTests,
+      'web_tests2': _runWebUnitTests,
+      'web_tests3': _runWebUnitTests,
+      'web_tests4': _runWebUnitTests,
       'web_integration_tests': _runWebIntegrationTests,
     });
   } on ExitException catch (error) {

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -53,11 +53,6 @@ const int kDeviceLabShardCount = 4;
 /// The last shard also runs the Web plugin tests.
 const int kWebShardCount = 8;
 
-/// Maximum number of Web tests to run in a single `flutter test`. We found that
-/// large batches can get flaky, possibly because we reuse a single instance of
-/// the browser, and after many tests the browser's state gets corrupted.
-const int kWebBatchSize = 20;
-
 /// Tests that we don't run on Web for various reasons.
 //
 // TODO(yjbanov): we're getting rid of this blacklist as part of https://github.com/flutter/flutter/projects/60
@@ -120,6 +115,10 @@ Future<void> main(List<String> args) async {
       'web_tests2': _runWebUnitTests,
       'web_tests3': _runWebUnitTests,
       'web_tests4': _runWebUnitTests,
+      'web_tests5': _runWebUnitTests,
+      'web_tests6': _runWebUnitTests,
+      'web_tests7': _runWebUnitTests,
+      'web_tests8': _runWebUnitTests,
       'web_integration_tests': _runWebIntegrationTests,
     });
   } on ExitException catch (error) {
@@ -688,31 +687,23 @@ Future<void> _runWebDebugTest(String target) async {
 }
 
 Future<void> _runFlutterWebTest(String workingDirectory, List<String> tests) async {
-  final List<String> batch = <String>[];
-  for (int i = 0; i < tests.length; i += 1) {
-    final String testFilePath = tests[i];
-    batch.add(testFilePath);
-    if (batch.length == kWebBatchSize || i == tests.length - 1) {
-      await runCommand(
-        flutter,
-        <String>[
-          'test',
-          if (ciProvider == CiProviders.cirrus)
-            '--concurrency=1',  // do not parallelize on Cirrus, to reduce flakiness
-          '-v',
-          '--platform=chrome',
-          ...?flutterTestArgs,
-          ...batch,
-        ],
-        workingDirectory: workingDirectory,
-        environment: <String, String>{
-          'FLUTTER_WEB': 'true',
-          'FLUTTER_LOW_RESOURCE_MODE': 'true',
-        },
-      );
-      batch.clear();
-    }
-  }
+  await runCommand(
+    flutter,
+    <String>[
+      'test',
+      if (ciProvider == CiProviders.cirrus)
+        '--concurrency=1',  // do not parallelize on Cirrus, to reduce flakiness
+      '-v',
+      '--platform=chrome',
+      ...?flutterTestArgs,
+      ...tests,
+    ],
+    workingDirectory: workingDirectory,
+    environment: <String, String>{
+      'FLUTTER_WEB': 'true',
+      'FLUTTER_LOW_RESOURCE_MODE': 'true',
+    },
+  );
 }
 
 Future<void> _pubRunTest(String workingDirectory, {

--- a/packages/flutter/test/material/bottom_app_bar_theme_test.dart
+++ b/packages/flutter/test/material/bottom_app_bar_theme_test.dart
@@ -82,7 +82,7 @@ void main() {
       find.byKey(_painterKey),
       matchesGoldenFile('bottom_app_bar_theme.custom_shape.png'),
     );
-  }, skip: isBrowser);
+  });
 
   testWidgets('BAB theme does not affect defaults', (WidgetTester tester) async {
     await tester.pumpWidget(const MaterialApp(

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -913,7 +913,7 @@ void main() {
     await tester.tap(find.text('Alarm'));
     await tester.pump(const Duration(seconds: 1));
     expect(Theme.of(tester.element(find.text('Alarm'))).brightness, equals(Brightness.dark));
-  }, skip: isBrowser);
+  });
 
   testWidgets('BottomNavigationBar iconSize test', (WidgetTester tester) async {
     double builderIconSize;
@@ -1023,7 +1023,7 @@ void main() {
 
     final RenderBox box = tester.renderObject(find.byType(BottomNavigationBar));
     expect(box.size.height, equals(66.0));
-  }, skip: isBrowser);
+  });
 
   testWidgets('BottomNavigationBar limits width of tiles with long titles', (WidgetTester tester) async {
     final Text longTextA = Text(''.padLeft(100, 'A'));
@@ -1055,7 +1055,7 @@ void main() {
     expect(itemBoxA.size, equals(const Size(400.0, 14.0)));
     final RenderBox itemBoxB = tester.renderObject(find.text(longTextB.data));
     expect(itemBoxB.size, equals(const Size(400.0, 14.0)));
-  }, skip: isBrowser);
+  });
 
   testWidgets('BottomNavigationBar paints circles', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -1125,7 +1125,7 @@ void main() {
           ..translate(x: 400.0)
           ..circle(x: 200.0),
     );
-  }, skip: isBrowser);
+  });
 
   testWidgets('BottomNavigationBar inactiveIcon shown', (WidgetTester tester) async {
     const Key filled = Key('filled');
@@ -1452,7 +1452,7 @@ void main() {
           find.byType(BottomNavigationBar),
           matchesGoldenFile('bottom_navigation_bar.shifting_transition.${pump - 1}.png'),
         );
-      }, skip: isBrowser); // TODO(yjbanov): web does not support golden tests yet: https://github.com/flutter/flutter/issues/40297
+      });
     }
   });
 

--- a/packages/flutter/test/material/dialog_theme_test.dart
+++ b/packages/flutter/test/material/dialog_theme_test.dart
@@ -132,7 +132,7 @@ void main() {
       find.byKey(_painterKey),
       matchesGoldenFile('dialog_theme.dialog_with_custom_border.png'),
     );
-  }, skip: isBrowser);
+  });
 
   testWidgets('Custom Title Text Style - Constructor Param', (WidgetTester tester) async {
     const String titleText = 'Title';

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -189,7 +189,7 @@ void main() {
       find.ancestor(of: buttonFinder, matching: find.byType(RepaintBoundary)).first,
       matchesGoldenFile('dropdown_test.default.png'),
     );
-  }, skip: isBrowser);
+  });
 
   testWidgets('Expanded dropdown golden', (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
@@ -201,7 +201,7 @@ void main() {
       find.ancestor(of: buttonFinder, matching: find.byType(RepaintBoundary)).first,
       matchesGoldenFile('dropdown_test.expanded.png'),
     );
-  }, skip: isBrowser);
+  });
 
   testWidgets('Dropdown button control test', (WidgetTester tester) async {
     String value = 'one';

--- a/packages/flutter/test/material/flexible_space_bar_stretch_mode_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_stretch_mode_test.dart
@@ -85,7 +85,7 @@ void main() {
       find.byType(FlexibleSpaceBar),
       matchesGoldenFile('flexible_space_bar_stretch_mode.blur_background.png'),
     );
-  }, skip: isBrowser);
+  });
 
   testWidgets('FlexibleSpaceBar stretch mode fadeTitle', (WidgetTester tester) async {
     await tester.pumpWidget(

--- a/packages/flutter/test/material/radio_test.dart
+++ b/packages/flutter/test/material/radio_test.dart
@@ -282,7 +282,7 @@ void main() {
       find.byKey(painterKey),
       matchesGoldenFile('radio.ink_ripple.png'),
     );
-  }, skip: isBrowser);
+  });
 
   testWidgets('Radio is focusable and has correct focus color', (WidgetTester tester) async {
     final FocusNode focusNode = FocusNode(debugLabel: 'Radio');

--- a/packages/flutter/test/material/tab_bar_theme_test.dart
+++ b/packages/flutter/test/material/tab_bar_theme_test.dart
@@ -269,7 +269,7 @@ void main() {
       find.byKey(_painterKey),
       matchesGoldenFile('tab_bar_theme.tab_indicator_size_tab.png'),
     );
-  }, skip: isBrowser);
+  });
 
   testWidgets('Tab bar theme overrides tab indicator size (label)', (WidgetTester tester) async {
     const TabBarTheme tabBarTheme = TabBarTheme(indicatorSize: TabBarIndicatorSize.label);
@@ -280,7 +280,7 @@ void main() {
       find.byKey(_painterKey),
       matchesGoldenFile('tab_bar_theme.tab_indicator_size_label.png'),
     );
-  }, skip: isBrowser);
+  });
 
   testWidgets('Tab bar theme - custom tab indicator', (WidgetTester tester) async {
     final TabBarTheme tabBarTheme = TabBarTheme(
@@ -296,7 +296,7 @@ void main() {
       find.byKey(_painterKey),
       matchesGoldenFile('tab_bar_theme.custom_tab_indicator.png'),
     );
-  }, skip: isBrowser);
+  });
 
   testWidgets('Tab bar theme - beveled rect indicator', (WidgetTester tester) async {
     final TabBarTheme tabBarTheme = TabBarTheme(
@@ -312,5 +312,5 @@ void main() {
       find.byKey(_painterKey),
       matchesGoldenFile('tab_bar_theme.beveled_rect_indicator.png'),
     );
-  }, skip: isBrowser);
+  });
 }

--- a/packages/flutter/test/rendering/localized_fonts_test.dart
+++ b/packages/flutter/test/rendering/localized_fonts_test.dart
@@ -52,7 +52,6 @@ void main() {
         matchesGoldenFile('localized_fonts.rich_text.styled_text_span.png'),
       );
     },
-    skip: isBrowser, // TODO(yjbanov): implement goldens on the Web: https://github.com/flutter/flutter/issues/40297
   );
 
   testWidgets(

--- a/packages/flutter/test/widgets/backdrop_filter_test.dart
+++ b/packages/flutter/test/widgets/backdrop_filter_test.dart
@@ -45,5 +45,5 @@ void main() {
       find.byType(RepaintBoundary).first,
       matchesGoldenFile('backdrop_filter_test.cull_rect.png'),
     );
-  }, skip: isBrowser);
+  });
 }

--- a/packages/flutter/test/widgets/clip_test.dart
+++ b/packages/flutter/test/widgets/clip_test.dart
@@ -383,7 +383,7 @@ void main() {
       find.byType(RepaintBoundary).first,
       matchesGoldenFile('clip.ClipRect.png'),
     );
-  }, skip: isBrowser);
+  });
 
   testWidgets('ClipRect save, overlay, and antialiasing', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -423,7 +423,7 @@ void main() {
       find.byType(RepaintBoundary).first,
       matchesGoldenFile('clip.ClipRectOverlay.png'),
     );
-  }, skip: isBrowser);
+  });
 
   testWidgets('ClipRRect painting', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -472,7 +472,7 @@ void main() {
       find.byType(RepaintBoundary).first,
       matchesGoldenFile('clip.ClipRRect.png'),
     );
-  }, skip: isBrowser);
+  });
 
   testWidgets('ClipOval painting', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -515,7 +515,7 @@ void main() {
       find.byType(RepaintBoundary).first,
       matchesGoldenFile('clip.ClipOval.png'),
     );
-  }, skip: isBrowser);
+  });
 
   testWidgets('ClipPath painting', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -563,7 +563,7 @@ void main() {
       find.byType(RepaintBoundary).first,
       matchesGoldenFile('clip.ClipPath.png'),
     );
-  }, skip: isBrowser);
+  });
 
   Center genPhysicalModel(Clip clipBehavior) {
     return Center(
@@ -608,7 +608,7 @@ void main() {
       find.byType(RepaintBoundary).first,
       matchesGoldenFile('clip.PhysicalModel.antiAlias.png'),
     );
-  }, skip: isBrowser);
+  });
 
   testWidgets('PhysicalModel painting with Clip.hardEdge', (WidgetTester tester) async {
     await tester.pumpWidget(genPhysicalModel(Clip.hardEdge));
@@ -616,7 +616,7 @@ void main() {
       find.byType(RepaintBoundary).first,
       matchesGoldenFile('clip.PhysicalModel.hardEdge.png'),
     );
-  }, skip: isBrowser);
+  });
 
   // There will be bleeding edges on the rect edges, but there shouldn't be any bleeding edges on the
   // round corners.
@@ -626,7 +626,7 @@ void main() {
       find.byType(RepaintBoundary).first,
       matchesGoldenFile('clip.PhysicalModel.antiAliasWithSaveLayer.png'),
     );
-  }, skip: isBrowser);
+  });
 
   testWidgets('Default PhysicalModel painting', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -668,7 +668,7 @@ void main() {
       find.byType(RepaintBoundary).first,
       matchesGoldenFile('clip.PhysicalModel.default.png'),
     );
-  }, skip: isBrowser);
+  });
 
   Center genPhysicalShape(Clip clipBehavior) {
     return Center(
@@ -717,7 +717,7 @@ void main() {
       find.byType(RepaintBoundary).first,
       matchesGoldenFile('clip.PhysicalShape.antiAlias.png'),
     );
-  }, skip: isBrowser);
+  });
 
   testWidgets('PhysicalShape painting with Clip.hardEdge', (WidgetTester tester) async {
     await tester.pumpWidget(genPhysicalShape(Clip.hardEdge));
@@ -725,7 +725,7 @@ void main() {
       find.byType(RepaintBoundary).first,
       matchesGoldenFile('clip.PhysicalShape.hardEdge.png'),
     );
-  }, skip: isBrowser);
+  });
 
   testWidgets('PhysicalShape painting with Clip.antiAliasWithSaveLayer', (WidgetTester tester) async {
     await tester.pumpWidget(genPhysicalShape(Clip.antiAliasWithSaveLayer));
@@ -733,7 +733,7 @@ void main() {
       find.byType(RepaintBoundary).first,
       matchesGoldenFile('clip.PhysicalShape.antiAliasWithSaveLayer.png'),
     );
-  }, skip: isBrowser);
+  });
 
   testWidgets('PhysicalShape painting', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -779,7 +779,7 @@ void main() {
       find.byType(RepaintBoundary).first,
       matchesGoldenFile('clip.PhysicalShape.default.png'),
     );
-  }, skip: isBrowser);
+  });
 
   testWidgets('ClipPath.shape', (WidgetTester tester) async {
     final List<String> logs = <String>[];

--- a/packages/flutter/test/widgets/invert_colors_test.dart
+++ b/packages/flutter/test/widgets/invert_colors_test.dart
@@ -22,7 +22,7 @@ void main() {
       find.byType(RepaintBoundary),
       matchesGoldenFile('invert_colors_test.0.png'),
     );
-  }, skip: isBrowser);
+  });
 
   testWidgets('InvertColors and ColorFilter',  (WidgetTester tester) async {
     await tester.pumpWidget(const RepaintBoundary(
@@ -40,7 +40,7 @@ void main() {
       find.byType(RepaintBoundary),
       matchesGoldenFile('invert_colors_test.1.png'),
     );
-  }, skip: isBrowser);
+  });
 }
 
 // Draws a rectangle sized by the parent widget with [color], [colorFilter],

--- a/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
@@ -594,7 +594,7 @@ void main() {
         find.byKey(const Key('list_wheel_scroll_view')),
         matchesGoldenFile('list_wheel_scroll_view.center_child.magnified.png'),
       );
-    }, skip: isBrowser);
+    });
 
     testWidgets('Default middle transform', (WidgetTester tester) async {
       await tester.pumpWidget(
@@ -648,7 +648,7 @@ void main() {
         find.byKey(const Key('list_wheel_scroll_view')),
         matchesGoldenFile('list_wheel_scroll_view.curved_wheel.left.png'),
       );
-    }, skip: isBrowser);
+    });
 
     testWidgets('Scrolling, diameterRatio, perspective all changes matrix', (WidgetTester tester) async {
       final ScrollController controller = ScrollController(initialScrollOffset: 200.0);

--- a/packages/flutter/test/widgets/opacity_test.dart
+++ b/packages/flutter/test/widgets/opacity_test.dart
@@ -180,7 +180,7 @@ void main() {
       find.byType(RepaintBoundary).first,
       matchesGoldenFile('opacity_test.offset.png'),
     );
-  }, skip: isBrowser);
+  });
 
   testWidgets('empty opacity does not crash', (WidgetTester tester) async {
     await tester.pumpWidget(

--- a/packages/flutter/test/widgets/physical_model_test.dart
+++ b/packages/flutter/test/widgets/physical_model_test.dart
@@ -112,7 +112,7 @@ void main() {
       find.byKey(key),
       matchesGoldenFile('physical_model_overflow.png'),
     );
-  }, skip: isBrowser);
+  });
 
   group('PhysicalModelLayer checks elevation', () {
     Future<void> _testStackChildren(

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -802,7 +802,9 @@ class BrowserManager {
           .add(<String, Object>{'command': 'closeSuite', 'id': suiteID});
       print('>>> $path finished');
       _suiteLock = null;
-      _suiteCompleter.complete();
+      if (!_suiteCompleter.isCompleted) {
+        _suiteCompleter.complete();
+      }
     }
 
     // The virtual channel will be closed when the suite is closed, in which

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -256,10 +256,8 @@ class FlutterWebPlatform extends PlatformPlugin {
       Uint8List bytes;
 
       try {
-        final Runtime browser = Runtime.chrome;
-        final BrowserManager browserManager = await _browserManagerFor(browser);
-        final ChromeTab chromeTab = await browserManager._browser.chromeConnection.getTab((ChromeTab tab) {
-          return tab.url.contains(browserManager._browser.url);
+        final ChromeTab chromeTab = await _browserManager._browser.chromeConnection.getTab((ChromeTab tab) {
+          return tab.url.contains(_browserManager._browser.url);
         });
         final WipConnection connection = await chromeTab.connect();
         final WipResponse response = await connection.sendCommand('Page.captureScreenshot', <String, Object>{
@@ -303,10 +301,7 @@ class FlutterWebPlatform extends PlatformPlugin {
 
   bool get _closed => _closeMemo.hasRun;
 
-  // A map from browser identifiers to futures that will complete to the
-  // [BrowserManager]s for those browsers, or `null` if they failed to load.
-  final Map<Runtime, Future<BrowserManager>> _browserManagers =
-      <Runtime, Future<BrowserManager>>{};
+  BrowserManager _browserManager;
 
   // A handler that serves wrapper files used to bootstrap tests.
   shelf.Response _wrapperHandler(shelf.Request request) {
@@ -330,6 +325,11 @@ class FlutterWebPlatform extends PlatformPlugin {
     return shelf.Response.notFound('Not found.');
   }
 
+  /// Allows only one test suite (typically one test file) to be loaded and run
+  /// at any given point in time. Loading more than one file at a time is known
+  /// to lead to flaky tests.
+  final Pool _suiteLock = Pool(1);
+
   @override
   Future<RunnerSuite> load(
     String path,
@@ -340,17 +340,28 @@ class FlutterWebPlatform extends PlatformPlugin {
     if (_closed) {
       return null;
     }
+    final PoolResource lockResource = await _suiteLock.request();
+
     final Runtime browser = platform.runtime;
-    final BrowserManager browserManager = await _browserManagerFor(browser);
-    if (_closed || browserManager == null) {
+    try {
+      _browserManager = await _launchBrowser(browser);
+    } on Error catch (_) {
+      await _suiteLock.close();
+      rethrow;
+    }
+
+    if (_closed) {
       return null;
     }
 
     final Uri suiteUrl = url.resolveUri(globals.fs.path.toUri(globals.fs.path.withoutExtension(
             globals.fs.path.relative(path, from: globals.fs.path.join(_root, 'test'))) +
         '.html'));
-    final RunnerSuite suite = await browserManager
-        .load(path, suiteUrl, suiteConfig, message);
+    final RunnerSuite suite = await _browserManager.load(path, suiteUrl, suiteConfig, message, onDone: () async {
+      await _browserManager.close();
+      _browserManager = null;
+      lockResource.release();
+    });
     if (_closed) {
       return null;
     }
@@ -364,11 +375,11 @@ class FlutterWebPlatform extends PlatformPlugin {
   /// Returns the [BrowserManager] for [runtime], which should be a browser.
   ///
   /// If no browser manager is running yet, starts one.
-  Future<BrowserManager> _browserManagerFor(Runtime browser) {
-    final Future<BrowserManager> managerFuture = _browserManagers[browser];
-    if (managerFuture != null) {
-      return managerFuture;
+  Future<BrowserManager> _launchBrowser(Runtime browser) {
+    if (_browserManager != null) {
+      throw StateError('Another browser is currently running.');
     }
+
     final Completer<WebSocketChannel> completer =
         Completer<WebSocketChannel>.sync();
     final String path =
@@ -383,48 +394,29 @@ class FlutterWebPlatform extends PlatformPlugin {
 
     globals.printTrace('Serving tests at $hostUrl');
 
-    final Future<BrowserManager> future = BrowserManager.start(
+    return BrowserManager.start(
       browser,
       hostUrl,
       completer.future,
       headless: !_config.pauseAfterLoad,
     );
-
-    // Store null values for browsers that error out so we know not to load them
-    // again.
-    _browserManagers[browser] = future.catchError((dynamic _) => null);
-
-    return future;
   }
 
   @override
-  Future<void> closeEphemeral() {
-    final List<Future<BrowserManager>> managers =
-        _browserManagers.values.toList();
-    _browserManagers.clear();
-    return Future.wait(managers.map((Future<BrowserManager> manager) async {
-      final BrowserManager result = await manager;
-      if (result == null) {
-        return;
-      }
-      await result.close();
-    }));
+  Future<void> closeEphemeral() async {
+    if (_browserManager != null) {
+      await _browserManager.close();
+    }
   }
 
   @override
   Future<void> close() => _closeMemo.runOnce(() async {
-    final List<Future<dynamic>> futures = _browserManagers.values
-      .map<Future<dynamic>>((Future<BrowserManager> future) async {
-        final BrowserManager result = await future;
-        if (result == null) {
-          return;
-        }
-        await result.close();
-      })
-      .toList();
-    futures.add(_server.close());
-    futures.add(_testGoldenComparator.close());
-    await Future.wait<void>(futures);
+    await Future.wait<void>(<Future<dynamic>>[
+      if (_browserManager != null)
+        _browserManager.close(),
+      _server.close(),
+      _testGoldenComparator.close(),
+    ]);
   });
 }
 
@@ -639,8 +631,8 @@ class BrowserManager {
 
     final Completer<BrowserManager> completer = Completer<BrowserManager>();
 
-    unawaited(chrome.onExit.then((void _) {
-      throwToolExit('${runtime.name} exited before connecting.');
+    unawaited(chrome.onExit.then((int browserExitCode) {
+      throwToolExit('${runtime.name} exited with code $browserExitCode before connecting.');
     }).catchError((dynamic error, StackTrace stackTrace) {
       if (completer.isCompleted) {
         return;
@@ -673,11 +665,6 @@ class BrowserManager {
         this, null, _browser.remoteDebuggerUri, _onRestartController.stream);
   }
 
-  /// Allows only one test suite (typically one test file) to be loaded and run
-  /// at any given point in time. Loading more than one file at a time is known
-  /// to lead to flaky tests.
-  final Pool _suiteLock = Pool(1);
-
   /// Tells the browser to load a test suite from the URL [url].
   ///
   /// [url] should be an HTML page with a reference to the JS-compiled test
@@ -691,9 +678,10 @@ class BrowserManager {
     Uri url,
     SuiteConfiguration suiteConfig,
     Object message,
+    {
+      Future<void> Function() onDone,
+    }
   ) async {
-    final PoolResource lockResource = await _suiteLock.request();
-
     url = url.replace(fragment: Uri.encodeFull(jsonEncode(<String, Object>{
       'metadata': suiteConfig.metadata.serialize(),
       'browser': _runtime.identifier,
@@ -718,7 +706,7 @@ class BrowserManager {
       StreamTransformer<dynamic, dynamic>.fromHandlers(handleDone: (EventSink<dynamic> sink) {
         closeIframe();
         sink.close();
-        lockResource.release();
+        onDone();
       }),
     );
 

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -24,8 +24,11 @@ import 'package:shelf_packages_handler/shelf_packages_handler.dart';
 import 'package:shelf_static/shelf_static.dart';
 import 'package:shelf_web_socket/shelf_web_socket.dart';
 import 'package:stream_channel/stream_channel.dart';
+import 'package:test_api/src/backend/metadata.dart';
+import 'package:test_api/src/backend/group.dart';
 import 'package:test_api/src/backend/runtime.dart';
 import 'package:test_api/src/backend/suite_platform.dart';
+import 'package:test_api/src/backend/test.dart';
 import 'package:test_core/src/runner/configuration.dart';
 import 'package:test_core/src/runner/environment.dart';
 import 'package:test_core/src/runner/platform.dart';
@@ -465,6 +468,69 @@ class OneOffHandler {
     }
     return handler(request.change(path: path));
   }
+}
+
+class FlutterWebRunnerSuite implements RunnerSuite {
+  @override
+  StreamChannel channel(String name) {
+    // TODO: implement channel
+    throw UnimplementedError();
+  }
+  
+  @override
+  Future close() {
+    // TODO: implement close
+    throw UnimplementedError();
+  }
+
+  @override
+  // TODO: implement config
+  SuiteConfiguration get config => throw UnimplementedError();
+
+  @override
+  // TODO: implement environment
+  Environment get environment => throw UnimplementedError();
+
+  @override
+  RunnerSuite filter(bool Function(Test) callback) {
+    // TODO: implement filter
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Map<String, >> gatherCoverage() {
+    // TODO: implement gatherCoverage
+    throw UnimplementedError();
+  }
+
+  @override
+  // TODO: implement group
+  Group get group => throw UnimplementedError();
+
+  @override
+  // TODO: implement isDebugging
+  bool get isDebugging => throw UnimplementedError();
+
+  @override
+  // TODO: implement isLoadSuite
+  bool get isLoadSuite => throw UnimplementedError();
+
+  @override
+  // TODO: implement metadata
+  Metadata get metadata => throw UnimplementedError();
+
+  @override
+  // TODO: implement onDebugging
+  Stream<bool> get onDebugging => throw UnimplementedError();
+
+  @override
+  // TODO: implement path
+  String get path => throw UnimplementedError();
+
+  @override
+  // TODO: implement platform
+  SuitePlatform get platform => throw UnimplementedError();
+
 }
 
 class PathHandler {

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -262,13 +262,11 @@ class Chrome {
   final ChromeConnection chromeConnection;
   final Uri remoteDebuggerUri;
 
-  static Completer<Chrome> _currentCompleter = Completer<Chrome>();
-
-  Future<void> get onExit => _currentCompleter.future;
+  Future<int> get onExit => _process.exitCode;
 
   Future<void> close() async {
-    if (_currentCompleter.isCompleted) {
-      _currentCompleter = Completer<Chrome>();
+    if (ChromeLauncher._currentCompleter.isCompleted) {
+      ChromeLauncher._currentCompleter = Completer<Chrome>();
     }
     chromeConnection.close();
     _process?.kill();


### PR DESCRIPTION
## Description

- Allow only one `RunnerSuite` to load and test at any given point in time, limiting the number of tests running concurrently. The previous method only serialized the loading part, not loading _and_ running.
- Enable most of the screenshot tests.

## Related Issues

Fixes #47003
