### PR TITLE
Remove Finder extended attributes from iOS project files

### DIFF
--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -22,6 +22,16 @@ import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fake_process_manager.dart';
 
+List<String> _xattrArgs(FlutterProject flutterProject) {
+  return <String>[
+    'xattr',
+    '-r',
+    '-d',
+    'com.apple.FinderInfo',
+    flutterProject.ios.hostAppRoot.path,
+  ];
+}
+
 const List<String> kRunReleaseArgs = <String>[
   '/usr/bin/env',
   'xcrun',
@@ -74,6 +84,7 @@ void main() {
     final FlutterProject flutterProject = FlutterProject.fromDirectory(fileSystem.currentDirectory);
     final BuildableIOSApp buildableIOSApp = BuildableIOSApp(flutterProject.ios, 'flutter');
 
+    processManager.addCommand(FakeCommand(command: _xattrArgs(flutterProject)));
     processManager.addCommand(const FakeCommand(command: kRunReleaseArgs));
     processManager.addCommand(const FakeCommand(command: <String>[...kRunReleaseArgs, '-showBuildSettings']));
     processManager.addCommand(FakeCommand(
@@ -123,6 +134,7 @@ void main() {
       final FlutterProject flutterProject = FlutterProject.fromDirectory(fileSystem.currentDirectory);
       final BuildableIOSApp buildableIOSApp = BuildableIOSApp(flutterProject.ios, 'flutter');
 
+      processManager.addCommand(FakeCommand(command: _xattrArgs(flutterProject)));
       processManager.addCommand(const FakeCommand(command: kRunReleaseArgs));
       // The first showBuildSettings call should timeout.
       processManager.addCommand(
@@ -194,6 +206,7 @@ void main() {
     final FlutterProject flutterProject = FlutterProject.fromDirectory(fileSystem.currentDirectory);
     final BuildableIOSApp buildableIOSApp = BuildableIOSApp(flutterProject.ios, 'flutter');
 
+    processManager.addCommand(FakeCommand(command: _xattrArgs(flutterProject)));
     // The first xcrun call should fail with a
     // concurrent build exception.
     processManager.addCommand(

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -439,7 +439,6 @@ Exited (sigterm)''',
     });
 
     testWithoutContext('removes xattr', () async {
-      bool processRun = false;
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         FakeCommand(command: <String>[
           'xattr',
@@ -447,13 +446,11 @@ Exited (sigterm)''',
           '-d',
           'com.apple.FinderInfo',
           iosProjectDirectory.path,
-        ], onRun: () {
-          processRun = true;
-        })
+        ])
       ]);
 
       await removeFinderExtendedAttributes(iosProjectDirectory, ProcessUtils(processManager: processManager, logger: logger), logger);
-      expect(processRun, isTrue);
+      expect(processManager.hasRemainingExpectations, false);
     });
 
     testWithoutContext('ignores errors', () async {
@@ -470,6 +467,7 @@ Exited (sigterm)''',
 
       await removeFinderExtendedAttributes(iosProjectDirectory, ProcessUtils(processManager: processManager, logger: logger), logger);
       expect(logger.traceText, contains('Failed to remove xattr com.apple.FinderInfo'));
+      expect(processManager.hasRemainingExpectations, false);
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -5,10 +5,12 @@
 import 'dart:async';
 
 import 'package:file/file.dart';
+import 'package:file/memory.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart' show ProcessResult;
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
@@ -426,6 +428,48 @@ Exited (sigterm)''',
         logger.statusText,
         isEmpty,
       );
+    });
+  });
+
+  group('remove Finder extended attributes', () {
+    Directory iosProjectDirectory;
+    setUp(() {
+      final MemoryFileSystem fs = MemoryFileSystem.test();
+      iosProjectDirectory = fs.directory('ios');
+    });
+
+    testWithoutContext('removes xattr', () async {
+      bool processRun = false;
+      final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(command: <String>[
+          'xattr',
+          '-r',
+          '-d',
+          'com.apple.FinderInfo',
+          iosProjectDirectory.path,
+        ], onRun: () {
+          processRun = true;
+        })
+      ]);
+
+      await removeFinderExtendedAttributes(iosProjectDirectory, ProcessUtils(processManager: processManager, logger: logger), logger);
+      expect(processRun, isTrue);
+    });
+
+    testWithoutContext('ignores errors', () async {
+      final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(command: <String>[
+          'xattr',
+          '-r',
+          '-d',
+          'com.apple.FinderInfo',
+          iosProjectDirectory.path,
+        ], exitCode: 1,
+        )
+      ]);
+
+      await removeFinderExtendedAttributes(iosProjectDirectory, ProcessUtils(processManager: processManager, logger: logger), logger);
+      expect(logger.traceText, contains('Failed to remove xattr com.apple.FinderInfo'));
     });
   });
 }


### PR DESCRIPTION
## Description

Remove the `com.apple.FinderInfo` extended attributes from everything in the iOS project before it builds.  This is a speculative fix since I wasn't able to reproduce, but my suspicion is that the xattrs are being added to files in the copied Flutter.framework, which then [can't be code signed](https://developer.apple.com/library/archive/qa/qa1940/_index.html) when it's copied into the Runner.app.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/49290

## Tests

mac_tests

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*