### PR TITLE
Test creation of Android AlertDialogs with a platform view context

### DIFF
--- a/dev/integration_tests/android_views/android/app/src/main/java/io/flutter/integration/androidviews/SimplePlatformView.java
+++ b/dev/integration_tests/android_views/android/app/src/main/java/io/flutter/integration/androidviews/SimplePlatformView.java
@@ -4,35 +4,37 @@
 
 package io.flutter.integration.platformviews;
 
+import android.app.AlertDialog;
 import android.content.Context;
 import android.view.MotionEvent;
 import android.view.View;
+import android.widget.TextView;
 
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.platform.PlatformView;
 
 public class SimplePlatformView implements PlatformView, MethodChannel.MethodCallHandler {
-    private final View mView;
-    private final MethodChannel mMethodChannel;
-    private final TouchPipe mTouchPipe;
+    private final View view;
+    private final MethodChannel methodChannel;
+    private final io.flutter.integration.platformviews.TouchPipe touchPipe;
 
     SimplePlatformView(Context context, MethodChannel methodChannel) {
-        mMethodChannel = methodChannel;
-        mView = new View(context) {
+        this.methodChannel = methodChannel;
+        view = new View(context) {
             @Override
             public boolean onTouchEvent(MotionEvent event) {
                 return super.onTouchEvent(event);
             }
         };
-        mView.setBackgroundColor(0xff0000ff);
-        mMethodChannel.setMethodCallHandler(this);
-        mTouchPipe = new TouchPipe(mMethodChannel, mView);
+        view.setBackgroundColor(0xff0000ff);
+        this.methodChannel.setMethodCallHandler(this);
+        touchPipe = new io.flutter.integration.platformviews.TouchPipe(this.methodChannel, view);
     }
 
     @Override
     public View getView() {
-        return mView;
+        return view;
     }
 
     @Override
@@ -43,14 +45,34 @@ public class SimplePlatformView implements PlatformView, MethodChannel.MethodCal
     public void onMethodCall(MethodCall methodCall, MethodChannel.Result result) {
         switch(methodCall.method) {
             case "pipeTouchEvents":
-                mTouchPipe.enable();
+                touchPipe.enable();
                 result.success(null);
                 return;
             case "stopTouchEvents":
-                mTouchPipe.disable();
+                touchPipe.disable();
                 result.success(null);
+                return;
+            case "showAndHideAlertDialog":
+                showAndHideAlertDialog(result);
                 return;
         }
         result.notImplemented();
     }
+
+    private void showAndHideAlertDialog(MethodChannel.Result result) {
+        Context context = view.getContext();
+        AlertDialog.Builder builder = new AlertDialog.Builder(context);
+        TextView textView = new TextView(context);
+        textView.setText("This alert dialog will close in 1 seconds");
+        builder.setView(textView);
+        final AlertDialog alertDialog = builder.show();
+        result.success(null);
+        view.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                alertDialog.hide();
+            }
+        }, 1000);
+    }
+
 }

--- a/dev/integration_tests/android_views/android/app/src/main/java/io/flutter/integration/androidviews/SimplePlatformView.java
+++ b/dev/integration_tests/android_views/android/app/src/main/java/io/flutter/integration/androidviews/SimplePlatformView.java
@@ -52,27 +52,21 @@ public class SimplePlatformView implements PlatformView, MethodChannel.MethodCal
                 touchPipe.disable();
                 result.success(null);
                 return;
-            case "showAndHideAlertDialog":
-                showAndHideAlertDialog(result);
+            case "showAlertDialog":
+                showAlertDialog(result);
                 return;
         }
         result.notImplemented();
     }
 
-    private void showAndHideAlertDialog(MethodChannel.Result result) {
+    private void showAlertDialog(MethodChannel.Result result) {
         Context context = view.getContext();
         AlertDialog.Builder builder = new AlertDialog.Builder(context);
         TextView textView = new TextView(context);
-        textView.setText("This alert dialog will close in 1 seconds");
+        textView.setText("Alert!");
         builder.setView(textView);
         final AlertDialog alertDialog = builder.show();
         result.success(null);
-        view.postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                alertDialog.hide();
-            }
-        }, 1000);
     }
 
 }

