### PR TITLE
[dart] expose Dart through the Flutter SDK

### DIFF
--- a/bin/dart
+++ b/bin/dart
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Copyright 2014 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+
+# ---------------------------------- NOTE ---------------------------------- #
+#
+# Please keep the logic in this file consistent with the logic in the
+# `flutter.bat`and script in the same directory to ensure that Flutter continues
+# to work across all platforms!
+#
+# -------------------------------------------------------------------------- #
+
+set -e
+
+unset CDPATH
+
+function follow_links() {
+  cd -P "${1%/*}"
+  local file="$PWD/${1##*/}"
+  while [[ -h "$file" ]]; do
+    # On Mac OS, readlink -f doesn't work.
+    cd -P "${file%/*}"
+    file="$(readlink "$file")"
+    cd -P "${file%/*}"
+    file="$PWD/${file##*/}"
+  done
+  echo "$PWD/${file##*/}"
+}
+
+# Convert a filesystem path to a format usable by Dart's URI parser.
+function path_uri() {
+  # Reduce multiple leading slashes to a single slash.
+  echo "$1" | sed -E -e "s,^/+,/,"
+}
+
+function _rmlock () {
+  [ -n "$FLUTTER_UPGRADE_LOCK" ] && rm -f "$FLUTTER_UPGRADE_LOCK"
+}
+
+function retry_upgrade {
+  local total_tries="10"
+  local remaining_tries=$((total_tries - 1))
+  while [[ "$remaining_tries" -gt 0 ]]; do
+    (cd "$FLUTTER_TOOLS_DIR" && "$PUB" upgrade "$VERBOSITY" --no-precompile) && break
+    echo "Error: Unable to 'pub upgrade' flutter tool. Retrying in five seconds... ($remaining_tries tries left)"
+    remaining_tries=$((remaining_tries - 1))
+    sleep 5
+  done
+
+  if [[ "$remaining_tries" == 0 ]]; then
+    echo "Command 'pub upgrade' still failed after $total_tries tries, giving up."
+    return 1
+  fi
+  return 0
+}
+
+function upgrade_flutter () {
+  mkdir -p "$FLUTTER_ROOT/bin/cache"
+
+  # This function is executed with a redirect that pipes the source of
+  # this script into file descriptor 3.
+  #
+  # To ensure that we don't simultaneously update Dart in multiple
+  # parallel instances, we try to obtain an exclusive lock on this
+  # file descriptor (and thus this script's source file) while we are
+  # updating Dart and compiling the script. To do this, we try to use
+  # the command line program "flock", which is available on many
+  # Unix-like platforms, in particular on most Linux distributions.
+  # You give it a file descriptor, and it locks the corresponding
+  # file, having inherited the file descriptor from the shell.
+  #
+  # Complicating matters, there are two major scenarios where this
+  # will not work.
+  #
+  # The first is if the platform doesn't have "flock", for example on Mac.
+  # There is not a direct equivalent, so on platforms that don't have flock,
+  # we fall back to using a lockfile and spinlock with "shlock".  This
+  # doesn't work as well over NFS as it relies on PIDs. Any platform
+  # without either of these tools has no locking at all. To determine if we
+  # have "flock" or "shlock" available, we abuse the "hash" shell built-in.
+  #
+  # The second complication is NFS. On NFS, to obtain an exclusive
+  # lock you need a file descriptor that is open for writing, because
+  # NFS implements exclusive locks by writing, or some such. Thus, we
+  # ignore errors from flock. We do so by using the '|| true' trick,
+  # since we are running in a 'set -e' environment wherein all errors
+  # are fatal, and by redirecting all output to /dev/null, since
+  # users will typically not care about errors from flock and are
+  # more likely to be confused by them than helped.
+  #
+  # For "flock", the lock is released when the file descriptor goes out of
+  # scope,  i.e. when this function returns.  The lock is released via
+  # a trap when using "shlock".
+  if hash flock 2>/dev/null; then
+    flock 3 2>/dev/null || true
+  elif hash shlock 2>/dev/null; then
+    FLUTTER_UPGRADE_LOCK="$FLUTTER_ROOT/bin/cache/.upgrade_lock"
+    while ! shlock -f "$FLUTTER_UPGRADE_LOCK" -p $$ ; do sleep .1 ; done
+    trap _rmlock EXIT
+  fi
+
+  local revision="$(cd "$FLUTTER_ROOT"; git rev-parse HEAD)"
+
+  # Invalidate cache if:
+  #  * SNAPSHOT_PATH is not a file, or
+  #  * STAMP_PATH is not a file with nonzero size, or
+  #  * Contents of STAMP_PATH is not our local git HEAD revision, or
+  #  * pubspec.yaml last modified after pubspec.lock
+  if [[ ! -f "$SNAPSHOT_PATH" || ! -s "$STAMP_PATH" || "$(cat "$STAMP_PATH")" != "$revision" || "$FLUTTER_TOOLS_DIR/pubspec.yaml" -nt "$FLUTTER_TOOLS_DIR/pubspec.lock" ]]; then
+    rm -f "$FLUTTER_ROOT/version"
+    touch "$FLUTTER_ROOT/bin/cache/.dartignore"
+    "$FLUTTER_ROOT/bin/internal/update_dart_sdk.sh"
+    VERBOSITY="--verbosity=error"
+
+    echo Building flutter tool...
+    if [[ "$CI" == "true" || "$BOT" == "true" || "$CONTINUOUS_INTEGRATION" == "true" || "$CHROME_HEADLESS" == "1" ]]; then
+      PUB_ENVIRONMENT="$PUB_ENVIRONMENT:flutter_bot"
+      VERBOSITY="--verbosity=normal"
+    fi
+    export PUB_ENVIRONMENT="$PUB_ENVIRONMENT:flutter_install"
+
+    if [[ -d "$FLUTTER_ROOT/.pub-cache" ]]; then
+      export PUB_CACHE="${PUB_CACHE:-"$FLUTTER_ROOT/.pub-cache"}"
+    fi
+
+    retry_upgrade
+
+    "$DART" $FLUTTER_TOOL_ARGS --snapshot="$SNAPSHOT_PATH" --packages="$FLUTTER_TOOLS_DIR/.packages" --no-enable-mirrors "$SCRIPT_PATH"
+    echo "$revision" > "$STAMP_PATH"
+  fi
+  # The exit here is duplicitous since the function is run in a subshell,
+  # but this serves as documentation that running the function in a
+  # subshell is required to make sure any lockfile created by shlock
+  # is cleaned up.
+  exit $?
+}
+
+PROG_NAME="$(path_uri "$(follow_links "$BASH_SOURCE")")"
+BIN_DIR="$(cd "${PROG_NAME%/*}" ; pwd -P)"
+export FLUTTER_ROOT="$(cd "${BIN_DIR}/.." ; pwd -P)"
+
+FLUTTER_TOOLS_DIR="$FLUTTER_ROOT/packages/flutter_tools"
+SNAPSHOT_PATH="$FLUTTER_ROOT/bin/cache/flutter_tools.snapshot"
+STAMP_PATH="$FLUTTER_ROOT/bin/cache/flutter_tools.stamp"
+SCRIPT_PATH="$FLUTTER_TOOLS_DIR/bin/flutter_tools.dart"
+DART_SDK_PATH="$FLUTTER_ROOT/bin/cache/dart-sdk"
+
+DART="$DART_SDK_PATH/bin/dart"
+PUB="$DART_SDK_PATH/bin/pub"
+
+# If running over git-bash, overrides the default UNIX
+# executables with win32 executables
+case "$(uname -s)" in
+  MINGW32*)
+    DART="$DART.exe"
+    PUB="$PUB.bat"
+    ;;
+esac
+
+# Test if running as superuser – but don't warn if running within Docker
+if [[ "$EUID" == "0" && ! -f /.dockerenv ]]; then
+  echo "   Woah! You appear to be trying to run flutter as root."
+  echo "   We strongly recommend running the flutter tool without superuser privileges."
+  echo "  /"
+  echo "📎"
+fi
+
+# Test if Git is available on the Host
+if ! hash git 2>/dev/null; then
+  echo "Error: Unable to find git in your PATH."
+  exit 1
+fi
+# Test if the flutter directory is a git clone (otherwise git rev-parse HEAD would fail)
+if [[ ! -e "$FLUTTER_ROOT/.git" ]]; then
+  echo "Error: The Flutter directory is not a clone of the GitHub project."
+  echo "       The flutter tool requires Git in order to operate properly;"
+  echo "       to set up Flutter, run the following command:"
+  echo "       git clone -b stable https://github.com/flutter/flutter.git"
+  exit 1
+fi
+
+(upgrade_flutter) 3< "$PROG_NAME"
+
+"$DART" "$@"

--- a/bin/dart.bat
+++ b/bin/dart.bat
@@ -1,0 +1,177 @@
+@ECHO off
+REM Copyright 2014 The Flutter Authors. All rights reserved.
+REM Use of this source code is governed by a BSD-style license that can be
+REM found in the LICENSE file.
+
+REM ---------------------------------- NOTE ----------------------------------
+REM
+REM Please keep the logic in this file consistent with the logic in the
+REM `flutter` script in the same directory to ensure that Flutter continues to
+REM work across all platforms!
+REM
+REM --------------------------------------------------------------------------
+
+SETLOCAL ENABLEDELAYEDEXPANSION
+
+FOR %%i IN ("%~dp0..") DO SET FLUTTER_ROOT=%%~fi
+
+SET flutter_tools_dir=%FLUTTER_ROOT%\packages\flutter_tools
+SET cache_dir=%FLUTTER_ROOT%\bin\cache
+SET snapshot_path=%cache_dir%\flutter_tools.snapshot
+SET stamp_path=%cache_dir%\flutter_tools.stamp
+SET script_path=%flutter_tools_dir%\bin\flutter_tools.dart
+SET dart_sdk_path=%cache_dir%\dart-sdk
+SET engine_stamp=%cache_dir%\engine-dart-sdk.stamp
+SET engine_version_path=%FLUTTER_ROOT%\bin\internal\engine.version
+SET pub_cache_path=%FLUTTER_ROOT%\.pub-cache
+
+SET dart=%dart_sdk_path%\bin\dart.exe
+SET pub=%dart_sdk_path%\bin\pub.bat
+
+REM If available, add location of bundled mingit to PATH
+SET mingit_path=%FLUTTER_ROOT%\bin\mingit\cmd
+IF EXIST "%mingit_path%" SET PATH=%PATH%;%mingit_path%
+
+REM Test if Git is available on the Host
+where /q git || ECHO Error: Unable to find git in your PATH. && EXIT /B 1
+REM  Test if the flutter directory is a git clone, otherwise git rev-parse HEAD would fail
+IF NOT EXIST "%flutter_root%\.git" (
+  ECHO Error: The Flutter directory is not a clone of the GitHub project.
+  ECHO        The flutter tool requires Git in order to operate properly;
+  ECHO        to set up Flutter, run the following command:
+  ECHO        git clone -b stable https://github.com/flutter/flutter.git
+  EXIT /B 1
+)
+
+REM Ensure that bin/cache exists.
+IF NOT EXIST "%cache_dir%" MKDIR "%cache_dir%"
+
+REM If the cache still doesn't exist, fail with an error that we probably don't have permissions.
+IF NOT EXIST "%cache_dir%" (
+  ECHO Error: Unable to create cache directory at
+  ECHO            %cache_dir%
+  ECHO.
+  ECHO        This may be because flutter doesn't have write permissions for
+  ECHO        this path. Try moving the flutter directory to a writable location,
+  ECHO        such as within your home directory.
+  EXIT /B 1
+)
+
+:acquire_lock
+2>NUL (
+  REM "3" is now stderr because of "2>NUL".
+  CALL :subroutine %* 2>&3 9> "%cache_dir%\flutter.bat.lock" || GOTO acquire_lock
+)
+GOTO :after_subroutine
+
+:subroutine
+  PUSHD "%flutter_root%"
+  FOR /f %%r IN ('git rev-parse HEAD') DO SET revision=%%r
+  POPD
+
+  REM The following IF conditions are all linked with a logical OR. However,
+  REM there is no OR operator in batch and a GOTO construct is used as replacement.
+
+  IF NOT EXIST "%engine_stamp%" GOTO do_sdk_update_and_snapshot
+  SET /P dart_required_version=<"%engine_version_path%"
+  SET /P dart_installed_version=<"%engine_stamp%"
+  IF !dart_required_version! NEQ !dart_installed_version! GOTO do_sdk_update_and_snapshot
+  IF NOT EXIST "%snapshot_path%" GOTO do_snapshot
+  IF NOT EXIST "%stamp_path%" GOTO do_snapshot
+  SET /P stamp_value=<"%stamp_path%"
+  IF !stamp_value! NEQ !revision! GOTO do_snapshot
+  SET pubspec_yaml_path=%flutter_tools_dir%\pubspec.yaml
+  SET pubspec_lock_path=%flutter_tools_dir%\pubspec.lock
+  FOR /F %%i IN ('DIR /B /O:D "%pubspec_yaml_path%" "%pubspec_lock_path%"') DO SET newer_file=%%i
+  FOR %%i IN (%pubspec_yaml_path%) DO SET pubspec_yaml_timestamp=%%~ti
+  FOR %%i IN (%pubspec_lock_path%) DO SET pubspec_lock_timestamp=%%~ti
+  IF "%pubspec_yaml_timestamp%" == "%pubspec_lock_timestamp%" SET newer_file=""
+  IF "%newer_file%" EQU "pubspec.yaml" GOTO do_snapshot
+
+  REM Everything is up-to-date - exit subroutine
+  EXIT /B
+
+  :do_sdk_update_and_snapshot
+    ECHO Checking Dart SDK version...
+    SET update_dart_bin=%FLUTTER_ROOT%/bin/internal/update_dart_sdk.ps1
+    REM Escape apostrophes from the executable path
+    SET "update_dart_bin=!update_dart_bin:'=''!"
+    PowerShell.exe -ExecutionPolicy Bypass -Command "Unblock-File -Path '%update_dart_bin%'; & '%update_dart_bin%'"
+    IF "%ERRORLEVEL%" NEQ "0" (
+      ECHO Error: Unable to update Dart SDK. Retrying...
+      timeout /t 5 /nobreak
+      GOTO :do_sdk_update_and_snapshot
+    )
+
+  :do_snapshot
+    IF EXIST "%FLUTTER_ROOT%\version" DEL "%FLUTTER_ROOT%\version"
+    ECHO: > "%cache_dir%\.dartignore"
+    ECHO Building flutter tool...
+    PUSHD "%flutter_tools_dir%"
+
+    REM Makes changes to PUB_ENVIRONMENT only visible to commands within SETLOCAL/ENDLOCAL
+    SETLOCAL
+      SET VERBOSITY=--verbosity=error
+      IF "%CI%" == "true" GOTO on_bot
+      IF "%BOT%" == "true" GOTO on_bot
+      IF "%CONTINUOUS_INTEGRATION%" == "true" GOTO on_bot
+      IF "%CHROME_HEADLESS%" == "1" GOTO on_bot
+      GOTO not_on_bot
+      :on_bot
+        SET PUB_ENVIRONMENT=%PUB_ENVIRONMENT%:flutter_bot
+        SET VERBOSITY=--verbosity=normal
+      :not_on_bot
+      SET PUB_ENVIRONMENT=%PUB_ENVIRONMENT%:flutter_install
+      IF "%PUB_CACHE%" == "" (
+        IF EXIST "%pub_cache_path%" SET PUB_CACHE=%pub_cache_path%
+      )
+
+      SET /A total_tries=10
+      SET /A remaining_tries=%total_tries%-1
+      :retry_pub_upgrade
+        ECHO Running pub upgrade...
+        CALL "%pub%" upgrade "%VERBOSITY%" --no-precompile
+        IF "%ERRORLEVEL%" EQU "0" goto :upgrade_succeeded
+        ECHO Error (%ERRORLEVEL%): Unable to 'pub upgrade' flutter tool. Retrying in five seconds... (%remaining_tries% tries left)
+        timeout /t 5 /nobreak 2>NUL
+        SET /A remaining_tries-=1
+        IF "%remaining_tries%" EQU "0" GOTO upgrade_retries_exhausted
+        GOTO :retry_pub_upgrade
+      :upgrade_retries_exhausted
+        SET exit_code=%ERRORLEVEL%
+        ECHO Error: 'pub upgrade' still failing after %total_tries% tries, giving up.
+        GOTO final_exit
+      :upgrade_succeeded
+    ENDLOCAL
+
+    POPD
+
+    IF "%FLUTTER_TOOL_ARGS%" == "" (
+      "%dart%" --snapshot="%snapshot_path%" --packages="%flutter_tools_dir%\.packages" --no-enable-mirrors "%script_path%"
+    ) else (
+      "%dart%" "%FLUTTER_TOOL_ARGS%" --snapshot="%snapshot_path%" --packages="%flutter_tools_dir%\.packages" "%script_path%"
+    )
+    IF "%ERRORLEVEL%" NEQ "0" (
+      ECHO Error: Unable to create dart snapshot for flutter tool.
+      SET exit_code=%ERRORLEVEL%
+      GOTO :final_exit
+    )
+    >"%stamp_path%" ECHO %revision%
+
+  REM Exit Subroutine
+  EXIT /B
+
+:after_subroutine
+
+REM Chaining the call to 'dart' and 'exit' with an ampersand ensures that
+REM Windows reads both commands into memory once before executing them. This
+REM avoids nasty errors that may otherwise occur when the dart command (e.g. as
+REM part of 'flutter upgrade') modifies this batch script while it is executing.
+REM
+REM Do not use the CALL command in the next line to execute Dart. CALL causes
+REM Windows to re-read the line from disk after the CALL command has finished
+REM regardless of the ampersand chain.
+"%dart%" %* & exit /B !ERRORLEVEL!
+
+:final_exit
+EXIT /B %exit_code%


### PR DESCRIPTION
## Description

Make the dart sdk visible through `flutter/bin`.

We'd like to expose `dart` and future `dartdev` commands to flutter users directly without proxying things through the flutter tool. It isn't sufficient to simply but `flutter/bin/cache/dart-sdk/bin` on the PATH as well, since this would bypass the Dart SDK staleness check that the entrypoint script runs.

If users currently have a separate dart on their path, this may interfere depending on ordering.

https://github.com/flutter/flutter/issues/57063


In the future, this would also let us deprecate/remove flutter_tools commands that are simply pass-throughs to dart commands