### PR TITLE
Uninstall app flag

### DIFF
--- a/dev/devicelab/bin/tasks/run_release_test.dart
+++ b/dev/devicelab/bin/tasks/run_release_test.dart
@@ -19,14 +19,36 @@ void main() {
     final Directory appDir = dir(path.join(flutterDirectory.path, 'dev/integration_tests/ui'));
     await inDirectory(appDir, () async {
       final Completer<void> ready = Completer<void>();
+      final List<String> stdout = <String>[];
+      final List<String> stderr = <String>[];
+
+      // Uninstall if the app is already installed on the device to get to a clean state.
+      print('uninstalling...');
+      final Process uninstall = await startProcess(
+        path.join(flutterDirectory.path, 'bin', 'flutter'),
+        <String>['--suppress-analytics', 'install', '--uninstall-only', '-d', device.deviceId],
+      )..stdout
+        .transform<String>(utf8.decoder)
+        .transform<String>(const LineSplitter())
+        .listen((String line) {
+        print('uninstall:stdout: $line');
+      })..stderr
+        .transform<String>(utf8.decoder)
+        .transform<String>(const LineSplitter())
+        .listen((String line) {
+        print('uninstall:stderr: $line');
+        stderr.add(line);
+      });
+      if (await uninstall.exitCode != 0) {
+        throw 'flutter install --uninstall-only failed.';
+      }
+
       print('run: starting...');
       final Process run = await startProcess(
         path.join(flutterDirectory.path, 'bin', 'flutter'),
         <String>['--suppress-analytics', 'run', '--release', '-d', device.deviceId, 'lib/main.dart'],
         isBot: false, // we just want to test the output, not have any debugging info
       );
-      final List<String> stdout = <String>[];
-      final List<String> stderr = <String>[];
       int runExitCode;
       run.stdout
         .transform<String>(utf8.decoder)

--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import 'package:flutter_tools/src/version.dart';
 import 'package:meta/meta.dart';
 import 'package:platform/platform.dart';
 import 'package:process/process.dart';

--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:flutter_tools/src/version.dart';
 import 'package:meta/meta.dart';
 import 'package:platform/platform.dart';
 import 'package:process/process.dart';
@@ -145,6 +146,8 @@ class IOSDeploy {
       '--id',
       deviceId,
       '--exists',
+      '--timeout', // If the device is not connected, ios-deploy will wait forever.
+      '10',
       '--bundle_id',
       bundleId,
     ];
@@ -152,10 +155,16 @@ class IOSDeploy {
       launchCommand,
       environment: iosDeployEnv,
     );
-    if (result.exitCode != 0) {
+    // Device successfully connected, but app not installed.
+    if (result.exitCode == 255) {
+      _logger.printTrace('$bundleId not installed on $deviceId');
       return false;
     }
-    return result.stdout.contains(bundleId);
+    if (result.exitCode != 0) {
+      _logger.printTrace('App install check failed: ${result.stderr}');
+      return false;
+    }
+    return true;
   }
 
   // Maps stdout line stream. Must return original line.

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
@@ -77,11 +77,6 @@ void main() {
   });
 
   group('isAppInstalled', () {
-    BufferLogger logger;
-    setUp(() {
-      logger = BufferLogger.test();
-    });
-
     testWithoutContext('catches ProcessException from ios-deploy', () async {
       final IOSApp iosApp = PrebuiltIOSApp(projectBundleId: 'app');
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
@@ -149,6 +144,7 @@ void main() {
           ...kDyLdLibEntry,
         }, exitCode: 255)
       ]);
+      final BufferLogger logger = BufferLogger.test();
       final IOSDevice device = setUpIOSDevice(processManager: processManager, logger: logger);
       final bool isAppInstalled = await device.isAppInstalled(iosApp);
 
@@ -176,6 +172,7 @@ void main() {
         }, stderr: stderr,
           exitCode: 253)
       ]);
+      final BufferLogger logger = BufferLogger.test();
       final IOSDevice device = setUpIOSDevice(processManager: processManager, logger: logger);
       final bool isAppInstalled = await device.isAppInstalled(iosApp);
 
