### PR TITLE
Revert "revive the android_views test"

### DIFF
--- a/dev/integration_tests/android_views/test_driver/main_test.dart
+++ b/dev/integration_tests/android_views/test_driver/main_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io' show Platform;
 import 'package:flutter_driver/flutter_driver.dart';
 import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 
@@ -19,12 +20,14 @@ Future<void> main() async {
 
   group('MotionEvents tests ', () {
     test('recomposition', () async {
-      final SerializableFinder motionEventsListTile =
-      find.byValueKey('MotionEventsListTile');
-      await driver.tap(motionEventsListTile);
-      await driver.waitFor(find.byValueKey('PlatformView'));
-      final String errorMessage = await driver.requestData('run test');
-      expect(errorMessage, '');
+      if (Platform.isAndroid) {
+        final SerializableFinder motionEventsListTile =
+        find.byValueKey('MotionEventsListTile');
+        await driver.tap(motionEventsListTile);
+        await driver.waitFor(find.byValueKey('PlatformView'));
+        final String errorMessage = await driver.requestData('run test');
+        expect(errorMessage, '');
+      }
     });
   });
 }


### PR DESCRIPTION
Reverts flutter/flutter#53963

Looks like the test regressed in the time it was disabled, reverting to unblock the tree until further investigation.

cc @cyanglaz 