### PR TITLE
[benchmarks] Handle multiple begin/end trace events

### DIFF
--- a/packages/flutter_driver/lib/src/driver/timeline_summary.dart
+++ b/packages/flutter_driver/lib/src/driver/timeline_summary.dart
@@ -150,15 +150,19 @@ class TimelineSummary {
     Duration extractor(TimelineEvent beginEvent, TimelineEvent endEvent),
   ) {
     final List<Duration> result = <Duration>[];
+    final List<TimelineEvent> events = _extractNamedEvents(name);
 
     // Timeline does not guarantee that the first event is the "begin" event.
-    final Iterator<TimelineEvent> events = _extractNamedEvents(name)
-        .skipWhile((TimelineEvent evt) => evt.phase != 'B').iterator;
-    while (events.moveNext()) {
-      final TimelineEvent beginEvent = events.current;
-      if (events.moveNext()) {
-        final TimelineEvent endEvent = events.current;
-        result.add(extractor(beginEvent, endEvent));
+    TimelineEvent begin;
+    for (final TimelineEvent event in events) {
+      if (event.phase == 'B') {
+        begin = event;
+      } else {
+        if (begin != null) {
+          result.add(extractor(begin, event));
+          // each begin only gets used once.
+          begin = null;
+        }
       }
     }
 

--- a/packages/flutter_driver/test/src/real_tests/timeline_summary_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/timeline_summary_test.dart
@@ -104,6 +104,31 @@ void main() {
           2.0,
         );
       });
+
+      // see https://github.com/flutter/flutter/issues/54095.
+      test('ignore multiple "end" events', () {
+        expect(
+          summarize(<Map<String, dynamic>>[
+            frameBegin(2000), frameEnd(4000),
+            frameEnd(4300), // rogue frame end.
+            frameBegin(5000), frameEnd(6000),
+          ]).computeAverageFrameBuildTimeMillis(),
+          1.5,
+        );
+      });
+
+      test('pick latest when there are multiple "begin" events', () {
+        expect(
+          summarize(<Map<String, dynamic>>[
+            frameBegin(1000), // rogue frame begin.
+            frameBegin(2000), frameEnd(4000),
+            frameEnd(4300), // rogue frame end.
+            frameBegin(4400), // rogue frame begin.
+            frameBegin(5000), frameEnd(6000),
+          ]).computeAverageFrameBuildTimeMillis(),
+          1.5,
+        );
+      });
     });
 
     group('worst_frame_build_time_millis', () {


### PR DESCRIPTION
Parser would earlier alternate after finding the first
begin event, now it looks for pairs.

Fixes: https://github.com/flutter/flutter/issues/54095