@@ -241,7 +238,7 @@ IOSDevice setUpIOSDevice({
   FileSystem fileSystem,
   Logger logger,
 }) {
-  logger = logger ?? BufferLogger.test();
+  logger ??= BufferLogger.test();
   final FakePlatform platform = FakePlatform(
     operatingSystem: 'macos',
     environment: <String, String>{},

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
@@ -76,28 +76,113 @@ void main() {
     expect(processManager.hasRemainingExpectations, false);
   });
 
-  testWithoutContext('IOSDevice.isAppInstalled catches ProcessException from ios-deploy', () async {
-    final IOSApp iosApp = PrebuiltIOSApp(projectBundleId: 'app');
-    final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
-      FakeCommand(command: const <String>[
-        'ios-deploy',
-        '--id',
-        '1234',
-        '--exists',
-        '--bundle_id',
-        'app',
-      ], environment: const <String, String>{
-        'PATH': '/usr/bin:null',
-        ...kDyLdLibEntry,
-      }, onRun: () {
-        throw const ProcessException('ios-deploy', <String>[]);
-      })
-    ]);
-    final IOSDevice device = setUpIOSDevice(processManager: processManager);
-    final bool isAppInstalled = await device.isAppInstalled(iosApp);
+  group('isAppInstalled', () {
+    BufferLogger logger;
+    setUp(() {
+      logger = BufferLogger.test();
+    });
 
-    expect(isAppInstalled, false);
-    expect(processManager.hasRemainingExpectations, false);
+    testWithoutContext('catches ProcessException from ios-deploy', () async {
+      final IOSApp iosApp = PrebuiltIOSApp(projectBundleId: 'app');
+      final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(command: const <String>[
+          'ios-deploy',
+          '--id',
+          '1234',
+          '--exists',
+          '--timeout',
+          '10',
+          '--bundle_id',
+          'app',
+        ], environment: const <String, String>{
+          'PATH': '/usr/bin:null',
+          ...kDyLdLibEntry,
+        }, onRun: () {
+          throw const ProcessException('ios-deploy', <String>[]);
+        })
+      ]);
+      final IOSDevice device = setUpIOSDevice(processManager: processManager);
+      final bool isAppInstalled = await device.isAppInstalled(iosApp);
+
+      expect(isAppInstalled, false);
+      expect(processManager.hasRemainingExpectations, false);
+    });
+
+    testWithoutContext('returns true when app is installed', () async {
+      final IOSApp iosApp = PrebuiltIOSApp(projectBundleId: 'app');
+      final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(command: <String>[
+          'ios-deploy',
+          '--id',
+          '1234',
+          '--exists',
+          '--timeout',
+          '10',
+          '--bundle_id',
+          'app',
+        ], environment: <String, String>{
+          'PATH': '/usr/bin:null',
+          ...kDyLdLibEntry,
+        }, exitCode: 0)
+      ]);
+      final IOSDevice device = setUpIOSDevice(processManager: processManager);
+      final bool isAppInstalled = await device.isAppInstalled(iosApp);
+
+      expect(isAppInstalled, isTrue);
+      expect(processManager.hasRemainingExpectations, false);
+    });
+
+    testWithoutContext('returns false when app is not installed', () async {
+      final IOSApp iosApp = PrebuiltIOSApp(projectBundleId: 'app');
+      final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(command: <String>[
+          'ios-deploy',
+          '--id',
+          '1234',
+          '--exists',
+          '--timeout',
+          '10',
+          '--bundle_id',
+          'app',
+        ], environment: <String, String>{
+          'PATH': '/usr/bin:null',
+          ...kDyLdLibEntry,
+        }, exitCode: 255)
+      ]);
+      final IOSDevice device = setUpIOSDevice(processManager: processManager, logger: logger);
+      final bool isAppInstalled = await device.isAppInstalled(iosApp);
+
+      expect(isAppInstalled, isFalse);
+      expect(processManager.hasRemainingExpectations, false);
+      expect(logger.traceText, contains('${iosApp.id} not installed on ${device.id}'));
+    });
+
+    testWithoutContext('returns false on command timeout or other error', () async {
+      final IOSApp iosApp = PrebuiltIOSApp(projectBundleId: 'app');
+      const String stderr = '2020-03-26 17:48:43.484 ios-deploy[21518:5501783] [ !! ] Timed out waiting for device';
+      final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(command: <String>[
+          'ios-deploy',
+          '--id',
+          '1234',
+          '--exists',
+          '--timeout',
+          '10',
+          '--bundle_id',
+          'app',
+        ], environment: <String, String>{
+          'PATH': '/usr/bin:null',
+          ...kDyLdLibEntry,
+        }, stderr: stderr,
+          exitCode: 253)
+      ]);
+      final IOSDevice device = setUpIOSDevice(processManager: processManager, logger: logger);
+      final bool isAppInstalled = await device.isAppInstalled(iosApp);
+
+      expect(isAppInstalled, isFalse);
+      expect(processManager.hasRemainingExpectations, false);
+      expect(logger.traceText, contains(stderr));
+    });
   });
 
   testWithoutContext('IOSDevice.installApp catches ProcessException from ios-deploy', () async {
@@ -154,7 +239,9 @@ void main() {
 IOSDevice setUpIOSDevice({
   @required ProcessManager processManager,
   FileSystem fileSystem,
+  Logger logger,
 }) {
+  logger = logger ?? BufferLogger.test();
   final FakePlatform platform = FakePlatform(
     operatingSystem: 'macos',
     environment: <String, String>{},
@@ -167,19 +254,19 @@ IOSDevice setUpIOSDevice({
   return IOSDevice(
     '1234',
     name: 'iPhone 1',
-    logger: BufferLogger.test(),
+    logger: logger,
     fileSystem: fileSystem ?? MemoryFileSystem.test(),
     sdkVersion: '13.3',
     cpuArchitecture: DarwinArch.arm64,
     platform: platform,
     iMobileDevice: IMobileDevice(
-      logger: BufferLogger.test(),
+      logger: logger,
       processManager: processManager,
       artifacts: artifacts,
       cache: cache,
     ),
     iosDeploy: IOSDeploy(
-      logger: BufferLogger.test(),
+      logger: logger,
       platform: platform,
       processManager: processManager,
       artifacts: artifacts,


### PR DESCRIPTION
## Description

- Add `--uninstall-only` flag to `flutter install`.  Also considered adding a new `flutter uninstall` command but we are trying to avoid adding new commands, plus there have [been requests for `flutter uninstall`](https://github.com/flutter/flutter/issues/15202) uninstallers, and it might be confusing.
- `IOSDeploy.isAppInstalled()` was never returning true.  Fix up output and exit code checks.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/53363

## Tests

Added ios_device_install_tests for apps being installed and not installed.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*