### PR TITLE
Overlay contains entry

### DIFF
--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -298,6 +298,11 @@ class OverlayState extends State<Overlay> with TickerProviderStateMixin {
     return _entries.length;
   }
 
+  /// Used to check whether given entry already exists on the overlay
+  bool containsEntry(OverlayEntry entry) {
+    return _entries.contains(entry);
+  }
+
   /// Insert the given entry into the overlay.
   ///
   /// If `below` is non-null, the entry is inserted just below `below`.

--- a/packages/flutter/test/widgets/overlay_test.dart
+++ b/packages/flutter/test/widgets/overlay_test.dart
@@ -941,6 +941,43 @@ void main() {
 
     expect(tester.getTopLeft(find.text('positioned child')), const Offset(145, 123));
   });
+
+  testWidgets('Can verify if OverlayEntry is already on the Overlay', (WidgetTester tester) async {
+    final GlobalKey<OverlayState> overlayKey = GlobalKey<OverlayState>();
+    final Key exists = UniqueKey();
+    final Key doNotExists = UniqueKey();
+    final Widget existsWidget = StatefulTestWidget(key: exists);
+    final Widget doNotExistsWidget = StatefulTestWidget(key: doNotExists);
+
+    final OverlayEntry existsEntry = OverlayEntry(
+      maintainState: true,
+      builder: (BuildContext context) {
+        return existsWidget;
+      }
+    );
+
+    final OverlayEntry doNotExistsEntry = OverlayEntry(
+      maintainState: true,
+      builder: (BuildContext context) {
+        return doNotExistsWidget;
+      }
+    );
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Overlay(
+          key: overlayKey,
+          initialEntries: <OverlayEntry>[
+            existsEntry,
+          ],
+        ),
+      ),
+    );
+
+    expect(overlayKey.currentState.containsEntry(existsEntry), true);
+    expect(overlayKey.currentState.containsEntry(doNotExistsEntry), false);
+  });
 }
 
 class StatefulTestWidget extends StatefulWidget {


### PR DESCRIPTION
## Description

Added a method to verify the existence of given OverlayEntry on the Overlay.

## Related Issues

#47532

## Tests

Added `Can verify if OverlayEntry is already on the Overlay` on `overlay_test`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
