### PR TITLE
[flutter_tools] fix type error with AppDomain current directory

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -587,7 +587,9 @@ class AppDomain extends Domain {
           'trace': '$trace',
         });
       } finally {
-        globals.fs.currentDirectory = cwd;
+        // If the full directory is used instead of the path then this causes
+        // a TypeError with the ErrorHandlingFileSystem.
+        globals.fs.currentDirectory = cwd.path;
         _apps.remove(app);
       }
     });


### PR DESCRIPTION
## Description

The currentDirectory can crash if it is set to a directory and not a path. Seems to be an issue with the ForwardingFileSystem. Since this isn't defined in the project, add a test to verify and a note to the work around for now

```
Thread 0 main thread CRASHED_TypeError: type 'LocalDirectory' is not a subtype of type 'String'

  | at _Directory.current= | (directory_impl.dart:80 )
-- | -- | --
  | at Directory.current= | (directory.dart:196 )
  | at LocalFileSystem.currentDirectory= | (local_file_system.dart:47 )
  | at ErrorHandlingFileSystem.currentDirectory= | (error_handling_file_system.dart:53 )
  | at AppDomain.launch.<anonymous closure> | (daemon.dart:590 )
  | at _rootRunUnary | (zone.dart:1141 )
  | at _CustomZone.runUnary | (zone.dart:1034 )
  | at _FutureListener.handleValue | (future_impl.dart:140 )
  | at Future._propagateToListeners.handleValueCallback | (future_impl.dart:681 )
  | at Future._propagateToListeners | (future_impl.dart:710 )
  | at Future._completeWithValue | (future_impl.dart:525 )
  | at _AsyncAwaitCompleter.complete | (async_patch.dart:34 )
  | at _completeOnAsyncReturn | (async_patch.dart:294 )
  | at HotRunner.attach | (run_hot.dart )
  | at _rootRunUnary | (zone.dart:1141 )
  | at _CustomZone.runUnary | (zone.dart:1034 )
  | at _FutureListener.handleValue | (future_impl.dart:140 )
  | at Future._propagateToListeners.handleValueCallback | (future_impl.dart:681 )
  | at Future._propagateToListeners | (future_impl.dart:710 )
  | at Future._completeWithValue | (future_impl.dart:525 )
  | at _AsyncAwaitCompleter.complete | (async_patch.dart:34 )
  | at _completeOnAsyncReturn | (async_patch.dart:294 )
```