### PR TITLE
Fix FlutterError.onError in debug mode

### DIFF
--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -727,14 +727,15 @@ class FlutterError extends Error with DiagnosticableTreeMixin implements Asserti
   /// recommended.
   static FlutterExceptionHandler onError = (FlutterErrorDetails details) => presentError(details);
 
-  /// Called whenever the Flutter framework wants to present error to the users.
+  /// Called whenever the Flutter framework wants to present an error to the
+  /// users.
   ///
   /// The default behavior is to call [dumpErrorToConsole].
   ///
-  /// Plugins can override how an error to be presented to the users. For
+  /// Plugins can override how an error is to be presented to the user. For
   /// example, the structured errors service extension sets its own method when
-  /// the extension is enabled. If ypu want change how flutter responds to an
-  /// error , use [onError] instead.
+  /// the extension is enabled. If you want to change how Flutter responds to an
+  /// error, use [onError] instead.
   static FlutterExceptionHandler presentError = dumpErrorToConsole;
 
   static int _errorCount = 0;

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -715,7 +715,7 @@ class FlutterError extends Error with DiagnosticableTreeMixin implements Asserti
 
   /// Called whenever the Flutter framework catches an error.
   ///
-  /// The default behavior is to call [dumpErrorToConsole].
+  /// The default behavior is to call [presentError].
   ///
   /// You can set this to your own function to override this default behavior.
   /// For example, you could report all errors to your server.
@@ -725,7 +725,17 @@ class FlutterError extends Error with DiagnosticableTreeMixin implements Asserti
   ///
   /// Set this to null to silently catch and ignore errors. This is not
   /// recommended.
-  static FlutterExceptionHandler onError = dumpErrorToConsole;
+  static FlutterExceptionHandler onError = presentError;
+
+  /// Called whenever the Flutter framework wants to present error to the users.
+  ///
+  /// The default behavior is to call [dumpErrorToConsole].
+  ///
+  /// Plugins can override how an error to be presented to the users. For
+  /// example, the structured errors service extension sets its own method when
+  /// the extension is enabled. If ypu want change how flutter responds to an
+  /// error , use [onError] instead.
+  static FlutterExceptionHandler presentError = dumpErrorToConsole;
 
   static int _errorCount = 0;
 

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -725,7 +725,7 @@ class FlutterError extends Error with DiagnosticableTreeMixin implements Asserti
   ///
   /// Set this to null to silently catch and ignore errors. This is not
   /// recommended.
-  static FlutterExceptionHandler onError = presentError;
+  static FlutterExceptionHandler onError = (FlutterErrorDetails details) => presentError(details);
 
   /// Called whenever the Flutter framework wants to present error to the users.
   ///

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -958,17 +958,14 @@ mixin WidgetInspectorService {
 
     SchedulerBinding.instance.addPersistentFrameCallback(_onFrameStart);
 
-    final FlutterExceptionHandler defaultExceptionHandler = FlutterError.onError;
-    final FlutterExceptionHandler structuredExceptionHandler = (FlutterErrorDetails details) {
-      _reportError(details);
-      defaultExceptionHandler?.call(details);
-    };
+    final FlutterExceptionHandler structuredExceptionHandler = _reportError;
+    final FlutterExceptionHandler defaultExceptionHandler = FlutterError.presentError;
 
     _registerBoolServiceExtension(
       name: 'structuredErrors',
-      getter: () async => FlutterError.onError == structuredExceptionHandler,
+      getter: () async => FlutterError.presentError == structuredExceptionHandler,
       setter: (bool value) {
-        FlutterError.onError = value ? structuredExceptionHandler : defaultExceptionHandler;
+        FlutterError.presentError = value ? structuredExceptionHandler : defaultExceptionHandler;
         return Future<void>.value();
       },
     );
@@ -2429,6 +2426,7 @@ class _RenderInspectorOverlay extends RenderBox {
   }
 }
 
