### PR TITLE
Reset autovalidate in the text input form field of the Date Picker when switching input modes.

### DIFF
--- a/packages/flutter/lib/src/material/pickers/date_picker_dialog.dart
+++ b/packages/flutter/lib/src/material/pickers/date_picker_dialog.dart
@@ -296,6 +296,7 @@ class _DatePickerDialogState extends State<_DatePickerDialog> {
     setState(() {
       switch (_entryMode) {
         case DatePickerEntryMode.calendar:
+          _autoValidate = false;
           _entryMode = DatePickerEntryMode.input;
           break;
         case DatePickerEntryMode.input:

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -136,6 +136,30 @@ void main() {
       });
     });
 
+    testWidgets('Switching to input mode resets input error state', (WidgetTester tester) async {
+      await prepareDatePicker(tester, (Future<DateTime> date) async {
+        // Enter text input mode and type an invalid date to get error.
+        await tester.tap(find.byIcon(Icons.edit));
+        await tester.pumpAndSettle();
+        await tester.enterText(find.byType(TextField), '1234567');
+        await tester.tap(find.text('OK'));
+        await tester.pumpAndSettle();
+        expect(find.text('Invalid format.'), findsOneWidget);
+
+        // Toggle to calender mode and then back to input mode
+        await tester.tap(find.byIcon(Icons.calendar_today));
+        await tester.pumpAndSettle();
+        await tester.tap(find.byIcon(Icons.edit));
+        await tester.pumpAndSettle();
+        expect(find.text('Invalid format.'), findsNothing);
+
+        // Edit the text, the error should not be showing until ok is tapped
+        await tester.enterText(find.byType(TextField), '1234567');
+        await tester.pumpAndSettle();
+        expect(find.text('Invalid format.'), findsNothing);
+      });
+    });
+
     testWidgets('builder parameter', (WidgetTester tester) async {
       Widget buildFrame(TextDirection textDirection) {
         return MaterialApp(


### PR DESCRIPTION
## Description

This fixes a bug where the error state of the Date PIcker's text input form was always showing if you switched back to it from the calendar mode.  See #53432 for more details.

We just needed to reset the `autovalidate` property in the dialog when switching back to input mode so that it didn't automatically show an error on text entry.

## Related Issues

Fixes #53432

## Tests

I added a test to verify the autovalidate state doesn't persist when switching back and forth between the calendar and text input modes of the Date Picker dialog.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them?

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
