### PR TITLE
[RefreshIndicator] adds strokeWidth parameter to RefreshIndicator

### DIFF
--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -155,7 +155,7 @@ class RefreshIndicator extends StatefulWidget {
   /// {@macro flutter.material.progressIndicator.semanticsValue}
   final String semanticsValue;
 
-  /// Defines `strokeWidth` for `RefreshIndicator`. 
+  /// Defines `strokeWidth` for `RefreshIndicator`.
   ///
   /// By default, the value of `strokeWidth` is 2.0 pixels.
   final double strokeWidth;

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -155,8 +155,9 @@ class RefreshIndicator extends StatefulWidget {
   /// {@macro flutter.material.progressIndicator.semanticsValue}
   final String semanticsValue;
 
-  /// Defines `strokeWidth` for `RefreshIndicator`. By default value of
-  /// `strokeWidth` is 2.0
+  /// Defines `strokeWidth` for `RefreshIndicator`. 
+  ///
+  /// By default, the value of `strokeWidth` is 2.0 pixels.
   final double strokeWidth;
 
   @override

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -106,9 +106,11 @@ class RefreshIndicator extends StatefulWidget {
     this.notificationPredicate = defaultScrollNotificationPredicate,
     this.semanticsLabel,
     this.semanticsValue,
+    this.strokeWidth = 2.0
   }) : assert(child != null),
        assert(onRefresh != null),
        assert(notificationPredicate != null),
+       assert(strokeWidth != null),
        super(key: key);
 
   /// The widget below this widget in the tree.
@@ -152,6 +154,10 @@ class RefreshIndicator extends StatefulWidget {
 
   /// {@macro flutter.material.progressIndicator.semanticsValue}
   final String semanticsValue;
+
+  /// Defines `strokeWidth` for `RefreshIndicator`. By default value of
+  /// `strokeWidth` is 2.0
+  final double strokeWidth;
 
   @override
   RefreshIndicatorState createState() => RefreshIndicatorState();
@@ -462,6 +468,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
                       value: showIndeterminateIndicator ? null : _value.value,
                       valueColor: _valueColor,
                       backgroundColor: widget.backgroundColor,
+                      strokeWidth: widget.strokeWidth,
                     );
                   },
                 ),

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -455,4 +455,71 @@ void main() {
 
     expect(layoutCount, 1);
   });
+
+  testWidgets('strokeWidth cannot be in RefreshIndicator', (WidgetTester tester) async {
+    try {
+      await tester.pumpWidget(
+          MaterialApp(
+            home: RefreshIndicator(
+              onRefresh: () async {},
+              strokeWidth: null,
+              child: ListView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                children: <String>['A', 'B', 'C', 'D', 'E', 'F'].map<Widget>((String item) {
+                  return SizedBox(
+                    height: 200.0,
+                    child: Text(item),
+                  );
+                }).toList(),
+              ),
+            ),
+          )
+      );
+    } on AssertionError catch(_){
+      return;
+    }
+    fail('The assertion was not thrown when strokeWidth was null');
+  });
+
+  testWidgets('RefreshIndicator responds to strokeWidth', (WidgetTester tester) async {
+    await tester.pumpWidget(
+        MaterialApp(
+          home: RefreshIndicator(
+            onRefresh: () async {},
+            child: ListView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              children: <String>['A', 'B', 'C', 'D', 'E', 'F'].map<Widget>((String item) {
+                return SizedBox(
+                  height: 200.0,
+                  child: Text(item),
+                );
+              }).toList(),
+            ),
+          ),
+        )
+    );
+
+    //By default the value of strokeWidth is 2.0
+    expect(tester.widget<RefreshIndicator>(find.byType(RefreshIndicator)).strokeWidth,2.0);
+
+    await tester.pumpWidget(
+        MaterialApp(
+          home: RefreshIndicator(
+            onRefresh: () async {},
+            strokeWidth: 4.0,
+            child: ListView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              children: <String>['A', 'B', 'C', 'D', 'E', 'F'].map<Widget>((String item) {
+                return SizedBox(
+                  height: 200.0,
+                  child: Text(item),
+                );
+              }).toList(),
+            ),
+          ),
+        )
+    );
+
+    expect(tester.widget<RefreshIndicator>(find.byType(RefreshIndicator)).strokeWidth,4.0);
+  });
 }

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -475,7 +475,7 @@ void main() {
             ),
           )
       );
-    } on AssertionError catch(_){
+    } on AssertionError catch(_) {
       return;
     }
     fail('The assertion was not thrown when strokeWidth was null');
@@ -500,7 +500,10 @@ void main() {
     );
 
     //By default the value of strokeWidth is 2.0
-    expect(tester.widget<RefreshIndicator>(find.byType(RefreshIndicator)).strokeWidth,2.0);
+    expect(
+        tester.widget<RefreshIndicator>(find.byType(RefreshIndicator)).strokeWidth,
+        2.0,
+    );
 
     await tester.pumpWidget(
         MaterialApp(
@@ -520,6 +523,9 @@ void main() {
         )
     );
 
-    expect(tester.widget<RefreshIndicator>(find.byType(RefreshIndicator)).strokeWidth,4.0);
+    expect(
+        tester.widget<RefreshIndicator>(find.byType(RefreshIndicator)).strokeWidth,
+        4.0,
+    );
   });
 }

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -456,7 +456,7 @@ void main() {
     expect(layoutCount, 1);
   });
 
-  testWidgets('strokeWidth cannot be in RefreshIndicator', (WidgetTester tester) async {
+  testWidgets('strokeWidth cannot be null in RefreshIndicator', (WidgetTester tester) async {
     try {
       await tester.pumpWidget(
           MaterialApp(


### PR DESCRIPTION
## Description

Adds `strokeWidth` parameter to `RefreshIndicator`.

## Related Issues

Fixes: #42570

## Tests

I added the following tests:
 
 - Test to check the assert for `strokeWidth`
 - Test to check whether `RefreshIndicator` responds to `strokeWidth`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
