### PR TITLE
Update utils.dart to work with the breaking change of SDK issue 40678

### DIFF
--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -19,21 +19,30 @@ import 'framework.dart';
 String cwd = Directory.current.path;
 
 /// The local engine to use for [flutter] and [evalFlutter], if any.
-String get localEngine =>
-    (const String.fromEnvironment('localEngine', defaultValue: 'a') ==
-            const String.fromEnvironment('localEngine', defaultValue: 'b'))
-        ? const String.fromEnvironment('localEngine')
-        : null;
-
+String get localEngine {
+  // Use two distinct `defaultValue`s to determine whether a 'localEngine'
+  // declaration exists in the environment.
+  const isDefined =
+      String.fromEnvironment('localEngine', defaultValue: 'a') ==
+      String.fromEnvironment('localEngine', defaultValue: 'b');
+  return isDefined
+      ? const String.fromEnvironment('localEngine')
+      : null;
+}
+      
 /// The local engine source path to use if a local engine is used for [flutter]
 /// and [evalFlutter].
-String get localEngineSrcPath =>
-    (const String.fromEnvironment('localEngineSrcPath', defaultValue: 'a') ==
-            const String.fromEnvironment('localEngineSrcPath',
-                defaultValue: 'b'))
-        ? const String.fromEnvironment('localEngineSrcPath')
-        : null;
-
+String get localEngineSrcPath {
+  // Use two distinct `defaultValue`s to determine whether a
+  // 'localEngineSrcPath' declaration exists in the environment.
+  const isDefined =
+      String.fromEnvironment('localEngineSrcPath', defaultValue: 'a') ==
+      String.fromEnvironment('localEngineSrcPath', defaultValue: 'b');
+  return isDefined
+      ? const String.fromEnvironment('localEngineSrcPath')
+      : null;
+}
+    
 List<ProcessInfo> _runningProcesses = <ProcessInfo>[];
 ProcessManager _processManager = const LocalProcessManager();
 

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -22,8 +22,9 @@ String cwd = Directory.current.path;
 String get localEngine {
   // Use two distinct `defaultValue`s to determine whether a 'localEngine'
   // declaration exists in the environment.
-  const isDefined = String.fromEnvironment('localEngine', defaultValue: 'a') ==
-      String.fromEnvironment('localEngine', defaultValue: 'b');
+  const bool isDefined =
+      String.fromEnvironment('localEngine', defaultValue: 'a') ==
+          String.fromEnvironment('localEngine', defaultValue: 'b');
   return isDefined ? const String.fromEnvironment('localEngine') : null;
 }
 
@@ -32,7 +33,7 @@ String get localEngine {
 String get localEngineSrcPath {
   // Use two distinct `defaultValue`s to determine whether a
   // 'localEngineSrcPath' declaration exists in the environment.
-  const isDefined =
+  const bool isDefined =
       String.fromEnvironment('localEngineSrcPath', defaultValue: 'a') ==
           String.fromEnvironment('localEngineSrcPath', defaultValue: 'b');
   return isDefined ? const String.fromEnvironment('localEngineSrcPath') : null;

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -22,14 +22,11 @@ String cwd = Directory.current.path;
 String get localEngine {
   // Use two distinct `defaultValue`s to determine whether a 'localEngine'
   // declaration exists in the environment.
-  const isDefined =
-      String.fromEnvironment('localEngine', defaultValue: 'a') ==
+  const isDefined = String.fromEnvironment('localEngine', defaultValue: 'a') ==
       String.fromEnvironment('localEngine', defaultValue: 'b');
-  return isDefined
-      ? const String.fromEnvironment('localEngine')
-      : null;
+  return isDefined ? const String.fromEnvironment('localEngine') : null;
 }
-      
+
 /// The local engine source path to use if a local engine is used for [flutter]
 /// and [evalFlutter].
 String get localEngineSrcPath {
@@ -37,12 +34,10 @@ String get localEngineSrcPath {
   // 'localEngineSrcPath' declaration exists in the environment.
   const isDefined =
       String.fromEnvironment('localEngineSrcPath', defaultValue: 'a') ==
-      String.fromEnvironment('localEngineSrcPath', defaultValue: 'b');
-  return isDefined
-      ? const String.fromEnvironment('localEngineSrcPath')
-      : null;
+          String.fromEnvironment('localEngineSrcPath', defaultValue: 'b');
+  return isDefined ? const String.fromEnvironment('localEngineSrcPath') : null;
 }
-    
+
 List<ProcessInfo> _runningProcesses = <ProcessInfo>[];
 ProcessManager _processManager = const LocalProcessManager();
 

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -19,11 +19,20 @@ import 'framework.dart';
 String cwd = Directory.current.path;
 
 /// The local engine to use for [flutter] and [evalFlutter], if any.
-String get localEngine => const String.fromEnvironment('localEngine');
+String get localEngine =>
+    (const String.fromEnvironment('localEngine', defaultValue: 'a') ==
+            const String.fromEnvironment('localEngine', defaultValue: 'b'))
+        ? const String.fromEnvironment('localEngine')
+        : null;
 
 /// The local engine source path to use if a local engine is used for [flutter]
 /// and [evalFlutter].
-String get localEngineSrcPath => const String.fromEnvironment('localEngineSrcPath');
+String get localEngineSrcPath =>
+    (const String.fromEnvironment('localEngineSrcPath', defaultValue: 'a') ==
+            const String.fromEnvironment('localEngineSrcPath',
+                defaultValue: 'b'))
+        ? const String.fromEnvironment('localEngineSrcPath')
+        : null;
 
 List<ProcessInfo> _runningProcesses = <ProcessInfo>[];
 ProcessManager _processManager = const LocalProcessManager();

--- a/dev/devicelab/test/utils_test.dart
+++ b/dev/devicelab/test/utils_test.dart
@@ -33,4 +33,11 @@ void main() {
       expect(parseServicePort(badOutput), null);
     });
   });
+
+  group('engine environment declarations', () {
+    test('localEngine', () {
+      expect(localEngine, null);
+      expect(localEngineSrcPath, null);
+    });
+  });
 }

--- a/dev/devicelab/test/utils_test.dart
+++ b/dev/devicelab/test/utils_test.dart
@@ -33,11 +33,4 @@ void main() {
       expect(parseServicePort(badOutput), null);
     });
   });
-
-  group('engine environment declarations', () {
-    test('localEngine', () {
-      expect(localEngine, null);
-      expect(localEngineSrcPath, null);
-    });
-  });
 }

--- a/dev/devicelab/test/utils_test.dart
+++ b/dev/devicelab/test/utils_test.dart
@@ -33,4 +33,9 @@ void main() {
       expect(parseServicePort(badOutput), null);
     });
   });
+
+  group('engine environment declarations', () {
+      expect(localEngine, null);
+      expect(localEngineSrcPath, null);
+  });
 }

--- a/dev/devicelab/test/utils_test.dart
+++ b/dev/devicelab/test/utils_test.dart
@@ -35,7 +35,9 @@ void main() {
   });
 
   group('engine environment declarations', () {
+    test('localEngine', () {
       expect(localEngine, null);
       expect(localEngineSrcPath, null);
+    });
   });
 }


### PR DESCRIPTION
## Description

This PR changes the usages of `fromEnvironment` constant constructors in Flutter such that the semantics is preserved when the breaking change of SDK issue [40678](https://github.com/dart-lang/sdk/issues/40678) is landed.

## Related Issues

Issue https://github.com/flutter/flutter/issues/53092 requests this change.

## Tests

A test is added to 'dev/devicelab/test/utils_test.dart'.