### PR TITLE
Collect chrome://tracing data in Web benchmarks

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_text_layout.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_text_layout.dart
@@ -191,31 +191,51 @@ class BenchTextCachedLayout extends RawRecorder {
 /// build are unique.
 int _counter = 0;
 
-/// Measures how expensive it is to construct material checkboxes.
+/// Which mode to run [BenchBuildColorsGrid] in.
+enum BenchBuildColorsGridMode {
+  /// Uses the HTML rendering backend with the canvas 2D text layout.
+  useCanvasTextLayout,
+
+  /// Uses the HTML rendering backend with the DOM text layout.
+  useDomTextLayout,
+
+  /// Uses CanvasKit for everything.
+  useCanvasKit,
+}
+
+/// Measures how expensive it is to construct a realistic text-heavy piece of UI.
 ///
-/// Creates a 10x10 grid of tristate checkboxes.
+/// The benchmark constructs a tabbed view, where each tab displays a list of
+/// colors. Each color's description is made of several [Text] nodes.
 class BenchBuildColorsGrid extends WidgetBuildRecorder {
-  BenchBuildColorsGrid({@required this.useCanvas})
-      : super(name: useCanvas ? canvasBenchmarkName : domBenchmarkName);
+  BenchBuildColorsGrid.canvas()
+      : mode = BenchBuildColorsGridMode.useCanvasTextLayout, super(name: canvasBenchmarkName);
+  BenchBuildColorsGrid.dom()
+      : mode = BenchBuildColorsGridMode.useDomTextLayout, super(name: domBenchmarkName);
+  BenchBuildColorsGrid.canvasKit()
+      : mode = BenchBuildColorsGridMode.useCanvasKit, super(name: canvasKitBenchmarkName);
 
   static const String domBenchmarkName = 'text_dom_color_grid';
   static const String canvasBenchmarkName = 'text_canvas_color_grid';
+  static const String canvasKitBenchmarkName = 'text_canvas_kit_color_grid';
 
   /// Whether to use the new canvas-based text measurement implementation.
-  final bool useCanvas;
+  final BenchBuildColorsGridMode mode;
 
   num _textLayoutMicros = 0;
 
   @override
-  void setUpAll() {
-    _useCanvasText(useCanvas);
+  Future<void> setUpAll() async {
+    if (mode == BenchBuildColorsGridMode.useCanvasTextLayout) {
+      _useCanvasText(true);
+    }
     _onBenchmark((String name, num value) {
       _textLayoutMicros += value;
     });
   }
 
   @override
-  void tearDownAll() {
+  Future<void> tearDownAll() async {
     _useCanvasText(null);
     _onBenchmark(null);
   }
@@ -230,7 +250,7 @@ class BenchBuildColorsGrid extends WidgetBuildRecorder {
   void frameDidDraw() {
     // We need to do this before calling [super.frameDidDraw] because the latter
     // updates the value of [showWidget] in preparation for the next frame.
-    if (showWidget) {
+    if (showWidget && mode != BenchBuildColorsGridMode.useCanvasKit) {
       profile.addDataPoint(
         'text_layout',
         Duration(microseconds: _textLayoutMicros.toInt()),

--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_text_layout.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_text_layout.dart
@@ -192,7 +192,7 @@ class BenchTextCachedLayout extends RawRecorder {
 int _counter = 0;
 
 /// Which mode to run [BenchBuildColorsGrid] in.
-enum BenchBuildColorsGridMode {
+enum _TestMode {
   /// Uses the HTML rendering backend with the canvas 2D text layout.
   useCanvasTextLayout,
 
@@ -209,25 +209,28 @@ enum BenchBuildColorsGridMode {
 /// colors. Each color's description is made of several [Text] nodes.
 class BenchBuildColorsGrid extends WidgetBuildRecorder {
   BenchBuildColorsGrid.canvas()
-      : mode = BenchBuildColorsGridMode.useCanvasTextLayout, super(name: canvasBenchmarkName);
+      : mode = _TestMode.useCanvasTextLayout, super(name: canvasBenchmarkName);
   BenchBuildColorsGrid.dom()
-      : mode = BenchBuildColorsGridMode.useDomTextLayout, super(name: domBenchmarkName);
+      : mode = _TestMode.useDomTextLayout, super(name: domBenchmarkName);
   BenchBuildColorsGrid.canvasKit()
-      : mode = BenchBuildColorsGridMode.useCanvasKit, super(name: canvasKitBenchmarkName);
+      : mode = _TestMode.useCanvasKit, super(name: canvasKitBenchmarkName);
 
   static const String domBenchmarkName = 'text_dom_color_grid';
   static const String canvasBenchmarkName = 'text_canvas_color_grid';
   static const String canvasKitBenchmarkName = 'text_canvas_kit_color_grid';
 
   /// Whether to use the new canvas-based text measurement implementation.
-  final BenchBuildColorsGridMode mode;
+  final _TestMode mode;
 
   num _textLayoutMicros = 0;
 
   @override
   Future<void> setUpAll() async {
-    if (mode == BenchBuildColorsGridMode.useCanvasTextLayout) {
+    if (mode == _TestMode.useCanvasTextLayout) {
       _useCanvasText(true);
+    }
+    if (mode == _TestMode.useDomTextLayout) {
+      _useCanvasText(false);
     }
     _onBenchmark((String name, num value) {
       _textLayoutMicros += value;
@@ -250,7 +253,8 @@ class BenchBuildColorsGrid extends WidgetBuildRecorder {
   void frameDidDraw() {
     // We need to do this before calling [super.frameDidDraw] because the latter
     // updates the value of [showWidget] in preparation for the next frame.
-    if (showWidget && mode != BenchBuildColorsGridMode.useCanvasKit) {
+    // TODO(yjbanov): https://github.com/flutter/flutter/issues/53877
+    if (showWidget && mode != _TestMode.useCanvasKit) {
       profile.addDataPoint(
         'text_layout',
         Duration(microseconds: _textLayoutMicros.toInt()),

--- a/dev/devicelab/lib/framework/browser.dart
+++ b/dev/devicelab/lib/framework/browser.dart
@@ -2,11 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+import 'dart:convert' show json, utf8, LineSplitter, JsonEncoder;
 import 'dart:io' as io;
+import 'dart:math' as math;
 
 import 'package:meta/meta.dart';
-
-import 'utils.dart' show forwardStandardStreams;
+import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 /// Options passed to Chrome when launching it.
 class ChromeOptions {
@@ -52,7 +54,7 @@ typedef ChromeErrorCallback = void Function(String);
 
 /// Manages a single Chrome process.
 class Chrome {
-  Chrome._(this._chromeProcess, this._onError) {
+  Chrome._(this._chromeProcess, this._onError, this._debugConnection) {
     // If the Chrome process quits before it was asked to quit, notify the
     // error listener.
     _chromeProcess.exitCode.then((int exitCode) {
@@ -71,6 +73,7 @@ class Chrome {
     final io.ProcessResult versionResult = io.Process.runSync(_findSystemChromeExecutable(), const <String>['--version']);
     print('Launching ${versionResult.stdout}');
 
+    final bool withDebugging = options.debugPort != null;
     final List<String> args = <String>[
       if (options.userDataDirectory != null)
         '--user-data-dir=${options.userDataDirectory}',
@@ -80,7 +83,7 @@ class Chrome {
         '--no-sandbox',
       if (options.headless)
         '--headless',
-      if (options.debugPort != null)
+      if (withDebugging)
         '--remote-debugging-port=${options.debugPort}',
       '--window-size=${options.windowWidth},${options.windowHeight}',
       '--disable-extensions',
@@ -97,13 +100,83 @@ class Chrome {
       args,
       workingDirectory: workingDirectory,
     );
-    forwardStandardStreams(chromeProcess);
-    return Chrome._(chromeProcess, onError);
+
+    WipConnection debugConnection;
+    if (withDebugging) {
+      debugConnection = await _connectToChromeDebugPort(chromeProcess, options.debugPort);
+    }
+
+    return Chrome._(chromeProcess, onError, debugConnection);
   }
 
   final io.Process _chromeProcess;
   final ChromeErrorCallback _onError;
+  final WipConnection _debugConnection;
   bool _isStopped = false;
+
+  Completer<void> _tracingCompleter;
+  StreamSubscription<WipEvent> _tracingSubscription;
+  List<Map<String, dynamic>> _tracingData;
+
+  /// Starts recording a performance trace.
+  ///
+  /// If there is already a tracing session in progress, throws an error. Call
+  /// [endRecordingPerformance] before starting a new tracing session.
+  ///
+  /// The [label] is for debugging convenience.
+  Future<void> beginRecordingPerformance(String label) async {
+    if (_tracingCompleter != null) {
+      throw StateError(
+        'Cannot start a new performance trace. A tracing session labeled '
+        '"$label" is already in progress.'
+      );
+    }
+    _tracingCompleter = Completer<void>();
+    _tracingData = <Map<String, dynamic>>[];
+
+    // Subscribe to tracing events prior to calling "Tracing.start". Otherwise,
+    // we'll miss tracing data.
+    _tracingSubscription = _debugConnection.onNotification.listen((WipEvent event) {
+      // We receive data as a sequence of "Tracing.dataCollected" followed by
+      // "Tracing.tracingComplete" at the end. Until "Tracing.tracingComplete"
+      // is received, the data may be incomplete.
+      if (event.method == 'Tracing.tracingComplete') {
+        _tracingCompleter.complete();
+        _tracingSubscription.cancel();
+        _tracingSubscription = null;
+      } else if (event.method == 'Tracing.dataCollected') {
+        _tracingData.addAll((event.params['value'] as List<dynamic>).cast<Map<String, dynamic>>());
+      }
+    });
+    await _debugConnection.sendCommand('Tracing.start', <String, dynamic>{
+      // The choice of categories is as follows:
+      //
+      // blink:
+      //   provides everything on the UI thread, including scripting,
+      //   style recalculations, layout, painting, and some compositor
+      //   work.
+      // blink.user_timing:
+      //   provides marks recorded using window.performance. We use marks
+      //   to find frames that the benchmark cares to measure.
+      // gpu:
+      //   provides tracing data from the GPU data
+      // TODO(yjbanov): extract useful GPU data
+      'categories': 'blink,blink.user_timing,gpu',
+      'transferMode': 'SendAsStream',
+    });
+  }
+
+  /// Stops a performance tracing session started by [beginRecordingPerformance].
+  ///
+  /// Returns all the collected tracing data unfiltered.
+  Future<List<Map<String, dynamic>>> endRecordingPerformance() async {
+    await _debugConnection.sendCommand('Tracing.end');
+    await _tracingCompleter.future;
+    final List<Map<String, dynamic>> data = _tracingData;
+    _tracingCompleter = null;
+    _tracingData = null;
+    return data;
+  }
 
   /// Stops the Chrome process.
   void stop() {
@@ -135,4 +208,257 @@ String _findSystemChromeExecutable() {
   } else {
     throw Exception('Web benchmarks cannot run on ${io.Platform.operatingSystem} yet.');
   }
+}
+
+/// Waits for Chrome to print DevTools URI and connects to it.
+Future<WipConnection> _connectToChromeDebugPort(io.Process chromeProcess, int port) async {
+  chromeProcess.stdout
+    .transform(utf8.decoder)
+    .transform(const LineSplitter())
+    .listen((String line) {
+      print('[CHROME]: $line');
+    });
+
+  await chromeProcess.stderr
+    .transform(utf8.decoder)
+    .transform(const LineSplitter())
+    .map((String line) {
+      print('[CHROME]: $line');
+      return line;
+    })
+    .firstWhere((String line) => line.startsWith('DevTools listening'), orElse: () {
+      throw Exception('Failed to spawn stderr');
+    });
+
+  final Uri devtoolsUri = await _getRemoteDebuggerUrl(Uri.parse('http://localhost:$port'));
+  print('Connecting to DevTools: $devtoolsUri');
+  final ChromeConnection chromeConnection = ChromeConnection('localhost', port);
+  final Iterable<ChromeTab> tabs = (await chromeConnection.getTabs()).where((ChromeTab tab) {
+    return tab.url.startsWith('http://localhost');
+  });
+  final ChromeTab tab = tabs.single;
+  return tab.connect();
+}
+
+/// Gets the Chrome debugger URL for the web page being benchmarked.
+Future<Uri> _getRemoteDebuggerUrl(Uri base) async {
+  final io.HttpClient client = io.HttpClient();
+  final io.HttpClientRequest request = await client.getUrl(base.resolve('/json/list'));
+  final io.HttpClientResponse response = await request.close();
+  final List<dynamic> jsonObject = await json.fuse(utf8).decoder.bind(response).single as List<dynamic>;
+  if (jsonObject == null || jsonObject.isEmpty) {
+    return base;
+  }
+  return base.resolve(jsonObject.first['webSocketDebuggerUrl'] as String);
+}
+
+/// Summarizes a Blink trace down to a few interesting values.
+class BlinkTraceSummary {
+  BlinkTraceSummary._({
+    @required this.averageBeginFrameTime,
+    @required this.averageUpdateLifecyclePhasesTime,
+  }) : averageTotalUIFrameTime = averageBeginFrameTime + averageUpdateLifecyclePhasesTime;
+
+  static BlinkTraceSummary fromJson(List<Map<String, dynamic>> traceJson) {
+    try {
+      // Convert raw JSON data to BlinkTraceEvent objects sorted by timestamp.
+      List<BlinkTraceEvent> events = traceJson
+        .map<BlinkTraceEvent>(BlinkTraceEvent.fromJson)
+        .toList()
+        ..sort((BlinkTraceEvent a, BlinkTraceEvent b) => a.ts - b.ts);
+
+      // Filter out data from unrelated processes
+      final BlinkTraceEvent processLabel = events
+        .where((BlinkTraceEvent event) {
+          return event.name == 'thread_name' && event.args['name'] == 'CrRendererMain';
+        })
+        .single;
+      final int tabPid = processLabel.pid;
+      events = events.where((BlinkTraceEvent element) => element.pid == tabPid).toList();
+
+      // Extract frame data.
+      final List<BlinkFrame> frames = <BlinkFrame>[];
+      int skipCount = 0;
+      BlinkFrame frame = BlinkFrame();
+      for (final BlinkTraceEvent event in events) {
+        if (event.ph == 'X' && event.name == 'WebViewImpl::beginFrame') {
+          frame.beginFrame = event;
+        } else if (event.ph == 'X' && event.name == 'WebViewImpl::updateAllLifecyclePhases') {
+          frame.updateAllLifecyclePhases = event;
+          if (frame.endMeasuredFrame != null) {
+            frames.add(frame);
+          } else {
+            skipCount += 1;
+          }
+          frame = BlinkFrame();
+        } else if (event.ph == 'b' && event.name == 'measured_frame') {
+          frame.beginMeasuredFrame = event;
+        } else if (event.ph == 'e' && event.name == 'measured_frame') {
+          frame.endMeasuredFrame = event;
+        }
+      }
+
+      print('Extracted ${frames.length} measured frames.');
+      print('Skipped $skipCount non-measured frames.');
+
+      if (frames.isEmpty) {
+        // The benchmark is not measuring frames.
+        return null;
+      }
+
+      // Compute averages and summarize.
+      return BlinkTraceSummary._(
+        averageBeginFrameTime: _computeAverageDuration(frames.map((BlinkFrame frame) => frame.beginFrame).toList()),
+        averageUpdateLifecyclePhasesTime: _computeAverageDuration(frames.map((BlinkFrame frame) => frame.updateAllLifecyclePhases).toList()),
+      );
+    } catch (_, __) {
+      final io.File traceFile = io.File('./chrome-trace.json');
+      io.stderr.writeln('Failed to interpret the Chrome trace contents. The trace was saved in ${traceFile.path}');
+      traceFile.writeAsStringSync(const JsonEncoder.withIndent('  ').convert(traceJson));
+      rethrow;
+    }
+  }
+
+  /// The average duration of "WebViewImpl::beginFrame" events.
+  ///
+  /// This event contains all of scripting time of an animation frame, plus an
+  /// unknown small amount of work browser does before and after scripting.
+  final Duration averageBeginFrameTime;
+
+  /// The average duration of "WebViewImpl::updateAllLifecyclePhases" events.
+  ///
+  /// This event contains style, layout, painting, and compositor computations,
+  /// which are not included in the scripting time. This event does not
+  /// include GPU time, which happens on a separate thread.
+  final Duration averageUpdateLifecyclePhasesTime;
+
+  /// The average sum of [averageBeginFrameTime] and
+  /// [averageUpdateLifecyclePhasesTime].
+  ///
+  /// This value contains the vast majority of work the UI thread performs in
+  /// any given animation frame.
+  final Duration averageTotalUIFrameTime;
+
+  @override
+  String toString() => '$BlinkTraceSummary('
+    'averageBeginFrameTime: ${averageBeginFrameTime.inMicroseconds / 1000}ms, '
+    'averageUpdateLifecyclePhasesTime: ${averageUpdateLifecyclePhasesTime.inMicroseconds / 1000}ms)';
+}
+
+/// Contains events pertaining to a single frame in the Blink trace data.
+class BlinkFrame {
+  /// Corresponds to 'WebViewImpl::beginFrame' event.
+  BlinkTraceEvent beginFrame;
+
+  /// Corresponds to 'WebViewImpl::updateAllLifecyclePhases' event.
+  BlinkTraceEvent updateAllLifecyclePhases;
+
+  /// Corresponds to 'measured_frame' begin event.
+  BlinkTraceEvent beginMeasuredFrame;
+
+  /// Corresponds to 'measured_frame' end event.
+  BlinkTraceEvent endMeasuredFrame;
+}
+
+/// Takes a list of events that have non-null [BlinkTraceEvent.tdur] computes
+/// their average as a [Duration] value.
+Duration _computeAverageDuration(List<BlinkTraceEvent> events) {
+  final double total = events
+    .skip(math.max(events.length - 10, 0))
+    .fold(0.0, (double previousValue, BlinkTraceEvent event) {
+      if (event.tdur == null) {
+        throw event;
+      }
+      return previousValue + event.tdur;
+    });
+  final int sampleCount = math.min(events.length, 10);
+  return Duration(microseconds: total ~/ sampleCount);
+}
+
+/// An event collected by the Blink tracer (in Chrome accessible using chrome://tracing).
+///
+/// See also:
+///  * https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview
+class BlinkTraceEvent {
+  BlinkTraceEvent._({
+    @required this.args,
+    @required this.cat,
+    @required this.name,
+    @required this.ph,
+    @required this.pid,
+    @required this.tid,
+    @required this.ts,
+    @required this.tts,
+    @required this.tdur,
+  });
+
+  /// Parses an event from its JSON representation.
+  static BlinkTraceEvent fromJson(Map<String, dynamic> json) {
+    return BlinkTraceEvent._(
+      args: json['args'] as Map<String, dynamic>,
+      cat: json['cat'] as String,
+      name: json['name'] as String,
+      ph: json['ph'] as String,
+      pid: _readInt(json, 'pid'),
+      tid: _readInt(json, 'tid'),
+      ts: _readInt(json, 'ts'),
+      tts: _readInt(json, 'tts'),
+      tdur: _readInt(json, 'tdur'),
+    );
+  }
+
+  /// Event-specific data.
+  final Map<String, dynamic> args;
+
+  /// Event category.
+  final String cat;
+
+  /// Event name.
+  final String name;
+
+  /// Event "phase".
+  final String ph;
+
+  /// Process ID of the process that emitted the event.
+  final int pid;
+
+  /// Thread ID of the thread that emitted the event.
+  final int tid;
+
+  /// Timestamp in microseconds using tracer clock.
+  final int ts;
+
+  /// Timestamp in microseconds using thread clock.
+  final int tts;
+
+  /// Event duration in microseconds.
+  final int tdur;
+
+  @override
+  String toString() => '$BlinkTraceEvent('
+    'args: ${json.encode(args)}, '
+    'cat: $cat, '
+    'name: $name, '
+    'ph: $ph, '
+    'pid: $pid, '
+    'tid: $tid, '
+    'ts: $ts, '
+    'tts: $tts, '
+    'tdur: $tdur)';
+}
+
+/// Read an integer out of [json] stored under [key].
+///
+/// Since JSON does not distinguish between `int` and `double`, extra
+/// validation and conversion is needed.
+///
+/// Returns null if the value is null.
+int _readInt(Map<String, dynamic> json, String key) {
+  final num jsonValue = json[key] as num;
+
+  if (jsonValue == null) {
+    return null;
+  }
+
+  return jsonValue.toInt();
 }

--- a/dev/devicelab/lib/tasks/web_benchmarks.dart
+++ b/dev/devicelab/lib/tasks/web_benchmarks.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:convert' show json;
 import 'dart:io' as io;
 
+import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 import 'package:shelf/shelf.dart';
@@ -18,8 +19,11 @@ import 'package:flutter_devicelab/framework/utils.dart';
 
 /// The port number used by the local benchmark server.
 const int benchmarkServerPort = 9999;
+const int chromeDebugPort = 10000;
 
 Future<TaskResult> runWebBenchmark({ @required bool useCanvasKit }) async {
+  // Reduce logging level. Otherwise, package:webkit_inspection_protocol is way too spammy.
+  Logger.root.level = Level.INFO;
   final String macrobenchmarksDirectory = path.join(flutterDirectory.path, 'dev', 'benchmarks', 'macrobenchmarks');
   return await inDirectory(macrobenchmarksDirectory, () async {
     await evalFlutter('build', options: <String>[
@@ -38,51 +42,79 @@ Future<TaskResult> runWebBenchmark({ @required bool useCanvasKit }) async {
     List<String> benchmarks;
     Iterator<String> benchmarkIterator;
 
+    // This future fixes a race condition between the web-page loading and
+    // asking to run a benchmark, and us connecting to Chrome's DevTools port.
+    // Sometime one wins. Other times, the other wins.
+    Future<Chrome> whenChromeIsReady;
+    Chrome chrome;
     io.HttpServer server;
     Cascade cascade = Cascade();
+    List<Map<String, dynamic>> latestPerformanceTrace;
     cascade = cascade.add((Request request) async {
-      if (request.requestedUri.path.endsWith('/profile-data')) {
-        final Map<String, dynamic> profile = json.decode(await request.readAsString()) as Map<String, dynamic>;
-        final String benchmarkName = profile['name'] as String;
-        if (benchmarkName != benchmarkIterator.current) {
-          profileData.completeError(Exception(
-            'Browser returned benchmark results from a wrong benchmark.\n'
-            'Requested to run bechmark ${benchmarkIterator.current}, but '
-            'got results for $benchmarkName.',
-          ));
+      try {
+        chrome ??= await whenChromeIsReady;
+        if (request.requestedUri.path.endsWith('/profile-data')) {
+          final Map<String, dynamic> profile = json.decode(await request.readAsString()) as Map<String, dynamic>;
+          final String benchmarkName = profile['name'] as String;
+          if (benchmarkName != benchmarkIterator.current) {
+            profileData.completeError(Exception(
+              'Browser returned benchmark results from a wrong benchmark.\n'
+              'Requested to run bechmark ${benchmarkIterator.current}, but '
+              'got results for $benchmarkName.',
+            ));
+            server.close();
+          }
+
+          final BlinkTraceSummary traceSummary = BlinkTraceSummary.fromJson(latestPerformanceTrace);
+
+          // Trace summary can be null if the benchmark is not frame-based, such as RawRecorder.
+          if (traceSummary != null) {
+            profile['totalUiFrame.average'] = traceSummary.averageTotalUIFrameTime.inMicroseconds;
+            profile['scoreKeys'] ??= <dynamic>[]; // using dynamic for consistency with JSON
+            profile['scoreKeys'].add('totalUiFrame.average');
+          }
+          latestPerformanceTrace = null;
+          collectedProfiles.add(profile);
+          return Response.ok('Profile received');
+        } else if (request.requestedUri.path.endsWith('/start-performance-tracing')) {
+          latestPerformanceTrace = null;
+          await chrome.beginRecordingPerformance(request.requestedUri.queryParameters['label']);
+          return Response.ok('Started performance tracing');
+        } else if (request.requestedUri.path.endsWith('/stop-performance-tracing')) {
+          latestPerformanceTrace = await chrome.endRecordingPerformance();
+          return Response.ok('Stopped performance tracing');
+        } else if (request.requestedUri.path.endsWith('/on-error')) {
+          final Map<String, dynamic> errorDetails = json.decode(await request.readAsString()) as Map<String, dynamic>;
           server.close();
-        }
-        collectedProfiles.add(profile);
-        return Response.ok('Profile received');
-      } else if (request.requestedUri.path.endsWith('/on-error')) {
-        final Map<String, dynamic> errorDetails = json.decode(await request.readAsString()) as Map<String, dynamic>;
-        server.close();
-        // Keep the stack trace as a string. It's thrown in the browser, not this Dart VM.
-        profileData.completeError('${errorDetails['error']}\n${errorDetails['stackTrace']}');
-        return Response.ok('');
-      } else if (request.requestedUri.path.endsWith('/next-benchmark')) {
-        if (benchmarks == null) {
-          benchmarks = (json.decode(await request.readAsString()) as List<dynamic>).cast<String>();
-          benchmarkIterator = benchmarks.iterator;
-        }
-        if (benchmarkIterator.moveNext()) {
-          final String nextBenchmark = benchmarkIterator.current;
-          print('Launching benchmark "$nextBenchmark"');
-          return Response.ok(nextBenchmark);
+          // Keep the stack trace as a string. It's thrown in the browser, not this Dart VM.
+          profileData.completeError('${errorDetails['error']}\n${errorDetails['stackTrace']}');
+          return Response.ok('');
+        } else if (request.requestedUri.path.endsWith('/next-benchmark')) {
+          if (benchmarks == null) {
+            benchmarks = (json.decode(await request.readAsString()) as List<dynamic>).cast<String>();
+            benchmarkIterator = benchmarks.iterator;
+          }
+          if (benchmarkIterator.moveNext()) {
+            final String nextBenchmark = benchmarkIterator.current;
+            print('Launching benchmark "$nextBenchmark"');
+            return Response.ok(nextBenchmark);
+          } else {
+            profileData.complete(collectedProfiles);
+            return Response.notFound('Finished running benchmarks.');
+          }
         } else {
-          profileData.complete(collectedProfiles);
-          return Response.notFound('Finished running benchmarks.');
+          return Response.notFound(
+              'This request is not handled by the profile-data handler.');
         }
-      } else {
-        return Response.notFound(
-            'This request is not handled by the profile-data handler.');
+      } catch (error, stackTrace) {
+        profileData.completeError(error, stackTrace);
+        return Response.internalServerError(body: '$error');
       }
     }).add(createStaticHandler(
       path.join(macrobenchmarksDirectory, 'build', 'web'),
     ));
 
     server = await io.HttpServer.bind('localhost', benchmarkServerPort);
-    Chrome chrome;
     try {
       shelf_io.serveRequests(server, cascade.handler);
 
@@ -102,13 +134,11 @@ Future<TaskResult> runWebBenchmark({ @required bool useCanvasKit }) async {
         windowHeight: 1024,
         windowWidth: 1024,
         headless: isUncalibratedSmokeTest,
-        // When running in headless mode Chrome exits immediately unless
-        // a debug port is specified.
-        debugPort: isUncalibratedSmokeTest ? benchmarkServerPort + 1 : null,
+        debugPort: chromeDebugPort,
       );
 
       print('Launching Chrome.');
-      chrome = await Chrome.launch(
+      whenChromeIsReady = Chrome.launch(
         options,
         onError: (String error) {
           profileData.completeError(Exception(error));
@@ -151,8 +181,8 @@ Future<TaskResult> runWebBenchmark({ @required bool useCanvasKit }) async {
       }
       return TaskResult.success(taskResult, benchmarkScoreKeys: benchmarkScoreKeys);
     } finally {
-      server.close();
-      chrome.stop();
+      server?.close();
+      chrome?.stop();
     }
   });
 }


### PR DESCRIPTION
## Description

Extract Chrome tracing data (accessible manually via chrome://tracing) in Web benchmarks and compute average frame times.

## Related Issues

https://github.com/flutter/flutter/projects/116
https://github.com/flutter/flutter/issues/42987