+@immutable
 class _TransformedRect {
   _TransformedRect(RenderObject object)
     : rect = object.semanticBounds,
@@ -2454,8 +2452,9 @@ class _TransformedRect {
 ///
 /// The equality operator can be used to determine whether the overlay needs to
 /// be rendered again.
+@immutable
 class _InspectorOverlayRenderState {
-  _InspectorOverlayRenderState({
+  const _InspectorOverlayRenderState({
     @required this.overlayRect,
     @required this.selected,
     @required this.candidates,

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -958,8 +958,11 @@ mixin WidgetInspectorService {
 
     SchedulerBinding.instance.addPersistentFrameCallback(_onFrameStart);
 
-    final FlutterExceptionHandler structuredExceptionHandler = _reportError;
     final FlutterExceptionHandler defaultExceptionHandler = FlutterError.onError;
+    final FlutterExceptionHandler structuredExceptionHandler = (FlutterErrorDetails details) {
+      _reportError(details);
+      defaultExceptionHandler?.call(details);
+    };
 
     _registerBoolServiceExtension(
       name: 'structuredErrors',

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -1840,7 +1840,7 @@ void main() {
         final GlobalKey<ScaffoldState> key = GlobalKey<ScaffoldState>();
         const Key buttonKey = Key('button');
         final List<FlutterErrorDetails> errors = <FlutterErrorDetails>[];
-        FlutterError.onError = (FlutterErrorDetails error) => errors.add(error);
+        FlutterError.presentError = (FlutterErrorDetails error) => errors.add(error);
         int state = 0;
         await tester.pumpWidget(
           MaterialApp(

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -527,6 +527,7 @@ void main() {
     final ImageListener listener = (ImageInfo info, bool synchronous) {
       capturedImage = info;
     };
+    final FlutterExceptionHandler oldHandler = FlutterError.onError;
     FlutterError.onError = (FlutterErrorDetails flutterError) {
       reportedException = flutterError.exception;
       reportedStackTrace = flutterError.stack;
@@ -563,6 +564,7 @@ void main() {
     // The image stream error handler should have the original exception.
     expect(capturedException, testException);
     expect(capturedStackTrace, testStack);
+    FlutterError.onError = oldHandler;
   });
 
   testWidgets('Duplicate listener registration does not affect error listeners', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/widget_inspector_structure_error_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_structure_error_test.dart
@@ -13,7 +13,7 @@ void main() {
 class StructureErrorTestWidgetInspectorService extends TestWidgetInspectorService {
 
   static void runTests() {
-    final TestWidgetInspectorService service = TestWidgetInspectorService();
+    final StructureErrorTestWidgetInspectorService service = StructureErrorTestWidgetInspectorService();
     WidgetInspectorService.instance = service;
 
     test('ext.flutter.inspector.structuredErrors still report error to original on error', () async {

--- a/packages/flutter/test/widgets/widget_inspector_structure_error_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_structure_error_test.dart
@@ -10,11 +10,11 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'widget_inspector_test.dart';
-
 void main() {
   StructureErrorTestWidgetInspectorService.runTests();
 }
+
+typedef InspectorServiceExtensionCallback = FutureOr<Map<String, Object>> Function(Map<String, String> parameters);
 
 class StructureErrorTestWidgetInspectorService extends Object with WidgetInspectorService {
   final Map<String, InspectorServiceExtensionCallback> extensions = <String, InspectorServiceExtensionCallback>{};

--- a/packages/flutter/test/widgets/widget_inspector_structure_error_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_structure_error_test.dart
@@ -1,5 +1,8 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/widgets/widget_inspector_structure_error_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_structure_error_test.dart
@@ -28,12 +28,12 @@ class StructureErrorTestWidgetInspectorService extends TestWidgetInspectorServic
 
       WidgetsFlutterBinding.ensureInitialized();
       try {
-        // Enable structured errors.
+        // Enables structured errors.
         expect(await service.testBoolExtension(
           'structuredErrors', <String, String>{'enabled': 'true'}),
           equals('true'));
 
-        // Create an error.
+        // Creates an error.
         final FlutterErrorDetails expectedError = FlutterErrorDetailsForRendering(
           library: 'rendering library',
           context: ErrorDescription('during layout'),
@@ -41,7 +41,7 @@ class StructureErrorTestWidgetInspectorService extends TestWidgetInspectorServic
         );
         FlutterError.reportError(expectedError);
 
-        // Validate the spy still received an error.
+        // Validates the spy still received an error.
         expect(actualError, expectedError);
       } finally {
         FlutterError.onError = oldHandler;

--- a/packages/flutter/test/widgets/widget_inspector_structure_error_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_structure_error_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'widget_inspector_test.dart';
+
+void main() {
+  StructureErrorTestWidgetInspectorService.runTests();
+}
+
+class StructureErrorTestWidgetInspectorService extends TestWidgetInspectorService {
+
+  static void runTests() {
+    final TestWidgetInspectorService service = TestWidgetInspectorService();
+    WidgetInspectorService.instance = service;
+
+    test('ext.flutter.inspector.structuredErrors still report error to original on error', () async {
+      final FlutterExceptionHandler oldHandler = FlutterError.onError;
+
+      FlutterErrorDetails actualError;
+      // Creates a spy onError. This spy needs to be set before widgets binding
+      // initializes.
+      FlutterError.onError = (FlutterErrorDetails details) {
+        actualError = details;
+      };
+
+      WidgetsFlutterBinding.ensureInitialized();
+      try {
+        // Enable structured errors.
+        expect(await service.testBoolExtension(
+          'structuredErrors', <String, String>{'enabled': 'true'}),
+          equals('true'));
+
+        // Create an error.
+        final FlutterErrorDetails expectedError = FlutterErrorDetailsForRendering(
+          library: 'rendering library',
+          context: ErrorDescription('during layout'),
+          exception: StackTrace.current,
+        );
+        FlutterError.reportError(expectedError);
+
+        // Validate the spy still received an error.
+        expect(actualError, expectedError);
+      } finally {
+        FlutterError.onError = oldHandler;
+      }
+    });
+  }
+}

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -2280,7 +2280,7 @@ class TestWidgetInspectorService extends Object with WidgetInspectorService {
       List<Map<Object, Object>> flutterErrorEvents = service.getEventsDispatched('Flutter.Error');
       expect(flutterErrorEvents, isEmpty);
 
-      final FlutterExceptionHandler oldHandler = FlutterError.onError;
+      final FlutterExceptionHandler oldHandler = FlutterError.presentError;
 
       try {
         // Enable structured errors.
@@ -2337,7 +2337,7 @@ class TestWidgetInspectorService extends Object with WidgetInspectorService {
         error = flutterErrorEvents.last;
         expect(error['errorsSinceReload'], 0);
       } finally {
-        FlutterError.onError = oldHandler;
+        FlutterError.presentError = oldHandler;
       }
     });
 

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -572,9 +572,9 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   }) {
     assert(description != null);
     assert(inTest);
-    _oldExceptionHandler = FlutterError.onError;
+    _oldExceptionHandler = FlutterError.presentError;
     int _exceptionCount = 0; // number of un-taken exceptions
-    FlutterError.onError = (FlutterErrorDetails details) {
+    FlutterError.presentError = (FlutterErrorDetails details) {
       if (_pendingExceptionDetails != null) {
         debugPrint = debugPrintOverride; // just in case the test overrides it -- otherwise we won't see the errors!
         if (_exceptionCount == 0) {
@@ -800,7 +800,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   /// Called by the [testWidgets] function after a test is executed.
   void postTest() {
     assert(inTest);
-    FlutterError.onError = _oldExceptionHandler;
+    FlutterError.presentError = _oldExceptionHandler;
     _pendingExceptionDetails = null;
     _parentZone = null;
     buildOwner.focusManager = FocusManager();


### PR DESCRIPTION
## Description

Based on https://github.com/flutter/flutter/pull/52728

This pr added a test

## Related Issues

Fixes https://github.com/flutter/flutter/issues/47447
Fixes https://github.com/flutter/flutter/issues/44407

## Tests

I added the following tests:

"ext.flutter.inspector.structuredErrors still report error to original on error"

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
