### PR TITLE
save and restore the chrome session local storage information

### DIFF
--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -122,7 +122,7 @@ class ChromeLauncher {
     }
 
     final String chromeExecutable = findChromeExecutable(_platform, _fileSystem);
-    final Directory userDataDir = _fileSystem.systemTempDirectory.createTempSync('flutter_tool.');
+    final Directory userDataDir = _fileSystem.systemTempDirectory.createTempSync('flutter_tools_chrome_device.');
 
     if (cacheDir != null) {
       // Seed data dir with previous state.
@@ -198,6 +198,9 @@ class ChromeLauncher {
 
   /// Copy Chrome user information from a Chrome session into a per-project
   /// cache.
+  ///
+  /// Note: more detailed docs of the Chrome user preferences store exists here:
+  /// https://www.chromium.org/developers/design-documents/preferences.
   void _cacheUserSessionInformation(Directory userDataDir, Directory cacheDir) {
     final File targetPreferencesFile = _fileSystem.file(_fileSystem.path.join(cacheDir?.path ?? '', _preferencesPath));
     final File sourcePreferencesFile = _fileSystem.file(_fileSystem.path.join(userDataDir.path, _preferencesPath));

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -15,6 +15,7 @@ import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/os.dart';
 import '../convert.dart';
+import '../globals.dart' as globals;
 
 /// An environment variable used to override the location of chrome.
 const String kChromeEnvironment = 'CHROME_EXECUTABLE';
@@ -115,27 +116,17 @@ class ChromeLauncher {
   /// port is picked automatically.
   ///
   /// `skipCheck` does not attempt to make a devtools connection before returning.
-  Future<Chrome> launch(String url, { bool headless = false, int debugPort, bool skipCheck = false, Directory dataDir }) async {
+  Future<Chrome> launch(String url, { bool headless = false, int debugPort, bool skipCheck = false, Directory cacheDir }) async {
     if (_currentCompleter.isCompleted) {
       throwToolExit('Only one instance of chrome can be started.');
     }
 
-    // This is a JSON file which contains configuration from the
-    // browser session, such as window position. It is located
-    // under the Chrome data-dir folder.
-    final String preferencesPath = _fileSystem.path.join('Default', 'preferences');
-
     final String chromeExecutable = findChromeExecutable(_platform, _fileSystem);
-    final Directory activeDataDir = _fileSystem.systemTempDirectory.createTempSync('flutter_tool.');
-    // Seed data dir with previous state.
+    final Directory userDataDir = _fileSystem.systemTempDirectory.createTempSync('flutter_tool.');
 
-    final File savedPreferencesFile = _fileSystem.file(_fileSystem.path.join(dataDir?.path ?? '', preferencesPath));
-    final File destinationFile = _fileSystem.file(_fileSystem.path.join(activeDataDir.path, preferencesPath));
-    if (dataDir != null) {
-      if (savedPreferencesFile.existsSync()) {
-        destinationFile.parent.createSync(recursive: true);
-        savedPreferencesFile.copySync(destinationFile.path);
-      }
+    if (cacheDir != null) {
+      // Seed data dir with previous state.
+      _restoreUserSessionInformation(cacheDir, userDataDir);
     }
 
     final int port = debugPort ?? await _operatingSystemUtils.findFreePort();
@@ -143,7 +134,7 @@ class ChromeLauncher {
       chromeExecutable,
       // Using a tmp directory ensures that a new instance of chrome launches
       // allowing for the remote debug port to be enabled.
-      '--user-data-dir=${activeDataDir.path}',
+      '--user-data-dir=${userDataDir.path}',
       '--remote-debugging-port=$port',
       // When the DevTools has focus we don't want to slow down the application.
       '--disable-background-timer-throttling',
@@ -163,18 +154,10 @@ class ChromeLauncher {
 
     final Process process = await _processManager.start(args);
 
-    // When the process exits, copy the user settings back to the provided
-    // data-dir.
-    if (dataDir != null) {
+    // When the process exits, copy the user settings back to the provided data-dir.
+    if (cacheDir != null) {
       unawaited(process.exitCode.whenComplete(() {
-        if (destinationFile.existsSync()) {
-          savedPreferencesFile.parent.createSync(recursive: true);
-          // If the file contains a crash string, remove it to hide
-          // the popup on next run.
-          final String contents = destinationFile.readAsStringSync();
-          savedPreferencesFile.writeAsStringSync(contents
-            .replaceFirst('"exit_type":"Crashed"', '"exit_type":"Normal"'));
-        }
+        _cacheUserSessionInformation(userDataDir, cacheDir);
       }));
     }
 
@@ -204,6 +187,54 @@ class ChromeLauncher {
       process: process,
       remoteDebuggerUri: remoteDebuggerUri,
     ), skipCheck);
+  }
+
+  // This is a JSON file which contains configuration from the browser session,
+  // such as window position. It is located under the Chrome data-dir folder.
+  String get _preferencesPath => _fileSystem.path.join('Default', 'preferences');
+
+  // The directory that Chrome uses to store local storage information for web apps.
+  String get _localStoragePath => _fileSystem.path.join('Default', 'Local Storage');
+
+  /// Copy Chrome user information from a Chrome session into a per-project
+  /// cache.
+  void _cacheUserSessionInformation(Directory userDataDir, Directory cacheDir) {
+    final File targetPreferencesFile = _fileSystem.file(_fileSystem.path.join(cacheDir?.path ?? '', _preferencesPath));
+    final File sourcePreferencesFile = _fileSystem.file(_fileSystem.path.join(userDataDir.path, _preferencesPath));
+    final Directory targetLocalStorageDir = _fileSystem.directory(_fileSystem.path.join(cacheDir?.path ?? '', _localStoragePath));
+    final Directory sourceLocalStorageDir = _fileSystem.directory(_fileSystem.path.join(userDataDir.path, _localStoragePath));
+
+    if (sourcePreferencesFile.existsSync()) {
+      targetPreferencesFile.parent.createSync(recursive: true);
+      // If the file contains a crash string, remove it to hide the popup on next run.
+      final String contents = sourcePreferencesFile.readAsStringSync();
+      targetPreferencesFile.writeAsStringSync(contents
+          .replaceFirst('"exit_type":"Crashed"', '"exit_type":"Normal"'));
+    }
+
+    if (sourceLocalStorageDir.existsSync()) {
+      targetLocalStorageDir.createSync(recursive: true);
+      globals.fsUtils.copyDirectorySync(sourceLocalStorageDir, targetLocalStorageDir);
+    }
+  }
+
+  /// Restore Chrome user information from a per-project cache into Chrome's
+  /// user data directory.
+  void _restoreUserSessionInformation(Directory cacheDir, Directory userDataDir) {
+    final File sourcePreferencesFile = _fileSystem.file(_fileSystem.path.join(cacheDir.path ?? '', _preferencesPath));
+    final File targetPreferencesFile = _fileSystem.file(_fileSystem.path.join(userDataDir.path, _preferencesPath));
+    final Directory sourceLocalStorageDir = _fileSystem.directory(_fileSystem.path.join(cacheDir.path ?? '', _localStoragePath));
+    final Directory targetLocalStorageDir = _fileSystem.directory(_fileSystem.path.join(userDataDir.path, _localStoragePath));
+
+    if (sourcePreferencesFile.existsSync()) {
+      targetPreferencesFile.parent.createSync(recursive: true);
+      sourcePreferencesFile.copySync(targetPreferencesFile.path);
+    }
+
+    if (sourceLocalStorageDir.existsSync()) {
+      targetLocalStorageDir.createSync(recursive: true);
+      globals.fsUtils.copyDirectorySync(sourceLocalStorageDir, targetLocalStorageDir);
+    }
   }
 
   static Future<Chrome> _connect(Chrome chrome, bool skipCheck) async {

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -138,7 +138,7 @@ class ChromeDevice extends Device {
     if (launchChrome) {
       _chrome = await globals.chromeLauncher.launch(
         url,
-        dataDir: globals.fs.currentDirectory
+        cacheDir: globals.fs.currentDirectory
             .childDirectory('.dart_tool')
             .childDirectory('chrome-device'),
         headless: debuggingOptions.webRunHeadless,

--- a/packages/flutter_tools/test/general.shard/web/chrome_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/chrome_test.dart
@@ -63,14 +63,14 @@ void main() {
   });
 
   test('can launch chrome and connect to the devtools', () async {
-    await testLaunchChrome('/.tmp_rand0/flutter_tool.rand0', processManager, chromeLauncher);
+    await testLaunchChrome('/.tmp_rand0/flutter_tools_chrome_device.rand0', processManager, chromeLauncher);
   });
 
   test('cannot have two concurrent instances of chrome', () async {
-    await testLaunchChrome('/.tmp_rand0/flutter_tool.rand0', processManager, chromeLauncher);
+    await testLaunchChrome('/.tmp_rand0/flutter_tools_chrome_device.rand0', processManager, chromeLauncher);
     bool pass = false;
     try {
-      await testLaunchChrome('/.tmp_rand0/flutter_tool.rand1', processManager, chromeLauncher);
+      await testLaunchChrome('/.tmp_rand0/flutter_tools_chrome_device.rand1', processManager, chromeLauncher);
     } on ToolExit catch (_) {
       pass = true;
     }
@@ -78,16 +78,16 @@ void main() {
   });
 
   test('can launch new chrome after stopping a previous chrome', () async {
-    final Chrome  chrome = await testLaunchChrome('/.tmp_rand0/flutter_tool.rand0', processManager, chromeLauncher);
+    final Chrome  chrome = await testLaunchChrome('/.tmp_rand0/flutter_tools_chrome_device.rand0', processManager, chromeLauncher);
     await chrome.close();
-    await testLaunchChrome('/.tmp_rand0/flutter_tool.rand1', processManager, chromeLauncher);
+    await testLaunchChrome('/.tmp_rand0/flutter_tools_chrome_device.rand1', processManager, chromeLauncher);
   });
 
   test('can launch chrome with a custom debug port', () async {
     processManager.addCommand(const FakeCommand(
       command: <String>[
         'example_chrome',
-        '--user-data-dir=/.tmp_rand1/flutter_tool.rand1',
+        '--user-data-dir=/.tmp_rand1/flutter_tools_chrome_device.rand1',
         '--remote-debugging-port=10000',
         ..._kChromeArgs,
         'example_url',
@@ -106,7 +106,7 @@ void main() {
     processManager.addCommand(const FakeCommand(
       command: <String>[
         'example_chrome',
-        '--user-data-dir=/.tmp_rand1/flutter_tool.rand1',
+        '--user-data-dir=/.tmp_rand1/flutter_tools_chrome_device.rand1',
         '--remote-debugging-port=1234',
         ..._kChromeArgs,
         '--headless',
@@ -146,7 +146,7 @@ void main() {
 
     processManager.addCommand(FakeCommand(command: const <String>[
       'example_chrome',
-      '--user-data-dir=/.tmp_rand1/flutter_tool.rand1',
+      '--user-data-dir=/.tmp_rand1/flutter_tools_chrome_device.rand1',
       '--remote-debugging-port=1234',
       ..._kChromeArgs,
       'example_url',
@@ -160,7 +160,7 @@ void main() {
 
     // validate preferences
     final File tempFile = fileSystem
-      .directory('.tmp_rand1/flutter_tool.rand1')
+      .directory('.tmp_rand1/flutter_tools_chrome_device.rand1')
       .childDirectory('Default')
       .childFile('preferences');
 
@@ -176,7 +176,7 @@ void main() {
 
     // validate local storage
     final Directory storageDir = fileSystem
-        .directory('.tmp_rand1/flutter_tool.rand1')
+        .directory('.tmp_rand1/flutter_tools_chrome_device.rand1')
         .childDirectory('Default')
         .childDirectory('Local Storage')
         .childDirectory('leveldb');


### PR DESCRIPTION
## Description

This PR saves and restores the chrome session local storage information for flutter web chrome devices. When running chrome devices, we already save and restore the userDataDir preferences file, containing things like the window size and location. This PR also saves are restores the local storage info for web apps, allowing the local storage info to persist across app runs.

## Related Issues

None, but this addresses an issue found while developing DevTools. I'll link the PR in here once that work is complete.

## Tests

I updated the following tests:
- `flutter_tools/test/general.shard/web/chrome_test.dart`: `'can seed chrome temp directory with existing preferences'` (renamed to `'can seed chrome temp directory with existing session data'`)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
