### PR TITLE
Allow user to specify which Chrome binary to use.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -544,7 +544,7 @@ Future<async_io.WebDriver> _createDriver(String driverPort, Browser browser, boo
 /// Returns desired capabilities for given [browser], [headless] and
 /// [chromeBinary].
 @visibleForTesting
-Map<String, dynamic> getDesiredCapabilities(Browser browser, bool headless, String chromeBinary) {
+Map<String, dynamic> getDesiredCapabilities(Browser browser, bool headless, [String chromeBinary]) {
   switch (browser) {
     case Browser.chrome:
       final Map<String, dynamic> chromeOptions = <String, dynamic>{

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -547,35 +547,33 @@ Future<async_io.WebDriver> _createDriver(String driverPort, Browser browser, boo
 Map<String, dynamic> getDesiredCapabilities(Browser browser, bool headless, [String chromeBinary]) {
   switch (browser) {
     case Browser.chrome:
-      final Map<String, dynamic> chromeOptions = <String, dynamic>{
-        'w3c': false,
-        'args': <String>[
-          '--bwsi',
-          '--disable-background-timer-throttling',
-          '--disable-default-apps',
-          '--disable-extensions',
-          '--disable-popup-blocking',
-          '--disable-translate',
-          '--no-default-browser-check',
-          '--no-sandbox',
-          '--no-first-run',
-          if (headless) '--headless'
-        ],
-        'perfLoggingPrefs': <String, String>{
-          'traceCategories':
-          'devtools.timeline,'
-              'v8,blink.console,benchmark,blink,'
-              'blink.user_timing'
-        }
-      };
-      if (chromeBinary != null) {
-        chromeOptions['binary'] = chromeBinary;
-      }
       return <String, dynamic>{
         'acceptInsecureCerts': true,
         'browserName': 'chrome',
         'goog:loggingPrefs': <String, String>{ async_io.LogType.performance: 'ALL'},
-        'chromeOptions': chromeOptions,
+        'chromeOptions': <String, dynamic>{
+          if (chromeBinary != null)
+            'binary': chromeBinary,
+          'w3c': false,
+          'args': <String>[
+            '--bwsi',
+            '--disable-background-timer-throttling',
+            '--disable-default-apps',
+            '--disable-extensions',
+            '--disable-popup-blocking',
+            '--disable-translate',
+            '--no-default-browser-check',
+            '--no-sandbox',
+            '--no-first-run',
+            if (headless) '--headless'
+          ],
+          'perfLoggingPrefs': <String, String>{
+            'traceCategories':
+            'devtools.timeline,'
+                'v8,blink.console,benchmark,blink,'
+                'blink.user_timing'
+          }
+        },
       };
       break;
     case Browser.firefox:

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -248,7 +248,7 @@ class DriveCommand extends RunCommandBase {
           driverPort,
           browser,
           argResults['headless'].toString() == 'true',
-          argResults['chrome-binary'] as String,
+          stringArg('chrome-binary'),
         );
       } on Exception catch (ex) {
         throwToolExit(

--- a/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
@@ -612,11 +612,13 @@ void main() {
     });
 
     test('Chrome with headless off', () {
+      const String chromeBinary = 'random-binary';
       final Map<String, dynamic> expected = <String, dynamic>{
         'acceptInsecureCerts': true,
         'browserName': 'chrome',
         'goog:loggingPrefs': <String, String>{ sync_io.LogType.performance: 'ALL'},
         'chromeOptions': <String, dynamic>{
+          'binary': chromeBinary,
           'w3c': false,
           'args': <String>[
             '--bwsi',
@@ -638,7 +640,7 @@ void main() {
         }
       };
 
-      expect(getDesiredCapabilities(Browser.chrome, false), expected);
+      expect(getDesiredCapabilities(Browser.chrome, false, chromeBinary), expected);
 
     });
 


### PR DESCRIPTION
## Description

Allow user to specify which Chrome binary to use via argument `chrome-binary`.

For example,

flutter drive --target=test_driver/scroll_perf_web.dart -v --browser-name=chrome --no-headless --release --chrome-binary="/Applications/Google Chrome 2.app/Contents/MacOS/Google Chrome"

## Related Issues

#53179 

## Tests

Updated drive.test to reflect new changes.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
