### PR TITLE
Renamed test class to avoid conflict with the navigator page api.

### DIFF
--- a/dev/integration_tests/android_views/lib/main.dart
+++ b/dev/integration_tests/android_views/lib/main.dart
@@ -7,7 +7,7 @@ import 'package:flutter_driver/driver_extension.dart';
 import 'motion_events_page.dart';
 import 'page.dart';
 
-final List<Page> _allPages = <Page>[
+final List<PageWidget> _allPages = <PageWidget>[
   const MotionEventsPage(),
 ];
 
@@ -31,7 +31,7 @@ class Home extends StatelessWidget {
     );
   }
 
-  void _pushPage(BuildContext context, Page page) {
+  void _pushPage(BuildContext context, PageWidget page) {
     Navigator.of(context).push(MaterialPageRoute<void>(
         builder: (_) => Scaffold(
               body: page,

--- a/dev/integration_tests/android_views/lib/motion_events_page.dart
+++ b/dev/integration_tests/android_views/lib/motion_events_page.dart
@@ -18,7 +18,7 @@ MethodChannel channel = const MethodChannel('android_views_integration');
 
 const String kEventsFileName = 'touchEvents';
 
-class MotionEventsPage extends Page {
+class MotionEventsPage extends PageWidget {
   const MotionEventsPage()
       : super('Motion Event Tests', const ValueKey<String>('MotionEventsListTile'));
 

--- a/dev/integration_tests/android_views/lib/page.dart
+++ b/dev/integration_tests/android_views/lib/page.dart
@@ -7,8 +7,8 @@ import 'package:flutter/material.dart';
 /// The base class of all the testing pages
 //
 /// A testing page has to override this in order to be put as one of the items in the main page.
-abstract class Page extends StatelessWidget {
-  const Page(this.title, this.tileKey);
+abstract class PageWidget extends StatelessWidget {
+  const PageWidget(this.title, this.tileKey);
 
   /// The title of the testing page
   ///

--- a/dev/integration_tests/flutter_driver_screenshot_test/lib/image_page.dart
+++ b/dev/integration_tests/flutter_driver_screenshot_test/lib/image_page.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import './page.dart';
 
 /// The page that shows an image.
-class ImagePage extends Page {
+class ImagePage extends PageWidget {
 
   /// Constructs the ImagePage object.
   const ImagePage()

--- a/dev/integration_tests/flutter_driver_screenshot_test/lib/main.dart
+++ b/dev/integration_tests/flutter_driver_screenshot_test/lib/main.dart
@@ -9,7 +9,7 @@ import 'package:device_info/device_info.dart';
 import './image_page.dart';
 import './page.dart';
 
-final List<Page> _allPages = <Page>[
+final List<PageWidget> _allPages = <PageWidget>[
   const ImagePage(),
 ];
 
@@ -62,7 +62,7 @@ class _MyHomePageState extends State<_MyHomePage> {
     );
   }
 
-  void _pushPage(BuildContext context, Page page) {
+  void _pushPage(BuildContext context, PageWidget page) {
     Navigator.of(context).push(MaterialPageRoute<void>(
       builder: (_) => page,
     ));

--- a/dev/integration_tests/flutter_driver_screenshot_test/lib/page.dart
+++ b/dev/integration_tests/flutter_driver_screenshot_test/lib/page.dart
@@ -5,10 +5,10 @@
 import 'package:flutter/material.dart';
 
 /// The base class for all the pages in this test.
-abstract class Page extends StatelessWidget {
+abstract class PageWidget extends StatelessWidget {
 
   /// Constructs a `Page` object.
-  const Page({@required this.title, @required Key key}):super(key: key);
+  const PageWidget({@required this.title, @required Key key}):super(key: key);
 
   /// The text that shows on the list item on the main page as well as the navigation bar on the sub page.
   final String title;


### PR DESCRIPTION
## Description

We introduced a new class Page in navigator page api. However, there are several classes in tests that use the same name. This pr rename those test classes to avoid future conflict.
The page api pr https://github.com/flutter/flutter/pull/50362
## Related Issues

https://github.com/flutter/flutter/issues/45938

## Tests

I added the following tests:

N/A

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
