### PR TITLE
add lock.yml

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,39 @@
+# Configuration for Lock Threads - https://github.com/dessant/lock-threads-app
+
+# Number of days of inactivity before a closed issue or pull request is locked
+daysUntilLock: 14
+
+# Skip issues and pull requests created before a given timestamp. Timestamp must
+# follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable
+skipCreatedBefore: false
+
+# Issues and pull requests with these labels will be ignored. Set to `[]` to disable
+exemptLabels: []
+
+# Label to add before locking, such as `outdated`. Set to `false` to disable
+lockLabel: false
+
+# Comment to post before locking. Set to `false` to disable
+lockComment: >
+  This thread has been automatically locked since there has not been
+  any recent activity after it was closed. If you are still experiencing a
+  similar issue, please open a new bug, including the output of
+  `flutter doctor -v` and a minimal reproduction of the issue.
+
+# Assign `resolved` as the reason for locking. Set to `false` to disable
+setLockReason: false
+
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Optionally, specify configuration settings just for `issues` or `pulls`
+# issues:
+#   exemptLabels:
+#     - help-wanted
+#   lockLabel: outdated
+
+# pulls:
+#   daysUntilLock: 30
+
+# Repository to extend settings from
+# _extends: repo


### PR DESCRIPTION
## Description

Configuration for https://github.com/apps/lock

I have separately submitted a request to install the application, which has to be approved by one of the reviewers tagged here.

The purpose of this app (and configuration) is to lock issues and pull requests from further discussion after 14 days of inactivity.  This is meant to help reduce missed reports by users who may be pinging bugs no one is subscribed to, and from reducing noise to subscribers on old bugs that are likely not the exact same problem as what a user is newly posting about.

## Related Issues

This, along with actually enabling the app, fixes https://github.com/flutter/flutter/issues/50552