### PR TITLE
Delete unused NDK location checks

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -104,169 +104,8 @@ String getAvdManagerPath([ AndroidSdk existingSdk ]) {
     AndroidSdk.locateAndroidSdk()?.avdManagerPath;
 }
 
-class AndroidNdkSearchError {
-  AndroidNdkSearchError(this.reason);
-
-  /// The message explaining why NDK was not found.
-  final String reason;
-}
-
-class AndroidNdk {
-  AndroidNdk._(this.directory, this.compiler, this.compilerArgs);
-
-  /// The path to the NDK.
-  final String directory;
-
-  /// The path to the NDK compiler.
-  final String compiler;
-
-  /// The mandatory arguments to the NDK compiler.
-  final List<String> compilerArgs;
-
-  /// Locate NDK within the given SDK or throw [AndroidNdkSearchError].
-  static AndroidNdk locateNdk(String androidHomeDir) {
-    if (androidHomeDir == null) {
-      throw AndroidNdkSearchError('Can not locate NDK because no SDK is found');
-    }
-
-    String findBundle(String androidHomeDir) {
-      final String ndkDirectory = globals.fs.path.join(androidHomeDir, 'ndk-bundle');
-      if (!globals.fs.isDirectorySync(ndkDirectory)) {
-        throw AndroidNdkSearchError('Can not locate ndk-bundle, tried: $ndkDirectory');
-      }
-      return ndkDirectory;
-    }
-
-    // Returns list that contains toolchain bin folder and compiler binary name.
-    List<String> findToolchainAndCompiler(String ndkDirectory) {
-      String directory;
-      if (globals.platform.isLinux) {
-        directory = 'linux-x86_64';
-      } else if (globals.platform.isMacOS) {
-        directory = 'darwin-x86_64';
-      } else {
-        throw AndroidNdkSearchError('Only Linux and macOS are supported');
-      }
-
-      final String toolchainBin = globals.fs.path.join(ndkDirectory,
-          'toolchains', 'arm-linux-androideabi-4.9', 'prebuilt', directory,
-          'bin');
-      final String ndkCompiler = globals.fs.path.join(toolchainBin,
-          'arm-linux-androideabi-gcc');
-      if (!globals.fs.isFileSync(ndkCompiler)) {
-        throw AndroidNdkSearchError('Can not locate GCC binary, tried $ndkCompiler');
-      }
-
-      return <String>[toolchainBin, ndkCompiler];
-    }
-
-    List<String> findSysroot(String ndkDirectory) {
-      // If entity represents directory with name android-<version> that
-      // contains arch-arm subdirectory then returns version, otherwise
-      // returns null.
-      int toPlatformVersion(FileSystemEntity entry) {
-        if (entry is! Directory) {
-          return null;
-        }
-
-        if (!globals.fs.isDirectorySync(globals.fs.path.join(entry.path, 'arch-arm'))) {
-          return null;
-        }
-
-        final String name = globals.fs.path.basename(entry.path);
-
-        const String platformPrefix = 'android-';
-        if (!name.startsWith(platformPrefix)) {
-          return null;
-        }
-
-        return int.tryParse(name.substring(platformPrefix.length));
-      }
-
-      final String platformsDir = globals.fs.path.join(ndkDirectory, 'platforms');
-      final List<int> versions = globals.fs
-          .directory(platformsDir)
-          .listSync()
-          .map(toPlatformVersion)
-          .where((int version) => version != null)
-          .toList(growable: false);
-      versions.sort();
-
-      final int suitableVersion = versions
-          .firstWhere((int version) => version >= 9, orElse: () => null);
-      if (suitableVersion == null) {
-        throw AndroidNdkSearchError('Can not locate a suitable platform ARM sysroot (need android-9 or newer), tried to look in $platformsDir');
-      }
-
-      final String armPlatform = globals.fs.path.join(ndkDirectory, 'platforms',
-          'android-$suitableVersion', 'arch-arm');
-      return <String>['--sysroot', armPlatform];
-    }
-
-    int findNdkMajorVersion(String ndkDirectory) {
-      final String propertiesFile = globals.fs.path.join(ndkDirectory, 'source.properties');
-      if (!globals.fs.isFileSync(propertiesFile)) {
-        throw AndroidNdkSearchError('Can not establish ndk-bundle version: $propertiesFile not found');
-      }
-
-      // Parse source.properties: each line has Key = Value format.
-      final Iterable<String> propertiesFileLines = globals.fs.file(propertiesFile)
-          .readAsStringSync()
-          .split('\n')
-          .map<String>((String line) => line.trim())
-          .where((String line) => line.isNotEmpty);
-      final Map<String, String> properties = <String, String>{};
-      for (final String line in propertiesFileLines) {
-        final List<String> parts = line.split(' = ');
-        if (parts.length == 2) {
-          properties[parts[0]] = parts[1];
-        } else {
-          globals.printError('Malformed line in ndk source.properties: "$line".');
-        }
-      }
-
-      if (!properties.containsKey('Pkg.Revision')) {
-        throw AndroidNdkSearchError('Can not establish ndk-bundle version: $propertiesFile does not contain Pkg.Revision');
-      }
-
-      // Extract major version from Pkg.Revision property which looks like <ndk-version>.x.y.
-      return int.parse(properties['Pkg.Revision'].split('.').first);
-    }
-
-    final String ndkDir = findBundle(androidHomeDir);
-    final int ndkVersion = findNdkMajorVersion(ndkDir);
-    final List<String> ndkToolchainAndCompiler = findToolchainAndCompiler(ndkDir);
-    final String ndkToolchain = ndkToolchainAndCompiler[0];
-    final String ndkCompiler = ndkToolchainAndCompiler[1];
-    final List<String> ndkCompilerArgs = findSysroot(ndkDir);
-    if (ndkVersion >= 18) {
-      // Newer versions of NDK use clang instead of gcc, which falls back to
-      // system linker instead of using toolchain linker. Force clang to
-      // use appropriate linker by passing -fuse-ld=<path-to-ld> command line
-      // flag.
-      final String ndkLinker = globals.fs.path.join(ndkToolchain, 'arm-linux-androideabi-ld');
-      if (!globals.fs.isFileSync(ndkLinker)) {
-        throw AndroidNdkSearchError('Can not locate linker binary, tried $ndkLinker');
-      }
-      ndkCompilerArgs.add('-fuse-ld=$ndkLinker');
-    }
-    return AndroidNdk._(ndkDir, ndkCompiler, ndkCompilerArgs);
-  }
-
-  /// Returns a descriptive message explaining why NDK can not be found within
-  /// the given SDK.
-  static String explainMissingNdk(String androidHomeDir) {
-    try {
-      locateNdk(androidHomeDir);
-      return 'Unexpected error: found NDK on the second try';
-    } on AndroidNdkSearchError catch (e) {
-      return e.reason;
-    }
-  }
-}
-
 class AndroidSdk {
-  AndroidSdk(this.directory, [this.ndk]) {
+  AndroidSdk(this.directory) {
     reinitialize();
   }
 
@@ -275,9 +114,6 @@ class AndroidSdk {
 
   /// The path to the Android SDK.
   final String directory;
-
-  /// Android NDK (can be `null`).
-  final AndroidNdk ndk;
 
   List<AndroidSdkVersion> _sdkVersions;
   AndroidSdkVersion _latestVersion;
@@ -380,16 +216,7 @@ class AndroidSdk {
       return null;
     }
 
-    // Try to find the NDK compiler. If we can't find it, it's also ok.
-    AndroidNdk ndk;
-    try {
-      ndk = AndroidNdk.locateNdk(androidHomeDir);
-    } on AndroidNdkSearchError {
-      // Ignore AndroidNdkSearchError's but don't ignore any other
-      // exceptions.
-    }
-
-    return AndroidSdk(androidHomeDir, ndk);
+    return AndroidSdk(androidHomeDir);
   }
 
   static bool validSdkDirectory(String dir) {

--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -166,10 +166,6 @@ class AndroidValidator extends DoctorValidator {
 
     messages.add(ValidationMessage(_userMessages.androidSdkLocation(_androidSdk.directory)));
 
-    messages.add(ValidationMessage(_androidSdk.ndk == null
-          ? _userMessages.androidMissingNdk
-          : _userMessages.androidNdkLocation(_androidSdk.ndk.directory)));
-
     String sdkVersionText;
     if (_androidSdk.latestVersion != null) {
       if (_androidSdk.latestVersion.sdkLevel < 28 || _androidSdk.latestVersion.buildToolsVersion < kAndroidSdkBuildToolsMinVersion) {

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -77,8 +77,6 @@ class UserMessages {
   String androidSdkInstallHelp(Platform platform) =>
       'Try re-installing or updating your Android SDK,\n'
       'visit ${_androidSdkInstallUrl(platform)} for detailed instructions.';
-  String get androidMissingNdk => 'Android NDK location not configured (optional; useful for native profiling support)';
-  String androidNdkLocation(String directory) => 'Android NDK at $directory';
   // Also occurs in AndroidLicenseValidator
   String androidStatusInfo(String version) => 'Android SDK version $version';
 

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -63,9 +63,6 @@ class MockApplicationPackageFactory extends Mock implements ApplicationPackageFa
 class MockAndroidSdk extends Mock implements AndroidSdk {
   static Directory createSdkDirectory({
     bool withAndroidN = false,
-    String withNdkDir,
-    int ndkVersion = 16,
-    bool withNdkSysroot = false,
     bool withSdkManager = true,
     bool withPlatformTools = true,
     bool withBuildTools = true,
@@ -98,41 +95,6 @@ class MockAndroidSdk extends Mock implements AndroidSdk {
 
     if (withSdkManager) {
       _createSdkFile(dir, 'tools/bin/sdkmanager$bat');
-    }
-
-    if (withNdkDir != null) {
-      final String ndkToolchainBin = globals.fs.path.join(
-        'ndk-bundle',
-        'toolchains',
-        'arm-linux-androideabi-4.9',
-        'prebuilt',
-        withNdkDir,
-        'bin',
-      );
-      final String ndkCompiler = globals.fs.path.join(
-        ndkToolchainBin,
-        'arm-linux-androideabi-gcc',
-      );
-      final String ndkLinker = globals.fs.path.join(
-        ndkToolchainBin,
-        'arm-linux-androideabi-ld',
-      );
-      _createSdkFile(dir, ndkCompiler);
-      _createSdkFile(dir, ndkLinker);
-      _createSdkFile(dir, globals.fs.path.join('ndk-bundle', 'source.properties'), contents: '''
-Pkg.Desc = Android NDK[]
-Pkg.Revision = $ndkVersion.1.5063045
-
-''');
-    }
-    if (withNdkSysroot) {
-      final String armPlatform = globals.fs.path.join(
-        'ndk-bundle',
-        'platforms',
-        'android-9',
-        'arch-arm',
-      );
-      _createDir(dir, armPlatform);
     }
 
     return dir;


### PR DESCRIPTION
## Description

NDK compiler usage was removed in https://github.com/flutter/flutter/pull/33611.  Remove doctor validator check.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/53684.

## Tests

Removed NDK tests.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*