### PR TITLE
Remove use of "implements Function" in tests.

### DIFF
--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -12,10 +12,10 @@ import '../rendering/mock_canvas.dart';
 import '../widgets/semantics_tester.dart';
 import 'feedback_tester.dart';
 
-class MockOnPressedFunction implements Function {
+class MockOnPressedFunction {
   int called = 0;
 
-  void call() {
+  void handler() {
     called++;
   }
 }
@@ -31,7 +31,7 @@ void main() {
     await tester.pumpWidget(
       wrap(
           child: IconButton(
-            onPressed: mockOnPressedFunction,
+            onPressed: mockOnPressedFunction.handler,
             icon: const Icon(Icons.link),
           ),
       ),
@@ -49,7 +49,7 @@ void main() {
       wrap(
           child: IconButton(
             iconSize: 10.0,
-            onPressed: mockOnPressedFunction,
+            onPressed: mockOnPressedFunction.handler,
             icon: const Icon(Icons.link),
           ),
       ),
@@ -65,7 +65,7 @@ void main() {
           child: IconButton(
             iconSize: 10.0,
             padding: const EdgeInsets.all(30.0),
-            onPressed: mockOnPressedFunction,
+            onPressed: mockOnPressedFunction.handler,
             icon: const Icon(Icons.link),
           ),
       ),
@@ -80,7 +80,7 @@ void main() {
       wrap(
         child: IconButton(
           iconSize: 10.0,
-          onPressed: mockOnPressedFunction,
+          onPressed: mockOnPressedFunction.handler,
           icon: const Icon(Icons.link),
           constraints: const BoxConstraints(),
         ),
@@ -100,7 +100,7 @@ void main() {
         child: IconButton(
           iconSize: 10.0,
           padding: const EdgeInsets.all(3.0),
-          onPressed: mockOnPressedFunction,
+          onPressed: mockOnPressedFunction.handler,
           icon: const Icon(Icons.link),
           constraints: const BoxConstraints(),
         ),
@@ -121,7 +121,7 @@ void main() {
           data: ThemeData(visualDensity: const VisualDensity(horizontal: 1, vertical: -1)),
           child: IconButton(
             iconSize: 10.0,
-            onPressed: mockOnPressedFunction,
+            onPressed: mockOnPressedFunction.handler,
             icon: const Icon(Icons.link),
             constraints: const BoxConstraints(minWidth: 32.0, minHeight: 32.0),
           ),
@@ -143,7 +143,7 @@ void main() {
       wrap(
           child: IconButton(
             padding: EdgeInsets.zero,
-            onPressed: mockOnPressedFunction,
+            onPressed: mockOnPressedFunction.handler,
             icon: const Icon(Icons.ac_unit),
             iconSize: 80.0,
           ),
@@ -163,7 +163,7 @@ void main() {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: <Widget> [
               IconButton(
-                onPressed: mockOnPressedFunction,
+                onPressed: mockOnPressedFunction.handler,
                 icon: const Icon(Icons.ac_unit),
               ),
             ],
@@ -180,7 +180,7 @@ void main() {
     await tester.pumpWidget(
       wrap(
           child: IconButton(
-            onPressed: mockOnPressedFunction,
+            onPressed: mockOnPressedFunction.handler,
             icon: const Icon(Icons.ac_unit),
             iconSize: 80.0,
           ),
@@ -197,7 +197,7 @@ void main() {
         home: Material(
           child: Center(
             child: IconButton(
-              onPressed: mockOnPressedFunction,
+              onPressed: mockOnPressedFunction.handler,
               icon: const Icon(Icons.ac_unit),
             ),
           ),
@@ -215,7 +215,7 @@ void main() {
         home: Material(
           child: Center(
             child: IconButton(
-              onPressed: mockOnPressedFunction,
+              onPressed: mockOnPressedFunction.handler,
               icon: const Icon(Icons.ac_unit),
               tooltip: 'Test tooltip',
             ),
@@ -239,7 +239,7 @@ void main() {
             actions: <Widget>[
               IconButton(
                 padding: EdgeInsets.zero,
-                onPressed: mockOnPressedFunction,
+                onPressed: mockOnPressedFunction.handler,
                 icon: const Icon(Icons.ac_unit),
               ),
             ],
@@ -343,7 +343,7 @@ void main() {
     await tester.pumpWidget(
       wrap(
         child: IconButton(
-          onPressed: mockOnPressedFunction,
+          onPressed: mockOnPressedFunction.handler,
           icon: const Icon(Icons.link, semanticLabel: 'link'),
         ),
       ),

--- a/packages/flutter/test/widgets/implicit_animations_test.dart
+++ b/packages/flutter/test/widgets/implicit_animations_test.dart
@@ -6,10 +6,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 
-class MockOnEndFunction implements Function {
+class MockOnEndFunction {
   int called = 0;
 
-  void call() {
+  void handler() {
     called++;
   }
 }
@@ -70,7 +70,7 @@ void main() {
   testWidgets('AnimatedContainer onEnd callback test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
-        callback: mockOnEndFunction,
+        callback: mockOnEndFunction.handler,
         switchKey: switchKey,
         state: _TestAnimatedContainerWidgetState(),
       )
@@ -91,7 +91,7 @@ void main() {
   testWidgets('AnimatedPadding onEnd callback test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
-        callback: mockOnEndFunction,
+        callback: mockOnEndFunction.handler,
         switchKey: switchKey,
         state: _TestAnimatedPaddingWidgetState(),
       )
@@ -112,7 +112,7 @@ void main() {
   testWidgets('AnimatedAlign onEnd callback test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
-        callback: mockOnEndFunction,
+        callback: mockOnEndFunction.handler,
         switchKey: switchKey,
         state: _TestAnimatedAlignWidgetState(),
       )
@@ -133,7 +133,7 @@ void main() {
   testWidgets('AnimatedPositioned onEnd callback test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
-        callback: mockOnEndFunction,
+        callback: mockOnEndFunction.handler,
         switchKey: switchKey,
         state: _TestAnimatedPositionedWidgetState(),
       )
@@ -154,7 +154,7 @@ void main() {
   testWidgets('AnimatedPositionedDirectional onEnd callback test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
-        callback: mockOnEndFunction,
+        callback: mockOnEndFunction.handler,
         switchKey: switchKey,
         state: _TestAnimatedPositionedDirectionalWidgetState(),
       )
@@ -175,7 +175,7 @@ void main() {
   testWidgets('AnimatedOpacity onEnd callback test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
-        callback: mockOnEndFunction,
+        callback: mockOnEndFunction.handler,
         switchKey: switchKey,
         state: _TestAnimatedOpacityWidgetState(),
       )
@@ -223,7 +223,7 @@ void main() {
 
   testWidgets('SliverAnimatedOpacity onEnd callback test', (WidgetTester tester) async {
     await tester.pumpWidget(TestAnimatedWidget(
-      callback: mockOnEndFunction,
+      callback: mockOnEndFunction.handler,
       switchKey: switchKey,
       state: _TestSliverAnimatedOpacityWidgetState(),
     ));
@@ -271,7 +271,7 @@ void main() {
   testWidgets('AnimatedDefaultTextStyle onEnd callback test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
-        callback: mockOnEndFunction,
+        callback: mockOnEndFunction.handler,
         switchKey: switchKey,
         state: _TestAnimatedDefaultTextStyleWidgetState(),
       )
@@ -292,7 +292,7 @@ void main() {
   testWidgets('AnimatedPhysicalModel onEnd callback test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
-        callback: mockOnEndFunction,
+        callback: mockOnEndFunction.handler,
         switchKey: switchKey,
         state: _TestAnimatedPhysicalModelWidgetState(),
       )
@@ -313,7 +313,7 @@ void main() {
   testWidgets('TweenAnimationBuilder onEnd callback test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
-        callback: mockOnEndFunction,
+        callback: mockOnEndFunction.handler,
         switchKey: switchKey,
         state: _TestTweenAnimationBuilderWidgetState(),
       )
@@ -334,7 +334,7 @@ void main() {
   testWidgets('AnimatedTheme onEnd callback test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
-        callback: mockOnEndFunction,
+        callback: mockOnEndFunction.handler,
         switchKey: switchKey,
         state: _TestAnimatedThemeWidgetState(),
       )


### PR DESCRIPTION
## Description

implements/extends Function is being deprecated. This PR prepares flutter code base.

## Related Issues

Example Dart roll failure: https://cirrus-ci.com/task/4670267658076160

## Tests

Already covered by icon_button_test and implicit_animations_test.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*
