### PR TITLE
Revert "Move processUtils into globals (#53209)"

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -225,7 +225,7 @@ class AndroidDevice extends Device {
     bool allowReentrantFlutter = false,
     Map<String, String> environment,
   }) {
-    return globals.processUtils.runSync(
+    return processUtils.runSync(
       adbCommandForDevice(params),
       throwOnError: true,
       workingDirectory: workingDirectory,
@@ -240,7 +240,7 @@ class AndroidDevice extends Device {
     String workingDirectory,
     bool allowReentrantFlutter = false,
   }) async {
-    return globals.processUtils.run(
+    return processUtils.run(
       adbCommandForDevice(params),
       throwOnError: true,
       workingDirectory: workingDirectory,
@@ -278,7 +278,7 @@ class AndroidDevice extends Device {
     }
 
     try {
-      final RunResult adbVersion = await globals.processUtils.run(
+      final RunResult adbVersion = await processUtils.run(
         <String>[getAdbPath(androidSdk), 'version'],
         throwOnError: true,
       );
@@ -299,7 +299,7 @@ class AndroidDevice extends Device {
       // output lines like this, which we want to ignore:
       //   adb server is out of date.  killing..
       //   * daemon started successfully *
-      await globals.processUtils.run(
+      await processUtils.run(
         <String>[getAdbPath(androidSdk), 'start-server'],
         throwOnError: true,
       );
@@ -336,7 +336,7 @@ class AndroidDevice extends Device {
   }
 
   Future<String> _getDeviceApkSha1(AndroidApk apk) async {
-    final RunResult result = await globals.processUtils.run(
+    final RunResult result = await processUtils.run(
       adbCommandForDevice(<String>['shell', 'cat', _getDeviceSha1Path(apk)]));
     return result.stdout;
   }
@@ -380,7 +380,7 @@ class AndroidDevice extends Device {
     }
 
     final Status status = globals.logger.startProgress('Installing ${globals.fs.path.relative(app.file.path)}...', timeout: timeoutConfiguration.slowOperation);
-    final RunResult installResult = await globals.processUtils.run(
+    final RunResult installResult = await processUtils.run(
       adbCommandForDevice(<String>['install', '-t', '-r', app.file.path]));
     status.stop();
     // Some versions of adb exit with exit code 0 even on failure :(
@@ -416,7 +416,7 @@ class AndroidDevice extends Device {
 
     String uninstallOut;
     try {
-      final RunResult uninstallResult = await globals.processUtils.run(
+      final RunResult uninstallResult = await processUtils.run(
         adbCommandForDevice(<String>['uninstall', app.id]),
         throwOnError: true,
       );
@@ -647,13 +647,13 @@ class AndroidDevice extends Device {
   @override
   Future<bool> stopApp(AndroidApk app) {
     final List<String> command = adbCommandForDevice(<String>['shell', 'am', 'force-stop', app.id]);
-    return globals.processUtils.stream(command).then<bool>(
+    return processUtils.stream(command).then<bool>(
         (int exitCode) => exitCode == 0 || allowHeapCorruptionOnWindows(exitCode));
   }
 
   @override
   Future<MemoryInfo> queryMemoryInfo() async {
-    final RunResult runResult = await globals.processUtils.run(adbCommandForDevice(<String>[
+    final RunResult runResult = await processUtils.run(adbCommandForDevice(<String>[
       'shell',
       'dumpsys',
       'meminfo',
@@ -669,7 +669,7 @@ class AndroidDevice extends Device {
 
   @override
   void clearLogs() {
-    globals.processUtils.runSync(adbCommandForDevice(<String>['logcat', '-c']));
+    processUtils.runSync(adbCommandForDevice(<String>['logcat', '-c']));
   }
 
   @override
@@ -709,7 +709,7 @@ class AndroidDevice extends Device {
   Future<void> takeScreenshot(File outputFile) async {
     const String remotePath = '/data/local/tmp/flutter_screenshot.png';
     await runAdbCheckedAsync(<String>['shell', 'screencap', '-p', remotePath]);
-    await globals.processUtils.run(
+    await processUtils.run(
       adbCommandForDevice(<String>['pull', remotePath, outputFile.path]),
       throwOnError: true,
     );
@@ -1074,7 +1074,7 @@ class _AndroidDevicePortForwarder extends DevicePortForwarder {
 
     String stdout;
     try {
-      stdout = globals.processUtils.runSync(
+      stdout = processUtils.runSync(
         device.adbCommandForDevice(<String>['forward', '--list']),
         throwOnError: true,
       ).stdout.trim();
@@ -1118,7 +1118,7 @@ class _AndroidDevicePortForwarder extends DevicePortForwarder {
       'tcp:$hostPort',
       'tcp:$devicePort',
     ];
-    final RunResult process = await globals.processUtils.run(
+    final RunResult process = await processUtils.run(
       device.adbCommandForDevice(forwardCommand),
       throwOnError: true,
     );
@@ -1171,7 +1171,7 @@ class _AndroidDevicePortForwarder extends DevicePortForwarder {
       '--remove',
       'tcp:${forwardedPort.hostPort}',
     ];
-    await globals.processUtils.run(
+    await processUtils.run(
       device.adbCommandForDevice(unforwardCommand),
       throwOnError: true,
     );

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -11,6 +11,7 @@ import '../android/android_workflow.dart';
 import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
+import '../base/process.dart';
 import '../base/utils.dart';
 import '../convert.dart';
 import '../device.dart';
@@ -53,7 +54,7 @@ class AndroidEmulator extends Emulator {
 
   @override
   Future<void> launch() async {
-    final Process process = await globals.processUtils.start(
+    final Process process = await processUtils.start(
       <String>[getEmulatorPath(androidSdk), '-avd', id],
     );
 
@@ -116,7 +117,7 @@ List<AndroidEmulator> getEmulatorAvds() {
     return <AndroidEmulator>[];
   }
 
-  final String listAvdsOutput = globals.processUtils.runSync(
+  final String listAvdsOutput = processUtils.runSync(
     <String>[emulatorPath, '-list-avds']).stdout.trim();
 
   final List<AndroidEmulator> emulators = <AndroidEmulator>[];

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -582,7 +582,7 @@ class AndroidSdk {
     // See: http://stackoverflow.com/questions/14292698/how-do-i-check-if-the-java-jdk-is-installed-on-mac.
     if (platform.isMacOS) {
       try {
-        final String javaHomeOutput = globals.processUtils.runSync(
+        final String javaHomeOutput = processUtils.runSync(
           <String>['/usr/libexec/java_home'],
           throwOnError: true,
           hideStdout: true,
@@ -628,7 +628,7 @@ class AndroidSdk {
     if (!globals.processManager.canRun(sdkManagerPath)) {
       throwToolExit('Android sdkmanager not found. Update to the latest Android SDK to resolve this.');
     }
-    final RunResult result = globals.processUtils.runSync(
+    final RunResult result = processUtils.runSync(
       <String>[sdkManagerPath, '--version'],
       environment: sdkManagerEnv,
     );

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -310,7 +310,7 @@ class AndroidStudio implements Comparable<AndroidStudio> {
     } else {
       RunResult result;
       try {
-        result = globals.processUtils.runSync(<String>[javaExecutable, '-version']);
+        result = processUtils.runSync(<String>[javaExecutable, '-version']);
       } on ProcessException catch (e) {
         _validationMessages.add('Failed to run Java: $e');
       }

--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -14,6 +14,7 @@ import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/os.dart';
+import '../base/process.dart';
 import '../base/user_messages.dart';
 import '../base/utils.dart';
 import '../base/version.dart';
@@ -322,7 +323,7 @@ class AndroidLicenseValidator extends DoctorValidator {
     }
 
     try {
-      final Process process = await globals.processUtils.start(
+      final Process process = await processUtils.start(
         <String>[androidSdk.sdkManagerPath, '--licenses'],
         environment: androidSdk.sdkManagerEnv,
       );
@@ -359,7 +360,7 @@ class AndroidLicenseValidator extends DoctorValidator {
     }
 
     try {
-      final Process process = await globals.processUtils.start(
+      final Process process = await processUtils.start(
         <String>[androidSdk.sdkManagerPath, '--licenses'],
         environment: androidSdk.sdkManagerEnv,
       );

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -142,7 +142,7 @@ Future<void> checkGradleDependencies() async {
     timeout: timeoutConfiguration.slowOperation,
   );
   final FlutterProject flutterProject = FlutterProject.current();
-  await globals.processUtils.run(<String>[
+  await processUtils.run(<String>[
       gradleUtils.getExecutable(flutterProject),
       'dependencies',
     ],
@@ -382,7 +382,7 @@ Future<void> buildGradleApp({
   final Stopwatch sw = Stopwatch()..start();
   int exitCode = 1;
   try {
-    exitCode = await globals.processUtils.stream(
+    exitCode = await processUtils.stream(
       command,
       workingDirectory: project.android.hostAppGradleRoot.path,
       allowReentrantFlutter: true,
@@ -584,7 +584,7 @@ Future<void> buildGradleAar({
   final Stopwatch sw = Stopwatch()..start();
   RunResult result;
   try {
-    result = await globals.processUtils.run(
+    result = await processUtils.run(
       command,
       workingDirectory: project.android.hostAppGradleRoot.path,
       allowReentrantFlutter: true,

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -270,7 +270,7 @@ final GradleHandledError flavorUndefinedHandler = GradleHandledError(
     bool usesAndroidX,
     bool shouldBuildPluginAsAar,
   }) async {
-    final RunResult tasksRunResult = await globals.processUtils.run(
+    final RunResult tasksRunResult = await processUtils.run(
       <String>[
         gradleUtils.getExecutable(project),
         'app:tasks' ,

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -117,7 +117,7 @@ class AndroidApk extends ApplicationPackage {
 
     String apptStdout;
     try {
-      apptStdout = globals.processUtils.runSync(
+      apptStdout = processUtils.runSync(
         <String>[
           aaptPath,
           'dump',

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -180,6 +180,8 @@ class RunResult {
 
 typedef RunResultChecker = bool Function(int);
 
+ProcessUtils get processUtils => ProcessUtils.instance;
+
 abstract class ProcessUtils {
   factory ProcessUtils({
     @required ProcessManager processManager,
@@ -188,6 +190,8 @@ abstract class ProcessUtils {
     processManager: processManager,
     logger: logger,
   );
+
+  static ProcessUtils get instance => context.get<ProcessUtils>();
 
   /// Spawns a child process to run the command [cmd].
   ///

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -224,7 +224,7 @@ class DebugUniveralFramework extends Target {
       '-output',
       lipoOutputFile.path
     ];
-    final RunResult lipoResult = await globals.processUtils.run(
+    final RunResult lipoResult = await processUtils.run(
       lipoCommand,
     );
 

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -984,7 +984,7 @@ class AndroidMavenArtifacts extends ArtifactSet {
     try {
       final String gradleExecutable = gradle.absolute.path;
       final String flutterSdk = globals.fsUtils.escapePath(Cache.flutterRoot);
-      final RunResult processResult = await globals.processUtils.run(
+      final RunResult processResult = await processUtils.run(
         <String>[
           gradleExecutable,
           '-b', globals.fs.path.join(flutterSdk, 'packages', 'flutter_tools', 'gradle', 'resolve_dependencies.gradle'),

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -324,7 +324,7 @@ end
           '-output',
           fatFlutterFrameworkBinary.path
         ];
-        final RunResult lipoResult = await globals.processUtils.run(
+        final RunResult lipoResult = await processUtils.run(
           lipoCommand,
           allowReentrantFlutter: false,
         );
@@ -406,7 +406,7 @@ end
       destinationAppFrameworkDirectory.childFile(binaryName).path
     ];
 
-    final RunResult lipoResult = await globals.processUtils.run(
+    final RunResult lipoResult = await processUtils.run(
       lipoCommand,
       allowReentrantFlutter: false,
     );
@@ -478,7 +478,7 @@ end
         'BUILD_LIBRARY_FOR_DISTRIBUTION=YES',
       ];
 
-      RunResult buildPluginsResult = await globals.processUtils.run(
+      RunResult buildPluginsResult = await processUtils.run(
         pluginsBuildCommand,
         workingDirectory: _project.ios.hostAppRoot.childDirectory('Pods').path,
         allowReentrantFlutter: false,
@@ -504,7 +504,7 @@ end
           'BUILD_LIBRARY_FOR_DISTRIBUTION=YES',
         ];
 
-        buildPluginsResult = await globals.processUtils.run(
+        buildPluginsResult = await processUtils.run(
           pluginsBuildCommand,
           workingDirectory: _project.ios.hostAppRoot
             .childDirectory('Pods')
@@ -556,7 +556,7 @@ end
               modeDirectory.childDirectory(podFrameworkName).childFile(binaryName).path
             ];
 
-            final RunResult pluginsLipoResult = await globals.processUtils.run(
+            final RunResult pluginsLipoResult = await processUtils.run(
               lipoCommand,
               workingDirectory: outputDirectory.path,
               allowReentrantFlutter: false,
@@ -587,7 +587,7 @@ end
               modeDirectory.childFile('$binaryName.xcframework').path
             ];
 
-            final RunResult xcframeworkResult = await globals.processUtils.run(
+            final RunResult xcframeworkResult = await processUtils.run(
               xcframeworkCommand,
               workingDirectory: outputDirectory.path,
               allowReentrantFlutter: false,
@@ -664,7 +664,7 @@ end
         armFlutterFrameworkBinary.path
       ];
 
-      RunResult lipoResult = await globals.processUtils.run(
+      RunResult lipoResult = await processUtils.run(
         lipoCommand,
         allowReentrantFlutter: false,
       );
@@ -690,7 +690,7 @@ end
         simulatorFlutterFrameworkBinary.path
       ];
 
-      lipoResult = await globals.processUtils.run(
+      lipoResult = await processUtils.run(
         lipoCommand,
         allowReentrantFlutter: false,
       );
@@ -712,7 +712,7 @@ end
             .path
       ];
 
-      final RunResult xcframeworkResult = await globals.processUtils.run(
+      final RunResult xcframeworkResult = await processUtils.run(
         xcframeworkCommand,
         allowReentrantFlutter: false,
       );
@@ -744,7 +744,7 @@ end
           .path
     ];
 
-    final RunResult xcframeworkResult = await globals.processUtils.run(
+    final RunResult xcframeworkResult = await processUtils.run(
       xcframeworkCommand,
       allowReentrantFlutter: false,
     );

--- a/packages/flutter_tools/lib/src/commands/channel.dart
+++ b/packages/flutter_tools/lib/src/commands/channel.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import '../base/common.dart';
+import '../base/process.dart';
 import '../cache.dart';
 import '../globals.dart' as globals;
 import '../runner/flutter_command.dart';
@@ -60,7 +61,7 @@ class ChannelCommand extends FlutterCommand {
     showAll = showAll || currentChannel != currentBranch;
 
     globals.printStatus('Flutter channels:');
-    final int result = await globals.processUtils.stream(
+    final int result = await processUtils.stream(
       <String>['git', 'branch', '-r'],
       workingDirectory: Cache.flutterRoot,
       mapFunction: (String line) {
@@ -139,28 +140,28 @@ class ChannelCommand extends FlutterCommand {
 
   static Future<void> _checkout(String branchName) async {
     // Get latest refs from upstream.
-    int result = await globals.processUtils.stream(
+    int result = await processUtils.stream(
       <String>['git', 'fetch'],
       workingDirectory: Cache.flutterRoot,
       prefix: 'git: ',
     );
 
     if (result == 0) {
-      result = await globals.processUtils.stream(
+      result = await processUtils.stream(
         <String>['git', 'show-ref', '--verify', '--quiet', 'refs/heads/$branchName'],
         workingDirectory: Cache.flutterRoot,
         prefix: 'git: ',
       );
       if (result == 0) {
         // branch already exists, try just switching to it
-        result = await globals.processUtils.stream(
+        result = await processUtils.stream(
           <String>['git', 'checkout', branchName, '--'],
           workingDirectory: Cache.flutterRoot,
           prefix: 'git: ',
         );
       } else {
         // branch does not exist, we have to create it
-        result = await globals.processUtils.stream(
+        result = await processUtils.stream(
           <String>['git', 'checkout', '--track', '-b', branchName, 'origin/$branchName'],
           workingDirectory: Cache.flutterRoot,
           prefix: 'git: ',

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -11,6 +11,7 @@ import 'package:webdriver/async_io.dart' as async_io;
 import '../application_package.dart';
 import '../base/common.dart';
 import '../base/file_system.dart';
+import '../base/process.dart';
 import '../build_info.dart';
 import '../cache.dart';
 import '../dart/package_map.dart';
@@ -467,7 +468,7 @@ Future<void> _runTests(List<String> testArgs, Map<String, String> environment) a
 
   PackageMap.globalPackagesPath = globals.fs.path.normalize(globals.fs.path.absolute(PackageMap.globalPackagesPath));
   final String dartVmPath = globals.fs.path.join(dartSdkPath, 'bin', 'dart');
-  final int result = await globals.processUtils.stream(
+  final int result = await processUtils.stream(
     <String>[
       dartVmPath,
       ...dartVmFlags,

--- a/packages/flutter_tools/lib/src/commands/format.dart
+++ b/packages/flutter_tools/lib/src/commands/format.dart
@@ -5,8 +5,8 @@
 import 'dart:async';
 
 import '../base/common.dart';
+import '../base/process.dart';
 import '../dart/sdk.dart';
-import '../globals.dart' as globals;
 import '../runner/flutter_command.dart';
 
 class FormatCommand extends FlutterCommand {
@@ -71,7 +71,7 @@ class FormatCommand extends FlutterCommand {
       ...argResults.rest,
     ];
 
-    final int result = await globals.processUtils.stream(command);
+    final int result = await processUtils.stream(command);
     if (result != 0) {
       throwToolExit('Formatting failed: $result', exitCode: result);
     }

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -61,7 +61,7 @@ class UpgradeCommand extends FlutterCommand {
       force: boolArg('force'),
       continueFlow: boolArg('continue'),
       testFlow: stringArg('working-directory') != null,
-      gitTagVersion: GitTagVersion.determine(globals.processUtils),
+      gitTagVersion: GitTagVersion.determine(processUtils),
       flutterVersion: stringArg('working-directory') == null
         ? globals.flutterVersion
         : FlutterVersion(const SystemClock(), _commandRunner.workingDirectory),
@@ -152,7 +152,7 @@ class UpgradeCommandRunner {
   }
 
   Future<void> flutterUpgradeContinue() async {
-    final int code = await globals.processUtils.stream(
+    final int code = await processUtils.stream(
       <String>[
         globals.fs.path.join('bin', 'flutter'),
         'upgrade',
@@ -182,7 +182,7 @@ class UpgradeCommandRunner {
 
   Future<bool> hasUncomittedChanges() async {
     try {
-      final RunResult result = await globals.processUtils.run(
+      final RunResult result = await processUtils.run(
         <String>['git', 'status', '-s'],
         throwOnError: true,
         workingDirectory: workingDirectory,
@@ -205,7 +205,7 @@ class UpgradeCommandRunner {
   /// Exits tool if there is no upstream.
   Future<void> verifyUpstreamConfigured() async {
     try {
-      await globals.processUtils.run(
+      await processUtils.run(
         <String>[ 'git', 'rev-parse', '@{u}'],
         throwOnError: true,
         workingDirectory: workingDirectory,
@@ -232,7 +232,7 @@ class UpgradeCommandRunner {
       tag = 'v${gitTagVersion.x}.${gitTagVersion.y}.${gitTagVersion.z}';
     }
     try {
-      await globals.processUtils.run(
+      await processUtils.run(
         <String>['git', 'reset', '--hard', tag],
         throwOnError: true,
         workingDirectory: workingDirectory,
@@ -264,7 +264,7 @@ class UpgradeCommandRunner {
   /// If the fast forward lands us on the same channel and revision, then
   /// returns true, otherwise returns false.
   Future<bool> attemptFastForward(FlutterVersion oldFlutterVersion) async {
-    final int code = await globals.processUtils.stream(
+    final int code = await processUtils.stream(
       <String>['git', 'pull', '--ff'],
       workingDirectory: workingDirectory,
       mapFunction: (String line) => matchesGitLine(line) ? null : line,
@@ -293,7 +293,7 @@ class UpgradeCommandRunner {
   Future<void> precacheArtifacts() async {
     globals.printStatus('');
     globals.printStatus('Upgrading engine...');
-    final int code = await globals.processUtils.stream(
+    final int code = await processUtils.stream(
       <String>[
         globals.fs.path.join('bin', 'flutter'), '--no-color', '--no-version-check', 'precache',
       ],
@@ -321,7 +321,7 @@ class UpgradeCommandRunner {
   Future<void> runDoctor() async {
     globals.printStatus('');
     globals.printStatus('Running flutter doctor...');
-    await globals.processUtils.stream(
+    await processUtils.stream(
       <String>[
         globals.fs.path.join('bin', 'flutter'), '--no-version-check', 'doctor',
       ],

--- a/packages/flutter_tools/lib/src/commands/version.dart
+++ b/packages/flutter_tools/lib/src/commands/version.dart
@@ -44,7 +44,7 @@ class VersionCommand extends FlutterCommand {
     globals.flutterVersion.fetchTagsAndUpdate();
     RunResult runResult;
     try {
-      runResult = await globals.processUtils.run(
+      runResult = await processUtils.run(
         <String>['git', 'tag', '-l', 'v*', '--sort=-creatordate'],
         throwOnError: true,
         workingDirectory: Cache.flutterRoot,
@@ -112,7 +112,7 @@ class VersionCommand extends FlutterCommand {
     }
 
     try {
-      await globals.processUtils.run(
+      await processUtils.run(
         <String>['git', 'checkout', 'v$version'],
         throwOnError: true,
         workingDirectory: Cache.flutterRoot,
@@ -131,7 +131,7 @@ class VersionCommand extends FlutterCommand {
     // if necessary.
     globals.printStatus('');
     globals.printStatus('Downloading engine...');
-    int code = await globals.processUtils.stream(<String>[
+    int code = await processUtils.stream(<String>[
       globals.fs.path.join('bin', 'flutter'),
       '--no-color',
       'precache',
@@ -158,7 +158,7 @@ class VersionCommand extends FlutterCommand {
     // Run a doctor check in case system requirements have changed.
     globals.printStatus('');
     globals.printStatus('Running flutter doctor...');
-    code = await globals.processUtils.stream(
+    code = await processUtils.stream(
       <String>[
         globals.fs.path.join('bin', 'flutter'),
         'doctor',

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -11,6 +11,7 @@ import '../base/context.dart';
 import '../base/file_system.dart';
 import '../base/io.dart' as io;
 import '../base/logger.dart';
+import '../base/process.dart';
 import '../cache.dart';
 import '../globals.dart' as globals;
 import '../reporting/reporting.dart';
@@ -254,7 +255,7 @@ class _DefaultPub implements Pub {
     int code;
     loop: while (true) {
       attempts += 1;
-      code = await globals.processUtils.stream(
+      code = await processUtils.stream(
         _pubCommand(arguments),
         workingDirectory: directory,
         mapFunction: filterWrapper, // may set versionSolvingFailed, lastPubMessage
@@ -300,7 +301,7 @@ class _DefaultPub implements Pub {
     String directory,
   }) async {
     Cache.releaseLockEarly();
-    final io.Process process = await globals.processUtils.start(
+    final io.Process process = await processUtils.start(
       _pubCommand(arguments),
       workingDirectory: directory,
       environment: await _createPubEnvironment(PubContext.interactive),

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -13,6 +13,7 @@ import 'base/async_guard.dart';
 import 'base/context.dart';
 import 'base/file_system.dart';
 import 'base/logger.dart';
+import 'base/process.dart';
 import 'base/terminal.dart';
 import 'base/user_messages.dart';
 import 'base/utils.dart';
@@ -666,7 +667,7 @@ class FlutterValidator extends DoctorValidator {
 bool _genSnapshotRuns(String genSnapshotPath) {
   const int kExpectedExitCode = 255;
   try {
-    return globals.processUtils.runSync(<String>[genSnapshotPath]).exitCode == kExpectedExitCode;
+    return processUtils.runSync(<String>[genSnapshotPath]).exitCode == kExpectedExitCode;
   } on Exception {
     return false;
   }

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -120,7 +120,7 @@ class EmulatorManager {
       '-k', sdkId,
       '-d', device,
     ];
-    final RunResult runResult = globals.processUtils.runSync(args,
+    final RunResult runResult = processUtils.runSync(args,
         environment: androidSdk?.sdkManagerEnv);
     return CreateEmulatorResult(
       name,
@@ -141,7 +141,7 @@ class EmulatorManager {
       'device',
       '-c',
     ];
-    final RunResult runResult = globals.processUtils.runSync(args,
+    final RunResult runResult = processUtils.runSync(args,
         environment: androidSdk?.sdkManagerEnv);
     if (runResult.exitCode != 0) {
       return null;
@@ -168,7 +168,7 @@ class EmulatorManager {
       'avd',
       '-n', 'temp',
     ];
-    final RunResult runResult = globals.processUtils.runSync(args,
+    final RunResult runResult = processUtils.runSync(args,
         environment: androidSdk?.sdkManagerEnv);
 
     // Get the list of IDs that match our criteria

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_build.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_build.dart
@@ -12,6 +12,7 @@ import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
+import '../base/process.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
 import '../bundle.dart';
@@ -107,7 +108,7 @@ Future<void> _genSnapshot(
     timeout: null,
   );
   try {
-    result = await globals.processUtils.stream(command, trace: true);
+    result = await processUtils.stream(command, trace: true);
   } finally {
     status.cancel();
   }

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -575,7 +575,7 @@ class FuchsiaDevice extends Device {
       throwToolExit('Cannot interact with device. No ssh config.\n'
                     'Try setting FUCHSIA_SSH_CONFIG or FUCHSIA_BUILD_DIR.');
     }
-    return await globals.processUtils.run(<String>[
+    return await processUtils.run(<String>[
       'ssh',
       '-F',
       globals.fuchsiaArtifacts.sshConfig.absolute.path,
@@ -590,7 +590,7 @@ class FuchsiaDevice extends Device {
       throwToolExit('Cannot interact with device. No ssh config.\n'
                     'Try setting FUCHSIA_SSH_CONFIG or FUCHSIA_BUILD_DIR.');
     }
-    return await globals.processUtils.run(<String>[
+    return await processUtils.run(<String>[
       'scp',
       '-F',
       globals.fuchsiaArtifacts.sshConfig.absolute.path,

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_kernel_compiler.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_kernel_compiler.dart
@@ -7,6 +7,7 @@ import 'package:meta/meta.dart';
 import '../artifacts.dart';
 import '../base/common.dart';
 import '../base/logger.dart';
+import '../base/process.dart';
 import '../build_info.dart';
 import '../globals.dart' as globals;
 import '../project.dart';
@@ -94,7 +95,7 @@ class FuchsiaKernelCompiler {
     );
     int result;
     try {
-      result = await globals.processUtils.stream(command, trace: true);
+      result = await processUtils.stream(command, trace: true);
     } finally {
       status.cancel();
     }

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_pm.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_pm.dart
@@ -121,7 +121,7 @@ class FuchsiaPM {
       '-l',
       '$host:$port',
     ];
-    final Process process = await globals.processUtils.start(command);
+    final Process process = await processUtils.start(command);
     process.stdout
         .transform(utf8.decoder)
         .transform(const LineSplitter())
@@ -155,7 +155,7 @@ class FuchsiaPM {
       throwToolExit('Fuchsia pm tool not found');
     }
     final List<String> command = <String>[globals.fuchsiaArtifacts.pm.path, ...args];
-    final RunResult result = await globals.processUtils.run(command);
+    final RunResult result = await processUtils.run(command);
     return result.exitCode == 0;
   }
 }

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -17,7 +17,6 @@ import 'base/io.dart';
 import 'base/logger.dart';
 import 'base/net.dart';
 import 'base/os.dart';
-import 'base/process.dart';
 import 'base/template.dart';
 import 'base/terminal.dart';
 import 'base/user_messages.dart';
@@ -65,7 +64,6 @@ const ProcessManager _kLocalProcessManager = LocalProcessManager();
 
 /// The active process manager.
 ProcessManager get processManager => context.get<ProcessManager>() ?? _kLocalProcessManager;
-ProcessUtils get processUtils => context.get<ProcessUtils>();
 
 const Platform _kLocalPlatform = LocalPlatform();
 

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -46,7 +46,7 @@ class IOSEmulator extends Emulator {
         globals.xcode.getSimulatorPath(),
       ];
 
-      final RunResult launchResult = await globals.processUtils.run(args);
+      final RunResult launchResult = await processUtils.run(args);
       if (launchResult.exitCode != 0) {
         globals.printError('$launchResult');
         return false;

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -329,7 +329,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   const Duration showBuildSettingsTimeout = Duration(minutes: 1);
   Map<String, String> buildSettings;
   try {
-    final RunResult showBuildSettingsResult = await globals.processUtils.run(
+    final RunResult showBuildSettingsResult = await processUtils.run(
       showBuildSettingsCommand,
       throwOnError: true,
       workingDirectory: app.project.hostAppRoot.path,
@@ -413,7 +413,7 @@ Future<RunResult> _runBuildWithRetries(List<String> buildCommands, BuildableIOSA
     remainingTries--;
     buildRetryDelaySeconds *= 2;
 
-    buildResult = await globals.processUtils.run(
+    buildResult = await processUtils.run(
       buildCommands,
       workingDirectory: app.project.hostAppRoot.path,
       allowReentrantFlutter: true,

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -579,12 +579,12 @@ class IOSSimulator extends Device {
 Future<Process> launchDeviceLogTool(IOSSimulator device) async {
   // Versions of iOS prior to iOS 11 log to the simulator syslog file.
   if (await device.sdkMajorVersion < 11) {
-    return globals.processUtils.start(<String>['tail', '-n', '0', '-F', device.logFilePath]);
+    return processUtils.start(<String>['tail', '-n', '0', '-F', device.logFilePath]);
   }
 
   // For iOS 11 and above, use /usr/bin/log to tail process logs.
   // Run in interactive mode (via script), otherwise /usr/bin/log buffers in 4k chunks. (radar: 34420207)
-  return globals.processUtils.start(<String>[
+  return processUtils.start(<String>[
     'script', '/dev/null', '/usr/bin/log', 'stream', '--style', 'syslog', '--predicate', 'processImagePath CONTAINS "${device.id}"',
   ]);
 }
@@ -592,7 +592,7 @@ Future<Process> launchDeviceLogTool(IOSSimulator device) async {
 Future<Process> launchSystemLogTool(IOSSimulator device) async {
   // Versions of iOS prior to 11 tail the simulator syslog file.
   if (await device.sdkMajorVersion < 11) {
-    return globals.processUtils.start(<String>['tail', '-n', '0', '-F', '/private/var/log/system.log']);
+    return processUtils.start(<String>['tail', '-n', '0', '-F', '/private/var/log/system.log']);
   }
 
   // For iOS 11 and later, all relevant detail is in the device log.

--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
+++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
@@ -6,6 +6,7 @@ import '../artifacts.dart';
 import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/logger.dart';
+import '../base/process.dart';
 import '../build_info.dart';
 import '../cache.dart';
 import '../globals.dart' as globals;
@@ -72,7 +73,7 @@ export PROJECT_DIR=${linuxProject.project.directory.path}
   );
   int result;
   try {
-    result = await globals.processUtils.stream(<String>[
+    result = await processUtils.stream(<String>[
       'make',
       '-C',
       linuxProject.makeFile.parent.path,

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -5,6 +5,7 @@
 import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/logger.dart';
+import '../base/process.dart';
 import '../build_info.dart';
 import '../globals.dart' as globals;
 import '../ios/xcodeproj.dart';
@@ -72,7 +73,7 @@ Future<void> buildMacOS({
   );
   int result;
   try {
-    result = await globals.processUtils.stream(<String>[
+    result = await processUtils.stream(<String>[
       '/usr/bin/env',
       'xcrun',
       'xcodebuild',

--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -161,7 +161,7 @@ class CoverageCollector extends TestWatcher {
       final Directory tempDir = globals.fs.systemTempDirectory.createTempSync('flutter_tools_test_coverage.');
       try {
         final File sourceFile = coverageFile.copySync(globals.fs.path.join(tempDir.path, 'lcov.source.info'));
-        final RunResult result = globals.processUtils.runSync(<String>[
+        final RunResult result = processUtils.runSync(<String>[
           'lcov',
           '--add-tracefile', baseCoverageData,
           '--add-tracefile', sourceFile.path,

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -53,10 +53,10 @@ class FlutterVersion {
   FlutterVersion([this._clock = const SystemClock(), this._workingDirectory]) {
     _frameworkRevision = _runGit(
       gitLog(<String>['-n', '1', '--pretty=format:%H']).join(' '),
-      globals.processUtils,
+      processUtils,
       _workingDirectory,
     );
-    _gitTagVersion = GitTagVersion.determine(globals.processUtils, workingDirectory: _workingDirectory, fetchTags: false);
+    _gitTagVersion = GitTagVersion.determine(processUtils, workingDirectory: _workingDirectory, fetchTags: false);
     _frameworkVersion = gitTagVersion.frameworkVersionFor(_frameworkRevision);
   }
 
@@ -67,7 +67,7 @@ class FlutterVersion {
   /// user explicitly wants to get the version, e.g. for `flutter --version` or
   /// `flutter doctor`.
   void fetchTagsAndUpdate() {
-    _gitTagVersion = GitTagVersion.determine(globals.processUtils, workingDirectory: _workingDirectory, fetchTags: true);
+    _gitTagVersion = GitTagVersion.determine(processUtils, workingDirectory: _workingDirectory, fetchTags: true);
     _frameworkVersion = gitTagVersion.frameworkVersionFor(_frameworkRevision);
   }
 
@@ -112,7 +112,7 @@ class FlutterVersion {
     if (_channel == null) {
       final String channel = _runGit(
         'git rev-parse --abbrev-ref --symbolic @{u}',
-        globals.processUtils,
+        processUtils,
         _workingDirectory,
       );
       final int slash = channel.indexOf('/');
@@ -120,7 +120,7 @@ class FlutterVersion {
         final String remote = channel.substring(0, slash);
         _repositoryUrl = _runGit(
           'git ls-remote --get-url $remote',
-          globals.processUtils,
+          processUtils,
           _workingDirectory,
         );
         _channel = channel.substring(slash + 1);
@@ -148,7 +148,7 @@ class FlutterVersion {
   String get frameworkAge {
     return _frameworkAge ??= _runGit(
       gitLog(<String>['-n', '1', '--pretty=format:%ar']).join(' '),
-      globals.processUtils,
+      processUtils,
       _workingDirectory,
     );
   }
@@ -288,7 +288,7 @@ class FlutterVersion {
   /// the branch name will be returned as `'[user-branch]'`.
   String getBranchName({ bool redactUnknownBranches = false }) {
     _branch ??= () {
-      final String branch = _runGit('git rev-parse --abbrev-ref HEAD', globals.processUtils);
+      final String branch = _runGit('git rev-parse --abbrev-ref HEAD', processUtils);
       return branch == 'HEAD' ? channel : branch;
     }();
     if (redactUnknownBranches || _branch.isEmpty) {

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -6,6 +6,7 @@ import '../artifacts.dart';
 import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/logger.dart';
+import '../base/process.dart';
 import '../build_info.dart';
 import '../cache.dart';
 import '../globals.dart' as globals;
@@ -85,7 +86,7 @@ Future<void> buildWindows(WindowsProject windowsProject, BuildInfo buildInfo, {
     // Run the script with a relative path to the project using the enclosing
     // directory as the workingDirectory, to avoid hitting the limit on command
     // lengths in batch scripts if the absolute path to the project is long.
-    result = await globals.processUtils.stream(<String>[
+    result = await processUtils.stream(<String>[
       buildScript,
       vcvarsScript,
       globals.fs.path.basename(solutionPath),

--- a/packages/flutter_tools/lib/src/windows/windows_device.dart
+++ b/packages/flutter_tools/lib/src/windows/windows_device.dart
@@ -87,7 +87,7 @@ final RegExp _whitespace = RegExp(r'\s+');
 @visibleForTesting
 List<String> runningProcess(String processName) {
   // TODO(jonahwilliams): find a way to do this without powershell.
-  final RunResult result = globals.processUtils.runSync(
+  final RunResult result = processUtils.runSync(
     <String>['powershell', '-script="Get-CimInstance Win32_Process"'],
   );
   if (result.exitCode != 0) {


### PR DESCRIPTION
## Description

Revert "Move processUtils into globals (#53209)"

This caused TAP errors.
```
google3_doctor.dart:250:31: Error: Getter not found: 'processUtils'.
```

## Related Issues

Reverts #53209