### PR TITLE
Do not throw when trying to discover a fuchsia device and the sshConfig is invalid

### DIFF
--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -423,11 +423,18 @@ class FuchsiaDevice extends Device {
   TargetPlatform _targetPlatform;
 
   Future<TargetPlatform> _queryTargetPlatform() async {
+    const TargetPlatform defaultTargetPlatform = TargetPlatform.fuchsia_arm64;
+    if (!globals.fuchsiaArtifacts.validateSshConfig()) {
+      globals.printError('Could not determine Fuchsia target platform because '
+                 'Fuchsia ssh configuration is missing.\n'
+                 'Defaulting to arm64.');
+      return defaultTargetPlatform;
+    }
     final RunResult result = await shell('uname -m');
     if (result.exitCode != 0) {
       globals.printError('Could not determine Fuchsia target platform type:\n$result\n'
                  'Defaulting to arm64.');
-      return TargetPlatform.fuchsia_arm64;
+      return defaultTargetPlatform;
     }
     final String machine = result.stdout.trim();
     switch (machine) {
@@ -438,7 +445,7 @@ class FuchsiaDevice extends Device {
       default:
         globals.printError('Unknown Fuchsia target platform "$machine". '
                    'Defaulting to arm64.');
-        return TargetPlatform.fuchsia_arm64;
+        return defaultTargetPlatform;
     }
   }
 
@@ -480,16 +487,22 @@ class FuchsiaDevice extends Device {
 
   @override
   Future<String> get sdkNameAndVersion async {
+    const String defaultName = 'Fuchsia';
+    if (!globals.fuchsiaArtifacts.validateSshConfig()) {
+      globals.printError('Could not determine Fuchsia sdk name or version '
+                 'because Fuchsia ssh configuration is missing.');
+      return defaultName;
+    }
     const String versionPath = '/pkgfs/packages/build-info/0/data/version';
     final RunResult catResult = await shell('cat $versionPath');
     if (catResult.exitCode != 0) {
       globals.printTrace('Failed to cat $versionPath: ${catResult.stderr}');
-      return 'Fuchsia';
+      return defaultName;
     }
     final String version = catResult.stdout.trim();
     if (version.isEmpty) {
       globals.printTrace('$versionPath was empty');
-      return 'Fuchsia';
+      return defaultName;
     }
     return 'Fuchsia $version';
   }

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -424,15 +424,15 @@ class FuchsiaDevice extends Device {
 
   Future<TargetPlatform> _queryTargetPlatform() async {
     const TargetPlatform defaultTargetPlatform = TargetPlatform.fuchsia_arm64;
-    if (!globals.fuchsiaArtifacts.validateSshConfig()) {
-      globals.printError('Could not determine Fuchsia target platform because '
+    if (!globals.fuchsiaArtifacts.hasSshConfig) {
+      globals.printTrace('Could not determine Fuchsia target platform because '
                  'Fuchsia ssh configuration is missing.\n'
                  'Defaulting to arm64.');
       return defaultTargetPlatform;
     }
     final RunResult result = await shell('uname -m');
     if (result.exitCode != 0) {
-      globals.printError('Could not determine Fuchsia target platform type:\n$result\n'
+      globals.printTrace('Could not determine Fuchsia target platform type:\n$result\n'
                  'Defaulting to arm64.');
       return defaultTargetPlatform;
     }
@@ -488,7 +488,7 @@ class FuchsiaDevice extends Device {
   @override
   Future<String> get sdkNameAndVersion async {
     const String defaultName = 'Fuchsia';
-    if (!globals.fuchsiaArtifacts.validateSshConfig()) {
+    if (!globals.fuchsiaArtifacts.hasSshConfig) {
       globals.printError('Could not determine Fuchsia sdk name or version '
                  'because Fuchsia ssh configuration is missing.');
       return defaultName;

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -432,7 +432,7 @@ class FuchsiaDevice extends Device {
     }
     final RunResult result = await shell('uname -m');
     if (result.exitCode != 0) {
-      globals.printTrace('Could not determine Fuchsia target platform type:\n$result\n'
+      globals.printError('Could not determine Fuchsia target platform type:\n$result\n'
                  'Defaulting to arm64.');
       return defaultTargetPlatform;
     }
@@ -489,7 +489,7 @@ class FuchsiaDevice extends Device {
   Future<String> get sdkNameAndVersion async {
     const String defaultName = 'Fuchsia';
     if (!globals.fuchsiaArtifacts.hasSshConfig) {
-      globals.printError('Could not determine Fuchsia sdk name or version '
+      globals.printTrace('Could not determine Fuchsia sdk name or version '
                  'because Fuchsia ssh configuration is missing.');
       return defaultName;
     }

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
@@ -158,8 +158,5 @@ class FuchsiaArtifacts {
   final File pm;
 
   /// Returns true if the [sshConfig] file is not null and exists.
-  bool validateSshConfig() {
-    return sshConfig != null
-        && sshConfig.existsSync();
-  }
+  bool get hasSshConfig => sshConfig != null && sshConfig.existsSync();
 }

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
@@ -156,4 +156,10 @@ class FuchsiaArtifacts {
 
   /// The pm tool.
   final File pm;
+
+  /// Returns true if the [sshConfig] file is not null and exists.
+  bool validateSshConfig() {
+    return sshConfig != null
+        && sshConfig.existsSync();
+  }
 }

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
@@ -43,6 +43,7 @@ void main() {
     setUp(() {
       memoryFileSystem = MemoryFileSystem();
       sshConfig = MockFile();
+      when(sshConfig.existsSync()).thenReturn(true);
       when(sshConfig.absolute).thenReturn(sshConfig);
     });
 
@@ -113,6 +114,15 @@ void main() {
     }, overrides: <Type, Generator>{
       FileSystem: () => memoryFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
+    });
+
+    testUsingContext('targetPlatform does not throw when sshConfig is missing', () async {
+      final FuchsiaDevice device = FuchsiaDevice('123');
+      expect(await device.targetPlatform, TargetPlatform.fuchsia_arm64);
+    }, overrides: <Type, Generator>{
+      FuchsiaArtifacts: () => FuchsiaArtifacts(sshConfig: null),
+      FuchsiaSdk: () => MockFuchsiaSdk(),
+      ProcessManager: () => MockProcessManager(),
     });
 
     testUsingContext('targetPlatform arm64 works', () async {
@@ -888,6 +898,7 @@ void main() {
 
     setUp(() {
       sshConfig = MockFile();
+      when(sshConfig.existsSync()).thenReturn(true);
       when(sshConfig.absolute).thenReturn(sshConfig);
 
       mockSuccessProcessManager = MockProcessManager();
@@ -913,6 +924,15 @@ void main() {
       when(emptyStdoutProcessResult.exitCode).thenReturn(0);
       when<String>(emptyStdoutProcessResult.stdout as String).thenReturn('');
       when<String>(emptyStdoutProcessResult.stderr as String).thenReturn('');
+    });
+
+    testUsingContext('does not throw on non-existant ssh config', () async {
+      final FuchsiaDevice device = FuchsiaDevice('123');
+      expect(await device.sdkNameAndVersion, equals('Fuchsia'));
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockSuccessProcessManager,
+      FuchsiaArtifacts: () => FuchsiaArtifacts(sshConfig: null),
+      FuchsiaSdk: () => MockFuchsiaSdk(),
     });
 
     testUsingContext('returns what we get from the device on success', () async {


### PR DESCRIPTION
## Description

If there is a Fuchsia device discoverable on your network (via dev_finder), but you don't have any ssh config set up (e.g. because you're not actually developing for Fuchsia on this machine), the tool currently throws if you try to `flutter run` or `flutter devices`.

This makes it so we print an error and return the same default as in other error conditions in these code paths.

## Related Issues

Fixes #52849 

## Tests

I added the following tests:

Test that we don't throw if the ssh config is not present.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
