### PR TITLE
Temporarily mark web benchmarks as flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -767,12 +767,14 @@ tasks:
       Runs Web benchmarks on Chrome on a Linux machine using the HTML rendering backend.
     stage: devicelab
     required_agent_capabilities: ["linux-vm"]
+    flaky: true
 
   web_benchmarks_canvaskit:
     description: >
       Runs Web benchmarks on Chrome on a Linux machine using the CanvasKit rendering backend.
     stage: devicelab
     required_agent_capabilities: ["linux-vm"]
+    flaky: true
 
   # run_without_leak_linux:
   #   description: >


### PR DESCRIPTION
Marking Web benchmarks as flaky. The flakiness only happens in the devicelab (locally and on Cirrus they are fine), so I'll have to debug this on devicelab itself.

TBR @ferhatb