### PR TITLE
Add entitlement checks to codesigning test

### DIFF
--- a/dev/bots/codesign.dart
+++ b/dev/bots/codesign.dart
@@ -61,9 +61,74 @@ bool checkCacheIsCurrent() {
   }
 }
 
-void main() {
-  final List<String> failures = <String>[];
+List<String> get binariesWithEntitlements => List<String>.unmodifiable(<String>[
+  'idevice_id',
+  'ideviceinfo',
+  'idevicename',
+  'idevicescreenshot',
+  'idevicesyslog',
+  'libimobiledevice.6.dylib',
+  'ideviceinstaller',
+  'libplist.3.dylib',
+  'iproxy',
+  'libusbmuxd.4.dylib',
+  'libssl.1.0.0.dylib',
+  'libcrypto.1.0.0.dylib',
+  'libzip.5.0.dylib',
+  'libzip.5.dylib',
+  'gen_snapshot',
+  'dart',
+  'flutter_tester',
+  'gen_snapshot_arm64',
+  'gen_snapshot_armv7',
+]);
 
+List<String> get expectedEntitlements => List<String>.unmodifiable(<String>[
+  'com.apple.security.cs.allow-jit',
+  'com.apple.security.cs.allow-unsigned-executable-memory',
+  'com.apple.security.cs.allow-dyld-environment-variables',
+  'com.apple.security.network.client',
+  'com.apple.security.network.server',
+  'com.apple.security.cs.disable-library-validation',
+]);
+
+
+/// Check if the binary has the expected entitlements.
+bool hasExpectedEntitlements(String binaryPath) {
+  try {
+    final ProcessResult entitlementResult = Process.runSync(
+      'codesign',
+      <String>[
+        '--display',
+        '--entitlements',
+        ':-',
+        binaryPath,
+      ],
+    );
+
+    if (entitlementResult.exitCode != 0) {
+      print('The `codesign --entitlements` command failed with exit code ${entitlementResult.exitCode}:\n'
+        '${entitlementResult.stderr}\n');
+      return false;
+    }
+
+    bool passes = true;
+    final String output = entitlementResult.stdout as String;
+    for (final String entitlement in expectedEntitlements) {
+      final bool entitlementExpected = binariesWithEntitlements.contains(path.basename(binaryPath));
+      if (output.contains(entitlement) != entitlementExpected) {
+        print('File "$binaryPath" ${entitlementExpected ? 'does not have expected' : 'has unexpected'} entitlement $entitlement.');
+        passes = false;
+      }
+    }
+    return passes;
+  } catch (e) {
+    print(e);
+    return false;
+  }
+}
+
+void main() {
   if (!Platform.isMacOS) {
     print('Error! Expected operating system "macos", actual operating system '
       'is: "${Platform.operatingSystem}"');
@@ -78,28 +143,45 @@ void main() {
     exit(1);
   }
 
+  final List<String> unsignedBinaries = <String>[];
+  final List<String> wrongEntitlementBinaries = <String>[];
   for (final String binaryPath in findBinaryPaths(cacheDirectory)) {
     print('Verifying the code signature of $binaryPath');
-    final ProcessResult result = Process.runSync(
+    final ProcessResult codeSignResult = Process.runSync(
       'codesign',
       <String>[
         '-vvv',
         binaryPath,
       ],
     );
-    if (result.exitCode != 0) {
-      failures.add(binaryPath);
+    if (codeSignResult.exitCode != 0) {
+      unsignedBinaries.add(binaryPath);
       print('File "$binaryPath" does not appear to be codesigned.\n'
-            'The `codesign` command failed with exit code ${result.exitCode}:\n'
-            '${result.stderr}\n');
+            'The `codesign` command failed with exit code ${codeSignResult.exitCode}:\n'
+            '${codeSignResult.stderr}\n');
+      continue;
+    } else {
+      print('Verifying entitlements of $binaryPath');
+      if (!hasExpectedEntitlements(binaryPath)) {
+        wrongEntitlementBinaries.add(binaryPath);
+      }
     }
   }
 
-  if (failures.isNotEmpty) {
-    print('Found ${failures.length} unsigned binaries.');
-    failures.forEach(print);
+  if (unsignedBinaries.isNotEmpty) {
+    print('Found ${unsignedBinaries.length} unsigned binaries:');
+    unsignedBinaries.forEach(print);
+  }
+
+  if (wrongEntitlementBinaries.isNotEmpty) {
+    print('Found ${wrongEntitlementBinaries.length} binaries with unexpected entitlements:');
+    wrongEntitlementBinaries.forEach(print);
+  }
+
+  if (unsignedBinaries.isNotEmpty) {
+    // TODO(jmagman): Also exit if `wrongEntitlementBinaries.isNotEmpty` after https://github.com/flutter/flutter/issues/46704 is done.
     exit(1);
   }
 
-  print('Verified that binaries are codesigned.');
+  print('Verified that binaries are codesigned and have expected entitlements.');
 }


### PR DESCRIPTION
## Description
Add entitlement checks, but don't actually fail the test (to be done once the script is fixed).
```
Verifying entitlements of /Users/m/Projects/flutter/bin/cache/dart-sdk/bin/dart
File "/Users/m/Projects/flutter/bin/cache/dart-sdk/bin/dart" does not have expected entitlement com.apple.security.network.client.
File "/Users/m/Projects/flutter/bin/cache/dart-sdk/bin/dart" does not have expected entitlement com.apple.security.network.server.
File "/Users/m/Projects/flutter/bin/cache/dart-sdk/bin/dart" does not have expected entitlement com.apple.security.cs.disable-library-validation.
```

## Related Issues

Fixes https://github.com/flutter/flutter/issues/52908

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*