### PR TITLE
Revert "Replace uses of deprecated CastError with TypeError (#53221)"

### DIFF
--- a/packages/flutter/test/services/platform_channel_test.dart
+++ b/packages/flutter/test/services/platform_channel_test.dart
@@ -70,7 +70,7 @@ void main() {
           }
         },
       );
-      expect(channel.invokeMethod<List<String>>('sayHello', 'hello'), throwsA(isInstanceOf<TypeError>()));
+      expect(channel.invokeMethod<List<String>>('sayHello', 'hello'), throwsA(isCastError));
       expect(await channel.invokeListMethod<String>('sayHello', 'hello'), <String>['hello', 'world']);
     });
 
@@ -102,7 +102,7 @@ void main() {
           }
         },
       );
-      expect(channel.invokeMethod<Map<String, String>>('sayHello', 'hello'), throwsA(isInstanceOf<TypeError>()));
+      expect(channel.invokeMethod<Map<String, String>>('sayHello', 'hello'), throwsA(isCastError));
       expect(await channel.invokeMapMethod<String, String>('sayHello', 'hello'), <String, String>{'hello': 'world'});
     });
 

--- a/packages/flutter_tools/lib/src/build_system/targets/icon_tree_shaker.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/icon_tree_shaker.dart
@@ -25,7 +25,7 @@ const bool kIconTreeShakerEnabledDefault = false;
 List<Map<String, dynamic>> _getList(dynamic object, String errorMessage) {
   try {
     return (object as List<dynamic>).cast<Map<String, dynamic>>();
-  } on TypeError catch (_) {
+  } on CastError catch (_) {
     throw IconTreeShakerException._(errorMessage);
   }
 }


### PR DESCRIPTION
This reverts commit 6c7c2e372ae6cbf20c6601f4eb11f9cbfb09b591.

## Description

The run_release_test and flutter_gallery_ios32__transition_perf bots went red on the CastError deprecation PR.   Reverting out of an abundance of caution, I'll sort it out and reland tomorrow.

TBR=dnfield