### PR TITLE
[flutter_tools] Prepare for OSError to implement Exception

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/icon_tree_shaker.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/icon_tree_shaker.dart
@@ -188,7 +188,7 @@ class IconTreeShaker {
       await fontSubsetProcess.stdin.close();
     } on Exception catch (_) {
       // handled by checking the exit code.
-    } on OSError catch (_) {
+    } on OSError catch (_) {  // ignore: dead_code_on_catch_subtype
       // handled by checking the exit code.
     }
 


### PR DESCRIPTION
`OSError` will soon implement `Exception`. Prepare for this by ignoring analyzer warnings about dead code in catch clauses that catch both `Exception` and `OSError`.

@ZichangG 