### PR TITLE
[flutter_tools] make verbose macOS builds actually verbose

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_macos.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos.dart
@@ -54,6 +54,7 @@ class BuildMacosCommand extends BuildSubCommand {
       flutterProject: flutterProject,
       buildInfo: buildInfo,
       targetOverride: targetFile,
+      verboseLogging: globals.logger.isVerbose,
     );
     return FlutterCommandResult.success();
   }

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:meta/meta.dart';
+
 import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/logger.dart';
@@ -18,6 +20,7 @@ Future<void> buildMacOS({
   FlutterProject flutterProject,
   BuildInfo buildInfo,
   String targetOverride,
+  @required bool verboseLogging,
 }) async {
   if (!flutterProject.macos.xcodeWorkspace.existsSync()) {
     throwToolExit('No macOS desktop project configured. '
@@ -83,6 +86,8 @@ Future<void> buildMacOS({
       '-derivedDataPath', flutterBuildDir.absolute.path,
       'OBJROOT=${globals.fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Intermediates.noindex')}',
       'SYMROOT=${globals.fs.path.join(flutterBuildDir.absolute.path, 'Build', 'Products')}',
+      if (verboseLogging)
+        'VERBOSE_SCRIPT_LOGGING=YES',
       'COMPILER_INDEX_STORE_ENABLE=NO',
       ...environmentVariablesAsXcodeBuildSettings(globals.platform)
     ], trace: true);

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -44,6 +44,7 @@ class MacOSDevice extends DesktopDevice {
       flutterProject: FlutterProject.current(),
       buildInfo: buildInfo,
       targetOverride: mainPath,
+      verboseLogging: globals.logger.isVerbose,
     );
   }
 


### PR DESCRIPTION
## Description

The `VERBOSE_SCRIPT_LOGGING` config was never set, causing verbose mode to not forward logs from re-entrant flutter or to place re-entrant flutter in verbose mode.

Related to https://github.com/flutter/flutter/issues/33582