### PR TITLE
[flutter_tools] disable added integration test due to Cirrus flakes

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -277,16 +277,12 @@ Future<void> _runToolTests() async {
       // on Windows.
       final String suffix = Platform.isWindows && subshard == 'commands'
         ? 'permeable'
-        : '';
-      // Only linux has Chrome installed and is running web integration tests.
-      // See `_pubRunTest` for more information.
-      final bool forceSingleCore = Platform.isLinux && subshard == 'integration';
+        : ''
       await _pubRunTest(
         toolsPath,
         testPaths: <String>[path.join(kTest, '$subshard$kDotShard', suffix)],
         tableData: bigqueryApi?.tabledata,
         enableFlutterToolAsserts: true,
-        forceSingleCore: forceSingleCore,
       );
     },
   );

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -277,7 +277,7 @@ Future<void> _runToolTests() async {
       // on Windows.
       final String suffix = Platform.isWindows && subshard == 'commands'
         ? 'permeable'
-        : ''
+        : '';
       await _pubRunTest(
         toolsPath,
         testPaths: <String>[path.join(kTest, '$subshard$kDotShard', suffix)],

--- a/packages/flutter_tools/test/integration.shard/debugger_stepping_web_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debugger_stepping_web_test.dart
@@ -47,7 +47,7 @@ void main() {
         reason: 'After $i steps, debugger should stop at $expectedLine but stopped at $actualLine'
       );
     }
-  }, skip: !Platform.isLinux); // only linux shards have Chrome installed.
+  }, skip: true); // This test is incredibly flaky on Cirrus
 
   tearDown(() async {
     await flutter.stop();


### PR DESCRIPTION
## Description

This test passed okay locally, but on cirrus its flaked 3 times in a row. Disable for now