### PR TITLE
[flutter_tools] use new output location for the apk

### DIFF
--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -44,7 +44,7 @@ void main() {
 
       expect(
         getApkDirectory(project).path,
-        equals(globals.fs.path.join('foo', 'app', 'outputs', 'apk')),
+        equals(globals.fs.path.join('foo', 'app', 'outputs', 'flutter-apk')),
       );
     });
 
@@ -57,7 +57,7 @@ void main() {
 
       expect(
         getApkDirectory(project).path,
-        equals(globals.fs.path.join('foo', 'host', 'outputs', 'apk')),
+        equals(globals.fs.path.join('foo', 'host', 'outputs', 'flutter-apk')),
       );
     });
 
@@ -312,107 +312,41 @@ void main() {
     });
   });
 
-  group('findApkFiles', () {
-    final Usage mockUsage = MockUsage();
-
-    testUsingContext('Finds APK without flavor in release', () {
-      final FlutterProject project = MockFlutterProject();
-      final AndroidProject androidProject = MockAndroidProject();
-
-      when(project.android).thenReturn(androidProject);
-      when(project.isModule).thenReturn(false);
-      when(androidProject.buildDirectory).thenReturn(globals.fs.directory('irrelevant'));
-
-      final Directory apkDirectory = globals.fs.directory(globals.fs.path.join('irrelevant', 'app', 'outputs', 'apk', 'release'));
-      apkDirectory.createSync(recursive: true);
-      apkDirectory.childFile('app-release.apk').createSync();
-
-      final Iterable<File> apks = findApkFiles(
-        project,
+  group('listApkPaths', () {
+    testWithoutContext('Finds APK without flavor in release', () {
+      final Iterable<String> apks = listApkPaths(
         const AndroidBuildInfo(BuildInfo(BuildMode.release, '', treeShakeIcons: false)),
       );
-      expect(apks.isNotEmpty, isTrue);
-      expect(apks.first.path, equals(globals.fs.path.join('irrelevant', 'app', 'outputs', 'apk', 'release', 'app-release.apk')));
-    }, overrides: <Type, Generator>{
-      FileSystem: () => MemoryFileSystem(),
-      ProcessManager: () => FakeProcessManager.any(),
+
+      expect(apks, <String>['app-release.apk']);
     });
 
-    testUsingContext('Finds APK with flavor in release mode', () {
-      final FlutterProject project = MockFlutterProject();
-      final AndroidProject androidProject = MockAndroidProject();
-
-      when(project.android).thenReturn(androidProject);
-      when(project.isModule).thenReturn(false);
-      when(androidProject.buildDirectory).thenReturn(globals.fs.directory('irrelevant'));
-
-      final Directory apkDirectory = globals.fs.directory(globals.fs.path.join('irrelevant', 'app', 'outputs', 'apk', 'release'));
-      apkDirectory.createSync(recursive: true);
-      apkDirectory.childFile('app-flavor1-release.apk').createSync();
-
-      final Iterable<File> apks = findApkFiles(
-        project,
+    testWithoutContext('Finds APK with flavor in release mode', () {
+      final Iterable<String> apks = listApkPaths(
         const AndroidBuildInfo(BuildInfo(BuildMode.release, 'flavor1', treeShakeIcons: false)),
       );
-      expect(apks.isNotEmpty, isTrue);
-      expect(apks.first.path, equals(globals.fs.path.join('irrelevant', 'app', 'outputs', 'apk', 'release', 'app-flavor1-release.apk')));
-    }, overrides: <Type, Generator>{
-      FileSystem: () => MemoryFileSystem(),
-      ProcessManager: () => FakeProcessManager.any(),
+
+      expect(apks, <String>['app-flavor1-release.apk']);
     });
 
-    testUsingContext('Finds APK with flavor in release mode - AGP v3', () {
-      final FlutterProject project = MockFlutterProject();
-      final AndroidProject androidProject = MockAndroidProject();
-
-      when(project.android).thenReturn(androidProject);
-      when(project.isModule).thenReturn(false);
-      when(androidProject.buildDirectory).thenReturn(globals.fs.directory('irrelevant'));
-
-      final Directory apkDirectory = globals.fs.directory(globals.fs.path.join('irrelevant', 'app', 'outputs', 'apk', 'flavor1', 'release'));
-      apkDirectory.createSync(recursive: true);
-      apkDirectory.childFile('app-flavor1-release.apk').createSync();
-
-      final Iterable<File> apks = findApkFiles(
-        project,
+    testWithoutContext('Finds APK with flavor in release mode - AGP v3', () {
+      final Iterable<String> apks = listApkPaths(
         const AndroidBuildInfo(BuildInfo(BuildMode.release, 'flavor1', treeShakeIcons: false)),
       );
-      expect(apks.isNotEmpty, isTrue);
-      expect(apks.first.path, equals(globals.fs.path.join('irrelevant', 'app', 'outputs', 'apk', 'flavor1', 'release', 'app-flavor1-release.apk')));
-    }, overrides: <Type, Generator>{
-      FileSystem: () => MemoryFileSystem(),
-      ProcessManager: () => FakeProcessManager.any(),
+
+      expect(apks, <String>['app-flavor1-release.apk']);
     });
 
-    testUsingContext('apk not found', () {
-      final FlutterProject project = FlutterProject.current();
-      expect(
-        () {
-          findApkFiles(
-            project,
-            const AndroidBuildInfo(BuildInfo(BuildMode.debug, 'foo_bar', treeShakeIcons: false)),
-          );
-        },
-        throwsToolExit(
-          message:
-            "Gradle build failed to produce an .apk file. It's likely that this file "
-            "was generated under ${project.android.buildDirectory.path}, but the tool couldn't find it."
-        )
+    testWithoutContext('Finds APK with split-per-abi', () {
+      final Iterable<String> apks = listApkPaths(
+        const AndroidBuildInfo(BuildInfo(BuildMode.release, 'flavor1', treeShakeIcons: false), splitPerAbi: true),
       );
-      verify(
-        mockUsage.sendEvent(
-          any,
-          any,
-          label: 'gradle-expected-file-not-found',
-          parameters: const <String, String> {
-            'cd37': 'androidGradlePluginVersion: 5.6.2, fileExtension: .apk',
-          },
-        ),
-      ).called(1);
-    }, overrides: <Type, Generator>{
-      FileSystem: () => MemoryFileSystem(),
-      ProcessManager: () => FakeProcessManager.any(),
-      Usage: () => mockUsage,
+
+      expect(apks, unorderedEquals(<String>[
+        'app-armeabi-v7a-flavor1-release.apk',
+        'app-arm64-v8a-flavor1-release.apk',
+        'app-x86_64-flavor1-release.apk',
+      ]));
     });
   });
 
@@ -1413,8 +1347,7 @@ plugin1=${plugin1.path}
       fileSystem.directory('build')
         .childDirectory('app')
         .childDirectory('outputs')
-        .childDirectory('apk')
-        .childDirectory('release')
+        .childDirectory('flutter-apk')
         .childFile('app-release.apk')
         .createSync(recursive: true);
 
@@ -1453,7 +1386,6 @@ plugin1=${plugin1.path}
         label: 'gradle-random-event-label-success',
         parameters: anyNamed('parameters'),
       )).called(1);
-
     }, overrides: <Type, Generator>{
       AndroidSdk: () => mockAndroidSdk,
       Cache: () => cache,
@@ -1551,17 +1483,6 @@ plugin1=${plugin1.path}
     });
 
     testUsingContext('indicates that an APK has been built successfully', () async {
-      when(mockProcessManager.start(any,
-        workingDirectory: anyNamed('workingDirectory'),
-        environment: anyNamed('environment')))
-      .thenAnswer((_) {
-        return Future<Process>.value(
-          createMockProcess(
-            exitCode: 0,
-            stdout: '',
-          ));
-      });
-
       fileSystem.directory('android')
         .childFile('build.gradle')
         .createSync(recursive: true);
@@ -1579,8 +1500,7 @@ plugin1=${plugin1.path}
       fileSystem.directory('build')
         .childDirectory('app')
         .childDirectory('outputs')
-        .childDirectory('apk')
-        .childDirectory('release')
+        .childDirectory('flutter-apk')
         .childFile('app-release.apk')
         .createSync(recursive: true);
 
@@ -1600,7 +1520,7 @@ plugin1=${plugin1.path}
 
       expect(
         testLogger.statusText,
-        contains('Built build/app/outputs/apk/release/app-release.apk (0.0MB)'),
+        contains('Built build/app/outputs/flutter-apk/app-release.apk (0.0MB)'),
       );
 
     }, overrides: <Type, Generator>{
@@ -1608,7 +1528,7 @@ plugin1=${plugin1.path}
       Cache: () => cache,
       FileSystem: () => fileSystem,
       Platform: () => android,
-      ProcessManager: () => mockProcessManager,
+      ProcessManager: () => FakeProcessManager.any(),
     });
 
     testUsingContext("doesn't indicate how to consume an AAR when printHowToConsumeAaar is false", () async {

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -57,7 +57,7 @@ void main() {
 
       expect(
         getApkDirectory(project).path,
-        equals(globals.fs.path.join('foo', 'host', 'outputs', 'flutter-apk')),
+        equals(globals.fs.path.join('foo', 'host', 'outputs', 'apk')),
       );
     });
 


### PR DESCRIPTION
## Description

From https://github.com/flutter/flutter/pull/53718 , flutter.gradle will copy the output APK to a known location. Use this instead of attempting to guess the APK location.

Fixes https://github.com/flutter/flutter/issues/52905 
Fixes https://github.com/flutter/flutter/issues/29509
Fixes https://github.com/flutter/flutter/issues/13977
Fixes https://github.com/flutter/flutter/issues/44796