### PR TITLE
Enable more material and cupertino tests on the Web

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -67,20 +67,11 @@ const List<String> kWebTestFileBlacklist = <String>[
   'test/widgets/editable_text_cursor_test.dart',
   'test/widgets/editable_text_test.dart',
   'test/material/animated_icons_private_test.dart',
-  'test/material/text_form_field_test.dart',
   'test/material/data_table_test.dart',
-  'test/cupertino/dialog_test.dart',
-  'test/cupertino/nav_bar_test.dart',
   'test/cupertino/nav_bar_transition_test.dart',
   'test/cupertino/refresh_test.dart',
-  'test/cupertino/switch_test.dart',
   'test/cupertino/text_field_test.dart',
-  'test/cupertino/date_picker_test.dart',
-  'test/cupertino/slider_test.dart',
-  'test/cupertino/text_field_test.dart',
-  'test/cupertino/segmented_control_test.dart',
   'test/cupertino/route_test.dart',
-  'test/cupertino/activity_indicator_test.dart',
 ];
 
 /// When you call this, you can pass additional arguments to pass custom

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -854,7 +854,7 @@ void main() {
     // We must explicitly cause an "up" gesture to avoid a crash.
     // todo(mattcarroll) remove this call when #19540 is fixed
     await gesture.up();
-  });
+  }, skip: isBrowser); // https://github.com/flutter/flutter/issues/52960
 
   testWidgets('ScaleTransition animation for showCupertinoDialog()', (WidgetTester tester) async {
     await tester.pumpWidget(

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -303,7 +303,7 @@ void main() {
 
     await tester.pump(const Duration(milliseconds: 200));
     expect(renderEditable, paintsExactlyCountTimes(#drawRect, 0));
-  });
+  }, skip: isBrowser); // we do not use Flutter-rendered context menu on the Web
 
   testWidgets('onTap is called upon tap', (WidgetTester tester) async {
     int tapCount = 0;


### PR DESCRIPTION
## Description

Enable the following tests on the Web:

- test/material/text_form_field_test.dart
- test/cupertino/dialog_test.dart
- test/cupertino/nav_bar_test.dart
- test/cupertino/switch_test.dart
- test/cupertino/date_picker_test.dart
- test/cupertino/slider_test.dart
- test/cupertino/text_field_test.dart
- test/cupertino/segmented_control_test.dart
- test/cupertino/activity_indicator_test.dart