### PR TITLE
[flutter_tools] switch benchmark to isolate runnable

### DIFF
--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -572,7 +572,7 @@ class HotRunner extends ResidentRunner {
         for (final FlutterView view in device.views) {
           isolateNotifications.add(
             view.owner.vm.vmService.onIsolateEvent.firstWhere((vm_service.Event event) {
-              return event.kind == vm_service.EventKind.kServiceExtensionAdded;
+              return event.kind == vm_service.EventKind.kIsolateRunnable;
             }),
           );
         }


### PR DESCRIPTION
## Description

From the logs, this event seems to occur after the service extension registration. The cause of https://github.com/flutter/flutter/issues/54368 is likely that we start the hot reload too quickly after the hot restart