### PR TITLE
Add visualDensity and focus support to ListTile

### DIFF
--- a/dev/manual_tests/lib/density.dart
+++ b/dev/manual_tests/lib/density.dart
@@ -252,7 +252,8 @@ class _OptionsState extends State<Options> {
                           min: VisualDensity.minimumDensity,
                           max: VisualDensity.maximumDensity,
                           onChanged: (double value) {
-                            widget.model.density = widget.model.density.copyWith(horizontal: value, vertical: widget.model.density.vertical);
+                            widget.model.density = widget.model.density.copyWith(
+                                horizontal: value, vertical: widget.model.density.vertical);
                           },
                           value: widget.model.density.horizontal,
                         ),
@@ -278,7 +279,8 @@ class _OptionsState extends State<Options> {
                           min: VisualDensity.minimumDensity,
                           max: VisualDensity.maximumDensity,
                           onChanged: (double value) {
-                            widget.model.density = widget.model.density.copyWith(horizontal: widget.model.density.horizontal, vertical: value);
+                            widget.model.density = widget.model.density.copyWith(
+                                horizontal: widget.model.density.horizontal, vertical: value);
                           },
                           value: widget.model.density.vertical,
                         ),
@@ -376,7 +378,9 @@ class _ControlTile extends StatelessWidget {
         padding: const EdgeInsets.all(8.0),
         child: Column(
           children: <Widget>[
-            Align(alignment: AlignmentDirectional.topStart, child: Text(label, textAlign: TextAlign.start)),
+            Align(
+                alignment: AlignmentDirectional.topStart,
+                child: Text(label, textAlign: TextAlign.start)),
             child,
           ],
         ),
@@ -419,9 +423,54 @@ class _MyHomePageState extends State<MyHomePage> {
       primarySwatch: m2Swatch,
     );
     final Widget label = Text(_model.rtl ? 'اضغط علي' : 'Press Me');
-    textController.text = _model.rtl ? 'يعتمد القرار الجيد على المعرفة وليس على الأرقام.' : 'A good decision is based on knowledge and not on numbers.';
+    textController.text = _model.rtl
+        ? 'يعتمد القرار الجيد على المعرفة وليس على الأرقام.'
+        : 'A good decision is based on knowledge and not on numbers.';
 
     final List<Widget> tiles = <Widget>[
+      _ControlTile(
+        label: _model.rtl ? 'حقل النص' : 'List Tile',
+        child: SizedBox(
+          width: 400,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              ListTile(
+                title: Text(_model.rtl ? 'هذا عنوان طويل نسبيا' : 'This is a relatively long title'),
+              ),
+              ListTile(
+                title: Text(_model.rtl ? 'هذا عنوان قصير' : 'This is a short title'),
+                subtitle:
+                    Text(_model.rtl ? 'هذا عنوان فرعي مناسب.' : 'This is an appropriate subtitle.'),
+                trailing: Icon(Icons.check_box),
+              ),
+              ListTile(
+                title: Text(_model.rtl ? 'هذا عنوان قصير' : 'This is a short title'),
+                subtitle:
+                    Text(_model.rtl ? 'هذا عنوان فرعي مناسب.' : 'This is an appropriate subtitle.'),
+                leading: Icon(Icons.check_box),
+                dense: true,
+              ),
+              ListTile(
+                title: Text(_model.rtl ? 'هذا عنوان قصير' : 'This is a short title'),
+                subtitle:
+                    Text(_model.rtl ? 'هذا عنوان فرعي مناسب.' : 'This is an appropriate subtitle.'),
+                dense: true,
+                leading: Icon(Icons.add_box),
+                trailing: Icon(Icons.check_box),
+              ),
+              ListTile(
+                title: Text(_model.rtl ? 'هذا عنوان قصير' : 'This is a short title'),
+                subtitle:
+                    Text(_model.rtl ? 'هذا عنوان فرعي مناسب.' : 'This is an appropriate subtitle.'),
+                isThreeLine: true,
+                leading: Icon(Icons.add_box),
+                trailing: Icon(Icons.check_box),
+              ),
+            ],
+          ),
+        ),
+      ),
       _ControlTile(
         label: _model.rtl ? 'حقل النص' : 'Text Field',
         child: SizedBox(

--- a/dev/manual_tests/lib/density.dart
+++ b/dev/manual_tests/lib/density.dart
@@ -253,7 +253,9 @@ class _OptionsState extends State<Options> {
                           max: VisualDensity.maximumDensity,
                           onChanged: (double value) {
                             widget.model.density = widget.model.density.copyWith(
-                                horizontal: value, vertical: widget.model.density.vertical);
+                              horizontal: value,
+                              vertical: widget.model.density.vertical,
+                            );
                           },
                           value: widget.model.density.horizontal,
                         ),
@@ -280,7 +282,9 @@ class _OptionsState extends State<Options> {
                           max: VisualDensity.maximumDensity,
                           onChanged: (double value) {
                             widget.model.density = widget.model.density.copyWith(
-                                horizontal: widget.model.density.horizontal, vertical: value);
+                              horizontal: widget.model.density.horizontal,
+                              vertical: value,
+                            );
                           },
                           value: widget.model.density.vertical,
                         ),
