### PR TITLE
fix and re-land "re-enable `android_view_test` (#54214)"

### DIFF
--- a/dev/integration_tests/android_views/android/app/src/main/java/io/flutter/integration/androidviews/SimplePlatformView.java
+++ b/dev/integration_tests/android_views/android/app/src/main/java/io/flutter/integration/androidviews/SimplePlatformView.java
@@ -63,7 +63,7 @@ public class SimplePlatformView implements PlatformView, MethodChannel.MethodCal
         Context context = view.getContext();
         AlertDialog.Builder builder = new AlertDialog.Builder(context);
         TextView textView = new TextView(context);
-        textView.setText("This alert dialog will close in 1 seconds");
+        textView.setText("This alert dialog will close in 1 second");
         builder.setView(textView);
         final AlertDialog alertDialog = builder.show();
         result.success(null);

--- a/dev/integration_tests/android_views/android/app/src/main/java/io/flutter/integration/androidviews/SimplePlatformView.java
+++ b/dev/integration_tests/android_views/android/app/src/main/java/io/flutter/integration/androidviews/SimplePlatformView.java
@@ -52,21 +52,27 @@ public class SimplePlatformView implements PlatformView, MethodChannel.MethodCal
                 touchPipe.disable();
                 result.success(null);
                 return;
-            case "showAlertDialog":
-                showAlertDialog(result);
+            case "showAndHideAlertDialog":
+                showAndHideAlertDialog(result);
                 return;
         }
         result.notImplemented();
     }
 
-    private void showAlertDialog(MethodChannel.Result result) {
+    private void showAndHideAlertDialog(MethodChannel.Result result) {
         Context context = view.getContext();
         AlertDialog.Builder builder = new AlertDialog.Builder(context);
         TextView textView = new TextView(context);
-        textView.setText("Alert!");
+        textView.setText("This alert dialog will close in 1 seconds");
         builder.setView(textView);
         final AlertDialog alertDialog = builder.show();
         result.success(null);
+        view.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                alertDialog.hide();
+            }
+        }, 1000);
     }
 
 }

