### PR TITLE
Fix `frameworkVersionFor` for flutter doctor and usage

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -1122,7 +1122,7 @@ String get gitHash {
 /// The string is an error message.
 Future<String> verifyVersion(File file) async {
   final RegExp pattern = RegExp(
-    r'^(\d+)\.(\d+)\.(\d+)(-\d+\.\d+)?(\.pre\.\d+)?$');
+    r'^(\d+)\.(\d+)\.(\d+)((-\d+\.\d+)?\.pre(\.\d+)?)?$');
   final String version = await file.readAsString();
   if (!file.existsSync())
     return 'The version logic failed to create the Flutter version file.';

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -1123,7 +1123,7 @@ String get gitHash {
 Future<String> verifyVersion(File file) async {
   // 1.18.0-5.0-pre.8
   final RegExp pattern = RegExp(
-    r'^(\d+)\.(\d+)\.(\d+)(-\d+\.\d+)?(-pre\.\d+)?$');
+    r'^(\d+)\.(\d+)\.(\d+)(-\d+\.\d+)?(\.pre\.\d+)?$');
   final String version = await file.readAsString();
   if (!file.existsSync())
     return 'The version logic failed to create the Flutter version file.';

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -1121,7 +1121,6 @@ String get gitHash {
 /// Returns null if the contents are good. Returns a string if they are bad.
 /// The string is an error message.
 Future<String> verifyVersion(File file) async {
-  // 1.18.0-5.0-pre.8
   final RegExp pattern = RegExp(
     r'^(\d+)\.(\d+)\.(\d+)(-\d+\.\d+)?(\.pre\.\d+)?$');
   final String version = await file.readAsString();

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -1121,7 +1121,9 @@ String get gitHash {
 /// Returns null if the contents are good. Returns a string if they are bad.
 /// The string is an error message.
 Future<String> verifyVersion(File file) async {
-  final RegExp pattern = RegExp(r'^\d+\.\d+\.\d+(\+hotfix\.\d+)?(-pre\.\d+)?$');
+  // 1.18.0-5.0-pre.8
+  final RegExp pattern = RegExp(
+    r'^(\d+)\.(\d+)\.(\d+)(-\d+\.\d+)?(-pre\.\d+)?$');
   final String version = await file.readAsString();
   if (!file.existsSync())
     return 'The version logic failed to create the Flutter version file.';

--- a/dev/bots/test/test_test.dart
+++ b/dev/bots/test/test_test.dart
@@ -23,9 +23,9 @@ void main() {
       const List<String> valid_versions = <String>[
         '1.2.3',
         '12.34.56',
-        '1.2.3-pre.1',
+        '1.2.3.pre.1',
         '1.2.3-4.5',
-        '1.2.3-5.0-pre.12',
+        '1.2.3-5.0.pre.12',
       ];
       for (final String version in valid_versions) {
         when(file.readAsString()).thenAnswer((Invocation invocation) => Future<String>.value(version));
@@ -41,8 +41,8 @@ void main() {
       const List<String> invalid_versions = <String>[
         '1.2.3.4',
         '1.2.3.',
-        '1.2-pre.1',
-        '1.2.3-pre',
+        '1.2.pre.1',
+        '1.2.3-pre.1',
         '1.2.3-pre.1+hotfix.1',
         '  1.2.3',
         '1.2.3-hotfix.1',

--- a/dev/bots/test/test_test.dart
+++ b/dev/bots/test/test_test.dart
@@ -24,7 +24,7 @@ void main() {
         '1.2.3',
         '12.34.56',
         '1.2.3.pre.1',
-        '1.2.3-4.5',
+        '1.2.3-4.5.pre',
         '1.2.3-5.0.pre.12',
       ];
       for (final String version in valid_versions) {

--- a/dev/bots/test/test_test.dart
+++ b/dev/bots/test/test_test.dart
@@ -24,8 +24,8 @@ void main() {
         '1.2.3',
         '12.34.56',
         '1.2.3-pre.1',
-        '1.2.3+hotfix.1',
-        '1.2.3+hotfix.12-pre.12',
+        '1.2.3-4.5',
+        '1.2.3-5.0-pre.12',
       ];
       for (final String version in valid_versions) {
         when(file.readAsString()).thenAnswer((Invocation invocation) => Future<String>.value(version));

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -843,12 +843,12 @@ class GitTagVersion {
     }
     if (hotfix != null) {
       // This is an unexpected state where untagged commits exist past a hotfix
-      return '$x.$y.$z+hotfix.${hotfix + 1}-pre.$commits';
+      return '$x.$y.$z+hotfix.${hotfix + 1}.pre.$commits';
     }
     if (devPatch != null && devVersion != null) {
-      return '$x.$y.$z-${devVersion + 1}.0-pre.$commits';
+      return '$x.$y.$z-${devVersion + 1}.0.pre.$commits';
     }
-    return '$x.$y.${z + 1}-pre.$commits';
+    return '$x.$y.${z + 1}.pre.$commits';
   }
 }
 

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -791,7 +791,7 @@ class GitTagVersion {
   /// Check for the release tag format of the form x.y.z-m.n.pre
   static GitTagVersion parseVersion(String version) {
     final RegExp versionPattern = RegExp(
-      r'^([0-9]+)\.([0-9]+)\.([0-9]+)(-[0-9]+\.[0-9]+\.pre)?-([0-9]+)-g([a-f0-9]+)$');
+      r'^(\d+)\.(\d+)\.(\d+)(-\d+\.\d+\.pre)?-(\d+)-g([a-f0-9]+)$');
     final List<String> parts = versionPattern.matchAsPrefix(version)?.groups(<int>[1, 2, 3, 4, 5, 6]);
     if (parts == null) {
       return const GitTagVersion.unknown();

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -778,10 +778,10 @@ class GitTagVersion {
     );
   }
 
-  /// Check for the release tag format from v1.17.0 on
+  /// Check for the release tag format of the form x.y.z-m.n.pre
   static GitTagVersion parseVersion(String version) {
     final RegExp versionPattern = RegExp(
-      r'^([0-9]+)\.([0-9]+)\.([0-9]+)(-dev\.[0-9]+\.[0-9]+)?-([0-9]+)-g([a-f0-9]+)$');
+      r'^([0-9]+)\.([0-9]+)\.([0-9]+)(-[0-9]+\.[0-9]+\.pre)?-([0-9]+)-g([a-f0-9]+)$');
     final List<String> parts = versionPattern.matchAsPrefix(version)?.groups(<int>[1, 2, 3, 4, 5, 6]);
     if (parts == null) {
       return const GitTagVersion.unknown();
@@ -790,7 +790,7 @@ class GitTagVersion {
       (String source) => source == null ? null : int.tryParse(source)).toList();
     List<int> devParts = <int>[null, null];
     if (parts[3] != null) {
-      devParts = RegExp(r'^-dev\.(\d+)\.(\d+)')
+      devParts = RegExp(r'^-(\d+)\.(\d+)\.pre')
         .matchAsPrefix(parts[3])
         ?.groups(<int>[1, 2])
         ?.map<int>(
@@ -805,7 +805,7 @@ class GitTagVersion {
       devPatch: devParts[1],
       commits: parsedParts[4],
       hash: parts[5],
-      gitTag: '${parts[0]}.${parts[1]}.${parts[2]}${parts[3] ?? ''}', // x.y.z-dev.m.n
+      gitTag: '${parts[0]}.${parts[1]}.${parts[2]}${parts[3] ?? ''}', // x.y.z-m.n.pre
     );
   }
 
@@ -836,7 +836,7 @@ class GitTagVersion {
       return '$x.$y.$z+hotfix.${hotfix + 1}-pre.$commits';
     }
     if (devPatch != null && devVersion != null) {
-      return '$x.$y.$z-dev.${devVersion + 1}.0-pre.$commits';
+      return '$x.$y.$z-${devVersion + 1}.0-pre.$commits';
     }
     return '$x.$y.${z + 1}-pre.$commits';
   }

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -835,6 +835,9 @@ class GitTagVersion {
       // This is an unexpected state where untagged commits exist past a hotfix
       return '$x.$y.$z+hotfix.${hotfix + 1}-pre.$commits';
     }
+    if (devPatch != null && devVersion != null) {
+      return '$x.$y.$z-dev.${devVersion + 1}.0-pre.$commits';
+    }
     return '$x.$y.${z + 1}-pre.$commits';
   }
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/version_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/version_test.dart
@@ -239,7 +239,7 @@ class MockProcessManager extends Mock implements ProcessManager {
       return ProcessResult(0, 0, 'v10.0.0\r\nv20.0.0\r\n30.0.0-dev.0.0', '');
     }
     if (command[0] == 'git' && command[1] == 'checkout') {
-      version = command[2] as String;
+      version = (command[2] as String).replaceFirst('v', '');
     }
     return ProcessResult(0, 0, '', '');
   }

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -394,19 +394,12 @@ void main() {
     const String hash = 'abcdef';
     GitTagVersion gitTagVersion;
 
-    // legacy tag format, master channel
-    gitTagVersion = GitTagVersion.parse('v1.2.3-4-g$hash');
-    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.4-pre.4');
-    expect(gitTagVersion.gitTag, 'v1.2.3');
-    expect(gitTagVersion.devVersion, null);
-    expect(gitTagVersion.devPatch, null);
-
-    // legacy tag format, dev channel
-    gitTagVersion = GitTagVersion.parse('v1.2.3-0-g$hash');
-    expect(gitTagVersion.frameworkVersionFor(hash), 'v1.2.3');
-    expect(gitTagVersion.gitTag, 'v1.2.3');
-    expect(gitTagVersion.devVersion, null);
-    expect(gitTagVersion.devPatch, null);
+    // legacy tag format (x.y.z-dev.m.n), master channel
+    gitTagVersion = GitTagVersion.parse('1.2.3-dev.4.5-4-g$hash');
+    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.3-5.0-pre.4');
+    expect(gitTagVersion.gitTag, '1.2.3-dev.4.5');
+    expect(gitTagVersion.devVersion, 4);
+    expect(gitTagVersion.devPatch, 5);
 
     // new tag release format, master channel
     gitTagVersion = GitTagVersion.parse('1.2.3-4.5.pre-13-g$hash');
@@ -437,9 +430,8 @@ void main() {
 
     expect(GitTagVersion.parse('98.76.54-32-g$hash').frameworkVersionFor(hash), '98.76.55-pre.32');
     expect(GitTagVersion.parse('10.20.30-0-g$hash').frameworkVersionFor(hash), '10.20.30');
-    expect(GitTagVersion.parse('v1.2.3+hotfix.1-4-g$hash').frameworkVersionFor(hash), '1.2.3+hotfix.2-pre.4');
     expect(testLogger.traceText, '');
-    expect(GitTagVersion.parse('1.2.3+hotfix.1-4-g$hash').frameworkVersionFor(hash), '0.0.0-unknown');
+    expect(GitTagVersion.parse('v1.2.3+hotfix.1-4-g$hash').frameworkVersionFor(hash), '0.0.0-unknown');
     expect(GitTagVersion.parse('x1.2.3-4-g$hash').frameworkVersionFor(hash), '0.0.0-unknown');
     expect(GitTagVersion.parse('1.0.0-unknown-0-g$hash').frameworkVersionFor(hash), '0.0.0-unknown');
     expect(GitTagVersion.parse('beta-1-g$hash').frameworkVersionFor(hash), '0.0.0-unknown');
@@ -448,7 +440,7 @@ void main() {
     expect(testLogger.errorText, '');
     expect(
       testLogger.traceText,
-      'Could not interpret results of "git describe": 1.2.3+hotfix.1-4-gabcdef\n'
+      'Could not interpret results of "git describe": v1.2.3+hotfix.1-4-gabcdef\n'
       'Could not interpret results of "git describe": x1.2.3-4-gabcdef\n'
       'Could not interpret results of "git describe": 1.0.0-unknown-0-gabcdef\n'
       'Could not interpret results of "git describe": beta-1-gabcdef\n'

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -394,21 +394,41 @@ void main() {
     const String hash = 'abcdef';
     GitTagVersion gitTagVersion;
 
-    // legacy tag release format
+    // legacy tag format, master channel
     gitTagVersion = GitTagVersion.parse('v1.2.3-4-g$hash');
     expect(gitTagVersion.frameworkVersionFor(hash), '1.2.4-pre.4');
     expect(gitTagVersion.gitTag, 'v1.2.3');
     expect(gitTagVersion.devVersion, null);
     expect(gitTagVersion.devPatch, null);
 
-    // new dev tag release format
+    // legacy tag format, dev channel
+    gitTagVersion = GitTagVersion.parse('v1.2.3-0-g$hash');
+    expect(gitTagVersion.frameworkVersionFor(hash), 'v1.2.3');
+    expect(gitTagVersion.gitTag, 'v1.2.3');
+    expect(gitTagVersion.devVersion, null);
+    expect(gitTagVersion.devPatch, null);
+
+    // new tag release format, master channel
     gitTagVersion = GitTagVersion.parse('1.2.3-dev.4.5-13-g$hash');
-    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.4-pre.13');
+    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.3-dev.5.0-pre.13');
     expect(gitTagVersion.gitTag, '1.2.3-dev.4.5');
     expect(gitTagVersion.devVersion, 4);
     expect(gitTagVersion.devPatch, 5);
 
-    // new stable tag release format
+    gitTagVersion = GitTagVersion.parse('1.2.3-13-g$hash');
+    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.4-pre.13');
+    expect(gitTagVersion.gitTag, '1.2.3');
+    expect(gitTagVersion.devVersion, null);
+    expect(gitTagVersion.devPatch, null);
+
+    // new tag release format, dev channel
+    gitTagVersion = GitTagVersion.parse('1.2.3-dev.4.5-0-g$hash');
+    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.3-dev.4.5');
+    expect(gitTagVersion.gitTag, '1.2.3-dev.4.5');
+    expect(gitTagVersion.devVersion, 4);
+    expect(gitTagVersion.devPatch, 5);
+
+    // new tag release format, stable channel
     gitTagVersion = GitTagVersion.parse('1.2.3-13-g$hash');
     expect(gitTagVersion.frameworkVersionFor(hash), '1.2.4-pre.13');
     expect(gitTagVersion.gitTag, '1.2.3');

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -397,18 +397,21 @@ void main() {
     // legacy tag release format
     gitTagVersion = GitTagVersion.parse('v1.2.3-4-g$hash');
     expect(gitTagVersion.frameworkVersionFor(hash), '1.2.4-pre.4');
+    expect(gitTagVersion.gitTag, 'v1.2.3');
     expect(gitTagVersion.devVersion, null);
     expect(gitTagVersion.devPatch, null);
 
     // new dev tag release format
     gitTagVersion = GitTagVersion.parse('1.2.3-dev.4.5-13-g$hash');
     expect(gitTagVersion.frameworkVersionFor(hash), '1.2.4-pre.13');
+    expect(gitTagVersion.gitTag, '1.2.3-dev.4.5');
     expect(gitTagVersion.devVersion, 4);
     expect(gitTagVersion.devPatch, 5);
 
     // new stable tag release format
     gitTagVersion = GitTagVersion.parse('1.2.3-13-g$hash');
     expect(gitTagVersion.frameworkVersionFor(hash), '1.2.4-pre.13');
+    expect(gitTagVersion.gitTag, '1.2.3');
     expect(gitTagVersion.devVersion, null);
     expect(gitTagVersion.devPatch, null);
 

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -409,9 +409,9 @@ void main() {
     expect(gitTagVersion.devPatch, null);
 
     // new tag release format, master channel
-    gitTagVersion = GitTagVersion.parse('1.2.3-dev.4.5-13-g$hash');
-    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.3-dev.5.0-pre.13');
-    expect(gitTagVersion.gitTag, '1.2.3-dev.4.5');
+    gitTagVersion = GitTagVersion.parse('1.2.3-4.5.pre-13-g$hash');
+    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.3-5.0-pre.13');
+    expect(gitTagVersion.gitTag, '1.2.3-4.5.pre');
     expect(gitTagVersion.devVersion, 4);
     expect(gitTagVersion.devPatch, 5);
 
@@ -422,9 +422,9 @@ void main() {
     expect(gitTagVersion.devPatch, null);
 
     // new tag release format, dev channel
-    gitTagVersion = GitTagVersion.parse('1.2.3-dev.4.5-0-g$hash');
-    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.3-dev.4.5');
-    expect(gitTagVersion.gitTag, '1.2.3-dev.4.5');
+    gitTagVersion = GitTagVersion.parse('1.2.3-4.5.pre-0-g$hash');
+    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.3-4.5.pre');
+    expect(gitTagVersion.gitTag, '1.2.3-4.5.pre');
     expect(gitTagVersion.devVersion, 4);
     expect(gitTagVersion.devPatch, 5);
 

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -396,20 +396,20 @@ void main() {
 
     // legacy tag format (x.y.z-dev.m.n), master channel
     gitTagVersion = GitTagVersion.parse('1.2.3-dev.4.5-4-g$hash');
-    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.3-5.0-pre.4');
+    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.3-5.0.pre.4');
     expect(gitTagVersion.gitTag, '1.2.3-dev.4.5');
     expect(gitTagVersion.devVersion, 4);
     expect(gitTagVersion.devPatch, 5);
 
     // new tag release format, master channel
     gitTagVersion = GitTagVersion.parse('1.2.3-4.5.pre-13-g$hash');
-    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.3-5.0-pre.13');
+    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.3-5.0.pre.13');
     expect(gitTagVersion.gitTag, '1.2.3-4.5.pre');
     expect(gitTagVersion.devVersion, 4);
     expect(gitTagVersion.devPatch, 5);
 
     gitTagVersion = GitTagVersion.parse('1.2.3-13-g$hash');
-    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.4-pre.13');
+    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.4.pre.13');
     expect(gitTagVersion.gitTag, '1.2.3');
     expect(gitTagVersion.devVersion, null);
     expect(gitTagVersion.devPatch, null);
@@ -423,12 +423,12 @@ void main() {
 
     // new tag release format, stable channel
     gitTagVersion = GitTagVersion.parse('1.2.3-13-g$hash');
-    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.4-pre.13');
+    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.4.pre.13');
     expect(gitTagVersion.gitTag, '1.2.3');
     expect(gitTagVersion.devVersion, null);
     expect(gitTagVersion.devPatch, null);
 
-    expect(GitTagVersion.parse('98.76.54-32-g$hash').frameworkVersionFor(hash), '98.76.55-pre.32');
+    expect(GitTagVersion.parse('98.76.54-32-g$hash').frameworkVersionFor(hash), '98.76.55.pre.32');
     expect(GitTagVersion.parse('10.20.30-0-g$hash').frameworkVersionFor(hash), '10.20.30');
     expect(testLogger.traceText, '');
     expect(GitTagVersion.parse('v1.2.3+hotfix.1-4-g$hash').frameworkVersionFor(hash), '0.0.0-unknown');


### PR DESCRIPTION
## Description

With the new release tag format, the Flutter tool failed to detect the new tags https://github.com/flutter/flutter/issues/53688. Tag **parsing** was fixed in https://github.com/flutter/flutter/pull/53715, however, version **reporting** was not updated, so flutter doctor and usage reporting would only include `x.y.z`, and not the additional `m.n` in pre-stable releases.

This PR fixes `frameworkVersionFor()` **AND** accounts for another modification to the release tag format (`1.2.3-dev.4.5 -> 1.2.3-4.5.pre`). Parsing of the `x.y.z-dev.m.n` format is being moved to the `parseLegacyVersion()` method, and we are dropping support for `vx.y.z+hotfix.m`. This parsing logic is only for the nearest tagged parent, thus we can drop parsing support for old formats once the new format has been published on that channel.

## Related Issues

fixes https://github.com/flutter/flutter/issues/54160, https://github.com/flutter/flutter/issues/53688

## Tests

I extended the existing test to verify more permutations are correctly being parsed.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*