### PR TITLE
Update Highlight mode initial value calculation.

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
@@ -1380,7 +1379,7 @@ class FocusManager with DiagnosticableTreeMixin, ChangeNotifier {
         case TargetPlatform.android:
         case TargetPlatform.fuchsia:
         case TargetPlatform.iOS:
-          _lastInteractionWasTouchValue = true;
+          _lastInteractionWasTouchValue = !WidgetsBinding.instance.mouseTracker.mouseIsConnected;
           break;
         case TargetPlatform.linux:
         case TargetPlatform.macOS:

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -1424,7 +1424,17 @@ class FocusManager with DiagnosticableTreeMixin, ChangeNotifier {
     //
     // This only affects the initial value: the ongoing value is updated as soon
     // as any input events are received.
-    _lastInteractionWasTouch ??= Platform.isAndroid || Platform.isIOS || !WidgetsBinding.instance.mouseTracker.mouseIsConnected;
+    if (_lastInteractionWasTouch == null) {
+      if (Platform.isAndroid || Platform.isIOS) {
+        _lastInteractionWasTouch = true;
+      } else {
+        if (Platform.isMacOS || Platform.isWindows || Platform.isLinux) {
+          _lastInteractionWasTouch = false;
+        } else {
+          _lastInteractionWasTouch = !WidgetsBinding.instance.mouseTracker.mouseIsConnected;
+        }
+      }
+    }
     FocusHighlightMode newMode;
     switch (highlightStrategy) {
       case FocusHighlightStrategy.automatic:

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -1,6 +1,7 @@
 // Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -828,6 +829,21 @@ void main() {
       // receive it.
       expect(receivedAnEvent, isEmpty);
     });
+    testWidgets('Initial highlight mode guesses correctly.', (WidgetTester tester) async {
+      FocusManager.instance.highlightStrategy = FocusHighlightStrategy.automatic;
+      switch (defaultTargetPlatform) {
+        case TargetPlatform.fuchsia:
+        case TargetPlatform.android:
+        case TargetPlatform.iOS:
+          expect(FocusManager.instance.highlightMode, equals(FocusHighlightMode.touch));
+          break;
+        case TargetPlatform.linux:
+        case TargetPlatform.macOS:
+        case TargetPlatform.windows:
+          expect(FocusManager.instance.highlightMode, equals(FocusHighlightMode.traditional));
+          break;
+      }
+    }, variant: TargetPlatformVariant.all());
     testWidgets('Events change focus highlight mode.', (WidgetTester tester) async {
       await setupWidget(tester);
       int callCount = 0;

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -1,7 +1,6 @@
 // Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';


### PR DESCRIPTION
## Description

This fixes the default value of `FocusManager.highlightMode` to be platform sensitive.  Also, instead of using `Platform` for determining what the default initial value should be, use `defaultTargetPlatform`, which makes it a lot easier to test.

## Tests

- Added a test to make sure that the initial value was being determined correctly.

## Breaking Change

- [X] No, this is *not* a breaking change.