### PR TITLE
[flutter_tools] ensure the tool can find SDK manager on windows

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -380,7 +380,11 @@ class AndroidSdk {
   /// was marked as obsolete in 3.6.
   String get sdkManagerPath {
     final File cmdlineTool = globals.fs.file(
-      globals.fs.path.join(directory, 'cmdline-tools', 'latest', 'bin', 'sdkmanager')
+      globals.fs.path.join(directory, 'cmdline-tools', 'latest', 'bin',
+        globals.platform.isWindows
+          ? 'sdkmanager.bat'
+          : 'sdkmanager'
+      ),
     );
     if (cmdlineTool.existsSync()) {
       return cmdlineTool.path;


### PR DESCRIPTION
## Description

The SDK manager lookup had a fallback path for checking the old version of platform tools that relies on file existence of `sdkmanager` executable. Unfortuantely, this file is called `sdkmanager.bat` on windows, so the test for this file fails.