### PR TITLE
Mark platform_views_scroll_perf__timeline_summary as flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -152,6 +152,7 @@ tasks:
       Measures the runtime performance of platform views in the Complex Layout sample app on Android.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
+    flaky: true
 
   home_scroll_perf__timeline_summary:
     description: >


### PR DESCRIPTION
For some reason, the tool can't find the observatory port:
```
2020-03-18T15:04:45.393059: stdout: [ +947 ms] Starting: Intent { act=android.intent.action.RUN flg=0x20000000 cmp=dev.benchmarks.platform_views_layout/.DummyPlatformViewActivity (has extras) }
2020-03-18T15:04:45.393664: stdout: [        ] Waiting for observatory port to be available...
2020-03-18T15:19:07.887231: Task timed out in framework.dart after 0:15:00.000000.
Cleaning up after task...
2020-03-18T15:19:08.890008: Force-quitting process:
command : /home/flutter/.cocoon/flutter/bin/flutter drive -v --profile --trace-startup -t test_driver/scroll_perf.dart -d ZY223TDZ7R
  started : 2020-03-18 15:04:09.954888
  pid     : 26806
2020-03-18T15:19:08.895811: "/home/flutter/.cocoon/flutter/bin/flutter" exit code: -15
2020-03-18T15:19:09.896829: Task execution finished

Task failed with the following reason:
Timeout waiting for task process to exit: Future not completed
```