### PR TITLE
Remove implements function

### DIFF
--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -12,7 +12,7 @@ import '../rendering/mock_canvas.dart';
 import '../widgets/semantics_tester.dart';
 import 'feedback_tester.dart';
 
-class MockOnPressedFunction implements Function {
+class MockOnPressedFunction {
   int called = 0;
 
   void call() {

--- a/packages/flutter/test/widgets/implicit_animations_test.dart
+++ b/packages/flutter/test/widgets/implicit_animations_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 
-class MockOnEndFunction implements Function {
+class MockOnEndFunction {
   int called = 0;
 
   void call() {


### PR DESCRIPTION
> In Dart 2 it is a no-op to extend, implement or mix in Function so the fix is to just remove `implements Function`.

Fixes error on https://ci.chromium.org/p/dart/g/flutter-hhh/console.

```
[ +199 ms] 
           test/material/icon_button_test.dart:15:7: Warning: Implementing 'Function' is deprecated.
           Try removing 'Function' from the 'implements' clause.
           class MockOnPressedFunction implements Function {
```

https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket.appspot.com/8885072505801270976/+/steps/flutter_test_web_tests/0/stdout

Initial cause: https://dart-review.googlesource.com/c/sdk/+/140042