### PR TITLE
fixes isAlwaysShown material scrollbar.dart

### DIFF
--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -238,15 +238,7 @@ class _CupertinoScrollbarState extends State<CupertinoScrollbar> with TickerProv
         ..color = CupertinoDynamicColor.resolve(_kScrollbarColor, context)
         ..padding = MediaQuery.of(context).padding;
     }
-    WidgetsBinding.instance.addPostFrameCallback((Duration duration) {
-      if (widget.isAlwaysShown) {
-        assert(widget.controller != null);
-        // Wait one frame and cause an empty scroll event.  This allows the
-        // thumb to show immediately when isAlwaysShown is true.  A scroll
-        // event is required in order to paint the thumb.
-        widget.controller.position.didUpdateScrollPositionBy(0);
-      }
-    });
+    _triggerScrollbar();
   }
 
   @override
@@ -254,7 +246,7 @@ class _CupertinoScrollbarState extends State<CupertinoScrollbar> with TickerProv
     super.didUpdateWidget(oldWidget);
     if (widget.isAlwaysShown != oldWidget.isAlwaysShown) {
       if (widget.isAlwaysShown == true) {
-        assert(widget.controller != null);
+        _triggerScrollbar();
         _fadeoutAnimationController.animateTo(1.0);
       } else {
         _fadeoutAnimationController.reverse();
@@ -276,6 +268,18 @@ class _CupertinoScrollbarState extends State<CupertinoScrollbar> with TickerProv
       minLength: _kScrollbarMinLength,
       minOverscrollLength: _kScrollbarMinOverscrollLength,
     );
+  }
+
+  // Wait one frame and cause an empty scroll event.  This allows the thumb to
+  // show immediately when isAlwaysShown is true.  A scroll event is required in
+  // order to paint the thumb.
+  void _triggerScrollbar() {
+    WidgetsBinding.instance.addPostFrameCallback((Duration duration) {
+      if (widget.isAlwaysShown) {
+        assert(widget.controller != null);
+        widget.controller.position.didUpdateScrollPositionBy(0);
+      }
+    });
   }
 
   // Handle a gesture that drags the scrollbar by the given amount.

--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -277,6 +277,7 @@ class _CupertinoScrollbarState extends State<CupertinoScrollbar> with TickerProv
     WidgetsBinding.instance.addPostFrameCallback((Duration duration) {
       if (widget.isAlwaysShown) {
         assert(widget.controller != null);
+        _fadeoutTimer?.cancel();
         widget.controller.position.didUpdateScrollPositionBy(0);
       }
     });

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -106,15 +106,7 @@ class _ScrollbarState extends State<Scrollbar> with TickerProviderStateMixin {
         _textDirection = Directionality.of(context);
         _materialPainter = _buildMaterialScrollbarPainter();
         _useCupertinoScrollbar = false;
-        WidgetsBinding.instance.addPostFrameCallback((Duration duration) {
-          if (widget.isAlwaysShown) {
-            assert(widget.controller != null);
-            // Wait one frame and cause an empty scroll event.  This allows the
-            // thumb to show immediately when isAlwaysShown is true.  A scroll
-            // event is required in order to paint the thumb.
-            widget.controller.position.didUpdateScrollPositionBy(0);
-          }
-        });
+        _triggerScrollbar();
         break;
     }
     assert(_useCupertinoScrollbar != null);
