### PR TITLE
Revert "fix and re-land "re-enable `android_view_test` (#54214)""

### DIFF
--- a/dev/integration_tests/android_views/android/app/src/main/java/io/flutter/integration/androidviews/SimplePlatformView.java
+++ b/dev/integration_tests/android_views/android/app/src/main/java/io/flutter/integration/androidviews/SimplePlatformView.java
@@ -52,27 +52,21 @@ public class SimplePlatformView implements PlatformView, MethodChannel.MethodCal
                 touchPipe.disable();
                 result.success(null);
                 return;
-            case "showAndHideAlertDialog":
-                showAndHideAlertDialog(result);
+            case "showAlertDialog":
+                showAlertDialog(result);
                 return;
         }
         result.notImplemented();
     }
 
-    private void showAndHideAlertDialog(MethodChannel.Result result) {
+    private void showAlertDialog(MethodChannel.Result result) {
         Context context = view.getContext();
         AlertDialog.Builder builder = new AlertDialog.Builder(context);
         TextView textView = new TextView(context);
-        textView.setText("This alert dialog will close in 1 second");
+        textView.setText("Alert!");
         builder.setView(textView);
         final AlertDialog alertDialog = builder.show();
         result.success(null);
-        view.postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                alertDialog.hide();
-            }
-        }, 1000);
     }
 
 }

--- a/dev/integration_tests/android_views/lib/motion_events_page.dart
+++ b/dev/integration_tests/android_views/lib/motion_events_page.dart
@@ -105,13 +105,6 @@ class MotionEventsBodyState extends State<MotionEventsBody> {
               child: const Text('PLAY FILE'),
               onPressed: () { playEventsFile(); },
             ),
-            Expanded(
-                child: RaisedButton(
-                  key: const ValueKey<String>('back'),
-                  child: const Text('BACK'),
-                  onPressed: () { Navigator.pop(context); },
-              ),
-            ),
           ],
         ),
       ],

--- a/dev/integration_tests/android_views/lib/wm_integrations.dart
+++ b/dev/integration_tests/android_views/lib/wm_integrations.dart
@@ -84,7 +84,7 @@ class WindowManagerBodyState extends State<WindowManagerBody> {
       });
     }
     try {
-      await viewChannel.invokeMethod<void>('showAndHideAlertDialog');
+      await viewChannel.invokeMethod<void>('showAlertDialog');
       setState(() {
         lastTestStatus = _LastTestStatus.success;
       });

--- a/dev/integration_tests/android_views/test_driver/main_test.dart
+++ b/dev/integration_tests/android_views/test_driver/main_test.dart
@@ -17,8 +17,6 @@ Future<void> main() async {
     driver.close();
   });
 
-  // Each test below must return back to the home page after finishing.
-
   test('MotionEvent recomposition', () async {
     final SerializableFinder motionEventsListTile =
     find.byValueKey('MotionEventsListTile');
@@ -26,8 +24,9 @@ Future<void> main() async {
     await driver.waitFor(find.byValueKey('PlatformView'));
     final String errorMessage = await driver.requestData('run test');
     expect(errorMessage, '');
-    await driver.tap(find.byValueKey('back'));
-  });
+  },
+  // TODO(amirh): enable this test https://github.com/flutter/flutter/issues/54022
+  skip: true);
 
   test('AlertDialog from platform view context', () async {
     final SerializableFinder wmListTile =
@@ -39,7 +38,5 @@ Future<void> main() async {
     await driver.tap(showAlertDialog);
     final String status = await driver.getText(find.byValueKey('Status'));
     expect(status, 'Success');
-    await driver.waitFor(find.pageBack());
-    await driver.tap(find.pageBack());
   });
 }


### PR DESCRIPTION
Reverts flutter/flutter#54312

This test is still broken:

```
flutter/dev/integration_tests/android_views/test_driver/main_test.dart --packages=/Users/flutter/.cocoon/flutter/dev/integration_tests/android_views/.packages -rexpanded
2020-04-09T12:24:54.813379: stdout: [+2611 ms] 00:00 [32m+0[0m: (setUpAll)[0m
2020-04-09T12:24:54.856850: stderr: [  +43 ms] VMServiceFlutterDriver: Connecting to Flutter application at http://127.0.0.1:61827/sdm9D_xG0tY=/
2020-04-09T12:24:55.485444: stderr: [ +628 ms] VMServiceFlutterDriver: Isolate found with number: 1714901085743907
2020-04-09T12:24:55.630: stderr: [ +144 ms] VMServiceFlutterDriver: Isolate is paused at start.
2020-04-09T12:24:55.654520: stderr: [  +24 ms] VMServiceFlutterDriver: Attempting to resume isolate
2020-04-09T12:24:55.873078: stderr: [ +218 ms] VMServiceFlutterDriver: Waiting for service extension
2020-04-09T12:24:58.909749: stderr: [+3036 ms] VMServiceFlutterDriver: Connected to Flutter application.
2020-04-09T12:24:58.916046: stdout: [   +6 ms] 00:04 [32m+0[0m: MotionEvent recomposition[0m
2020-04-09T12:25:00.269835: stdout: [+1353 ms] I/flutter (14959): replaying 67 motion events
2020-04-09T12:25:07.810142: stderr: [+7539 ms] VMServiceFlutterDriver: tap message is taking a long time to complete...
2020-04-09T12:25:28.933572: stdout: [+21124 ms] 00:34 [32m+0[0m[31m -1[0m: MotionEvent recomposition [1m[31m[E][0m[0m
2020-04-09T12:25:28.935454: stdout: [   +2 ms]   TimeoutException after 0:00:30.000000: Test timed out after 30 seconds. See https://pub.dev/packages/test#timeouts
2020-04-09T12:25:28.962508: stdout: [  +26 ms]   package:test_api/src/backend/invoker.dart 333:28               Invoker._handleError.<fn>
2020-04-09T12:25:28.962701: stdout: [        ]   dart:async/zone.dart 1180:38                                   _rootRun
2020-04-09T12:25:28.963199: stdout: [        ]   dart:async/zone.dart 1077:19                                   _CustomZone.run
2020-04-09T12:25:28.963330: stdout: [        ]   package:test_api/src/backend/invoker.dart 331:10               Invoker._handleError
2020-04-09T12:25:28.963806: stdout: [        ]   package:test_api/src/backend/invoker.dart 287:9                Invoker.heartbeat.<fn>.<fn>
stdout: [        ]   dart:async/zone.dart 1184:13                                   _rootRun
2020-04-09T12:25:28.964340: stdout: [        ]   dart:async/zone.dart 1077:19                                   _CustomZone.run
stdout: [        ]   package:test_api/src/backend/invoker.dart 286:38               Invoker.heartbeat.<fn>
2020-04-09T12:25:28.964777: stdout: [        ]   package:stack_trace/src/stack_zone_specification.dart 209:15   StackZoneSpecification._run
stdout: [        ]   package:stack_trace/src/stack_zone_specification.dart 119:48   StackZoneSpecification._registerCallback.<fn>
2020-04-09T12:25:28.965189: stdout: [        ]   dart:async/zone.dart 1184:13                                   _rootRun

```

TBR @cyanglaz 