### PR TITLE
[flutter_tools] allow passing non-config inputs

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/build_system.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_system.dart
@@ -295,6 +295,7 @@ class Environment {
     @required ProcessManager processManager,
     Directory buildDir,
     Map<String, String> defines = const <String, String>{},
+    Map<String, String> inputs = const <String, String>{},
   }) {
     // Compute a unique hash of this build's particular environment.
     // Sort the keys by key so that the result is stable. We always
@@ -325,6 +326,7 @@ class Environment {
       logger: logger,
       artifacts: artifacts,
       processManager: processManager,
+      inputs: inputs,
     );
   }
 
@@ -338,6 +340,7 @@ class Environment {
     Directory flutterRootDir,
     Directory buildDir,
     Map<String, String> defines = const <String, String>{},
+    Map<String, String> inputs = const <String, String>{},
     @required FileSystem fileSystem,
     @required Logger logger,
     @required Artifacts artifacts,
@@ -350,6 +353,7 @@ class Environment {
       flutterRootDir: flutterRootDir ?? testDirectory,
       buildDir: buildDir,
       defines: defines,
+      inputs: inputs,
       fileSystem: fileSystem,
       logger: logger,
       artifacts: artifacts,
@@ -369,6 +373,7 @@ class Environment {
     @required this.logger,
     @required this.fileSystem,
     @required this.artifacts,
+    @required this.inputs,
   });
 
   /// The [Source] value which is substituted with the path to [projectDir].
@@ -419,6 +424,16 @@ class Environment {
   /// Setting values here forces a unique build directory to be chosen
   /// which prevents the config from leaking into different builds.
   final Map<String, String> defines;
+
+  /// Additional input files passed to the build targets.
+  ///
+  /// Unlike [defines], values set here do not force a new build configuration.
+  /// This is useful for passing file inputs that may have changing paths
+  /// without running builds from scratch.
+  ///
+  /// It is the responsibility of the [Target] to declare that an input was
+  /// used in an output depfile.
+  final Map<String, String> inputs;
 
   /// The root build directory shared by all builds.
   final Directory rootBuildDir;

--- a/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
@@ -23,7 +23,7 @@ void main() {
     Cache: () => FakeCache(),
   });
 
-  testbed.test('Can run a build', () async {
+  testbed.test('flutter assemble can run a build', () async {
     when(globals.buildSystem.build(any, any, buildSystemConfig: anyNamed('buildSystemConfig')))
       .thenAnswer((Invocation invocation) async {
         return BuildResult(success: true);
@@ -34,7 +34,7 @@ void main() {
     expect(testLogger.traceText, contains('build succeeded.'));
   });
 
-  testbed.test('Can parse defines whose values contain =', () async {
+  testbed.test('flutter assemble can parse defines whose values contain =', () async {
     when(globals.buildSystem.build(any, any, buildSystemConfig: anyNamed('buildSystemConfig')))
       .thenAnswer((Invocation invocation) async {
         expect((invocation.positionalArguments[1] as Environment).defines, containsPair('FooBar', 'fizz=2'));
@@ -46,7 +46,19 @@ void main() {
     expect(testLogger.traceText, contains('build succeeded.'));
   });
 
-  testbed.test('Throws ToolExit if not provided with output', () async {
+  testbed.test('flutter assemble can parse inputs', () async {
+    when(globals.buildSystem.build(any, any, buildSystemConfig: anyNamed('buildSystemConfig')))
+      .thenAnswer((Invocation invocation) async {
+        expect((invocation.positionalArguments[1] as Environment).inputs, containsPair('Foo', 'Bar.txt'));
+        return BuildResult(success: true);
+      });
+    final CommandRunner<void> commandRunner = createTestCommandRunner(AssembleCommand());
+    await commandRunner.run(<String>['assemble', '-o Output', '-iFoo=Bar.txt', 'debug_macos_bundle_flutter_assets']);
+
+    expect(testLogger.traceText, contains('build succeeded.'));
+  });
+
+  testbed.test('flutter assemble throws ToolExit if not provided with output', () async {
     when(globals.buildSystem.build(any, any, buildSystemConfig: anyNamed('buildSystemConfig')))
       .thenAnswer((Invocation invocation) async {
         return BuildResult(success: true);
@@ -57,7 +69,7 @@ void main() {
       throwsToolExit());
   });
 
-  testbed.test('Throws ToolExit if called with non-existent rule', () async {
+  testbed.test('flutter assemble throws ToolExit if called with non-existent rule', () async {
     when(globals.buildSystem.build(any, any, buildSystemConfig: anyNamed('buildSystemConfig')))
       .thenAnswer((Invocation invocation) async {
         return BuildResult(success: true);
@@ -68,7 +80,7 @@ void main() {
       throwsToolExit());
   });
 
-  testbed.test('Does not log stack traces during build failure', () async {
+  testbed.test('flutter assemble does not log stack traces during build failure', () async {
     final StackTrace testStackTrace = StackTrace.current;
     when(globals.buildSystem.build(any, any, buildSystemConfig: anyNamed('buildSystemConfig')))
       .thenAnswer((Invocation invocation) async {
@@ -84,7 +96,7 @@ void main() {
     expect(testLogger.errorText, isNot(contains(testStackTrace.toString())));
   });
 
-  testbed.test('Only writes input and output files when the values change', () async {
+  testbed.test('flutter assemble only writes input and output files when the values change', () async {
     when(globals.buildSystem.build(any, any, buildSystemConfig: anyNamed('buildSystemConfig')))
       .thenAnswer((Invocation invocation) async {
         return BuildResult(

--- a/packages/flutter_tools/test/general.shard/build_system/build_system_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/build_system_test.dart
@@ -375,6 +375,31 @@ void main() {
     expect(environmentA.buildDir.path, isNot(environmentB.buildDir.path));
   });
 
+  testWithoutContext('Additional inputs do not change the build configuration',  () async {
+    final Environment environmentA = Environment.test(
+      fileSystem.currentDirectory,
+      artifacts: MockArtifacts(),
+      processManager: FakeProcessManager.any(),
+      fileSystem: fileSystem,
+      logger: BufferLogger.test(),
+      inputs: <String, String>{
+        'C': 'D',
+      }
+    );
+    final Environment environmentB = Environment.test(
+      fileSystem.currentDirectory,
+      artifacts: MockArtifacts(),
+      processManager: FakeProcessManager.any(),
+      fileSystem: fileSystem,
+      logger: BufferLogger.test(),
+      inputs: <String, String>{
+        'A': 'B',
+      }
+    );
+
+    expect(environmentA.buildDir.path, equals(environmentB.buildDir.path));
+  });
+
   testWithoutContext('A target with depfile dependencies can delete stale outputs on the first run',  () async {
     final BuildSystem buildSystem = setUpBuildSystem(fileSystem);
     int called = 0;


### PR DESCRIPTION
## Description

Create an additional type of configuration, `-i/--input` files, which do not create a new unique build directory when modified.

The current flutter assemble allows setting `defines` to configure parts of the build, such as the target platform, build mode, and the track-widget-creation transformer. These values are used to generate unique build directories to keep different builds isolated, which is a very useful property in genera!

There are other cases where I would like this to not happen though:

For example, for https://github.com/flutter/flutter/issues/53115 I would like the user to be able to specify a path to a SkSL shader bundle to include in their application. Since this is a file path, invalidating the entire build is unnecessary - it can instead be registered as an input for whatever target uses it. Furthermore, if we did implement this via a config, we would force the user to build from scratch even if they only adjusted the location of the same bundle