--- a/dev/integration_tests/android_views/lib/main.dart
+++ b/dev/integration_tests/android_views/lib/main.dart
@@ -20,7 +20,12 @@ class Home extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: ListView.builder(
+      body: ListView(
+        children: [
+          ListTile(
+            title: Text()
+          )
+        ]
         itemCount: _allPages.length,
         itemBuilder: (_, int index) => ListTile(
           title: Text(_allPages[index].title),
@@ -29,6 +34,10 @@ class Home extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  void  _buildTestListTile(BuildContext context, int index){
+
   }
 
   void _pushPage(BuildContext context, PageWidget page) {

--- a/dev/integration_tests/android_views/lib/main.dart
+++ b/dev/integration_tests/android_views/lib/main.dart
@@ -4,11 +4,14 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_driver/driver_extension.dart';
+
 import 'motion_events_page.dart';
 import 'page.dart';
+import 'wm_integrations.dart';
 
 final List<PageWidget> _allPages = <PageWidget>[
   const MotionEventsPage(),
+  const WindowManagerIntegrationsPage(),
 ];
 
 void main() {
@@ -21,23 +24,17 @@ class Home extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       body: ListView(
-        children: [
-          ListTile(
-            title: Text()
-          )
-        ]
-        itemCount: _allPages.length,
-        itemBuilder: (_, int index) => ListTile(
-          title: Text(_allPages[index].title),
-          key: _allPages[index].tileKey,
-          onTap: () => _pushPage(context, _allPages[index]),
-        ),
+         children: _allPages.map((PageWidget p) => _buildPageListTile(context, p)).toList(),
       ),
     );
   }
 
-  void  _buildTestListTile(BuildContext context, int index){
-
+  Widget _buildPageListTile(BuildContext context, PageWidget page) {
+    return ListTile(
+      title: Text(page.title),
+      key: page.tileKey,
+      onTap: () { _pushPage(context, page); },
+    );
   }
 
   void _pushPage(BuildContext context, PageWidget page) {

--- a/dev/integration_tests/android_views/lib/wm_integrations.dart
+++ b/dev/integration_tests/android_views/lib/wm_integrations.dart
@@ -84,7 +84,7 @@ class WindowManagerBodyState extends State<WindowManagerBody> {
       });
     }
     try {
-      await viewChannel.invokeMethod<void>('showAndHideAlertDialog');
+      await viewChannel.invokeMethod<void>('showAlertDialog');
       setState(() {
         lastTestStatus = _LastTestStatus.success;
       });

--- a/dev/integration_tests/android_views/lib/wm_integrations.dart
+++ b/dev/integration_tests/android_views/lib/wm_integrations.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/dev/integration_tests/android_views/lib/wm_integrations.dart
+++ b/dev/integration_tests/android_views/lib/wm_integrations.dart
@@ -102,4 +102,3 @@ class WindowManagerBodyState extends State<WindowManagerBody> {
     });
   }
 }
-

--- a/dev/integration_tests/android_views/lib/wm_integrations.dart
+++ b/dev/integration_tests/android_views/lib/wm_integrations.dart
@@ -1,0 +1,105 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+import 'page.dart';
+
+class WindowManagerIntegrationsPage extends PageWidget {
+  const WindowManagerIntegrationsPage()
+      : super('Window Manager Integrations Tests', const ValueKey<String>('WmIntegrationsListTile'));
+
+  @override
+  Widget build(BuildContext context) => WindowManagerBody();
+
+}
+
+class WindowManagerBody extends StatefulWidget {
+  @override
+  State<WindowManagerBody> createState() => WindowManagerBodyState();
+}
+
+enum _LastTestStatus {
+  pending,
+  success,
+  error
+}
+
+class WindowManagerBodyState extends State<WindowManagerBody> {
+
+  MethodChannel viewChannel;
+  _LastTestStatus lastTestStatus = _LastTestStatus.pending;
+  String lastError;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Window Manager Integrations'),
+      ),
+      body: Column(
+        children: <Widget>[
+          SizedBox(
+            height: 300,
+            child: AndroidView(
+              viewType: 'simple_view',
+              onPlatformViewCreated: onPlatformViewCreated,
+            ),
+          ),
+          if (lastTestStatus != _LastTestStatus.pending) _statusWidget(),
+          if (viewChannel != null) RaisedButton(
+            key: const ValueKey<String>('ShowAlertDialog'),
+            child: const Text('SHOW ALERT DIALOG'),
+            onPressed: onShowAlertDialogPressed,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _statusWidget() {
+    assert(lastTestStatus != _LastTestStatus.pending);
+    final String message = lastTestStatus == _LastTestStatus.success ? 'Success' : lastError;
+    return Container(
+      color: lastTestStatus == _LastTestStatus.success ? Colors.green : Colors.red,
+      child: Text(
+        message,
+        key: const ValueKey<String>('Status'),
+        style: TextStyle(
+          color: lastTestStatus == _LastTestStatus.error ? Colors.yellow : null,
+        ),
+      ),
+    );
+  }
+
+  Future<void> onShowAlertDialogPressed() async {
+    if (lastTestStatus != _LastTestStatus.pending) {
+      setState(() {
+        lastTestStatus = _LastTestStatus.pending;
+      });
+    }
+    try {
+      await viewChannel.invokeMethod<void>('showAndHideAlertDialog');
+      setState(() {
+        lastTestStatus = _LastTestStatus.success;
+      });
+    } catch(e) {
+      setState(() {
+        lastTestStatus = _LastTestStatus.error;
+        lastError = '$e';
+      });
+    }
+  }
+
+  void onPlatformViewCreated(int id) {
+    setState(() {
+      viewChannel = MethodChannel('simple_view/$id');
+    });
+  }
+}
+

--- a/dev/integration_tests/android_views/test_driver/main_test.dart
+++ b/dev/integration_tests/android_views/test_driver/main_test.dart
@@ -17,16 +17,29 @@ Future<void> main() async {
     driver.close();
   });
 
-  group('MotionEvents tests ', () {
-    test('recomposition', () async {
-      final SerializableFinder motionEventsListTile =
-      find.byValueKey('MotionEventsListTile');
-      await driver.tap(motionEventsListTile);
-      await driver.waitFor(find.byValueKey('PlatformView'));
-      final String errorMessage = await driver.requestData('run test');
-      expect(errorMessage, '');
-    },
-    // TODO(amirh): enable this test https://github.com/flutter/flutter/issues/54022
-    skip: true);
-  });
+  test('MotionEvent recomposition', () async {
+    final SerializableFinder motionEventsListTile =
+    find.byValueKey('MotionEventsListTile');
+    await driver.tap(motionEventsListTile);
+    await driver.waitFor(find.byValueKey('PlatformView'));
+    final String errorMessage = await driver.requestData('run test');
+    expect(errorMessage, '');
+  },
+  // TODO(amirh): enable this test https://github.com/flutter/flutter/issues/54022
+  skip: true);
+
+  test('AlertDialog from platform view context', () async {
+    final SerializableFinder wmListTile =
+    find.byValueKey('WmIntegrationsListTile');
+    await driver.tap(wmListTile);
+
+    final SerializableFinder showAlertDialog = find.byValueKey('ShowAlertDialog');
+    await driver.waitFor(showAlertDialog);
+    await driver.tap(showAlertDialog);
+    final String status = await driver.getText(find.byValueKey('Status'));
+    expect(status, 'Success');
+  },
+    // TODO(amirh): enable this test when https://github.com/flutter/flutter/issues/34248 is fixed.
+    skip: true,
+  );
 }


### PR DESCRIPTION
Creation of Android `AlertDialog`s with a platform view `Context` currently fails with a `ClassCastException`, this is the root cause for: #34248.

This PR just adds an integration test that creates an `AlertDialog` with a platform view context, the test is currently disabled (as it fails). I'm following up with a fix in the engine and will enable this test after the fix rolls.