### PR TITLE
Make TextFormFieldState.didChange change text fields value

### DIFF
--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -310,6 +310,14 @@ class _TextFormFieldState extends FormFieldState<String> {
   }
 
   @override
+  void didChange(String value) {
+    super.didChange(value);
+
+    if (_effectiveController.text != value)
+      _effectiveController.text = value;
+  }
+
+  @override
   void reset() {
     super.reset();
     setState(() {

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -320,9 +320,7 @@ class _TextFormFieldState extends FormFieldState<String> {
   @override
   void reset() {
     super.reset();
-    setState(() {
-      _effectiveController.text = widget.initialValue;
-    });
+    _effectiveController.text = widget.initialValue;
   }
 
   void _handleControllerChanged() {

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -320,7 +320,9 @@ class _TextFormFieldState extends FormFieldState<String> {
   @override
   void reset() {
     super.reset();
-    _effectiveController.text = widget.initialValue;
+    setState(() {
+      _effectiveController.text = widget.initialValue;
+    });
   }
 
   void _handleControllerChanged() {

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -331,4 +331,26 @@ void main() {
     await tester.pump(const Duration(milliseconds: 300));
     expect(tapCount, 3);
   });
+
+  testWidgets('didChange changes text fields value', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: TextFormField(
+              initialValue: 'initialValue',
+            ),
+          ),
+        ),
+      )
+    );
+
+    expect(find.text('initialValue'), findsOneWidget);
+
+    final FormFieldState<String> state = tester.state<FormFieldState<String>>(find.byType(TextFormField));
+    state.didChange('changedValue');
+
+    expect(find.text('initialValue'), findsNothing);
+    expect(find.text('changedValue'), findsOneWidget);
+  });
 }

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -332,6 +332,28 @@ void main() {
     expect(tapCount, 3);
   });
 
+  testWidgets('reset resets the text fields value to the initialValue', (WidgetTester tester) async {
+    await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Center(
+              child: TextFormField(
+                initialValue: 'initialValue',
+              ),
+            ),
+          ),
+        )
+    );
+
+    await tester.enterText(find.byType(TextFormField), 'changedValue');
+
+    final FormFieldState<String> state = tester.state<FormFieldState<String>>(find.byType(TextFormField));
+    state.reset();
+
+    expect(find.text('changedValue'), findsNothing);
+    expect(find.text('initialValue'), findsOneWidget);
+  });
+
   testWidgets('didChange changes text fields value', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -332,6 +332,7 @@ void main() {
     expect(tapCount, 3);
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/54472.
   testWidgets('reset resets the text fields value to the initialValue', (WidgetTester tester) async {
     await tester.pumpWidget(
         MaterialApp(
@@ -354,6 +355,7 @@ void main() {
     expect(find.text('initialValue'), findsOneWidget);
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/54472.
   testWidgets('didChange changes text fields value', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
## Description

Calling a `TextFormField`s state didChange method currently only updates the internal state of the form field but not the actual value of the underlying text field. This PR makes the didChange method change the internal state as well as the actual text field value.

In addition, this PR removes a unnecessary setState call from the reset method.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/54472

## Tests

I added the following tests:

* A test to ensure that the didChange method updates the text fields value
* A test to ensure that the reset method updates the text fields value to the initialValue

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
