### PR TITLE
Material Date Picker should honor DialogTheme shape, and elevation.

### DIFF
--- a/packages/flutter/lib/src/material/pickers/date_picker_dialog.dart
+++ b/packages/flutter/lib/src/material/pickers/date_picker_dialog.dart
@@ -475,9 +475,9 @@ class _DatePickerDialogState extends State<_DatePickerDialog> {
         ),
       ),
       insetPadding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 24.0),
-      // Only overriding shape because the material spec was updated to radius 4,
-      // but the default for Dialogs are radius 2 which can can't update without
-      // breaking apps.
+      // The default dialog shape is radius 2 rounded rect, but the spec has
+      // been updated to 4, so we will use that here for the Date Picker, but
+      // only if there isn't one provided in the theme.
       shape: dialogTheme.shape ?? const RoundedRectangleBorder(
         borderRadius: BorderRadius.all(Radius.circular(4.0))
       ),

--- a/packages/flutter/lib/src/material/pickers/date_picker_dialog.dart
+++ b/packages/flutter/lib/src/material/pickers/date_picker_dialog.dart
@@ -12,6 +12,7 @@ import '../button_theme.dart';
 import '../color_scheme.dart';
 import '../debug.dart';
 import '../dialog.dart';
+import '../dialog_theme.dart';
 import '../flat_button.dart';
 import '../icons.dart';
 import '../material_localizations.dart';
@@ -427,6 +428,7 @@ class _DatePickerDialogState extends State<_DatePickerDialog> {
     );
 
     final Size dialogSize = _dialogSize(context) * textScaleFactor;
+    final DialogTheme dialogTheme = Theme.of(context).dialogTheme;
     return Dialog(
       child: AnimatedContainer(
         width: dialogSize.width,
@@ -473,11 +475,13 @@ class _DatePickerDialogState extends State<_DatePickerDialog> {
         ),
       ),
       insetPadding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 24.0),
-      shape: const RoundedRectangleBorder(
+      // Only overriding shape because the material spec was updated to radius 4,
+      // but the default for Dialogs are radius 2 which can can't update without
+      // breaking apps.
+      shape: dialogTheme.shape ?? const RoundedRectangleBorder(
         borderRadius: BorderRadius.all(Radius.circular(4.0))
       ),
       clipBehavior: Clip.antiAlias,
-      elevation: 24.0,
     );
   }
 }

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -247,6 +247,77 @@ void main() {
       expect(nestedObserver.datePickerCount, 1);
     });
 
+    testWidgets('honors DialogTheme for shape and elevation', (WidgetTester tester) async {
+      // Test that the defaults work
+      const DialogTheme datePickerDefaultDialogTheme = DialogTheme(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(Radius.circular(4.0))
+        ),
+        elevation: 24,
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(
+            child: Builder(
+              builder: (BuildContext context) {
+                return RaisedButton(
+                  child: const Text('X'),
+                  onPressed: () {
+                    showDatePicker(
+                      context: context,
+                      initialDate: DateTime.now(),
+                      firstDate: DateTime(2018),
+                      lastDate: DateTime(2030),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('X'));
+      await tester.pumpAndSettle();
+      final Material defaultDialogMaterial = tester.widget<Material>(find.descendant(of: find.byType(Dialog), matching: find.byType(Material)).first);
+      expect(defaultDialogMaterial.shape, datePickerDefaultDialogTheme.shape);
+      expect(defaultDialogMaterial.elevation, datePickerDefaultDialogTheme.elevation);
+
+      // Test that it honors ThemeData.dialogTheme settings
+      const DialogTheme customDialogTheme = DialogTheme(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(Radius.circular(40.0))
+        ),
+        elevation: 50,
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.fallback().copyWith(dialogTheme: customDialogTheme),
+          home: Center(
+            child: Builder(
+              builder: (BuildContext context) {
+                return RaisedButton(
+                  child: const Text('X'),
+                  onPressed: () {
+                    showDatePicker(
+                      context: context,
+                      initialDate: DateTime.now(),
+                      firstDate: DateTime(2018),
+                      lastDate: DateTime(2030),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('X'));
+      await tester.pumpAndSettle();
+      final Material themeDialogMaterial = tester.widget<Material>(find.descendant(of: find.byType(Dialog), matching: find.byType(Material)).first);
+      expect(themeDialogMaterial.shape, customDialogTheme.shape);
+      expect(themeDialogMaterial.elevation, customDialogTheme.elevation);
+    });
+
   });
 
   group('Calendar mode', () {


### PR DESCRIPTION
## Description

The Material Date Picker currently hard codes the values for the dialog shape and elevation to match the Material Design spec. However, if an application would like to configure these values with a custom `DialogTheme` in their app, the picker won't honor these settings. This PR makes the Date Picker use the values of `DialogTheme.shape` and `DialogTheme.elevation` from the ambient `ThemeData.dialogTheme` if it exists. If these are null, then it will default to the shape and elevation given in the spec.

## Tests

I added a test that checks that the shape and elevation can be overridden by the DialogTheme.
 
## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them?

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