@@ -379,8 +383,12 @@ class _ControlTile extends StatelessWidget {
         child: Column(
           children: <Widget>[
             Align(
-                alignment: AlignmentDirectional.topStart,
-                child: Text(label, textAlign: TextAlign.start)),
+              alignment: AlignmentDirectional.topStart,
+              child: Text(
+                label,
+                textAlign: TextAlign.start,
+              ),
+            ),
             child,
           ],
         ),

--- a/dev/manual_tests/lib/density.dart
+++ b/dev/manual_tests/lib/density.dart
@@ -445,12 +445,14 @@ class _MyHomePageState extends State<MyHomePage> {
             children: <Widget>[
               ListTile(
                 title: Text(_model.rtl ? 'هذا عنوان طويل نسبيا' : 'This is a relatively long title'),
+                onTap: () {},
               ),
               ListTile(
                 title: Text(_model.rtl ? 'هذا عنوان قصير' : 'This is a short title'),
                 subtitle:
                     Text(_model.rtl ? 'هذا عنوان فرعي مناسب.' : 'This is an appropriate subtitle.'),
                 trailing: Icon(Icons.check_box),
+                onTap: () {},
               ),
               ListTile(
                 title: Text(_model.rtl ? 'هذا عنوان قصير' : 'This is a short title'),
@@ -458,6 +460,7 @@ class _MyHomePageState extends State<MyHomePage> {
                     Text(_model.rtl ? 'هذا عنوان فرعي مناسب.' : 'This is an appropriate subtitle.'),
                 leading: Icon(Icons.check_box),
                 dense: true,
+                onTap: () {},
               ),
               ListTile(
                 title: Text(_model.rtl ? 'هذا عنوان قصير' : 'This is a short title'),
@@ -466,6 +469,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 dense: true,
                 leading: Icon(Icons.add_box),
                 trailing: Icon(Icons.check_box),
+                onTap: () {},
               ),
               ListTile(
                 title: Text(_model.rtl ? 'هذا عنوان قصير' : 'This is a short title'),
@@ -474,6 +478,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 isThreeLine: true,
                 leading: Icon(Icons.add_box),
                 trailing: Icon(Icons.check_box),
+                onTap: () {},
               ),
             ],
           ),

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -1401,7 +1401,7 @@ void main() {
     await tester.pumpWidget(buildApp());
     await tester.pumpAndSettle();
 
-    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
     await tester.pumpAndSettle();
 
     expect(tapped, isTrue);

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -1270,11 +1270,13 @@ void main() {
       Material.of(tester.element(find.byKey(tileKey))),
       paints
         ..rect(
-            color: Colors.orange[500],
-            rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0))
+          color: Colors.orange[500],
+          rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0),
+        )
         ..rect(
-            color: const Color(0xffffffff),
-            rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0))
+          color: const Color(0xffffffff),
+          rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0),
+        ),
     );
 
     // Check when the list tile is disabled.

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -3,11 +3,15 @@
 // found in the LICENSE file.
 
 import 'dart:math' as math;