--- a/dev/integration_tests/android_views/lib/motion_events_page.dart
+++ b/dev/integration_tests/android_views/lib/motion_events_page.dart
@@ -63,60 +63,60 @@ class MotionEventsBodyState extends State<MotionEventsBody> {
   @override
   Widget build(BuildContext context) {
     return Column(
-        children: <Widget>[
-          SizedBox(
-            height: 300.0,
-            child: AndroidView(
-                key: const ValueKey<String>('PlatformView'),
-                viewType: 'simple_view',
-                onPlatformViewCreated: onPlatformViewCreated),
+      children: <Widget>[
+        SizedBox(
+          height: 300.0,
+          child: AndroidView(
+              key: const ValueKey<String>('PlatformView'),
+              viewType: 'simple_view',
+              onPlatformViewCreated: onPlatformViewCreated),
+        ),
+        Expanded(
+          child: ListView.builder(
+            itemBuilder: buildEventTile,
+            itemCount: flutterViewEvents.length,
           ),
-          Expanded(
-            child: ListView.builder(
-              itemBuilder: buildEventTile,
-              itemCount: flutterViewEvents.length,
+        ),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: <Widget>[
+            RaisedButton(
+              child: const Text('RECORD'),
+              onPressed: listenToFlutterViewEvents,
             ),
-          ),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            children: <Widget>[
-              RaisedButton(
-                child: const Text('RECORD'),
-                onPressed: listenToFlutterViewEvents,
-              ),
-              RaisedButton(
-                child: const Text('CLEAR'),
-                onPressed: () {
-                  setState(() {
-                    flutterViewEvents.clear();
-                    embeddedViewEvents.clear();
-                  });
-                },
-              ),
-              RaisedButton(
-                child: const Text('SAVE'),
-                onPressed: () {
-                  const StandardMessageCodec codec = StandardMessageCodec();
-                  saveRecordedEvents(
-                      codec.encodeMessage(flutterViewEvents), context);
-                },
-              ),
-              RaisedButton(
-                key: const ValueKey<String>('play'),
-                child: const Text('PLAY FILE'),
-                onPressed: () { playEventsFile(); },
-              ),
-              Expanded(
-                  child: RaisedButton(
+            RaisedButton(
+              child: const Text('CLEAR'),
+              onPressed: () {
+                setState(() {
+                  flutterViewEvents.clear();
+                  embeddedViewEvents.clear();
+                });
+              },
+            ),
+            RaisedButton(
+              child: const Text('SAVE'),
+              onPressed: () {
+                const StandardMessageCodec codec = StandardMessageCodec();
+                saveRecordedEvents(
+                    codec.encodeMessage(flutterViewEvents), context);
+              },
+            ),
+            RaisedButton(
+              key: const ValueKey<String>('play'),
+              child: const Text('PLAY FILE'),
+              onPressed: () { playEventsFile(); },
+            ),
+            Expanded(
+                child: RaisedButton(
                   key: const ValueKey<String>('back'),
                   child: const Text('BACK'),
                   onPressed: () { Navigator.pop(context); },
-                ),
               ),
-            ],
-          ),
-        ],
-      );
+            ),
+          ],
+        ),
+      ],
+    );
   }
 
   Future<String> playEventsFile() async {

--- a/dev/integration_tests/android_views/lib/motion_events_page.dart
+++ b/dev/integration_tests/android_views/lib/motion_events_page.dart
@@ -78,7 +78,6 @@ class MotionEventsBodyState extends State<MotionEventsBody> {
           ),
         ),
         Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           children: <Widget>[
             RaisedButton(
               child: const Text('RECORD'),

--- a/dev/integration_tests/android_views/lib/motion_events_page.dart
+++ b/dev/integration_tests/android_views/lib/motion_events_page.dart
@@ -63,52 +63,60 @@ class MotionEventsBodyState extends State<MotionEventsBody> {
   @override
   Widget build(BuildContext context) {
     return Column(
-      children: <Widget>[
-        SizedBox(
-          height: 300.0,
-          child: AndroidView(
-              key: const ValueKey<String>('PlatformView'),
-              viewType: 'simple_view',
-              onPlatformViewCreated: onPlatformViewCreated),
-        ),
-        Expanded(
-          child: ListView.builder(
-            itemBuilder: buildEventTile,
-            itemCount: flutterViewEvents.length,
+        children: <Widget>[
+          SizedBox(
+            height: 300.0,
+            child: AndroidView(
+                key: const ValueKey<String>('PlatformView'),
+                viewType: 'simple_view',
+                onPlatformViewCreated: onPlatformViewCreated),
           ),
-        ),
-        Row(
-          children: <Widget>[
-            RaisedButton(
-              child: const Text('RECORD'),
-              onPressed: listenToFlutterViewEvents,
+          Expanded(
+            child: ListView.builder(
+              itemBuilder: buildEventTile,
+              itemCount: flutterViewEvents.length,
             ),
-            RaisedButton(
-              child: const Text('CLEAR'),
-              onPressed: () {
-                setState(() {
-                  flutterViewEvents.clear();
-                  embeddedViewEvents.clear();
-                });
-              },
-            ),
-            RaisedButton(
-              child: const Text('SAVE'),
-              onPressed: () {
-                const StandardMessageCodec codec = StandardMessageCodec();
-                saveRecordedEvents(
-                    codec.encodeMessage(flutterViewEvents), context);
-              },
-            ),
-            RaisedButton(
-              key: const ValueKey<String>('play'),
-              child: const Text('PLAY FILE'),
-              onPressed: () { playEventsFile(); },
-            ),
-          ],
-        ),
-      ],
-    );
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: <Widget>[
+              RaisedButton(
+                child: const Text('RECORD'),
+                onPressed: listenToFlutterViewEvents,
+              ),
+              RaisedButton(
+                child: const Text('CLEAR'),
+                onPressed: () {
+                  setState(() {
+                    flutterViewEvents.clear();
+                    embeddedViewEvents.clear();
+                  });
+                },
+              ),
+              RaisedButton(
+                child: const Text('SAVE'),
+                onPressed: () {
+                  const StandardMessageCodec codec = StandardMessageCodec();
+                  saveRecordedEvents(
+                      codec.encodeMessage(flutterViewEvents), context);
+                },
+              ),
+              RaisedButton(
+                key: const ValueKey<String>('play'),
+                child: const Text('PLAY FILE'),
+                onPressed: () { playEventsFile(); },
+              ),
+              Expanded(
+                  child: RaisedButton(
+                  key: const ValueKey<String>('back'),
+                  child: const Text('BACK'),
+                  onPressed: () { Navigator.pop(context); },
+                ),
+              ),
+            ],
+          ),
+        ],
+      );
   }
 
   Future<String> playEventsFile() async {

--- a/dev/integration_tests/android_views/lib/wm_integrations.dart
+++ b/dev/integration_tests/android_views/lib/wm_integrations.dart
@@ -84,7 +84,7 @@ class WindowManagerBodyState extends State<WindowManagerBody> {
       });
     }
     try {
-      await viewChannel.invokeMethod<void>('showAlertDialog');
+      await viewChannel.invokeMethod<void>('showAndHideAlertDialog');
       setState(() {
         lastTestStatus = _LastTestStatus.success;
       });

--- a/dev/integration_tests/android_views/test_driver/main_test.dart
+++ b/dev/integration_tests/android_views/test_driver/main_test.dart
@@ -13,9 +13,11 @@ Future<void> main() async {
     driver = await FlutterDriver.connect();
   });
 
-  tearDownAll(() {
-    driver.close();
+  tearDownAll(() async {
+    await driver.close();
   });
+
+  // Each test below must return back to the home page after finishing.
 
   test('MotionEvent recomposition', () async {
     final SerializableFinder motionEventsListTile =
@@ -24,9 +26,8 @@ Future<void> main() async {
     await driver.waitFor(find.byValueKey('PlatformView'));
     final String errorMessage = await driver.requestData('run test');
     expect(errorMessage, '');
-  },
-  // TODO(amirh): enable this test https://github.com/flutter/flutter/issues/54022
-  skip: true);
+    await driver.tap(find.byValueKey('back'));
+  });
 
   test('AlertDialog from platform view context', () async {
     final SerializableFinder wmListTile =
@@ -38,5 +39,7 @@ Future<void> main() async {
     await driver.tap(showAlertDialog);
     final String status = await driver.getText(find.byValueKey('Status'));
     expect(status, 'Success');
+    await driver.waitFor(find.pageBack());
+    await driver.tap(find.pageBack());
   });
 }

--- a/dev/integration_tests/android_views/test_driver/main_test.dart
+++ b/dev/integration_tests/android_views/test_driver/main_test.dart
@@ -13,8 +13,8 @@ Future<void> main() async {
     driver = await FlutterDriver.connect();
   });
 
-  tearDownAll(() async {
-    await driver.close();
+  tearDownAll(() {
+    driver.close();
   });
 
   // Each test below must return back to the home page after finishing.


### PR DESCRIPTION
## Description

The tests were broken because each test assume it starts from the home page but none return to the home page after finishing.
Added mechanisms for each test page to go back to the home page.

## Related Issues

https://github.com/flutter/flutter/issues/54022

## Tests

I added the following tests:
`'MotionEvent recomposition`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
