### PR TITLE
[flutter_tools] attempt to fix benchmark mode test

### DIFF
--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -299,6 +299,9 @@ class HotRunner extends ResidentRunner {
       // Measure time to perform a hot restart.
       globals.printStatus('Benchmarking hot restart');
       await restart(fullRestart: true, benchmarkMode: true);
+      // Wait for notifications to finish. attempt to work around
+      // timing issue caused by sentinel.
+      await Future<void>.delayed(const Duration(seconds: 1));
       globals.printStatus('Benchmarking hot reload');
       // Measure time to perform a hot reload.
       await restart(fullRestart: false);


### PR DESCRIPTION
## Description

It looks like the next reload is still happening too soon and not returning before the vm service cache is updated. try waiting to reduce the flakiness until I can refactor the vm service usage