### PR TITLE
[flutter_driver] Reland add SceneDisplayLag stats to timeline summary

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -189,7 +189,6 @@ TaskFunction createColorFilterAndFadePerfTest() {
   ).run;
 }
 
-
 /// Measure application startup performance.
 class StartupTest {
   const StartupTest(this.testDirectory, { this.reportMetrics = true });
@@ -281,6 +280,9 @@ class PerfTest {
         'worst_frame_rasterizer_time_millis',
         '90th_percentile_frame_rasterizer_time_millis',
         '99th_percentile_frame_rasterizer_time_millis',
+        'average_vsync_transitions_missed',
+        '90th_percentile_vsync_transitions_missed',
+        '99th_percentile_vsync_transitions_missed',
         if (needsMeasureCpuGPu) 'cpu_percentage',
         if (needsMeasureCpuGPu) 'gpu_percentage',
       ]);

--- a/packages/flutter_driver/lib/src/driver/scene_display_lag_summarizer.dart
+++ b/packages/flutter_driver/lib/src/driver/scene_display_lag_summarizer.dart
@@ -1,0 +1,82 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'timeline.dart';
+
+/// Key for SceneDisplayLag timeline events.
+const String kSceneDisplayLagEvent = 'SceneDisplayLag';
+
+const String _kVsyncTransitionsMissed = 'vsync_transitions_missed';
+
+/// Returns the [p]-th percentile element from the [doubles].
+///
+/// Note: [doubles] will be sorted.
+double findPercentile(List<double> doubles, double p) {
+  assert(doubles.isNotEmpty);
+  doubles.sort();
+  return doubles[((doubles.length - 1) * (p / 100)).round()];
+}
+
+/// Summarizes [TimelineEvents]s corresponding to [kSceneDisplayLagEvent] events.
+///
+/// A sample event (some fields have been omitted for brewity):
+/// ```
+///     {
+///      "name": "SceneDisplayLag",
+///      "ts": 408920509340,
+///      "ph": "b", (this can be 'b' or 'e' for begin or end)
+///      "args": {
+///        "frame_target_time": "408920509340458",
+///        "current_frame_target_time": "408920542689291",
+///        "vsync_transitions_missed": "2"
+///      }
+///    },
+/// ```
+///
+/// `vsync_transitions_missed` corresponds to the elapsed number of frame budget
+/// durations between when the frame was scheduled to be displayed, i.e, the
+/// `frame_target_time` and the next vsync pulse timestamp, i.e, the
+/// `current_frame_target_time`.
+class SceneDisplayLagSummarizer {
+  /// Creates a SceneDisplayLagSummarizer given the timeline events.
+  SceneDisplayLagSummarizer(this.sceneDisplayLagEvents) {
+    for (final TimelineEvent event in sceneDisplayLagEvents) {
+      assert(event.name == kSceneDisplayLagEvent);
+    }
+  }
+
+  /// The scene display lag events.
+  final List<TimelineEvent> sceneDisplayLagEvents;
+
+  /// Computes the average of the `vsync_transitions_missed` over the lag events.
+  double computeAverageVsyncTransitionsMissed() {
+    if (sceneDisplayLagEvents.isEmpty) {
+      return 0;
+    }
+
+    final double total = sceneDisplayLagEvents
+        .map(_getVsyncTransitionsMissed)
+        .reduce((double a, double b) => a + b);
+    return total / sceneDisplayLagEvents.length;
+  }
+
+  /// The [percentile]-th percentile `vsync_transitions_missed` over the lag events.
+  double computePercentileVsyncTransitionsMissed(double percentile) {
+    if (sceneDisplayLagEvents.isEmpty) {
+      return 0;
+    }
+
+    final List<double> doubles =
+        sceneDisplayLagEvents.map(_getVsyncTransitionsMissed).toList();
+    return findPercentile(doubles, percentile);
+  }
+
+  double _getVsyncTransitionsMissed(TimelineEvent e) {
+    assert(e.name == kSceneDisplayLagEvent);
+    assert(e.arguments.containsKey(_kVsyncTransitionsMissed));
+    final dynamic transitionsMissed = e.arguments[_kVsyncTransitionsMissed];
+    assert(transitionsMissed is String);
+    return double.parse(transitionsMissed as String);
+  }
+}

--- a/packages/flutter_driver/lib/src/driver/timeline_summary.dart
+++ b/packages/flutter_driver/lib/src/driver/timeline_summary.dart
@@ -10,6 +10,7 @@ import 'package:file/file.dart';
 import 'package:path/path.dart' as path;
 
 import 'common.dart';
+import 'scene_display_lag_summarizer.dart';
 import 'timeline.dart';
 
 const JsonEncoder _prettyEncoder = JsonEncoder.withIndent('  ');
@@ -85,6 +86,8 @@ class TimelineSummary {
 
   /// Encodes this summary as JSON.
   Map<String, dynamic> get summaryJson {
+    final SceneDisplayLagSummarizer sceneDisplayLagSummarizer = _sceneDisplayLagSummarizer();
+
     return <String, dynamic>{
       'average_frame_build_time_millis': computeAverageFrameBuildTimeMillis(),
       '90th_percentile_frame_build_time_millis': computePercentileFrameBuildTimeMillis(90.0),
@@ -105,7 +108,10 @@ class TimelineSummary {
         .toList(),
       'frame_begin_times': _extractBeginTimestamps('Frame')
         .map<int>((Duration duration) => duration.inMicroseconds)
-        .toList()
+        .toList(),
+      'average_vsync_transitions_missed': sceneDisplayLagSummarizer.computeAverageVsyncTransitionsMissed(),
+      '90th_percentile_vsync_transitions_missed': sceneDisplayLagSummarizer.computePercentileVsyncTransitionsMissed(90.0),
+      '99th_percentile_vsync_transitions_missed': sceneDisplayLagSummarizer.computePercentileVsyncTransitionsMissed(99.0)
     };
   }
 
@@ -208,9 +214,7 @@ class TimelineSummary {
       throw ArgumentError('durations is empty!');
     assert(percentile >= 0.0 && percentile <= 100.0);
     final List<double> doubles = durations.map<double>((Duration duration) => duration.inMicroseconds.toDouble() / 1000.0).toList();
-    doubles.sort();
-    return doubles[((doubles.length - 1) * (percentile / 100)).round()];
-
+    return findPercentile(doubles, percentile);
   }
 
   double _maxInMillis(Iterable<Duration> durations) {
@@ -220,6 +224,8 @@ class TimelineSummary {
         .map<double>((Duration duration) => duration.inMicroseconds.toDouble() / 1000.0)
         .reduce(math.max);
   }
+
+  SceneDisplayLagSummarizer _sceneDisplayLagSummarizer() => SceneDisplayLagSummarizer(_extractNamedEvents(kSceneDisplayLagEvent));
 
   List<Duration> _extractGpuRasterizerDrawDurations() => _extractBeginEndEvents('GPURasterizer::Draw');
 


### PR DESCRIPTION
This was reverted as commit 50b4c39c5d3de8b7871fa102b87f80e129c5437f.

It caused errors like the following as args are formatted as strings
even if they are number like.

```
020-04-10T12:48:21.910010: stdout:   type 'String' is not a subtype of type 'num' in type cast
2020-04-10T12:48:21.910077: stdout:
2020-04-10T12:48:21.927762: stdout:
package:flutter_driver/src/driver/scene_display_lag_summarizer.dart 78:51
```

This along with the test have been fixed in `timeline_summary_test.dart`