### PR TITLE
Convert iOS simulator log reader to simctl, use unified logging filters

### DIFF
--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -580,20 +580,35 @@ class IOSSimulator extends Device {
   }
 }
 
-/// Launches the device log reader process on the host.
-Future<Process> launchDeviceLogTool(IOSSimulator device) async {
-  // Versions of iOS prior to iOS 11 log to the simulator syslog file.
-  if (await device.sdkMajorVersion < 11) {
-    return processUtils.start(<String>['tail', '-n', '0', '-F', device.logFilePath]);
+/// Launches the device log reader process on the host and parses the syslog.
+@visibleForTesting
+Future<Process> launchDeviceSystemLogTool(IOSSimulator device) async {
+  return processUtils.start(<String>['tail', '-n', '0', '-F', device.logFilePath]);
+}
+
+/// Launches the device log reader process on the host and parses unified logging.
+@visibleForTesting
+Future<Process> launchDeviceUnifiedLogging (IOSSimulator device, String appName) async {
+  final StringBuffer predicate = StringBuffer('eventType = logEvent AND ');
+
+  // Either from Flutter or Swift (maybe assertion or fatal error) or from the app itself.
+  predicate.write('(senderImagePath ENDSWITH "/Flutter" OR senderImagePath ENDSWITH "/libswiftCore.dylib" OR processImageUUID == senderImageUUID) AND ');
+  if (appName != null) {
+    predicate.write('processImagePath ENDSWITH "$appName" AND ');
   }
 
-  // For iOS 11 and above, use /usr/bin/log to tail process logs.
-  // Run in interactive mode (via script), otherwise /usr/bin/log buffers in 4k chunks. (radar: 34420207)
+  // Filter out some messages that clearly aren't related to Flutter.
+  predicate.write('NOT(eventMessage CONTAINS ": could not find icon for representation -> com.apple.") AND ');
+
+  // assertion failed: 15G1212 13E230: libxpc.dylib + 57882 [66C28065-C9DB-3C8E-926F-5A40210A6D1B]: 0x7d
+  predicate.write('NOT(eventMessage BEGINSWITH "assertion failed: " AND eventMessage CONTAINS " libxpc.dylib ")');
+
   return processUtils.start(<String>[
-    'script', '/dev/null', '/usr/bin/log', 'stream', '--style', 'syslog', '--predicate', 'processImagePath CONTAINS "${device.id}"',
+    _xcrunPath, 'simctl', 'spawn', device.id, 'log', 'stream', '--style', 'json', '--predicate', predicate.toString(),
   ]);
 }
 
+@visibleForTesting
 Future<Process> launchSystemLogTool(IOSSimulator device) async {
   // Versions of iOS prior to 11 tail the simulator syslog file.
   if (await device.sdkMajorVersion < 11) {
@@ -630,11 +645,18 @@ class _IOSSimulatorLogReader extends DeviceLogReader {
   String get name => device.name;
 
   Future<void> _start() async {
-    // Device log.
-    await device.ensureLogsExists();
-    _deviceProcess = await launchDeviceLogTool(device);
-    _deviceProcess.stdout.transform<String>(utf8.decoder).transform<String>(const LineSplitter()).listen(_onDeviceLine);
-    _deviceProcess.stderr.transform<String>(utf8.decoder).transform<String>(const LineSplitter()).listen(_onDeviceLine);
+    // Unified logging iOS 11 and greater (introduced in iOS 10).
+    if (await device.sdkMajorVersion >= 11) {
+      _deviceProcess = await launchDeviceUnifiedLogging(device, _appName);
+      _deviceProcess.stdout.transform<String>(utf8.decoder).transform<String>(const LineSplitter()).listen(_onUnifiedLoggingLine);
+      _deviceProcess.stderr.transform<String>(utf8.decoder).transform<String>(const LineSplitter()).listen(_onUnifiedLoggingLine);
+    } else {
+      // Fall back to syslog parsing.
+      await device.ensureLogsExists();
+      _deviceProcess = await launchDeviceSystemLogTool(device);
+      _deviceProcess.stdout.transform<String>(utf8.decoder).transform<String>(const LineSplitter()).listen(_onSysLogDeviceLine);
+      _deviceProcess.stderr.transform<String>(utf8.decoder).transform<String>(const LineSplitter()).listen(_onSysLogDeviceLine);
+    }
 
     // Track system.log crashes.
     // ReportCrash[37965]: Saved crash report for FlutterRunner[37941]...
@@ -729,7 +751,7 @@ class _IOSSimulatorLogReader extends DeviceLogReader {
 
   String _lastLine;
 
-  void _onDeviceLine(String line) {
+  void _onSysLogDeviceLine(String line) {
     globals.printTrace('[DEVICE LOG] $line');
     final Match multi = _lastMessageMultipleRegex.matchAsPrefix(line);
 
@@ -748,6 +770,19 @@ class _IOSSimulatorLogReader extends DeviceLogReader {
         _lastLineMatched = true;
       } else {
         _lastLineMatched = false;
+      }
+    }
+  }
+
+  //   "eventMessage" : "flutter: 21",
+  static final RegExp _unifiedLoggingEventMessageRegex = RegExp(r'.*"eventMessage" : (".*")');
+  void _onUnifiedLoggingLine(String line) {
+    // The log command predicate handles filtering, so every log eventMessage should be decoded and added.
+    final Match eventMessageMatch = _unifiedLoggingEventMessageRegex.firstMatch(line);
+    if (eventMessageMatch != null) {
+      final dynamic decodedJson = jsonDecode(eventMessageMatch.group(1));
+      if (decodedJson is String) {
+        _linesController.add(decodedJson);
       }
     }
   }

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -591,7 +591,7 @@ Future<Process> launchDeviceSystemLogTool(IOSSimulator device) async {
 Future<Process> launchDeviceUnifiedLogging (IOSSimulator device, String appName) async {
   // Make NSPredicate concatenation easier to read.
   String orP(List<String> clauses) => '(${clauses.join(" OR ")})';
-  String andP(List<String> clauses) => '${clauses.join(" AND ")}';
+  String andP(List<String> clauses) => clauses.join(' AND ');
   String notP(String clause) => 'NOT($clause)';
 
   final String predicate = andP(<String>[

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -451,10 +451,27 @@ void main() {
         xcode: mockXcode,
       );
       await launchDeviceUnifiedLogging(device, 'Runner');
+
+      const String expectedPredicate = 'eventType = logEvent AND '
+        'processImagePath ENDSWITH "Runner" AND '
+        '(senderImagePath ENDSWITH "/Flutter" OR senderImagePath ENDSWITH "/libswiftCore.dylib" OR processImageUUID == senderImageUUID) AND '
+        'NOT(eventMessage CONTAINS ": could not find icon for representation -> com.apple.") AND '
+        'NOT(eventMessage BEGINSWITH "assertion failed: ") AND '
+        'NOT(eventMessage CONTAINS " libxpc.dylib ")';
+
       final List<String> command = verify(mockProcessManager.start(captureAny, environment: null, workingDirectory: null)).captured.single as List<String>;
-      expect(command, contains('spawn'));
-      expect(command, contains('x'));
-      expect(command.last, contains('processImagePath ENDSWITH "Runner"'));
+      expect(command, <String>[
+        '/usr/bin/xcrun',
+        'simctl',
+        'spawn',
+        'x',
+        'log',
+        'stream',
+        '--style',
+        'json',
+        '--predicate',
+        expectedPredicate
+      ]);
     },
       overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
@@ -470,11 +487,26 @@ void main() {
         xcode: mockXcode,
       );
       await launchDeviceUnifiedLogging(device, null);
+
+      const String expectedPredicate = 'eventType = logEvent AND '
+        '(senderImagePath ENDSWITH "/Flutter" OR senderImagePath ENDSWITH "/libswiftCore.dylib" OR processImageUUID == senderImageUUID) AND '
+        'NOT(eventMessage CONTAINS ": could not find icon for representation -> com.apple.") AND '
+        'NOT(eventMessage BEGINSWITH "assertion failed: ") AND '
+        'NOT(eventMessage CONTAINS " libxpc.dylib ")';
+
       final List<String> command = verify(mockProcessManager.start(captureAny, environment: null, workingDirectory: null)).captured.single as List<String>;
-      expect(command, contains('spawn'));
-      expect(command, contains('x'));
-      expect(command.last, contains('(senderImagePath ENDSWITH "/Flutter" OR senderImagePath ENDSWITH "/libswiftCore.dylib" OR processImageUUID == senderImageUUID) AND NOT(eventMessage'));
-      expect(command.last.contains('processImagePath ENDSWITH'), isFalse);
+      expect(command, <String>[
+        '/usr/bin/xcrun',
+        'simctl',
+        'spawn',
+        'x',
+        'log',
+        'stream',
+        '--style',
+        'json',
+        '--predicate',
+        expectedPredicate
+      ]);
     },
       overrides: <Type, Generator>{
         ProcessManager: () => mockProcessManager,
@@ -618,7 +650,6 @@ void main() {
 },{
   "traceID" : 37579774151491588,
   "eventMessage" : "Multi line message\\n  continues...\\n  continues..."
-},{
 },{
   "traceID" : 37579774151491588,
   "eventMessage" : "Single line message, not the part of the above",

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -410,7 +410,7 @@ void main() {
     );
   });
 
-  group('launchDeviceLogTool', () {
+  group('device log tool', () {
     MockProcessManager mockProcessManager;
     MockXcode mockXcode;
     MockSimControl mockSimControl;
@@ -423,7 +423,7 @@ void main() {
       mockXcode = MockXcode();
     });
 
-    testUsingContext('uses tail on iOS versions prior to iOS 11', () async {
+    testUsingContext('syslog uses tail', () async {
       final IOSSimulator device = IOSSimulator(
         'x',
         name: 'iPhone SE',
@@ -431,7 +431,7 @@ void main() {
         simControl: mockSimControl,
         xcode: mockXcode,
       );
-      await launchDeviceLogTool(device);
+      await launchDeviceSystemLogTool(device);
       expect(
         verify(mockProcessManager.start(captureAny, environment: null, workingDirectory: null)).captured.single,
         contains('tail'),
@@ -442,7 +442,7 @@ void main() {
       FileSystem: () => fileSystem,
     });
 
-    testUsingContext('uses /usr/bin/log on iOS 11 and above', () async {
+    testUsingContext('unified logging with app name', () async {
       final IOSSimulator device = IOSSimulator(
         'x',
         name: 'iPhone SE',
@@ -450,52 +450,18 @@ void main() {
         simControl: mockSimControl,
         xcode: mockXcode,
       );
-      await launchDeviceLogTool(device);
-      expect(
-        verify(mockProcessManager.start(captureAny, environment: null, workingDirectory: null)).captured.single,
-        contains('/usr/bin/log'),
-      );
+      await launchDeviceUnifiedLogging(device, 'Runner');
+      final List<String> command = verify(mockProcessManager.start(captureAny, environment: null, workingDirectory: null)).captured.single as List<String>;
+      expect(command, contains('spawn'));
+      expect(command, contains('x'));
+      expect(command.last, contains('processImagePath ENDSWITH "Runner"'));
     },
-    overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-      FileSystem: () => fileSystem,
-    });
-  });
-
-  group('launchSystemLogTool', () {
-    MockProcessManager mockProcessManager;
-
-    MockSimControl mockSimControl;
-    MockXcode mockXcode;
-
-    setUp(() {
-      mockSimControl = MockSimControl();
-      mockXcode = MockXcode();
-      mockProcessManager = MockProcessManager();
-      when(mockProcessManager.start(any, environment: null, workingDirectory: null))
-        .thenAnswer((Invocation invocation) => Future<Process>.value(MockProcess()));
-    });
-
-    testUsingContext('uses tail on iOS versions prior to iOS 11', () async {
-      final IOSSimulator device = IOSSimulator(
-        'x',
-        name: 'iPhone SE',
-        simulatorCategory: 'iOS 9.3',
-        simControl: mockSimControl,
-        xcode: mockXcode,
-      );
-      await launchSystemLogTool(device);
-      expect(
-        verify(mockProcessManager.start(captureAny, environment: null, workingDirectory: null)).captured.single,
-        contains('tail'),
-      );
-    },
-    overrides: <Type, Generator>{
+      overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
       FileSystem: () => fileSystem,
     });
 
-    testUsingContext('uses /usr/bin/log on iOS 11 and above', () async {
+    testUsingContext('unified logging without app name', () async {
       final IOSSimulator device = IOSSimulator(
         'x',
         name: 'iPhone SE',
@@ -503,13 +469,17 @@ void main() {
         simControl: mockSimControl,
         xcode: mockXcode,
       );
-      await launchSystemLogTool(device);
-      verifyNever(mockProcessManager.start(any, environment: null, workingDirectory: null));
+      await launchDeviceUnifiedLogging(device, null);
+      final List<String> command = verify(mockProcessManager.start(captureAny, environment: null, workingDirectory: null)).captured.single as List<String>;
+      expect(command, contains('spawn'));
+      expect(command, contains('x'));
+      expect(command.last, contains('(senderImagePath ENDSWITH "/Flutter" OR senderImagePath ENDSWITH "/libswiftCore.dylib" OR processImageUUID == senderImageUUID) AND NOT(eventMessage'));
+      expect(command.last.contains('processImagePath ENDSWITH'), isFalse);
     },
-    overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-      FileSystem: () => fileSystem,
-    });
+      overrides: <Type, Generator>{
+        ProcessManager: () => mockProcessManager,
+        FileSystem: () => fileSystem,
+      });
   });
 
   group('log reader', () {
@@ -525,55 +495,62 @@ void main() {
       mockXcode = MockXcode();
     });
 
-    testUsingContext('simulator can output `)`', () async {
-      when(mockProcessManager.start(any, environment: null, workingDirectory: null))
-        .thenAnswer((Invocation invocation) {
+    group('syslog', () {
+      setUp(() {
+        final File syslog = fileSystem.file('system.log')..createSync();
+        osx.environment['IOS_SIMULATOR_LOG_FILE_PATH'] = syslog.path;
+      });
+
+      testUsingContext('simulator can output `)`', () async {
+        when(mockProcessManager.start(any, environment: null, workingDirectory: null))
+          .thenAnswer((Invocation invocation) {
           final Process mockProcess = MockProcess();
           when(mockProcess.stdout)
             .thenAnswer((Invocation invocation) {
-              return Stream<List<int>>.fromIterable(<List<int>>['''
+            return Stream<List<int>>.fromIterable(<List<int>>['''
 2017-09-13 15:26:57.228948-0700  localhost Runner[37195]: (Flutter) Observatory listening on http://127.0.0.1:57701/
 2017-09-13 15:26:57.228948-0700  localhost Runner[37195]: (Flutter) ))))))))))
 2017-09-13 15:26:57.228948-0700  localhost Runner[37195]: (Flutter) #0      Object.noSuchMethod (dart:core-patch/dart:core/object_patch.dart:46)'''
-                .codeUnits]);
-            });
+              .codeUnits]);
+          });
           when(mockProcess.stderr)
-              .thenAnswer((Invocation invocation) => const Stream<List<int>>.empty());
+            .thenAnswer((Invocation invocation) => const Stream<List<int>>.empty());
           // Delay return of exitCode until after stdout stream data, since it terminates the logger.
           when(mockProcess.exitCode)
-              .thenAnswer((Invocation invocation) => Future<int>.delayed(Duration.zero, () => 0));
+            .thenAnswer((Invocation invocation) => Future<int>.delayed(Duration.zero, () => 0));
           return Future<Process>.value(mockProcess);
         });
 
-      final IOSSimulator device = IOSSimulator(
-        '123456',
-        simulatorCategory: 'iOS 11.0',
-        simControl: mockSimControl,
-        xcode: mockXcode,
-      );
-      final DeviceLogReader logReader = device.getLogReader(
-        app: await BuildableIOSApp.fromProject(mockIosProject),
-      );
+        final IOSSimulator device = IOSSimulator(
+          '123456',
+          simulatorCategory: 'iOS 10.3',
+          simControl: mockSimControl,
+          xcode: mockXcode,
+        );
+        final DeviceLogReader logReader = device.getLogReader(
+          app: await BuildableIOSApp.fromProject(mockIosProject),
+        );
 
-      final List<String> lines = await logReader.logLines.toList();
-      expect(lines, <String>[
-        'Observatory listening on http://127.0.0.1:57701/',
-        '))))))))))',
-        '#0      Object.noSuchMethod (dart:core-patch/dart:core/object_patch.dart:46)',
-      ]);
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-      FileSystem: () => fileSystem,
-    });
+        final List<String> lines = await logReader.logLines.toList();
+        expect(lines, <String>[
+          'Observatory listening on http://127.0.0.1:57701/',
+          '))))))))))',
+          '#0      Object.noSuchMethod (dart:core-patch/dart:core/object_patch.dart:46)',
+        ]);
+      }, overrides: <Type, Generator>{
+        ProcessManager: () => mockProcessManager,
+        FileSystem: () => fileSystem,
+        Platform: () => osx,
+      });
 
-    testUsingContext('log reader handles multiline messages', () async {
-      when(mockProcessManager.start(any, environment: null, workingDirectory: null))
-        .thenAnswer((Invocation invocation) {
+      testUsingContext('log reader handles multiline messages', () async {
+        when(mockProcessManager.start(any, environment: null, workingDirectory: null))
+          .thenAnswer((Invocation invocation) {
           final Process mockProcess = MockProcess();
           when(mockProcess.stdout)
             .thenAnswer((Invocation invocation) {
-              // Messages from 2017 should pass through, 2020 message should not
-              return Stream<List<int>>.fromIterable(<List<int>>['''
+            // Messages from 2017 should pass through, 2020 message should not
+            return Stream<List<int>>.fromIterable(<List<int>>['''
 2017-09-13 15:26:57.228948-0700  localhost Runner[37195]: (Flutter) Single line message
 2017-09-13 15:26:57.228948-0700  localhost Runner[37195]: (Flutter) Multi line message
   continues...
@@ -588,40 +565,95 @@ void main() {
   and goes...
 2017-09-13 15:36:57.228948-0700  localhost Runner[37195]: (Flutter) Single line message, not the part of the above
 '''
-                .codeUnits]);
-            });
+              .codeUnits]);
+          });
           when(mockProcess.stderr)
-              .thenAnswer((Invocation invocation) => const Stream<List<int>>.empty());
+            .thenAnswer((Invocation invocation) => const Stream<List<int>>.empty());
           // Delay return of exitCode until after stdout stream data, since it terminates the logger.
           when(mockProcess.exitCode)
-              .thenAnswer((Invocation invocation) => Future<int>.delayed(Duration.zero, () => 0));
+            .thenAnswer((Invocation invocation) => Future<int>.delayed(Duration.zero, () => 0));
           return Future<Process>.value(mockProcess);
         });
 
-      final IOSSimulator device = IOSSimulator(
-        '123456',
-        simulatorCategory: 'iOS 11.0',
-        simControl: mockSimControl,
-        xcode: mockXcode,
-      );
-      final DeviceLogReader logReader = device.getLogReader(
-        app: await BuildableIOSApp.fromProject(mockIosProject),
-      );
+        final IOSSimulator device = IOSSimulator(
+          '123456',
+          simulatorCategory: 'iOS 10.3',
+          simControl: mockSimControl,
+          xcode: mockXcode,
+        );
+        final DeviceLogReader logReader = device.getLogReader(
+          app: await BuildableIOSApp.fromProject(mockIosProject),
+        );
 
-      final List<String> lines = await logReader.logLines.toList();
-      expect(lines, <String>[
-        'Single line message',
-        'Multi line message',
-        '  continues...',
-        '  continues...',
-        'Multi line message again',
-        '  and it goes...',
-        '  and goes...',
-        'Single line message, not the part of the above'
-      ]);
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-      FileSystem: () => fileSystem,
+        final List<String> lines = await logReader.logLines.toList();
+        expect(lines, <String>[
+          'Single line message',
+          'Multi line message',
+          '  continues...',
+          '  continues...',
+          'Multi line message again',
+          '  and it goes...',
+          '  and goes...',
+          'Single line message, not the part of the above'
+        ]);
+      }, overrides: <Type, Generator>{
+        ProcessManager: () => mockProcessManager,
+        FileSystem: () => fileSystem,
+        Platform: () => osx,
+      });
+    });
+
+    group('unified logging', () {
+      testUsingContext('log reader handles escaped multiline messages', () async {
+        when(mockProcessManager.start(any, environment: null, workingDirectory: null))
+          .thenAnswer((Invocation invocation) {
+          final Process mockProcess = MockProcess();
+          when(mockProcess.stdout)
+            .thenAnswer((Invocation invocation) {
+            return Stream<List<int>>.fromIterable(<List<int>>['''
+},{
+  "traceID" : 37579774151491588,
+  "eventMessage" : "Single line message",
+  "eventType" : "logEvent"
+},{
+  "traceID" : 37579774151491588,
+  "eventMessage" : "Multi line message\\n  continues...\\n  continues..."
+},{
+},{
+  "traceID" : 37579774151491588,
+  "eventMessage" : "Single line message, not the part of the above",
+  "eventType" : "logEvent"
+},{
+'''
+              .codeUnits]);
+          });
+          when(mockProcess.stderr)
+            .thenAnswer((Invocation invocation) => const Stream<List<int>>.empty());
+          // Delay return of exitCode until after stdout stream data, since it terminates the logger.
+          when(mockProcess.exitCode)
+            .thenAnswer((Invocation invocation) => Future<int>.delayed(Duration.zero, () => 0));
+          return Future<Process>.value(mockProcess);
+        });
+
+        final IOSSimulator device = IOSSimulator(
+          '123456',
+          simulatorCategory: 'iOS 11.0',
+          simControl: mockSimControl,
+          xcode: mockXcode,
+        );
+        final DeviceLogReader logReader = device.getLogReader(
+          app: await BuildableIOSApp.fromProject(mockIosProject),
+        );
+
+        final List<String> lines = await logReader.logLines.toList();
+        expect(lines, <String>[
+          'Single line message', 'Multi line message\n  continues...\n  continues...',
+          'Single line message, not the part of the above'
+        ]);
+      }, overrides: <Type, Generator>{
+        ProcessManager: () => mockProcessManager,
+        FileSystem: () => fileSystem,
+      });
     });
   });
 


### PR DESCRIPTION
## Description

1. Change `log stream` call to `simctl spawn ... log stream` which doesn't require admin access.
2. Move predicates from dart into the logging predicate, don't process every line in memory, let the `log` command leverage its db for queries.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/18409
https://github.com/flutter/flutter/issues/49314

## Tests

simulators_tests
No new Blaze failures.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*