### PR TITLE
Disable `flutter_driver_screenshot_test_ios`.

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -798,4 +798,3 @@ tasks:
   #   stage: devicelab_ios
   #   required_agent_capabilities: ["mac/ios", "ios/gl-render-image"]
   #   flaky: true
-  

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -571,13 +571,6 @@ tasks:
     required_agent_capabilities: ["mac/ios"]
     timeout_in_minutes: 20
 
-  flutter_driver_screenshot_test_ios:
-    description: >
-      Screenshot tests running on a specifc iPhone 6.
-      The test makes sure that there is no regression while renderring an image with gl on iOS.
-    stage: devicelab_ios
-    required_agent_capabilities: ["mac/ios", "ios/gl-render-image"]
-
   ios_platform_view_tests:
     description: >
       Runs end-to-end tests with platform views in the scene.
@@ -794,4 +787,14 @@ tasks:
   #     Runs end-to-end test of Flutter's Android splash behavior.
   #   stage: devicelab
   #   required_agent_capabilities: ["linux/android"]
+  #   flaky: true
+
+  # TODO(cyanglaz): Enable this test when we know how to test gold in device labs
+  # Or completely remove this test to LUCI when LUCI supports physical iOS devices.
+  # flutter_driver_screenshot_test_ios:
+  #   description: >
+  #     Screenshot tests running on a specifc iPhone 6.
+  #     The test makes sure that there is no regression while renderring an image with gl on iOS.
+  #   stage: devicelab_ios
+  #   required_agent_capabilities: ["mac/ios", "ios/gl-render-image"]
   #   flaky: true

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -798,3 +798,4 @@ tasks:
   #   stage: devicelab_ios
   #   required_agent_capabilities: ["mac/ios", "ios/gl-render-image"]
   #   flaky: true
+  


### PR DESCRIPTION
Temporary disable the `flutter_driver_screenshot_test_ios` as it is not WAI.
We want to know how to run gold test in device lab, or figure out running tests on physical iOS devices on lUCI before enable the test.