+import 'dart:ui';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../rendering/mock_canvas.dart';
 import '../widgets/semantics_tester.dart';
 
 class TestIcon extends StatefulWidget {
@@ -1230,5 +1234,211 @@ void main() {
 
     await tester.pump();
     expect(Focus.of(childKey.currentContext, nullOk: true).hasPrimaryFocus, isFalse);
+  });
+
+  testWidgets('ListTile is focusable and has correct focus color', (WidgetTester tester) async {
+    final FocusNode focusNode = FocusNode(debugLabel: 'ListTile');
+    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+    const Key tileKey = Key('listTile');
+    Widget buildApp({bool enabled = true}) {
+      return MaterialApp(
+        home: Material(
+          child: Center(
+            child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+              return Container(
+                width: 100,
+                height: 100,
+                color: Colors.white,
+                child: ListTile(
+                  key: tileKey,
+                  onTap: enabled ? () {} : null,
+                  focusColor: Colors.orange[500],
+                  autofocus: true,
+                  focusNode: focusNode,
+                ),
+              );
+            }),
+          ),
+        ),
+      );
+    }
+    await tester.pumpWidget(buildApp());
+
+    await tester.pumpAndSettle();
+    expect(focusNode.hasPrimaryFocus, isTrue);
+    expect(
+      Material.of(tester.element(find.byKey(tileKey))),
+      paints
+        ..rect(
+            color: Colors.orange[500],
+            rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0))
+        ..rect(
+            color: const Color(0xffffffff),
+            rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0))
+    );
+
+    // Check when the list tile is disabled.
+    await tester.pumpWidget(buildApp(enabled: false));
+    await tester.pumpAndSettle();
+    expect(focusNode.hasPrimaryFocus, isFalse);
+    expect(
+      Material.of(tester.element(find.byKey(tileKey))),
+      paints
+        ..rect(
+            color: const Color(0xffffffff),
+            rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0)),
+    );
+  });
+
+  testWidgets('ListTile can be hovered and has correct hover color', (WidgetTester tester) async {
+    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+    const Key tileKey = Key('ListTile');
+    Widget buildApp({bool enabled = true}) {
+      return MaterialApp(
+        home: Material(
+          child: Center(
+            child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+              return Container(
+                width: 100,
+                height: 100,
+                color: Colors.white,
+                child: ListTile(
+                  key: tileKey,
+                  onTap: enabled ? () {} : null,
+                  hoverColor: Colors.orange[500],
+                  autofocus: true,
+                ),
+              );
+            }),
+          ),
+        ),
+      );
+    }
+    await tester.pumpWidget(buildApp());
+
+    await tester.pump();
+    await tester.pumpAndSettle();
+    expect(
+      Material.of(tester.element(find.byKey(tileKey))),
+      paints
+        ..rect(
+            color: const Color(0x1f000000),
+            rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0))
+        ..rect(
+            color: const Color(0xffffffff),
+            rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0)),
+    );
+
+    // Start hovering
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(gesture.removePointer);
+    await gesture.moveTo(tester.getCenter(find.byKey(tileKey)));
+
+    await tester.pumpWidget(buildApp());
+    await tester.pump();
+    await tester.pumpAndSettle();
+    expect(
+        Material.of(tester.element(find.byKey(tileKey))),
+        paints
+          ..rect(
+              color: const Color(0x1f000000),
+              rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0))
+          ..rect(
+              color: Colors.orange[500],
+              rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0))
+          ..rect(
+              color: const Color(0xffffffff),
+              rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0)),
+    );
+
+    await tester.pumpWidget(buildApp(enabled: false));
+    await tester.pump();
+    await tester.pumpAndSettle();
+    expect(
+      Material.of(tester.element(find.byKey(tileKey))),
+      paints
+        ..rect(
+            color: Colors.orange[500],
+            rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0))
+        ..rect(
+            color: const Color(0xffffffff),
+            rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0)),
+    );
+  });
+
+  testWidgets('ListTile can be triggerd by keyboard shortcuts', (WidgetTester tester) async {
+    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+    const Key tileKey = Key('ListTile');
+    bool tapped = false;
+    Widget buildApp({bool enabled = true}) {
+      return MaterialApp(
+        home: Material(
+          child: Center(
+            child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+              return Container(
+                width: 200,
+                height: 100,
+                color: Colors.white,
+                child: ListTile(
+                  key: tileKey,
+                  onTap: enabled ? () {
+                    setState((){
+                      tapped = true;
+                    });
+                  } : null,
+                  hoverColor: Colors.orange[500],
+                  autofocus: true,
+                ),
+              );
+            }),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+
+    expect(tapped, isTrue);
+  });
+
+  testWidgets('ListTile responds to density changes.', (WidgetTester tester) async {
+    const Key key = Key('test');
+    Future<void> buildTest(VisualDensity visualDensity) async {
+      return await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Center(
+              child: ListTile(
+                key: key,
+                onTap: () {},
+                autofocus: true,
+                visualDensity: visualDensity,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    await buildTest(const VisualDensity());
+    final RenderBox box = tester.renderObject(find.byKey(key));
+    await tester.pumpAndSettle();
+    expect(box.size, equals(const Size(800, 56)));
+
+    await buildTest(const VisualDensity(horizontal: 3.0, vertical: 3.0));
+    await tester.pumpAndSettle();
+    expect(box.size, equals(const Size(800, 68)));
+
+    await buildTest(const VisualDensity(horizontal: -3.0, vertical: -3.0));
+    await tester.pumpAndSettle();
+    expect(box.size, equals(const Size(800, 44)));
+
+    await buildTest(const VisualDensity(horizontal: 3.0, vertical: -3.0));
+    await tester.pumpAndSettle();
+    expect(box.size, equals(const Size(800, 44)));
   });
 }

--- a/packages/flutter/test/material/radio_test.dart
+++ b/packages/flutter/test/material/radio_test.dart
@@ -418,7 +418,7 @@ void main() {
     );
   });
 
-  testWidgets('Radio can be hovered and has correct focus color', (WidgetTester tester) async {
+  testWidgets('Radio can be hovered and has correct hover color', (WidgetTester tester) async {
     tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
     int groupValue = 0;
     const Key radioKey = Key('radio');
@@ -479,7 +479,7 @@ void main() {
               color: const Color(0xffffffff),
               rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0))
           ..circle(color: Colors.orange[500])
-          ..circle(color: const Color(0x8a000000), style: PaintingStyle.stroke, strokeWidth: 2.0)
+          ..circle(color: const Color(0x8a000000), style: PaintingStyle.stroke, strokeWidth: 2.0),
     );
 
     // Check when the radio is selected, but disabled.


### PR DESCRIPTION
## Description

This adds `visualDensity` and focus support to the `ListTile` widget.

It actually sort of already had focus support, since it was using an `InkWell` it would already respond to focus changes, this just adds attributes for `focusNode`, `focusColor`, and `hoverColor` so that they may be passed through to the `InkWell`.

For `visualDensity` support, in addition to allowing visual density to affect the height of the tile, I added some control over spacing vertically between the subtitle and the title widgets.  Horizontally, it controls the size of the gaps between the leading and trailing widgets and the title and subtitle widgets. The width of the tile isn't affected, since it expands to fill its parent's width.

This PR doesn't affect the layout of `ListTile` with the default `visualDensity` of 0.0.

## Related Issues

- https://github.com/flutter/flutter/issues/43350

## Tests

- Added tests for focus, hover, and density controls on `ListTile`.

## Breaking Change

- [X] No, this is *not* a breaking change.