### PR TITLE
[flutter_tools] Don't crash when analytics fails to initialize

### DIFF
--- a/packages/flutter_tools/lib/src/reporting/usage.dart
+++ b/packages/flutter_tools/lib/src/reporting/usage.dart
@@ -74,11 +74,13 @@ abstract class Usage {
     String versionOverride,
     String configDirOverride,
     String logFile,
+    AnalyticsFactory analyticsIOFactory,
     @required bool runningOnBot,
   }) => _DefaultUsage(settingsName: settingsName,
                       versionOverride: versionOverride,
                       configDirOverride: configDirOverride,
                       logFile: logFile,
+                      analyticsIOFactory: analyticsIOFactory,
                       runningOnBot: runningOnBot);
 
   /// Uses the global [Usage] instance to send a 'command' to analytics.
@@ -152,12 +154,37 @@ abstract class Usage {
   void printWelcome();
 }
 
+typedef AnalyticsFactory = Analytics Function(
+  String trackingId,
+  String applicationName,
+  String applicationVersion, {
+  String analyticsUrl,
+  Directory documentDirectory,
+});
+
+Analytics _defaultAnalyticsIOFactory(
+  String trackingId,
+  String applicationName,
+  String applicationVersion, {
+  String analyticsUrl,
+  Directory documentDirectory,
+}) {
+  return AnalyticsIO(
+    trackingId,
+    applicationName,
+    applicationVersion,
+    analyticsUrl: analyticsUrl,
+    documentDirectory: documentDirectory,
+  );
+}
+
 class _DefaultUsage implements Usage {
   _DefaultUsage({
     String settingsName = 'flutter',
     String versionOverride,
     String configDirOverride,
     String logFile,
+    AnalyticsFactory analyticsIOFactory,
     @required bool runningOnBot,
   }) {
     final FlutterVersion flutterVersion = globals.flutterVersion;
@@ -165,6 +192,8 @@ class _DefaultUsage implements Usage {
     final bool suppressEnvFlag = globals.platform.environment['FLUTTER_SUPPRESS_ANALYTICS'] == 'true';
     final String logFilePath = logFile ?? globals.platform.environment['FLUTTER_ANALYTICS_LOG_FILE'];
     final bool usingLogFile = logFilePath != null && logFilePath.isNotEmpty;
+
+    analyticsIOFactory ??= _defaultAnalyticsIOFactory;
 
     if (// To support testing, only allow other signals to supress analytics
         // when analytics are not being shunted to a file.
@@ -187,13 +216,21 @@ class _DefaultUsage implements Usage {
     if (usingLogFile) {
       _analytics = LogToFileAnalytics(logFilePath);
     } else {
-      _analytics = AnalyticsIO(
-            _kFlutterUA,
-            settingsName,
-            version,
-            documentDirectory:
-                configDirOverride != null ? globals.fs.directory(configDirOverride) : null,
-          );
+      try {
+        _analytics = analyticsIOFactory(
+          _kFlutterUA,
+          settingsName,
+          version,
+          documentDirectory: configDirOverride != null
+            ? globals.fs.directory(configDirOverride)
+            : null,
+        );
+      } on Exception catch (e) {
+        globals.printTrace('Failed to initialize analytics reporting: $e');
+        suppressAnalytics = true;
+        _analytics = AnalyticsMock();
+        return;
+      }
     }
     assert(_analytics != null);
 


### PR DESCRIPTION
## Description

The AnalyticsIO constructor can throw exceptions. Instead of letting that crash the tool, this change logs the error and continues without analytics.

## Related Issues

https://github.com/flutter/flutter/issues/4674

## Tests

I added the following tests:

Added a test to analytics_test.dart.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

NB: The new parameter to the `Usage` constructor is non-`@required`.
