### PR TITLE
Delete UserMessages class, remove from dependency injection and globals

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_studio_validator.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio_validator.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import '../base/user_messages.dart';
+import '../base/user_messages.dart' as user_messages;
 import '../base/version.dart';
 import '../doctor.dart';
 import '../globals.dart' as globals;
@@ -35,9 +35,9 @@ class AndroidStudioValidator extends DoctorValidator {
 
     final String studioVersionText = _studio.version == Version.unknown
       ? null
-      : userMessages.androidStudioVersion(_studio.version.toString());
+      : user_messages.androidStudioVersion(_studio.version.toString());
     messages.add(ValidationMessage(
-      userMessages.androidStudioLocation(_studio.directory),
+      user_messages.androidStudioLocation(_studio.directory),
     ));
 
     final IntelliJPlugins plugins = IntelliJPlugins(_studio.pluginsPath);
@@ -61,9 +61,9 @@ class AndroidStudioValidator extends DoctorValidator {
       messages.addAll(_studio.validationMessages.map<ValidationMessage>(
         (String m) => ValidationMessage.error(m),
       ));
-      messages.add(ValidationMessage(userMessages.androidStudioNeedsUpdate));
+      messages.add(ValidationMessage(user_messages.androidStudioNeedsUpdate));
       if (_studio.configured != null) {
-        messages.add(ValidationMessage(userMessages.androidStudioResetDir));
+        messages.add(ValidationMessage(user_messages.androidStudioResetDir));
       }
     }
 
@@ -87,10 +87,10 @@ class NoAndroidStudioValidator extends DoctorValidator {
     ) as String;
     if (cfgAndroidStudio != null) {
       messages.add(ValidationMessage.error(
-        userMessages.androidStudioMissing(cfgAndroidStudio),
+        user_messages.androidStudioMissing(cfgAndroidStudio),
       ));
     }
-    messages.add(ValidationMessage(userMessages.androidStudioInstallation));
+    messages.add(ValidationMessage(user_messages.androidStudioInstallation));
 
     return ValidationResult(
       ValidationType.notAvailable,

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -15,7 +15,7 @@ import 'base/context.dart';
 import 'base/file_system.dart';
 import 'base/io.dart';
 import 'base/process.dart';
-import 'base/user_messages.dart';
+import 'base/user_messages.dart' as user_messages;
 import 'build_info.dart';
 import 'fuchsia/application_package.dart';
 import 'globals.dart' as globals;
@@ -111,7 +111,7 @@ class AndroidApk extends ApplicationPackage {
   factory AndroidApk.fromApk(File apk) {
     final String aaptPath = androidSdk?.latestVersion?.aaptPath;
     if (aaptPath == null) {
-      globals.printError(userMessages.aaptNotFound);
+      globals.printError(user_messages.aaptNotFound);
       return null;
     }
 

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -2,294 +2,290 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'context.dart';
 
-UserMessages get userMessages => context.get<UserMessages>();
+/// Strings that can be produced by Flutter tools.
 
-/// Class containing message strings that can be produced by Flutter tools.
-class UserMessages {
-  // Messages used in FlutterValidator
-  String flutterStatusInfo(String channel, String version, String os, String locale) =>
-      'Channel ${channel ?? 'unknown'}, v${version ?? 'Unknown'}, on $os, locale $locale';
-  String flutterVersion(String version, String flutterRoot) =>
-      'Flutter version $version at $flutterRoot';
-  String flutterRevision(String revision, String age, String date) =>
-      'Framework revision $revision ($age), $date';
-  String engineRevision(String revision) => 'Engine revision $revision';
-  String dartRevision(String revision) => 'Dart version $revision';
-  String get flutterBinariesDoNotRun =>
-      'Downloaded executables cannot execute on host.\n'
-      'See https://github.com/flutter/flutter/issues/6207 for more information';
-  String get flutterBinariesLinuxRepairCommands =>
-      'On Debian/Ubuntu/Mint: sudo apt-get install lib32stdc++6\n'
-      'On Fedora: dnf install libstdc++.i686\n'
-      'On Arch: pacman -S lib32-gcc-libs';
+// Messages used in FlutterValidator
+String flutterStatusInfo(String channel, String version, String os, String locale) =>
+  'Channel ${channel ?? 'unknown'}, v${version ?? 'Unknown'}, on $os, locale $locale';
+String flutterVersion(String version, String flutterRoot) =>
+  'Flutter version $version at $flutterRoot';
+String flutterRevision(String revision, String age, String date) =>
+  'Framework revision $revision ($age), $date';
+String engineRevision(String revision) => 'Engine revision $revision';
+String dartRevision(String revision) => 'Dart version $revision';
+String get flutterBinariesDoNotRun =>
+  'Downloaded executables cannot execute on host.\n'
+    'See https://github.com/flutter/flutter/issues/6207 for more information';
+String get flutterBinariesLinuxRepairCommands =>
+  'On Debian/Ubuntu/Mint: sudo apt-get install lib32stdc++6\n'
+    'On Fedora: dnf install libstdc++.i686\n'
+    'On Arch: pacman -S lib32-gcc-libs';
 
-  // Messages used in NoIdeValidator
-  String get noIdeStatusInfo => 'No supported IDEs installed';
-  String get noIdeInstallationInfo => 'IntelliJ - https://www.jetbrains.com/idea/';
+// Messages used in NoIdeValidator
+String get noIdeStatusInfo => 'No supported IDEs installed';
+String get noIdeInstallationInfo => 'IntelliJ - https://www.jetbrains.com/idea/';
 
-  // Messages used in IntellijValidator
-  String intellijStatusInfo(String version) => 'version $version';
-  String get intellijPluginInfo =>
-      'For information about installing plugins, see\n'
-      'https://flutter.dev/intellij-setup/#installing-the-plugins';
-  String intellijMinimumVersion(String minVersion) =>
-      'This install is older than the minimum recommended version of $minVersion.';
-  String intellijLocation(String installPath) => 'IntelliJ at $installPath';
+// Messages used in IntellijValidator
+String intellijStatusInfo(String version) => 'version $version';
+String get intellijPluginInfo =>
+  'For information about installing plugins, see\n'
+    'https://flutter.dev/intellij-setup/#installing-the-plugins';
+String intellijMinimumVersion(String minVersion) =>
+  'This install is older than the minimum recommended version of $minVersion.';
+String intellijLocation(String installPath) => 'IntelliJ at $installPath';
 
-  // Message used in IntellijValidatorOnMac
-  String get intellijMacUnknownResult => 'Cannot determine if IntelliJ is installed';
+// Message used in IntellijValidatorOnMac
+String get intellijMacUnknownResult => 'Cannot determine if IntelliJ is installed';
 
-  // Messages used in DeviceValidator
-  String get devicesMissing => 'No devices available';
-  String devicesAvailable(int devices) => '$devices available';
+// Messages used in DeviceValidator
+String get devicesMissing => 'No devices available';
+String devicesAvailable(int devices) => '$devices available';
 
-  // Messages used in AndroidValidator
-  String androidCantRunJavaBinary(String javaBinary) => 'Cannot execute $javaBinary to determine the version';
-  String get androidUnknownJavaVersion => 'Could not determine java version';
-  String androidJavaVersion(String javaVersion) => 'Java version $javaVersion';
-  String androidJavaMinimumVersion(String javaVersion) => 'Java version $javaVersion is older than the minimum recommended version of 1.8';
-  String androidSdkLicenseOnly(String envKey) =>
-      'Android SDK contains licenses only.\n'
-      'Your first build of an Android application will take longer than usual, '
-      'while gradle downloads the missing components. This functionality will '
-      'only work if the licenses in the licenses folder in $envKey are valid.\n'
-      'If the Android SDK has been installed to another location, set $envKey to that location.\n'
-      'You may also want to add it to your PATH environment variable.\n\n'
-      'Certain features, such as `flutter emulators` and `flutter devices`, will '
-      'not work without the currently missing SDK components.';
-  String androidBadSdkDir(String envKey, String homeDir) =>
-      '$envKey = $homeDir\n'
-      'but Android SDK not found at this location.';
-  String androidMissingSdkInstructions(String envKey) =>
-      'Unable to locate Android SDK.\n'
-      'Install Android Studio from: https://developer.android.com/studio/index.html\n'
-      'On first launch it will assist you in installing the Android SDK components.\n'
-      '(or visit https://flutter.dev/setup/#android-setup for detailed instructions).\n'
-      'If the Android SDK has been installed to a custom location, set $envKey to that location.\n'
-      'You may also want to add it to your PATH environment variable.\n';
-  String androidSdkLocation(String directory) => 'Android SDK at $directory';
-  String androidSdkPlatformToolsVersion(String platform, String tools) =>
-      'Platform $platform, build-tools $tools';
-  String get androidSdkInstallHelp =>
-      'Try re-installing or updating your Android SDK,\n'
-      'visit https://flutter.dev/setup/#android-setup for detailed instructions.';
-  String get androidMissingNdk => 'Android NDK location not configured (optional; useful for native profiling support)';
-  String androidNdkLocation(String directory) => 'Android NDK at $directory';
-  // Also occurs in AndroidLicenseValidator
-  String androidStatusInfo(String version) => 'Android SDK version $version';
+// Messages used in AndroidValidator
+String androidCantRunJavaBinary(String javaBinary) => 'Cannot execute $javaBinary to determine the version';
+String get androidUnknownJavaVersion => 'Could not determine java version';
+String androidJavaVersion(String javaVersion) => 'Java version $javaVersion';
+String androidJavaMinimumVersion(String javaVersion) => 'Java version $javaVersion is older than the minimum recommended version of 1.8';
+String androidSdkLicenseOnly(String envKey) =>
+  'Android SDK contains licenses only.\n'
+    'Your first build of an Android application will take longer than usual, '
+    'while gradle downloads the missing components. This functionality will '
+    'only work if the licenses in the licenses folder in $envKey are valid.\n'
+    'If the Android SDK has been installed to another location, set $envKey to that location.\n'
+    'You may also want to add it to your PATH environment variable.\n\n'
+    'Certain features, such as `flutter emulators` and `flutter devices`, will '
+    'not work without the currently missing SDK components.';
+String androidBadSdkDir(String envKey, String homeDir) =>
+  '$envKey = $homeDir\n'
+    'but Android SDK not found at this location.';
+String androidMissingSdkInstructions(String envKey) =>
+  'Unable to locate Android SDK.\n'
+    'Install Android Studio from: https://developer.android.com/studio/index.html\n'
+    'On first launch it will assist you in installing the Android SDK components.\n'
+    '(or visit https://flutter.dev/setup/#android-setup for detailed instructions).\n'
+    'If the Android SDK has been installed to a custom location, set $envKey to that location.\n'
+    'You may also want to add it to your PATH environment variable.\n';
+String androidSdkLocation(String directory) => 'Android SDK at $directory';
+String androidSdkPlatformToolsVersion(String platform, String tools) =>
+  'Platform $platform, build-tools $tools';
+String get androidSdkInstallHelp =>
+  'Try re-installing or updating your Android SDK,\n'
+    'visit https://flutter.dev/setup/#android-setup for detailed instructions.';
+String get androidMissingNdk => 'Android NDK location not configured (optional; useful for native profiling support)';
+String androidNdkLocation(String directory) => 'Android NDK at $directory';
+// Also occurs in AndroidLicenseValidator
+String androidStatusInfo(String version) => 'Android SDK version $version';
 
-  // Messages used in AndroidLicenseValidator
-  String get androidMissingJdk =>
-      'No Java Development Kit (JDK) found; You must have the environment '
-      'variable JAVA_HOME set and the java binary in your PATH. '
-      'You can download the JDK from https://www.oracle.com/technetwork/java/javase/downloads/.';
-  String androidJdkLocation(String location) => 'Java binary at: $location';
-  String get androidLicensesAll => 'All Android licenses accepted.';
-  String get androidLicensesSome => 'Some Android licenses not accepted.  To resolve this, run: flutter doctor --android-licenses';
-  String get androidLicensesNone => 'Android licenses not accepted.  To resolve this, run: flutter doctor --android-licenses';
-  String get androidLicensesUnknown =>
-      'Android license status unknown.\n'
-      'Try re-installing or updating your Android SDK Manager.\n'
-      'See https://developer.android.com/studio/#downloads or visit '
-      'https://flutter.dev/setup/#android-setup for detailed instructions.';
-  String androidSdkManagerOutdated(String managerPath) =>
-      'A newer version of the Android SDK is required. To update, run:\n'
-      '$managerPath --update\n';
-  String androidLicensesTimeout(String managerPath) => 'Intentionally killing $managerPath';
-  String get androidSdkShort => 'Unable to locate Android SDK.';
-  String androidMissingSdkManager(String sdkManagerPath) =>
-      'Android sdkmanager tool not found ($sdkManagerPath).\n'
-      'Try re-installing or updating your Android SDK,\n'
-      'visit https://flutter.dev/setup/#android-setup for detailed instructions.';
-  String androidCannotRunSdkManager(String sdkManagerPath, String error) =>
-      'Android sdkmanager tool was found, but failed to run ($sdkManagerPath): "$error".\n'
-      'Try re-installing or updating your Android SDK,\n'
-      'visit https://flutter.dev/setup/#android-setup for detailed instructions.';
-  String androidSdkBuildToolsOutdated(String managerPath, int sdkMinVersion, String buildToolsMinVersion) =>
-      'Flutter requires Android SDK $sdkMinVersion and the Android BuildTools $buildToolsMinVersion\n'
-      'To update using sdkmanager, run:\n'
-      '  "$managerPath" "platforms;android-$sdkMinVersion" "build-tools;$buildToolsMinVersion"\n'
-      'or visit https://flutter.dev/setup/#android-setup for detailed instructions.';
+// Messages used in AndroidLicenseValidator
+String get androidMissingJdk =>
+  'No Java Development Kit (JDK) found; You must have the environment '
+    'variable JAVA_HOME set and the java binary in your PATH. '
+    'You can download the JDK from https://www.oracle.com/technetwork/java/javase/downloads/.';
+String androidJdkLocation(String location) => 'Java binary at: $location';
+String get androidLicensesAll => 'All Android licenses accepted.';
+String get androidLicensesSome => 'Some Android licenses not accepted.  To resolve this, run: flutter doctor --android-licenses';
+String get androidLicensesNone => 'Android licenses not accepted.  To resolve this, run: flutter doctor --android-licenses';
+String get androidLicensesUnknown =>
+  'Android license status unknown.\n'
+    'Try re-installing or updating your Android SDK Manager.\n'
+    'See https://developer.android.com/studio/#downloads or visit '
+    'https://flutter.dev/setup/#android-setup for detailed instructions.';
+String androidSdkManagerOutdated(String managerPath) =>
+  'A newer version of the Android SDK is required. To update, run:\n'
+    '$managerPath --update\n';
+String androidLicensesTimeout(String managerPath) => 'Intentionally killing $managerPath';
+String get androidSdkShort => 'Unable to locate Android SDK.';
+String androidMissingSdkManager(String sdkManagerPath) =>
+  'Android sdkmanager tool not found ($sdkManagerPath).\n'
+    'Try re-installing or updating your Android SDK,\n'
+    'visit https://flutter.dev/setup/#android-setup for detailed instructions.';
+String androidCannotRunSdkManager(String sdkManagerPath, String error) =>
+  'Android sdkmanager tool was found, but failed to run ($sdkManagerPath): "$error".\n'
+    'Try re-installing or updating your Android SDK,\n'
+    'visit https://flutter.dev/setup/#android-setup for detailed instructions.';
+String androidSdkBuildToolsOutdated(String managerPath, int sdkMinVersion, String buildToolsMinVersion) =>
+  'Flutter requires Android SDK $sdkMinVersion and the Android BuildTools $buildToolsMinVersion\n'
+    'To update using sdkmanager, run:\n'
+    '  "$managerPath" "platforms;android-$sdkMinVersion" "build-tools;$buildToolsMinVersion"\n'
+    'or visit https://flutter.dev/setup/#android-setup for detailed instructions.';
 
-  // Messages used in AndroidStudioValidator
-  String androidStudioVersion(String version) => 'version $version';
-  String androidStudioLocation(String location) => 'Android Studio at $location';
-  String get androidStudioNeedsUpdate => 'Try updating or re-installing Android Studio.';
-  String get androidStudioResetDir =>
-      'Consider removing your android-studio-dir setting by running:\n'
-      'flutter config --android-studio-dir=';
-  String get aaptNotFound =>
-      'Could not locate aapt. Please ensure you have the Android buildtools installed.';
+// Messages used in AndroidStudioValidator
+String androidStudioVersion(String version) => 'version $version';
+String androidStudioLocation(String location) => 'Android Studio at $location';
+String get androidStudioNeedsUpdate => 'Try updating or re-installing Android Studio.';
+String get androidStudioResetDir =>
+  'Consider removing your android-studio-dir setting by running:\n'
+    'flutter config --android-studio-dir=';
+String get aaptNotFound =>
+  'Could not locate aapt. Please ensure you have the Android buildtools installed.';
 
-  // Messages used in NoAndroidStudioValidator
-  String androidStudioMissing(String location) =>
-      'android-studio-dir = $location\n'
-      'but Android Studio not found at this location.';
-  String get androidStudioInstallation =>
-      'Android Studio not found; download from https://developer.android.com/studio/index.html\n'
-      '(or visit https://flutter.dev/setup/#android-setup for detailed instructions).';
+// Messages used in NoAndroidStudioValidator
+String androidStudioMissing(String location) =>
+  'android-studio-dir = $location\n'
+    'but Android Studio not found at this location.';
+String get androidStudioInstallation =>
+  'Android Studio not found; download from https://developer.android.com/studio/index.html\n'
+    '(or visit https://flutter.dev/setup/#android-setup for detailed instructions).';
 
-  // Messages used in XcodeValidator
-  String xcodeLocation(String location) => 'Xcode at $location';
-  String xcodeOutdated(int versionMajor, int versionMinor) =>
-      'Flutter requires a minimum Xcode version of $versionMajor.$versionMinor.0.\n'
-      'Download the latest version or update via the Mac App Store.';
-  String get xcodeEula => "Xcode end user license agreement not signed; open Xcode or run the command 'sudo xcodebuild -license'.";
-  String get xcodeMissingSimct =>
-      'Xcode requires additional components to be installed in order to run.\n'
-      'Launch Xcode and install additional required components when prompted or run:\n'
-      '  sudo xcodebuild -runFirstLaunch';
-  String get xcodeMissing =>
-      'Xcode not installed; this is necessary for iOS development.\n'
-      'Download at https://developer.apple.com/xcode/download/.';
-  String get xcodeIncomplete =>
-      'Xcode installation is incomplete; a full installation is necessary for iOS development.\n'
-      'Download at: https://developer.apple.com/xcode/download/\n'
-      'Or install Xcode via the App Store.\n'
-      'Once installed, run:\n'
-      '  sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer\n'
-      '  sudo xcodebuild -runFirstLaunch';
+// Messages used in XcodeValidator
+String xcodeLocation(String location) => 'Xcode at $location';
+String xcodeOutdated(int versionMajor, int versionMinor) =>
+  'Flutter requires a minimum Xcode version of $versionMajor.$versionMinor.0.\n'
+    'Download the latest version or update via the Mac App Store.';
+String get xcodeEula => "Xcode end user license agreement not signed; open Xcode or run the command 'sudo xcodebuild -license'.";
+String get xcodeMissingSimct =>
+  'Xcode requires additional components to be installed in order to run.\n'
+    'Launch Xcode and install additional required components when prompted or run:\n'
+    '  sudo xcodebuild -runFirstLaunch';
+String get xcodeMissing =>
+  'Xcode not installed; this is necessary for iOS development.\n'
+    'Download at https://developer.apple.com/xcode/download/.';
+String get xcodeIncomplete =>
+  'Xcode installation is incomplete; a full installation is necessary for iOS development.\n'
+    'Download at: https://developer.apple.com/xcode/download/\n'
+    'Or install Xcode via the App Store.\n'
+    'Once installed, run:\n'
+    '  sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer\n'
+    '  sudo xcodebuild -runFirstLaunch';
 
-  // Messages used in CocoaPodsValidator
-  String cocoaPodsVersion(String version) => 'CocoaPods version $version';
-  String cocoaPodsUninitialized(String consequence) =>
-      'CocoaPods installed but not initialized.\n'
-      '$consequence\n'
-      'To initialize CocoaPods, run:\n'
-      '  pod setup\n'
-      "once to finalize CocoaPods' installation.";
-  String cocoaPodsMissing(String consequence, String installInstructions) =>
-      'CocoaPods not installed.\n'
-      '$consequence\n'
-      'To install:\n'
-      '$installInstructions';
-  String cocoaPodsUnknownVersion(String consequence, String upgradeInstructions) =>
-      'Unknown CocoaPods version installed.\n'
-      '$consequence\n'
-      'To upgrade:\n'
-      '$upgradeInstructions';
-  String cocoaPodsOutdated(String currentVersion, String recVersion, String consequence, String upgradeInstructions) =>
-      'CocoaPods $currentVersion out of date ($recVersion is recommended).\n'
-      '$consequence\n'
-      'To upgrade:\n'
-      '$upgradeInstructions';
-  String cocoaPodsBrokenInstall(String consequence, String reinstallInstructions) =>
-      'CocoaPods installed but not working.\n'
-      '$consequence\n'
-      'To re-install CocoaPods, run:\n'
-      '$reinstallInstructions';
+// Messages used in CocoaPodsValidator
+String cocoaPodsVersion(String version) => 'CocoaPods version $version';
+String cocoaPodsUninitialized(String consequence) =>
+  'CocoaPods installed but not initialized.\n'
+    '$consequence\n'
+    'To initialize CocoaPods, run:\n'
+    '  pod setup\n'
+    "once to finalize CocoaPods' installation.";
+String cocoaPodsMissing(String consequence, String installInstructions) =>
+  'CocoaPods not installed.\n'
+    '$consequence\n'
+    'To install:\n'
+    '$installInstructions';
+String cocoaPodsUnknownVersion(String consequence, String upgradeInstructions) =>
+  'Unknown CocoaPods version installed.\n'
+    '$consequence\n'
+    'To upgrade:\n'
+    '$upgradeInstructions';
+String cocoaPodsOutdated(String currentVersion, String recVersion, String consequence, String upgradeInstructions) =>
+  'CocoaPods $currentVersion out of date ($recVersion is recommended).\n'
+    '$consequence\n'
+    'To upgrade:\n'
+    '$upgradeInstructions';
+String cocoaPodsBrokenInstall(String consequence, String reinstallInstructions) =>
+  'CocoaPods installed but not working.\n'
+    '$consequence\n'
+    'To re-install CocoaPods, run:\n'
+    '$reinstallInstructions';
 
-  // Messages used in VsCodeValidator
-  String vsCodeVersion(String version) => 'version $version';
-  String vsCodeLocation(String location) => 'VS Code at $location';
-  String vsCodeFlutterExtensionMissing(String url) => 'Flutter extension not installed; install from\n$url';
+// Messages used in VsCodeValidator
+String vsCodeVersion(String version) => 'version $version';
+String vsCodeLocation(String location) => 'VS Code at $location';
+String vsCodeFlutterExtensionMissing(String url) => 'Flutter extension not installed; install from\n$url';
 
-  // Messages used in VisualStudioValidator
-  String visualStudioVersion(String name, String version) => '$name version $version';
-  String visualStudioLocation(String location) => 'Visual Studio at $location';
-  String visualStudioMissingComponents(String workload, List<String> components) =>
-      'Visual Studio is missing necessary components. Please re-run the '
-      'Visual Studio installer for the "$workload" workload, and include these components:\n'
-      '  ${components.join('\n  ')}';
-  String visualStudioMissing(String workload, List<String> components) =>
-      'Visual Studio not installed; this is necessary for Windows development.\n'
-      'Download at https://visualstudio.microsoft.com/downloads/.\n'
-      'Please install the "$workload" workload, including the following components:\n  ${components.join('\n  ')}';
-  String visualStudioTooOld(String minimumVersion, String workload, List<String> components) =>
-      'Visual Studio $minimumVersion or later is required.\n'
-      'Download at https://visualstudio.microsoft.com/downloads/.\n'
-      'Please install the "$workload" workload, including the following components:\n  ${components.join('\n  ')}';
-  String get visualStudioIsPrerelease => 'The current Visual Studio installation is a pre-release version. It may not be '
-      'supported by Flutter yet.';
-  String get visualStudioNotLaunchable =>
-      'The current Visual Studio installation is not launchable. Please reinstall Visual Studio.';
-  String get visualStudioIsIncomplete => 'The current Visual Studio installation is incomplete. Please reinstall Visual Studio.';
-  String get visualStudioRebootRequired => 'Visual Studio requires a reboot of your system to complete installation.';
+// Messages used in VisualStudioValidator
+String visualStudioVersion(String name, String version) => '$name version $version';
+String visualStudioLocation(String location) => 'Visual Studio at $location';
+String visualStudioMissingComponents(String workload, List<String> components) =>
+  'Visual Studio is missing necessary components. Please re-run the '
+    'Visual Studio installer for the "$workload" workload, and include these components:\n'
+    '  ${components.join('\n  ')}';
+String visualStudioMissing(String workload, List<String> components) =>
+  'Visual Studio not installed; this is necessary for Windows development.\n'
+    'Download at https://visualstudio.microsoft.com/downloads/.\n'
+    'Please install the "$workload" workload, including the following components:\n  ${components.join('\n  ')}';
+String visualStudioTooOld(String minimumVersion, String workload, List<String> components) =>
+  'Visual Studio $minimumVersion or later is required.\n'
+    'Download at https://visualstudio.microsoft.com/downloads/.\n'
+    'Please install the "$workload" workload, including the following components:\n  ${components.join('\n  ')}';
+String get visualStudioIsPrerelease => 'The current Visual Studio installation is a pre-release version. It may not be '
+  'supported by Flutter yet.';
+String get visualStudioNotLaunchable =>
+  'The current Visual Studio installation is not launchable. Please reinstall Visual Studio.';
+String get visualStudioIsIncomplete => 'The current Visual Studio installation is incomplete. Please reinstall Visual Studio.';
+String get visualStudioRebootRequired => 'Visual Studio requires a reboot of your system to complete installation.';
 
-  // Messages used in FlutterCommand
-  String flutterElapsedTime(String name, String elapsedTime) => '"flutter $name" took $elapsedTime.';
-  String get flutterNoDevelopmentDevice =>
-      "Unable to locate a development device; please run 'flutter doctor' "
-      'for information about installing additional components.';
-  String flutterNoMatchingDevice(String deviceId) => 'No devices found with name or id '
-      "matching '$deviceId'";
-  String get flutterNoDevicesFound => 'No devices found';
-  String get flutterNoSupportedDevices => 'No supported devices connected.';
-  String flutterFoundSpecifiedDevices(int count, String deviceId) =>
-      'Found $count devices with name or id matching $deviceId:';
-  String get flutterSpecifyDeviceWithAllOption =>
-      'More than one device connected; please specify a device with '
-      "the '-d <deviceId>' flag, or use '-d all' to act on all devices.";
-  String get flutterSpecifyDevice =>
-      'More than one device connected; please specify a device with '
-      "the '-d <deviceId>' flag.";
-  String get flutterNoConnectedDevices => 'No connected devices.';
-  String get flutterNoPubspec =>
-      'Error: No pubspec.yaml file found.\n'
-      'This command should be run from the root of your Flutter project.\n'
-      'Do not run this command from the root of your git clone of Flutter.';
-  String flutterTargetFileMissing(String path) => 'Target file "$path" not found.';
-  String get flutterBasePatchFlagsExclusive => 'Error: Only one of --baseline, --patch is allowed.';
-  String get flutterBaselineRequiresTraceFile => 'Error: --baseline requires --compilation-trace-file to be specified.';
-  String get flutterPatchRequiresTraceFile => 'Error: --patch requires --compilation-trace-file to be specified.';
+// Messages used in FlutterCommand
+String flutterElapsedTime(String name, String elapsedTime) => '"flutter $name" took $elapsedTime.';
+String get flutterNoDevelopmentDevice =>
+  "Unable to locate a development device; please run 'flutter doctor' "
+    'for information about installing additional components.';
+String flutterNoMatchingDevice(String deviceId) => 'No devices found with name or id '
+  "matching '$deviceId'";
+String get flutterNoDevicesFound => 'No devices found';
+String get flutterNoSupportedDevices => 'No supported devices connected.';
+String flutterFoundSpecifiedDevices(int count, String deviceId) =>
+  'Found $count devices with name or id matching $deviceId:';
+String get flutterSpecifyDeviceWithAllOption =>
+  'More than one device connected; please specify a device with '
+    "the '-d <deviceId>' flag, or use '-d all' to act on all devices.";
+String get flutterSpecifyDevice =>
+  'More than one device connected; please specify a device with '
+    "the '-d <deviceId>' flag.";
+String get flutterNoConnectedDevices => 'No connected devices.';
+String get flutterNoPubspec =>
+  'Error: No pubspec.yaml file found.\n'
+    'This command should be run from the root of your Flutter project.\n'
+    'Do not run this command from the root of your git clone of Flutter.';
+String flutterTargetFileMissing(String path) => 'Target file "$path" not found.';
+String get flutterBasePatchFlagsExclusive => 'Error: Only one of --baseline, --patch is allowed.';
+String get flutterBaselineRequiresTraceFile => 'Error: --baseline requires --compilation-trace-file to be specified.';
+String get flutterPatchRequiresTraceFile => 'Error: --patch requires --compilation-trace-file to be specified.';
 
-  // Messages used in FlutterCommandRunner
-  String runnerNoRoot(String error) => 'Unable to locate flutter root: $error';
-  String runnerWrapColumnInvalid(dynamic value) =>
-      'Argument to --wrap-column must be a positive integer. You supplied $value.';
-  String runnerWrapColumnParseError(dynamic value) =>
-      'Unable to parse argument --wrap-column=$value. Must be a positive integer.';
-  String runnerBugReportFinished(String zipFileName) =>
-      'Bug report written to $zipFileName.\n'
-      'Warning: this bug report contains local paths, device identifiers, and log snippets.';
-  String get runnerNoRecordTo => 'record-to location not specified';
-  String get runnerNoReplayFrom => 'replay-from location not specified';
-  String runnerNoEngineSrcDir(String enginePackageName, String engineEnvVar) =>
-      'Unable to detect local Flutter engine src directory.\n'
-      'Either specify a dependency_override for the $enginePackageName package in your pubspec.yaml and '
-      'ensure --package-root is set if necessary, or set the \$$engineEnvVar environment variable, or '
-      'use --local-engine-src-path to specify the path to the root of your flutter/engine repository.';
-  String runnerNoEngineBuildDirInPath(String engineSourcePath) =>
-      'Unable to detect a Flutter engine build directory in $engineSourcePath.\n'
-      "Please ensure that $engineSourcePath is a Flutter engine 'src' directory and that "
-      "you have compiled the engine in that directory, which should produce an 'out' directory";
-  String get runnerLocalEngineRequired =>
-      'You must specify --local-engine if you are using a locally built engine.';
-  String runnerNoEngineBuild(String engineBuildPath) =>
-      'No Flutter engine build found at $engineBuildPath.';
-  String runnerWrongFlutterInstance(String flutterRoot, String currentDir) =>
-      "Warning: the 'flutter' tool you are currently running is not the one from the current directory:\n"
-      '  running Flutter  : $flutterRoot\n'
-      '  current directory: $currentDir\n'
-      'This can happen when you have multiple copies of flutter installed. Please check your system path to verify '
-      "that you're running the expected version (run 'flutter --version' to see which flutter is on your path).\n";
-  String runnerRemovedFlutterRepo(String flutterRoot, String flutterPath) =>
-      'Warning! This package referenced a Flutter repository via the .packages file that is '
-      "no longer available. The repository from which the 'flutter' tool is currently "
-      'executing will be used instead.\n'
-      '  running Flutter tool: $flutterRoot\n'
-      '  previous reference  : $flutterPath\n'
-      'This can happen if you deleted or moved your copy of the Flutter repository, or '
-      'if it was on a volume that is no longer mounted or has been mounted at a '
-      'different location. Please check your system path to verify that you are running '
-      "the expected version (run 'flutter --version' to see which flutter is on your path).\n";
-  String runnerChangedFlutterRepo(String flutterRoot, String flutterPath) =>
-      "Warning! The 'flutter' tool you are currently running is from a different Flutter "
-      'repository than the one last used by this package. The repository from which the '
-      "'flutter' tool is currently executing will be used instead.\n"
-      '  running Flutter tool: $flutterRoot\n'
-      '  previous reference  : $flutterPath\n'
-      'This can happen when you have multiple copies of flutter installed. Please check '
-      'your system path to verify that you are running the expected version (run '
-      "'flutter --version' to see which flutter is on your path).\n";
-  String invalidVersionSettingHintMessage(String invalidVersion) =>
-      'Invalid version $invalidVersion found, default value will be used.\n'
-      'In pubspec.yaml, a valid version should look like: build-name+build-number.\n'
-      'In Android, build-name is used as versionName while build-number used as versionCode.\n'
-      'Read more about Android versioning at https://developer.android.com/studio/publish/versioning\n'
-      'In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.\n'
-      'Read more about iOS versioning at\n'
-      'https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html\n';
-}
+// Messages used in FlutterCommandRunner
+String runnerNoRoot(String error) => 'Unable to locate flutter root: $error';
+String runnerWrapColumnInvalid(dynamic value) =>
+  'Argument to --wrap-column must be a positive integer. You supplied $value.';
+String runnerWrapColumnParseError(dynamic value) =>
+  'Unable to parse argument --wrap-column=$value. Must be a positive integer.';
+String runnerBugReportFinished(String zipFileName) =>
+  'Bug report written to $zipFileName.\n'
+    'Warning: this bug report contains local paths, device identifiers, and log snippets.';
+String get runnerNoRecordTo => 'record-to location not specified';
+String get runnerNoReplayFrom => 'replay-from location not specified';
+String runnerNoEngineSrcDir(String enginePackageName, String engineEnvVar) =>
+  'Unable to detect local Flutter engine src directory.\n'
+    'Either specify a dependency_override for the $enginePackageName package in your pubspec.yaml and '
+    'ensure --package-root is set if necessary, or set the \$$engineEnvVar environment variable, or '
+    'use --local-engine-src-path to specify the path to the root of your flutter/engine repository.';
+String runnerNoEngineBuildDirInPath(String engineSourcePath) =>
+  'Unable to detect a Flutter engine build directory in $engineSourcePath.\n'
+    "Please ensure that $engineSourcePath is a Flutter engine 'src' directory and that "
+    "you have compiled the engine in that directory, which should produce an 'out' directory";
+String get runnerLocalEngineRequired =>
+  'You must specify --local-engine if you are using a locally built engine.';
+String runnerNoEngineBuild(String engineBuildPath) =>
+  'No Flutter engine build found at $engineBuildPath.';
+String runnerWrongFlutterInstance(String flutterRoot, String currentDir) =>
+  "Warning: the 'flutter' tool you are currently running is not the one from the current directory:\n"
+    '  running Flutter  : $flutterRoot\n'
+    '  current directory: $currentDir\n'
+    'This can happen when you have multiple copies of flutter installed. Please check your system path to verify '
+    "that you're running the expected version (run 'flutter --version' to see which flutter is on your path).\n";
+String runnerRemovedFlutterRepo(String flutterRoot, String flutterPath) =>
+  'Warning! This package referenced a Flutter repository via the .packages file that is '
+    "no longer available. The repository from which the 'flutter' tool is currently "
+    'executing will be used instead.\n'
+    '  running Flutter tool: $flutterRoot\n'
+    '  previous reference  : $flutterPath\n'
+    'This can happen if you deleted or moved your copy of the Flutter repository, or '
+    'if it was on a volume that is no longer mounted or has been mounted at a '
+    'different location. Please check your system path to verify that you are running '
+    "the expected version (run 'flutter --version' to see which flutter is on your path).\n";
+String runnerChangedFlutterRepo(String flutterRoot, String flutterPath) =>
+  "Warning! The 'flutter' tool you are currently running is from a different Flutter "
+    'repository than the one last used by this package. The repository from which the '
+    "'flutter' tool is currently executing will be used instead.\n"
+    '  running Flutter tool: $flutterRoot\n'
+    '  previous reference  : $flutterPath\n'
+    'This can happen when you have multiple copies of flutter installed. Please check '
+    'your system path to verify that you are running the expected version (run '
+    "'flutter --version' to see which flutter is on your path).\n";
+String invalidVersionSettingHintMessage(String invalidVersion) =>
+  'Invalid version $invalidVersion found, default value will be used.\n'
+    'In pubspec.yaml, a valid version should look like: build-name+build-number.\n'
+    'In Android, build-name is used as versionName while build-number used as versionCode.\n'
+    'Read more about Android versioning at https://developer.android.com/studio/publish/versioning\n'
+    'In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.\n'
+    'Read more about iOS versioning at\n'
+    'https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html\n';

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -19,7 +19,6 @@ import 'base/os.dart';
 import 'base/process.dart';
 import 'base/signals.dart';
 import 'base/time.dart';
-import 'base/user_messages.dart';
 import 'build_system/build_system.dart';
 import 'cache.dart';
 import 'compile.dart';
@@ -82,7 +81,6 @@ Future<T> runInContext<T>(
         logger: globals.logger,
         platform: globals.platform,
         processManager: globals.processManager,
-        userMessages: globals.userMessages,
       ),
       AndroidWorkflow: () => AndroidWorkflow(),
       ApplicationPackageFactory: () => ApplicationPackageFactory(),
@@ -184,9 +182,7 @@ Future<T> runInContext<T>(
       Usage: () => Usage(
         runningOnBot: runningOnBot,
       ),
-      UserMessages: () => UserMessages(),
       VisualStudioValidator: () => VisualStudioValidator(
-        userMessages: globals.userMessages,
         visualStudio: VisualStudio(
           fileSystem: globals.fs,
           platform: globals.platform,

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -15,7 +15,7 @@ import 'base/file_system.dart';
 import 'base/logger.dart';
 import 'base/process.dart';
 import 'base/terminal.dart';
-import 'base/user_messages.dart';
+import 'base/user_messages.dart' as user_messages;
 import 'base/utils.dart';
 import 'base/version.dart';
 import 'cache.dart';
@@ -620,17 +620,17 @@ class FlutterValidator extends DoctorValidator {
       final FlutterVersion version = globals.flutterVersion;
       versionChannel = version.channel;
       frameworkVersion = version.frameworkVersion;
-      messages.add(ValidationMessage(userMessages.flutterVersion(
+      messages.add(ValidationMessage(user_messages.flutterVersion(
         frameworkVersion,
         Cache.flutterRoot,
       )));
-      messages.add(ValidationMessage(userMessages.flutterRevision(
+      messages.add(ValidationMessage(user_messages.flutterRevision(
         version.frameworkRevisionShort,
         version.frameworkAge,
         version.frameworkDate,
       )));
-      messages.add(ValidationMessage(userMessages.engineRevision(version.engineRevisionShort)));
-      messages.add(ValidationMessage(userMessages.dartRevision(version.dartSdkVersion)));
+      messages.add(ValidationMessage(user_messages.engineRevision(version.engineRevisionShort)));
+      messages.add(ValidationMessage(user_messages.dartRevision(version.dartSdkVersion)));
     } on VersionCheckError catch (e) {
       messages.add(ValidationMessage.error(e.message));
       valid = ValidationType.partial;
@@ -643,9 +643,9 @@ class FlutterValidator extends DoctorValidator {
     if (globals.fs.file(genSnapshotPath).existsSync()
         && !_genSnapshotRuns(genSnapshotPath)) {
       final StringBuffer buf = StringBuffer();
-      buf.writeln(userMessages.flutterBinariesDoNotRun);
+      buf.writeln(user_messages.flutterBinariesDoNotRun);
       if (globals.platform.isLinux) {
-        buf.writeln(userMessages.flutterBinariesLinuxRepairCommands);
+        buf.writeln(user_messages.flutterBinariesLinuxRepairCommands);
       }
       messages.add(ValidationMessage.error(buf.toString()));
       valid = ValidationType.partial;
@@ -654,7 +654,7 @@ class FlutterValidator extends DoctorValidator {
     return ValidationResult(
       valid,
       messages,
-      statusInfo: userMessages.flutterStatusInfo(
+      statusInfo: user_messages.flutterStatusInfo(
         versionChannel,
         frameworkVersion,
         globals.os.name,
@@ -679,8 +679,8 @@ class NoIdeValidator extends DoctorValidator {
   @override
   Future<ValidationResult> validate() async {
     return ValidationResult(ValidationType.missing, <ValidationMessage>[
-      ValidationMessage(userMessages.noIdeInstallationInfo),
-    ], statusInfo: userMessages.noIdeStatusInfo);
+      ValidationMessage(user_messages.noIdeInstallationInfo),
+    ], statusInfo: user_messages.noIdeStatusInfo);
   }
 }
 
@@ -716,7 +716,7 @@ abstract class IntelliJValidator extends DoctorValidator {
     if (pluginsPath == null) {
       messages.add(ValidationMessage.error('Invalid IntelliJ version number.'));
     } else {
-      messages.add(ValidationMessage(userMessages.intellijLocation(installPath)));
+      messages.add(ValidationMessage(user_messages.intellijLocation(installPath)));
 
       final IntelliJPlugins plugins = IntelliJPlugins(pluginsPath);
       plugins.validatePackage(messages, <String>['flutter-intellij', 'flutter-intellij.jar'],
@@ -724,7 +724,7 @@ abstract class IntelliJValidator extends DoctorValidator {
       plugins.validatePackage(messages, <String>['Dart'], 'Dart');
 
       if (_hasIssues(messages)) {
-        messages.add(ValidationMessage(userMessages.intellijPluginInfo));
+        messages.add(ValidationMessage(user_messages.intellijPluginInfo));
       }
 
       _validateIntelliJVersion(messages, kMinIdeaVersion);
@@ -733,7 +733,7 @@ abstract class IntelliJValidator extends DoctorValidator {
     return ValidationResult(
       _hasIssues(messages) ? ValidationType.partial : ValidationType.installed,
       messages,
-      statusInfo: userMessages.intellijStatusInfo(version));
+      statusInfo: user_messages.intellijStatusInfo(version));
   }
 
   bool _hasIssues(List<ValidationMessage> messages) {
@@ -752,7 +752,7 @@ abstract class IntelliJValidator extends DoctorValidator {
     }
 
     if (installedVersion < minVersion) {
-      messages.add(ValidationMessage.error(userMessages.intellijMinimumVersion(minVersion.toString())));
+      messages.add(ValidationMessage.error(user_messages.intellijMinimumVersion(minVersion.toString())));
     }
   }
 }
@@ -856,7 +856,7 @@ class IntelliJValidatorOnMac extends IntelliJValidator {
       }
     } on FileSystemException catch (e) {
       validators.add(ValidatorWithResult(
-          userMessages.intellijMacUnknownResult,
+          user_messages.intellijMacUnknownResult,
           ValidationResult(ValidationType.missing, <ValidationMessage>[
             ValidationMessage.error(e.message),
           ]),
@@ -930,7 +930,7 @@ class DeviceValidator extends DoctorValidator {
       if (diagnostics.isNotEmpty) {
         messages = diagnostics.map<ValidationMessage>((String message) => ValidationMessage(message)).toList();
       } else {
-        messages = <ValidationMessage>[ValidationMessage.hint(userMessages.devicesMissing)];
+        messages = <ValidationMessage>[ValidationMessage.hint(user_messages.devicesMissing)];
       }
     } else {
       messages = await Device.descriptions(devices)
@@ -940,7 +940,7 @@ class DeviceValidator extends DoctorValidator {
     if (devices.isEmpty) {
       return ValidationResult(ValidationType.notAvailable, messages);
     } else {
-      return ValidationResult(ValidationType.installed, messages, statusInfo: userMessages.devicesAvailable(devices.length));
+      return ValidationResult(ValidationType.installed, messages, statusInfo: user_messages.devicesAvailable(devices.length));
     }
   }
 }

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -7,7 +7,7 @@ import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml/yaml.dart';
 
 import 'base/file_system.dart';
-import 'base/user_messages.dart';
+import 'base/user_messages.dart' as user_messages;
 import 'base/utils.dart';
 import 'cache.dart';
 import 'globals.dart' as globals;
@@ -91,7 +91,7 @@ class FlutterManifest {
       version = Version.parse(verStr);
     } on Exception {
       if (!_hasShowInvalidVersionMsg) {
-        globals.printStatus(userMessages.invalidVersionSettingHintMessage(verStr), emphasis: true);
+        globals.printStatus(user_messages.invalidVersionSettingHintMessage(verStr), emphasis: true);
         _hasShowInvalidVersionMsg = true;
       }
     }

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -19,7 +19,6 @@ import 'base/net.dart';
 import 'base/os.dart';
 import 'base/template.dart';
 import 'base/terminal.dart';
-import 'base/user_messages.dart';
 import 'cache.dart';
 import 'fuchsia/fuchsia_sdk.dart';
 import 'ios/ios_deploy.dart';
@@ -77,7 +76,6 @@ IOSDeploy get iosDeploy => context.get<IOSDeploy>();
 IOSSimulatorUtils get iosSimulatorUtils => context.get<IOSSimulatorUtils>();
 IOSWorkflow get iosWorkflow => context.get<IOSWorkflow>();
 SimControl get simControl => context.get<SimControl>();
-UserMessages get userMessages => context.get<UserMessages>();
 Xcode get xcode => context.get<Xcode>();
 XcodeProjectInterpreter get xcodeProjectInterpreter => context.get<XcodeProjectInterpreter>();
 

--- a/packages/flutter_tools/lib/src/macos/cocoapods_validator.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods_validator.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 
 import '../base/context.dart';
-import '../base/user_messages.dart';
+import '../base/user_messages.dart' as user_messages;
 import '../doctor.dart';
 import 'cocoapods.dart';
 
@@ -24,30 +24,30 @@ class CocoaPodsValidator extends DoctorValidator {
     ValidationType status = ValidationType.installed;
     if (cocoaPodsStatus == CocoaPodsStatus.recommended) {
       if (await cocoaPods.isCocoaPodsInitialized) {
-        messages.add(ValidationMessage(userMessages.cocoaPodsVersion(await cocoaPods.cocoaPodsVersionText)));
+        messages.add(ValidationMessage(user_messages.cocoaPodsVersion(await cocoaPods.cocoaPodsVersionText)));
       } else {
         status = ValidationType.partial;
-        messages.add(ValidationMessage.error(userMessages.cocoaPodsUninitialized(noCocoaPodsConsequence)));
+        messages.add(ValidationMessage.error(user_messages.cocoaPodsUninitialized(noCocoaPodsConsequence)));
       }
     } else {
       if (cocoaPodsStatus == CocoaPodsStatus.notInstalled) {
         status = ValidationType.missing;
         messages.add(ValidationMessage.error(
-            userMessages.cocoaPodsMissing(noCocoaPodsConsequence, cocoaPodsInstallInstructions)));
+          user_messages.cocoaPodsMissing(noCocoaPodsConsequence, cocoaPodsInstallInstructions)));
       } else if (cocoaPodsStatus == CocoaPodsStatus.brokenInstall) {
         status = ValidationType.missing;
         messages.add(ValidationMessage.error(
-            userMessages.cocoaPodsBrokenInstall(brokenCocoaPodsConsequence, cocoaPodsInstallInstructions)));
+          user_messages.cocoaPodsBrokenInstall(brokenCocoaPodsConsequence, cocoaPodsInstallInstructions)));
 
       } else if (cocoaPodsStatus == CocoaPodsStatus.unknownVersion) {
         status = ValidationType.partial;
         messages.add(ValidationMessage.hint(
-            userMessages.cocoaPodsUnknownVersion(unknownCocoaPodsConsequence, cocoaPodsUpgradeInstructions)));
+          user_messages.cocoaPodsUnknownVersion(unknownCocoaPodsConsequence, cocoaPodsUpgradeInstructions)));
       } else {
         status = ValidationType.partial;
         final String currentVersionText = await cocoaPods.cocoaPodsVersionText;
         messages.add(ValidationMessage.hint(
-            userMessages.cocoaPodsOutdated(currentVersionText, cocoaPods.cocoaPodsRecommendedVersion, noCocoaPodsConsequence, cocoaPodsUpgradeInstructions)));
+          user_messages.cocoaPodsOutdated(currentVersionText, cocoaPods.cocoaPodsRecommendedVersion, noCocoaPodsConsequence, cocoaPodsUpgradeInstructions)));
       }
     }
 

--- a/packages/flutter_tools/lib/src/macos/xcode_validator.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode_validator.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import '../base/context.dart';
-import '../base/user_messages.dart';
+import '../base/user_messages.dart' as user_messages;
 import '../doctor.dart';
 import '../globals.dart' as globals;
 import 'xcode.dart';
@@ -22,7 +22,7 @@ class XcodeValidator extends DoctorValidator {
     if (globals.xcode.isInstalled) {
       xcodeStatus = ValidationType.installed;
 
-      messages.add(ValidationMessage(userMessages.xcodeLocation(globals.xcode.xcodeSelectPath)));
+      messages.add(ValidationMessage(user_messages.xcodeLocation(globals.xcode.xcodeSelectPath)));
 
       xcodeVersionInfo = globals.xcode.versionText;
       if (xcodeVersionInfo.contains(',')) {
@@ -33,25 +33,25 @@ class XcodeValidator extends DoctorValidator {
       if (!globals.xcode.isInstalledAndMeetsVersionCheck) {
         xcodeStatus = ValidationType.partial;
         messages.add(ValidationMessage.error(
-            userMessages.xcodeOutdated(kXcodeRequiredVersionMajor, kXcodeRequiredVersionMinor)
+            user_messages.xcodeOutdated(kXcodeRequiredVersionMajor, kXcodeRequiredVersionMinor)
         ));
       }
 
       if (!globals.xcode.eulaSigned) {
         xcodeStatus = ValidationType.partial;
-        messages.add(ValidationMessage.error(userMessages.xcodeEula));
+        messages.add(ValidationMessage.error(user_messages.xcodeEula));
       }
       if (!globals.xcode.isSimctlInstalled) {
         xcodeStatus = ValidationType.partial;
-        messages.add(ValidationMessage.error(userMessages.xcodeMissingSimct));
+        messages.add(ValidationMessage.error(user_messages.xcodeMissingSimct));
       }
 
     } else {
       xcodeStatus = ValidationType.missing;
       if (globals.xcode.xcodeSelectPath == null || globals.xcode.xcodeSelectPath.isEmpty) {
-        messages.add(ValidationMessage.error(userMessages.xcodeMissing));
+        messages.add(ValidationMessage.error(user_messages.xcodeMissing));
       } else {
-        messages.add(ValidationMessage.error(userMessages.xcodeIncomplete));
+        messages.add(ValidationMessage.error(user_messages.xcodeIncomplete));
       }
     }
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -16,7 +16,7 @@ import '../base/context.dart';
 import '../base/io.dart' as io;
 import '../base/signals.dart';
 import '../base/time.dart';
-import '../base/user_messages.dart';
+import '../base/user_messages.dart' as user_messages;
 import '../base/utils.dart';
 import '../build_info.dart';
 import '../build_system/targets/icon_tree_shaker.dart' show kIconTreeShakerEnabledDefault;
@@ -612,7 +612,7 @@ abstract class FlutterCommand extends Command<void> {
           commandResult = await verifyThenRunCommand(commandPath);
         } finally {
           final DateTime endTime = systemClock.now();
-          globals.printTrace(userMessages.flutterElapsedTime(name, getElapsedAsMilliseconds(endTime.difference(startTime))));
+          globals.printTrace(user_messages.flutterElapsedTime(name, getElapsedAsMilliseconds(endTime.difference(startTime))));
           _sendPostUsage(commandPath, commandResult, startTime, endTime);
         }
       },
@@ -732,26 +732,26 @@ abstract class FlutterCommand extends Command<void> {
   /// then print an error message and return null.
   Future<List<Device>> findAllTargetDevices() async {
     if (!doctor.canLaunchAnything) {
-      globals.printError(userMessages.flutterNoDevelopmentDevice);
+      globals.printError(user_messages.flutterNoDevelopmentDevice);
       return null;
     }
 
     List<Device> devices = await deviceManager.findTargetDevices(FlutterProject.current());
 
     if (devices.isEmpty && deviceManager.hasSpecifiedDeviceId) {
-      globals.printStatus(userMessages.flutterNoMatchingDevice(deviceManager.specifiedDeviceId));
+      globals.printStatus(user_messages.flutterNoMatchingDevice(deviceManager.specifiedDeviceId));
       return null;
     } else if (devices.isEmpty && deviceManager.hasSpecifiedAllDevices) {
-      globals.printStatus(userMessages.flutterNoDevicesFound);
+      globals.printStatus(user_messages.flutterNoDevicesFound);
       return null;
     } else if (devices.isEmpty) {
-      globals.printStatus(userMessages.flutterNoSupportedDevices);
+      globals.printStatus(user_messages.flutterNoSupportedDevices);
       return null;
     } else if (devices.length > 1 && !deviceManager.hasSpecifiedAllDevices) {
       if (deviceManager.hasSpecifiedDeviceId) {
-       globals.printStatus(userMessages.flutterFoundSpecifiedDevices(devices.length, deviceManager.specifiedDeviceId));
+       globals.printStatus(user_messages.flutterFoundSpecifiedDevices(devices.length, deviceManager.specifiedDeviceId));
       } else {
-        globals.printStatus(userMessages.flutterSpecifyDeviceWithAllOption);
+        globals.printStatus(user_messages.flutterSpecifyDeviceWithAllOption);
         devices = await deviceManager.getAllConnectedDevices();
       }
       globals.printStatus('');
@@ -771,7 +771,7 @@ abstract class FlutterCommand extends Command<void> {
       return null;
     }
     if (deviceList.length > 1) {
-      globals.printStatus(userMessages.flutterSpecifyDevice);
+      globals.printStatus(user_messages.flutterSpecifyDevice);
       deviceList = await deviceManager.getAllConnectedDevices();
       globals.printStatus('');
       await Device.printDevices(deviceList);
@@ -792,7 +792,7 @@ abstract class FlutterCommand extends Command<void> {
       while (!globals.fs.isFileSync('pubspec.yaml')) {
         final Directory nextCurrent = globals.fs.currentDirectory.parent;
         if (nextCurrent == null || nextCurrent.path == globals.fs.currentDirectory.path) {
-          throw ToolExit(userMessages.flutterNoPubspec);
+          throw ToolExit(user_messages.flutterNoPubspec);
         }
         globals.fs.currentDirectory = nextCurrent;
         changedDirectory = true;
@@ -813,7 +813,7 @@ abstract class FlutterCommand extends Command<void> {
     if (_usesTargetOption) {
       final String targetPath = targetFile;
       if (!globals.fs.isFileSync(targetPath)) {
-        throw ToolExit(userMessages.flutterTargetFileMissing(targetPath));
+        throw ToolExit(user_messages.flutterTargetFileMissing(targetPath));
       }
     }
   }

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -16,7 +16,7 @@ import '../base/context.dart';
 import '../base/file_system.dart';
 import '../base/logger.dart';
 import '../base/terminal.dart';
-import '../base/user_messages.dart';
+import '../base/user_messages.dart' as user_messages;
 import '../base/utils.dart';
 import '../cache.dart';
 import '../convert.dart';
@@ -192,7 +192,7 @@ class FlutterCommandRunner extends CommandRunner<void> {
     } on Exception catch (error) {
       // we don't have a logger at the time this is run
       // (which is why we don't use printTrace here)
-      print(userMessages.runnerNoRoot('$error'));
+      print(user_messages.runnerNoRoot('$error'));
     }
     return '.';
   }
@@ -249,10 +249,10 @@ class FlutterCommandRunner extends CommandRunner<void> {
       try {
         wrapColumn = int.parse(topLevelResults['wrap-column'] as String);
         if (wrapColumn < 0) {
-          throwToolExit(userMessages.runnerWrapColumnInvalid(topLevelResults['wrap-column']));
+          throwToolExit(user_messages.runnerWrapColumnInvalid(topLevelResults['wrap-column']));
         }
       } on FormatException {
-        throwToolExit(userMessages.runnerWrapColumnParseError(topLevelResults['wrap-column']));
+        throwToolExit(user_messages.runnerWrapColumnParseError(topLevelResults['wrap-column']));
       }
     }
 
@@ -365,7 +365,7 @@ class FlutterCommandRunner extends CommandRunner<void> {
           engineSourcePath = globals.fs.directory(engineUri.path)?.parent?.parent?.parent?.parent?.parent?.parent?.path;
           if (engineSourcePath != null && (engineSourcePath == globals.fs.path.dirname(engineSourcePath) || engineSourcePath.isEmpty)) {
             engineSourcePath = null;
-            throwToolExit(userMessages.runnerNoEngineSrcDir(kFlutterEnginePackageName, kFlutterEngineEnvironmentVariableName),
+            throwToolExit(user_messages.runnerNoEngineSrcDir(kFlutterEnginePackageName, kFlutterEngineEnvironmentVariableName),
               exitCode: 2);
           }
         }
@@ -379,7 +379,7 @@ class FlutterCommandRunner extends CommandRunner<void> {
     }
 
     if (engineSourcePath != null && _tryEnginePath(engineSourcePath) == null) {
-      throwToolExit(userMessages.runnerNoEngineBuildDirInPath(engineSourcePath),
+      throwToolExit(user_messages.runnerNoEngineBuildDirInPath(engineSourcePath),
         exitCode: 2);
     }
 
@@ -404,19 +404,19 @@ class FlutterCommandRunner extends CommandRunner<void> {
     if (globalResults['local-engine'] != null) {
       localEngine = globalResults['local-engine'] as String;
     } else {
-      throwToolExit(userMessages.runnerLocalEngineRequired, exitCode: 2);
+      throwToolExit(user_messages.runnerLocalEngineRequired, exitCode: 2);
     }
 
     final String engineBuildPath = globals.fs.path.normalize(globals.fs.path.join(enginePath, 'out', localEngine));
     if (!globals.fs.isDirectorySync(engineBuildPath)) {
-      throwToolExit(userMessages.runnerNoEngineBuild(engineBuildPath), exitCode: 2);
+      throwToolExit(user_messages.runnerNoEngineBuild(engineBuildPath), exitCode: 2);
     }
 
     final String basename = globals.fs.path.basename(engineBuildPath);
     final String hostBasename = _getHostEngineBasename(basename);
     final String engineHostBuildPath = globals.fs.path.normalize(globals.fs.path.join(globals.fs.path.dirname(engineBuildPath), hostBasename));
     if (!globals.fs.isDirectorySync(engineHostBuildPath)) {
-      throwToolExit(userMessages.runnerNoEngineBuild(engineHostBuildPath), exitCode: 2);
+      throwToolExit(user_messages.runnerNoEngineBuild(engineHostBuildPath), exitCode: 2);
     }
 
     return EngineBuildPaths(targetEngine: engineBuildPath, hostEngine: engineHostBuildPath);
@@ -476,7 +476,7 @@ class FlutterCommandRunner extends CommandRunner<void> {
     while (directory.isNotEmpty) {
       if (_isDirectoryFlutterRepo(directory)) {
         if (!_compareResolvedPaths(directory, Cache.flutterRoot)) {
-          globals.printError(userMessages.runnerWrongFlutterInstance(Cache.flutterRoot, directory));
+          globals.printError(user_messages.runnerWrongFlutterInstance(Cache.flutterRoot, directory));
         }
 
         break;
@@ -509,9 +509,9 @@ class FlutterCommandRunner extends CommandRunner<void> {
         final String flutterPath = globals.fs.path.normalize(globals.fs.file(rootUri).absolute.path);
 
         if (!globals.fs.isDirectorySync(flutterPath)) {
-          globals.printError(userMessages.runnerRemovedFlutterRepo(Cache.flutterRoot, flutterPath));
+          globals.printError(user_messages.runnerRemovedFlutterRepo(Cache.flutterRoot, flutterPath));
         } else if (!_compareResolvedPaths(flutterPath, Cache.flutterRoot)) {
-          globals.printError(userMessages.runnerChangedFlutterRepo(Cache.flutterRoot, flutterPath));
+          globals.printError(user_messages.runnerChangedFlutterRepo(Cache.flutterRoot, flutterPath));
         }
       }
     }

--- a/packages/flutter_tools/lib/src/vscode/vscode_validator.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode_validator.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import '../base/user_messages.dart';
+import '../base/user_messages.dart' as user_messages;
 import '../base/version.dart';
 import '../doctor.dart';
 import 'vscode.dart';
@@ -24,7 +24,7 @@ class VsCodeValidator extends DoctorValidator {
   Future<ValidationResult> validate() async {
     final String vsCodeVersionText = _vsCode.version == Version.unknown
         ? null
-        : userMessages.vsCodeVersion(_vsCode.version.toString());
+        : user_messages.vsCodeVersion(_vsCode.version.toString());
 
     final ValidationType validationType = _vsCode.isValid
         ? ValidationType.installed

--- a/packages/flutter_tools/lib/src/windows/visual_studio_validator.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio_validator.dart
@@ -5,7 +5,7 @@
 import 'package:meta/meta.dart';
 
 import '../base/context.dart';
-import '../base/user_messages.dart' hide userMessages;
+import '../base/user_messages.dart' as user_messages;
 import '../doctor.dart';
 import 'visual_studio.dart';
 
@@ -14,13 +14,10 @@ VisualStudioValidator get visualStudioValidator => context.get<VisualStudioValid
 class VisualStudioValidator extends DoctorValidator {
   const VisualStudioValidator({
     @required VisualStudio visualStudio,
-    @required UserMessages userMessages,
   }) : _visualStudio = visualStudio,
-       _userMessages = userMessages,
        super('Visual Studio - develop for Windows');
 
   final VisualStudio _visualStudio;
-  final UserMessages _userMessages;
 
   @override
   Future<ValidationResult> validate() async {
@@ -32,23 +29,23 @@ class VisualStudioValidator extends DoctorValidator {
       status = ValidationType.installed;
 
       messages.add(ValidationMessage(
-          _userMessages.visualStudioLocation(_visualStudio.installLocation)
+          user_messages.visualStudioLocation(_visualStudio.installLocation)
       ));
 
-      messages.add(ValidationMessage(_userMessages.visualStudioVersion(
+      messages.add(ValidationMessage(user_messages.visualStudioVersion(
           _visualStudio.displayName,
           _visualStudio.fullVersion,
       )));
 
       if (_visualStudio.isPrerelease) {
-        messages.add(ValidationMessage(_userMessages.visualStudioIsPrerelease));
+        messages.add(ValidationMessage(user_messages.visualStudioIsPrerelease));
       }
 
       // Messages for faulty installations.
       if (!_visualStudio.isAtLeastMinimumVersion) {
         status = ValidationType.partial;
         messages.add(ValidationMessage.error(
-            _userMessages.visualStudioTooOld(
+            user_messages.visualStudioTooOld(
                 _visualStudio.minimumVersionDescription,
                 _visualStudio.workloadDescription,
                 _visualStudio.necessaryComponentDescriptions(),
@@ -56,17 +53,17 @@ class VisualStudioValidator extends DoctorValidator {
         ));
       } else if (_visualStudio.isRebootRequired) {
         status = ValidationType.partial;
-        messages.add(ValidationMessage.error(_userMessages.visualStudioRebootRequired));
+        messages.add(ValidationMessage.error(user_messages.visualStudioRebootRequired));
       } else if (!_visualStudio.isComplete) {
         status = ValidationType.partial;
-        messages.add(ValidationMessage.error(_userMessages.visualStudioIsIncomplete));
+        messages.add(ValidationMessage.error(user_messages.visualStudioIsIncomplete));
       } else if (!_visualStudio.isLaunchable) {
         status = ValidationType.partial;
-        messages.add(ValidationMessage.error(_userMessages.visualStudioNotLaunchable));
+        messages.add(ValidationMessage.error(user_messages.visualStudioNotLaunchable));
       } else if (!_visualStudio.hasNecessaryComponents) {
         status = ValidationType.partial;
         messages.add(ValidationMessage.error(
-            _userMessages.visualStudioMissingComponents(
+            user_messages.visualStudioMissingComponents(
                 _visualStudio.workloadDescription,
                 _visualStudio.necessaryComponentDescriptions(),
             ),
@@ -76,7 +73,7 @@ class VisualStudioValidator extends DoctorValidator {
     } else {
       status = ValidationType.missing;
       messages.add(ValidationMessage.error(
-        _userMessages.visualStudioMissing(
+        user_messages.visualStudioMissing(
           _visualStudio.workloadDescription,
           _visualStudio.necessaryComponentDescriptions(),
         ),

--- a/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
@@ -12,7 +12,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 
 import 'package:flutter_tools/src/base/terminal.dart';
-import 'package:flutter_tools/src/base/user_messages.dart';
+import 'package:flutter_tools/src/base/user_messages.dart' as user_messages;
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/doctor.dart';
 import 'package:flutter_tools/src/doctor.dart';
@@ -515,11 +515,11 @@ void main() {
 
       expect(await FlutterValidatorDoctor().diagnose(verbose: false), isTrue);
       final List<String> statusLines = testLogger.statusText.split('\n');
-      for (final String msg in userMessages.flutterBinariesDoNotRun.split('\n')) {
+      for (final String msg in user_messages.flutterBinariesDoNotRun.split('\n')) {
         expect(statusLines, contains(contains(msg)));
       }
       if (globals.platform.isLinux) {
-        for (final String msg in userMessages.flutterBinariesLinuxRepairCommands.split('\n')) {
+        for (final String msg in user_messages.flutterBinariesLinuxRepairCommands.split('\n')) {
           expect(statusLines, contains(contains(msg)));
         }
       }

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -14,7 +14,7 @@ import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
-import 'package:flutter_tools/src/base/user_messages.dart';
+import 'package:flutter_tools/src/base/user_messages.dart' as user_messages;
 import 'package:flutter_tools/src/base/net.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
@@ -225,7 +225,7 @@ void main() {
           expect(e.message, null);
         }
 
-        expect(testLogger.statusText, contains(userMessages.flutterNoSupportedDevices));
+        expect(testLogger.statusText, contains(user_messages.flutterNoSupportedDevices));
       }, overrides: <Type, Generator>{
         DeviceManager: () => mockDeviceManager,
         FileSystem: () => fs,

--- a/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
@@ -12,7 +12,7 @@ import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/android/android_workflow.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/terminal.dart' show AnsiTerminal, OutputPreferences;
-import 'package:flutter_tools/src/base/user_messages.dart';
+import 'package:flutter_tools/src/base/user_messages.dart' as user_messages;
 import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/doctor.dart';
 
@@ -33,7 +33,6 @@ void main() {
   MemoryFileSystem fs;
   MockProcessManager processManager;
   MockStdio stdio;
-  UserMessages userMessages;
 
   setUp(() {
     sdk = MockAndroidSdk();
@@ -48,7 +47,6 @@ void main() {
     );
     processManager = MockProcessManager();
     stdio = MockStdio();
-    userMessages = UserMessages();
   });
 
   MockProcess Function(List<String>) processMetaFactory(List<String> stdout) {
@@ -205,12 +203,11 @@ void main() {
       logger: logger,
       processManager: processManager,
       platform: FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
-      userMessages: userMessages,
     ).validate();
     expect(validationResult.type, ValidationType.partial);
     expect(
       validationResult.messages.last.message,
-      userMessages.androidSdkLicenseOnly(kAndroidHome),
+      user_messages.androidSdkLicenseOnly(kAndroidHome),
     );
   });
 
@@ -226,7 +223,7 @@ void main() {
     when(sdk.latestVersion).thenReturn(mockSdkVersion);
     when(sdk.validateSdkWellFormed()).thenReturn(<String>[]);
     when(processManager.runSync(<String>['which', 'java'])).thenReturn(ProcessResult(123, 1, '', ''));
-    final String errorMessage = userMessages.androidSdkBuildToolsOutdated(
+    final String errorMessage = user_messages.androidSdkBuildToolsOutdated(
       sdk.sdkManagerPath,
       kAndroidSdkMinVersion,
       kAndroidSdkBuildToolsMinVersion.toString(),
@@ -239,7 +236,6 @@ void main() {
       logger: logger,
       processManager: processManager,
       platform: FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
-      userMessages: userMessages,
     );
 
     ValidationResult validationResult = await androidValidator.validate();
@@ -289,7 +285,7 @@ void main() {
     const String javaVersionText = 'openjdk version "1.7.0_212"';
     when(processManager.run(argThat(contains('-version')))).thenAnswer((_) =>
       Future<ProcessResult>.value(ProcessResult(0, 0, null, javaVersionText)));
-    final String errorMessage = userMessages.androidJavaMinimumVersion(javaVersionText);
+    final String errorMessage = user_messages.androidJavaMinimumVersion(javaVersionText);
 
     final ValidationResult validationResult = await AndroidValidator(
       androidSdk: sdk,
@@ -298,7 +294,6 @@ void main() {
       logger: logger,
       platform: FakePlatform()..environment = <String, String>{'HOME': '/home/me', 'JAVA_HOME': 'home/java'},
       processManager: processManager,
-      userMessages: userMessages,
     ).validate();
     expect(validationResult.type, ValidationType.partial);
     expect(
@@ -315,7 +310,6 @@ void main() {
       logger: logger,
       platform: FakePlatform()..environment = <String, String>{'HOME': '/home/me', 'JAVA_HOME': 'home/java'},
       processManager: processManager,
-      userMessages: userMessages,
     ).validate();
     expect(
       validationResult.messages.any(

--- a/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/targets/dart.dart';
 import 'package:flutter_tools/src/build_system/targets/macos.dart';
 import 'package:flutter_tools/src/cache.dart';
-import 'package:flutter_tools/src/macos/cocoapods.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:mockito/mockito.dart';
@@ -193,7 +192,6 @@ void main() {
 }
 
 class MockPlatform extends Mock implements Platform {}
-class MockCocoaPods extends Mock implements CocoaPods {}
 class MockProcessManager extends Mock implements ProcessManager {}
 class MockGenSnapshot extends Mock implements GenSnapshot {}
 class MockXcode extends Mock implements Xcode {}

--- a/packages/flutter_tools/test/general.shard/windows/visual_studio_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/visual_studio_validator_test.dart
@@ -2,15 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter_tools/src/base/user_messages.dart' hide userMessages;
+import 'package:flutter_tools/src/base/user_messages.dart' as user_messages;
 import 'package:flutter_tools/src/doctor.dart';
 import 'package:flutter_tools/src/windows/visual_studio.dart';
 import 'package:flutter_tools/src/windows/visual_studio_validator.dart';
 import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
-
-final UserMessages userMessages = UserMessages();
 
 void main() {
   group('Visual Studio validation', () {
@@ -63,28 +61,26 @@ void main() {
 
     testWithoutContext('Emits a message when Visual Studio is a pre-release version', () async {
       final VisualStudioValidator validator = VisualStudioValidator(
-        userMessages: userMessages,
         visualStudio: mockVisualStudio,
       );
       _configureMockVisualStudioAsInstalled();
       when(mockVisualStudio.isPrerelease).thenReturn(true);
 
       final ValidationResult result = await validator.validate();
-      final ValidationMessage expectedMessage = ValidationMessage(userMessages.visualStudioIsPrerelease);
+      final ValidationMessage expectedMessage = ValidationMessage(user_messages.visualStudioIsPrerelease);
 
       expect(result.messages.contains(expectedMessage), true);
     });
 
     testWithoutContext('Emits a partial status when Visual Studio installation is incomplete', () async {
       final VisualStudioValidator validator = VisualStudioValidator(
-        userMessages: userMessages,
         visualStudio: mockVisualStudio,
       );
       _configureMockVisualStudioAsInstalled();
       when(mockVisualStudio.isComplete).thenReturn(false);
 
       final ValidationResult result = await validator.validate();
-      final ValidationMessage expectedMessage = ValidationMessage.error(userMessages.visualStudioIsIncomplete);
+      final ValidationMessage expectedMessage = ValidationMessage.error(user_messages.visualStudioIsIncomplete);
 
       expect(result.messages.contains(expectedMessage), true);
       expect(result.type, ValidationType.partial);
@@ -92,14 +88,13 @@ void main() {
 
     testWithoutContext('Emits a partial status when Visual Studio installation needs rebooting', () async {
       final VisualStudioValidator validator = VisualStudioValidator(
-        userMessages: userMessages,
         visualStudio: mockVisualStudio,
       );
       _configureMockVisualStudioAsInstalled();
       when(mockVisualStudio.isRebootRequired).thenReturn(true);
 
       final ValidationResult result = await validator.validate();
-      final ValidationMessage expectedMessage = ValidationMessage.error(userMessages.visualStudioRebootRequired);
+      final ValidationMessage expectedMessage = ValidationMessage.error(user_messages.visualStudioRebootRequired);
 
       expect(result.messages.contains(expectedMessage), true);
       expect(result.type, ValidationType.partial);
@@ -107,14 +102,13 @@ void main() {
 
     testWithoutContext('Emits a partial status when Visual Studio installation is not launchable', () async {
       final VisualStudioValidator validator = VisualStudioValidator(
-        userMessages: userMessages,
         visualStudio: mockVisualStudio,
       );
       _configureMockVisualStudioAsInstalled();
       when(mockVisualStudio.isLaunchable).thenReturn(false);
 
       final ValidationResult result = await validator.validate();
-      final ValidationMessage expectedMessage = ValidationMessage.error(userMessages.visualStudioNotLaunchable);
+      final ValidationMessage expectedMessage = ValidationMessage.error(user_messages.visualStudioNotLaunchable);
 
       expect(result.messages.contains(expectedMessage), true);
       expect(result.type, ValidationType.partial);
@@ -122,14 +116,13 @@ void main() {
 
     testWithoutContext('Emits partial status when Visual Studio is installed but too old', () async {
       final VisualStudioValidator validator = VisualStudioValidator(
-        userMessages: userMessages,
         visualStudio: mockVisualStudio,
       );
       _configureMockVisualStudioAsTooOld();
 
       final ValidationResult result = await validator.validate();
       final ValidationMessage expectedMessage = ValidationMessage.error(
-        userMessages.visualStudioTooOld(
+        user_messages.visualStudioTooOld(
           mockVisualStudio.minimumVersionDescription,
           mockVisualStudio.workloadDescription,
           mockVisualStudio.necessaryComponentDescriptions(),
@@ -142,7 +135,6 @@ void main() {
 
     testWithoutContext('Emits partial status when Visual Studio is installed without necessary components', () async {
       final VisualStudioValidator validator = VisualStudioValidator(
-        userMessages: userMessages,
         visualStudio: mockVisualStudio,
       );
       _configureMockVisualStudioAsInstalled();
@@ -154,14 +146,13 @@ void main() {
 
     testWithoutContext('Emits installed status when Visual Studio is installed with necessary components', () async {
       final VisualStudioValidator validator = VisualStudioValidator(
-        userMessages: userMessages,
         visualStudio: mockVisualStudio,
       );
       _configureMockVisualStudioAsInstalled();
 
       final ValidationResult result = await validator.validate();
       final ValidationMessage expectedDisplayNameMessage = ValidationMessage(
-        userMessages.visualStudioVersion(mockVisualStudio.displayName, mockVisualStudio.fullVersion));
+        user_messages.visualStudioVersion(mockVisualStudio.displayName, mockVisualStudio.fullVersion));
 
       expect(result.messages.contains(expectedDisplayNameMessage), true);
       expect(result.type, ValidationType.installed);
@@ -169,14 +160,13 @@ void main() {
 
     testWithoutContext('Emits missing status when Visual Studio is not installed', () async {
       final VisualStudioValidator validator = VisualStudioValidator(
-        userMessages: userMessages,
         visualStudio: mockVisualStudio,
       );
       _configureMockVisualStudioAsNotInstalled();
 
       final ValidationResult result = await validator.validate();
       final ValidationMessage expectedMessage = ValidationMessage.error(
-        userMessages.visualStudioMissing(
+        user_messages.visualStudioMissing(
           mockVisualStudio.workloadDescription,
           mockVisualStudio.necessaryComponentDescriptions(),
         ),


### PR DESCRIPTION
## Description

`UserMessages` was being fetch through the context and preventing `testWithoutContext`, but there's not really any need for this to be a class.
Convert usage to user_messages library prefix.

## Related Issues

https://github.com/flutter/flutter/issues/47161

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*