### PR TITLE
Remove flutter attach test timeout

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_attach_test_android.dart
+++ b/dev/devicelab/bin/tasks/flutter_attach_test_android.dart
@@ -57,8 +57,9 @@ Future<void> testReload(Process process, { Future<void> Function() onListening }
   }
 
   await eventOrExit(listening.future);
-  await eventOrExit(ready.future).timeout(const Duration(seconds: 15), onTimeout: () {
-    // If it can't attach in 15 seconds, it's not capable of finding the
+  await eventOrExit(ready.future).timeout(const Duration(seconds: 30), onTimeout: () {
+    // The attach process is slow (https://github.com/flutter/flutter/issues/53313).
+    // But if it can't attach in 30 seconds, it's not capable of finding the
     // observatory URL in the logs.
     throw TaskResult.failure('Failed to attach to running Flutter process');
   });

--- a/dev/devicelab/bin/tasks/flutter_attach_test_android.dart
+++ b/dev/devicelab/bin/tasks/flutter_attach_test_android.dart
@@ -57,12 +57,7 @@ Future<void> testReload(Process process, { Future<void> Function() onListening }
   }
 
   await eventOrExit(listening.future);
-  await eventOrExit(ready.future).timeout(const Duration(seconds: 30), onTimeout: () {
-    // The attach process is slow (https://github.com/flutter/flutter/issues/53313).
-    // But if it can't attach in 30 seconds, it's not capable of finding the
-    // observatory URL in the logs.
-    throw TaskResult.failure('Failed to attach to running Flutter process');
-  });
+  await eventOrExit(ready.future);
 
   if (exitCode != null)
     throw TaskResult.failure('Failed to attach to test app; command unexpected exited, with exit code $exitCode.');

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -373,6 +373,7 @@ tasks:
       Tests the `flutter attach` command.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
+    timeout_in_minutes: 20
 
   named_isolates_test:
     description: >


### PR DESCRIPTION
~~I made the test flaky. Comically looking at the logs, it's taking right around 15s~~

Remove the timeout according to https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#never-check-if-a-port-is-available-before-using-it-never-add-timeouts-and-other-race-conditions

```
2020-03-25T16:57:03.773410: stdout: Starting: Intent { cmp=com.yourcompany.integration_ui/.MainActivity }
2020-03-25T16:57:03.837708: "/home/flutter/Android/Sdk/platform-tools/adb" exit code: 0
2020-03-25T16:57:09.744410: attach:stdout: Syncing files to device Moto G 4...                              6,107ms (!)
2020-03-25T16:57:10.165472: attach:stdout: Flutter is taking longer than expected to report its views. Still trying...
2020-03-25T16:57:18.845876: 

════════════════════════════╡ ••• Uninstalling ••• ╞════════════════════════════

2020-03-25T16:57:18.846091: 
Executing: /home/flutter/Android/Sdk/platform-tools/adb -s ZY223TDZ7R uninstall com.yourcompany.integration_ui in /home/flutter/.cocoon/flutter/dev/integration_tests/ui
2020-03-25T16:57:19.251263: attach:stdout: 
2020-03-25T16:57:19.253168: attach:stdout: Flutter run key commands.
2020-03-25T16:57:19.259983: attach:stdout: r Hot reload. 🔥🔥🔥
2020-03-25T16:57:19.261670: attach:stdout: R Hot restart.
```

19.25-03.77=15.48 🤷‍♂️