### PR TITLE
explicitly catch ArgumentError in `exitsHappy()`, and add tests

### DIFF
--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -542,6 +542,9 @@ class _DefaultProcessUtils implements ProcessUtils {
     } on Exception catch (error) {
       _logger.printTrace('$cli failed with $error');
       return false;
+    } on ArgumentError catch (error) {
+      _logger.printTrace('$cli failed with $error');
+      return false;
     }
   }
 
@@ -554,6 +557,9 @@ class _DefaultProcessUtils implements ProcessUtils {
     try {
       return (await _processManager.run(cli, environment: environment)).exitCode == 0;
     } on Exception catch (error) {
+      _logger.printTrace('$cli failed with $error');
+      return false;
+    } on ArgumentError catch (error) {
       _logger.printTrace('$cli failed with $error');
       return false;
     }

--- a/packages/flutter_tools/test/general.shard/base/process_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/process_test.dart
@@ -360,6 +360,20 @@ void main() {
       );
       expect(processUtils.exitsHappySync(<String>['boohoo']), isFalse);
     });
+
+    testWithoutContext('catches Exception and returns false', () {
+      when(mockProcessManager.runSync(<String>['boohoo'])).thenThrow(
+        const ProcessException('Process failed', <String>[]),
+      );
+      expect(processUtils.exitsHappySync(<String>['boohoo']), isFalse);
+    });
+
+    testWithoutContext('catches ArgumentError and returns false', () {
+      when(mockProcessManager.runSync(<String>['nonesuch'])).thenThrow(
+        ArgumentError('Invalid argument(s): Cannot find executable for nonesuch')
+      );
+      expect(processUtils.exitsHappySync(<String>['nonesuch']), isFalse);
+    });
   });
 
   group('exitsHappy', () {
@@ -386,6 +400,20 @@ void main() {
         return Future<ProcessResult>.value(ProcessResult(0, 1, '', ''));
       });
       expect(await processUtils.exitsHappy(<String>['boohoo']), isFalse);
+    });
+
+    testWithoutContext('catches Exception and returns false', () async {
+      when(mockProcessManager.run(<String>['boohoo'])).thenThrow(
+        const ProcessException('Process failed', <String>[]),
+      );
+      expect(await processUtils.exitsHappy(<String>['boohoo']), isFalse);
+    });
+
+    testWithoutContext('catches ArgumentError and returns false', () async {
+      when(mockProcessManager.run(<String>['nonesuch'])).thenThrow(
+        ArgumentError('Invalid argument(s): Cannot find executable for nonesuch'),
+      );
+      expect(await processUtils.exitsHappy(<String>['nonesuch']), isFalse);
     });
   });
 


### PR DESCRIPTION
## Description

After https://github.com/flutter/flutter/pull/52021, `exitsHappy()` and `exitsHappySync()` only catch `Exception`s but not `ArgumentError`s, such as when the command being invoked doesn't exist. This PR explicitly catches `ArgumentError`.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/52702

## Tests

I added tests for both `exitsHappy()` and `exitsHappySync()` that it catches both `Exception`s and `ArgumentError`s.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*