### PR TITLE
Use stable IDs for TextSpan SemanticsNodes

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:collection';
 import 'dart:math' as math;
 import 'dart:ui' as ui show Gradient, Shader, TextBox, PlaceholderAlignment, TextHeightBehavior;
 
@@ -844,6 +845,12 @@ class RenderParagraph extends RenderBox
     }
   }
 
+  // Caches [SemanticsNode]s created during [assembleSemanticsNode] so they
+  // can be re-used when [assembleSemanticsNode] is called again. This ensures
+  // stable ids for the [SemanticsNode]s of [TextSpan]s across
+  // [assembleSemanticsNode] invocations.
+  Queue<SemanticsNode> _cachedChildNodes;
+
   @override
   void assembleSemanticsNode(SemanticsNode node, SemanticsConfiguration config, Iterable<SemanticsNode> children) {
     assert(_semanticsInfo != null && _semanticsInfo.isNotEmpty);
@@ -854,6 +861,7 @@ class RenderParagraph extends RenderBox
     int start = 0;
     int placeholderIndex = 0;
     RenderBox child = firstChild;
+    final Queue<SemanticsNode> newChildCache = Queue<SemanticsNode>();
     for (final InlineSpanSemanticsInformation info in _combineSemanticsInfo()) {
       final TextDirection initialDirection = currentDirection;
       final TextSelection selection = TextSelection(
@@ -914,15 +922,25 @@ class RenderParagraph extends RenderBox
             assert(false);
           }
         }
-        newChildren.add(
-          SemanticsNode()
-            ..updateWith(config: configuration)
-            ..rect = currentRect,
-        );
+        final SemanticsNode newChild = (_cachedChildNodes?.isNotEmpty == true)
+            ? _cachedChildNodes.removeFirst()
+            : SemanticsNode();
+        newChild
+          ..updateWith(config: configuration)
+          ..rect = currentRect;
+        newChildCache.addLast(newChild);
+        newChildren.add(newChild);
       }
       start += info.text.length;
     }
+    _cachedChildNodes = newChildCache;
     node.updateWith(config: config, childrenInInversePaintOrder: newChildren);
+  }
+
+  @override
+  void clearSemantics() {
+    super.clearSemantics();
+    _cachedChildNodes = null;
   }
 
   @override

