### PR TITLE
Application templates should default to publish_to: none

### DIFF
--- a/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
@@ -1,8 +1,9 @@
 name: {{projectName}}
 description: {{description}}
-{{#withPluginHook}}
-publish_to: 'none'
-{{/withPluginHook}}
+
+# The following line prevents the package from being accidentally published to
+# pub.dev using `pub publish`. This is preferred for private packages.
+publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 {{^withPluginHook}}
 
 # The following defines the version and build number for your application.


### PR DESCRIPTION
@dnfield, you originally introduced `publish_to: none` for plugin examples, any reason we don't want to apply this for the application template.
If people try to publish it, they should be told they can't because of the `publish_to: none`, specifically it'll say:
```
$ pub publish
A private package cannot be published.
You can enable this by changing the "publish_to" field in your pubspec.
```

I assume users don't want to accidentally publish application to `pub.dev`, in fact some users might be scared of leaking proprietary apps.

-----
It's possible I have missed some side-effects or use-cases, I'm not familiar with all the places this template is used.