### PR TITLE
[flutter_tools] update asset manifest to use package_config instead of package_map

### DIFF
--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -150,9 +150,12 @@ class _ManifestAssetBundle implements AssetBundle {
     final String assetBasePath = globals.fs.path.dirname(globals.fs.path.absolute(manifestPath));
     final PackageConfig packageConfig = await loadPackageConfigUri(
       globals.fs.file(packagesPath).absolute.uri,
-      preferNewest: false,
       loader: (Uri uri) {
-        return globals.fs.file(uri).readAsBytes();
+        final File file = globals.fs.file(uri);
+        if (!file.existsSync()) {
+          return null;
+        }
+        return file.readAsBytes();
       },
     );
     final List<Uri> wildcardDirectories = <Uri>[];

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:meta/meta.dart';
+import 'package:package_config/package_config.dart';
 import 'package:yaml/yaml.dart';
 
 import 'base/context.dart';
@@ -147,8 +148,13 @@ class _ManifestAssetBundle implements AssetBundle {
     }
 
     final String assetBasePath = globals.fs.path.dirname(globals.fs.path.absolute(manifestPath));
-
-    final PackageMap packageMap = PackageMap(packagesPath, fileSystem: globals.fs);
+    final PackageConfig packageConfig = await loadPackageConfigUri(
+      globals.fs.file(packagesPath).absolute.uri,
+      preferNewest: false,
+      loader: (Uri uri) {
+        return globals.fs.file(uri).readAsBytes();
+      },
+    );
     final List<Uri> wildcardDirectories = <Uri>[];
 
     // The _assetVariants map contains an entry for each asset listed
@@ -156,7 +162,7 @@ class _ManifestAssetBundle implements AssetBundle {
     // value of each image asset is a list of resolution-specific "variants",
     // see _AssetDirectoryCache.
     final Map<_Asset, List<_Asset>> assetVariants = _parseAssets(
-      packageMap,
+      packageConfig,
       flutterManifest,
       wildcardDirectories,
       assetBasePath,
@@ -170,14 +176,14 @@ class _ManifestAssetBundle implements AssetBundle {
     final List<Map<String, dynamic>> fonts = _parseFonts(
       flutterManifest,
       includeDefaultFonts,
-      packageMap,
+      packageConfig,
     );
 
     // Add fonts and assets from packages.
-    for (final String packageName in packageMap.map.keys) {
-      final Uri package = packageMap.map[packageName];
-      if (package != null && package.scheme == 'file') {
-        final String packageManifestPath = globals.fs.path.fromUri(package.resolve('../pubspec.yaml'));
+    for (final Package package in packageConfig.packages) {
+      final Uri packageUri = package.packageUriRoot;
+      if (packageUri != null && packageUri.scheme == 'file') {
+        final String packageManifestPath = globals.fs.path.fromUri(packageUri.resolve('../pubspec.yaml'));
         final FlutterManifest packageFlutterManifest = FlutterManifest.createFromPath(packageManifestPath);
         if (packageFlutterManifest == null) {
           continue;
@@ -189,11 +195,11 @@ class _ManifestAssetBundle implements AssetBundle {
         final String packageBasePath = globals.fs.path.dirname(packageManifestPath);
 
         final Map<_Asset, List<_Asset>> packageAssets = _parseAssets(
-          packageMap,
+          packageConfig,
           packageFlutterManifest,
           wildcardDirectories,
           packageBasePath,
-          packageName: packageName,
+          packageName: package.name,
         );
 
         if (packageAssets == null) {
@@ -204,8 +210,8 @@ class _ManifestAssetBundle implements AssetBundle {
         fonts.addAll(_parseFonts(
           packageFlutterManifest,
           includeDefaultFonts,
-          packageMap,
-          packageName: packageName,
+          packageConfig,
+          packageName: package.name,
         ));
       }
     }
@@ -253,7 +259,7 @@ class _ManifestAssetBundle implements AssetBundle {
     entries[kFontManifestJson] = DevFSStringContent(json.encode(fonts));
 
     // TODO(ianh): Only do the following line if we've changed packages or if our LICENSE file changed
-    final LicenseResult licenseResult = licenseCollector.obtainLicenses(packageMap);
+    final LicenseResult licenseResult = licenseCollector.obtainLicenses(packageConfig);
     entries[_license] = DevFSStringContent(licenseResult.combinedLicenses);
     additionalDependencies = licenseResult.dependencies;
 
@@ -383,18 +389,18 @@ class LicenseCollector {
 
   /// Obtain licenses from the `packageMap` into a single result.
   LicenseResult obtainLicenses(
-    PackageMap packageMap,
+    PackageConfig packageConfig,
   ) {
     final Map<String, Set<String>> packageLicenses = <String, Set<String>>{};
     final Set<String> allPackages = <String>{};
     final List<File> dependencies = <File>[];
 
-    for (final String packageName in packageMap.map.keys) {
-      final Uri package = packageMap.map[packageName];
-      if (package == null || package.scheme != 'file') {
+    for (final Package package in packageConfig.packages) {
+      final Uri packageUri = package.packageUriRoot;
+      if (packageUri == null || packageUri.scheme != 'file') {
         continue;
       }
-      final File file = _fileSystem.file(package.resolve('../LICENSE'));
+      final File file = _fileSystem.file(packageUri.resolve('../LICENSE'));
       if (!file.existsSync()) {
         continue;
       }
@@ -414,7 +420,7 @@ class LicenseCollector {
           }
         }
         if (licenseText == null) {
-          packageNames = <String>[packageName];
+          packageNames = <String>[package.name];
           licenseText = rawLicense;
         }
         packageLicenses.putIfAbsent(licenseText, () => <String>{})
@@ -476,7 +482,7 @@ DevFSContent _createAssetManifest(Map<_Asset, List<_Asset>> assetVariants) {
 List<Map<String, dynamic>> _parseFonts(
   FlutterManifest manifest,
   bool includeDefaultFonts,
-  PackageMap packageMap, {
+  PackageConfig packageConfig, {
   String packageName,
 }) {
   return <Map<String, dynamic>>[
@@ -488,7 +494,7 @@ List<Map<String, dynamic>> _parseFonts(
       ..._createFontsDescriptor(_parsePackageFonts(
         manifest,
         packageName,
-        packageMap,
+        packageConfig,
       )),
   ];
 }
@@ -498,7 +504,7 @@ List<Map<String, dynamic>> _parseFonts(
 List<Font> _parsePackageFonts(
   FlutterManifest manifest,
   String packageName,
-  PackageMap packageMap,
+  PackageConfig packageConfig,
 ) {
   final List<Font> packageFonts = <Font>[];
   for (final Font font in manifest.fonts) {
@@ -506,7 +512,8 @@ List<Font> _parsePackageFonts(
     for (final FontAsset fontAsset in font.fontAssets) {
       final Uri assetUri = fontAsset.assetUri;
       if (assetUri.pathSegments.first == 'packages' &&
-          !globals.fs.isFileSync(globals.fs.path.fromUri(packageMap.map[packageName].resolve('../${assetUri.path}')))) {
+          !globals.fs.isFileSync(globals.fs.path.fromUri(
+            packageConfig[packageName].packageUriRoot.resolve('../${assetUri.path}')))) {
         packageFontAssets.add(FontAsset(
           fontAsset.assetUri,
           weight: fontAsset.weight,
@@ -605,7 +612,7 @@ class _AssetDirectoryCache {
 ///
 
 Map<_Asset, List<_Asset>> _parseAssets(
-  PackageMap packageMap,
+  PackageConfig packageConfig,
   FlutterManifest flutterManifest,
   List<Uri> wildcardDirectories,
   String assetBase, {
@@ -618,11 +625,11 @@ Map<_Asset, List<_Asset>> _parseAssets(
   for (final Uri assetUri in flutterManifest.assets) {
     if (assetUri.toString().endsWith('/')) {
       wildcardDirectories.add(assetUri);
-      _parseAssetsFromFolder(packageMap, flutterManifest, assetBase,
+      _parseAssetsFromFolder(packageConfig, flutterManifest, assetBase,
           cache, result, assetUri,
           excludeDirs: excludeDirs, packageName: packageName);
     } else {
-      _parseAssetFromFile(packageMap, flutterManifest, assetBase,
+      _parseAssetFromFile(packageConfig, flutterManifest, assetBase,
           cache, result, assetUri,
           excludeDirs: excludeDirs, packageName: packageName);
     }
@@ -632,7 +639,7 @@ Map<_Asset, List<_Asset>> _parseAssets(
   for (final Font font in flutterManifest.fonts) {
     for (final FontAsset fontAsset in font.fontAssets) {
       final _Asset baseAsset = _resolveAsset(
-        packageMap,
+        packageConfig,
         assetBase,
         fontAsset.assetUri,
         packageName,
@@ -650,7 +657,7 @@ Map<_Asset, List<_Asset>> _parseAssets(
 }
 
 void _parseAssetsFromFolder(
-  PackageMap packageMap,
+  PackageConfig packageConfig,
   FlutterManifest flutterManifest,
   String assetBase,
   _AssetDirectoryCache cache,
@@ -675,14 +682,14 @@ void _parseAssetsFromFolder(
 
       final Uri uri = Uri.file(relativePath, windows: globals.platform.isWindows);
 
-      _parseAssetFromFile(packageMap, flutterManifest, assetBase, cache, result,
+      _parseAssetFromFile(packageConfig, flutterManifest, assetBase, cache, result,
           uri, packageName: packageName);
     }
   }
 }
 
 void _parseAssetFromFile(
-  PackageMap packageMap,
+  PackageConfig packageConfig,
   FlutterManifest flutterManifest,
   String assetBase,
   _AssetDirectoryCache cache,
@@ -692,7 +699,7 @@ void _parseAssetFromFile(
   String packageName,
 }) {
   final _Asset asset = _resolveAsset(
-    packageMap,
+    packageConfig,
     assetBase,
     assetUri,
     packageName,
@@ -718,7 +725,7 @@ void _parseAssetFromFile(
 }
 
 _Asset _resolveAsset(
-  PackageMap packageMap,
+  PackageConfig packageConfig,
   String assetsBaseDir,
   Uri assetUri,
   String packageName,
@@ -727,7 +734,7 @@ _Asset _resolveAsset(
   if (assetUri.pathSegments.first == 'packages' && !globals.fs.isFileSync(globals.fs.path.join(assetsBaseDir, assetPath))) {
     // The asset is referenced in the pubspec.yaml as
     // 'packages/PACKAGE_NAME/PATH/TO/ASSET .
-    final _Asset packageAsset = _resolvePackageAsset(assetUri, packageMap);
+    final _Asset packageAsset = _resolvePackageAsset(assetUri, packageConfig);
     if (packageAsset != null) {
       return packageAsset;
     }
@@ -742,11 +749,11 @@ _Asset _resolveAsset(
   );
 }
 
-_Asset _resolvePackageAsset(Uri assetUri, PackageMap packageMap) {
+_Asset _resolvePackageAsset(Uri assetUri, PackageConfig packageConfig) {
   assert(assetUri.pathSegments.first == 'packages');
   if (assetUri.pathSegments.length > 1) {
     final String packageName = assetUri.pathSegments[1];
-    final Uri packageUri = packageMap.map[packageName];
+    final Uri packageUri = packageConfig[packageName]?.packageUriRoot;
     if (packageUri != null && packageUri.scheme == 'file') {
       return _Asset(
         baseDir: globals.fs.path.fromUri(packageUri),

--- a/packages/flutter_tools/test/general.shard/license_collector_test.dart
+++ b/packages/flutter_tools/test/general.shard/license_collector_test.dart
@@ -39,13 +39,16 @@ const String _kApacheLicense = r'''
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
+
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
    1. Definitions.
+
       "License" shall mean the terms and conditions for use, reproduction,
       and distribution as defined by Sections 1 through 9 of this document.
       "Licensor" shall mean the copyright owner or entity authorized by
       the copyright owner that is granting the License.
+
       "Legal Entity" shall mean the union of the acting entity and all
       other entities that control, are controlled by, or are under common
       control with that entity. For the purposes of this definition,
@@ -53,19 +56,23 @@ const String _kApacheLicense = r'''
       direction or management of such entity, whether by contract or
       otherwise, or (ii) ownership of fifty percent (50%) or more of the
       outstanding shares, or (iii) beneficial ownership of such entity.
+
       "You" (or "Your") shall mean an individual or Legal Entity
       exercising permissions granted by this License.
       "Source" form shall mean the preferred form for making modifications,
       including but not limited to software source code, documentation
       source, and configuration files.
+
       "Object" form shall mean any form resulting from mechanical
       transformation or translation of a Source form, including but
       not limited to compiled object code, generated documentation,
       and conversions to other media types.
+
       "Work" shall mean the work of authorship, whether in Source or
       Object form, made available under the License, as indicated by a
       copyright notice that is included in or attached to the work
       (an example is provided in the Appendix below).
+
       "Derivative Works" shall mean any work, whether in Source or Object
       form, that is based on (or derived from) the Work and for which the
       editorial revisions, annotations, elaborations, or other modifications
@@ -73,6 +80,7 @@ const String _kApacheLicense = r'''
       of this License, Derivative Works shall not include works that remain
       separable from, or merely link (or bind by name) to the interfaces of,
       the Work and Derivative Works thereof.
+
       "Contribution" shall mean any work of authorship, including
       the original version of the Work and any modifications or additions
       to that Work or Derivative Works thereof, that is intentionally
@@ -117,15 +125,19 @@ const String _kApacheLicense = r'''
       Work or Derivative Works thereof in any medium, with or without
       modifications, and in Source or Object form, provided that You
       meet the following conditions:
+
       (a) You must give any other recipients of the Work or
           Derivative Works a copy of this License; and
+
       (b) You must cause any modified files to carry prominent notices
           stating that You changed the files; and
+
       (c) You must retain, in the Source form of any Derivative Works
           that You distribute, all copyright, patent, trademark, and
           attribution notices from the Source form of the Work,
           excluding those notices that do not pertain to any part of
           the Derivative Works; and
+
       (d) If the Work includes a "NOTICE" text file as part of its
           distribution, then any Derivative Works that You distribute must
           include a readable copy of the attribution notices contained
@@ -142,6 +154,7 @@ const String _kApacheLicense = r'''
           or as an addendum to the NOTICE text from the Work, provided
           that such additional attribution notices cannot be construed
           as modifying the License.
+
       You may add Your own copyright statement to Your modifications and
       may provide additional or different license terms and conditions
       for use, reproduction, or distribution of Your modifications, or
@@ -194,8 +207,11 @@ const String _kApacheLicense = r'''
       defend, and hold each Contributor harmless for any liability
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
+
    END OF TERMS AND CONDITIONS
+
    APPENDIX: How to apply the Apache License to your work.
+
       To apply the Apache License to your work, attach the following
       boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
@@ -229,7 +245,7 @@ void main() {
     licenseCollector = LicenseCollector(fileSystem: fileSystem);
   });
 
-  testWithoutContext('processes dependant licenses according to instructions', () async {
+  testWithoutContext('processes dependent licenses according to instructions', () async {
     fileSystem.file('foo/LICENSE')
       ..createSync(recursive: true)
       ..writeAsStringSync(_kMitLicense);

--- a/packages/flutter_tools/test/general.shard/license_collector_test.dart
+++ b/packages/flutter_tools/test/general.shard/license_collector_test.dart
@@ -5,25 +5,23 @@
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/asset.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/dart/package_map.dart';
+import 'package:flutter_tools/src/convert.dart';
+import 'package:package_config/package_config.dart';
+import 'package:package_config/package_config_types.dart';
 
 import '../src/common.dart';
 
 const String _kMitLicense = r'''
 MIT License
-
 Copyright (c) 6789 Lester
-
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
-
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
-
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -37,17 +35,12 @@ const String _kApacheLicense = r'''
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
-
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
    1. Definitions.
-
       "License" shall mean the terms and conditions for use, reproduction,
       and distribution as defined by Sections 1 through 9 of this document.
-
       "Licensor" shall mean the copyright owner or entity authorized by
       the copyright owner that is granting the License.
-
       "Legal Entity" shall mean the union of the acting entity and all
       other entities that control, are controlled by, or are under common
       control with that entity. For the purposes of this definition,
@@ -55,24 +48,19 @@ const String _kApacheLicense = r'''
       direction or management of such entity, whether by contract or
       otherwise, or (ii) ownership of fifty percent (50%) or more of the
       outstanding shares, or (iii) beneficial ownership of such entity.
-
       "You" (or "Your") shall mean an individual or Legal Entity
       exercising permissions granted by this License.
-
       "Source" form shall mean the preferred form for making modifications,
       including but not limited to software source code, documentation
       source, and configuration files.
-
       "Object" form shall mean any form resulting from mechanical
       transformation or translation of a Source form, including but
       not limited to compiled object code, generated documentation,
       and conversions to other media types.
-
       "Work" shall mean the work of authorship, whether in Source or
       Object form, made available under the License, as indicated by a
       copyright notice that is included in or attached to the work
       (an example is provided in the Appendix below).
-
       "Derivative Works" shall mean any work, whether in Source or Object
       form, that is based on (or derived from) the Work and for which the
       editorial revisions, annotations, elaborations, or other modifications
@@ -80,7 +68,6 @@ const String _kApacheLicense = r'''
       of this License, Derivative Works shall not include works that remain
       separable from, or merely link (or bind by name) to the interfaces of,
       the Work and Derivative Works thereof.
-
       "Contribution" shall mean any work of authorship, including
       the original version of the Work and any modifications or additions
       to that Work or Derivative Works thereof, that is intentionally
@@ -94,18 +81,15 @@ const String _kApacheLicense = r'''
       Licensor for the purpose of discussing and improving the Work, but
       excluding communication that is conspicuously marked or otherwise
       designated in writing by the copyright owner as "Not a Contribution."
-
       "Contributor" shall mean Licensor and any individual or Legal Entity
       on behalf of whom a Contribution has been received by Licensor and
       subsequently incorporated within the Work.
-
    2. Grant of Copyright License. Subject to the terms and conditions of
       this License, each Contributor hereby grants to You a perpetual,
       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
       copyright license to reproduce, prepare Derivative Works of,
       publicly display, publicly perform, sublicense, and distribute the
       Work and such Derivative Works in Source or Object form.
-
    3. Grant of Patent License. Subject to the terms and conditions of
       this License, each Contributor hereby grants to You a perpetual,
       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
@@ -121,24 +105,19 @@ const String _kApacheLicense = r'''
       or contributory patent infringement, then any patent licenses
       granted to You under this License for that Work shall terminate
       as of the date such litigation is filed.
-
    4. Redistribution. You may reproduce and distribute copies of the
       Work or Derivative Works thereof in any medium, with or without
       modifications, and in Source or Object form, provided that You
       meet the following conditions:
-
       (a) You must give any other recipients of the Work or
           Derivative Works a copy of this License; and
-
       (b) You must cause any modified files to carry prominent notices
           stating that You changed the files; and
-
       (c) You must retain, in the Source form of any Derivative Works
           that You distribute, all copyright, patent, trademark, and
           attribution notices from the Source form of the Work,
           excluding those notices that do not pertain to any part of
           the Derivative Works; and
-
       (d) If the Work includes a "NOTICE" text file as part of its
           distribution, then any Derivative Works that You distribute must
           include a readable copy of the attribution notices contained
@@ -155,14 +134,12 @@ const String _kApacheLicense = r'''
           or as an addendum to the NOTICE text from the Work, provided
           that such additional attribution notices cannot be construed
           as modifying the License.
-
       You may add Your own copyright statement to Your modifications and
       may provide additional or different license terms and conditions
       for use, reproduction, or distribution of Your modifications, or
       for any such Derivative Works as a whole, provided Your use,
       reproduction, and distribution of the Work otherwise complies with
       the conditions stated in this License.
-
    5. Submission of Contributions. Unless You explicitly state otherwise,
       any Contribution intentionally submitted for inclusion in the Work
       by You to the Licensor shall be under the terms and conditions of
@@ -170,12 +147,10 @@ const String _kApacheLicense = r'''
       Notwithstanding the above, nothing herein shall supersede or modify
       the terms of any separate license agreement you may have executed
       with Licensor regarding such Contributions.
-
    6. Trademarks. This License does not grant permission to use the trade
       names, trademarks, service marks, or product names of the Licensor,
       except as required for reasonable and customary use in describing the
       origin of the Work and reproducing the content of the NOTICE file.
-
    7. Disclaimer of Warranty. Unless required by applicable law or
       agreed to in writing, Licensor provides the Work (and each
       Contributor provides its Contributions) on an "AS IS" BASIS,
@@ -185,7 +160,6 @@ const String _kApacheLicense = r'''
       PARTICULAR PURPOSE. You are solely responsible for determining the
       appropriateness of using or redistributing the Work and assume any
       risks associated with Your exercise of permissions under this License.
-
    8. Limitation of Liability. In no event and under no legal theory,
       whether in tort (including negligence), contract, or otherwise,
       unless required by applicable law (such as deliberate and grossly
@@ -197,7 +171,6 @@ const String _kApacheLicense = r'''
       work stoppage, computer failure or malfunction, or any and all
       other commercial damages or losses), even if such Contributor
       has been advised of the possibility of such damages.
-
    9. Accepting Warranty or Additional Liability. While redistributing
       the Work or Derivative Works thereof, You may choose to offer,
       and charge a fee for, acceptance of support, warranty, indemnity,
@@ -208,11 +181,8 @@ const String _kApacheLicense = r'''
       defend, and hold each Contributor harmless for any liability
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
-
    END OF TERMS AND CONDITIONS
-
    APPENDIX: How to apply the Apache License to your work.
-
       To apply the Apache License to your work, attach the following
       boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
@@ -221,15 +191,11 @@ const String _kApacheLicense = r'''
       file or class name and description of purpose be included on the
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
-
    Copyright 1234 Tester
-
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
-
        http://www.apache.org/licenses/LICENSE-2.0
-
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -246,7 +212,7 @@ void main() {
     licenseCollector = LicenseCollector(fileSystem: fileSystem);
   });
 
-  testWithoutContext('processes dependant licenses according to instructions', () {
+  testWithoutContext('processes dependant licenses according to instructions', () async {
     fileSystem.file('foo/LICENSE')
       ..createSync(recursive: true)
       ..writeAsStringSync(_kMitLicense);
@@ -257,13 +223,34 @@ void main() {
       ..createSync(recursive: true)
       ..writeAsStringSync(_kMitLicense); // intentionally a duplicate
 
-    final PackageMap packageMap = PackageMap.test(<String, Uri>{
-      'foo': Uri.parse('file:///foo/lib/'),
-      'bar': Uri.parse('file:///bar/lib/'),
-      'fizz': Uri.parse('file:///fizz/lib/'),
-    }, fileSystem: fileSystem);
-
-    final LicenseResult result = licenseCollector.obtainLicenses(packageMap);
+    final File packageConfigFile = fileSystem.file('package_config.json')
+      ..writeAsStringSync(json.encode(
+        <String, Object>{
+          'configVersion': 2,
+          'packages': <Object>[
+            <String, Object>{
+              'name': 'foo',
+              'rootUri': 'file:///foo/',
+              'packageUri': 'lib/',
+              'languageVersion': '2.2'
+            },
+            <String, Object>{
+              'name': 'bar',
+              'rootUri': 'file:///bar/',
+              'packageUri': 'lib/',
+              'languageVersion': '2.2'
+            },
+            <String, Object>{
+              'name': 'fizz',
+              'rootUri': 'file:///fizz/',
+              'packageUri': 'lib/',
+              'languageVersion': '2.2'
+            },
+          ],
+        }
+      ));
+    final PackageConfig packageConfig = await loadPackageConfig(packageConfigFile.absolute);
+    final LicenseResult result = licenseCollector.obtainLicenses(packageConfig);
 
     // All included licenses are combined in the result.
     expect(result.combinedLicenses, contains(_kApacheLicense));

--- a/packages/flutter_tools/test/general.shard/license_collector_test.dart
+++ b/packages/flutter_tools/test/general.shard/license_collector_test.dart
@@ -13,15 +13,19 @@ import '../src/common.dart';
 
 const String _kMitLicense = r'''
 MIT License
+
 Copyright (c) 6789 Lester
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
+
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
+
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -36,6 +40,7 @@ const String _kApacheLicense = r'''
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
    1. Definitions.
       "License" shall mean the terms and conditions for use, reproduction,
       and distribution as defined by Sections 1 through 9 of this document.
@@ -84,12 +89,14 @@ const String _kApacheLicense = r'''
       "Contributor" shall mean Licensor and any individual or Legal Entity
       on behalf of whom a Contribution has been received by Licensor and
       subsequently incorporated within the Work.
+
    2. Grant of Copyright License. Subject to the terms and conditions of
       this License, each Contributor hereby grants to You a perpetual,
       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
       copyright license to reproduce, prepare Derivative Works of,
       publicly display, publicly perform, sublicense, and distribute the
       Work and such Derivative Works in Source or Object form.
+
    3. Grant of Patent License. Subject to the terms and conditions of
       this License, each Contributor hereby grants to You a perpetual,
       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
@@ -105,6 +112,7 @@ const String _kApacheLicense = r'''
       or contributory patent infringement, then any patent licenses
       granted to You under this License for that Work shall terminate
       as of the date such litigation is filed.
+
    4. Redistribution. You may reproduce and distribute copies of the
       Work or Derivative Works thereof in any medium, with or without
       modifications, and in Source or Object form, provided that You
@@ -140,6 +148,7 @@ const String _kApacheLicense = r'''
       for any such Derivative Works as a whole, provided Your use,
       reproduction, and distribution of the Work otherwise complies with
       the conditions stated in this License.
+
    5. Submission of Contributions. Unless You explicitly state otherwise,
       any Contribution intentionally submitted for inclusion in the Work
       by You to the Licensor shall be under the terms and conditions of
@@ -147,10 +156,12 @@ const String _kApacheLicense = r'''
       Notwithstanding the above, nothing herein shall supersede or modify
       the terms of any separate license agreement you may have executed
       with Licensor regarding such Contributions.
+
    6. Trademarks. This License does not grant permission to use the trade
       names, trademarks, service marks, or product names of the Licensor,
       except as required for reasonable and customary use in describing the
       origin of the Work and reproducing the content of the NOTICE file.
+
    7. Disclaimer of Warranty. Unless required by applicable law or
       agreed to in writing, Licensor provides the Work (and each
       Contributor provides its Contributions) on an "AS IS" BASIS,
@@ -160,6 +171,7 @@ const String _kApacheLicense = r'''
       PARTICULAR PURPOSE. You are solely responsible for determining the
       appropriateness of using or redistributing the Work and assume any
       risks associated with Your exercise of permissions under this License.
+
    8. Limitation of Liability. In no event and under no legal theory,
       whether in tort (including negligence), contract, or otherwise,
       unless required by applicable law (such as deliberate and grossly
@@ -171,6 +183,7 @@ const String _kApacheLicense = r'''
       work stoppage, computer failure or malfunction, or any and all
       other commercial damages or losses), even if such Contributor
       has been advised of the possibility of such damages.
+
    9. Accepting Warranty or Additional Liability. While redistributing
       the Work or Derivative Works thereof, You may choose to offer,
       and charge a fee for, acceptance of support, warranty, indemnity,
@@ -191,11 +204,15 @@ const String _kApacheLicense = r'''
       file or class name and description of purpose be included on the
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
+
    Copyright 1234 Tester
+
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
+
        http://www.apache.org/licenses/LICENSE-2.0
+
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/packages/flutter_tools/test/general.shard/license_collector_test.dart
+++ b/packages/flutter_tools/test/general.shard/license_collector_test.dart
@@ -46,6 +46,7 @@ const String _kApacheLicense = r'''
 
       "License" shall mean the terms and conditions for use, reproduction,
       and distribution as defined by Sections 1 through 9 of this document.
+
       "Licensor" shall mean the copyright owner or entity authorized by
       the copyright owner that is granting the License.
 
@@ -59,6 +60,7 @@ const String _kApacheLicense = r'''
 
       "You" (or "Your") shall mean an individual or Legal Entity
       exercising permissions granted by this License.
+
       "Source" form shall mean the preferred form for making modifications,
       including but not limited to software source code, documentation
       source, and configuration files.
@@ -94,6 +96,7 @@ const String _kApacheLicense = r'''
       Licensor for the purpose of discussing and improving the Work, but
       excluding communication that is conspicuously marked or otherwise
       designated in writing by the copyright owner as "Not a Contribution."
+
       "Contributor" shall mean Licensor and any individual or Legal Entity
       on behalf of whom a Contribution has been received by Licensor and
       subsequently incorporated within the Work.


### PR DESCRIPTION
## Description

Eventually the tool will need to switch entirely to package_config to support null safety, and the .packages will be removed at some point in the distant future.

https://github.com/flutter/flutter/issues/53665