### PR TITLE
Add API to services package that overrides HTTP ban

### DIFF
--- a/packages/flutter/lib/services.dart
+++ b/packages/flutter/lib/services.dart
@@ -22,6 +22,7 @@ export 'src/services/message_codec.dart';
 export 'src/services/message_codecs.dart';
 export 'src/services/platform_channel.dart';
 export 'src/services/platform_messages.dart';
+export 'src/services/platform_network.dart';
 export 'src/services/platform_views.dart';
 export 'src/services/raw_keyboard.dart';
 export 'src/services/raw_keyboard_android.dart';

--- a/packages/flutter/lib/src/services/platform_network.dart
+++ b/packages/flutter/lib/src/services/platform_network.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -22,5 +22,6 @@ import 'dart:async';
 /// Best Practices:
 /// - Do not wrap your entire app with [allowHttp]. Wrap *exactly* what you need and nothing more.
 /// - Avoid libraries that require accessing HTTP URLs.
-T allowHttp<T>(T action()) =>
-    runZoned<T>(action, zoneValues: {#dart.library.io.allow_http: true});
+T allowHttp<T>(T action()) {
+  return runZoned<T>(action, zoneValues: {#dart.library.io.allow_http: true});
+}

--- a/packages/flutter/lib/src/services/platform_network.dart
+++ b/packages/flutter/lib/src/services/platform_network.dart
@@ -7,7 +7,7 @@ import 'dart:async';
 /// Allows an operation executed via [action] to access insecure HTTP URLs.
 ///
 /// On some platforms (notably iOS and Android), HTTP is disallowed by default.
-/// You should strive to access secure URLs from your app but we recognize that
+/// You should strive to access secure URLs from your app, but we recognize that
 /// sometimes that is not possible. In such cases, use the function below to
 /// allow access to HTTP URLs.
 ///

--- a/packages/flutter/lib/src/services/platform_network.dart
+++ b/packages/flutter/lib/src/services/platform_network.dart
@@ -1,0 +1,26 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+/// Allows an operation executed via [action] to access insecure HTTP URLs.
+///
+/// On some platforms (notably iOS and Android), HTTP is disallowed by default.
+/// You should strive to access secure URLs from your app but we recognize that
+/// sometimes that is not possible. In such cases, use the function below to
+/// allow access to HTTP URLs.
+///
+/// Sample usage:
+///
+/// ```dart
+/// import 'package:flutter/services.dart' as services;
+///
+/// final Image image = services.allowHttp(() => Image.network('http://some_insecure_url');
+/// ```
+///
+/// Best Practices:
+/// - Do not wrap your entire app with [allowHttp]. Wrap *exactly* what you need and nothing more.
+/// - Avoid libraries that require accessing HTTP URLs.
+T allowHttp<T>(T action()) =>
+    runZoned<T>(action, zoneValues: {#dart.library.io.allow_http: true});

--- a/packages/flutter/lib/src/services/platform_network.dart
+++ b/packages/flutter/lib/src/services/platform_network.dart
@@ -23,5 +23,5 @@ import 'dart:async';
 /// - Do not wrap your entire app with [allowHttp]. Wrap *exactly* what you need and nothing more.
 /// - Avoid libraries that require accessing HTTP URLs.
 T allowHttp<T>(T action()) {
-  return runZoned<T>(action, zoneValues: {#dart.library.io.allow_http: true});
+  return runZoned<T>(action, zoneValues: <Symbol, bool>{#dart.library.io.allow_http: true});
 }

--- a/packages/flutter/test/services/platform_network_test.dart
+++ b/packages/flutter/test/services/platform_network_test.dart
@@ -1,0 +1,43 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// Note that these tests would not work on a mobile device as opening up an
+// [HttpServer] is not allowed. They are meant for hosts only.
+Future<void> _testHttp(Future<void> testCode(HttpClient client, Uri uri)) async {
+  final httpClient = new HttpClient();
+  final server = await HttpServer.bind(Platform.localHostname, 0);
+  final uri = Uri(scheme: 'http', host: Platform.localHostname, port: server.port);
+  try {
+    await testCode(httpClient, uri);
+  } finally {
+    httpClient.close(force: true);
+    await server.close();
+  }
+}
+
+void main() {
+  test('allowHttp allows HTTP', () async {
+    await _testHttp((httpClient, uri) async {
+      final HttpClientRequest result = await allowHttp(() => httpClient.getUrl(uri));
+      expect(result, isNotNull);
+    });
+  });
+
+  // This test ensures the zone variable used in Dart SDK does not change.
+  //
+  // If this symbol changes, then update [allowHttp] function as well.
+  test('Zone variable can override HTTP behavior', () async {
+    await _testHttp((httpClient, uri) async {
+    expect(() => runZoned(
+        () async => await httpClient.getUrl(uri),
+        zoneValues: {#dart.library.io.allow_http: false}), throwsA(isA<StateError>()));
+    });
+  });
+}

--- a/packages/flutter/test/services/platform_network_test.dart
+++ b/packages/flutter/test/services/platform_network_test.dart
@@ -1,43 +1,20 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
 import 'dart:async';
 import 'dart:io';
 
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-// Note that these tests would not work on a mobile device as opening up an
-// [HttpServer] is not allowed. They are meant for hosts only.
-Future<void> _testHttp(Future<void> testCode(HttpClient client, Uri uri)) async {
-  final httpClient = new HttpClient();
-  final server = await HttpServer.bind(Platform.localHostname, 0);
-  final uri = Uri(scheme: 'http', host: Platform.localHostname, port: server.port);
-  try {
-    await testCode(httpClient, uri);
-  } finally {
-    httpClient.close(force: true);
-    await server.close();
-  }
-}
-
 void main() {
-  test('allowHttp allows HTTP', () async {
-    await _testHttp((httpClient, uri) async {
-      final HttpClientRequest result = await allowHttp(() => httpClient.getUrl(uri));
-      expect(result, isNotNull);
-    });
-  });
-
   // This test ensures the zone variable used in Dart SDK does not change.
   //
   // If this symbol changes, then update [allowHttp] function as well.
   test('Zone variable can override HTTP behavior', () async {
-    await _testHttp((httpClient, uri) async {
+    final httpClient = new HttpClient();
     expect(() => runZoned(
-        () async => await httpClient.getUrl(uri),
+        () async => await httpClient.getUrl(Uri.parse('http://${Platform.localHostname}')),
         zoneValues: {#dart.library.io.allow_http: false}), throwsA(isA<StateError>()));
-    });
   });
 }

--- a/packages/flutter/test/services/platform_network_test.dart
+++ b/packages/flutter/test/services/platform_network_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  final Symbol _symbol = #dart.library.io.allow_http;
+  const Symbol _symbol = #dart.library.io.allow_http;
 
   test('AllowHTTP sets the correct zone variable', () async {
     expect(Zone.current[_symbol], isNull);

--- a/packages/flutter/test/services/platform_network_test.dart
+++ b/packages/flutter/test/services/platform_network_test.dart
@@ -10,10 +10,12 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  final Symbol _symbol = #dart.library.io.allow_http;
 
   test('AllowHTTP sets the correct zone variable', () async {
+    expect(Zone.current[_symbol], isNull);
     allowHttp(() {
-      expect(Zone.current[#dart.library.io.allow_http], isTrue);
+      expect(Zone.current[_symbol], isTrue);
     });
   });
 
@@ -24,8 +26,9 @@ void main() {
     final HttpClient httpClient = HttpClient();
     try {
       await runZoned(
-          () async => await httpClient.getUrl(Uri.parse('http://${Platform.localHostname}')),
-          zoneValues: <Symbol, bool>{#dart.library.io.allow_http: false});
+        () async => await httpClient.getUrl(Uri.parse('http://${Platform.localHostname}')),
+        zoneValues: <Symbol, bool>{_symbol: false},
+      );
       fail('This should have thrown a StateError. '
            'Check if the symbol for setting allow_http behavior has changed');
     } on StateError catch(e) {

--- a/packages/flutter/test/services/platform_network_test.dart
+++ b/packages/flutter/test/services/platform_network_test.dart
@@ -12,9 +12,9 @@ void main() {
   //
   // If this symbol changes, then update [allowHttp] function as well.
   test('Zone variable can override HTTP behavior', () async {
-    final httpClient = new HttpClient();
+    final HttpClient httpClient = HttpClient();
     expect(() => runZoned(
         () async => await httpClient.getUrl(Uri.parse('http://${Platform.localHostname}')),
-        zoneValues: {#dart.library.io.allow_http: false}), throwsA(isA<StateError>()));
+        zoneValues: <Symbol, bool>{#dart.library.io.allow_http: false}), throwsA(isA<StateError>()));
   });
 }


### PR DESCRIPTION
This is being submitted in preparation of breaking change described in https://github.com/dart-lang/sdk/issues/40548.

The Dart SDK support for this is added https://github.com/dart-lang/sdk/commit/74a20b7bfd9f2694cf9d1c38a68b47686a06a018. 

Following this PR, I will draft and send out an announcement for flutter-announce@. Afterwards, I will submit the change to engine to ban HTTP by default on iOS and Android.