### PR TITLE
[flutter_tools] Refresh VM state before executing hot reload

### DIFF
--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -825,6 +825,13 @@ abstract class ResidentRunner {
     await Future.wait(futures);
   }
 
+  Future<void> refreshVM() async {
+    final List<Future<void>> futures = <Future<void>>[
+      for (final FlutterDevice device in flutterDevices) device.getVMs(),
+    ];
+    await Future.wait(futures);
+  }
+
   Future<void> debugDumpApp() async {
     await refreshViews();
     for (final FlutterDevice device in flutterDevices) {

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -798,6 +798,7 @@ class HotRunner extends ResidentRunner {
 
     if (!_isPaused()) {
       globals.printTrace('Refreshing active FlutterViews before reloading.');
+      await refreshVM();
       await refreshViews();
     }
 

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -111,6 +111,7 @@ void main() {
       });
     when(mockFlutterDevice.vmService).thenReturn(mockVMService);
     when(mockFlutterDevice.refreshViews()).thenAnswer((Invocation invocation) async { });
+    when(mockFlutterDevice.getVMs()).thenAnswer((Invocation invocation) async { });
     when(mockFlutterDevice.reloadSources(any, pause: anyNamed('pause'))).thenReturn(<Future<Map<String, dynamic>>>[
       Future<Map<String, dynamic>>.value(<String, dynamic>{
         'type': 'ReloadReport',


### PR DESCRIPTION
The VM's cached collection of isolates may contain stale data such as
references to isolates that have exited.  It should be refreshed
before hot reload sends reloadSources requests to each isolate.

Fixes https://github.com/flutter/flutter/issues/53094
