### PR TITLE
Prepare Flutter for SDK changes to `runZoned`.

### DIFF
--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -68,7 +68,7 @@ Future<int> run(
         return await _handleToolError(
             error, stackTrace, verbose, args, reportCrashes, getVersion);
       }
-    }, onError: (Object error, StackTrace stackTrace) async {
+    }, onError: (Object error, StackTrace stackTrace) async { // ignore: deprecated_member_use
       // If sending a crash report throws an error into the zone, we don't want
       // to re-try sending the crash report with *that* error. Rather, we want
       // to send the original error that triggered the crash report.

--- a/packages/flutter_tools/lib/src/base/async_guard.dart
+++ b/packages/flutter_tools/lib/src/base/async_guard.dart
@@ -117,7 +117,7 @@ Future<T> asyncGuard<T>(
     } catch (e, s) { // ignore: avoid_catches_without_on_clauses
       handleError(e, s);
     }
-  }, onError: (Object e, StackTrace s) {
+  }, onError: (Object e, StackTrace s) { // ignore: deprecated_member_use
     handleError(e, s);
   });
 

--- a/packages/flutter_tools/test/general.shard/runner/runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/runner_test.dart
@@ -55,7 +55,7 @@ void main() {
           ));
           return null;
         },
-        onError: (Object error) {
+        onError: (Object error, StackTrace stack) { // ignore: deprecated_member_use
           expect(error, 'test exit');
           completer.complete();
         },
@@ -103,7 +103,7 @@ void main() {
         ));
         return null;
         },
-        onError: (Object error) {
+        onError: (Object error, StackTrace stack) { // ignore: deprecated_member_use
           expect(error, 'test exit');
           completer.complete();
         },

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -158,7 +158,7 @@ void testUsingContext(
               _printBufferedErrors(context);
               rethrow;
             }
-          }, onError: (dynamic error, StackTrace stackTrace) {
+          }, onError: (Object error, StackTrace stackTrace) { // ignore: deprecated_member_use
             io.stdout.writeln(error);
             io.stdout.writeln(stackTrace);
             _printBufferedErrors(context);


### PR DESCRIPTION
## Description

Inserts 5 counts of `// ignore: deprecated_member_use`.

The `runZoned` method deprecates the `onError` parameter.
Invocations using that parameter must use `runZonedGuarded` instead.

This prepares Flutter for the deprecation. The same places need to be migrated to using
`runZonedGuarded` when the SDK change has been ported to Flutter.
Then the deprecated member will be removed in a follow-up CL when the most important
packages have been migrated.

This change is needed to enable landing the initial Dart SDK change, which must happen before the migration can begin. See: https://dart-review.googlesource.com/c/sdk/+/137302/24

## Related Issues

https://github.com/dart-lang/sdk/issues/40681

