### PR TITLE
fixed typo in HttpClient failure message

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -467,7 +467,7 @@ Future<void> _runFrameworkTests() async {
       'Warning: At least one test in this suite creates an HttpClient. When\n'
       'running a test suite that uses TestWidgetsFlutterBinding, all HTTP\n'
       'requests will return status code 400, and no network request will\n'
-      'actually be made. Any test expecting an real network connection and\n'
+      'actually be made. Any test expecting a real network connection and\n'
       'status code will fail.\n'
       'To test code that needs an HttpClient, provide your own HttpClient\n'
       'implementation to the code under test, so that your test can\n'

--- a/packages/flutter_test/lib/src/_binding_io.dart
+++ b/packages/flutter_test/lib/src/_binding_io.dart
@@ -84,7 +84,7 @@ class _MockHttpOverrides extends HttpOverrides {
         'Warning: At least one test in this suite creates an HttpClient. When\n'
         'running a test suite that uses TestWidgetsFlutterBinding, all HTTP\n'
         'requests will return status code 400, and no network request will\n'
-        'actually be made. Any test expecting an real network connection and\n'
+        'actually be made. Any test expecting a real network connection and\n'
         'status code will fail.\n'
         'To test code that needs an HttpClient, provide your own HttpClient\n'
         'implementation to the code under test, so that your test can\n'


### PR DESCRIPTION
## Description

Fixed a typo in the failure message that appears when running a test that creates an HttpClient ("an real" -> "a real"). I saw this message when testing my own app and thought I might as well submit a PR.

## Related Issues

No related issues as the tree hygiene wiki page implies trivial changes don't need a corresponding issue.

## Tests

No new tests added but 1 existing test modified to account for the missing character. Didn't create a breaking change document as it seemed overkill for this change, but I can if it's required.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
