### PR TITLE
Add support for custom xcode toolchain

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -181,12 +181,15 @@ Future<XcodeBuildResult> buildXcodeProject({
     buildInfo: buildInfo,
   );
   await processPodsIfNeeded(project.ios, getIosBuildDirectory(), buildInfo.mode);
+  
+  final String toolchain = platform.environment['XCODE_TOOLCHAIN'] ?? "XcodeDefault";
 
   final List<String> buildCommands = <String>[
     '/usr/bin/env',
     'xcrun',
     'xcodebuild',
     '-configuration', configuration,
+    '-toolchain', toolchain
   ];
 
   if (globals.logger.isVerbose) {

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:meta/meta.dart';
+import 'package:platform/platform.dart';
 
 import '../application_package.dart';
 import '../artifacts.dart';


### PR DESCRIPTION
## Description

When using a custom Swift toolchain it's impossible to use it in flutter when building from command line. Added XCODE_TOOLCHAIN environment variable to pass the custom toolchain name into xcodebuild.
