### PR TITLE
Enable the android_views AlertDialog test

### DIFF
--- a/dev/integration_tests/android_views/test_driver/main_test.dart
+++ b/dev/integration_tests/android_views/test_driver/main_test.dart
@@ -38,8 +38,5 @@ Future<void> main() async {
     await driver.tap(showAlertDialog);
     final String status = await driver.getText(find.byValueKey('Status'));
     expect(status, 'Success');
-  },
-    // TODO(amirh): enable this test when https://github.com/flutter/flutter/issues/34248 is fixed.
-    skip: true,
-  );
+  });
 }


### PR DESCRIPTION
https://github.com/flutter/engine/pull/17511 fixed the AlertDialog failure described in https://github.com/flutter/flutter/issues/34248.

As the change was rolled into the framework we can now enable the integration test that verifies the fix (test was introduced in https://github.com/flutter/flutter/pull/53980).