### PR TITLE
Add root path of the flutter web app URL in service worker

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -386,6 +386,7 @@ String generateServiceWorker(Map<String, String> resources) {
 'use strict';
 const CACHE_NAME = 'flutter-app-cache';
 const RESOURCES = {
+  "/" :"constant",
   ${resources.entries.map((MapEntry<String, String> entry) => '"${entry.key}": "${entry.value}"').join(",\n")}
 };
 


### PR DESCRIPTION
## Description
The service worker for the flutter web app when deployed , doesn't work when the app first requests for the root resource.
This makes the PWA app not work offline.
This PR adds the root path to the list of resources to be cached.

## Related Issues

Fixes #53631