### PR TITLE
Dev

### DIFF
--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -127,10 +127,10 @@ class CupertinoApp extends StatefulWidget {
   /// system values.
   final CupertinoThemeData theme;
 
-  /// Themeto use in event user has enabled system-wide dark mode
+  /// Theme to use in event user has enabled system-wide dark mode, similiar to [MaterialApp.darkTheme]
   final CupertinoThemeData darkTheme;
 
-  /// Cupertino Theme Mode
+  /// Cupertino Theme Mode, similiar to [MaterialApp.themeMode]
   final CupertinoThemeMode themeMode;
   /// The application's top-level routing table.
   ///
@@ -302,12 +302,11 @@ class _CupertinoAppState extends State<CupertinoApp> {
               onGenerateRoute: widget.onGenerateRoute,
               onUnknownRoute: widget.onUnknownRoute,
               builder: (BuildContext context, Widget child) {
+                // Theme resolving is nested inside the WidgetsApp so MediaQuery can resolve PlatformBrightness
                 final CupertinoThemeMode mode = widget.themeMode ?? CupertinoThemeMode.system;
                 CupertinoThemeData theme;
                 if (widget.darkTheme != null) {
-                  print("not null");
                   final ui.Brightness platformBrightness = MediaQuery.platformBrightnessOf(context);
-                  print(platformBrightness);
                   if (mode == CupertinoThemeMode.dark ||
                   (mode == CupertinoThemeMode.system && platformBrightness == ui.Brightness.dark)) {
                     theme = widget.darkTheme;

--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -1,10 +1,10 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2018 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
-
+import 'dart:ui' as ui;
 import 'button.dart';
 import 'colors.dart';
 import 'icons.dart';
@@ -15,6 +15,18 @@ import 'theme.dart';
 
 /// An application that uses Cupertino design.
 ///
+/// Describes which theme will be used by [CupertinoApp].
+enum CupertinoThemeMode {
+  /// Use either the light or dark theme based on what the user has selected in
+  /// the system settings.
+  system,
+
+  /// Always use the light mode regardless of system preference.
+  light,
+
+  /// Always use the dark mode (if available) regardless of system preference.
+  dark,
+}
 /// A convenience widget that wraps a number of widgets that are commonly
 /// required for an iOS-design targeting application. It builds upon a
 /// [WidgetsApp] by iOS specific defaulting such as fonts and scrolling
@@ -72,10 +84,11 @@ class CupertinoApp extends StatefulWidget {
     this.navigatorKey,
     this.home,
     this.theme,
+    this.darkTheme,
+    this.themeMode = CupertinoThemeMode.system, // added dark theme
     this.routes = const <String, WidgetBuilder>{},
     this.initialRoute,
     this.onGenerateRoute,
-    this.onGenerateInitialRoutes,
     this.onUnknownRoute,
     this.navigatorObservers = const <NavigatorObserver>[],
     this.builder,
@@ -92,8 +105,6 @@ class CupertinoApp extends StatefulWidget {
     this.checkerboardOffscreenLayers = false,
     this.showSemanticsDebugger = false,
     this.debugShowCheckedModeBanner = true,
-    this.shortcuts,
-    this.actions,
   }) : assert(routes != null),
        assert(navigatorObservers != null),
        assert(title != null),
@@ -116,6 +127,11 @@ class CupertinoApp extends StatefulWidget {
   /// system values.
   final CupertinoThemeData theme;
 
+  /// Themeto use in event user has enabled system-wide dark mode
+  final CupertinoThemeData darkTheme;
+
+  /// Cupertino Theme Mode
+  final CupertinoThemeMode themeMode;
   /// The application's top-level routing table.
   ///
   /// When a named route is pushed with [Navigator.pushNamed], the route name is
@@ -131,9 +147,6 @@ class CupertinoApp extends StatefulWidget {
 
   /// {@macro flutter.widgets.widgetsApp.onGenerateRoute}
   final RouteFactory onGenerateRoute;
-
-  /// {@macro flutter.widgets.widgetsApp.onGenerateInitialRoutes}
-  final InitialRouteListFactory onGenerateInitialRoutes;
 
   /// {@macro flutter.widgets.widgetsApp.onUnknownRoute}
   final RouteFactory onUnknownRoute;
@@ -197,67 +210,6 @@ class CupertinoApp extends StatefulWidget {
 
   /// {@macro flutter.widgets.widgetsApp.debugShowCheckedModeBanner}
   final bool debugShowCheckedModeBanner;
-
-  /// {@macro flutter.widgets.widgetsApp.shortcuts}
-  /// {@tool snippet}
-  /// This example shows how to add a single shortcut for
-  /// [LogicalKeyboardKey.select] to the default shortcuts without needing to
-  /// add your own [Shortcuts] widget.
-  ///
-  /// Alternatively, you could insert a [Shortcuts] widget with just the mapping
-  /// you want to add between the [WidgetsApp] and its child and get the same
-  /// effect.
-  ///
-  /// ```dart
-  /// Widget build(BuildContext context) {
-  ///   return WidgetsApp(
-  ///     shortcuts: <LogicalKeySet, Intent>{
-  ///       ... WidgetsApp.defaultShortcuts,
-  ///       LogicalKeySet(LogicalKeyboardKey.select): const Intent(ActivateAction.key),
-  ///     },
-  ///     color: const Color(0xFFFF0000),
-  ///     builder: (BuildContext context, Widget child) {
-  ///       return const Placeholder();
-  ///     },
-  ///   );
-  /// }
-  /// ```
-  /// {@end-tool}
-  /// {@macro flutter.widgets.widgetsApp.shortcuts.seeAlso}
-  final Map<LogicalKeySet, Intent> shortcuts;
-
-  /// {@macro flutter.widgets.widgetsApp.actions}
-  /// {@tool snippet}
-  /// This example shows how to add a single action handling an
-  /// [ActivateAction] to the default actions without needing to
-  /// add your own [Actions] widget.
-  ///
-  /// Alternatively, you could insert a [Actions] widget with just the mapping
-  /// you want to add between the [WidgetsApp] and its child and get the same
-  /// effect.
-  ///
-  /// ```dart
-  /// Widget build(BuildContext context) {
-  ///   return WidgetsApp(
-  ///     actions: <LocalKey, ActionFactory>{
-  ///       ... WidgetsApp.defaultActions,
-  ///       ActivateAction.key: () => CallbackAction(
-  ///         ActivateAction.key,
-  ///         onInvoke: (FocusNode focusNode, Intent intent) {
-  ///           // Do something here...
-  ///         },
-  ///       ),
-  ///     },
-  ///     color: const Color(0xFFFF0000),
-  ///     builder: (BuildContext context, Widget child) {
-  ///       return const Placeholder();
-  ///     },
-  ///   );
-  /// }
-  /// ```
-  /// {@end-tool}
-  /// {@macro flutter.widgets.widgetsApp.actions.seeAlso}
-  final Map<LocalKey, ActionFactory> actions;
 
   @override
   _CupertinoAppState createState() => _CupertinoAppState();
@@ -332,61 +284,76 @@ class _CupertinoAppState extends State<CupertinoApp> {
 
   @override
   Widget build(BuildContext context) {
-    final CupertinoThemeData effectiveThemeData = widget.theme ?? const CupertinoThemeData();
-
     return ScrollConfiguration(
       behavior: _AlwaysCupertinoScrollBehavior(),
       child: CupertinoUserInterfaceLevel(
         data: CupertinoUserInterfaceLevelData.base,
-        child: CupertinoTheme(
-          data: effectiveThemeData,
-          child: Builder(
-            builder: (BuildContext context) {
-              return WidgetsApp(
-                key: GlobalObjectKey(this),
-                navigatorKey: widget.navigatorKey,
-                navigatorObservers: _navigatorObservers,
-                pageRouteBuilder: <T>(RouteSettings settings, WidgetBuilder builder) =>
-                  CupertinoPageRoute<T>(settings: settings, builder: builder),
-                home: widget.home,
-                routes: widget.routes,
-                initialRoute: widget.initialRoute,
-                onGenerateRoute: widget.onGenerateRoute,
-                onGenerateInitialRoutes: widget.onGenerateInitialRoutes,
-                onUnknownRoute: widget.onUnknownRoute,
-                builder: widget.builder,
-                title: widget.title,
-                onGenerateTitle: widget.onGenerateTitle,
-                textStyle: CupertinoTheme.of(context).textTheme.textStyle,
-                color: CupertinoDynamicColor.resolve(widget.color ?? effectiveThemeData.primaryColor, context),
-                locale: widget.locale,
-                localizationsDelegates: _localizationsDelegates,
-                localeResolutionCallback: widget.localeResolutionCallback,
-                localeListResolutionCallback: widget.localeListResolutionCallback,
-                supportedLocales: widget.supportedLocales,
-                showPerformanceOverlay: widget.showPerformanceOverlay,
-                checkerboardRasterCacheImages: widget.checkerboardRasterCacheImages,
-                checkerboardOffscreenLayers: widget.checkerboardOffscreenLayers,
-                showSemanticsDebugger: widget.showSemanticsDebugger,
-                debugShowCheckedModeBanner: widget.debugShowCheckedModeBanner,
-                inspectorSelectButtonBuilder: (BuildContext context, VoidCallback onPressed) {
-                  return CupertinoButton.filled(
-                    child: const Icon(
-                      CupertinoIcons.search,
-                      size: 28.0,
-                      color: CupertinoColors.white,
-                    ),
-                    padding: EdgeInsets.zero,
-                    onPressed: onPressed,
-                  );
-                },
-                shortcuts: widget.shortcuts,
-                actions: widget.actions,
-              );
-            },
-          ),
-        ),
-      ),
+        child: Builder(
+          builder: (BuildContext context) {
+            return WidgetsApp(
+              key: GlobalObjectKey(this),
+              navigatorKey: widget.navigatorKey,
+              navigatorObservers: _navigatorObservers,
+              pageRouteBuilder: <T>(RouteSettings settings, WidgetBuilder builder) =>
+                CupertinoPageRoute<T>(settings: settings, builder: builder),
+              home: widget.home,
+              routes: widget.routes,
+              initialRoute: widget.initialRoute,
+              onGenerateRoute: widget.onGenerateRoute,
+              onUnknownRoute: widget.onUnknownRoute,
+              builder: (BuildContext context, Widget child) {
+                final CupertinoThemeMode mode = widget.themeMode ?? CupertinoThemeMode.system;
+                CupertinoThemeData theme;
+                if (widget.darkTheme != null) {
+                  print("not null");
+                  final ui.Brightness platformBrightness = MediaQuery.platformBrightnessOf(context);
+                  print(platformBrightness);
+                  if (mode == CupertinoThemeMode.dark ||
+                  (mode == CupertinoThemeMode.system && platformBrightness == ui.Brightness.dark)) {
+                    theme = widget.darkTheme;
+                  }
+                }
+                theme ??= widget.theme ?? CupertinoThemeData();
+                return CupertinoTheme(
+                  data: theme,
+                  child: widget.builder != null
+                    ? Builder(
+                        builder: (BuildContext context) {
+                          return widget.builder(context, child);
+                        },
+                      )
+                    : child,
+                );
+              },
+              title: widget.title,
+              onGenerateTitle: widget.onGenerateTitle,
+              textStyle: CupertinoTheme.of(context).textTheme.textStyle,
+              color: widget.color ?? widget.theme?.primaryColor ?? CupertinoColors.white,
+              locale: widget.locale,
+              localizationsDelegates: _localizationsDelegates,
+              localeResolutionCallback: widget.localeResolutionCallback,
+              localeListResolutionCallback: widget.localeListResolutionCallback,
+              supportedLocales: widget.supportedLocales,
+              showPerformanceOverlay: widget.showPerformanceOverlay,
+              checkerboardRasterCacheImages: widget.checkerboardRasterCacheImages,
+              checkerboardOffscreenLayers: widget.checkerboardOffscreenLayers,
+              showSemanticsDebugger: widget.showSemanticsDebugger,
+              debugShowCheckedModeBanner: widget.debugShowCheckedModeBanner,
+              inspectorSelectButtonBuilder: (BuildContext context, VoidCallback onPressed) {
+                return CupertinoButton.filled(
+                  child: const Icon(
+                    CupertinoIcons.search,
+                    size: 28.0,
+                    color: CupertinoColors.white,
+                  ),
+                  padding: EdgeInsets.zero,
+                  onPressed: onPressed,
+                );
+              },
+            );
+          } 
+        )
+      )
     );
   }
 }


### PR DESCRIPTION
## Description
Hello,

* I have added the darkTheme property featured in the MaterialApp widget to the CupertinoApp widget to take advantage of automatic detection of system-wide dark mode. This is especially useful for iOS developers who use the CupertinoApp widget if they want their app to automatically change themes depending on the system's theme. Note that I am not an experienced flutter developer nor am I especially familiar with the internal workings of the engine.
## Related Issues
* darkTheme property lacking from CupertinoApp widget

## Tests
I added the following tests:

* hello_world test succeeded

## Checklist
Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes ([x]). This will ensure a smooth and quick review process.

 I read the Contributor Guide and followed the process outlined there for submitting PRs.
 I signed the CLA.
 I read and followed the Flutter Style Guide, including Features we expect every widget to implement.
 I read the Tree Hygiene wiki page, which explains my responsibilities.
 I updated/added relevant documentation (doc comments with ///).
 All existing and new tests are passing.
 The analyzer (flutter analyze --flutter-repo) does not report any problems on my PR.
 I am willing to follow-up on review comments in a timely manner.
Breaking Change
Did any tests fail when you ran them? Please read Handling breaking changes.

 No, no existing tests failed, so this is not a breaking change.
 Yes, this is a breaking change. If not, delete the remainder of this section.
 I wrote a design doc: https://flutter.dev/go/template Replace this with a link to your design doc's short link
 I got input from the developer relations team, specifically from: Replace with the names of who gave advice
 I wrote a migration guide: Replace with a link to your migration guide*