### PR TITLE
[flutter_tools] don't trim log messages from the web

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -672,7 +672,7 @@ class _ResidentWebRunner extends ResidentWebRunner {
         // thrown if we're not already subscribed.
       }
       _stdOutSub = _vmService.onStdoutEvent.listen((vmservice.Event log) {
-        final String message = utf8.decode(base64.decode(log.bytes)).trim();
+        final String message = utf8.decode(base64.decode(log.bytes));
         globals.printStatus(message);
       });
       unawaited(_vmService.registerService('reloadSources', 'FlutterTools'));

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -497,7 +497,7 @@ void main() {
       kind: 'Stdout',
       bytes: base64.encode(utf8.encode('    This is a message with 4 leading and trailing spaces    '))),
     );
-    // Wait one event look for the stream listener to fire.
+    // Wait one event loop for the stream listener to fire.
     await null;
 
     expect(testLogger.statusText,

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -480,6 +480,30 @@ void main() {
     Usage: () => MockFlutterUsage(),
   }));
 
+  test('Faithfully displays stdout messages with leading/trailing spaces', () => testbed.run(() async {
+    _setupMocks();
+    final StreamController<Event> stdoutController = StreamController<Event>();
+    when(mockVmService.onStdoutEvent).thenAnswer((Invocation invocation) {
+      return stdoutController.stream;
+    });
+    final Completer<DebugConnectionInfo> connectionInfoCompleter = Completer<DebugConnectionInfo>();
+    unawaited(residentWebRunner.run(
+      connectionInfoCompleter: connectionInfoCompleter,
+    ));
+    await connectionInfoCompleter.future;
+
+    stdoutController.add(Event(
+      timestamp: 0,
+      kind: 'Stdout',
+      bytes: base64.encode(utf8.encode('    This is a message with 4 leading and trailing spaces    '))),
+    );
+    // Wait one event look for the stream listener to fire.
+    await null;
+
+    expect(testLogger.statusText,
+      contains('    This is a message with 4 leading and trailing spaces    '));
+  }));
+
   test('Fails on compilation errors in hot restart', () => testbed.run(() async {
     _setupMocks();
     final Completer<DebugConnectionInfo> connectionInfoCompleter = Completer<DebugConnectionInfo>();


### PR DESCRIPTION
## Description

The extra trim removes leading/trailing whitespace from messages accidentally.