### PR TITLE
[flutter_tools] cache the base URL as index.html

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -354,6 +354,10 @@ class WebServiceWorker extends Target {
         ).toString();
       final String hash = md5.convert(await file.readAsBytes()).toString();
       urlToHash[url] = hash;
+      // Add an additional entry for the base URL.
+      if (globals.fs.path.basename(url) == 'index.html') {
+        urlToHash['/'] = hash;
+      }
     }
 
     final File serviceWorkerFile = environment.outputDir

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -462,6 +462,21 @@ void main() {
     // Depends on resource file.
     expect(environment.buildDir.childFile('service_worker.d').readAsStringSync(), contains('a/a.txt'));
   }));
+
+  test('WebServiceWorker contains baseUrl cache', () => testbed.run(() async {
+    environment.outputDir
+      .childFile('index.html')
+      .createSync(recursive: true);
+    await const WebServiceWorker().build(environment);
+
+    expect(environment.outputDir.childFile('flutter_service_worker.js'), exists);
+    // Contains file hash for both `/` and index.html.
+    expect(environment.outputDir.childFile('flutter_service_worker.js').readAsStringSync(),
+      contains('"/": "d41d8cd98f00b204e9800998ecf8427e"'));
+    expect(environment.outputDir.childFile('flutter_service_worker.js').readAsStringSync(),
+      contains('"index.html": "d41d8cd98f00b204e9800998ecf8427e"'));
+    expect(environment.buildDir.childFile('service_worker.d'), exists);
+  }));
 }
 
 class MockProcessManager extends Mock implements ProcessManager {}


### PR DESCRIPTION
## Description

Fixes https://github.com/flutter/flutter/issues/53631

Does `/` need to be configured as a baseUrl, or does it work on ~subdomains~ subdirectory automagically? 