### PR TITLE
Improve downgrade-upgrade integration test

### DIFF
--- a/packages/flutter_tools/test/integration.shard/downgrade_upgrade_integration_test.dart
+++ b/packages/flutter_tools/test/integration.shard/downgrade_upgrade_integration_test.dart
@@ -50,20 +50,23 @@ void main() {
     final Directory testDirectory = parentDirectory.childDirectory('flutter');
     testDirectory.createSync(recursive: true);
 
+    int exitCode = 0;
+
     // Enable longpaths for windows integration test.
     await processManager.run(<String>[
       'git', 'config', '--system', 'core.longpaths', 'true',
     ]);
 
     // Step 1. Clone the dev branch of flutter into the test directory.
-    await processUtils.stream(<String>[
+    exitCode = await processUtils.stream(<String>[
       'git',
       'clone',
       'https://github.com/flutter/flutter.git',
     ], workingDirectory: parentDirectory.path, trace: true);
+    expect(exitCode, 0);
 
     // Step 2. Switch to the dev branch.
-    await processUtils.stream(<String>[
+    exitCode = await processUtils.stream(<String>[
       'git',
       'checkout',
       '--track',
@@ -71,22 +74,26 @@ void main() {
       _kBranch,
       'origin/$_kBranch',
     ], workingDirectory: testDirectory.path, trace: true);
+    expect(exitCode, 0);
 
     // Step 3. Revert to a prior version.
-    await processUtils.stream(<String>[
+    exitCode = await processUtils.stream(<String>[
       'git',
       'reset',
       '--hard',
       _kInitialVersion,
     ], workingDirectory: testDirectory.path, trace: true);
+    expect(exitCode, 0);
 
     // Step 4. Upgrade to the newest dev. This should update the persistent
     // tool state with the sha for v1.14.3
-    await processUtils.stream(<String>[
+    exitCode = await processUtils.stream(<String>[
       flutterBin,
       'upgrade',
+      '--verbose',
       '--working-directory=${testDirectory.path}'
     ], workingDirectory: testDirectory.path, trace: true);
+    expect(exitCode, 0);
 
     // Step 5. Verify that the version is different.
     final RunResult versionResult = await processUtils.run(<String>[
@@ -101,12 +108,13 @@ void main() {
     expect(versionResult.stdout, isNot(contains(_kInitialVersion)));
 
     // Step 6. Downgrade back to initial version.
-    await processUtils.stream(<String>[
+    exitCode = await processUtils.stream(<String>[
        flutterBin,
       'downgrade',
       '--no-prompt',
       '--working-directory=${testDirectory.path}'
     ], workingDirectory: testDirectory.path, trace: true);
+    expect(exitCode, 0);
 
     // Step 7. Verify downgraded version matches original version.
     final RunResult oldVersionResult = await processUtils.run(<String>[

--- a/packages/flutter_tools/test/integration.shard/downgrade_upgrade_integration_test.dart
+++ b/packages/flutter_tools/test/integration.shard/downgrade_upgrade_integration_test.dart
@@ -12,8 +12,8 @@ import 'package:process/process.dart';
 
 import '../src/common.dart';
 
-const String _kInitialVersion = 'v1.9.1+hotfix.6';
-const String _kBranch = 'stable';
+const String _kInitialVersion = 'v1.9.1';
+const String _kBranch = 'dev';
 const FileSystem fileSystem = LocalFileSystem();
 const ProcessManager processManager = LocalProcessManager();
 final Stdio stdio = Stdio();


### PR DESCRIPTION
## Description

Before this PR, the `downgrade_upgrade_integration_test.dart` was failing during fast forward, however the test swallowed the tool exit. The fast forward would fail because the upgrade command's `resetChanges()` method, intended to roll back from a hotfix commit back to the last published dev tag (e.g. from `v1.9.1+hotfix.6 -> v1.9.1`), however, in this test it was actually jumping forward from the temp repo's hotfix tag (e.g. `v1.9.1+hotfix.6`) to the source repo's last dev tag (e.g. `v1.6.4`), and then trying to fast forward resulted in a merge conflict, causing the `git pull -ff` to fail.

This PR gets rid of the merge conflict by starting from the dev branch, so that the reset is to a tag that is on the current branch, making a fast forward valid. It also checks the exit code of each step, to protect against regression.

## Related Issues

Part of https://github.com/flutter/flutter/issues/53688.

## Tests

This improves an existing test.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*