### PR TITLE
[flutter_tool] Timeout the Azure bot detector http request

### DIFF
--- a/packages/flutter_tools/lib/src/base/bot_detector.dart
+++ b/packages/flutter_tools/lib/src/base/bot_detector.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:meta/meta.dart';
 import 'package:platform/platform.dart';
 
@@ -95,12 +97,14 @@ class AzureDetector {
     if (_isRunningOnAzure != null) {
       return _isRunningOnAzure;
     }
+    const Duration connectionTimeout = Duration(milliseconds: 250);
+    const Duration requestTimeout = Duration(seconds: 1);
     final HttpClient client = _httpClientFactory()
-      ..connectionTimeout = const Duration(milliseconds: 250);
+      ..connectionTimeout = connectionTimeout;
     try {
       final HttpClientRequest request = await client.getUrl(
         Uri.parse(_serviceUrl),
-      );
+      ).timeout(requestTimeout);
       request.headers.add('Metadata', true);
       await request.close();
     } on SocketException {
@@ -111,6 +115,10 @@ class AzureDetector {
       // If the connection gets set up, but encounters an error condition, it
       // still means we're on Azure.
       return _isRunningOnAzure = true;
+    } on TimeoutException {
+      // The HttpClient connected to a host, but it did not respond in a timely
+      // fashion. Assume we are not on a bot.
+      return _isRunningOnAzure = false;
     }
     // We got a response. We're running on Azure.
     return _isRunningOnAzure = true;


### PR DESCRIPTION
## Description

When not on Azure, depending on the environment, the connection setup might not timeout, but the http request will. This PR adds a timeout for this case.

## Related Issues

https://github.com/flutter/flutter/issues/53098

## Tests

I added the following tests:

Added test to bot_detector_test.dart

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
