### PR TITLE
Reland fixes sliver list child layout offset calculation

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -928,13 +928,16 @@ class SliverLogicalParentData extends ParentData {
   ///
   /// The number of pixels from from the zero scroll offset of the parent sliver
   /// (the line at which its [SliverConstraints.scrollOffset] is zero) to the
-  /// side of the child closest to that offset.
+  /// side of the child closest to that offset. A [layoutOffset] can be null
+  /// when it cannot be determined. The value will be set after layout.
   ///
   /// In a typical list, this does not change as the parent is scrolled.
-  double layoutOffset = 0.0;
+  ///
+  /// Defaults to null.
+  double layoutOffset;
 
   @override
-  String toString() => 'layoutOffset=${layoutOffset.toStringAsFixed(1)}';
+  String toString() => 'layoutOffset=${layoutOffset == null ? 'None': layoutOffset.toStringAsFixed(1)}';
 }
 
 /// Parent data for slivers that have multiple children and that position their

--- a/packages/flutter/lib/src/rendering/sliver_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_list.dart
@@ -91,8 +91,28 @@ class RenderSliverList extends RenderSliverMultiBoxAdaptor {
     // it's possible for a child to get removed without notice.
     RenderBox leadingChildWithLayout, trailingChildWithLayout;
 
-    // Find the last child that is at or before the scrollOffset.
     RenderBox earliestUsefulChild = firstChild;
+
+    // A firstChild with null layout offset is likely a result of children
+    // reordering.
+    //
+    // We rely on firstChild to have accurate layout offset. In the case of null
+    // layout offset, we have to find the first child that has valid layout
+    // offset.
+    if (childScrollOffset(firstChild) == null) {
+      int leadingChildrenWithoutLayoutOffset = 0;
+      while (childScrollOffset(earliestUsefulChild) == null) {
+        earliestUsefulChild = childAfter(firstChild);
+        leadingChildrenWithoutLayoutOffset += 1;
+      }
+      // We should be able to destroy children with null layout offset safely,
+      // because they are likely outside of viewport
+      collectGarbage(leadingChildrenWithoutLayoutOffset, 0);
+      assert(firstChild != null);
+    }
+
+    // Find the last child that is at or before the scrollOffset.
+    earliestUsefulChild = firstChild;
     for (double earliestScrollOffset = childScrollOffset(earliestUsefulChild);
         earliestScrollOffset > scrollOffset;
         earliestScrollOffset = childScrollOffset(earliestUsefulChild)) {
@@ -140,12 +160,15 @@ class RenderSliverList extends RenderSliverMultiBoxAdaptor {
           correction += paintExtentOf(firstChild);
           earliestUsefulChild = insertAndLayoutLeadingChild(childConstraints, parentUsesSize: true);
         }
-        geometry = SliverGeometry(
-          scrollOffsetCorrection: correction - earliestScrollOffset,
-        );
-        final SliverMultiBoxAdaptorParentData childParentData = firstChild.parentData as SliverMultiBoxAdaptorParentData;
-        childParentData.layoutOffset = 0.0;
-        return;
+        earliestUsefulChild = firstChild;
+        if ((correction - earliestScrollOffset).abs() > precisionErrorTolerance) {
+          geometry = SliverGeometry(
+            scrollOffsetCorrection: correction - earliestScrollOffset,
+          );
+          final SliverMultiBoxAdaptorParentData childParentData = firstChild.parentData as SliverMultiBoxAdaptorParentData;
+          childParentData.layoutOffset = 0.0;
+          return;
+        }
       }
 
       final SliverMultiBoxAdaptorParentData childParentData = earliestUsefulChild.parentData as SliverMultiBoxAdaptorParentData;

--- a/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
+++ b/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
@@ -578,7 +578,6 @@ abstract class RenderSliverMultiBoxAdaptor extends RenderSliver
     assert(child != null);
     assert(child.parent == this);
     final SliverMultiBoxAdaptorParentData childParentData = child.parentData as SliverMultiBoxAdaptorParentData;
-    assert(childParentData.layoutOffset != null);
     return childParentData.layoutOffset;
   }
 

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1069,6 +1069,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
     assert(_currentlyUpdatingChildIndex == null);
     try {
       final SplayTreeMap<int, Element> newChildren = SplayTreeMap<int, Element>();
+      final Map<int, double> indexToLayoutOffset = HashMap<int, double>();
 
       void processElement(int index) {
         _currentlyUpdatingChildIndex = index;
@@ -1080,17 +1081,31 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
         if (newChild != null) {
           _childElements[index] = newChild;
           final SliverMultiBoxAdaptorParentData parentData = newChild.renderObject.parentData as SliverMultiBoxAdaptorParentData;
+          if (index == 0) {
+            parentData.layoutOffset = 0.0;
+          } else if (indexToLayoutOffset.containsKey(index)) {
+            parentData.layoutOffset = indexToLayoutOffset[index];
+          }
           if (!parentData.keptAlive)
             _currentBeforeChild = newChild.renderObject as RenderBox;
         } else {
           _childElements.remove(index);
         }
       }
-
       for (final int index in _childElements.keys.toList()) {
         final Key key = _childElements[index].widget.key;
         final int newIndex = key == null ? null : widget.delegate.findIndexByKey(key);
+        final SliverMultiBoxAdaptorParentData childParentData =
+          _childElements[index].renderObject?.parentData as SliverMultiBoxAdaptorParentData;
+
+        if (childParentData != null && childParentData.layoutOffset != null)
+          indexToLayoutOffset[index] = childParentData.layoutOffset;
+
         if (newIndex != null && newIndex != index) {
+          // The layout offset of the child being moved is no longer accurate.
+          if (childParentData != null)
+            childParentData.layoutOffset = null;
+
           newChildren[newIndex] = _childElements[index];
           // We need to make sure the original index gets processed.
           newChildren.putIfAbsent(index, () => null);
@@ -1309,7 +1324,8 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
           break;
       }
 
-      return parentData.layoutOffset < renderObject.constraints.scrollOffset + renderObject.constraints.remainingPaintExtent &&
+      return parentData.layoutOffset != null &&
+          parentData.layoutOffset < renderObject.constraints.scrollOffset + renderObject.constraints.remainingPaintExtent &&
           parentData.layoutOffset + itemExtent > renderObject.constraints.scrollOffset;
     }).forEach(visitor);
   }

