### PR TITLE
Increase xcdevice timeout to 2 seconds

### DIFF
--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -249,8 +249,8 @@ class XCDevice {
           'xcrun',
           'xcdevice',
           'list',
-          '--timeout',
-          timeout.inSeconds.toString(),
+          if (timeout != null)
+            ...<String>['--timeout', timeout.inSeconds.toString()]
         ],
         throwOnError: true,
       );
@@ -273,7 +273,7 @@ class XCDevice {
 
   /// [timeout] defaults to 1 second.
   Future<List<IOSDevice>> getAvailableTetheredIOSDevices({ Duration timeout }) async {
-    final List<dynamic> allAvailableDevices = await _getAllDevices(timeout: timeout ?? const Duration(seconds: 1));
+    final List<dynamic> allAvailableDevices = await _getAllDevices(timeout: timeout);
 
     if (allAvailableDevices == null) {
       return const <IOSDevice>[];
@@ -358,7 +358,7 @@ class XCDevice {
         sdkVersion: _sdkVersion(deviceProperties),
         artifacts: globals.artifacts,
         fileSystem: globals.fs,
-        logger: globals.logger,
+        logger: _logger,
         iosDeploy: globals.iosDeploy,
         iMobileDevice: _iMobileDevice,
         platform: globals.platform,
@@ -511,7 +511,6 @@ class XCDevice {
   Future<List<String>> getDiagnostics() async {
     final List<dynamic> allAvailableDevices = await _getAllDevices(
       useCache: true,
-      timeout: const Duration(seconds: 1)
     );
 
     if (allAvailableDevices == null) {

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -233,7 +233,7 @@ class XCDevice {
 
   Future<List<dynamic>> _getAllDevices({
     bool useCache = false,
-    Duration timeout
+    @required Duration timeout
   }) async {
     if (!isInstalled) {
       _logger.printTrace("Xcode not found. Run 'flutter doctor' for more information.");
@@ -249,8 +249,8 @@ class XCDevice {
           'xcrun',
           'xcdevice',
           'list',
-          if (timeout != null)
-            ...<String>['--timeout', timeout.inSeconds.toString()]
+          '--timeout',
+          timeout.inSeconds.toString(),
         ],
         throwOnError: true,
       );
@@ -271,8 +271,9 @@ class XCDevice {
 
   List<dynamic> _cachedListResults;
 
+  /// [timeout] defaults to 2 seconds.
   Future<List<IOSDevice>> getAvailableTetheredIOSDevices({ Duration timeout }) async {
-    final List<dynamic> allAvailableDevices = await _getAllDevices(timeout: timeout);
+    final List<dynamic> allAvailableDevices = await _getAllDevices(timeout: timeout ?? const Duration(seconds: 2));
 
     if (allAvailableDevices == null) {
       return const <IOSDevice>[];
@@ -357,7 +358,7 @@ class XCDevice {
         sdkVersion: _sdkVersion(deviceProperties),
         artifacts: globals.artifacts,
         fileSystem: globals.fs,
-        logger: _logger,
+        logger: globals.logger,
         iosDeploy: globals.iosDeploy,
         iMobileDevice: _iMobileDevice,
         platform: globals.platform,
@@ -510,6 +511,7 @@ class XCDevice {
   Future<List<String>> getDiagnostics() async {
     final List<dynamic> allAvailableDevices = await _getAllDevices(
       useCache: true,
+      timeout: const Duration(seconds: 2)
     );
 
     if (allAvailableDevices == null) {

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -233,7 +233,7 @@ class XCDevice {
 
   Future<List<dynamic>> _getAllDevices({
     bool useCache = false,
-    @required Duration timeout
+    Duration timeout
   }) async {
     if (!isInstalled) {
       _logger.printTrace("Xcode not found. Run 'flutter doctor' for more information.");
@@ -271,7 +271,6 @@ class XCDevice {
 
   List<dynamic> _cachedListResults;
 
-  /// [timeout] defaults to 1 second.
   Future<List<IOSDevice>> getAvailableTetheredIOSDevices({ Duration timeout }) async {
     final List<dynamic> allAvailableDevices = await _getAllDevices(timeout: timeout);
 

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -261,8 +261,8 @@ void main() {
         when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
             .thenReturn(ProcessResult(1, 0, '/path/to/xcdevice', ''));
 
-        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '1']))
-            .thenThrow(const ProcessException('xcrun', <String>['xcdevice', 'list', '--timeout', '1']));
+        when(processManager.run(<String>['xcrun', 'xcdevice', 'list']))
+            .thenThrow(const ProcessException('xcrun', <String>['xcdevice', 'list']));
 
         expect(await xcdevice.getAvailableTetheredIOSDevices(), isEmpty);
       });
@@ -366,7 +366,7 @@ void main() {
 ]
 ''';
 
-        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '1']))
+        when(processManager.run(<String>['xcrun', 'xcdevice', 'list']))
             .thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 0, devicesOutput, '')));
         final List<IOSDevice> devices = await xcdevice.getAvailableTetheredIOSDevices();
         expect(devices, hasLength(3));
@@ -428,7 +428,7 @@ void main() {
 ]
 ''';
 
-        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '1']))
+        when(processManager.run(<String>['xcrun', 'xcdevice', 'list']))
             .thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 0, devicesOutput, '')));
         final List<IOSDevice> devices = await xcdevice.getAvailableTetheredIOSDevices();
         expect(devices, hasLength(1));
@@ -455,8 +455,8 @@ void main() {
         when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
             .thenReturn(ProcessResult(1, 0, '/path/to/xcdevice', ''));
 
-        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '1']))
-            .thenThrow(const ProcessException('xcrun', <String>['xcdevice', 'list', '--timeout', '1']));
+        when(processManager.run(<String>['xcrun', 'xcdevice', 'list']))
+            .thenThrow(const ProcessException('xcrun', <String>['xcdevice', 'list']));
 
         expect(await xcdevice.getDiagnostics(), isEmpty);
       });
@@ -488,7 +488,7 @@ void main() {
 ]
 ''';
 
-        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '1']))
+        when(processManager.run(<String>['xcrun', 'xcdevice', 'list']))
             .thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 0, devicesOutput, '')));
         await xcdevice.getAvailableTetheredIOSDevices();
         final List<String> errors = await xcdevice.getDiagnostics();
@@ -590,7 +590,7 @@ void main() {
 ]
 ''';
 
-        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '1']))
+        when(processManager.run(<String>['xcrun', 'xcdevice', 'list']))
             .thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 0, devicesOutput, '')));
         final List<String> errors = await xcdevice.getDiagnostics();
         expect(errors, hasLength(4));

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -261,8 +261,8 @@ void main() {
         when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
             .thenReturn(ProcessResult(1, 0, '/path/to/xcdevice', ''));
 
-        when(processManager.run(<String>['xcrun', 'xcdevice', 'list']))
-            .thenThrow(const ProcessException('xcrun', <String>['xcdevice', 'list']));
+        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '2']))
+            .thenThrow(const ProcessException('xcrun', <String>['xcdevice', 'list', '--timeout', '2']));
 
         expect(await xcdevice.getAvailableTetheredIOSDevices(), isEmpty);
       });