@@ -124,13 +116,25 @@ class _ScrollbarState extends State<Scrollbar> with TickerProviderStateMixin {
   void didUpdateWidget(Scrollbar oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.isAlwaysShown != oldWidget.isAlwaysShown) {
-      assert(widget.controller != null);
       if (widget.isAlwaysShown == false) {
         _fadeoutAnimationController.reverse();
       } else {
+        _triggerScrollbar();
         _fadeoutAnimationController.animateTo(1.0);
       }
     }
+  }
+
+  // Wait one frame and cause an empty scroll event.  This allows the thumb to
+  // show immediately when isAlwaysShown is true.  A scroll event is required in
+  // order to paint the thumb.
+  void _triggerScrollbar() {
+    WidgetsBinding.instance.addPostFrameCallback((Duration duration) {
+      if (widget.isAlwaysShown) {
+        assert(widget.controller != null);
+        widget.controller.position.didUpdateScrollPositionBy(0);
+      }
+    });
   }
 
   ScrollbarPainter _buildMaterialScrollbarPainter() {

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -132,6 +132,7 @@ class _ScrollbarState extends State<Scrollbar> with TickerProviderStateMixin {
     WidgetsBinding.instance.addPostFrameCallback((Duration duration) {
       if (widget.isAlwaysShown) {
         assert(widget.controller != null);
+        _fadeoutTimer?.cancel();
         widget.controller.position.didUpdateScrollPositionBy(0);
       }
     });

--- a/packages/flutter/test/cupertino/scrollbar_test.dart
+++ b/packages/flutter/test/cupertino/scrollbar_test.dart
@@ -287,6 +287,59 @@ void main() {
   });
 
   testWidgets(
+      'With isAlwaysShown: false, set isAlwaysShown: true. The thumb should be always shown directly',
+      (WidgetTester tester) async {
+    final ScrollController controller = ScrollController();
+    bool isAlwaysShown = false;
+    Widget viewWithScroll() {
+      return StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          return Directionality(
+            textDirection: TextDirection.ltr,
+            child: MediaQuery(
+              data: const MediaQueryData(),
+              child: Stack(
+                children: <Widget>[
+                  CupertinoScrollbar(
+                    isAlwaysShown: isAlwaysShown,
+                    controller: controller,
+                    child: SingleChildScrollView(
+                      controller: controller,
+                      child: const SizedBox(
+                        width: 4000.0,
+                        height: 4000.0,
+                      ),
+                    ),
+                  ),
+                  Positioned(
+                    bottom: 10,
+                    child: CupertinoButton(
+                      onPressed: () {
+                        setState(() {
+                          isAlwaysShown = !isAlwaysShown;
+                        });
+                      },
+                      child: const Text('change isAlwaysShown'),
+                    ),
+                  )
+                ],
+              ),
+            ),
+          );
+        },
+      );
+    }
+
+    await tester.pumpWidget(viewWithScroll());
+    await tester.pumpAndSettle();
+    expect(find.byType(CupertinoScrollbar), isNot(paints..rrect()));
+
+    await tester.tap(find.byType(CupertinoButton));
+    await tester.pumpAndSettle();
+    expect(find.byType(CupertinoScrollbar), paints..rrect());
+  });
+
+  testWidgets(
       'With isAlwaysShown: false, fling a scroll. While it is still scrolling, set isAlwaysShown: true. The thumb should not fade even after the scrolling stops',
       (WidgetTester tester) async {
     final ScrollController controller = ScrollController();

--- a/packages/flutter/test/cupertino/scrollbar_test.dart
+++ b/packages/flutter/test/cupertino/scrollbar_test.dart
@@ -385,6 +385,7 @@ void main() {
 
     await tester.pumpWidget(viewWithScroll());
     await tester.pumpAndSettle();
+    expect(find.byType(CupertinoScrollbar), isNot(paints..rrect()));
     await tester.fling(
       find.byType(SingleChildScrollView),
       const Offset(0.0, -10.0),
@@ -393,7 +394,13 @@ void main() {
     expect(find.byType(CupertinoScrollbar), paints..rrect());
 
     await tester.tap(find.byType(CupertinoButton));
+    await tester.pump();
+    expect(find.byType(CupertinoScrollbar), paints..rrect());
+
+    // Wait for the timer delay to expire.
+    await tester.pump(const Duration(milliseconds: 600)); // _kScrollbarTimeToFade
     await tester.pumpAndSettle();
+    // Scrollbar thumb is showing after scroll finishes and timer ends.
     expect(find.byType(CupertinoScrollbar), paints..rrect());
   });
 

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -309,6 +309,54 @@ void main() {
   });
 
   testWidgets(
+      'With isAlwaysShown: false, set isAlwaysShown: true. The thumb should be always shown directly',
+      (WidgetTester tester) async {
+    final ScrollController controller = ScrollController();
+    bool isAlwaysShown = false;
+    Widget viewWithScroll() {
+      return _buildBoilerplate(
+        child: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return Theme(
+              data: ThemeData(),
+              child: Scaffold(
+                floatingActionButton: FloatingActionButton(
+                  child: const Icon(Icons.threed_rotation),
+                  onPressed: () {
+                    setState(() {
+                      isAlwaysShown = !isAlwaysShown;
+                    });
+                  },
+                ),
+                body: Scrollbar(
+                  isAlwaysShown: isAlwaysShown,
+                  controller: controller,
+                  child: SingleChildScrollView(
+                    controller: controller,
+                    child: const SizedBox(
+                      width: 4000.0,
+                      height: 4000.0,
+                    ),
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
+      );
+    }
+
+    await tester.pumpWidget(viewWithScroll());
+    await tester.pumpAndSettle();
+    expect(find.byType(Scrollbar), isNot(paints..rect()));
+
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pumpAndSettle();
+    // Scrollbar is not showing after scroll finishes
+    expect(find.byType(Scrollbar), paints..rect());
+  });
+
+  testWidgets(
       'With isAlwaysShown: false, fling a scroll. While it is still scrolling, set isAlwaysShown: true. The thumb should not fade even after the scrolling stops',
       (WidgetTester tester) async {
     final ScrollController controller = ScrollController();

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -396,6 +396,7 @@ void main() {
 
     await tester.pumpWidget(viewWithScroll());
     await tester.pumpAndSettle();
+    expect(find.byType(Scrollbar), isNot(paints..rect()));
     await tester.fling(
       find.byType(SingleChildScrollView),
       const Offset(0.0, -10.0),
@@ -404,8 +405,13 @@ void main() {
     expect(find.byType(Scrollbar), paints..rect());
 
     await tester.tap(find.byType(FloatingActionButton));
+    await tester.pump();
+    expect(find.byType(Scrollbar), paints..rect());
+
+    // Wait for the timer delay to expire.
+    await tester.pump(const Duration(milliseconds: 600)); // _kScrollbarTimeToFade
     await tester.pumpAndSettle();
-    // Scrollbar is not showing after scroll finishes
+    // Scrollbar thumb is showing after scroll finishes and timer ends.
     expect(find.byType(Scrollbar), paints..rect());
   });
 


### PR DESCRIPTION
## Description

1: `Scrollbar`'s `isAlwaysShown` property is false
2: toggle it to true
3: expect to be shown

first of all, `CupertinoScrollbar` works fine but in material `Scrollbar` the `didChangeDependencies` not calling after a dependency(`isAlwaysShown`) change. However, this progress works fine in `CupertinoScrollbar` so that I  update `didUpdateWidget` as following
```dart
  @override
  void didUpdateWidget(Scrollbar oldWidget) {
    super.didUpdateWidget(oldWidget);
    if (widget.isAlwaysShown != oldWidget.isAlwaysShown) {
      assert(widget.controller != null);
      if (widget.isAlwaysShown == false) {
        _fadeoutAnimationController.reverse();
      } else {
        widget.controller.position.didUpdateScrollPositionBy(0);
        _fadeoutAnimationController.animateTo(1.0);
      }
    }
  }
```
this line added 
`        widget.controller.position.didUpdateScrollPositionBy(0); `

it solves the current bug but I think we should figure out why `didChangeDependencies`

## Related Issues

#53771

## Tests

tests are already added in previous branch which was merged

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
