### PR TITLE
Update Windows and Linux plugin templates

### DIFF
--- a/packages/flutter_tools/templates/plugin/linux.tmpl/projectName_plugin.cc.tmpl
+++ b/packages/flutter_tools/templates/plugin/linux.tmpl/projectName_plugin.cc.tmpl
@@ -72,13 +72,7 @@ void {{pluginClass}}::HandleMethodCall(
 
 void {{pluginClass}}RegisterWithRegistrar(
     FlutterDesktopPluginRegistrarRef registrar) {
-  // The plugin registrar wrappers owns the plugins, registered callbacks, etc.,
-  // so must remain valid for the life of the application.
-  static auto *plugin_registrars =
-      new std::map<FlutterDesktopPluginRegistrarRef,
-                   std::unique_ptr<flutter::PluginRegistrarGlfw>>;
-  auto insert_result = plugin_registrars->emplace(
-      registrar, std::make_unique<flutter::PluginRegistrarGlfw>(registrar));
-
-  {{pluginClass}}::RegisterWithRegistrar(insert_result.first->second.get());
+  {{pluginClass}}::RegisterWithRegistrar(
+      flutter::PluginRegistrarManager::GetInstance()
+          ->GetRegistrar<flutter::PluginRegistrarGlfw>(registrar));
 }

--- a/packages/flutter_tools/templates/plugin/windows.tmpl/projectName_plugin.cpp.tmpl
+++ b/packages/flutter_tools/templates/plugin/windows.tmpl/projectName_plugin.cpp.tmpl
@@ -83,13 +83,7 @@ void {{pluginClass}}::HandleMethodCall(
 
 void {{pluginClass}}RegisterWithRegistrar(
     FlutterDesktopPluginRegistrarRef registrar) {
-  // The plugin registrar wrappers owns the plugins, registered callbacks, etc.,
-  // so must remain valid for the life of the application.
-  static auto *plugin_registrars =
-      new std::map<FlutterDesktopPluginRegistrarRef,
-                   std::unique_ptr<flutter::PluginRegistrarWindows>>;
-  auto insert_result = plugin_registrars->emplace(
-      registrar, std::make_unique<flutter::PluginRegistrarWindows>(registrar));
-
-  {{pluginClass}}::RegisterWithRegistrar(insert_result.first->second.get());
+  {{pluginClass}}::RegisterWithRegistrar(
+      flutter::PluginRegistrarManager::GetInstance()
+          ->GetRegistrar<flutter::PluginRegistrarWindows>(registrar));
 }


### PR DESCRIPTION
## Description

Updates Windows and Linux templates to use the new PluginRegistrarManager, improving lifetime handling and reducing boilerplate.

## Related Issues

#53496

## Tests

I added the following tests: None.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
