### PR TITLE
disable MotionEvents test

### DIFF
--- a/dev/integration_tests/android_views/test_driver/main_test.dart
+++ b/dev/integration_tests/android_views/test_driver/main_test.dart
@@ -25,6 +25,8 @@ Future<void> main() async {
       await driver.waitFor(find.byValueKey('PlatformView'));
       final String errorMessage = await driver.requestData('run test');
       expect(errorMessage, '');
-    });
+    },
+    // TODO(amirh): enable this test https://github.com/flutter/flutter/issues/54022
+    skip: true);
   });
 }


### PR DESCRIPTION
The test seem to have regressed during the period it was accidentally disabled, see: https://github.com/flutter/flutter/issues/54022

Skipping to unblock the tree.