### PR TITLE
[macos] build: add build-number and buid-name arguments

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_macos.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos.dart
@@ -26,6 +26,7 @@ class BuildMacosCommand extends BuildSubCommand {
     usesBuildNumberOption();
     usesBuildNameOption();
   }
+
   @override
   final String name = 'macos';
 

--- a/packages/flutter_tools/lib/src/commands/build_macos.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos.dart
@@ -23,8 +23,9 @@ class BuildMacosCommand extends BuildSubCommand {
     addBuildModeFlags();
     addDartObfuscationOption();
     usesExtraFrontendOptions();
+    usesBuildNumberOption();
+    usesBuildNameOption();
   }
-
   @override
   final String name = 'macos';
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -191,7 +191,8 @@ void main() {
     Platform: () => macosPlatform,
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
   });
-  testUsingContext('macOS build supports build name and number', () async {
+
+  testUsingContext('macOS build supports build-name and build-number', () async {
     final BuildCommand command = BuildCommand();
     createMinimalMockProjectFiles();
 
@@ -204,9 +205,9 @@ void main() {
         '--build-number=42',
       ],
     );
-    final String contents = fileSystem.file(
-        './macos/Flutter/ephemeral/Flutter-Generated.xcconfig')
-        .readAsStringSync();
+    final String contents = fileSystem
+      .file('./macos/Flutter/ephemeral/Flutter-Generated.xcconfig')
+      .readAsStringSync();
 
     expect(contents, contains('FLUTTER_BUILD_NAME=1.2.3'));
     expect(contents, contains('FLUTTER_BUILD_NUMBER=42'));

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -191,6 +191,33 @@ void main() {
     Platform: () => macosPlatform,
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
   });
+  testUsingContext('macOS build supports build name and number', () async {
+    final BuildCommand command = BuildCommand();
+    createMinimalMockProjectFiles();
+
+    await createTestCommandRunner(command).run(
+      const <String>[
+        'build',
+        'macos',
+        '--debug',
+        '--build-name=1.2.3',
+        '--build-number=42',
+      ],
+    );
+    final String contents = fileSystem.file(
+        './macos/Flutter/ephemeral/Flutter-Generated.xcconfig')
+        .readAsStringSync();
+
+    expect(contents, contains('FLUTTER_BUILD_NAME=1.2.3'));
+    expect(contents, contains('FLUTTER_BUILD_NUMBER=42'));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
+      setUpMockXcodeBuildHandler('Debug')
+    ]),
+    Platform: () => macosPlatform,
+    FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
+  });
 
   testUsingContext('Refuses to build for macOS when feature is disabled', () {
     final CommandRunner<void> runner = createTestCommandRunner(BuildCommand());


### PR DESCRIPTION
## Description

This simply adds the options `--build-number` and `--build-name` to the `flutter build macos` command. It already supports writing the `buildInfo` into the generated files used by the macos app templates, so just enabling the options already passes it through to the macos build.

## Tests

I did not add any tests, please advise if tests are necessary and how to test this. I've tried looking at the build tests for iOS but couldn't find how the parameters are tested there?

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

