### PR TITLE
Convert idevicescreenshot and upgradePbxProjWithFlutterAssets tests to testWithoutContext

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -66,7 +66,7 @@ class IMobileDevice {
 
   /// Captures a screenshot to the specified outputFile.
   Future<void> takeScreenshot(File outputFile) {
-    return processUtils.run(
+    return _processUtils.run(
       <String>[
         _idevicescreenshotPath,
         outputFile.path,
@@ -87,7 +87,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   DarwinArch activeArch,
   bool codesign = true,
 }) async {
-  if (!upgradePbxProjWithFlutterAssets(app.project)) {
+  if (!upgradePbxProjWithFlutterAssets(app.project, globals.logger)) {
     return XcodeBuildResult(success: false);
   }
 
@@ -562,7 +562,7 @@ bool _checkXcodeVersion() {
 }
 
 // TODO(jmagman): Refactor to IOSMigrator.
-bool upgradePbxProjWithFlutterAssets(IosProject project) {
+bool upgradePbxProjWithFlutterAssets(IosProject project, Logger logger) {
   final File xcodeProjectFile = project.xcodeProjectInfoFile;
   assert(xcodeProjectFile.existsSync());
   final List<String> lines = xcodeProjectFile.readAsLinesSync();
@@ -575,7 +575,7 @@ bool upgradePbxProjWithFlutterAssets(IosProject project) {
     final Match match = oldAssets.firstMatch(line);
     if (match != null) {
       if (printedStatuses.add(match.group(1))) {
-        globals.printStatus('Removing obsolete reference to ${match.group(1)} from ${project.hostAppBundleName}');
+        logger.printStatus('Removing obsolete reference to ${match.group(1)} from ${project.hostAppBundleName}');
       }
     } else {
       buffer.writeln(line);

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:math';
 
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/artifacts.dart';

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:math';
 
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/artifacts.dart';
@@ -36,15 +37,19 @@ class MockXcodeProjectInterpreter extends Mock implements XcodeProjectInterprete
 class MockIosProject extends Mock implements IosProject {}
 
 void main() {
+  BufferLogger logger;
+
+  setUp(() {
+    logger = BufferLogger.test();
+  });
+
   group('IMobileDevice', () {
     final String libimobiledevicePath = globals.fs.path.join('bin', 'cache', 'artifacts', 'libimobiledevice');
     final String idevicescreenshotPath = globals.fs.path.join(libimobiledevicePath, 'idevicescreenshot');
     MockArtifacts mockArtifacts;
     MockCache mockCache;
-    Logger logger;
 
     setUp(() {
-      logger = BufferLogger.test();
       mockCache = MockCache();
       mockArtifacts = MockArtifacts();
       when(mockArtifacts.getArtifactPath(Artifact.idevicescreenshot, platform: anyNamed('platform'))).thenReturn(idevicescreenshotPath);
@@ -83,7 +88,7 @@ void main() {
         expect(() async => await iMobileDevice.takeScreenshot(mockOutputFile), throwsA(anything));
       });
 
-      testUsingContext('idevicescreenshot captures and returns screenshot', () async {
+      testWithoutContext('idevicescreenshot captures and returns screenshot', () async {
         when(mockOutputFile.path).thenReturn(outputPath);
         when(mockProcessManager.run(any, environment: anyNamed('environment'), workingDirectory: null)).thenAnswer(
             (Invocation invocation) => Future<ProcessResult>.value(ProcessResult(4, 0, '', '')));
@@ -100,8 +105,6 @@ void main() {
             environment: <String, String>{'DYLD_LIBRARY_PATH': libimobiledevicePath},
             workingDirectory: null,
         ));
-      }, overrides: <Type, Generator>{
-        ProcessManager: () => mockProcessManager,
       });
     });
   });
@@ -389,7 +392,7 @@ Exited (sigterm)''',
       'another line',
     ];
 
-    testUsingContext('upgradePbxProjWithFlutterAssets', () async {
+    testWithoutContext('upgradePbxProjWithFlutterAssets', () async {
       final MockIosProject project = MockIosProject();
       final MockFile pbxprojFile = MockFile();
 
@@ -400,30 +403,30 @@ Exited (sigterm)''',
       when(pbxprojFile.existsSync())
           .thenAnswer((_) => true);
 
-      bool result = upgradePbxProjWithFlutterAssets(project);
+      bool result = upgradePbxProjWithFlutterAssets(project, logger);
       expect(result, true);
       expect(
-        testLogger.statusText,
+        logger.statusText,
         contains('Removing obsolete reference to flutter_assets'),
       );
-      testLogger.clear();
+      logger.clear();
 
       when(pbxprojFile.readAsLinesSync())
           .thenAnswer((_) => appFlxPbxProjLines);
-      result = upgradePbxProjWithFlutterAssets(project);
+      result = upgradePbxProjWithFlutterAssets(project, logger);
       expect(result, true);
       expect(
-        testLogger.statusText,
+        logger.statusText,
         contains('Removing obsolete reference to app.flx'),
       );
-      testLogger.clear();
+      logger.clear();
 
       when(pbxprojFile.readAsLinesSync())
           .thenAnswer((_) => cleanPbxProjLines);
-      result = upgradePbxProjWithFlutterAssets(project);
+      result = upgradePbxProjWithFlutterAssets(project, logger);
       expect(result, true);
       expect(
-        testLogger.statusText,
+        logger.statusText,
         isEmpty,
       );
     });


### PR DESCRIPTION
## Description

Inject logger into upgradePbxProjWithFlutterAssets, use existing _processUtils in idevicescreenshot.

## Related Issues

#47161

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*