### PR TITLE
Remove network images from cache on any exception during loading

### DIFF
--- a/packages/flutter/lib/src/painting/_network_image_io.dart
+++ b/packages/flutter/lib/src/painting/_network_image_io.dart
@@ -82,7 +82,9 @@ class NetworkImage extends image_provider.ImageProvider<image_provider.NetworkIm
       assert(key == this);
 
       final Uri resolved = Uri.base.resolve(key.url);
+
       final HttpClientRequest request = await _httpClient.getUrl(resolved);
+
       headers?.forEach((String name, String value) {
         request.headers.add(name, value);
       });
@@ -91,7 +93,6 @@ class NetworkImage extends image_provider.ImageProvider<image_provider.NetworkIm
         // The network may be only temporarily unavailable, or the file will be
         // added on the server later. Avoid having future calls to resolve
         // fail to check the network again.
-        PaintingBinding.instance.imageCache.evict(key);
         throw image_provider.NetworkImageLoadException(statusCode: response.statusCode, uri: resolved);
       }
 
@@ -108,6 +109,15 @@ class NetworkImage extends image_provider.ImageProvider<image_provider.NetworkIm
         throw Exception('NetworkImage is an empty file: $resolved');
 
       return decode(bytes);
+    } catch (e) {
+      // Depending on where the exception was thrown, the image cache may not
+      // have had a chance to track the key in the cache at all.
+      // Schedule a microtask to give the cache a chance to add the key.
+      scheduleMicrotask(() {
+        final bool removed = PaintingBinding.instance.imageCache.evict(key);
+        assert(removed);
+      });
+      rethrow;
     } finally {
       chunkEvents.close();
     }

--- a/packages/flutter/lib/src/painting/_network_image_io.dart
+++ b/packages/flutter/lib/src/painting/_network_image_io.dart
@@ -114,8 +114,7 @@ class NetworkImage extends image_provider.ImageProvider<image_provider.NetworkIm
       // have had a chance to track the key in the cache at all.
       // Schedule a microtask to give the cache a chance to add the key.
       scheduleMicrotask(() {
-        final bool removed = PaintingBinding.instance.imageCache.evict(key);
-        assert(removed);
+        PaintingBinding.instance.imageCache.evict(key);
       });
       rethrow;
     } finally {


### PR DESCRIPTION
## Description

Makes network image resolution evict from the cache on any exception - previously, we'd miss various things like socket exceptions during an http request and get stuck with a bad image in the cache.

This means that we'd also refuse to keep a 0 length image in the cache even if everything else succeeds, which seems fine to me - it seems likely that is either a network error or a cheap thing to retry, and we still report the error.

## Related Issues

Fixes #47270 again

## Tests

I added the following tests:

Test covering eviction of the image from the cache on a socket exception

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
