### PR TITLE
only auto-lock issues, not pull requests

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -24,7 +24,7 @@ lockComment: >
 setLockReason: false
 
 # Limit to only `issues` or `pulls`
-# only: issues
+only: issues
 
 # Optionally, specify configuration settings just for `issues` or `pulls`
 # issues:


### PR DESCRIPTION
## Description

The bot is working through every PR ever merged, and locking it. This seems unneccessary, my understanding is the primary motivation for setting up this bot was for issues. This change sets the bot to only lock issues, not PRs.

## Issues

Fixes https://github.com/flutter/flutter/issues/53854