### PR TITLE
Convert cocoapods_validator_test to testWithoutContext

### DIFF
--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -106,7 +106,10 @@ Future<T> runInContext<T>(
         platform: globals.platform,
       ),
       CocoaPods: () => CocoaPods(),
-      CocoaPodsValidator: () => const CocoaPodsValidator(),
+      CocoaPodsValidator: () => CocoaPodsValidator(
+        globals.cocoaPods,
+        globals.userMessages,
+      ),
       Config: () => Config(
         Config.kFlutterSettings,
         fileSystem: globals.fs,

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -28,6 +28,7 @@ import 'ios/mac.dart';
 import 'ios/plist_parser.dart';
 import 'ios/simulators.dart';
 import 'ios/xcodeproj.dart';
+import 'macos/cocoapods.dart';
 import 'macos/xcode.dart';
 import 'persistent_tool_state.dart';
 import 'reporting/reporting.dart';
@@ -70,6 +71,7 @@ Platform get platform => context.get<Platform>() ?? _kLocalPlatform;
 
 AndroidStudio get androidStudio => context.get<AndroidStudio>();
 AndroidSdk get androidSdk => context.get<AndroidSdk>();
+CocoaPods get cocoaPods => context.get<CocoaPods>();
 FlutterVersion get flutterVersion => context.get<FlutterVersion>();
 FuchsiaArtifacts get fuchsiaArtifacts => context.get<FuchsiaArtifacts>();
 IMobileDevice get iMobileDevice => context.get<IMobileDevice>();

--- a/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
@@ -10,7 +10,6 @@ import '../globals.dart' as globals;
 import '../ios/xcodeproj.dart';
 import '../plugins.dart';
 import '../project.dart';
-import 'cocoapods.dart';
 
 /// For a given build, determines whether dependencies have changed since the
 /// last call to processPods, then calls processPods with that information.
@@ -33,7 +32,7 @@ Future<void> processPodsIfNeeded(XcodeBasedProject xcodeProject, String buildDir
     properties: <String, String>{},
   );
 
-  final bool didPodInstall = await cocoaPods.processPods(
+  final bool didPodInstall = await globals.cocoaPods.processPods(
     xcodeProject: xcodeProject,
     engineDir: flutterFrameworkDir(buildMode),
     dependenciesChanged: !fingerprinter.doesFingerprintMatch(),

--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -8,7 +8,6 @@ import 'package:file/file.dart';
 import 'package:meta/meta.dart';
 
 import '../base/common.dart';
-import '../base/context.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
@@ -44,8 +43,6 @@ const String cocoaPodsUpgradeInstructions = '''
 
 const String podfileMigrationInstructions = '''
   rm ios/Podfile''';
-
-CocoaPods get cocoaPods => context.get<CocoaPods>();
 
 /// Result of evaluating the CocoaPods installation.
 enum CocoaPodsStatus {

--- a/packages/flutter_tools/lib/src/macos/cocoapods_validator.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods_validator.dart
@@ -12,42 +12,51 @@ import 'cocoapods.dart';
 CocoaPodsValidator get cocoapodsValidator => context.get<CocoaPodsValidator>();
 
 class CocoaPodsValidator extends DoctorValidator {
-  const CocoaPodsValidator() : super('CocoaPods subvalidator');
+  CocoaPodsValidator(
+    CocoaPods cocoaPods,
+    UserMessages userMessages,
+  ) : _cocoaPods = cocoaPods,
+      _userMessages = userMessages,
+      super('CocoaPods subvalidator');
+
+  final CocoaPods _cocoaPods;
+  final UserMessages _userMessages;
 
   @override
   Future<ValidationResult> validate() async {
     final List<ValidationMessage> messages = <ValidationMessage>[];
 
-    final CocoaPodsStatus cocoaPodsStatus = await cocoaPods
-        .evaluateCocoaPodsInstallation;
+    final CocoaPodsStatus cocoaPodsStatus = await _cocoaPods
+      .evaluateCocoaPodsInstallation;
 
     ValidationType status = ValidationType.installed;
     if (cocoaPodsStatus == CocoaPodsStatus.recommended) {
-      if (await cocoaPods.isCocoaPodsInitialized) {
-        messages.add(ValidationMessage(userMessages.cocoaPodsVersion(await cocoaPods.cocoaPodsVersionText)));
+      if (await _cocoaPods.isCocoaPodsInitialized) {
+        messages.add(ValidationMessage(_userMessages.cocoaPodsVersion(await _cocoaPods.cocoaPodsVersionText)));
       } else {
         status = ValidationType.partial;
-        messages.add(ValidationMessage.error(userMessages.cocoaPodsUninitialized(noCocoaPodsConsequence)));
+        messages.add(ValidationMessage.error(_userMessages.cocoaPodsUninitialized(noCocoaPodsConsequence)));
       }
     } else {
       if (cocoaPodsStatus == CocoaPodsStatus.notInstalled) {
         status = ValidationType.missing;
         messages.add(ValidationMessage.error(
-            userMessages.cocoaPodsMissing(noCocoaPodsConsequence, cocoaPodsInstallInstructions)));
+          _userMessages.cocoaPodsMissing(noCocoaPodsConsequence, cocoaPodsInstallInstructions)));
+
       } else if (cocoaPodsStatus == CocoaPodsStatus.brokenInstall) {
         status = ValidationType.missing;
         messages.add(ValidationMessage.error(
-            userMessages.cocoaPodsBrokenInstall(brokenCocoaPodsConsequence, cocoaPodsInstallInstructions)));
+          _userMessages.cocoaPodsBrokenInstall(brokenCocoaPodsConsequence, cocoaPodsInstallInstructions)));
 
       } else if (cocoaPodsStatus == CocoaPodsStatus.unknownVersion) {
         status = ValidationType.partial;
         messages.add(ValidationMessage.hint(
-            userMessages.cocoaPodsUnknownVersion(unknownCocoaPodsConsequence, cocoaPodsUpgradeInstructions)));
+          _userMessages.cocoaPodsUnknownVersion(unknownCocoaPodsConsequence, cocoaPodsUpgradeInstructions)));
       } else {
         status = ValidationType.partial;
-        final String currentVersionText = await cocoaPods.cocoaPodsVersionText;
+        final String currentVersionText = await _cocoaPods.cocoaPodsVersionText;
         messages.add(ValidationMessage.hint(
-            userMessages.cocoaPodsOutdated(currentVersionText, cocoaPods.cocoaPodsRecommendedVersion, noCocoaPodsConsequence, cocoaPodsUpgradeInstructions)));
+          _userMessages.cocoaPodsOutdated(currentVersionText, _cocoaPods.cocoaPodsRecommendedVersion, noCocoaPodsConsequence, cocoaPodsUpgradeInstructions)));
       }
     }
 

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -15,7 +15,6 @@ import 'convert.dart';
 import 'dart/package_map.dart';
 import 'features.dart';
 import 'globals.dart' as globals;
-import 'macos/cocoapods.dart';
 import 'platform_plugins.dart';
 import 'project.dart';
 import 'windows/property_sheet.dart';
@@ -1058,12 +1057,12 @@ void refreshPluginsList(FlutterProject project, {bool checkProjects = false}) {
   if (changed || legacyChanged) {
     createPluginSymlinks(project, force: true);
     if (!checkProjects || project.ios.existsSync()) {
-      cocoaPods.invalidatePodInstallOutput(project.ios);
+      globals.cocoaPods.invalidatePodInstallOutput(project.ios);
     }
     // TODO(stuartmorgan): Potentially add checkProjects once a decision has
     // made about how to handle macOS in existing projects.
     if (project.macos.existsSync()) {
-      cocoaPods.invalidatePodInstallOutput(project.macos);
+      globals.cocoaPods.invalidatePodInstallOutput(project.macos);
     }
   }
 }
@@ -1097,14 +1096,13 @@ Future<void> injectPlugins(FlutterProject project, {bool checkProjects = false})
   }
   for (final XcodeBasedProject subproject in <XcodeBasedProject>[project.ios, project.macos]) {
     if (!project.isModule && (!checkProjects || subproject.existsSync())) {
-      final CocoaPods cocoaPods = CocoaPods();
       if (plugins.isNotEmpty) {
-        await cocoaPods.setupPodfile(subproject);
+        await globals.cocoaPods.setupPodfile(subproject);
       }
       /// The user may have a custom maintained Podfile that they're running `pod install`
       /// on themselves.
       else if (subproject.podfile.existsSync() && subproject.podfileLock.existsSync()) {
-        cocoaPods.addPodsDependencyToFlutterXcconfig(subproject);
+        globals.cocoaPods.addPodsDependencyToFlutterXcconfig(subproject);
       }
     }
   }

--- a/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/targets/dart.dart';
 import 'package:flutter_tools/src/build_system/targets/macos.dart';
 import 'package:flutter_tools/src/cache.dart';
-import 'package:flutter_tools/src/macos/cocoapods.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:mockito/mockito.dart';
@@ -193,7 +192,6 @@ void main() {
 }
 
 class MockPlatform extends Mock implements Platform {}
-class MockCocoaPods extends Mock implements CocoaPods {}
 class MockProcessManager extends Mock implements ProcessManager {}
 class MockGenSnapshot extends Mock implements GenSnapshot {}
 class MockXcode extends Mock implements Xcode {}

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_validator_test.dart
@@ -2,13 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter_tools/src/base/user_messages.dart';
 import 'package:flutter_tools/src/doctor.dart';
 import 'package:flutter_tools/src/macos/cocoapods.dart';
 import 'package:flutter_tools/src/macos/cocoapods_validator.dart';
 import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
-import '../../src/context.dart';
 
 void main() {
   group('CocoaPods validation', () {
@@ -22,44 +22,36 @@ void main() {
       when(cocoaPods.cocoaPodsVersionText).thenAnswer((_) async => '1.8.0');
     });
 
-    testUsingContext('Emits installed status when CocoaPods is installed', () async {
-      const CocoaPodsValidator workflow = CocoaPodsValidator();
+    testWithoutContext('Emits installed status when CocoaPods is installed', () async {
+      final CocoaPodsValidator workflow = CocoaPodsValidator(cocoaPods, UserMessages());
       final ValidationResult result = await workflow.validate();
       expect(result.type, ValidationType.installed);
-    }, overrides: <Type, Generator>{
-      CocoaPods: () => cocoaPods,
     });
 
-    testUsingContext('Emits missing status when CocoaPods is not installed', () async {
+    testWithoutContext('Emits missing status when CocoaPods is not installed', () async {
       when(cocoaPods.evaluateCocoaPodsInstallation)
           .thenAnswer((_) async => CocoaPodsStatus.notInstalled);
-      const CocoaPodsValidator workflow = CocoaPodsValidator();
+      final CocoaPodsValidator workflow = CocoaPodsValidator(cocoaPods, UserMessages());
       final ValidationResult result = await workflow.validate();
       expect(result.type, ValidationType.missing);
-    }, overrides: <Type, Generator>{
-      CocoaPods: () => cocoaPods,
     });
 
-    testUsingContext('Emits partial status when CocoaPods is installed with unknown version', () async {
+    testWithoutContext('Emits partial status when CocoaPods is installed with unknown version', () async {
       when(cocoaPods.evaluateCocoaPodsInstallation)
           .thenAnswer((_) async => CocoaPodsStatus.unknownVersion);
-      const CocoaPodsValidator workflow = CocoaPodsValidator();
+      final CocoaPodsValidator workflow = CocoaPodsValidator(cocoaPods, UserMessages());
       final ValidationResult result = await workflow.validate();
       expect(result.type, ValidationType.partial);
-    }, overrides: <Type, Generator>{
-      CocoaPods: () => cocoaPods,
     });
 
-    testUsingContext('Emits partial status when CocoaPods is not initialized', () async {
+    testWithoutContext('Emits partial status when CocoaPods is not initialized', () async {
       when(cocoaPods.isCocoaPodsInitialized).thenAnswer((_) async => false);
-      const CocoaPodsValidator workflow = CocoaPodsValidator();
+      final CocoaPodsValidator workflow = CocoaPodsValidator(cocoaPods, UserMessages());
       final ValidationResult result = await workflow.validate();
       expect(result.type, ValidationType.partial);
-    }, overrides: <Type, Generator>{
-      CocoaPods: () => cocoaPods,
     });
 
-    testUsingContext('Emits partial status when CocoaPods version is too low', () async {
+    testWithoutContext('Emits partial status when CocoaPods version is too low', () async {
       when(cocoaPods.evaluateCocoaPodsInstallation)
           .thenAnswer((_) async => CocoaPodsStatus.belowRecommendedVersion);
       const String currentVersion = '1.4.0';
@@ -68,7 +60,7 @@ void main() {
       const String recommendedVersion = '1.8.0';
       when(cocoaPods.cocoaPodsRecommendedVersion)
           .thenAnswer((_) => recommendedVersion);
-      const CocoaPodsValidator workflow = CocoaPodsValidator();
+      final CocoaPodsValidator workflow = CocoaPodsValidator(cocoaPods, UserMessages());
       final ValidationResult result = await workflow.validate();
       expect(result.type, ValidationType.partial);
       expect(result.messages.length, 1);
@@ -76,8 +68,6 @@ void main() {
       expect(message.type, ValidationMessageType.hint);
       expect(message.message, contains('CocoaPods $currentVersion out of date'));
       expect(message.message, contains('($recommendedVersion is recommended)'));
-    }, overrides: <Type, Generator>{
-      CocoaPods: () => cocoaPods,
     });
   });
 }


### PR DESCRIPTION
## Description

Move CocoaPods to globals.

## Related Issues

#47161

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*