### PR TITLE
Enable CupertinoContextMenu on Web

### DIFF
--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -515,17 +515,19 @@ class _DecoyChildState extends State<_DecoyChild> with TickerProviderStateMixin 
       // TODO(justinmc): When ShaderMask is supported on web, remove this
       // conditional and use ShaderMask everywhere.
       // https://github.com/flutter/flutter/issues/52967.
-      child: kIsWeb ? widget.child : ShaderMask(
-        key: _childGlobalKey,
-        shaderCallback: (Rect bounds) {
-          return LinearGradient(
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            colors: <Color>[color, color],
-          ).createShader(bounds);
-        },
-        child: widget.child,
-      ),
+      child: kIsWeb
+          ? Container(key: _childGlobalKey, child: widget.child)
+          : ShaderMask(
+            key: _childGlobalKey,
+            shaderCallback: (Rect bounds) {
+              return LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: <Color>[color, color],
+              ).createShader(bounds);
+            },
+            child: widget.child,
+          ),
     );
   }
 

--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -5,6 +5,7 @@
 import 'dart:math' as math;
 import 'dart:ui' as ui;
 import 'package:flutter/gestures.dart' show kMinFlingVelocity, kLongPressTimeout;
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
@@ -511,7 +512,10 @@ class _DecoyChildState extends State<_DecoyChild> with TickerProviderStateMixin 
       : _mask.value;
     return Positioned.fromRect(
       rect: _rect.value,
-      child: ShaderMask(
+      // TODO(justinmc): When ShaderMask is supported on web, remove this
+      // conditional and use ShaderMask everywhere.
+      // https://github.com/flutter/flutter/issues/52967.
+      child: kIsWeb ? widget.child : ShaderMask(
         key: _childGlobalKey,
         shaderCallback: (Rect bounds) {
           return LinearGradient(

--- a/packages/flutter/test/cupertino/context_menu_test.dart
+++ b/packages/flutter/test/cupertino/context_menu_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 
 void main() {
   final TestWidgetsFlutterBinding binding =
@@ -102,6 +103,11 @@ void main() {
       expect(_findDecoyChild(child), findsOneWidget);
       Rect decoyChildRect = tester.getRect(_findDecoyChild(child));
       expect(childRect, equals(decoyChildRect));
+
+      // TODO(justinmc): When ShaderMask is supported on web, remove this
+      // conditional and just check for ShaderMask.
+      // https://github.com/flutter/flutter/issues/52967.
+      expect(find.byType(ShaderMask), kIsWeb ? findsNothing : findsOneWidget);
 
       // After a small delay, the _DecoyChild has begun to animate.
       await tester.pump(const Duration(milliseconds: 100));


### PR DESCRIPTION
## Description

CupertinoContextMenu is currently broken on web.  This fixes it with the caveat that the small color mask during opening will not appear on web.  Once ShaderMask is supported on web, the conditional in this PR can be removed, and web should work like other platforms.

## Related Issues

https://github.com/flutter/flutter/issues/52967
https://github.com/flutter/flutter/issues/44152
https://github.com/flutter/flutter/issues/52766

## Tests

I added a check that ShaderMask exists on non-web platforms and that it does not exist on the web.

I also manually verified that the [CupertinoContextMenu docs](https://api.flutter.dev/flutter/cupertino/CupertinoContextMenu-class.html) example runs without error in the browser locally.

## Breaking Change

Not a breaking change.