### PR TITLE
Replace isInstanceOf<T> uses with isA<T>

### DIFF
--- a/packages/flutter/test/services/platform_channel_test.dart
+++ b/packages/flutter/test/services/platform_channel_test.dart
@@ -70,7 +70,7 @@ void main() {
           }
         },
       );
-      expect(channel.invokeMethod<List<String>>('sayHello', 'hello'), throwsA(isInstanceOf<TypeError>()));
+      expect(channel.invokeMethod<List<String>>('sayHello', 'hello'), throwsA(isA<TypeError>()));
       expect(await channel.invokeListMethod<String>('sayHello', 'hello'), <String>['hello', 'world']);
     });
 
@@ -102,7 +102,7 @@ void main() {
           }
         },
       );
-      expect(channel.invokeMethod<Map<String, String>>('sayHello', 'hello'), throwsA(isInstanceOf<TypeError>()));
+      expect(channel.invokeMethod<Map<String, String>>('sayHello', 'hello'), throwsA(isA<TypeError>()));
       expect(await channel.invokeMapMethod<String, String>('sayHello', 'hello'), <String, String>{'hello': 'world'});
     });
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -105,7 +105,7 @@ void main() {
         ]);
         fail('Expect exception');
       } on Exception catch (e) {
-        expect(e, isInstanceOf<ToolExit>());
+        expect(e, isA<ToolExit>());
       }
       final BufferLogger bufferLogger = globals.logger as BufferLogger;
       expect(bufferLogger.statusText, contains(
@@ -162,7 +162,7 @@ void main() {
         ]);
         fail('Expect exception');
       } on Exception catch (e) {
-        expect(e, isInstanceOf<ToolExit>());
+        expect(e, isA<ToolExit>());
         expect(e.toString(), contains('No pubspec.yaml file found'));
       }
     }, overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
@@ -77,7 +77,7 @@ void main() {
     androidEnvironment.defines.remove(kBuildMode);
     expect(
       const KernelSnapshot().build(androidEnvironment),
-      throwsA(isInstanceOf<MissingDefineException>()));
+      throwsA(isA<MissingDefineException>()));
   }));
 
   test('KernelSnapshot handles null result from kernel compilation', () => testbed.run(() async {
@@ -328,33 +328,33 @@ void main() {
     androidEnvironment.defines.remove(kBuildMode);
 
     expect(const AotElfProfile().build(androidEnvironment),
-      throwsA(isInstanceOf<MissingDefineException>()));
+      throwsA(isA<MissingDefineException>()));
   }));
 
   test('AotElfProfile throws error if missing target platform', () => testbed.run(() async {
     androidEnvironment.defines.remove(kTargetPlatform);
 
     expect(const AotElfProfile().build(androidEnvironment),
-      throwsA(isInstanceOf<MissingDefineException>()));
+      throwsA(isA<MissingDefineException>()));
   }));
 
   test('AotAssemblyProfile throws error if missing build mode', () => testbed.run(() async {
     iosEnvironment.defines.remove(kBuildMode);
 
     expect(const AotAssemblyProfile().build(iosEnvironment),
-      throwsA(isInstanceOf<MissingDefineException>()));
+      throwsA(isA<MissingDefineException>()));
   }));
 
   test('AotAssemblyProfile throws error if missing target platform', () => testbed.run(() async {
     iosEnvironment.defines.remove(kTargetPlatform);
 
     expect(const AotAssemblyProfile().build(iosEnvironment),
-      throwsA(isInstanceOf<MissingDefineException>()));
+      throwsA(isA<MissingDefineException>()));
   }));
 
   test('AotAssemblyProfile throws error if built for non-iOS platform', () => testbed.run(() async {
     expect(const AotAssemblyProfile().build(androidEnvironment),
-      throwsA(isInstanceOf<Exception>()));
+      throwsA(isA<Exception>()));
   }));
 
   test('AotAssemblyProfile generates multiple arches and lipos together', () => testbed.run(() async {

--- a/packages/flutter_tools/test/general.shard/testbed_test.dart
+++ b/packages/flutter_tools/test/general.shard/testbed_test.dart
@@ -95,7 +95,7 @@ void main() {
         ProcessUtils: () => null,
       });
 
-      expect(() => testbed.run(() {}), throwsA(isInstanceOf<StateError>()));
+      expect(() => testbed.run(() {}), throwsA(isA<StateError>()));
     });
   });
 }


### PR DESCRIPTION
## Description

Remove usage of isInstanceOf

## Related Issues

https://github.com/dart-lang/test/issues/2375

## Tests

Cleanup.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*
