### PR TITLE
Remove dead vmservice.RPCError catch

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -520,8 +520,6 @@ class _ResidentWebRunner extends ResidentWebRunner {
       return OperationResult(1, err.toString(), fatal: true);
     } on WipError catch (err) {
       return OperationResult(1, err.toString(), fatal: true);
-    } on vmservice.RPCError catch (err) {
-      return OperationResult(1, err.toString(), fatal: true);
     } finally {
       status.stop();
     }


### PR DESCRIPTION
## Description
analysis failure on devicelab:
```
2020-03-24T13:18:41.666233: stdout:    info • Dead code: This on-catch block won’t be executed because 'RPCError' is a subtype of 'Exception' and hence will have been caught already • packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart:523:7 • dead_code_on_catch_subtype
```

## Related Issues

Introduced in https://github.com/flutter/flutter/pull/53183.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*