--- a/packages/flutter/test/rendering/slivers_block_test.dart
+++ b/packages/flutter/test/rendering/slivers_block_test.dart
@@ -340,18 +340,20 @@ void main() {
     final SliverMultiBoxAdaptorParentData candidate = SliverMultiBoxAdaptorParentData();
     expect(candidate.keepAlive, isFalse);
     expect(candidate.index, isNull);
-    expect(candidate.toString(), 'index=null; layoutOffset=0.0');
+    expect(candidate.toString(), 'index=null; layoutOffset=None');
     candidate.keepAlive = null;
-    expect(candidate.toString(), 'index=null; layoutOffset=0.0');
+    expect(candidate.toString(), 'index=null; layoutOffset=None');
     candidate.keepAlive = true;
-    expect(candidate.toString(), 'index=null; keepAlive; layoutOffset=0.0');
+    expect(candidate.toString(), 'index=null; keepAlive; layoutOffset=None');
     candidate.keepAlive = false;
-    expect(candidate.toString(), 'index=null; layoutOffset=0.0');
+    expect(candidate.toString(), 'index=null; layoutOffset=None');
     candidate.index = 0;
-    expect(candidate.toString(), 'index=0; layoutOffset=0.0');
+    expect(candidate.toString(), 'index=0; layoutOffset=None');
     candidate.index = 1;
-    expect(candidate.toString(), 'index=1; layoutOffset=0.0');
+    expect(candidate.toString(), 'index=1; layoutOffset=None');
     candidate.index = -1;
-    expect(candidate.toString(), 'index=-1; layoutOffset=0.0');
+    expect(candidate.toString(), 'index=-1; layoutOffset=None');
+    candidate.layoutOffset = 100.0;
+    expect(candidate.toString(), 'index=-1; layoutOffset=100.0');
   });
 }

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -50,7 +50,8 @@ Future<void> testSliverFixedExtentList(WidgetTester tester, List<String> items) 
               findChildIndexCallback: (Key key) {
                 final ValueKey<String> valueKey = key as ValueKey<String>;
                 final String data = valueKey.value;
-                return items.indexOf(data);
+                final int index = items.indexOf(data);
+                return index == -1 ? null : index;
               },
             ),
           ),


### PR DESCRIPTION
This reverts commit 3998549d529cb21488e5720a4c81cb20015e18e6.

## Description

Previous pr was reverted due to internal test failure. This is now ready to reland

## Related Issues

Fixes https://github.com/flutter/flutter/issues/42142

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