--- a/packages/flutter/test/widgets/text_semantics_test.dart
+++ b/packages/flutter/test/widgets/text_semantics_test.dart
@@ -1,0 +1,133 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+import 'semantics_tester.dart';
+
+void main() {
+  testWidgets('SemanticsNode ids are stable', (WidgetTester tester) async {
+    // Regression test for b/151732341.
+    final SemanticsTester semantics = SemanticsTester(tester);
+    await tester.pumpWidget(Directionality(
+    textDirection: TextDirection.ltr,
+      child: Text.rich(
+        TextSpan(
+          text: 'Hallo ',
+          recognizer: TapGestureRecognizer()..onTap = () {},
+          children: <TextSpan>[
+            TextSpan(
+              text: 'Welt ',
+              recognizer: TapGestureRecognizer()..onTap = () {},
+            ),
+            TextSpan(
+              text: '!!!',
+              recognizer: TapGestureRecognizer()..onTap = () {},
+            ),
+          ],
+        ),
+      ),
+    ));
+    expect(find.text('Hallo Welt !!!'), findsOneWidget);
+    final SemanticsNode node = tester.getSemantics(find.text('Hallo Welt !!!'));
+    final Map<String, int> labelToNodeId = <String, int>{};
+    node.visitChildren((SemanticsNode node) {
+      labelToNodeId[node.label] = node.id;
+       return true;
+    });
+    expect(node.id, 1);
+    expect(labelToNodeId['Hallo '], 2);
+    expect(labelToNodeId['Welt '], 3);
+    expect(labelToNodeId['!!!'], 4);
+    expect(labelToNodeId.length, 3);
+
+    // Rebuild semantics.
+    tester.renderObject(find.text('Hallo Welt !!!')).markNeedsSemanticsUpdate();
+    await tester.pump();
+
+    final SemanticsNode nodeAfterRebuild = tester.getSemantics(find.text('Hallo Welt !!!'));
+    final Map<String, int> labelToNodeIdAfterRebuild = <String, int>{};
+    nodeAfterRebuild.visitChildren((SemanticsNode node) {
+      labelToNodeIdAfterRebuild[node.label] = node.id;
+      return true;
+    });
+
+    // Node IDs are stable.
+    expect(nodeAfterRebuild.id, node.id);
+    expect(labelToNodeIdAfterRebuild['Hallo '], labelToNodeId['Hallo ']);
+    expect(labelToNodeIdAfterRebuild['Welt '], labelToNodeId['Welt ']);
+    expect(labelToNodeIdAfterRebuild['!!!'], labelToNodeId['!!!']);
+    expect(labelToNodeIdAfterRebuild.length, 3);
+
+    // Remove one node.
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: Text.rich(
+        TextSpan(
+          text: 'Hallo ',
+          recognizer: TapGestureRecognizer()..onTap = () {},
+          children: <TextSpan>[
+            TextSpan(
+              text: 'Welt ',
+              recognizer: TapGestureRecognizer()..onTap = () {},
+            ),
+          ],
+        ),
+      ),
+    ));
+
+    final SemanticsNode nodeAfterRemoval = tester.getSemantics(find.text('Hallo Welt '));
+    final Map<String, int> labelToNodeIdAfterRemoval = <String, int>{};
+    nodeAfterRemoval.visitChildren((SemanticsNode node) {
+      labelToNodeIdAfterRemoval[node.label] = node.id;
+      return true;
+    });
+
+    // Node IDs are stable.
+    expect(nodeAfterRemoval.id, node.id);
+    expect(labelToNodeIdAfterRemoval['Hallo '], labelToNodeId['Hallo ']);
+    expect(labelToNodeIdAfterRemoval['Welt '], labelToNodeId['Welt ']);
+    expect(labelToNodeIdAfterRemoval.length, 2);
+
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: Text.rich(
+        TextSpan(
+          text: 'Hallo ',
+          recognizer: TapGestureRecognizer()..onTap = () {},
+          children: <TextSpan>[
+            TextSpan(
+              text: 'Welt ',
+              recognizer: TapGestureRecognizer()..onTap = () {},
+            ),
+            TextSpan(
+              text: '!!!',
+              recognizer: TapGestureRecognizer()..onTap = () {},
+            ),
+          ],
+        ),
+      ),
+    ));
+    expect(find.text('Hallo Welt !!!'), findsOneWidget);
+    final SemanticsNode nodeAfterAddition = tester.getSemantics(find.text('Hallo Welt !!!'));
+    final Map<String, int> labelToNodeIdAfterAddition = <String, int>{};
+    nodeAfterAddition.visitChildren((SemanticsNode node) {
+      labelToNodeIdAfterAddition[node.label] = node.id;
+      return true;
+    });
+
+    // New node gets a new ID.
+    expect(nodeAfterAddition.id, node.id);
+    expect(labelToNodeIdAfterAddition['Hallo '], labelToNodeId['Hallo ']);
+    expect(labelToNodeIdAfterAddition['Welt '], labelToNodeId['Welt ']);
+    expect(labelToNodeIdAfterAddition['!!!'], isNot(labelToNodeId['!!!']));
+    expect(labelToNodeIdAfterAddition['!!!'], isNotNull);
+    expect(labelToNodeIdAfterAddition.length, 3);
+
+    semantics.dispose();
+  });
+}


### PR DESCRIPTION
## Description

When the semantics tree was rebuild, the RenderParagraph has been creating new SemanticsNodes for its TextSpans. Those nodes had new ids even though their content was the same. The new IDs confused some accessibility services. This fixes the problem by re-using the existing SemanticsNodes and their IDs.

## Related Issues

fixes b/151732341

## Tests

I added the following tests:

* Regression test

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
