### PR TITLE
Enable gesture recognizer in selectable rich text

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1554,6 +1554,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     if (event is PointerDownEvent) {
       // Checks if there is any gesture recognizer in the text span.
       final Offset offset = entry.localPosition;
+      _layoutText(minWidth: constraints.minWidth, maxWidth: constraints.maxWidth);
       final TextPosition position = _textPainter.getPositionForOffset(offset);
       final InlineSpan span = _textPainter.text.getSpanForPosition(position);
       if (span != null && span is TextSpan) {

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -300,12 +300,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// Whether the [handleEvent] will propagate pointer events to selection
   /// handlers.
   ///
-  /// If this property is true, the [handleEvent] assumed that this renderer
+  /// If this property is true, the [handleEvent] assumes that this renderer
   /// will be notified of input gestures via [handleTapDown], [handleTap],
   /// [handleDoubleTap], and [handleLongPress].
   ///
-  /// If there is any gesture recognizers in the text span, the [handleEvent] will
-  /// still propagate pointer events to those recognizers
+  /// If there are any gesture recognizers in the text span, the [handleEvent]
+  /// will still propagate pointer events to those recognizers
   ///
   /// The default value of this property is false.
   bool ignorePointer;

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -297,9 +297,15 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// Called during the paint phase when the caret location changes.
   CaretChangedHandler onCaretChanged;
 
-  /// If true [handleEvent] does nothing and it's assumed that this
-  /// renderer will be notified of input gestures via [handleTapDown],
-  /// [handleTap], [handleDoubleTap], and [handleLongPress].
+  /// Whether the [handleEvent] will propagate pointer events to selection
+  /// handlers.
+  ///
+  /// If this property is true, the [handleEvent] assumed that this renderer
+  /// will be notified of input gestures via [handleTapDown], [handleTap],
+  /// [handleDoubleTap], and [handleLongPress].
+  ///
+  /// If there is any gesture recognizers in the text span, the [handleEvent] will
+  /// still propagate pointer events to those recognizers
   ///
   /// The default value of this property is false.
   bool ignorePointer;
@@ -1544,12 +1550,20 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   @override
   void handleEvent(PointerEvent event, BoxHitTestEntry entry) {
-    if (ignorePointer)
-      return;
     assert(debugHandleEvent(event, entry));
-    if (event is PointerDownEvent && onSelectionChanged != null) {
-      _tap.addPointer(event);
-      _longPress.addPointer(event);
+    if (event is PointerDownEvent) {
+      // Hit test the text span
+      final Offset offset = entry.localPosition;
+      final TextPosition position = _textPainter.getPositionForOffset(offset);
+      final InlineSpan span = _textPainter.text.getSpanForPosition(position);
+      if (span != null && span is TextSpan) {
+        final TextSpan textSpan = span;
+        textSpan.recognizer?.addPointer(event);
+      }
+      if (!ignorePointer && onSelectionChanged != null) {
+        _tap.addPointer(event);
+        _longPress.addPointer(event);
+      }
     }
   }
 

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1552,7 +1552,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   void handleEvent(PointerEvent event, BoxHitTestEntry entry) {
     assert(debugHandleEvent(event, entry));
     if (event is PointerDownEvent) {
-      // Hit test the text span
+      // Checks if there is any gesture recognizer in the text span.
       final Offset offset = entry.localPosition;
       final TextPosition position = _textPainter.getPositionForOffset(offset);
       final InlineSpan span = _textPainter.text.getSpanForPosition(position);
@@ -1560,7 +1560,9 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
         final TextSpan textSpan = span;
         textSpan.recognizer?.addPointer(event);
       }
+
       if (!ignorePointer && onSelectionChanged != null) {
+        // Propagates the pointer event to selection handlers.
         _tap.addPointer(event);
         _longPress.addPointer(event);
       }

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1552,9 +1552,9 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   void handleEvent(PointerEvent event, BoxHitTestEntry entry) {
     assert(debugHandleEvent(event, entry));
     if (event is PointerDownEvent) {
+      assert(!debugNeedsLayout);
       // Checks if there is any gesture recognizer in the text span.
       final Offset offset = entry.localPosition;
-      _layoutText(minWidth: constraints.minWidth, maxWidth: constraints.maxWidth);
       final TextPosition position = _textPainter.getPositionForOffset(offset);
       final InlineSpan span = _textPainter.text.getSpanForPosition(position);
       if (span != null && span is TextSpan) {

--- a/packages/flutter/test/rendering/editable_gesture_test.dart
+++ b/packages/flutter/test/rendering/editable_gesture_test.dart
@@ -36,6 +36,8 @@ void main() {
       ),
       onSelectionChanged: (_, __, ___) { },
     );
+    editable.layout(BoxConstraints.loose(const Size(1000.0, 1000.0)));
+
     final PipelineOwner owner = PipelineOwner(onNeedVisualUpdate: () { });
     final _PointerRouterSpy spy = GestureBinding.instance.pointerRouter as _PointerRouterSpy;
     editable.attach(owner);

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -3744,7 +3744,7 @@ void main() {
     },
   );
 
-  testWidgets('text span with tap gesture recognizer work in selectable rich text', (WidgetTester tester) async {
+  testWidgets('text span with tap gesture recognizer works in selectable rich text', (WidgetTester tester) async {
     int spyTaps = 0;
     final TapGestureRecognizer spyRecognizer = TapGestureRecognizer()
       ..onTap = () {
@@ -3794,7 +3794,7 @@ void main() {
     expect(spyTaps, 1);
   });
 
-  testWidgets('text span with long press gesture recognizer work in selectable rich text', (WidgetTester tester) async {
+  testWidgets('text span with long press gesture recognizer works in selectable rich text', (WidgetTester tester) async {
     int spyLongPress = 0;
     final LongPressGestureRecognizer spyRecognizer = LongPressGestureRecognizer()
       ..onLongPress = () {

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/gestures.dart' show DragStartBehavior, PointerDeviceKind;
+import 'package:flutter/gestures.dart';
 
 import '../widgets/semantics_tester.dart';
 
@@ -3743,4 +3743,105 @@ void main() {
       expect(editableText.selectionOverlay.handlesAreVisible, isFalse);
     },
   );
+
+  testWidgets('text span with tap gesture recognizer work in selectable rich text', (WidgetTester tester) async {
+    int spyTaps = 0;
+    final TapGestureRecognizer spyRecognizer = TapGestureRecognizer()
+      ..onTap = () {
+        spyTaps += 1;
+      };
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: SelectableText.rich(
+              TextSpan(
+                children: <TextSpan>[
+                  const TextSpan(text: 'Atwater '),
+                  TextSpan(text: 'Peel', recognizer: spyRecognizer),
+                  const TextSpan(text: ' Sherbrooke Bonaventure'),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(spyTaps, 0);
+    final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
+
+    await tester.tapAt(selectableTextStart + const Offset(150.0, 5.0));
+    expect(spyTaps, 1);
+
+    // Waits for a while to avoid double taps.
+    await tester.pump(const Duration(seconds: 1));
+
+    // Starts a long press.
+    final TestGesture gesture =
+      await tester.startGesture(selectableTextStart + const Offset(150.0, 5.0));
+    await tester.pump(const Duration(milliseconds: 500));
+    await gesture.up();
+    await tester.pump();
+    final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
+
+    final TextEditingController controller = editableTextWidget.controller;
+    // Long press still triggers selection.
+    expect(
+      controller.selection,
+      const TextSelection(baseOffset: 8, extentOffset: 12),
+    );
+    // Long press does not trigger gesture recognizer.
+    expect(spyTaps, 1);
+  });
+
+  testWidgets('text span with long press gesture recognizer work in selectable rich text', (WidgetTester tester) async {
+    int spyLongPress = 0;
+    final LongPressGestureRecognizer spyRecognizer = LongPressGestureRecognizer()
+      ..onLongPress = () {
+        spyLongPress += 1;
+      };
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: SelectableText.rich(
+              TextSpan(
+                children: <TextSpan>[
+                  const TextSpan(text: 'Atwater '),
+                  TextSpan(text: 'Peel', recognizer: spyRecognizer),
+                  const TextSpan(text: ' Sherbrooke Bonaventure'),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(spyLongPress, 0);
+    final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
+
+    await tester.tapAt(selectableTextStart + const Offset(150.0, 5.0));
+    expect(spyLongPress, 0);
+
+    // Waits for a while to avoid double taps.
+    await tester.pump(const Duration(seconds: 1));
+
+    // Starts a long press.
+    final TestGesture gesture =
+    await tester.startGesture(selectableTextStart + const Offset(150.0, 5.0));
+    await tester.pump(const Duration(milliseconds: 500));
+    await gesture.up();
+    await tester.pump();
+    final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
+
+    final TextEditingController controller = editableTextWidget.controller;
+    // Long press does not trigger selection if there is text span with long
+    // press recognizer.
+    expect(
+      controller.selection,
+      const TextSelection(baseOffset: 11, extentOffset: 11, affinity: TextAffinity.upstream),
+    );
+    // Long press triggers gesture recognizer.
+    expect(spyLongPress, 1);
+  });
 }


### PR DESCRIPTION
## Description

The gesture recognizer is not wired up in render editable. This pr wires it up.
migration guide https://github.com/flutter/website/pull/3959

## Related Issues

Fixes https://github.com/flutter/flutter/issues/43494

## Tests

I added the following tests:

"text span with tap gesture recognizer works in selectable rich text"
"text span with long press gesture recognizer works in selectable rich text"

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
