### PR TITLE
Fixing precision error for stretched SliverAppBars

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
@@ -178,7 +178,7 @@ abstract class RenderSliverPersistentHeader extends RenderSliver with RenderObje
     }());
     double stretchOffset = 0.0;
     if (stretchConfiguration != null && childMainAxisPosition(child) == 0.0)
-      stretchOffset += constraints.overlap.abs();
+      stretchOffset += constraints.overlap.abs();//.floorToDouble();
 
     child?.layout(
       constraints.asBoxConstraints(

--- a/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
@@ -178,7 +178,7 @@ abstract class RenderSliverPersistentHeader extends RenderSliver with RenderObje
     }());
     double stretchOffset = 0.0;
     if (stretchConfiguration != null && childMainAxisPosition(child) == 0.0)
-      stretchOffset += constraints.overlap.abs();//.floorToDouble();
+      stretchOffset += constraints.overlap.abs().floorToDouble();
 
     child?.layout(
       constraints.asBoxConstraints(

--- a/packages/flutter/test/widgets/slivers_appbar_stretch_test.dart
+++ b/packages/flutter/test/widgets/slivers_appbar_stretch_test.dart
@@ -46,6 +46,42 @@ void main() {
       expect(header.child.size.height, equals(200.0));
     });
 
+    testWidgets('fills overscroll precision error', (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/53823
+      const Key anchor = Key('drag');
+      await tester.pumpWidget(
+        MaterialApp(
+          home: CustomScrollView(
+            physics: const BouncingScrollPhysics(),
+            slivers: <Widget>[
+              const SliverAppBar(
+                stretch: true,
+                expandedHeight: 100.0,
+              ),
+              SliverToBoxAdapter(
+                child: Container(
+                  key: anchor,
+                  height: 800,
+                )
+              ),
+              SliverToBoxAdapter(
+                child: Container(
+                  height: 800,
+                )
+              ),
+            ],
+          ),
+        ),
+      );
+
+      final RenderSliverScrollingPersistentHeader header = tester.renderObject(
+        find.byType(SliverAppBar)
+      );
+      expect(header.child.size.height, equals(100.0));
+      await slowDrag(tester, anchor, const Offset(0.0, 100.5));
+      expect(header.child.size.height, equals(200));
+    });
+
     testWidgets('does not stretch without overscroll physics', (WidgetTester tester) async {
       const Key anchor = Key('drag');
       await tester.pumpWidget(


### PR DESCRIPTION
## Description

This fixes a precision error that is apparent when aligning elements in the `Stack` of a `FlexibleSpace` along the bottom of the stretched `SliverAppBar`.

## Related Issues

Fixes #53823 

## Tests

Stretch fills overscroll and handles precision error.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
