### PR TITLE
Revert "re-enable `android_view_test`"

### DIFF
--- a/dev/integration_tests/android_views/test_driver/main_test.dart
+++ b/dev/integration_tests/android_views/test_driver/main_test.dart
@@ -24,7 +24,9 @@ Future<void> main() async {
     await driver.waitFor(find.byValueKey('PlatformView'));
     final String errorMessage = await driver.requestData('run test');
     expect(errorMessage, '');
-  });
+  },
+  // TODO(amirh): enable this test https://github.com/flutter/flutter/issues/54022
+  skip: true);
 
   test('AlertDialog from platform view context', () async {
     final SerializableFinder wmListTile =


### PR DESCRIPTION
Reverts flutter/flutter#54214

Test appears to still be broken, or else inclusion causes next test to fail:

```
2020-04-08T13:16:55.874900: stdout: [+3313 ms] 00:00 [32m+0[0m: (setUpAll)[0m
2020-04-08T13:16:55.924118: stderr: [  +49 ms] VMServiceFlutterDriver: Connecting to Flutter application at http://127.0.0.1:62761/RxYlfB57sY4=/
2020-04-08T13:16:56.556514: stderr: [ +632 ms] VMServiceFlutterDriver: Isolate found with number: 195772137669095
2020-04-08T13:16:56.742855: stderr: [ +185 ms] VMServiceFlutterDriver: Isolate is paused at start.
2020-04-08T13:16:56.762699: stderr: [  +19 ms] VMServiceFlutterDriver: Attempting to resume isolate
2020-04-08T13:16:57.014340: stderr: [ +251 ms] VMServiceFlutterDriver: Waiting for service extension
2020-04-08T13:17:00.051960: stderr: [+3037 ms] VMServiceFlutterDriver: Connected to Flutter application.
2020-04-08T13:17:00.058653: stdout: [   +6 ms] 00:04 [32m+0[0m: MotionEvent recomposition[0m
2020-04-08T13:17:01.484285: stdout: [+1425 ms] I/flutter (29628): replaying 67 motion events
2020-04-08T13:17:03.753548: stdout: [+2269 ms] 00:07 [32m+1[0m: AlertDialog from platform view context[0m
2020-04-08T13:17:08.762701: stderr: [+5008 ms] VMServiceFlutterDriver: tap message is taking a long time to complete...
2020-04-08T13:17:33.762440: stdout: [+25000 ms] 00:37 [32m+1[0m[31m -1[0m: AlertDialog from platform view context [1m[31m[E][0m[0m
2020-04-08T13:17:33.764935: stdout: [   +2 ms]   TimeoutException after 0:00:30.000000: Test timed out after 30 seconds. See https://pub.dev/packages/test#timeouts
2020-04-08T13:17:33.792812: stdout: [  +27 ms]   package:test_api/src/backend/invoker.dart 333:28               Invoker._handleError.<fn>
2020-04-08T13:17:33.793450: stdout: [        ]   dart:async/zone.dart 1180:38                                   _rootRun
stdout: [        ]   dart:async/zone.dart 1077:19                                   _CustomZone.run
stdout: [        ]   package:test_api/src/backend/invoker.dart 331:10               Invoker._handleError
2020-04-08T13:17:33.793970: stdout: [        ]   package:test_api/src/backend/invoker.dart 287:9                Invoker.heartbeat.<fn>.<fn>
stdout: [        ]   dart:async/zone.dart 1184:13                                   _rootRun
2020-04-08T13:17:33.794413: stdout: [        ]   dart:async/zone.dart 1077:19                                   _CustomZone.run
stdout: [        ]   package:test_api/src/backend/invoker.dart 286:38               Invoker.heartbeat.<fn>
2020-04-08T13:17:33.794850: stdout: [        ]   package:stack_trace/src/stack_zone_specification.dart 209:15   StackZoneSpecification._run
stdout: [        ]   package:stack_trace/src/stack_zone_specification.dart 119:48   StackZoneSpecification._registerCallback.<fn>

```

BTR @cyanglaz 