### PR TITLE
Fixed a bug with the month grid showing the wrong month after selecting a date.

### DIFF
--- a/packages/flutter/lib/src/material/pickers/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/pickers/calendar_date_picker.dart
@@ -592,7 +592,6 @@ class _MonthPickerState extends State<_MonthPicker> {
           _DayHeaders(),
           Expanded(
             child: PageView.builder(
-              key: ValueKey<DateTime>(widget.selectedDate),
               controller: _pageController,
               itemBuilder: _buildItems,
               itemCount: utils.monthDelta(widget.firstDate, widget.lastDate) + 1,

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -278,6 +278,20 @@ void main() {
       });
     });
 
+    testWidgets('Selecting date does not change displayed month', (WidgetTester tester) async {
+      initialDate = DateTime(2020, DateTime.march, 15);
+      await prepareDatePicker(tester, (Future<DateTime> date) async {
+        await tester.tap(nextMonthIcon);
+        await tester.pumpAndSettle(const Duration(seconds: 1));
+        expect(find.text('April 2020'), findsOneWidget);
+        await tester.tap(find.text('25'));
+        await tester.pumpAndSettle();
+        expect(find.text('April 2020'), findsOneWidget);
+        // There isn't a 31 in April so there shouldn't be one if it is showing April
+        expect(find.text('31'), findsNothing);
+      });
+    });
+
     testWidgets('Changing year does not change selected date', (WidgetTester tester) async {
       await prepareDatePicker(tester, (Future<DateTime> date) async {
         await tester.tap(find.text('January 2016'));


### PR DESCRIPTION
## Description

After navigating to a new month and then selecting a date the day grid would be displaying the days from the original month and not the current one. 

This was a problem with the page view's key being based off the selected date. After the last pageController refactoring this is no longer needed.

## Related Issues

Fixes: #53564

## Tests

I added a new test that will check for this case and verify it doesn't change the month grid display when selecting a date.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them?

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
