### PR TITLE
Un-gate value setting in formatter repeat check logic

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1676,11 +1676,10 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       value = _whitespaceFormatter.formatEditUpdate(_value, value);
       _lastFormattedValue = value;
     }
-    // If the text, selection, or composing region has changed, we should update the
-    // locally stored TextEditingValue to the new one.
-    if (!isRepeatText || !isRepeatSelection || !isRepeatComposing) {
-      _value = value;
-    } else if (textChanged && _lastFormattedValue != null) {
+
+    _value = value;
+    // Use the last formatted value when a repeat pass is detected.
+    if (textChanged && _lastFormattedValue != null) {
       _value = _lastFormattedValue;
     }
     // Always attempt to send the value. If the value has changed, then it will send,

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1678,10 +1678,11 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     }
 
     _value = value;
+    // Use the last formatted value when an identical repeat pass is detected.
     if (isRepeatText && isRepeatSelection && isRepeatComposing && textChanged && _lastFormattedValue != null) {
-    // // Use the last formatted value when an identical repeat pass is detected.
       _value = _lastFormattedValue;
     }
+
     // Always attempt to send the value. If the value has changed, then it will send,
     // otherwise, it will short-circuit.
     _updateRemoteEditingValueIfNeeded();

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1678,8 +1678,8 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     }
 
     _value = value;
-    // Use the last formatted value when a repeat pass is detected.
-    if (textChanged && _lastFormattedValue != null) {
+    if (isRepeatText && isRepeatSelection && isRepeatComposing && textChanged && _lastFormattedValue != null) {
+    // // Use the last formatted value when an identical repeat pass is detected.
       _value = _lastFormattedValue;
     }
     // Always attempt to send the value. If the value has changed, then it will send,

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4313,6 +4313,7 @@ void main() {
     expect(formatter.log, referenceLog);
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/53612
   testWidgets('formatter logic handles initial repeat edge case', (WidgetTester tester) async {
     final MockTextFormatter formatter = MockTextFormatter();
     await tester.pumpWidget(

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4298,6 +4298,10 @@ void main() {
     expect(formatter.formatCallCount, 4);
     expect(formatter.lastOldValue.composing, const TextRange(start: 1, end: 2));
     expect(formatter.lastNewValue.composing, const TextRange(start: -1, end: -1));
+    state.updateEditingValue(const TextEditingValue(text: '01234', selection: TextSelection.collapsed(offset: 2), composing: TextRange(start: 1, end: 2)));
+    state.updateEditingValue(const TextEditingValue(text: '01234', selection: TextSelection.collapsed(offset: 2), composing: TextRange(start: 1, end: 2)));
+    state.updateEditingValue(const TextEditingValue(text: '01234', selection: TextSelection.collapsed(offset: 2), composing: TextRange(start: 1, end: 2)));
+    state.updateEditingValue(const TextEditingValue(text: '01234', selection: TextSelection.collapsed(offset: 2), composing: TextRange(start: 1, end: 2)));
 
     const List<String> referenceLog = <String>[
       '[1]: , 01',
@@ -4307,10 +4311,52 @@ void main() {
       '[3]: aaaa, 0123',
       '[3]: normal aaaaaa',
       '[4]: 0123, 01234',
-      '[4]: normal aaaaaaaa'
+      '[4]: normal aaaaaaaa',
     ];
 
     expect(formatter.log, referenceLog);
+  });
+
+  testWidgets('formatter logic handles initial repeat edge case', (WidgetTester tester) async {
+    final MockTextFormatter formatter = MockTextFormatter();
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(devicePixelRatio: 1.0),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: FocusScope(
+            node: focusScopeNode,
+            autofocus: true,
+            child: EditableText(
+              backgroundCursorColor: Colors.grey,
+              controller: controller,
+              focusNode: focusNode,
+              maxLines: 1, // Sets text keyboard implicitly.
+              style: textStyle,
+              cursorColor: cursorColor,
+              inputFormatters: <TextInputFormatter>[formatter],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(EditableText));
+    await tester.showKeyboard(find.byType(EditableText));
+    controller.text = '';
+    await tester.idle();
+
+    final EditableTextState state =
+        tester.state<EditableTextState>(find.byType(EditableText));
+    expect(tester.testTextInput.editingState['text'], equals(''));
+    expect(state.wantKeepAlive, true);
+
+    expect(formatter.formatCallCount, 0);
+    state.updateEditingValue(const TextEditingValue(text: ''));
+    state.updateEditingValue(const TextEditingValue(text: '', composing: TextRange(start: 1, end: 2)));
+    state.updateEditingValue(const TextEditingValue(text: '0')); // pass to formatter once to check the values.
+    expect(formatter.lastOldValue.composing, const TextRange(start: 1, end: 2));
+    expect(formatter.lastOldValue.text, '');
   });
 
   testWidgets('Whitespace directionality formatter input Arabic', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4298,10 +4298,6 @@ void main() {
     expect(formatter.formatCallCount, 4);
     expect(formatter.lastOldValue.composing, const TextRange(start: 1, end: 2));
     expect(formatter.lastNewValue.composing, const TextRange(start: -1, end: -1));
-    state.updateEditingValue(const TextEditingValue(text: '01234', selection: TextSelection.collapsed(offset: 2), composing: TextRange(start: 1, end: 2)));
-    state.updateEditingValue(const TextEditingValue(text: '01234', selection: TextSelection.collapsed(offset: 2), composing: TextRange(start: 1, end: 2)));
-    state.updateEditingValue(const TextEditingValue(text: '01234', selection: TextSelection.collapsed(offset: 2), composing: TextRange(start: 1, end: 2)));
-    state.updateEditingValue(const TextEditingValue(text: '01234', selection: TextSelection.collapsed(offset: 2), composing: TextRange(start: 1, end: 2)));
 
     const List<String> referenceLog = <String>[
       '[1]: , 01',

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4311,7 +4311,7 @@ void main() {
       '[3]: aaaa, 0123',
       '[3]: normal aaaaaa',
       '[4]: 0123, 01234',
-      '[4]: normal aaaaaaaa',
+      '[4]: normal aaaaaaaa'
     ];
 
     expect(formatter.log, referenceLog);


### PR DESCRIPTION
## Description

Fixes https://github.com/flutter/flutter/issues/53612

Do not gate the value setting behind the repeat check.

This was causing Samsung keyboards to freeze/crash when it was re-shown after dismissal.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
