### PR TITLE
Add ability to shard customer tests

### DIFF
--- a/dev/customer_testing/run_tests.dart
+++ b/dev/customer_testing/run_tests.dart
@@ -25,6 +25,18 @@ Future<bool> run(List<String> arguments) async {
       help: 'How many times to run each test. Set to a high value to look for flakes.',
       valueHelp: 'count',
     )
+    ..addOption(
+      'shards',
+      defaultsTo: '1',
+      help: 'How many shards to split the tests into. Used in continuous integration.',
+      valueHelp: 'count',
+    )
+    ..addOption(
+      'shard-index',
+      defaultsTo: '0',
+      help: 'The current shard to run the tests as. Used in continuous integration.',
+      valueHelp: 'count',
+    )
     ..addFlag(
       'skip-on-fetch-failure',
       defaultsTo: false,
@@ -70,6 +82,8 @@ Future<bool> run(List<String> arguments) async {
   final bool skipTemplate = parsedArguments['skip-template'] as bool;
   final bool verbose = parsedArguments['verbose'] as bool;
   final bool help = parsedArguments['help'] as bool;
+  final int numberShards = int.tryParse(parsedArguments['shards'] as String);
+  final int shardIndex = int.tryParse(parsedArguments['shard-index'] as String);
   final List<File> files = parsedArguments
     .rest
     .expand((String path) => Glob(path).listSync())
@@ -91,6 +105,21 @@ Future<bool> run(List<String> arguments) async {
     return help;
   }
 
+  if (files.length < shardIndex)
+    print('Warning: There are more shards than tests. Some shards will not run any tests.');
+
+  // Best attempt at evenly splitting tests among the shards
+  final List<File> shardedFiles = <File>[];
+  for (int i = shardIndex; i < files.length; i += numberShards) {
+    shardedFiles.add(files[i]);
+  }
+
+  if (verbose) {
+    print('Tests in this shard:');
+    for (final File file in shardedFiles)
+      print(file.path);
+  }
+
   if (verbose)
     print('Starting run_tests.dart...');
 
@@ -99,11 +128,12 @@ Future<bool> run(List<String> arguments) async {
 
   if (verbose) {
     final String s = files.length == 1 ? '' : 's';
-    print('${files.length} file$s specified.');
+    final String ss = shardedFiles.length == 1 ? '' : 's';
+    print('${files.length} file$s specified. ${shardedFiles.length} test$ss in shard #$shardIndex');
     print('');
   }
 
-  for (final File file in files) {
+  for (final File file in shardedFiles) {
     if (verbose)
       print('Processing ${file.path}...');
     TestFile instructions;

--- a/dev/customer_testing/run_tests.dart
+++ b/dev/customer_testing/run_tests.dart
@@ -34,7 +34,7 @@ Future<bool> run(List<String> arguments) async {
     ..addOption(
       'shard-index',
       defaultsTo: '0',
-      help: 'The current shard to run the tests as. Used in continuous integration.',
+      help: 'The current shard to run the tests with the range [0 .. shards - 1]. Used in continuous integration.',
       valueHelp: 'count',
     )
     ..addFlag(
@@ -105,8 +105,16 @@ Future<bool> run(List<String> arguments) async {
     return help;
   }
 
+  if (verbose)
+    print('Starting run_tests.dart...');
+
   if (files.length < shardIndex)
     print('Warning: There are more shards than tests. Some shards will not run any tests.');
+
+  if (numberShards <= shardIndex) {
+    print('Error: There are more shard indexes than shards.');
+    return help;
+  }
 
   // Best attempt at evenly splitting tests among the shards
   final List<File> shardedFiles = <File>[];
@@ -114,24 +122,22 @@ Future<bool> run(List<String> arguments) async {
     shardedFiles.add(files[i]);
   }
 
-  if (verbose) {
-    print('Tests in this shard:');
-    for (final File file in shardedFiles)
-      print(file.path);
-  }
-
-  if (verbose)
-    print('Starting run_tests.dart...');
-
   int testCount = 0;
   int failures = 0;
 
   if (verbose) {
     final String s = files.length == 1 ? '' : 's';
     final String ss = shardedFiles.length == 1 ? '' : 's';
-    print('${files.length} file$s specified. ${shardedFiles.length} test$ss in shard #$shardIndex');
+    print('${files.length} file$s specified. ${shardedFiles.length} test$ss in shard #$shardIndex.');
     print('');
   }
+
+  if (verbose) {
+    print('Tests in this shard:');
+    for (final File file in shardedFiles)
+      print(file.path);
+  }
+  print('');
 
   for (final File file in shardedFiles) {
     if (verbose)


### PR DESCRIPTION
## Description

Adds the options `--shards int` and `--shard-index int` to `customer_testing/run_tests.dart`. This allows for sharding these tests to reduce the time they take to run.

This is intended for only running on flutter/tests repo cirrus, however, I added it to this repo so it can be used in the future for sharding on the flutter/flutter repo if needed.

## Related Issues

https://github.com/flutter/tests/pull/26#discussion_r397453538 (comment suggesting we shard flutter/tests instead of increasing timeout)

## Tests

I didn't see any tests for this script, so I manually verified different edge cases:

(1) All tests run if no sharding info is provided
(2) All tests have their own shard if number of tests == number of shards
(3) All tests are assigned a shard if there is an unequal number of tests per shard

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*