### PR TITLE
Mark stable devicelab tests as unflaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -152,7 +152,6 @@ tasks:
       Measures the runtime performance of platform views in the Complex Layout sample app on Android.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
-    flaky: true
 
   home_scroll_perf__timeline_summary:
     description: >
@@ -340,7 +339,6 @@ tasks:
     description: >
       Builds an APK with a --dart-define and verifies it can be used as a constant
     stage: devicelab
-    flaky: true
     required_agent_capabilities: ["linux/android"]
 
   android_obfuscate_test:
@@ -424,7 +422,6 @@ tasks:
     description: >
       Builds a Framework with a --dart-define and verifies it can be used as a constant
     stage: devicelab
-    flaky: true
     required_agent_capabilities: ["mac/ios"]
 
   ios_content_validation_test:
@@ -579,9 +576,6 @@ tasks:
       The test makes sure that there is no regression while renderring an image with gl on iOS.
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios", "ios/gl-render-image"]
-    #TODO(cyanglaz): The flaky flag is added because it is the first screenshot test we added.
-    # Remove the flaky flag when we are sure the test is stable.
-    flaky: true
 
   ios_platform_view_tests:
     description: >


### PR DESCRIPTION
## Description

These all look stable in devicelab, remove flaky so we get notified on failures.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*