### PR TITLE
revive the android_views test

### DIFF
--- a/dev/integration_tests/android_views/test_driver/main_test.dart
+++ b/dev/integration_tests/android_views/test_driver/main_test.dart
@@ -20,14 +20,12 @@ Future<void> main() async {
 
   group('MotionEvents tests ', () {
     test('recomposition', () async {
-      if (Platform.isAndroid) {
-        final SerializableFinder motionEventsListTile =
-        find.byValueKey('MotionEventsListTile');
-        await driver.tap(motionEventsListTile);
-        await driver.waitFor(find.byValueKey('PlatformView'));
-        final String errorMessage = await driver.requestData('run test');
-        expect(errorMessage, '');
-      }
+      final SerializableFinder motionEventsListTile =
+      find.byValueKey('MotionEventsListTile');
+      await driver.tap(motionEventsListTile);
+      await driver.waitFor(find.byValueKey('PlatformView'));
+      final String errorMessage = await driver.requestData('run test');
+      expect(errorMessage, '');
     });
   });
 }

--- a/dev/integration_tests/android_views/test_driver/main_test.dart
+++ b/dev/integration_tests/android_views/test_driver/main_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' show Platform;
 import 'package:flutter_driver/flutter_driver.dart';
 import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 


### PR DESCRIPTION
## Description

https://github.com/flutter/flutter/pull/36200 wrapped the driver test code with `if(Platform.isAndroid)` which always evaluates to false as the code is executed on the host.

This PR removes that check so we run the test again.
