### PR TITLE
disable the "gpu" tracing category

### DIFF
--- a/dev/devicelab/lib/framework/browser.dart
+++ b/dev/devicelab/lib/framework/browser.dart
@@ -171,8 +171,9 @@ class Chrome {
       //   to find frames that the benchmark cares to measure.
       // gpu:
       //   provides tracing data from the GPU data
+      //   disabled due to https://bugs.chromium.org/p/chromium/issues/detail?id=1068259
       // TODO(yjbanov): extract useful GPU data
-      'categories': 'blink,blink.user_timing,gpu',
+      'categories': 'blink,blink.user_timing',
       'transferMode': 'SendAsStream',
     });
   }


### PR DESCRIPTION
## Description

According to my local testing the "gpu" category affects the layout + style recalc numbers on the UI thread. This change disables the "gpu" category. We are not collecting data from this category for now anyway.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/54101
Chrome issue: https://bugs.chromium.org/p/chromium/issues/detail?id=1068259
