### PR TITLE
Add null check in TextStyle.apply for TextBaseline

### DIFF
--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -842,7 +842,7 @@ class TextStyle with Diagnosticable {
       fontStyle: fontStyle ?? this.fontStyle,
       letterSpacing: letterSpacing == null ? null : letterSpacing * letterSpacingFactor + letterSpacingDelta,
       wordSpacing: wordSpacing == null ? null : wordSpacing * wordSpacingFactor + wordSpacingDelta,
-      textBaseline: textBaseline,
+      textBaseline: textBaseline ?? this.textBaseline,
       height: height == null ? null : height * heightFactor + heightDelta,
       locale: locale ?? this.locale,
       foreground: foreground,

--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -374,13 +374,13 @@ void main() {
   });
 
   test('TextStyle apply', () {
-    const TextStyle style = TextStyle(fontSize: 10, shadows: const <ui.Shadow>[], fontStyle: FontStyle.normal, fontFeatures: const <ui.FontFeature>[],textBaseline: TextBaseline.alphabetic);
+    const TextStyle style = TextStyle(fontSize: 10, shadows: <ui.Shadow>[], fontStyle: FontStyle.normal, fontFeatures: <ui.FontFeature>[],textBaseline: TextBaseline.alphabetic);
     expect(style.apply().shadows, const <ui.Shadow>[]);
     expect(style.apply(shadows: const <ui.Shadow>[ui.Shadow(blurRadius: 2.0)]).shadows, const <ui.Shadow>[ui.Shadow(blurRadius: 2.0)]);
     expect(style.apply().fontStyle, FontStyle.normal);
     expect(style.apply(fontStyle: FontStyle.italic).fontStyle, FontStyle.italic);
     expect(style.apply().locale, isNull);
-    expect(style.apply(locale: const Locale.fromSubtags(languageCode: 'es')).locale, const Locale.fromSubtags(languageCode: 'es'));
+    expect(style.apply(locale: const Locale.fromSubtags(languageCode: 'es'))c.locale, const Locale.fromSubtags(languageCode: 'es'));
     expect(style.apply().fontFeatures, const <ui.FontFeature>[]);
     expect(style.apply(fontFeatures: const <ui.FontFeature>[ui.FontFeature.enable('test')]).fontFeatures, const <ui.FontFeature>[ui.FontFeature.enable('test')]);
     expect(style.apply().textBaseline, TextBaseline.alphabetic);

--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -374,14 +374,16 @@ void main() {
   });
 
   test('TextStyle apply', () {
-    const TextStyle style = TextStyle(fontSize: 10);
-    expect(style.apply().shadows, isNull);
+    const TextStyle style = TextStyle(fontSize: 10, shadows: const <ui.Shadow>[], fontStyle: FontStyle.normal, fontFeatures: const <ui.FontFeature>[],textBaseline: TextBaseline.alphabetic);
+    expect(style.apply().shadows, const <ui.Shadow>[]);
     expect(style.apply(shadows: const <ui.Shadow>[ui.Shadow(blurRadius: 2.0)]).shadows, const <ui.Shadow>[ui.Shadow(blurRadius: 2.0)]);
-    expect(style.apply().fontStyle, isNull);
+    expect(style.apply().fontStyle, FontStyle.normal);
     expect(style.apply(fontStyle: FontStyle.italic).fontStyle, FontStyle.italic);
     expect(style.apply().locale, isNull);
     expect(style.apply(locale: const Locale.fromSubtags(languageCode: 'es')).locale, const Locale.fromSubtags(languageCode: 'es'));
-    expect(style.apply().fontFeatures, isNull);
+    expect(style.apply().fontFeatures, const <ui.FontFeature>[]);
     expect(style.apply(fontFeatures: const <ui.FontFeature>[ui.FontFeature.enable('test')]).fontFeatures, const <ui.FontFeature>[ui.FontFeature.enable('test')]);
+    expect(style.apply().textBaseline, TextBaseline.alphabetic);
+    expect(style.apply(textBaseline: TextBaseline.ideographic).textBaseline, TextBaseline.ideographic);
   });
 }

--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -374,13 +374,13 @@ void main() {
   });
 
   test('TextStyle apply', () {
-    const TextStyle style = TextStyle(fontSize: 10, shadows: <ui.Shadow>[], fontStyle: FontStyle.normal, fontFeatures: <ui.FontFeature>[],textBaseline: TextBaseline.alphabetic);
+    const TextStyle style = TextStyle(fontSize: 10, shadows: <ui.Shadow>[], fontStyle: FontStyle.normal, fontFeatures: <ui.FontFeature>[], textBaseline: TextBaseline.alphabetic);
     expect(style.apply().shadows, const <ui.Shadow>[]);
     expect(style.apply(shadows: const <ui.Shadow>[ui.Shadow(blurRadius: 2.0)]).shadows, const <ui.Shadow>[ui.Shadow(blurRadius: 2.0)]);
     expect(style.apply().fontStyle, FontStyle.normal);
     expect(style.apply(fontStyle: FontStyle.italic).fontStyle, FontStyle.italic);
     expect(style.apply().locale, isNull);
-    expect(style.apply(locale: const Locale.fromSubtags(languageCode: 'es'))c.locale, const Locale.fromSubtags(languageCode: 'es'));
+    expect(style.apply(locale: const Locale.fromSubtags(languageCode: 'es')).locale, const Locale.fromSubtags(languageCode: 'es'));
     expect(style.apply().fontFeatures, const <ui.FontFeature>[]);
     expect(style.apply(fontFeatures: const <ui.FontFeature>[ui.FontFeature.enable('test')]).fontFeatures, const <ui.FontFeature>[ui.FontFeature.enable('test')]);
     expect(style.apply().textBaseline, TextBaseline.alphabetic);


### PR DESCRIPTION
## Description

This line was missed in https://github.com/flutter/flutter/pull/54305, causing a bug where TextBaseline was being reset to null.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change
