### PR TITLE
Remove URL shortening from GitHub reporter similar issues URL

### DIFF
--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -165,7 +165,7 @@ Future<void> _informUserOfCrash(List<String> args, dynamic error, StackTrace sta
     flutterProjectFactory: globals.projectFactory,
     client: clientFactory != null ? clientFactory() : HttpClient(),
   );
-  final String similarIssuesURL = await GitHubTemplateCreator.toolCrashSimilarIssuesURL(errorString);
+  final String similarIssuesURL = GitHubTemplateCreator.toolCrashSimilarIssuesURL(errorString);
   globals.printStatus('$similarIssuesURL\n', wrap: false);
   globals.printStatus('To report your crash to the Flutter team, first read the guide to filing a bug.', emphasis: true);
   globals.printStatus('https://flutter.dev/docs/resources/bug-reports\n', wrap: false);

--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -165,7 +165,7 @@ Future<void> _informUserOfCrash(List<String> args, dynamic error, StackTrace sta
     flutterProjectFactory: globals.projectFactory,
     client: clientFactory != null ? clientFactory() : HttpClient(),
   );
-  final String similarIssuesURL = await gitHubTemplateCreator.toolCrashSimilarIssuesGitHubURL(errorString);
+  final String similarIssuesURL = await GitHubTemplateCreator.toolCrashSimilarIssuesURL(errorString);
   globals.printStatus('$similarIssuesURL\n', wrap: false);
   globals.printStatus('To report your crash to the Flutter team, first read the guide to filing a bug.', emphasis: true);
   globals.printStatus('https://flutter.dev/docs/resources/bug-reports\n', wrap: false);

--- a/packages/flutter_tools/lib/src/reporting/github_template.dart
+++ b/packages/flutter_tools/lib/src/reporting/github_template.dart
@@ -32,9 +32,8 @@ class GitHubTemplateCreator {
   final FlutterProjectFactory _flutterProjectFactory;
   final HttpClient _client;
 
-  Future<String> toolCrashSimilarIssuesGitHubURL(String errorString) async {
-    final String fullURL = 'https://github.com/flutter/flutter/issues?q=is%3Aissue+${Uri.encodeQueryComponent(errorString)}';
-    return await _shortURL(fullURL);
+  static Future<String> toolCrashSimilarIssuesURL(String errorString) async {
+    return 'https://github.com/flutter/flutter/issues?q=is%3Aissue+${Uri.encodeQueryComponent(errorString)}';
   }
 
   /// GitHub URL to present to the user containing encoded suggested template.

--- a/packages/flutter_tools/lib/src/reporting/github_template.dart
+++ b/packages/flutter_tools/lib/src/reporting/github_template.dart
@@ -32,7 +32,7 @@ class GitHubTemplateCreator {
   final FlutterProjectFactory _flutterProjectFactory;
   final HttpClient _client;
 
-  static Future<String> toolCrashSimilarIssuesURL(String errorString) async {
+  static String toolCrashSimilarIssuesURL(String errorString) {
     return 'https://github.com/flutter/flutter/issues?q=is%3Aissue+${Uri.encodeQueryComponent(errorString)}';
   }
 

--- a/packages/flutter_tools/test/general.shard/github_template_test.dart
+++ b/packages/flutter_tools/test/general.shard/github_template_test.dart
@@ -25,30 +25,10 @@ void main() {
 
   group('GitHub template creator', () {
     testWithoutContext('similar issues URL', () async {
-      final GitHubTemplateCreator creator = GitHubTemplateCreator(
-        fileSystem: fs,
-        logger: logger,
-        client: SuccessShortenURLFakeHttpClient(),
-        flutterProjectFactory: FlutterProjectFactory(),
-      );
       expect(
-        await creator.toolCrashSimilarIssuesGitHubURL('this is a 100% error'),
-        _kShortURL
+        await GitHubTemplateCreator.toolCrashSimilarIssuesURL('this is a 100% error'),
+        'https://github.com/flutter/flutter/issues?q=is%3Aissue+this+is+a+100%25+error',
       );
-    });
-
-    testWithoutContext('similar issues URL with network failure', () async {
-      final GitHubTemplateCreator creator = GitHubTemplateCreator(
-        fileSystem: fs,
-        logger: logger,
-        client: FakeHttpClient(),
-        flutterProjectFactory: FlutterProjectFactory(),
-      );
-      expect(
-        await creator.toolCrashSimilarIssuesGitHubURL('this is a 100% error'),
-        'https://github.com/flutter/flutter/issues?q=is%3Aissue+this+is+a+100%25+error'
-      );
-      expect(logger.traceText, contains('Failed to shorten GitHub template URL'));
     });
 
     group('new issue template URL', () {

--- a/packages/flutter_tools/test/general.shard/github_template_test.dart
+++ b/packages/flutter_tools/test/general.shard/github_template_test.dart
@@ -26,7 +26,7 @@ void main() {
   group('GitHub template creator', () {
     testWithoutContext('similar issues URL', () async {
       expect(
-        await GitHubTemplateCreator.toolCrashSimilarIssuesURL('this is a 100% error'),
+        GitHubTemplateCreator.toolCrashSimilarIssuesURL('this is a 100% error'),
         'https://github.com/flutter/flutter/issues?q=is%3Aissue+this+is+a+100%25+error',
       );
     });

--- a/packages/flutter_tools/test/general.shard/github_template_test.dart
+++ b/packages/flutter_tools/test/general.shard/github_template_test.dart
@@ -24,7 +24,7 @@ void main() {
   });
 
   group('GitHub template creator', () {
-    testWithoutContext('similar issues URL', () async {
+    testWithoutContext('similar issues URL', () {
       expect(
         GitHubTemplateCreator.toolCrashSimilarIssuesURL('this is a 100% error'),
         'https://github.com/flutter/flutter/issues?q=is%3Aissue+this+is+a+100%25+error',

--- a/packages/flutter_tools/test/general.shard/runner/runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/runner_test.dart
@@ -81,9 +81,6 @@ void main() {
     });
 
     testUsingContext('GitHub issue template', () async {
-      const String similarURL = 'https://example.com/1';
-      when(mockGitHubTemplateCreator.toolCrashSimilarIssuesGitHubURL(any))
-        .thenAnswer((_) async => similarURL);
       const String templateURL = 'https://example.com/2';
       when(mockGitHubTemplateCreator.toolCrashIssueTemplateGitHubURL(any, any, any, any, any))
         .thenAnswer((_) async => templateURL);
@@ -115,7 +112,7 @@ void main() {
       expect(errorText, contains('Oops; flutter has exited unexpectedly: "an exception % --".\n'));
 
       final String statusText = testLogger.statusText;
-      expect(statusText, contains(similarURL));
+      expect(statusText, contains('https://github.com/flutter/flutter/issues?q=is%3Aissue+an+exception+%25+--'));
       expect(statusText, contains('https://flutter.dev/docs/resources/bug-reports'));
       expect(statusText, contains(templateURL));
 


### PR DESCRIPTION
## Description

Remove the URL from the similar issues URL.  This URL was only a few lines, it's the "file an issue" URL that's a mile long.
![Screen Shot 2020-04-02 at 4 23 22 PM](https://user-images.githubusercontent.com/682784/78308795-4799d300-74fe-11ea-9140-fb90b005443f.png)

Make the URL static on a class in anticipation of being overridden in g3 with https://github.com/flutter/flutter/issues/53766.

## Related Issues

Part 1 of https://github.com/flutter/flutter/issues/53140

## Tests

Updated runner_test and github_template_test.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*