@@ -366,7 +366,7 @@ void main() {
 ]
 ''';
 
-        when(processManager.run(<String>['xcrun', 'xcdevice', 'list']))
+        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '2']))
             .thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 0, devicesOutput, '')));
         final List<IOSDevice> devices = await xcdevice.getAvailableTetheredIOSDevices();
         expect(devices, hasLength(3));
@@ -428,7 +428,7 @@ void main() {
 ]
 ''';
 
-        when(processManager.run(<String>['xcrun', 'xcdevice', 'list']))
+        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '2']))
             .thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 0, devicesOutput, '')));
         final List<IOSDevice> devices = await xcdevice.getAvailableTetheredIOSDevices();
         expect(devices, hasLength(1));
@@ -455,8 +455,8 @@ void main() {
         when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
             .thenReturn(ProcessResult(1, 0, '/path/to/xcdevice', ''));
 
-        when(processManager.run(<String>['xcrun', 'xcdevice', 'list']))
-            .thenThrow(const ProcessException('xcrun', <String>['xcdevice', 'list']));
+        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '2']))
+            .thenThrow(const ProcessException('xcrun', <String>['xcdevice', 'list', '--timeout', '2']));
 
         expect(await xcdevice.getDiagnostics(), isEmpty);
       });
@@ -488,7 +488,7 @@ void main() {
 ]
 ''';
 
-        when(processManager.run(<String>['xcrun', 'xcdevice', 'list']))
+        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '2']))
             .thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 0, devicesOutput, '')));
         await xcdevice.getAvailableTetheredIOSDevices();
         final List<String> errors = await xcdevice.getDiagnostics();
@@ -590,7 +590,7 @@ void main() {
 ]
 ''';
 
-        when(processManager.run(<String>['xcrun', 'xcdevice', 'list']))
+        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '2']))
             .thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 0, devicesOutput, '')));
         final List<String> errors = await xcdevice.getDiagnostics();
         expect(errors, hasLength(4));


### PR DESCRIPTION
## Description

`xcdevice` was returning before it found all tethered devices on some machines, flakily.  Up the timeout to 2 seconds.  :-(

## Related Issues

Fixes https://github.com/flutter/flutter/issues/53182

## Tests

Updated xcode_tests with new behavior.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*