### PR TITLE
Remove escape dollar parameter in localizations_utils

### DIFF
--- a/dev/tools/localization/localizations_utils.dart
+++ b/dev/tools/localization/localizations_utils.dart
@@ -387,21 +387,8 @@ class $classNamePrefix$camelCaseName extends $superClass {''';
 /// foo\\nbar => 'foo\\\\nbar'
 /// foo\\bar => 'foo\\\\bar'
 /// foo\ bar => 'foo\\ bar'
-/// ```
-///
-/// When [shouldEscapeDollar] is set to true, the '$' characters in the
-/// input will be replaced by '$' in the returned string:
-/// ```
 /// foo$bar = 'foo\$bar'
 /// ```
-///
-/// When [shouldEscapeDollar] is set to false, '$' will be replaced
-/// by '\$' in the returned string:
-/// ```
-/// foo$bar => 'foo\\\$bar'
-/// ```
-///
-/// [shouldEscapeDollar] is true by default.
 String generateString(String value) {
   const String backslash = '__BACKSLASH__';
   assert(

--- a/dev/tools/localization/localizations_utils.dart
+++ b/dev/tools/localization/localizations_utils.dart
@@ -402,9 +402,7 @@ class $classNamePrefix$camelCaseName extends $superClass {''';
 /// ```
 ///
 /// [shouldEscapeDollar] is true by default.
-String generateString(String value, { bool escapeDollar = true }) {
-  assert(escapeDollar != null);
-
+String generateString(String value) {
   const String backslash = '__BACKSLASH__';
   assert(
     !value.contains(backslash),
@@ -412,12 +410,12 @@ String generateString(String value, { bool escapeDollar = true }) {
     '"__BACKSLASH__", as it is used as part of '
     'backslash character processing.'
   );
-  value = value.replaceAll('\\', backslash);
-
-  if (escapeDollar)
-    value = value.replaceAll('\$', '\\\$');
 
   value = value
+    // Replace backslashes with a placeholder for now to properly parse
+    // other special characters.
+    .replaceAll('\\', backslash)
+    .replaceAll('\$', '\\\$')
     .replaceAll("'", "\\'")
     .replaceAll('"', '\\"')
     .replaceAll('\n', '\\n')
@@ -425,6 +423,7 @@ String generateString(String value, { bool escapeDollar = true }) {
     .replaceAll('\t', '\\t')
     .replaceAll('\r', '\\r')
     .replaceAll('\b', '\\b')
+    // Reintroduce escaped backslashes into generated Dart string.
     .replaceAll(backslash, '\\\\');
 
   return "'$value'";

--- a/dev/tools/test/localization/localizations_utils_test.dart
+++ b/dev/tools/test/localization/localizations_utils_test.dart
@@ -37,11 +37,7 @@ void main() {
     });
 
     test('escapes dollar when escapeDollar is true', () {
-      expect(generateString(r'ab$c', escapeDollar: true), "'ab\\\$c'");
-    });
-
-    test('does not escape dollar when escapeDollar  is false', () {
-      expect(generateString(r'ab$c', escapeDollar: false), "'ab\$c'");
+      expect(generateString(r'ab$c'), "'ab\\\$c'");
     });
 
     test('handles backslash', () {


### PR DESCRIPTION
Removes the escape dollar flag from `generateString`, since it is no longer being used by any of the l10n tools as a result of the fix in https://github.com/flutter/flutter/pull/54185