### PR TITLE
Pass showCheckboxColumn parameter to DataTable

### DIFF
--- a/packages/flutter/lib/src/material/paginated_data_table.dart
+++ b/packages/flutter/lib/src/material/paginated_data_table.dart
@@ -474,6 +474,7 @@ class PaginatedDataTableState extends State<PaginatedDataTable> {
                     headingRowHeight: widget.headingRowHeight,
                     horizontalMargin: widget.horizontalMargin,
                     columnSpacing: widget.columnSpacing,
+                    showCheckboxColumn: widget.showCheckboxColumn,
                     rows: _getRows(_firstRowIndex, widget.rowsPerPage),
                   ),
                 ),

--- a/packages/flutter/test/material/paginated_data_table_test.dart
+++ b/packages/flutter/test/material/paginated_data_table_test.dart
@@ -732,19 +732,17 @@ void main() {
     await binding.setSurfaceSize(const Size(800, 800));
 
     Widget buildTable(bool checkbox) => MaterialApp(
-          home: PaginatedDataTable(
-            header: const Text('Test table'),
-            source: TestDataSource(
-              onSelectChanged: (bool value) {},
-            ),
-            showCheckboxColumn: checkbox,
-            columns: const <DataColumn>[
-              DataColumn(label: Text('Name')),
-              DataColumn(label: Text('Calories'), numeric: true),
-              DataColumn(label: Text('Generation')),
-            ],
-          ),
-        );
+      home: PaginatedDataTable(
+        header: const Text('Test table'),
+        source: TestDataSource(onSelectChanged: (bool value) {}),
+        showCheckboxColumn: checkbox,
+        columns: const <DataColumn>[
+          DataColumn(label: Text('Name')),
+          DataColumn(label: Text('Calories'), numeric: true),
+          DataColumn(label: Text('Generation')),
+        ],
+      ),
+    );
 
     await tester.pumpWidget(buildTable(true));
     expect(find.byType(Checkbox), findsNWidgets(11));

--- a/packages/flutter/test/material/paginated_data_table_test.dart
+++ b/packages/flutter/test/material/paginated_data_table_test.dart
@@ -727,8 +727,7 @@ void main() {
     await binding.setSurfaceSize(originalSize);
   });
 
-  testWidgets('PaginatedDataTable with optional column checkbox',
-      (WidgetTester tester) async {
+  testWidgets('PaginatedDataTable with optional column checkbox', (WidgetTester tester) async {
     await binding.setSurfaceSize(const Size(800, 800));
 
     Widget buildTable(bool checkbox) => MaterialApp(

--- a/packages/flutter/test/material/paginated_data_table_test.dart
+++ b/packages/flutter/test/material/paginated_data_table_test.dart
@@ -726,4 +726,30 @@ void main() {
     // Reset the surface size.
     await binding.setSurfaceSize(originalSize);
   });
+
+  testWidgets("PaginatedDataTable with optional column checkbox",
+      (WidgetTester tester) async {
+    await binding.setSurfaceSize(const Size(800, 800));
+
+    Widget buildTable(bool checkbox) => MaterialApp(
+          home: PaginatedDataTable(
+            header: const Text('Test table'),
+            source: TestDataSource(
+              onSelectChanged: (bool value) {},
+            ),
+            showCheckboxColumn: checkbox,
+            columns: const <DataColumn>[
+              DataColumn(label: Text('Name')),
+              DataColumn(label: Text('Calories'), numeric: true),
+              DataColumn(label: Text('Generation')),
+            ],
+          ),
+        );
+
+    await tester.pumpWidget(buildTable(true));
+    expect(find.byType(Checkbox), findsNWidgets(11));
+
+    await tester.pumpWidget(buildTable(false));
+    expect(find.byType(Checkbox), findsNothing);
+  });
 }

--- a/packages/flutter/test/material/paginated_data_table_test.dart
+++ b/packages/flutter/test/material/paginated_data_table_test.dart
@@ -727,7 +727,7 @@ void main() {
     await binding.setSurfaceSize(originalSize);
   });
 
-  testWidgets("PaginatedDataTable with optional column checkbox",
+  testWidgets('PaginatedDataTable with optional column checkbox',
       (WidgetTester tester) async {
     await binding.setSurfaceSize(const Size(800, 800));
 


### PR DESCRIPTION
## Description

This fixes and test if the `PaginatedDataTable`  add a checkbox column only if needed

## Related Issues

Fixes https://github.com/flutter/flutter/issues/53654

## Tests

I added the following tests:

* Draw a `PaginatedDataTable` with and without `showCheckboxColumn` parameter and check if checkboxes are present only if needed 

## Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.
