### PR TITLE
Push iMobileDevice and iosDeploy instantiation into XCDevice constructor

### DIFF
--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -33,9 +33,7 @@ import 'fuchsia/fuchsia_device.dart' show FuchsiaDeviceTools;
 import 'fuchsia/fuchsia_sdk.dart' show FuchsiaSdk, FuchsiaArtifacts;
 import 'fuchsia/fuchsia_workflow.dart' show FuchsiaWorkflow;
 import 'globals.dart' as globals;
-import 'ios/ios_deploy.dart';
 import 'ios/ios_workflow.dart';
-import 'ios/mac.dart';
 import 'ios/simulators.dart';
 import 'ios/xcodeproj.dart';
 import 'macos/cocoapods.dart';
@@ -207,19 +205,9 @@ Future<T> runInContext<T>(
       XCDevice: () => XCDevice(
         processManager: globals.processManager,
         logger: globals.logger,
-        iMobileDevice: IMobileDevice(
-          artifacts: globals.artifacts,
-          cache: globals.cache,
-          logger: globals.logger,
-          processManager: globals.processManager,
-        ),
-        iosDeploy: IOSDeploy(
-          artifacts: globals.artifacts,
-          cache: globals.cache,
-          logger: globals.logger,
-          platform: globals.platform,
-          processManager: globals.processManager,
-        ),
+        artifacts: globals.artifacts,
+        cache: globals.cache,
+        platform: globals.platform,
         xcode: globals.xcode,
       ),
       XcodeProjectInterpreter: () => XcodeProjectInterpreter(

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -8,12 +8,14 @@ import 'package:meta/meta.dart';
 import 'package:platform/platform.dart';
 import 'package:process/process.dart';
 
+import '../artifacts.dart';
 import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
 import '../build_info.dart';
+import '../cache.dart';
 import '../convert.dart';
 import '../globals.dart' as globals;
 import '../ios/devices.dart';
@@ -195,15 +197,27 @@ class Xcode {
 /// A utility class for interacting with Xcode xcdevice command line tools.
 class XCDevice {
   XCDevice({
+    @required Artifacts artifacts,
+    @required Cache cache,
     @required ProcessManager processManager,
     @required Logger logger,
     @required Xcode xcode,
-    @required IMobileDevice iMobileDevice,
-    @required IOSDeploy iosDeploy,
+    @required Platform platform,
   }) : _processUtils = ProcessUtils(logger: logger, processManager: processManager),
       _logger = logger,
-      _iMobileDevice = iMobileDevice,
-      _iosDeploy = iosDeploy,
+      _iMobileDevice = IMobileDevice(
+        artifacts: artifacts,
+        cache: cache,
+        logger: logger,
+        processManager: processManager,
+      ),
+      _iosDeploy = IOSDeploy(
+        artifacts: artifacts,
+        cache: cache,
+        logger: logger,
+        platform: platform,
+        processManager: processManager,
+      ),
       _xcode = xcode;
 
   final ProcessUtils _processUtils;

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -3,10 +3,12 @@
 // found in the LICENSE file.
 
 import 'package:file/memory.dart';
+import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart' show ProcessException, ProcessResult;
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
@@ -209,15 +211,20 @@ void main() {
   group('xcdevice', () {
     XCDevice xcdevice;
     MockXcode mockXcode;
+    MockArtifacts mockArtifacts;
+    MockCache mockCache;
 
     setUp(() {
       mockXcode = MockXcode();
+      mockArtifacts = MockArtifacts();
+      mockCache = MockCache();
       xcdevice = XCDevice(
         processManager: processManager,
         logger: logger,
         xcode: mockXcode,
-        iMobileDevice: null,
-        iosDeploy: null,
+        platform: null,
+        artifacts: mockArtifacts,
+        cache: mockCache,
       );
     });
 
@@ -610,3 +617,5 @@ class MockXcode extends Mock implements Xcode {}
 class MockProcessManager extends Mock implements ProcessManager {}
 class MockXcodeProjectInterpreter extends Mock implements XcodeProjectInterpreter {}
 class MockPlatform extends Mock implements Platform {}
+class MockArtifacts extends Mock implements Artifacts {}
+class MockCache extends Mock implements Cache {}


### PR DESCRIPTION
## Description

Push iMobileDevice and iosDeploy instantiation into XCDevice constructor so the caller doesn't need to know any details about these objects.

## Related Issues

Follow up on #53144 and #53203

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*