### PR TITLE
[web] Don't collect trace info in the color grid benchmark

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_text_layout.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_text_layout.dart
@@ -215,6 +215,13 @@ class BenchBuildColorsGrid extends WidgetBuildRecorder {
   BenchBuildColorsGrid.canvasKit()
       : mode = _TestMode.useCanvasKit, super(name: canvasKitBenchmarkName);
 
+  /// Disables tracing for this benchmark.
+  ///
+  /// When tracing is enabled, DOM layout takes longer to complete. This has a
+  /// significant effect on the benchmark since we do a lot of text layout
+  /// operations that trigger synchronous DOM layout.
+  ///
+  /// Tracing has a negative effect only in [_TestMode.useDomTextLayout] mode.
   @override
   bool get isTracingEnabled => false;
 

--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_text_layout.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_text_layout.dart
@@ -215,6 +215,9 @@ class BenchBuildColorsGrid extends WidgetBuildRecorder {
   BenchBuildColorsGrid.canvasKit()
       : mode = _TestMode.useCanvasKit, super(name: canvasKitBenchmarkName);
 
+  @override
+  bool get isTracingEnabled => false;
+
   static const String domBenchmarkName = 'text_dom_color_grid';
   static const String canvasBenchmarkName = 'text_canvas_color_grid';
   static const String canvasKitBenchmarkName = 'text_canvas_kit_color_grid';


### PR DESCRIPTION
## Description

The color grid benchmark has regressed since we started collecting trace information from Chrome. In this test, we are focusing on the text layout numbers, so I'm disabling the collection of trace info in this benchmark.

I confirmed locally by disabling trace, we gain back 20%-30% in text layout and frame duration numbers.

## Related Issues

https://github.com/flutter/flutter/issues/54101