### PR TITLE
Use feature flags for desktop cache

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -47,13 +47,13 @@ class DevelopmentArtifact {
   static const DevelopmentArtifact web = DevelopmentArtifact._('web', feature: flutterWebFeature);
 
   /// Artifacts required for desktop macOS.
-  static const DevelopmentArtifact macOS = DevelopmentArtifact._('macos', unstable: true);
+  static const DevelopmentArtifact macOS = DevelopmentArtifact._('macos', feature: flutterMacOSDesktopFeature);
 
   /// Artifacts required for desktop Windows.
-  static const DevelopmentArtifact windows = DevelopmentArtifact._('windows', unstable: true);
+  static const DevelopmentArtifact windows = DevelopmentArtifact._('windows', feature: flutterWindowsDesktopFeature);
 
   /// Artifacts required for desktop Linux.
-  static const DevelopmentArtifact linux = DevelopmentArtifact._('linux', unstable: true);
+  static const DevelopmentArtifact linux = DevelopmentArtifact._('linux', feature: flutterLinuxDesktopFeature);
 
   /// Artifacts required for Fuchsia.
   static const DevelopmentArtifact fuchsia = DevelopmentArtifact._('fuchsia', unstable: true);

--- a/packages/flutter_tools/test/commands.shard/hermetic/precache_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/precache_test.dart
@@ -63,6 +63,87 @@ void main() {
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: false),
   });
 
+  testUsingContext('precache downloads macOS artifacts on dev branch when macOS is enabled.', () async {
+    final PrecacheCommand command = PrecacheCommand();
+    applyMocksToCommand(command);
+    await createTestCommandRunner(command).run(const <String>['precache', '--macos', '--no-android', '--no-ios']);
+
+    expect(artifacts, unorderedEquals(<DevelopmentArtifact>{
+      DevelopmentArtifact.universal,
+      DevelopmentArtifact.macOS,
+    }));
+  }, overrides: <Type, Generator>{
+    Cache: () => cache,
+    FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
+  });
+
+  testUsingContext('precache does not download macOS artifacts on dev branch when feature is enabled.', () async {
+    final PrecacheCommand command = PrecacheCommand();
+    applyMocksToCommand(command);
+    await createTestCommandRunner(command).run(const <String>['precache', '--macos', '--no-android', '--no-ios']);
+
+    expect(artifacts, unorderedEquals(<DevelopmentArtifact>{
+      DevelopmentArtifact.universal,
+    }));
+  }, overrides: <Type, Generator>{
+    Cache: () => cache,
+    FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: false),
+  });
+
+  testUsingContext('precache downloads Windows artifacts on dev branch when feature is enabled.', () async {
+    final PrecacheCommand command = PrecacheCommand();
+    applyMocksToCommand(command);
+    await createTestCommandRunner(command).run(const <String>['precache', '--windows', '--no-android', '--no-ios']);
+
+    expect(artifacts, unorderedEquals(<DevelopmentArtifact>{
+      DevelopmentArtifact.universal,
+      DevelopmentArtifact.windows,
+    }));
+  }, overrides: <Type, Generator>{
+    Cache: () => cache,
+    FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),
+  });
+
+  testUsingContext('precache does not download Windows artifacts on dev branch when feature is enabled.', () async {
+    final PrecacheCommand command = PrecacheCommand();
+    applyMocksToCommand(command);
+    await createTestCommandRunner(command).run(const <String>['precache', '--windows', '--no-android', '--no-ios']);
+
+    expect(artifacts, unorderedEquals(<DevelopmentArtifact>{
+      DevelopmentArtifact.universal,
+    }));
+  }, overrides: <Type, Generator>{
+    Cache: () => cache,
+    FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: false),
+  });
+
+  testUsingContext('precache downloads Linux artifacts on dev branch when feature is enabled.', () async {
+    final PrecacheCommand command = PrecacheCommand();
+    applyMocksToCommand(command);
+    await createTestCommandRunner(command).run(const <String>['precache', '--linux', '--no-android', '--no-ios']);
+
+    expect(artifacts, unorderedEquals(<DevelopmentArtifact>{
+      DevelopmentArtifact.universal,
+      DevelopmentArtifact.linux,
+    }));
+  }, overrides: <Type, Generator>{
+    Cache: () => cache,
+    FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: true),
+  });
+
+  testUsingContext('precache does not download Linux artifacts on dev branch when feature is enabled.', () async {
+    final PrecacheCommand command = PrecacheCommand();
+    applyMocksToCommand(command);
+    await createTestCommandRunner(command).run(const <String>['precache', '--linux', '--no-android', '--no-ios']);
+
+    expect(artifacts, unorderedEquals(<DevelopmentArtifact>{
+      DevelopmentArtifact.universal,
+    }));
+  }, overrides: <Type, Generator>{
+    Cache: () => cache,
+    FeatureFlags: () => TestFeatureFlags(isLinuxEnabled: false),
+  });
+
   testUsingContext('precache exits if requesting mismatched artifacts.', () async {
     final PrecacheCommand command = PrecacheCommand();
     applyMocksToCommand(command);
@@ -107,7 +188,12 @@ void main() {
     }));
   }, overrides: <Type, Generator>{
     Cache: () => cache,
-    FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
+    FeatureFlags: () => TestFeatureFlags(
+      isWebEnabled: true,
+      isLinuxEnabled: true,
+      isMacOSEnabled: true,
+      isWindowsEnabled: true,
+    ),
     FlutterVersion: () => masterFlutterVersion,
   });
 

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -264,9 +264,9 @@ void main() {
 
   test('Unstable artifacts', () {
     expect(DevelopmentArtifact.web.unstable, false);
-    expect(DevelopmentArtifact.linux.unstable, true);
-    expect(DevelopmentArtifact.macOS.unstable, true);
-    expect(DevelopmentArtifact.windows.unstable, true);
+    expect(DevelopmentArtifact.linux.unstable, false);
+    expect(DevelopmentArtifact.macOS.unstable, false);
+    expect(DevelopmentArtifact.windows.unstable, false);
     expect(DevelopmentArtifact.fuchsia.unstable, true);
     expect(DevelopmentArtifact.flutterRunner.unstable, true);
   });


### PR DESCRIPTION
## Description

Desktop precache was using the "unstable" flag, rather than the more precise feature flags.

## Related Issues

None.

## Tests

I added the following tests: Verify each desktop platform artifact is based on its feature flag.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

This change does break one existing test, but the user-observable effect of that test—that the artifacts aren't cached when on a stable branch—are preserved by this change, so it doesn't actually affect anything. Also, desktop is not currently subject to breaking change requirements.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
