### PR TITLE
[flutter_tools] use package uuid consistently

### DIFF
--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:math' show Random, max;
+import 'dart:math' show max;
 
 import 'package:intl/intl.dart';
 import 'package:meta/meta.dart';
@@ -139,40 +139,6 @@ class SettingsFile {
       return '$key=${values[key]}';
     }).join('\n'));
   }
-}
-
-/// A UUID generator. This will generate unique IDs in the format:
-///
-///     f47ac10b-58cc-4372-a567-0e02b2c3d479
-///
-/// The generated UUIDs are 128 bit numbers encoded in a specific string format.
-///
-/// For more information, see
-/// http://en.wikipedia.org/wiki/Universally_unique_identifier.
-class Uuid {
-  final Random _random = Random();
-
-  /// Generate a version 4 (random) UUID. This is a UUID scheme that only uses
-  /// random numbers as the source of the generated UUID.
-  String generateV4() {
-    // Generate xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx / 8-4-4-4-12.
-    final int special = 8 + _random.nextInt(4);
-
-    return
-      '${_bitsDigits(16, 4)}${_bitsDigits(16, 4)}-'
-          '${_bitsDigits(16, 4)}-'
-          '4${_bitsDigits(12, 3)}-'
-          '${_printDigits(special, 1)}${_bitsDigits(12, 3)}-'
-          '${_bitsDigits(16, 4)}${_bitsDigits(16, 4)}${_bitsDigits(16, 4)}';
-  }
-
-  String _bitsDigits(int bitCount, int digitCount) =>
-      _printDigits(_generateBits(bitCount), digitCount);
-
-  int _generateBits(int bitCount) => _random.nextInt(1 << bitCount);
-
-  String _printDigits(int value, int count) =>
-      value.toRadixString(16).padLeft(count, '0');
 }
 
 /// Given a data structure which is a Map of String to dynamic values, return

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:meta/meta.dart';
+import 'package:uuid/uuid.dart';
 
 import '../android/android.dart' as android;
 import '../android/android_sdk.dart' as android_sdk;
@@ -610,7 +611,7 @@ To edit platform code in an IDE see https://flutter.dev/developing-packages/#edi
       'pluginClass': pluginClass,
       'pluginDartClass': pluginDartClass,
       'pluginCppHeaderGuard': projectName.toUpperCase(),
-      'pluginProjectUUID': Uuid().generateV4().toUpperCase(),
+      'pluginProjectUUID': Uuid().v4().toUpperCase(),
       'withPluginHook': withPluginHook,
       'androidLanguage': androidLanguage,
       'iosLanguage': iosLanguage,

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:meta/meta.dart';
+import 'package:uuid/uuid.dart';
 
 import '../base/common.dart';
 import '../base/context.dart';
@@ -439,7 +440,7 @@ class AppDomain extends Domain {
 
   static final Uuid _uuidGenerator = Uuid();
 
-  static String _getNewAppId() => _uuidGenerator.generateV4();
+  static String _getNewAppId() => _uuidGenerator.v4();
 
   final List<AppInstance> _apps = <AppInstance>[];
 

--- a/packages/flutter_tools/test/general.shard/utils_test.dart
+++ b/packages/flutter_tools/test/general.shard/utils_test.dart
@@ -24,67 +24,6 @@ baz=qux
     });
   });
 
-  group('uuid', () {
-    // xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
-    test('simple', () {
-      final Uuid uuid = Uuid();
-      final String result = uuid.generateV4();
-      expect(result.length, 36);
-      expect(result[8], '-');
-      expect(result[13], '-');
-      expect(result[18], '-');
-      expect(result[23], '-');
-    });
-
-    test('can parse', () {
-      final Uuid uuid = Uuid();
-      final String result = uuid.generateV4();
-      expect(int.parse(result.substring(0, 8), radix: 16), isNotNull);
-      expect(int.parse(result.substring(9, 13), radix: 16), isNotNull);
-      expect(int.parse(result.substring(14, 18), radix: 16), isNotNull);
-      expect(int.parse(result.substring(19, 23), radix: 16), isNotNull);
-      expect(int.parse(result.substring(24, 36), radix: 16), isNotNull);
-    });
-
-    test('special bits', () {
-      final Uuid uuid = Uuid();
-      String result = uuid.generateV4();
-      expect(result[14], '4');
-      expect(result[19].toLowerCase(), isIn('89ab'));
-
-      result = uuid.generateV4();
-      expect(result[19].toLowerCase(), isIn('89ab'));
-
-      result = uuid.generateV4();
-      expect(result[19].toLowerCase(), isIn('89ab'));
-    });
-
-    test('is pretty random', () {
-      final Set<String> set = <String>{};
-
-      Uuid uuid = Uuid();
-      for (int i = 0; i < 64; i++) {
-        final String val = uuid.generateV4();
-        expect(set, isNot(contains(val)));
-        set.add(val);
-      }
-
-      uuid = Uuid();
-      for (int i = 0; i < 64; i++) {
-        final String val = uuid.generateV4();
-        expect(set, isNot(contains(val)));
-        set.add(val);
-      }
-
-      uuid = Uuid();
-      for (int i = 0; i < 64; i++) {
-        final String val = uuid.generateV4();
-        expect(set, isNot(contains(val)));
-        set.add(val);
-      }
-    });
-  });
-
   group('Version', () {
     test('can parse and compare', () {
       expect(Version.unknown.toString(), equals('unknown'));


### PR DESCRIPTION
## Description

This was originally added in 2016 from https://github.com/flutter/flutter/pull/6113 , but since the tool already uses `package:uuid` we can rely on that instead