### PR TITLE
Update roll_dev to work with new version numbers

### DIFF
--- a/dev/tools/lib/roll_dev.dart
+++ b/dev/tools/lib/roll_dev.dart
@@ -180,7 +180,7 @@ Match parseFullTag(String version) {
 
 String getVersionFromParts(List<int> parts) {
   assert(parts.length == 5);
-  StringBuffer buf = StringBuffer()
+  final StringBuffer buf = StringBuffer()
     ..write(parts.take(3).join('.'))
     ..write('-dev.')
     ..write(parts.skip(3).join('.'));

--- a/dev/tools/lib/roll_dev.dart
+++ b/dev/tools/lib/roll_dev.dart
@@ -105,10 +105,10 @@ void main(List<String> args) {
     exit(1);
   }
 
-  final List<int> parts = match.groups(<int>[1, 2, 3]).map<int>(int.parse).toList();
+  final List<int> parts = match.groups(<int>[1, 2, 3, 4, 5]).map<int>(int.parse).toList();
 
-  if (match.group(4) == '0') {
-    print('This commit has already been released, as version ${parts.join(".")}.');
+  if (match.group(6) == '0') {
+    print('This commit has already been released, as version ${getVersionFromParts(parts)}.');
     exit(0);
   }
 
@@ -117,19 +117,25 @@ void main(List<String> args) {
       parts[0] += 1;
       parts[1] = 0;
       parts[2] = 0;
+      parts[3] = 0;
+      parts[4] = 0;
       break;
     case kY:
       parts[1] += 1;
       parts[2] = 0;
+      parts[3] = 0;
+      parts[4] = 0;
       break;
     case kZ:
-      parts[2] += 1;
+      parts[2] = 0;
+      parts[3] += 1;
+      parts[4] = 0;
       break;
     default:
       print('Unknown increment level. The valid values are "$kX", "$kY", and "$kZ".');
       exit(1);
   }
-  version = parts.join('.');
+  version = getVersionFromParts(parts);
 
   if (justPrint) {
     print(version);
@@ -138,7 +144,7 @@ void main(List<String> args) {
 
   final String hash = getGitOutput('rev-parse HEAD', 'Get git hash for $commit');
 
-  runGit('tag v$version', 'tag the commit with the version label');
+  runGit('tag $version', 'tag the commit with the version label');
 
   // PROMPT
 
@@ -149,27 +155,36 @@ void main(List<String> args) {
       'to the "dev" channel.');
     stdout.write('Are you? [yes/no] ');
     if (stdin.readLineSync() != 'yes') {
-      runGit('tag -d v$version', 'remove the tag you did not want to publish');
+      runGit('tag -d $version', 'remove the tag you did not want to publish');
       print('The dev roll has been aborted.');
       exit(0);
     }
   }
 
-  runGit('push $origin v$version', 'publish the version');
+  runGit('push $origin $version', 'publish the version');
   runGit('push $origin HEAD:dev', 'land the new version on the "dev" branch');
   print('Flutter version $version has been rolled to the "dev" channel!');
 }
 
 String getFullTag() {
   return getGitOutput(
-    'describe --match v*.*.* --first-parent --long --tags',
+    'describe --match *.*.*-dev.*.* --first-parent --long --tags',
     'obtain last released version number',
   );
 }
 
 Match parseFullTag(String version) {
-  final RegExp versionPattern = RegExp(r'^v([0-9]+)\.([0-9]+)\.([0-9]+)-([0-9]+)-g([a-f0-9]+)$');
+  final RegExp versionPattern = RegExp(r'^([0-9]+)\.([0-9]+)\.([0-9]+)-dev\.([0-9]+)\.([0-9]+)-([0-9]+)-g([a-f0-9]+)$');
   return versionPattern.matchAsPrefix(version);
+}
+
+String getVersionFromParts(List<int> parts) {
+  assert(parts.length == 5);
+  StringBuffer buf = StringBuffer()
+    ..write(parts.take(3).join('.'))
+    ..write('-dev.')
+    ..write(parts.skip(3).join('.'));
+  return buf.toString();
 }
 
 String getGitOutput(String command, String explanation) {


### PR DESCRIPTION
## Description

This updates `roll_dev.dart` to deal in the new version numbers (`[x].[y].[z]-dev.[n].[m]`).  It maintains the same set of arguments for the `--increment` flag, but it maps the `--increment=z` value to the `[n]` digit in the version number, since that maps to the new release process.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.
