### PR TITLE
Convert some code_signing_tests to testWithoutContext

### DIFF
--- a/packages/flutter_tools/lib/src/ios/code_signing.dart
+++ b/packages/flutter_tools/lib/src/ios/code_signing.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:meta/meta.dart';
+import 'package:process/process.dart';
 import 'package:quiver/strings.dart';
 
 import '../application_package.dart';
@@ -98,7 +99,7 @@ final RegExp _certificateOrganizationalUnitExtractionPattern = RegExp(r'OU=([a-z
 /// project has a development team set in the project's build settings.
 Future<Map<String, String>> getCodeSigningIdentityDevelopmentTeam({
   @required BuildableIOSApp iosApp,
-  @required ProcessUtils processUtils,
+  @required ProcessManager processManager,
   @required Logger logger,
 }) async {
   final Map<String, String> buildSettings = await iosApp.project.buildSettings;
@@ -122,6 +123,7 @@ Future<Map<String, String>> getCodeSigningIdentityDevelopmentTeam({
 
   // If the user's environment is missing the tools needed to find and read
   // certificates, abandon. Tools should be pre-equipped on macOS.
+  final ProcessUtils processUtils = ProcessUtils(processManager: processManager, logger: logger);
   if (!await processUtils.exitsHappy(const <String>['which', 'security']) ||
       !await processUtils.exitsHappy(const <String>['which', 'openssl'])) {
     return null;

--- a/packages/flutter_tools/lib/src/ios/code_signing.dart
+++ b/packages/flutter_tools/lib/src/ios/code_signing.dart
@@ -4,11 +4,13 @@
 
 import 'dart:async';
 
+import 'package:meta/meta.dart';
 import 'package:quiver/strings.dart';
 
 import '../application_package.dart';
 import '../base/common.dart';
 import '../base/io.dart';
+import '../base/logger.dart';
 import '../base/process.dart';
 import '../convert.dart' show utf8;
 import '../globals.dart' as globals;
@@ -95,7 +97,9 @@ final RegExp _certificateOrganizationalUnitExtractionPattern = RegExp(r'OU=([a-z
 /// Will return null if none are found, if the user cancels or if the Xcode
 /// project has a development team set in the project's build settings.
 Future<Map<String, String>> getCodeSigningIdentityDevelopmentTeam({
-  BuildableIOSApp iosApp,
+  @required BuildableIOSApp iosApp,
+  @required ProcessUtils processUtils,
+  @required Logger logger,
 }) async {
   final Map<String, String> buildSettings = await iosApp.project.buildSettings;
   if (buildSettings == null) {
@@ -105,7 +109,7 @@ Future<Map<String, String>> getCodeSigningIdentityDevelopmentTeam({
   // If the user already has it set in the project build settings itself,
   // continue with that.
   if (isNotEmpty(buildSettings['DEVELOPMENT_TEAM'])) {
-    globals.printStatus(
+    logger.printStatus(
       'Automatically signing iOS for device deployment using specified development '
       'team in Xcode project: ${buildSettings['DEVELOPMENT_TEAM']}'
     );
@@ -133,7 +137,7 @@ Future<Map<String, String>> getCodeSigningIdentityDevelopmentTeam({
       throwOnError: true,
     )).stdout.trim();
   } on ProcessException catch (error) {
-    globals.printTrace('Unexpected failure from find-identity: $error.');
+    logger.printTrace('Unexpected failure from find-identity: $error.');
     return null;
   }
 
@@ -148,14 +152,14 @@ Future<Map<String, String>> getCodeSigningIdentityDevelopmentTeam({
       .toSet() // Unique.
       .toList();
 
-  final String signingIdentity = await _chooseSigningIdentity(validCodeSigningIdentities);
+  final String signingIdentity = await _chooseSigningIdentity(validCodeSigningIdentities, logger);
 
   // If none are chosen, return null.
   if (signingIdentity == null) {
     return null;
   }
 
-  globals.printStatus('Signing iOS app for device deployment using developer identity: "$signingIdentity"');
+  logger.printStatus('Signing iOS app for device deployment using developer identity: "$signingIdentity"');
 
   final String signingCertificateId =
       _securityFindIdentityCertificateCnExtractionPattern
@@ -174,7 +178,7 @@ Future<Map<String, String>> getCodeSigningIdentityDevelopmentTeam({
       throwOnError: true,
     )).stdout.trim();
   } on ProcessException catch (error) {
-    globals.printTrace("Couldn't find the certificate: $error.");
+    logger.printTrace("Couldn't find the certificate: $error.");
     return null;
   }
 
@@ -198,10 +202,10 @@ Future<Map<String, String>> getCodeSigningIdentityDevelopmentTeam({
   };
 }
 
-Future<String> _chooseSigningIdentity(List<String> validCodeSigningIdentities) async {
+Future<String> _chooseSigningIdentity(List<String> validCodeSigningIdentities, Logger logger) async {
   // The user has no valid code signing identities.
   if (validCodeSigningIdentities.isEmpty) {
-    globals.printError(noCertificatesInstruction, emphasis: true);
+    logger.printError(noCertificatesInstruction, emphasis: true);
     throwToolExit('No development certificates available to code sign app for device deployment');
   }
 
@@ -214,10 +218,10 @@ Future<String> _chooseSigningIdentity(List<String> validCodeSigningIdentities) a
 
     if (savedCertChoice != null) {
       if (validCodeSigningIdentities.contains(savedCertChoice)) {
-        globals.printStatus('Found saved certificate choice "$savedCertChoice". To clear, use "flutter config".');
+        logger.printStatus('Found saved certificate choice "$savedCertChoice". To clear, use "flutter config".');
         return savedCertChoice;
       } else {
-        globals.printError('Saved signing certificate "$savedCertChoice" is not a valid development certificate');
+        logger.printError('Saved signing certificate "$savedCertChoice" is not a valid development certificate');
       }
     }
 
@@ -228,14 +232,14 @@ Future<String> _chooseSigningIdentity(List<String> validCodeSigningIdentities) a
     }
 
     final int count = validCodeSigningIdentities.length;
-    globals.printStatus(
+    logger.printStatus(
       'Multiple valid development certificates available (your choice will be saved):',
       emphasis: true,
     );
     for (int i=0; i<count; i++) {
-      globals.printStatus('  ${i+1}) ${validCodeSigningIdentities[i]}', emphasis: true);
+      logger.printStatus('  ${i+1}) ${validCodeSigningIdentities[i]}', emphasis: true);
     }
-    globals.printStatus('  a) Abort', emphasis: true);
+    logger.printStatus('  a) Abort', emphasis: true);
 
     final String choice = await globals.terminal.promptForCharInput(
       List<String>.generate(count, (int number) => '${number + 1}')
@@ -243,14 +247,14 @@ Future<String> _chooseSigningIdentity(List<String> validCodeSigningIdentities) a
       prompt: 'Please select a certificate for code signing',
       displayAcceptedCharacters: true,
       defaultChoiceIndex: 0, // Just pressing enter chooses the first one.
-      logger: globals.logger,
+      logger: logger,
     );
 
     if (choice == 'a') {
       throwToolExit('Aborted. Code signing is required to build a deployable iOS app.');
     } else {
       final String selectedCert = validCodeSigningIdentities[int.parse(choice) - 1];
-      globals.printStatus('Certificate choice "$selectedCert" saved');
+      logger.printStatus('Certificate choice "$selectedCert" saved');
       globals.config.setValue('ios-signing-cert', selectedCert);
       return selectedCert;
     }

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -160,7 +160,11 @@ Future<XcodeBuildResult> buildXcodeProject({
 
   Map<String, String> autoSigningConfigs;
   if (codesign && buildForDevice) {
-    autoSigningConfigs = await getCodeSigningIdentityDevelopmentTeam(iosApp: app);
+    autoSigningConfigs = await getCodeSigningIdentityDevelopmentTeam(
+      iosApp: app,
+      processUtils: processUtils,
+      logger: globals.logger
+    );
   }
 
   final FlutterProject project = FlutterProject.current();

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -162,7 +162,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   if (codesign && buildForDevice) {
     autoSigningConfigs = await getCodeSigningIdentityDevelopmentTeam(
       iosApp: app,
-      processUtils: processUtils,
+      processManager: globals.processManager,
       logger: globals.logger
     );
   }

--- a/packages/flutter_tools/test/general.shard/ios/code_signing_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/code_signing_test.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter_tools/src/base/logger.dart';
-import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:mockito/mockito.dart';
 import 'package:flutter_tools/src/application_package.dart';
@@ -52,7 +51,7 @@ void main() {
       when(mockIosProject.buildSettings).thenReturn(null);
       final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(
         iosApp: app,
-        processUtils: ProcessUtils(processManager: mockProcessManager, logger: logger),
+        processManager: mockProcessManager,
         logger: logger,
       );
       expect(signingConfigs, isNull);
@@ -66,7 +65,7 @@ void main() {
       });
       final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(
         iosApp: app,
-        processUtils: ProcessUtils(processManager: mockProcessManager, logger: logger),
+        processManager: mockProcessManager,
         logger: logger,
       );
       expect(signingConfigs, isNull);
@@ -80,7 +79,7 @@ void main() {
           .thenAnswer((_) => Future<ProcessResult>.value(exitsFail));
       final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(
         iosApp: app,
-        processUtils: ProcessUtils(processManager: mockProcessManager, logger: logger),
+        processManager: mockProcessManager,
         logger: logger,
       );
       expect(signingConfigs, isNull);
@@ -108,7 +107,7 @@ void main() {
       try {
         signingConfigs = await getCodeSigningIdentityDevelopmentTeam(
           iosApp: app,
-          processUtils: ProcessUtils(processManager: mockProcessManager, logger: logger),
+          processManager: mockProcessManager,
           logger: logger,
         );
         fail('No identity should throw tool error');
@@ -177,7 +176,7 @@ void main() {
 
       final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(
         iosApp: app,
-        processUtils: ProcessUtils(processManager: mockProcessManager, logger: logger),
+        processManager: mockProcessManager,
         logger: logger,
       );
 
@@ -245,7 +244,7 @@ void main() {
       try {
         signingConfigs = await getCodeSigningIdentityDevelopmentTeam(
           iosApp: app,
-          processUtils: ProcessUtils(processManager: mockProcessManager, logger: logger),
+          processManager: mockProcessManager,
           logger: logger,
         );
       } on Exception catch (e) {
@@ -319,7 +318,7 @@ void main() {
 
       final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(
         iosApp: app,
-        processUtils: ProcessUtils(processManager: mockProcessManager, logger: logger),
+        processManager: mockProcessManager,
         logger: logger,
       );
 
@@ -404,7 +403,7 @@ void main() {
 
       final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(
         iosApp: app,
-        processUtils: ProcessUtils(processManager: mockProcessManager, logger: logger),
+        processManager: mockProcessManager,
         logger: logger,
       );
 
@@ -481,7 +480,7 @@ void main() {
 
       final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(
         iosApp: app,
-        processUtils: ProcessUtils(processManager: mockProcessManager, logger: logger),
+        processManager: mockProcessManager,
         logger: logger,
       );
 
@@ -564,7 +563,7 @@ void main() {
 
       final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(
         iosApp: app,
-        processUtils: ProcessUtils(processManager: mockProcessManager, logger: logger),
+        processManager: mockProcessManager,
         logger: logger,
       );
 
@@ -605,7 +604,7 @@ void main() {
 
       final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(
         iosApp: app,
-        processUtils: ProcessUtils(processManager: mockProcessManager, logger: logger),
+        processManager: mockProcessManager,
         logger: logger,
       );
       expect(signingConfigs, isNull);
@@ -648,7 +647,7 @@ void main() {
 
       final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(
         iosApp: app,
-        processUtils: ProcessUtils(processManager: mockProcessManager, logger: logger),
+        processManager: mockProcessManager,
         logger: logger,
       );
       expect(signingConfigs, isNull);

--- a/packages/flutter_tools/test/general.shard/ios/code_signing_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/code_signing_test.dart
@@ -5,6 +5,8 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:mockito/mockito.dart';
 import 'package:flutter_tools/src/application_package.dart';
@@ -27,8 +29,10 @@ void main() {
     IosProject mockIosProject;
     BuildableIOSApp app;
     AnsiTerminal testTerminal;
+    BufferLogger logger;
 
     setUp(() async {
+      logger = BufferLogger.test();
       mockProcessManager = MockProcessManager();
       // Assume all binaries exist and are executable
       when(mockProcessManager.canRun(any)).thenReturn(true);
@@ -44,35 +48,42 @@ void main() {
       app = await BuildableIOSApp.fromProject(mockIosProject);
     });
 
-    testUsingContext('No auto-sign if Xcode project settings are not available', () async {
+    testWithoutContext('No auto-sign if Xcode project settings are not available', () async {
       when(mockIosProject.buildSettings).thenReturn(null);
-      final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(iosApp: app);
+      final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(
+        iosApp: app,
+        processUtils: ProcessUtils(processManager: mockProcessManager, logger: logger),
+        logger: logger,
+      );
       expect(signingConfigs, isNull);
     });
 
-    testUsingContext('No discovery if development team specified in Xcode project', () async {
+    testWithoutContext('No discovery if development team specified in Xcode project', () async {
       when(mockIosProject.buildSettings).thenAnswer((_) {
         return Future<Map<String, String>>.value(<String, String>{
           'DEVELOPMENT_TEAM': 'abc',
         });
       });
-      final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(iosApp: app);
+      final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(
+        iosApp: app,
+        processUtils: ProcessUtils(processManager: mockProcessManager, logger: logger),
+        logger: logger,
+      );
       expect(signingConfigs, isNull);
-      expect(testLogger.statusText, equals(
+      expect(logger.statusText, equals(
         'Automatically signing iOS for device deployment using specified development team in Xcode project: abc\n'
       ));
-    }, overrides: <Type, Generator>{
-      OutputPreferences: () => OutputPreferences(wrapText: false),
     });
 
-    testUsingContext('No auto-sign if security or openssl not available', () async {
+    testWithoutContext('No auto-sign if security or openssl not available', () async {
       when(mockProcessManager.run(<String>['which', 'security']))
           .thenAnswer((_) => Future<ProcessResult>.value(exitsFail));
-      final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(iosApp: app);
+      final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(
+        iosApp: app,
+        processUtils: ProcessUtils(processManager: mockProcessManager, logger: logger),
+        logger: logger,
+      );
       expect(signingConfigs, isNull);
-    },
-    overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
     });
 
     testUsingContext('No valid code signing certificates shows instructions', () async {
@@ -95,19 +106,22 @@ void main() {
 
       Map<String, String> signingConfigs;
       try {
-        signingConfigs = await getCodeSigningIdentityDevelopmentTeam(iosApp: app);
+        signingConfigs = await getCodeSigningIdentityDevelopmentTeam(
+          iosApp: app,
+          processUtils: ProcessUtils(processManager: mockProcessManager, logger: logger),
+          logger: logger,
+        );
         fail('No identity should throw tool error');
       } on ToolExit {
         expect(signingConfigs, isNull);
-        expect(testLogger.errorText, contains('No valid code signing certificates were found'));
+        expect(logger.errorText, contains('No valid code signing certificates were found'));
       }
     },
     overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
       OutputPreferences: () => OutputPreferences(wrapText: false),
     });
 
-    testUsingContext('Test single identity and certificate organization works', () async {
+    testWithoutContext('Test single identity and certificate organization works', () async {
       when(mockProcessManager.run(
         <String>['which', 'security'],
         workingDirectory: anyNamed('workingDirectory'),
@@ -161,20 +175,19 @@ void main() {
       when(mockProcess.stderr).thenAnswer((Invocation invocation) => mockStdErr);
       when(mockProcess.exitCode).thenAnswer((_) async => 0);
 
-      final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(iosApp: app);
+      final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(
+        iosApp: app,
+        processUtils: ProcessUtils(processManager: mockProcessManager, logger: logger),
+        logger: logger,
+      );
 
-      expect(testLogger.statusText, contains('iPhone Developer: Profile 1 (1111AAAA11)'));
-      expect(testLogger.errorText, isEmpty);
+      expect(logger.statusText, contains('iPhone Developer: Profile 1 (1111AAAA11)'));
+      expect(logger.errorText, isEmpty);
       verify(mockStdIn.write('This is a mock certificate'));
       expect(signingConfigs, <String, String>{'DEVELOPMENT_TEAM': '3333CCCC33'});
-    },
-    overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-      OutputPreferences: () => OutputPreferences(wrapText: false),
     });
 
-
-    testUsingContext('Test single identity (Catalina format) and certificate organization works', () async {
+    testWithoutContext('Test single identity (Catalina format) and certificate organization works', () async {
       when(mockProcessManager.run(
         <String>['which', 'security'],
         workingDirectory: anyNamed('workingDirectory'),
@@ -230,20 +243,20 @@ void main() {
 
       Map<String, String> signingConfigs;
       try {
-        signingConfigs = await getCodeSigningIdentityDevelopmentTeam(iosApp: app);
+        signingConfigs = await getCodeSigningIdentityDevelopmentTeam(
+          iosApp: app,
+          processUtils: ProcessUtils(processManager: mockProcessManager, logger: logger),
+          logger: logger,
+        );
       } on Exception catch (e) {
         // This should not throw
         fail('Code signing threw: $e');
       }
 
-      expect(testLogger.statusText, contains('Apple Development: Profile 1 (1111AAAA11)'));
-      expect(testLogger.errorText, isEmpty);
+      expect(logger.statusText, contains('Apple Development: Profile 1 (1111AAAA11)'));
+      expect(logger.errorText, isEmpty);
       verify(mockStdIn.write('This is a mock certificate'));
       expect(signingConfigs, <String, String>{'DEVELOPMENT_TEAM': '3333CCCC33'});
-    },
-    overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-      OutputPreferences: () => OutputPreferences(wrapText: false),
     });
 
     testUsingContext('Test multiple identity and certificate organization works', () async {
@@ -304,24 +317,27 @@ void main() {
       when(mockOpenSslProcess.stderr).thenAnswer((Invocation invocation) => mockOpenSslStdErr);
       when(mockOpenSslProcess.exitCode).thenAnswer((_) => Future<int>.value(0));
 
-      final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(iosApp: app);
+      final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(
+        iosApp: app,
+        processUtils: ProcessUtils(processManager: mockProcessManager, logger: logger),
+        logger: logger,
+      );
 
       expect(
-        testLogger.statusText,
+        logger.statusText,
         contains('Please select a certificate for code signing [<bold>1</bold>|2|3|a]: 3'),
       );
       expect(
-        testLogger.statusText,
+        logger.statusText,
         contains('Signing iOS app for device deployment using developer identity: "iPhone Developer: Profile 3 (3333CCCC33)"'),
       );
-      expect(testLogger.errorText, isEmpty);
+      expect(logger.errorText, isEmpty);
       verify(mockOpenSslStdIn.write('This is a mock certificate'));
       expect(signingConfigs, <String, String>{'DEVELOPMENT_TEAM': '4444DDDD44'});
 
       verify(globals.config.setValue('ios-signing-cert', 'iPhone Developer: Profile 3 (3333CCCC33)'));
     },
     overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
       Config: () => mockConfig,
       AnsiTerminal: () => testTerminal,
       OutputPreferences: () => OutputPreferences(wrapText: false),
@@ -386,18 +402,21 @@ void main() {
       when(mockOpenSslProcess.stderr).thenAnswer((Invocation invocation) => mockOpenSslStdErr);
       when(mockOpenSslProcess.exitCode).thenAnswer((_) => Future<int>.value(0));
 
-      final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(iosApp: app);
+      final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(
+        iosApp: app,
+        processUtils: ProcessUtils(processManager: mockProcessManager, logger: logger),
+        logger: logger,
+      );
 
       expect(
-        testLogger.statusText,
+        logger.statusText,
         contains('Signing iOS app for device deployment using developer identity: "iPhone Developer: Profile 1 (1111AAAA11)"'),
       );
-      expect(testLogger.errorText, isEmpty);
+      expect(logger.errorText, isEmpty);
       verify(mockOpenSslStdIn.write('This is a mock certificate'));
       expect(signingConfigs, <String, String>{'DEVELOPMENT_TEAM': '5555EEEE55'});
     },
     overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
       Config: () => mockConfig,
       AnsiTerminal: () => testTerminal,
       OutputPreferences: () => OutputPreferences(wrapText: false),
@@ -460,22 +479,25 @@ void main() {
       when(mockOpenSslProcess.exitCode).thenAnswer((_) => Future<int>.value(0));
       when<String>(mockConfig.getValue('ios-signing-cert') as String).thenReturn('iPhone Developer: Profile 3 (3333CCCC33)');
 
-      final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(iosApp: app);
+      final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(
+        iosApp: app,
+        processUtils: ProcessUtils(processManager: mockProcessManager, logger: logger),
+        logger: logger,
+      );
 
       expect(
-        testLogger.statusText,
+        logger.statusText,
         contains('Found saved certificate choice "iPhone Developer: Profile 3 (3333CCCC33)". To clear, use "flutter config"'),
       );
       expect(
-        testLogger.statusText,
+        logger.statusText,
         contains('Signing iOS app for device deployment using developer identity: "iPhone Developer: Profile 3 (3333CCCC33)"'),
       );
-      expect(testLogger.errorText, isEmpty);
+      expect(logger.errorText, isEmpty);
       verify(mockOpenSslStdIn.write('This is a mock certificate'));
       expect(signingConfigs, <String, String>{'DEVELOPMENT_TEAM': '4444DDDD44'});
     },
     overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
       Config: () => mockConfig,
       OutputPreferences: () => OutputPreferences(wrapText: false),
     });
@@ -540,26 +562,29 @@ void main() {
       when(mockOpenSslProcess.exitCode).thenAnswer((_) => Future<int>.value(0));
       when<String>(mockConfig.getValue('ios-signing-cert') as String).thenReturn('iPhone Developer: Invalid Profile');
 
-      final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(iosApp: app);
+      final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(
+        iosApp: app,
+        processUtils: ProcessUtils(processManager: mockProcessManager, logger: logger),
+        logger: logger,
+      );
 
       expect(
-        testLogger.errorText.replaceAll('\n', ' '),
+        logger.errorText.replaceAll('\n', ' '),
         contains('Saved signing certificate "iPhone Developer: Invalid Profile" is not a valid development certificate'),
       );
       expect(
-        testLogger.statusText,
+        logger.statusText,
         contains('Certificate choice "iPhone Developer: Profile 3 (3333CCCC33)"'),
       );
       expect(signingConfigs, <String, String>{'DEVELOPMENT_TEAM': '4444DDDD44'});
       verify(globals.config.setValue('ios-signing-cert', 'iPhone Developer: Profile 3 (3333CCCC33)'));
     },
     overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
       Config: () => mockConfig,
       AnsiTerminal: () => testTerminal,
     });
 
-    testUsingContext('find-identity failure', () async {
+    testWithoutContext('find-identity failure', () async {
       when(mockProcessManager.run(
         <String>['which', 'security'],
         workingDirectory: anyNamed('workingDirectory'),
@@ -578,13 +603,12 @@ void main() {
         ProcessResult(0, 1, '', '')
       ));
 
-      final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(iosApp: app);
+      final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(
+        iosApp: app,
+        processUtils: ProcessUtils(processManager: mockProcessManager, logger: logger),
+        logger: logger,
+      );
       expect(signingConfigs, isNull);
-    },
-    overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-      Config: () => mockConfig,
-      AnsiTerminal: () => testTerminal,
     });
 
     testUsingContext('find-certificate failure', () async {
@@ -622,11 +646,14 @@ void main() {
         ProcessResult(1, 1, '', '' ))
       );
 
-      final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(iosApp: app);
+      final Map<String, String> signingConfigs = await getCodeSigningIdentityDevelopmentTeam(
+        iosApp: app,
+        processUtils: ProcessUtils(processManager: mockProcessManager, logger: logger),
+        logger: logger,
+      );
       expect(signingConfigs, isNull);
     },
     overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
       Config: () => mockConfig,
       AnsiTerminal: () => testTerminal,
     });


### PR DESCRIPTION
## Description

A few code_signing_tests to testWithoutContext (the easy ones)

## Related Issues

https://github.com/flutter/flutter/issues/47161

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*