### PR TITLE
Added ability to change dropdown colour manually

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -203,12 +203,14 @@ class _DropdownMenu<T> extends StatefulWidget {
     this.route,
     this.buttonRect,
     this.constraints,
+    this.dropdownColor,
   }) : super(key: key);
 
   final _DropdownRoute<T> route;
   final EdgeInsets padding;
   final Rect buttonRect;
   final BoxConstraints constraints;
+  final Color dropdownColor;
 
   @override
   _DropdownMenuState<T> createState() => _DropdownMenuState<T>();
@@ -265,7 +267,7 @@ class _DropdownMenuState<T> extends State<_DropdownMenu<T>> {
       opacity: _fadeOpacity,
       child: CustomPaint(
         painter: _DropdownMenuPainter(
-          color: Theme.of(context).canvasColor,
+          color: widget.dropdownColor ?? Theme.of(context).canvasColor,
           elevation: route.elevation,
           selectedIndex: route.selectedIndex,
           resize: _resize,
@@ -400,6 +402,7 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
     @required this.style,
     this.barrierLabel,
     this.itemHeight,
+    this.dropdownColor,
   }) : assert(style != null),
        itemHeights = List<double>.filled(items.length, itemHeight ?? kMinInteractiveDimension);
 
@@ -411,6 +414,7 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
   final ThemeData theme;
   final TextStyle style;
   final double itemHeight;
+  final Color dropdownColor;
 
   final List<double> itemHeights;
   ScrollController scrollController;
@@ -441,6 +445,7 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
           elevation: elevation,
           theme: theme,
           style: style,
+          dropdownColor: dropdownColor,
         );
       }
     );
@@ -526,6 +531,7 @@ class _DropdownRoutePage<T> extends StatelessWidget {
     this.elevation = 8,
     this.theme,
     this.style,
+    this.dropdownColor,
   }) : super(key: key);
 
   final _DropdownRoute<T> route;
