### PR TITLE
Disable tracing for non-frame based Web benchmarks

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/web_benchmarks.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/web_benchmarks.dart
@@ -70,19 +70,14 @@ Future<void> _runBenchmark(String benchmarkName) async {
   }
 
   try {
-    final Runner runner = Runner(
-      recorder: recorderFactory(),
-      setUpAllDidRun: () async {
-        if (!_client.isInManualMode) {
-          await _client.startPerformanceTracing(benchmarkName);
-        }
-      },
-      tearDownAllWillRun: () async {
-        if (!_client.isInManualMode) {
-          await _client.stopPerformanceTracing();
-        }
-      },
-    );
+    final Recorder recorder = recorderFactory();
+    final Runner runner = recorder.isTracingEnabled && !_client.isInManualMode
+      ? Runner(
+          recorder: recorder,
+          setUpAllDidRun: () => _client.startPerformanceTracing(benchmarkName),
+          tearDownAllWillRun: _client.stopPerformanceTracing,
+        )
+      : Runner(recorder: recorder);
 
     final Profile profile = await runner.run();
     if (!_client.isInManualMode) {

--- a/dev/devicelab/lib/framework/browser.dart
+++ b/dev/devicelab/lib/framework/browser.dart
@@ -282,6 +282,14 @@ class BlinkTraceSummary {
         .toList()
         ..sort((BlinkTraceEvent a, BlinkTraceEvent b) => a.ts - b.ts);
 
+      Exception noMeasuredFramesFound() => Exception(
+        'No measured frames found in benchmark tracing data. This likely '
+        'indicates a bug in the benchmark. For example, the benchmark failed '
+        'to pump enough frames. It may also indicate a change in Chrome\'s '
+        'tracing data format. Check if Chrome version changed recently and '
+        'adjust the parsing code accordingly.',
+      );
+
       // Use the pid from the first "measured_frame" event since the event is
       // emitted by the script running on the process we're interested in.
       //
@@ -290,7 +298,7 @@ class BlinkTraceSummary {
       // sometimes, causing to flakes.
       final BlinkTraceEvent firstMeasuredFrameEvent = events.firstWhere(
         (BlinkTraceEvent event) => event.isBeginMeasuredFrame,
-        orElse: () => null,
+        orElse: () => throw noMeasuredFramesFound(),
       );
 
       if (firstMeasuredFrameEvent == null) {
@@ -330,8 +338,7 @@ class BlinkTraceSummary {
       print('Skipped $skipCount non-measured frames.');
 
       if (frames.isEmpty) {
-        // The benchmark is not measuring frames.
-        return null;
+        throw noMeasuredFramesFound();
       }
 
       // Compute averages and summarize.

--- a/dev/devicelab/lib/tasks/web_benchmarks.dart
+++ b/dev/devicelab/lib/tasks/web_benchmarks.dart
@@ -65,15 +65,14 @@ Future<TaskResult> runWebBenchmark({ @required bool useCanvasKit }) async {
             server.close();
           }
 
-          final BlinkTraceSummary traceSummary = BlinkTraceSummary.fromJson(latestPerformanceTrace);
-
-          // Trace summary can be null if the benchmark is not frame-based, such as RawRecorder.
-          if (traceSummary != null) {
+          // Trace data is null when the benchmark is not frame-based, such as RawRecorder.
+          if (latestPerformanceTrace != null) {
+            final BlinkTraceSummary traceSummary = BlinkTraceSummary.fromJson(latestPerformanceTrace);
             profile['totalUiFrame.average'] = traceSummary.averageTotalUIFrameTime.inMicroseconds;
             profile['scoreKeys'] ??= <dynamic>[]; // using dynamic for consistency with JSON
             profile['scoreKeys'].add('totalUiFrame.average');
+            latestPerformanceTrace = null;
           }
-          latestPerformanceTrace = null;
           collectedProfiles.add(profile);
           return Response.ok('Profile received');
         } else if (request.requestedUri.path.endsWith('/start-performance-tracing')) {


### PR DESCRIPTION
## Description

Disable tracing for non-frame based benchmarks. The logic is as follows: the benchmarks that are affected by https://github.com/flutter/flutter/issues/54101 the most are those that use `RawRecorder`, which doesn't pump frames anyway, so there's no need to enable tracing. Having said that, the long-term solution is to ask Chrome to make tracing faster. Otherwise, different benchmarks record different numbers for the same stuff.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/54101