### PR TITLE
[flutter_tools] Launch DevTools with 'v'

### DIFF
--- a/packages/flutter_tools/lib/src/base/command_help.dart
+++ b/packages/flutter_tools/lib/src/base/command_help.dart
@@ -140,6 +140,12 @@ class CommandHelp {
     'debugDumpRenderTree',
   );
 
+  CommandHelpOption _v;
+  CommandHelpOption get v => _v ??= _makeOption(
+    'v',
+    'Launch DevTools.',
+  );
+
   CommandHelpOption _w;
   CommandHelpOption get w => _w ??= _makeOption(
     'w',

--- a/packages/flutter_tools/test/general.shard/base/command_help_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/command_help_test.dart
@@ -66,6 +66,7 @@ void _testMessageLength({
   expect(commandHelp.r.toString().length, lessThanOrEqualTo(expectedWidth));
   expect(commandHelp.s.toString().length, lessThanOrEqualTo(expectedWidth));
   expect(commandHelp.t.toString().length, lessThanOrEqualTo(expectedWidth));
+  expect(commandHelp.v.toString().length, lessThanOrEqualTo(expectedWidth));
   expect(commandHelp.w.toString().length, lessThanOrEqualTo(expectedWidth));
   expect(commandHelp.z.toString().length, lessThanOrEqualTo(expectedWidth));
 }
@@ -95,6 +96,7 @@ void main() {
         expect(commandHelp.r.toString(), startsWith('\x1B[1mr\x1B[22m'));
         expect(commandHelp.s.toString(), startsWith('\x1B[1ms\x1B[22m'));
         expect(commandHelp.t.toString(), startsWith('\x1B[1mt\x1B[22m'));
+        expect(commandHelp.v.toString(), startsWith('\x1B[1mv\x1B[22m'));
         expect(commandHelp.w.toString(), startsWith('\x1B[1mw\x1B[22m'));
         expect(commandHelp.z.toString(), startsWith('\x1B[1mz\x1B[22m'));
       });
@@ -170,6 +172,7 @@ void main() {
         expect(commandHelp.r.toString(), equals('\x1B[1mr\x1B[22m Hot reload. $fire$fire$fire'));
         expect(commandHelp.s.toString(), equals('\x1B[1ms\x1B[22m Save a screenshot to flutter.png.'));
         expect(commandHelp.t.toString(), equals('\x1B[1mt\x1B[22m Dump rendering tree to the console.                          \x1B[1;30m(debugDumpRenderTree)\x1B[39m'));
+        expect(commandHelp.v.toString(), equals('\x1B[1mv\x1B[22m Launch DevTools.'));
         expect(commandHelp.w.toString(), equals('\x1B[1mw\x1B[22m Dump widget hierarchy to the console.                               \x1B[1;30m(debugDumpApp)\x1B[39m'));
         expect(commandHelp.z.toString(), equals('\x1B[1mz\x1B[22m Toggle elevation checker.'));
       });
@@ -195,6 +198,7 @@ void main() {
         expect(commandHelp.r.toString(), equals('r Hot reload. $fire$fire$fire'));
         expect(commandHelp.s.toString(), equals('s Save a screenshot to flutter.png.'));
         expect(commandHelp.t.toString(), equals('t Dump rendering tree to the console.                          (debugDumpRenderTree)'));
+        expect(commandHelp.v.toString(), equals('v Launch DevTools.'));
         expect(commandHelp.w.toString(), equals('w Dump widget hierarchy to the console.                               (debugDumpApp)'));
         expect(commandHelp.z.toString(), equals('z Toggle elevation checker.'));
       });

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -406,6 +406,7 @@ void main() {
           commandHelp.p,
           commandHelp.o,
           commandHelp.z,
+          commandHelp.v,
           commandHelp.P,
           commandHelp.a,
           'An Observatory debugger and profiler on null is available at: null',

--- a/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
@@ -364,6 +364,13 @@ void main() {
       verifyNever(mockResidentRunner.debugDumpSemanticsTreeInInverseHitTestOrder());
     });
 
+    testUsingContext('v - launchDevTools', () async {
+      when(mockResidentRunner.supportsServiceProtocol).thenReturn(true);
+      await terminalHandler.processTerminalInput('v');
+
+      verify(mockResidentRunner.launchDevTools()).called(1);
+    });
+
     testUsingContext('w,W - debugDumpApp with service protocol', () async {
       await terminalHandler.processTerminalInput('w');
       await terminalHandler.processTerminalInput('W');


### PR DESCRIPTION
## Description

Launch DevTools from the resident runner with 'v' when there is a vm service available.

## Related Issues

https://github.com/flutter/flutter/issues/41407

## Tests

I added the following tests:

I updated tests of the command help.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
