### PR TITLE
Fix right alignment TWB longestLine

### DIFF
--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -564,7 +564,7 @@ class TextPainter {
     _paragraph.layout(ui.ParagraphConstraints(width: maxWidth));
     if (minWidth != maxWidth) {
       final double newWidth = maxIntrinsicWidth.clamp(minWidth, maxWidth) as double;
-      if (newWidth != width) {
+      if (newWidth != _applyFloatingPointHack(_paragraph.width)) {
         _paragraph.layout(ui.ParagraphConstraints(width: newWidth));
       }
     }

--- a/packages/flutter/test/widgets/text_test.dart
+++ b/packages/flutter/test/widgets/text_test.dart
@@ -808,7 +808,7 @@ void main() {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
+              children: const <Widget>[
                 Text(
                   'LEFT ALIGNED, PARENT',
                   textAlign: TextAlign.left,

--- a/packages/flutter/test/widgets/text_test.dart
+++ b/packages/flutter/test/widgets/text_test.dart
@@ -800,6 +800,56 @@ void main() {
     expect(textSizeLongestLine.height, equals(fontHeight * 2));
   }, skip: isBrowser);  // TODO(yjbanov): https://github.com/flutter/flutter/issues/44020
 
+  testWidgets('textWidthBasis with textAlign still obeys parent alignment', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  'LEFT ALIGNED, PARENT',
+                  textAlign: TextAlign.left,
+                  textWidthBasis: TextWidthBasis.parent,
+                ),
+                Text(
+                  'RIGHT ALIGNED, PARENT',
+                  textAlign: TextAlign.right,
+                  textWidthBasis: TextWidthBasis.parent,
+                ),
+                Text(
+                  'LEFT ALIGNED, LONGEST LINE',
+                  textAlign: TextAlign.left,
+                  textWidthBasis: TextWidthBasis.longestLine,
+                ),
+                Text(
+                  'RIGHT ALIGNED, LONGEST LINE',
+                  textAlign: TextAlign.right,
+                  textWidthBasis: TextWidthBasis.longestLine,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // All Texts have the same horizontal alignment.
+    final double offsetX = tester.getTopLeft(find.text('LEFT ALIGNED, PARENT')).dx;
+    expect(tester.getTopLeft(find.text('RIGHT ALIGNED, PARENT')).dx, equals(offsetX));
+    expect(tester.getTopLeft(find.text('LEFT ALIGNED, LONGEST LINE')).dx, equals(offsetX));
+    expect(tester.getTopLeft(find.text('RIGHT ALIGNED, LONGEST LINE')).dx, equals(offsetX));
+
+    // All Texts are less than or equal to the width of the Column.
+    final double width = tester.getSize(find.byType(Column)).width;
+    expect(tester.getSize(find.text('LEFT ALIGNED, PARENT')).width, lessThan(width));
+    expect(tester.getSize(find.text('RIGHT ALIGNED, PARENT')).width, lessThan(width));
+    expect(tester.getSize(find.text('LEFT ALIGNED, LONGEST LINE')).width, lessThan(width));
+    expect(tester.getSize(find.text('RIGHT ALIGNED, LONGEST LINE')).width, equals(width));
+  }, skip: isBrowser);  // TODO(yjbanov): https://github.com/flutter/flutter/issues/44020
+
   testWidgets('Paragraph.getBoxesForRange returns nothing when selection range is zero length', (WidgetTester tester) async {
     final ui.ParagraphBuilder builder = ui.ParagraphBuilder(ui.ParagraphStyle());
     builder.addText('hello');


### PR DESCRIPTION
## Description

Currently, there is a bug with `TextWidthBasis.longestLine` and `TextAlign.right` when aligned by a parent:

![screen shot of bug](https://user-images.githubusercontent.com/551196/73048586-7f193e80-3e2e-11ea-99e9-e3e1c5065dfe.png)

This PR fixes a bug in my implementation of TextWidthBasis (originally from https://github.com/flutter/flutter/pull/30988) where the wrong width is used for comparison.  This makes the broken case align based on its parent like the other cases:

![Screen Shot 2020-04-07 at 2 47 30 PM](https://user-images.githubusercontent.com/389558/78722695-e21f5b00-78de-11ea-80f7-892a81b19c42.png)

## Related Issues

Closes https://github.com/flutter/flutter/issues/49412

## Tests

I added the following tests:

  1. Render all combinations of textWidthBasis and textAlign, and ensure that their behavior is all the same and all obeys the alignment of their parent.