### PR TITLE
allow setting the active tab background color

### DIFF
--- a/packages/flutter/lib/src/cupertino/bottom_tab_bar.dart
+++ b/packages/flutter/lib/src/cupertino/bottom_tab_bar.dart
@@ -56,6 +56,7 @@ class CupertinoTabBar extends StatelessWidget implements PreferredSizeWidget {
     this.currentIndex = 0,
     this.backgroundColor,
     this.activeColor,
+    this.activeBackgroundColor = const Color(0x00000000),
     this.inactiveColor = _kDefaultTabBarInactiveColor,
     this.iconSize = 30.0,
     this.border = const Border(
@@ -100,6 +101,11 @@ class CupertinoTabBar extends StatelessWidget implements PreferredSizeWidget {
   ///
   /// Defaults to [CupertinoTheme]'s `barBackgroundColor` when null.
   final Color backgroundColor;
+
+  /// The background color of the active tab bar item.
+  ///
+  /// Defaults to transparent when null.
+  final Color activeBackgroundColor;
 
   /// The foreground color of the icon and title for the [BottomNavigationBarItem]
   /// of the selected tab.
@@ -176,13 +182,10 @@ class CupertinoTabBar extends StatelessWidget implements PreferredSizeWidget {
           data: IconThemeData(color: inactive, size: iconSize),
           child: DefaultTextStyle( // Default with the inactive state.
             style: CupertinoTheme.of(context).textTheme.tabLabelTextStyle.copyWith(color: inactive),
-            child: Padding(
-              padding: EdgeInsets.only(bottom: bottomPadding),
-              child: Row(
-                // Align bottom since we want the labels to be aligned.
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: _buildTabItems(context),
-              ),
+            child: Row(
+              // Align bottom since we want the labels to be aligned.
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: _buildTabItems(context),
             ),
           ),
         ),
@@ -204,6 +207,7 @@ class CupertinoTabBar extends StatelessWidget implements PreferredSizeWidget {
 
   List<Widget> _buildTabItems(BuildContext context) {
     final List<Widget> result = <Widget>[];
+    final double bottomPadding = MediaQuery.of(context).padding.bottom;
 
     for (int index = 0; index < items.length; index += 1) {
       final bool active = index == currentIndex;
@@ -218,11 +222,14 @@ class CupertinoTabBar extends StatelessWidget implements PreferredSizeWidget {
               child: GestureDetector(
                 behavior: HitTestBehavior.opaque,
                 onTap: onTap == null ? null : () { onTap(index); },
-                child: Padding(
-                  padding: const EdgeInsets.only(bottom: 4.0),
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    children: _buildSingleTabItem(items[index], active),
+                child: Container(
+                  color: active ? activeBackgroundColor : null,
+                  child: Padding(
+                    padding: EdgeInsets.only(bottom: bottomPadding + 4, top: 4),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      children: _buildSingleTabItem(items[index], active),
+                    ),
                   ),
                 ),
               ),
@@ -269,6 +276,7 @@ class CupertinoTabBar extends StatelessWidget implements PreferredSizeWidget {
     Key key,
     List<BottomNavigationBarItem> items,
     Color backgroundColor,
+    Color activeBackgroundColor,
     Color activeColor,
     Color inactiveColor,
     double iconSize,
@@ -280,6 +288,7 @@ class CupertinoTabBar extends StatelessWidget implements PreferredSizeWidget {
       key: key ?? this.key,
       items: items ?? this.items,
       backgroundColor: backgroundColor ?? this.backgroundColor,
+      activeBackgroundColor: activeBackgroundColor ?? this.activeBackgroundColor,
       activeColor: activeColor ?? this.activeColor,
       inactiveColor: inactiveColor ?? this.inactiveColor,
       iconSize: iconSize ?? this.iconSize,

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -178,6 +178,7 @@ class BottomNavigationBar extends StatefulWidget {
     this.backgroundColor,
     this.iconSize = 24.0,
     Color selectedItemColor,
+    this.activeBackgroundColor = Colors.transparent,
     this.unselectedItemColor,
     this.selectedIconTheme = const IconThemeData(),
     this.unselectedIconTheme = const IconThemeData(),
@@ -247,6 +248,11 @@ class BottomNavigationBar extends StatefulWidget {
   /// [items]s, have [BottomNavigationBarItem.backgroundColor] set, the [item]'s
   /// backgroundColor will splash and overwrite this color.
   final Color backgroundColor;
+
+  /// The color of the active [BottomNavigationBar] item.
+  ///
+  /// defaults to transparent when null
+  final Color activeBackgroundColor;
 
   /// The size of all of the [BottomNavigationBarItem] icons.
   ///
@@ -363,6 +369,7 @@ class _BottomNavigationTile extends StatelessWidget {
     this.colorTween,
     this.flex,
     this.selected = false,
+    this.activeBackgroundColor,
     @required this.selectedLabelStyle,
     @required this.unselectedLabelStyle,
     @required this.selectedIconTheme,
@@ -392,6 +399,7 @@ class _BottomNavigationTile extends StatelessWidget {
   final String indexLabel;
   final bool showSelectedLabels;
   final bool showUnselectedLabels;
+  final Color activeBackgroundColor;
 
   @override
   Widget build(BuildContext context) {
@@ -471,52 +479,55 @@ class _BottomNavigationTile extends StatelessWidget {
 
     return Expanded(
       flex: size,
-      child: Semantics(
-        container: true,
-        selected: selected,
-        child: Stack(
-          children: <Widget>[
-            InkResponse(
-              onTap: onTap,
-              child: Padding(
-                padding: EdgeInsets.only(top: topPadding, bottom: bottomPadding),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  mainAxisSize: MainAxisSize.min,
-                  children: <Widget>[
-                    _TileIcon(
-                      colorTween: colorTween,
-                      animation: animation,
-                      iconSize: iconSize,
-                      selected: selected,
-                      item: item,
-                      selectedIconTheme: selectedIconTheme,
-                      unselectedIconTheme: unselectedIconTheme,
-                    ),
-                    _Label(
-                      colorTween: colorTween,
-                      animation: animation,
-                      item: item,
-                      selectedLabelStyle: selectedLabelStyle,
-                      unselectedLabelStyle: unselectedLabelStyle,
-                      showSelectedLabels: showSelectedLabels,
-                      showUnselectedLabels: showUnselectedLabels,
-                    ),
-                  ],
+      child: Container(
+        color: selected ? activeBackgroundColor : Colors.transparent,
+        child: Semantics(
+          container: true,
+          selected: selected,
+          child: Stack(
+            children: <Widget>[
+              InkResponse(
+                onTap: onTap,
+                child: Padding(
+                  padding:
+                      EdgeInsets.only(top: topPadding, bottom: bottomPadding),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    mainAxisSize: MainAxisSize.min,
+                    children: <Widget>[
+                      _TileIcon(
+                        colorTween: colorTween,
+                        animation: animation,
+                        iconSize: iconSize,
+                        selected: selected,
+                        item: item,
+                        selectedIconTheme: selectedIconTheme,
+                        unselectedIconTheme: unselectedIconTheme,
+                      ),
+                      _Label(
+                        colorTween: colorTween,
+                        animation: animation,
+                        item: item,
+                        selectedLabelStyle: selectedLabelStyle,
+                        unselectedLabelStyle: unselectedLabelStyle,
+                        showSelectedLabels: showSelectedLabels,
+                        showUnselectedLabels: showUnselectedLabels,
+                      ),
+                    ],
+                  ),
                 ),
               ),
-            ),
-            Semantics(
-              label: indexLabel,
-            ),
-          ],
+              Semantics(
+                label: indexLabel,
+              ),
+            ],
+          ),
         ),
       ),
     );
   }
 }
-
 
 class _TileIcon extends StatelessWidget {
   const _TileIcon({
@@ -825,6 +836,7 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
         _animations[i],
         widget.iconSize,
         selectedIconTheme: widget.selectedIconTheme,
+        activeBackgroundColor: widget.activeBackgroundColor,
         unselectedIconTheme: widget.unselectedIconTheme,
         selectedLabelStyle: effectiveSelectedLabelStyle,
         unselectedLabelStyle: effectiveUnselectedLabelStyle,


### PR DESCRIPTION
## Description

This PR adds the possibility to change the active background color for a  `BottomNavigationBarItem` within a `CupertinoTabBar`
e.g.

```dart
//ios
CupertinoTabBar(
          backgroundColor: Colors.black,
          activeBackgroundColor: Colors.red, //this is the change
          items: [/* items here */],
        );

// android
BottomNavigationBar(
          items: [/* items here */],
          backgroundColor: Colors.black,
          activeBackgroundColor: Colors.red, // this is the change
        )
```

## Related Issues

Fixes #34788


## Tests

I added the following tests:

* none (needed?)

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.
