### PR TITLE
Disable deploy_gallery-macos shard while we investigate cert issues

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -595,24 +595,24 @@ task:
         - git clone https://github.com/flutter/tests.git bin/cache/pkg/tests
         - dart --enable-asserts dev/customer_testing/run_tests.dart --skip-on-fetch-failure --skip-template bin/cache/pkg/tests/registry/*.test
 
-    # TODO(tvolkert): Re-enable once certificate issues are fixed (https://github.com/flutter/flutter/issues/54017)
-    # - name: deploy_gallery-macos # linux- and macos- only
-    #   # Do not add more tasks here. Nothing is currently deployed from master branch, so it is safe to run
-    #   # even if a test has failed. The behavior of failing dependencies is non-ideal for infra health.
-    #   # See also: https://github.com/flutter/flutter/pull/49454
-    #   depends_on:
-    #     - analyze-linux
-    #   environment:
-    #     # Apple Fastlane password.
-    #     FASTLANE_PASSWORD: ENCRYPTED[4b1f0b8d52874e9de965acd46c79743f3b81f3a513614179b9be7cf53dc8258753e257bdadb11a298ee455259df21865]
-    #     # Private repo for publishing certificates.
-    #     PUBLISHING_MATCH_CERTIFICATE_REPO: ENCRYPTED[3c0e78877d933fc80107aa6f3790fd1cf927250b852d6cb53202be696b4903ed8ca839b809626aaf18050bf7e436fab7]
-    #     PUBLISHING_MATCH_REPO_TOKEN: ENCRYPTED[3d1230b744c6ed6c788a91bec741b769401dbcd426b18f9af8080bfeefdfc21913ca4047980c5b5b7ce823f12e7b6b19]
-    #     # Apple Certificates Match Passphrase
-    #     MATCH_PASSWORD: ENCRYPTED[db07f252234397090e3ec59152d9ec1831f5ecd0ef97d247b1dca757bbb9ef9b7c832a39bce2caf1949ccdf097e59a73]
-    #   script:
-    #     - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
-    #     - ./dev/bots/deploy_gallery.sh
+    - name: deploy_gallery-macos # linux- and macos- only
+      # Do not add more tasks here. Nothing is currently deployed from master branch, so it is safe to run
+      # even if a test has failed. The behavior of failing dependencies is non-ideal for infra health.
+      # See also: https://github.com/flutter/flutter/pull/49454
+      depends_on:
+        - analyze-linux
+      skip: true # https://github.com/flutter/flutter/issues/54016
+      environment:
+        # Apple Fastlane password.
+        FASTLANE_PASSWORD: ENCRYPTED[4b1f0b8d52874e9de965acd46c79743f3b81f3a513614179b9be7cf53dc8258753e257bdadb11a298ee455259df21865]
+        # Private repo for publishing certificates.
+        PUBLISHING_MATCH_CERTIFICATE_REPO: ENCRYPTED[3c0e78877d933fc80107aa6f3790fd1cf927250b852d6cb53202be696b4903ed8ca839b809626aaf18050bf7e436fab7]
+        PUBLISHING_MATCH_REPO_TOKEN: ENCRYPTED[3d1230b744c6ed6c788a91bec741b769401dbcd426b18f9af8080bfeefdfc21913ca4047980c5b5b7ce823f12e7b6b19]
+        # Apple Certificates Match Passphrase
+        MATCH_PASSWORD: ENCRYPTED[db07f252234397090e3ec59152d9ec1831f5ecd0ef97d247b1dca757bbb9ef9b7c832a39bce2caf1949ccdf097e59a73]
+      script:
+        - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
+        - ./dev/bots/deploy_gallery.sh
 
     - name: verify_binaries_codesigned-macos # macos-only
       # TODO(fujino): remove this `only_if` after https://github.com/flutter/flutter/issues/44372

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -595,23 +595,24 @@ task:
         - git clone https://github.com/flutter/tests.git bin/cache/pkg/tests
         - dart --enable-asserts dev/customer_testing/run_tests.dart --skip-on-fetch-failure --skip-template bin/cache/pkg/tests/registry/*.test
 
-    - name: deploy_gallery-macos # linux- and macos- only
-      # Do not add more tasks here. Nothing is currently deployed from master branch, so it is safe to run
-      # even if a test has failed. The behavior of failing dependencies is non-ideal for infra health.
-      # See also: https://github.com/flutter/flutter/pull/49454
-      depends_on:
-        - analyze-linux
-      environment:
-        # Apple Fastlane password.
-        FASTLANE_PASSWORD: ENCRYPTED[4b1f0b8d52874e9de965acd46c79743f3b81f3a513614179b9be7cf53dc8258753e257bdadb11a298ee455259df21865]
-        # Private repo for publishing certificates.
-        PUBLISHING_MATCH_CERTIFICATE_REPO: ENCRYPTED[3c0e78877d933fc80107aa6f3790fd1cf927250b852d6cb53202be696b4903ed8ca839b809626aaf18050bf7e436fab7]
-        PUBLISHING_MATCH_REPO_TOKEN: ENCRYPTED[3d1230b744c6ed6c788a91bec741b769401dbcd426b18f9af8080bfeefdfc21913ca4047980c5b5b7ce823f12e7b6b19]
-        # Apple Certificates Match Passphrase
-        MATCH_PASSWORD: ENCRYPTED[db07f252234397090e3ec59152d9ec1831f5ecd0ef97d247b1dca757bbb9ef9b7c832a39bce2caf1949ccdf097e59a73]
-      script:
-        - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
-        - ./dev/bots/deploy_gallery.sh
+    # TODO(tvolkert): Re-enable once certificate issues are fixed (https://github.com/flutter/flutter/issues/54017)
+    # - name: deploy_gallery-macos # linux- and macos- only
+    #   # Do not add more tasks here. Nothing is currently deployed from master branch, so it is safe to run
+    #   # even if a test has failed. The behavior of failing dependencies is non-ideal for infra health.
+    #   # See also: https://github.com/flutter/flutter/pull/49454
+    #   depends_on:
+    #     - analyze-linux
+    #   environment:
+    #     # Apple Fastlane password.
+    #     FASTLANE_PASSWORD: ENCRYPTED[4b1f0b8d52874e9de965acd46c79743f3b81f3a513614179b9be7cf53dc8258753e257bdadb11a298ee455259df21865]
+    #     # Private repo for publishing certificates.
+    #     PUBLISHING_MATCH_CERTIFICATE_REPO: ENCRYPTED[3c0e78877d933fc80107aa6f3790fd1cf927250b852d6cb53202be696b4903ed8ca839b809626aaf18050bf7e436fab7]
+    #     PUBLISHING_MATCH_REPO_TOKEN: ENCRYPTED[3d1230b744c6ed6c788a91bec741b769401dbcd426b18f9af8080bfeefdfc21913ca4047980c5b5b7ce823f12e7b6b19]
+    #     # Apple Certificates Match Passphrase
+    #     MATCH_PASSWORD: ENCRYPTED[db07f252234397090e3ec59152d9ec1831f5ecd0ef97d247b1dca757bbb9ef9b7c832a39bce2caf1949ccdf097e59a73]
+    #   script:
+    #     - ulimit -S -n 2048 # https://github.com/flutter/flutter/issues/2976
+    #     - ./dev/bots/deploy_gallery.sh
 
     - name: verify_binaries_codesigned-macos # macos-only
       # TODO(fujino): remove this `only_if` after https://github.com/flutter/flutter/issues/44372


### PR DESCRIPTION
## Description

The test is consistently failing while the cert issues are being investigated.

## Related Issues

https://github.com/flutter/flutter/issues/54016

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.