@@ -537,6 +543,7 @@ class _DropdownRoutePage<T> extends StatelessWidget {
   final int elevation;
   final ThemeData theme;
   final TextStyle style;
+  final Color dropdownColor;
 
   @override
   Widget build(BuildContext context) {
@@ -559,6 +566,7 @@ class _DropdownRoutePage<T> extends StatelessWidget {
       padding: padding.resolve(textDirection),
       buttonRect: buttonRect,
       constraints: constraints,
+      dropdownColor: dropdownColor,
     );
 
     if (theme != null)
@@ -811,6 +819,7 @@ class DropdownButton<T> extends StatefulWidget {
     this.focusColor,
     this.focusNode,
     this.autofocus = false,
+    this.dropdownColor,
   }) : assert(items == null || items.isEmpty || value == null ||
               items.where((DropdownMenuItem<T> item) {
                 return item.value == value;
@@ -1049,6 +1058,8 @@ class DropdownButton<T> extends StatefulWidget {
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
 
+  final Color dropdownColor;
+
   @override
   _DropdownButtonState<T> createState() => _DropdownButtonState<T>();
 }
@@ -1189,6 +1200,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
       style: _textStyle,
       barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
       itemHeight: widget.itemHeight,
+      dropdownColor: widget.dropdownColor,
     );
 
     Navigator.push(context, _dropdownRoute).then<void>((_DropdownRouteResult<T> newValue) {

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -799,7 +799,7 @@ class DropdownButton<T> extends StatefulWidget {
   /// [isExpanded] arguments must not be null.
   ///
   /// The [dropdownColor] argument specifies the background color of the
-  /// dropdown when it is open. If it is null the current theme's
+  /// dropdown when it is open. If it is null, the current theme's
   /// [ThemeData.canvasColor] will be used instead.
   DropdownButton({
     Key key,
@@ -1062,9 +1062,10 @@ class DropdownButton<T> extends StatefulWidget {
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
 
-  /// The color of the dropdown's background color.
+  /// The background color of the dropdown.
   ///
-  /// If not provided the theme's [ThemeData.canvasColor] will be used instead.
+  /// If it is not provided the theme's [ThemeData.canvasColor] will be used
+  /// instead.
   final Color dropdownColor;
 
   @override

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -797,6 +797,10 @@ class DropdownButton<T> extends StatefulWidget {
   /// The [elevation] and [iconSize] arguments must not be null (they both have
   /// defaults, so do not need to be specified). The boolean [isDense] and
   /// [isExpanded] arguments must not be null.
+  ///
+  /// The [dropdownColor] argument specifies the background color of the
+  /// dropdown when it is open. If it is null the current theme's
+  /// [ThemeData.canvasColor] will be used instead.
   DropdownButton({
     Key key,
     @required this.items,
@@ -1058,8 +1062,9 @@ class DropdownButton<T> extends StatefulWidget {
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
 
-  /// The color of the dropdown's background color. If not provided the theme's
-  /// canvas color will be used instead.
+  /// The color of the dropdown's background color.
+  ///
+  /// If not provided the theme's [ThemeData.canvasColor] will be used instead.
   final Color dropdownColor;
 
   @override

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1058,6 +1058,8 @@ class DropdownButton<T> extends StatefulWidget {
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
 
+  /// The color of the dropdown's background color. If not provided the theme's
+  /// canvas color will be used instead.
   final Color dropdownColor;
 
   @override

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1064,7 +1064,7 @@ class DropdownButton<T> extends StatefulWidget {
 
   /// The background color of the dropdown.
   ///
-  /// If it is not provided the theme's [ThemeData.canvasColor] will be used
+  /// If it is not provided, the theme's [ThemeData.canvasColor] will be used
   /// instead.
   final Color dropdownColor;
 

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -207,7 +207,7 @@ Future<void> checkDropdownColor(WidgetTester tester, {Color color}) async {
         ..rrect()
         ..rrect()
         ..rrect()
-        ..rrect(color: color ?? const Color.fromRGBO(250, 250, 250, 1), hasMaskFilter: false)
+        ..rrect(color: color ?? Colors.grey[50], hasMaskFilter: false)
   );
 }
 

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -53,6 +53,7 @@ Widget buildFrame({
   FocusNode focusNode,
   bool autofocus = false,
   Color focusColor,
+  Color dropdownColor,
 }) {
   return TestApp(
     textDirection: textDirection,
@@ -78,6 +79,7 @@ Widget buildFrame({
             focusNode: focusNode,
             autofocus: autofocus,
             focusColor: focusColor,
+            dropdownColor: dropdownColor,
             items: items == null ? null : items.map<DropdownMenuItem<String>>((String item) {
               return DropdownMenuItem<String>(
                 key: ValueKey<String>(item),

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -176,6 +176,41 @@ void verifyPaintedShadow(Finder customPaint, int elevation) {
   );
 }
 
+Future<void> checkDropdownColor(WidgetTester tester, {Color color}) async {
+  const String text = 'foo';
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Material(
+        child: DropdownButton<String>(
+          dropdownColor: color,
+          value: text,
+          items: const <DropdownMenuItem<String>>[
+            DropdownMenuItem<String>(
+              value: text,
+              child: Text(text),
+            ),
+          ],
+          onChanged: (_) { },
+        ),
+      ),
+    ),
+  );
+  await tester.tap(find.text(text));
+  await tester.pump();
+
+  expect(
+      find.ancestor(
+          of: find.text(text).last,
+          matching: find.byType(CustomPaint)).at(2),
+      paints
+        ..save()
+        ..rrect()
+        ..rrect()
+        ..rrect()
+        ..rrect(color: color ?? const Color.fromRGBO(250, 250, 250, 1), hasMaskFilter: false)
+  );
+}
+
 bool sameGeometry(RenderBox box1, RenderBox box2) {
   expect(box1.localToGlobal(Offset.zero), equals(box2.localToGlobal(Offset.zero)));
   expect(box1.size.height, equals(box2.size.height));
@@ -1776,42 +1811,12 @@ void main() {
     expect(find.text('Two as an Arabic numeral: 2'), findsOneWidget);
   });
 
-  testWidgets('DropdownButton uses dropdownColor when expanded', (WidgetTester tester) async {
-    const String value = 'foo';
-    final UniqueKey itemKey = UniqueKey();
-    const Color colorToTest = Color.fromRGBO(100, 200, 50, 0.9);
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Material(
-          child: DropdownButton<String>(
-            dropdownColor: colorToTest,
-            value: value,
-            items: <DropdownMenuItem<String>>[
-              DropdownMenuItem<String>(
-                key: itemKey,
-                value: value,
-                child: const Text(value),
-              ),
-            ],
-            onChanged: (_) { },
-          ),
-        ),
-      ),
-    );
-    await tester.tap(find.text(value));
-    await tester.pump();
+  testWidgets('DropdownButton uses default color when expanded', (WidgetTester tester) async {
+    await checkDropdownColor(tester);
+  });
 
-    expect(
-        find.ancestor(
-            of: find.byKey(itemKey).last,
-            matching: find.byType(CustomPaint)).at(2),
-        paints
-          ..save()
-          ..rrect()
-          ..rrect()
-          ..rrect()
-          ..rrect(color: colorToTest, hasMaskFilter: false)
-    );
+  testWidgets('DropdownButton uses dropdownColor when expanded when given', (WidgetTester tester) async {
+    await checkDropdownColor(tester, color: const Color.fromRGBO(120, 220, 70, 0.8));
   });
 
   testWidgets('DropdownButton hint displays properly when selectedItemBuilder is defined', (WidgetTester tester) async {

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -1776,6 +1776,44 @@ void main() {
     expect(find.text('Two as an Arabic numeral: 2'), findsOneWidget);
   });
 
+  testWidgets('DropdownButton uses dropdownColor when expanded', (WidgetTester tester) async {
+    const String value = 'foo';
+    final UniqueKey itemKey = UniqueKey();
+    const Color colorToTest = Color.fromRGBO(100, 200, 50, 0.9);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: DropdownButton<String>(
+            dropdownColor: colorToTest,
+            value: value,
+            items: <DropdownMenuItem<String>>[
+              DropdownMenuItem<String>(
+                key: itemKey,
+                value: value,
+                child: const Text(value),
+              ),
+            ],
+            onChanged: (_) { },
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text(value));
+    await tester.pump();
+
+    expect(
+        find.ancestor(
+            of: find.byKey(itemKey).last,
+            matching: find.byType(CustomPaint)).at(2),
+        paints
+          ..save()
+          ..rrect()
+          ..rrect()
+          ..rrect()
+          ..rrect(color: colorToTest, hasMaskFilter: false)
+    );
+  });
+
   testWidgets('DropdownButton hint displays properly when selectedItemBuilder is defined', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/42340
     final List<String> items = <String>['1', '2', '3'];

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -199,15 +199,15 @@ Future<void> checkDropdownColor(WidgetTester tester, {Color color}) async {
   await tester.pump();
 
   expect(
-      find.ancestor(
-          of: find.text(text).last,
-          matching: find.byType(CustomPaint)).at(2),
-      paints
-        ..save()
-        ..rrect()
-        ..rrect()
-        ..rrect()
-        ..rrect(color: color ?? Colors.grey[50], hasMaskFilter: false)
+    find.ancestor(
+      of: find.text(text).last,
+      matching: find.byType(CustomPaint)).at(2),
+    paints
+      ..save()
+      ..rrect()
+      ..rrect()
+      ..rrect()
+      ..rrect(color: color ?? Colors.grey[50], hasMaskFilter: false)
   );
 }
 


### PR DESCRIPTION
## Description

Before there was no way to manually set the colour of a dropdown (when it is open) and is always set to the theme's `canvasColor`. This is a bit weird as most other widgets have an option to override their default colour. This PR adds that ability using the new `dropdownColor` parameter.

## Related Issues

## Tests

~~No tests as I could not find a way to easily start a dropdown as expanded. Did add a hook in /packages/flutter/test/material/dropdown_test.dart to test the functionality though.~~

'DropdownButton uses default color when expanded' and 'DropdownButton hint displays properly when selectedItemBuilder is defined' in dropdown_test.dart.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*