### PR TITLE
Added const constructors to widgets A thru M

### DIFF
--- a/packages/flutter/lib/analysis_options_user.yaml
+++ b/packages/flutter/lib/analysis_options_user.yaml
@@ -62,6 +62,8 @@ linter:
     - package_api_docs
     - package_names
     - package_prefixed_library_names
+    - prefer_const_constructors
+    - prefer_const_constructors_in_immutables
     - prefer_is_not_empty
     # - prefer_mixin # https://github.com/dart-lang/language/issues/32
     # - public_member_api_docs

--- a/packages/flutter/lib/analysis_options_user.yaml
+++ b/packages/flutter/lib/analysis_options_user.yaml
@@ -62,8 +62,6 @@ linter:
     - package_api_docs
     - package_names
     - package_prefixed_library_names
-    - prefer_const_constructors
-    - prefer_const_constructors_in_immutables
     - prefer_is_not_empty
     # - prefer_mixin # https://github.com/dart-lang/language/issues/32
     # - public_member_api_docs

--- a/packages/flutter/lib/src/widgets/container.dart
+++ b/packages/flutter/lib/src/widgets/container.dart
@@ -486,7 +486,7 @@ class Container extends StatelessWidget {
 
 /// A clipper that uses [Decoration.getClipPath] to clip.
 class _DecorationClipper extends CustomClipper<Path> {
-  _DecorationClipper({
+  const _DecorationClipper({
     TextDirection textDirection,
     @required this.decoration
   }) : assert (decoration != null),

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -190,7 +190,7 @@ class Dismissible extends StatefulWidget {
 }
 
 class _DismissibleClipper extends CustomClipper<Rect> {
-  _DismissibleClipper({
+  const _DismissibleClipper({
     @required this.axis,
     @required this.moveAnimation,
   }) : assert(axis != null),

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -440,7 +440,7 @@ class DraggableDetails {
   /// If [wasAccepted] is not specified, it will default to `false`.
   ///
   /// The [velocity] or [offset] arguments must not be `null`.
-  DraggableDetails({
+  const DraggableDetails({
     this.wasAccepted = false,
     @required this.velocity,
     @required this.offset,

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -62,7 +62,7 @@ typedef FocusOnKeyCallback = bool Function(FocusNode node, RawKeyEvent event);
 class FocusAttachment {
   /// A private constructor, because [FocusAttachment]s are only to be created
   /// by [FocusNode.attach].
-  FocusAttachment._(this._node) : assert(_node != null);
+  const FocusAttachment._(this._node) : assert(_node != null);
 
   // The focus node that this attachment manages an attachment for. The node may
   // not yet have a parent, or may have been detached from this attachment, so

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -332,7 +332,7 @@ class LabeledGlobalKey<T extends State<StatefulWidget>> extends GlobalKey<T> {
   ///
   /// The label does not affect the key's identity.
   // ignore: prefer_const_constructors_in_immutables , never use const for this class
-  const LabeledGlobalKey(this._debugLabel) : super.constructor();
+  LabeledGlobalKey(this._debugLabel) : super.constructor();
 
   final String _debugLabel;
 
@@ -2045,7 +2045,7 @@ typedef ElementVisitor = void Function(Element element);
 /// [BuildContext] objects are actually [Element] objects. The [BuildContext]
 /// interface is used to discourage direct manipulation of [Element] objects.
 abstract class BuildContext {
-  /// Constant constructor so that if anyone subclasses it, they can be made 
+  /// Constant constructor so that if anyone subclasses it, they can be made
   /// const as well.
   const BuildContext();
   /// The current configuration of the [Element] that is this [BuildContext].

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -332,7 +332,7 @@ class LabeledGlobalKey<T extends State<StatefulWidget>> extends GlobalKey<T> {
   ///
   /// The label does not affect the key's identity.
   // ignore: prefer_const_constructors_in_immutables , never use const for this class
-  LabeledGlobalKey(this._debugLabel) : super.constructor();
+  const LabeledGlobalKey(this._debugLabel) : super.constructor();
 
   final String _debugLabel;
 
@@ -2045,6 +2045,9 @@ typedef ElementVisitor = void Function(Element element);
 /// [BuildContext] objects are actually [Element] objects. The [BuildContext]
 /// interface is used to discourage direct manipulation of [Element] objects.
 abstract class BuildContext {
+  /// Constant constructor so that if anyone subclasses it, they can be made 
+  /// const as well.
+  const BuildContext();
   /// The current configuration of the [Element] that is this [BuildContext].
   Widget get widget;
 
@@ -5969,7 +5972,7 @@ class MultiChildRenderObjectElement extends RenderObjectElement {
 /// message.
 class DebugCreator {
   /// Create a [DebugCreator] instance with input [Element].
-  DebugCreator(this.element);
+  const DebugCreator(this.element);
 
   /// The creator of the [RenderObject].
   final Element element;

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -1116,7 +1116,7 @@ abstract class SemanticsGestureDelegate {
 // Instead, a normal delegate will store callbacks as properties, and use them
 // in `assignSemantics`.
 class _DefaultSemanticsGestureDelegate extends SemanticsGestureDelegate {
-  _DefaultSemanticsGestureDelegate(this.detectorState);
+  const _DefaultSemanticsGestureDelegate(this.detectorState);
 
   final RawGestureDetectorState detectorState;
 

--- a/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
@@ -39,6 +39,9 @@ import 'scrollable.dart';
 ///  * [ListWheelChildBuilderDelegate], a delegate that supplies children using
 ///    a builder callback.
 abstract class ListWheelChildDelegate {
+  /// Const constructor so that if anyone inherits from it, they can make their 
+  /// constructor const also.
+  const ListWheelChildDelegate();
   /// Return the child at the given index. If the child at the given
   /// index does not exist, return null.
   Widget build(BuildContext context, int index);
@@ -82,7 +85,7 @@ abstract class ListWheelChildDelegate {
 /// conditions.
 class ListWheelChildListDelegate extends ListWheelChildDelegate {
   /// Constructs the delegate from a concrete list of children.
-  ListWheelChildListDelegate({@required this.children}) : assert(children != null);
+  const ListWheelChildListDelegate({@required this.children}) : assert(children != null);
 
   /// The list containing all children that can be supplied.
   final List<Widget> children;
@@ -125,7 +128,7 @@ class ListWheelChildListDelegate extends ListWheelChildDelegate {
 /// conditions.
 class ListWheelChildLoopingListDelegate extends ListWheelChildDelegate {
   /// Constructs the delegate from a concrete list of children.
-  ListWheelChildLoopingListDelegate({@required this.children}) : assert(children != null);
+  const ListWheelChildLoopingListDelegate({@required this.children}) : assert(children != null);
 
   /// The list containing all children that can be supplied.
   final List<Widget> children;
@@ -158,7 +161,7 @@ class ListWheelChildLoopingListDelegate extends ListWheelChildDelegate {
 /// not have to be built until they are displayed.
 class ListWheelChildBuilderDelegate extends ListWheelChildDelegate {
   /// Constructs the delegate from a builder callback.
-  ListWheelChildBuilderDelegate({
+  const ListWheelChildBuilderDelegate({
     @required this.builder,
     this.childCount,
   }) : assert(builder != null);

--- a/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
@@ -39,7 +39,7 @@ import 'scrollable.dart';
 ///  * [ListWheelChildBuilderDelegate], a delegate that supplies children using
 ///    a builder callback.
 abstract class ListWheelChildDelegate {
-  /// Const constructor so that if anyone inherits from it, they can make their 
+  /// Const constructor so that if anyone inherits from it, they can make their
   /// constructor const also.
   const ListWheelChildDelegate();
   /// Return the child at the given index. If the child at the given

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -20,7 +20,7 @@ import 'framework.dart';
 // Used by loadAll() to record LocalizationsDelegate.load() futures we're
 // waiting for.
 class _Pending {
-  _Pending(this.delegate, this.futureValue);
+  const _Pending(this.delegate, this.futureValue);
   final LocalizationsDelegate<dynamic> delegate;
   final Future<dynamic> futureValue;
 }
@@ -149,6 +149,9 @@ abstract class LocalizationsDelegate<T> {
 ///  * [DefaultWidgetsLocalizations], which implements this interface and
 ///    supports a variety of locales.
 abstract class WidgetsLocalizations {
+  /// Constructor is constant so that anyone who inherits from this can have
+  /// a const constructor also.
+  const WidgetsLocalizations();
   /// The reading direction for text in this locale.
   TextDirection get textDirection;
 


### PR DESCRIPTION
## Description

Const constructors can help to speed apps up but developers can only create const constructors if the class from which they are inheriting has a const constructor. I added const to certain existing constructors and added const constructors to other classes.

(Thank you to @slightfoot for the idea and guidance).

## Related Issues

#54399 

## Tests

I added the following tests:

* None needed - no new functionality

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
