### PR TITLE
Unforward VM service connection port on iOS on failure

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -1256,7 +1256,7 @@ class AndroidDevicePortForwarder extends DevicePortForwarder {
   }
 
   @override
-  Future<int> forward(int devicePort, { int hostPort }) async {
+  Future<ForwardedPort> forward(int devicePort, { int hostPort }) async {
     hostPort ??= 0;
     final RunResult process = await _processUtils.run(
       <String>[
@@ -1308,7 +1308,7 @@ class AndroidDevicePortForwarder extends DevicePortForwarder {
       }
     }
 
-    return hostPort;
+    return ForwardedPort(hostPort, devicePort);
   }
 
   @override

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -854,8 +854,8 @@ class DeviceDomain extends Domain {
       throw "device '$deviceId' not found";
     }
 
-    hostPort = await device.portForwarder.forward(devicePort, hostPort: hostPort);
-
+    final ForwardedPort forwardedPort = await device.portForwarder.forward(devicePort, hostPort: hostPort);
+    hostPort = forwardedPort?.hostPort;
     return <String, dynamic>{'hostPort': hostPort};
   }
 

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -939,7 +939,7 @@ abstract class DevicePortForwarder {
   /// Forward [hostPort] on the host to [devicePort] on the device.
   /// If [hostPort] is null or zero, will auto select a host port.
   /// Returns a Future that completes with the host port.
-  Future<int> forward(int devicePort, { int hostPort });
+  Future<ForwardedPort> forward(int devicePort, { int hostPort });
 
   /// Stops forwarding [forwardedPort].
   Future<void> unforward(ForwardedPort forwardedPort);
@@ -1001,7 +1001,7 @@ class NoOpDevicePortForwarder implements DevicePortForwarder {
   const NoOpDevicePortForwarder();
 
   @override
-  Future<int> forward(int devicePort, { int hostPort }) async => devicePort;
+  Future<ForwardedPort> forward(int devicePort, { int hostPort }) async => ForwardedPort(hostPort, devicePort);
 
   @override
   List<ForwardedPort> get forwardedPorts => <ForwardedPort>[];

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -819,7 +819,7 @@ class IOSDevicePortForwarder extends DevicePortForwarder {
   static const Duration _kiProxyPortForwardTimeout = Duration(seconds: 1);
 
   @override
-  Future<int> forward(int devicePort, { int hostPort }) async {
+  Future<ForwardedPort> forward(int devicePort, { int hostPort }) async {
     final bool autoselect = hostPort == null || hostPort == 0;
     if (autoselect) {
       final int freePort = await _operatingSystemUtils?.findFreePort();
@@ -855,7 +855,7 @@ class IOSDevicePortForwarder extends DevicePortForwarder {
     );
     _logger.printTrace('Forwarded port $forwardedPort');
     forwardedPorts.add(forwardedPort);
-    return hostPort;
+    return forwardedPort;
   }
 
   @override

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -911,13 +911,14 @@ class _IOSSimulatorDevicePortForwarder extends DevicePortForwarder {
   List<ForwardedPort> get forwardedPorts => _ports;
 
   @override
-  Future<int> forward(int devicePort, { int hostPort }) async {
+  Future<ForwardedPort> forward(int devicePort, { int hostPort }) async {
     if (hostPort == null || hostPort == 0) {
       hostPort = devicePort;
     }
     assert(devicePort == hostPort);
-    _ports.add(ForwardedPort(devicePort, hostPort));
-    return hostPort;
+    final ForwardedPort forwardedPort = ForwardedPort(devicePort, hostPort);
+    _ports.add(forwardedPort);
+    return forwardedPort;
   }
 
   @override

--- a/packages/flutter_tools/lib/src/mdns_discovery.dart
+++ b/packages/flutter_tools/lib/src/mdns_discovery.dart
@@ -237,9 +237,8 @@ Future<Uri> buildObservatoryUri(
   if (!path.endsWith('/')) {
     path += '/';
   }
-  hostVmservicePort ??= 0;
   final int actualHostPort = hostVmservicePort == 0 ?
-    await device.portForwarder.forward(devicePort) :
+    (await device.portForwarder.forward(devicePort))?.hostPort :
     hostVmservicePort;
   return Uri(scheme: 'http', host: host, port: actualHostPort, path: path);
 }

--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -150,7 +150,8 @@ class ProtocolDiscovery {
 
     if (portForwarder != null) {
       final int actualDevicePort = deviceUri.port;
-      final int actualHostPort = await portForwarder.forward(actualDevicePort, hostPort: hostPort);
+      final ForwardedPort forwardedPort = await portForwarder.forward(actualDevicePort, hostPort: hostPort);
+      final int actualHostPort = forwardedPort?.hostPort;
       globals.printTrace('Forwarded host port $actualHostPort to device port $actualDevicePort for $serviceName');
       hostUri = deviceUri.replace(port: actualHostPort);
     }

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -380,7 +380,7 @@ void main() {
       when(device.portForwarder)
         .thenReturn(portForwarder);
       final ForwardedPort forwardedPort = ForwardedPort(hostPort, devicePort);
-      
+
       when(device.portForwarder).thenReturn(portForwarder);
       when(device.getLogReader(includePastLogs: anyNamed('includePastLogs')))
         .thenAnswer((_) => mockLogReader);

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -83,10 +83,11 @@ void main() {
         mockDds = MockDartDevelopmentService();
         when(device.portForwarder)
           .thenReturn(portForwarder);
+        final ForwardedPort forwardedPort = ForwardedPort(hostPort, devicePort);
         when(portForwarder.forward(devicePort, hostPort: anyNamed('hostPort')))
-          .thenAnswer((_) async => hostPort);
+          .thenAnswer((_) async => forwardedPort);
         when(portForwarder.forwardedPorts)
-          .thenReturn(<ForwardedPort>[ForwardedPort(hostPort, devicePort)]);
+          .thenReturn(<ForwardedPort>[forwardedPort]);
         when(portForwarder.unforward(any))
           .thenAnswer((_) async {});
         when(device.dds).thenReturn(mockDds);
@@ -295,14 +296,15 @@ void main() {
       final MockAndroidDevice device = MockAndroidDevice();
       final MockHotRunner mockHotRunner = MockHotRunner();
       final MockHotRunnerFactory mockHotRunnerFactory = MockHotRunnerFactory();
+      final ForwardedPort forwardedPort = ForwardedPort(hostPort, devicePort);
       when(device.portForwarder)
         .thenReturn(portForwarder);
       when(device.dds)
         .thenReturn(mockDds);
       when(portForwarder.forward(devicePort, hostPort: anyNamed('hostPort')))
-        .thenAnswer((_) async => hostPort);
+        .thenAnswer((_) async => forwardedPort);
       when(portForwarder.forwardedPorts)
-        .thenReturn(<ForwardedPort>[ForwardedPort(hostPort, devicePort)]);
+        .thenReturn(<ForwardedPort>[forwardedPort]);
       when(portForwarder.unforward(any))
         .thenAnswer((_) async {});
       when(mockHotRunner.attach(appStartedCompleter: anyNamed('appStartedCompleter')))
@@ -377,14 +379,15 @@ void main() {
       final MockHotRunnerFactory mockHotRunnerFactory = MockHotRunnerFactory();
       when(device.portForwarder)
         .thenReturn(portForwarder);
-      when(device.dds)
-        .thenReturn(mockDds);
+      final ForwardedPort forwardedPort = ForwardedPort(hostPort, devicePort);
+      
+      when(device.portForwarder).thenReturn(portForwarder);
       when(device.getLogReader(includePastLogs: anyNamed('includePastLogs')))
         .thenAnswer((_) => mockLogReader);
       when(portForwarder.forward(devicePort, hostPort: anyNamed('hostPort')))
-        .thenAnswer((_) async => hostPort);
+        .thenAnswer((_) async => forwardedPort);
       when(portForwarder.forwardedPorts)
-        .thenReturn(<ForwardedPort>[ForwardedPort(hostPort, devicePort)]);
+        .thenReturn(<ForwardedPort>[forwardedPort]);
       when(portForwarder.unforward(any))
         .thenAnswer((_) async {});
       when(mockHotRunner.attach(appStartedCompleter: anyNamed('appStartedCompleter')))
@@ -435,13 +438,14 @@ void main() {
         portForwarder = MockPortForwarder();
         final MockDartDevelopmentService mockDds = MockDartDevelopmentService();
         device = MockAndroidDevice();
+        final ForwardedPort forwardedPort = ForwardedPort(hostPort, devicePort);
 
         when(device.portForwarder)
           .thenReturn(portForwarder);
         when(portForwarder.forward(devicePort))
-          .thenAnswer((_) async => hostPort);
+          .thenAnswer((_) async => forwardedPort);
         when(portForwarder.forwardedPorts)
-          .thenReturn(<ForwardedPort>[ForwardedPort(hostPort, devicePort)]);
+          .thenReturn(<ForwardedPort>[forwardedPort]);
         when(portForwarder.unforward(any))
           .thenAnswer((_) async {});
         when(device.dds)

--- a/packages/flutter_tools/test/general.shard/android/android_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_test.dart
@@ -355,56 +355,46 @@ flutter:
       fileSystem: MemoryFileSystem.test(),
       logger: BufferLogger.test(),
       platform: FakePlatform(operatingSystem: 'linux'),
-      processManager: FakeProcessManager.any(),
+      processManager: mockProcessManager,
     );
     final DevicePortForwarder forwarder = device.portForwarder;
 
-    testUsingContext('returns the generated host port from stdout', () async {
+    testWithoutContext('returns the generated host port from stdout', () async {
       when(mockProcessManager.run(argThat(contains('forward'))))
           .thenAnswer((_) async => ProcessResult(0, 0, '456', ''));
 
       expect((await forwarder.forward(123)).hostPort, equals(456));
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
     });
 
-    testUsingContext('returns the supplied host port when stdout is empty', () async {
+    testWithoutContext('returns the supplied host port when stdout is empty', () async {
       when(mockProcessManager.run(argThat(contains('forward'))))
           .thenAnswer((_) async => ProcessResult(0, 0, '', ''));
 
       expect((await forwarder.forward(123, hostPort: 456)).hostPort, equals(456));
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
     });
 
-    testUsingContext('returns the supplied host port when stdout is the host port', () async {
+    testWithoutContext('returns the supplied host port when stdout is the host port', () async {
       when(mockProcessManager.run(argThat(contains('forward'))))
           .thenAnswer((_) async => ProcessResult(0, 0, '456', ''));
 
       expect((await forwarder.forward(123, hostPort: 456)).hostPort, equals(456));
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
     });
 
-    testUsingContext('throws an error when stdout is not blank nor the host port', () async {
+    testWithoutContext('throws an error when stdout is not blank nor the host port', () async {
       when(mockProcessManager.run(argThat(contains('forward'))))
           .thenAnswer((_) async => ProcessResult(0, 0, '123456', ''));
 
       expect(forwarder.forward(123, hostPort: 456), throwsA(isA<ProcessException>()));
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
     });
 
-    testUsingContext('forwardedPorts returns empty list when forward failed', () {
+    testWithoutContext('forwardedPorts returns empty list when forward failed', () {
       when(mockProcessManager.runSync(argThat(contains('forward'))))
           .thenReturn(ProcessResult(0, 1, '', ''));
 
       expect(forwarder.forwardedPorts, equals(const <ForwardedPort>[]));
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
     });
 
-    testUsingContext('disposing device disposes the portForwarder', () async {
+    testWithoutContext('disposing device disposes the portForwarder', () async {
       bool unforwardCalled = false;
       when(mockProcessManager.run(argThat(containsAll(<String>[
         'forward',
@@ -430,8 +420,6 @@ flutter:
       await device.dispose();
 
       expect(unforwardCalled, isTrue);
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
     });
   });
 

--- a/packages/flutter_tools/test/general.shard/desktop_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/desktop_device_test.dart
@@ -188,8 +188,10 @@ void main() {
   test('Port forwarder is a no-op', () async {
     final FakeDesktopDevice device = FakeDesktopDevice();
     final DevicePortForwarder portForwarder = device.portForwarder;
-    final int result = await portForwarder.forward(2);
-    expect(result, 2);
+
+    final ForwardedPort result = await portForwarder.forward(1, hostPort: 2);
+    expect(result.devicePort, 1);
+    expect(result.hostPort, 2);
     expect(portForwarder.forwardedPorts.isEmpty, true);
   });
 }

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
@@ -780,7 +780,7 @@ void main() {
       when(fuchsiaDevice.servicePorts())
           .thenAnswer((Invocation invocation) async => <int>[1]);
       when(portForwarder.forward(1))
-          .thenAnswer((Invocation invocation) async => 2);
+          .thenAnswer((Invocation invocation) async => ForwardedPort(2, 100));
       setHttpAddress(Uri.parse('example'), fakeVmServiceHost.vmService);
       return await discoveryProtocol.uri;
     }

--- a/packages/flutter_tools/test/general.shard/ios/fallback_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/fallback_discovery_test.dart
@@ -45,7 +45,7 @@ void main() {
       pollingDelay: Duration.zero,
     );
     when(mockPortForwarder.forward(23, hostPort: anyNamed('hostPort')))
-      .thenAnswer((Invocation invocation) async => 1);
+      .thenAnswer((Invocation invocation) async => ForwardedPort(1, 23));
   });
 
   testWithoutContext('Selects assumed port if VM service connection is successful', () async {
@@ -67,6 +67,7 @@ void main() {
       usesIpv6: false,
       packageName: 'hello',
     ), Uri.parse('http://localhost:1'));
+    verifyNever(mockPortForwarder.unforward(any));
   });
 
   testWithoutContext('Selects assumed port when another isolate has no root library', () async {
@@ -92,6 +93,7 @@ void main() {
       usesIpv6: false,
       packageName: 'hello',
     ), Uri.parse('http://localhost:1'));
+    verifyNever(mockPortForwarder.unforward(any));
   });
 
   testWithoutContext('Selects mdns discovery if VM service connecton fails due to Sentinel', () async {
@@ -121,8 +123,9 @@ void main() {
       hostVmservicePort: 1,
       packageId: 'hello',
       usesIpv6: false,
-       packageName: 'hello',
+      packageName: 'hello',
     ), Uri.parse('http://localhost:1234'));
+    verify(mockPortForwarder.unforward(any)).called(1);
   });
 
   testWithoutContext('Selects mdns discovery if VM service connecton fails', () async {
@@ -145,6 +148,7 @@ void main() {
       usesIpv6: false,
        packageName: 'hello',
     ), Uri.parse('http://localhost:1234'));
+    verify(mockPortForwarder.unforward(any)).called(1);
   });
 
   testWithoutContext('Selects log scanning if both VM Service and mDNS fails', () async {
@@ -167,6 +171,7 @@ void main() {
       usesIpv6: false,
       packageName: 'hello',
     ), Uri.parse('http://localhost:5678'));
+    verify(mockPortForwarder.unforward(any)).called(1);
   });
 }
 

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_port_forwarder_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_port_forwarder_test.dart
@@ -43,7 +43,7 @@ void main() {
       logger: BufferLogger.test(),
         operatingSystemUtils: operatingSystemUtils,
     );
-    final int hostPort = await portForwarder.forward(devicePort);
+    final int hostPort = (await portForwarder.forward(devicePort))?.hostPort;
 
     // First port tried (49154) should fail, then succeed on the next
     expect(hostPort, 49154 + 1);

--- a/packages/flutter_tools/test/general.shard/protocol_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/protocol_discovery_test.dart
@@ -372,12 +372,12 @@ class MockPortForwarder extends DevicePortForwarder {
   final int availablePort;
 
   @override
-  Future<int> forward(int devicePort, { int hostPort }) async {
+  Future<ForwardedPort> forward(int devicePort, { int hostPort }) async {
     hostPort ??= 0;
     if (hostPort == 0) {
-      return availablePort;
+      return ForwardedPort(availablePort, devicePort);
     }
-    return hostPort;
+    return ForwardedPort(hostPort, devicePort);
   }
 
   @override

--- a/packages/flutter_tools/test/general.shard/web/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devices_test.dart
@@ -50,7 +50,9 @@ void main() {
     expect(await chromeDevice.isLocalEmulator, false);
     expect(chromeDevice.getLogReader(), isA<NoOpDeviceLogReader>());
     expect(chromeDevice.getLogReader(), isA<NoOpDeviceLogReader>());
-    expect(await chromeDevice.portForwarder.forward(1), 1);
+    final ForwardedPort forwardedPort = await chromeDevice.portForwarder.forward(1, hostPort: 2);
+    expect(forwardedPort.devicePort, 1);
+    expect(forwardedPort.hostPort, 2);
 
     expect(chromeDevice.supportsRuntimeMode(BuildMode.debug), true);
     expect(chromeDevice.supportsRuntimeMode(BuildMode.profile), true);
@@ -76,7 +78,9 @@ void main() {
     expect(await chromeDevice.isLocalEmulator, false);
     expect(chromeDevice.getLogReader(), isA<NoOpDeviceLogReader>());
     expect(chromeDevice.getLogReader(), isA<NoOpDeviceLogReader>());
-    expect(await chromeDevice.portForwarder.forward(1), 1);
+    final ForwardedPort forwardedPort = await chromeDevice.portForwarder.forward(1, hostPort: 2);
+    expect(forwardedPort.devicePort, 1);
+    expect(forwardedPort.hostPort, 2);
 
     expect(chromeDevice.supportsRuntimeMode(BuildMode.debug), true);
     expect(chromeDevice.supportsRuntimeMode(BuildMode.profile), true);
@@ -99,7 +103,9 @@ void main() {
     expect(await device.isLocalEmulator, false);
     expect(device.getLogReader(), isA<NoOpDeviceLogReader>());
     expect(device.getLogReader(), isA<NoOpDeviceLogReader>());
-    expect(await device.portForwarder.forward(1), 1);
+    final ForwardedPort forwardedPort = await device.portForwarder.forward(1, hostPort: 2);
+    expect(forwardedPort.devicePort, 1);
+    expect(forwardedPort.hostPort, 2);
 
     expect(device.supportsRuntimeMode(BuildMode.debug), true);
     expect(device.supportsRuntimeMode(BuildMode.profile), true);


### PR DESCRIPTION
## Description

Port forwarding is leaking iproxy processes when the VM connection fails before mDNS fallback.  For `FallbackDiscovery` to unforward,  `DevicePortForwarder` needs to return the full ForwardedPort object to make sure the right process (context) gets unforwarded.

## Related Issues

https://github.com/flutter/flutter/issues/53447

## Tests

Updated tests to use `ForwardedPort`, verify unforward behavior in `fallback_discovery_test`.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*