### PR TITLE
Fix disappearing text in offscreen field

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1121,8 +1121,11 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
 
   AnimationController _floatingCursorResetController;
 
+  // True iff the text has ever changed since instantiation.
+  bool _textChanged = false;
+
   @override
-  bool get wantKeepAlive => widget.focusNode.hasFocus;
+  bool get wantKeepAlive => widget.focusNode.hasFocus || _textChanged;
 
   Color get _cursorColor => widget.cursorColor.withOpacity(_cursorBlinkOpacityController.value);
 
@@ -1783,6 +1786,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     _startOrStopCursorTimerIfNeeded();
     _updateOrDisposeSelectionOverlayIfNeeded();
     _textChangedSinceLastCaretUpdate = true;
+    _textChanged = true;
     // TODO(abarth): Teach RenderEditable about ValueNotifier<TextEditingValue>
     // to avoid this setState().
     setState(() { /* We use widget.controller.value in build(). */ });

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -7361,6 +7361,7 @@ void main() {
   });
 
   testWidgets('when scrolled offscreen and unfocused, doesn\'t lose value', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/17385.
     final ScrollController scrollController = ScrollController();
     final GlobalKey key1 = GlobalKey();
     final GlobalKey key2 = GlobalKey();


### PR DESCRIPTION
## Description

Currently, it's possible to lose text entered into a text field by scrolling it out of view, focusing on another field, and scrolling back.  This PR fixes it by keeping fields alive if they have modified text.

## Related Issues

Closes https://github.com/flutter/flutter/issues/17385

## Tests

I added a test that performs the steps described above for reproducing the bug.  I confirmed that it fails without these changes.