### PR TITLE
[flutter_tools] refactor FlutterManifest to be context-free

### DIFF
--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -128,7 +128,11 @@ class _ManifestAssetBundle implements AssetBundle {
     packagesPath ??= globals.fs.path.absolute(PackageMap.globalPackagesPath);
     FlutterManifest flutterManifest;
     try {
-      flutterManifest = FlutterManifest.createFromPath(manifestPath);
+      flutterManifest = FlutterManifest.createFromPath(
+        manifestPath,
+        logger: globals.logger,
+        fileSystem: globals.fs,
+      );
     } on Exception catch (e) {
       globals.printStatus('Error detected in pubspec.yaml:', emphasis: true);
       globals.printError('$e');
@@ -187,7 +191,11 @@ class _ManifestAssetBundle implements AssetBundle {
       final Uri packageUri = package.packageUriRoot;
       if (packageUri != null && packageUri.scheme == 'file') {
         final String packageManifestPath = globals.fs.path.fromUri(packageUri.resolve('../pubspec.yaml'));
-        final FlutterManifest packageFlutterManifest = FlutterManifest.createFromPath(packageManifestPath);
+        final FlutterManifest packageFlutterManifest = FlutterManifest.createFromPath(
+          packageManifestPath,
+          logger: globals.logger,
+          fileSystem: globals.fs,
+        );
         if (packageFlutterManifest == null) {
           continue;
         }

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -43,7 +43,10 @@ Logger get logger => context.get<Logger>();
 OperatingSystemUtils get os => context.get<OperatingSystemUtils>();
 PersistentToolState get persistentToolState => PersistentToolState.instance;
 Usage get flutterUsage => context.get<Usage>();
-FlutterProjectFactory get projectFactory => context.get<FlutterProjectFactory>() ?? FlutterProjectFactory();
+FlutterProjectFactory get projectFactory => context.get<FlutterProjectFactory>() ?? FlutterProjectFactory(
+  logger: logger,
+  fileSystem: fs,
+);
 
 const FileSystem _kLocalFs = LocalFileSystem();
 

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
@@ -271,6 +271,53 @@ flutter:
     ]));
   });
 
+  testWithoutContext('FlutterManifest.fontsDescriptor combines descriptors from '
+    'individual fonts', () {
+    const String manifest = '''
+name: test
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+  uses-material-design: true
+  fonts:
+    - family: foo
+      fonts:
+        - asset: a/bar
+        - asset: a/bar
+          weight: 400
+          style: italic
+    - family: bar
+      fonts:
+        - asset: a/baz
+        - weight: 400
+          asset: a/baz
+          style: italic
+''';
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
+
+    expect(flutterManifest.fontsDescriptor, <Object>[
+      <String, Object>{
+        'family': 'foo',
+        'fonts': <Object>[
+          <String, Object>{'asset': 'a/bar'},
+          <String, Object>{'weight': 400, 'style': 'italic', 'asset': 'a/bar'},
+        ],
+      },
+      <String, Object>{
+        'family': 'bar',
+        'fonts': <Object>[
+          <String, Object>{'asset': 'a/baz'},
+          <String, Object>{'weight': 400, 'style': 'italic', 'asset': 'a/baz'},
+        ],
+      },
+    ]);
+  });
+
   testWithoutContext('FlutterManifest has only one of two font families when '
     'one declaration is missing the "family" option', () async {
     const String manifest = '''

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
@@ -850,7 +850,7 @@ flutter:
     );
   });
 
-  testWithoutContext('FlutterManifest with MemoryFileSystem', () {
+  testWithoutContext('FlutterManifest can parse manifest on posix filesystem', () {
     const String manifest = '''
 name: test
 dependencies:
@@ -870,7 +870,7 @@ flutter:
     expect(flutterManifest.isEmpty, false);
   });
 
-  testWithoutContext('FlutterManifest can parse manifest on posix filesystem', () {
+  testWithoutContext('FlutterManifest can parse manifest on windows filesystem', () {
     const String manifest = '''
 name: test
 dependencies:

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
@@ -2,54 +2,60 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
-import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/flutter_manifest.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
-import '../src/pubspec_schema.dart';
 
 void main() {
   setUpAll(() {
     Cache.flutterRoot = getFlutterRoot();
   });
 
-  group('FlutterManifest', () {
-    testUsingContext('is empty when the pubspec.yaml file is empty', () async {
-      final FlutterManifest flutterManifest = FlutterManifest.createFromString('');
-      expect(flutterManifest.isEmpty, true);
-      expect(flutterManifest.appName, '');
-      expect(flutterManifest.usesMaterialDesign, false);
-      expect(flutterManifest.fontsDescriptor, isEmpty);
-      expect(flutterManifest.fonts, isEmpty);
-      expect(flutterManifest.assets, isEmpty);
-    });
+  testWithoutContext('FlutterManifest is empty when the pubspec.yaml file is empty', () async {
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      '',
+      logger: logger,
+    );
 
-    test('has no fonts or assets when the "flutter" section is empty', () async {
-      const String manifest = '''
+    expect(flutterManifest.isEmpty, true);
+    expect(flutterManifest.appName, '');
+    expect(flutterManifest.usesMaterialDesign, false);
+    expect(flutterManifest.fontsDescriptor, isEmpty);
+    expect(flutterManifest.fonts, isEmpty);
+    expect(flutterManifest.assets, isEmpty);
+  });
+
+  testWithoutContext('FlutterManifest has no fonts or assets when the "flutter" section is empty', () async {
+    const String manifest = '''
 name: test
 dependencies:
   flutter:
     sdk: flutter
 ''';
-      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
-      expect(flutterManifest, isNotNull);
-      expect(flutterManifest.isEmpty, false);
-      expect(flutterManifest.appName, 'test');
-      expect(flutterManifest.usesMaterialDesign, false);
-      expect(flutterManifest.fontsDescriptor, isEmpty);
-      expect(flutterManifest.fonts, isEmpty);
-      expect(flutterManifest.assets, isEmpty);
-    });
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
 
-    test('knows if material design is used', () async {
-      const String manifest = '''
+    expect(flutterManifest, isNotNull);
+    expect(flutterManifest.isEmpty, false);
+    expect(flutterManifest.appName, 'test');
+    expect(flutterManifest.usesMaterialDesign, false);
+    expect(flutterManifest.fontsDescriptor, isEmpty);
+    expect(flutterManifest.fonts, isEmpty);
+    expect(flutterManifest.assets, isEmpty);
+  });
+
+  testWithoutContext('FlutterManifest knows if material design is used', () async {
+    const String manifest = '''
 name: test
 dependencies:
   flutter:
@@ -57,12 +63,17 @@ dependencies:
 flutter:
   uses-material-design: true
 ''';
-      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
-      expect(flutterManifest.usesMaterialDesign, true);
-    });
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
 
-    test('has two assets', () async {
-      const String manifest = '''
+    expect(flutterManifest.usesMaterialDesign, true);
+  });
+
+  testWithoutContext('FlutterManifest has two assets', () async {
+    const String manifest = '''
 name: test
 dependencies:
   flutter:
@@ -73,14 +84,20 @@ flutter:
     - a/foo
     - a/bar
 ''';
-      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
-      expect(flutterManifest.assets.length, 2);
-      expect(flutterManifest.assets[0], Uri.parse('a/foo'));
-      expect(flutterManifest.assets[1], Uri.parse('a/bar'));
-    });
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
 
-    test('has one font family with one asset', () async {
-      const String manifest = '''
+    expect(flutterManifest.assets, <Uri>[
+      Uri.parse('a/foo'),
+      Uri.parse('a/bar'),
+    ]);
+  });
+
+  testWithoutContext('FlutterManifest has one font family with one asset', () async {
+    const String manifest = '''
 name: test
 dependencies:
   flutter:
@@ -92,24 +109,29 @@ flutter:
       fonts:
         - asset: a/bar
 ''';
-      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
-      final dynamic expectedFontsDescriptor = [{'fonts': [{'asset': 'a/bar'}], 'family': 'foo'}]; // ignore: always_specify_types
-      expect(flutterManifest.fontsDescriptor, expectedFontsDescriptor);
-      final List<Font> fonts = flutterManifest.fonts;
-      expect(fonts.length, 1);
-      final Font font = fonts[0];
-      final dynamic fooFontDescriptor = {'family': 'foo', 'fonts': [{'asset': 'a/bar'}]}; // ignore: always_specify_types
-      expect(font.descriptor, fooFontDescriptor);
-      expect(font.familyName, 'foo');
-      final List<FontAsset> assets = font.fontAssets;
-      expect(assets.length, 1);
-      final FontAsset fontAsset = assets[0];
-      expect(fontAsset.assetUri.path, 'a/bar');
-      expect(fontAsset.weight, isNull);
-      expect(fontAsset.style, isNull);
-    });
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
 
-    test('has one font family with a simple asset and one with weight', () async {
+    expect(flutterManifest.fonts, hasLength(1));
+    expect(flutterManifest.fonts.single, matchesFont(
+      familyName: 'foo',
+      descriptor: <String, Object>{
+        'family': 'foo',
+        'fonts': <Object>[
+          <String, Object>{'asset': 'a/bar'},
+        ],
+      },
+      fontAssets: <Matcher>[
+        matchesFontAsset(assetUri: Uri.parse('a/bar')),
+      ],
+    ));
+  });
+
+  testWithoutContext('FlutterManifest has one font family with a simple asset '
+    'and one with weight', () async {
       const String manifest = '''
 name: test
 dependencies:
@@ -124,29 +146,32 @@ flutter:
         - asset: a/bar
           weight: 400
 ''';
-      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
-      final dynamic expectedFontsDescriptor = [{'fonts': [{'asset': 'a/bar'}, {'weight': 400, 'asset': 'a/bar'}], 'family': 'foo'}]; // ignore: always_specify_types
-      expect(flutterManifest.fontsDescriptor, expectedFontsDescriptor);
-      final List<Font> fonts = flutterManifest.fonts;
-      expect(fonts.length, 1);
-      final Font font = fonts[0];
-      final dynamic fooFontDescriptor = {'family': 'foo', 'fonts': [{'asset': 'a/bar'}, {'weight': 400, 'asset': 'a/bar'}]}; // ignore: always_specify_types
-      expect(font.descriptor, fooFontDescriptor);
-      expect(font.familyName, 'foo');
-      final List<FontAsset> assets = font.fontAssets;
-      expect(assets.length, 2);
-      final FontAsset fontAsset0 = assets[0];
-      expect(fontAsset0.assetUri.path, 'a/bar');
-      expect(fontAsset0.weight, isNull);
-      expect(fontAsset0.style, isNull);
-      final FontAsset fontAsset1 = assets[1];
-      expect(fontAsset1.assetUri.path, 'a/bar');
-      expect(fontAsset1.weight, 400);
-      expect(fontAsset1.style, isNull);
-    });
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
 
-    test('has one font family with a simple asset and one with weight and style', () async {
-      const String manifest = '''
+    expect(flutterManifest.fonts, hasLength(1));
+    expect(flutterManifest.fonts.single, matchesFont(
+      familyName: 'foo',
+      descriptor: <String, Object>{
+        'family': 'foo',
+        'fonts': <Object>[
+          <String, Object>{'asset': 'a/bar'},
+          <String, Object>{'weight': 400, 'asset': 'a/bar'},
+        ],
+      },
+      fontAssets: <Matcher>[
+        matchesFontAsset(assetUri: Uri.parse('a/bar')),
+        matchesFontAsset(assetUri: Uri.parse('a/bar'), weight: 400),
+      ])
+    );
+  });
+
+  testWithoutContext('FlutterManifest has one font family with a simple asset '
+    'and one with weight and style', () {
+    const String manifest = '''
 name: test
 dependencies:
   flutter:
@@ -161,30 +186,32 @@ flutter:
           weight: 400
           style: italic
 ''';
-      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
-      final dynamic expectedFontsDescriptor = [{'fonts': [{'asset': 'a/bar'}, {'style': 'italic', 'weight': 400, 'asset': 'a/bar'}], 'family': 'foo'}]; // ignore: always_specify_types
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
 
-      expect(flutterManifest.fontsDescriptor, expectedFontsDescriptor);
-      final List<Font> fonts = flutterManifest.fonts;
-      expect(fonts.length, 1);
-      final Font font = fonts[0];
-      final dynamic fooFontDescriptor = {'family': 'foo', 'fonts': [{'asset': 'a/bar'}, {'weight': 400, 'style': 'italic', 'asset': 'a/bar'}]}; // ignore: always_specify_types
-      expect(font.descriptor, fooFontDescriptor);
-      expect(font.familyName, 'foo');
-      final List<FontAsset> assets = font.fontAssets;
-      expect(assets.length, 2);
-      final FontAsset fontAsset0 = assets[0];
-      expect(fontAsset0.assetUri.path, 'a/bar');
-      expect(fontAsset0.weight, isNull);
-      expect(fontAsset0.style, isNull);
-      final FontAsset fontAsset1 = assets[1];
-      expect(fontAsset1.assetUri.path, 'a/bar');
-      expect(fontAsset1.weight, 400);
-      expect(fontAsset1.style, 'italic');
-    });
+    expect(flutterManifest.fonts, hasLength(1));
+    expect(flutterManifest.fonts.single, matchesFont(
+      familyName: 'foo',
+      descriptor: <String, Object>{
+        'family': 'foo',
+        'fonts': <Object>[
+          <String, Object>{'asset': 'a/bar'},
+          <String, Object>{'weight': 400, 'style': 'italic', 'asset': 'a/bar'},
+        ],
+      },
+      fontAssets: <Matcher>[
+        matchesFontAsset(assetUri: Uri.parse('a/bar')),
+        matchesFontAsset(assetUri: Uri.parse('a/bar'), weight: 400, style: 'italic'),
+      ],
+    ));
+  });
 
-    test('has two font families, each with one simple asset and one with weight and style', () async {
-      const String manifest = '''
+  testWithoutContext('FlutterManifest has two font families, each with one '
+    'simple asset and one with weight and style', () {
+    const String manifest = '''
 name: test
 dependencies:
   flutter:
@@ -205,48 +232,48 @@ flutter:
           asset: a/baz
           style: italic
 ''';
-      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
-      final dynamic expectedFontsDescriptor = <dynamic>[
-        {'fonts': [{'asset': 'a/bar'}, {'style': 'italic', 'weight': 400, 'asset': 'a/bar'}], 'family': 'foo'}, // ignore: always_specify_types
-        {'fonts': [{'asset': 'a/baz'}, {'style': 'italic', 'weight': 400, 'asset': 'a/baz'}], 'family': 'bar'}, // ignore: always_specify_types
-      ];
-      expect(flutterManifest.fontsDescriptor, expectedFontsDescriptor);
-      final List<Font> fonts = flutterManifest.fonts;
-      expect(fonts.length, 2);
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
 
-      final Font fooFont = fonts[0];
-      final dynamic fooFontDescriptor = {'family': 'foo', 'fonts': [{'asset': 'a/bar'}, {'weight': 400, 'style': 'italic', 'asset': 'a/bar'}]}; // ignore: always_specify_types
-      expect(fooFont.descriptor, fooFontDescriptor);
-      expect(fooFont.familyName, 'foo');
-      final List<FontAsset> fooAassets = fooFont.fontAssets;
-      expect(fooAassets.length, 2);
-      final FontAsset fooFontAsset0 = fooAassets[0];
-      expect(fooFontAsset0.assetUri.path, 'a/bar');
-      expect(fooFontAsset0.weight, isNull);
-      expect(fooFontAsset0.style, isNull);
-      final FontAsset fooFontAsset1 = fooAassets[1];
-      expect(fooFontAsset1.assetUri.path, 'a/bar');
-      expect(fooFontAsset1.weight, 400);
-      expect(fooFontAsset1.style, 'italic');
+    expect(flutterManifest.fonts, hasLength(2));
+    expect(flutterManifest.fonts, containsAll(<Matcher>[
+      matchesFont(
+        familyName: 'foo',
+        descriptor:  <String, Object>{
+          'family': 'foo',
+          'fonts': <Object>[
+            <String, Object>{'asset': 'a/bar'},
+            <String, Object>{'weight': 400, 'style': 'italic', 'asset': 'a/bar'},
+          ],
+        },
+        fontAssets: <Matcher>[
+          matchesFontAsset(assetUri: Uri.parse('a/bar')),
+          matchesFontAsset(assetUri: Uri.parse('a/bar'), weight: 400, style: 'italic'),
+        ],
+      ),
+      matchesFont(
+        familyName: 'bar',
+        descriptor: <String, Object>{
+          'family': 'bar',
+          'fonts': <Object>[
+            <String, Object>{'asset': 'a/baz'},
+            <String, Object>{'weight': 400, 'style': 'italic', 'asset': 'a/baz'},
+          ],
+        },
+        fontAssets: <Matcher>[
+          matchesFontAsset(assetUri: Uri.parse('a/baz')),
+          matchesFontAsset(assetUri: Uri.parse('a/baz'), weight: 400, style: 'italic'),
+        ],
+      ),
+    ]));
+  });
 
-      final Font barFont = fonts[1];
-      const String fontDescriptor = '{family: bar, fonts: [{asset: a/baz}, {weight: 400, style: italic, asset: a/baz}]}'; // ignore: always_specify_types
-      expect(barFont.descriptor.toString(), fontDescriptor);
-      expect(barFont.familyName, 'bar');
-      final List<FontAsset> barAssets = barFont.fontAssets;
-      expect(barAssets.length, 2);
-      final FontAsset barFontAsset0 = barAssets[0];
-      expect(barFontAsset0.assetUri.path, 'a/baz');
-      expect(barFontAsset0.weight, isNull);
-      expect(barFontAsset0.style, isNull);
-      final FontAsset barFontAsset1 = barAssets[1];
-      expect(barFontAsset1.assetUri.path, 'a/baz');
-      expect(barFontAsset1.weight, 400);
-      expect(barFontAsset1.style, 'italic');
-    });
-
-    testUsingContext('has only one of two font families when one declaration is missing the "family" option', () async {
-      const String manifest = '''
+  testWithoutContext('FlutterManifest has only one of two font families when '
+    'one declaration is missing the "family" option', () async {
+    const String manifest = '''
 name: test
 dependencies:
   flutter:
@@ -266,30 +293,34 @@ flutter:
           weight: 400
           style: italic
 ''';
-      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
 
-      final dynamic expectedFontsDescriptor = [{'fonts': [{'asset': 'a/bar'}, {'style': 'italic', 'weight': 400, 'asset': 'a/bar'}], 'family': 'foo'}]; // ignore: always_specify_types
-      expect(flutterManifest.fontsDescriptor, expectedFontsDescriptor);
-      final List<Font> fonts = flutterManifest.fonts;
-      expect(fonts.length, 1);
-      final Font fooFont = fonts[0];
-      final dynamic fooFontDescriptor = {'family': 'foo', 'fonts': [{'asset': 'a/bar'}, {'weight': 400, 'style': 'italic', 'asset': 'a/bar'}]}; // ignore: always_specify_types
-      expect(fooFont.descriptor, fooFontDescriptor);
-      expect(fooFont.familyName, 'foo');
-      final List<FontAsset> fooAassets = fooFont.fontAssets;
-      expect(fooAassets.length, 2);
-      final FontAsset fooFontAsset0 = fooAassets[0];
-      expect(fooFontAsset0.assetUri.path, 'a/bar');
-      expect(fooFontAsset0.weight, isNull);
-      expect(fooFontAsset0.style, isNull);
-      final FontAsset fooFontAsset1 = fooAassets[1];
-      expect(fooFontAsset1.assetUri.path, 'a/bar');
-      expect(fooFontAsset1.weight, 400);
-      expect(fooFontAsset1.style, 'italic');
-    });
+    expect(flutterManifest.fonts, hasLength(1));
+    expect(flutterManifest.fonts, containsAll(<Matcher>[
+      matchesFont(
+        familyName: 'foo',
+        descriptor:  <String, Object>{
+          'family': 'foo',
+          'fonts': <Object>[
+            <String, Object>{'asset': 'a/bar'},
+            <String, Object>{'weight': 400, 'style': 'italic', 'asset': 'a/bar'},
+          ],
+        },
+        fontAssets: <Matcher>[
+          matchesFontAsset(assetUri: Uri.parse('a/bar')),
+          matchesFontAsset(assetUri: Uri.parse('a/bar'), weight: 400, style: 'italic'),
+        ],
+      ),
+    ]));
+  });
 
-    testUsingContext('has only one of two font families when one declaration is missing the "fonts" option', () async {
-      const String manifest = '''
+  testWithoutContext('FlutterManifest has only one of two font families when '
+    'one declaration is missing the "fonts" option', () async {
+    const String manifest = '''
 name: test
 dependencies:
   flutter:
@@ -305,29 +336,34 @@ flutter:
           style: italic
     - family: bar
 ''';
-      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
-      final dynamic expectedFontsDescriptor = [{'fonts': [{'asset': 'a/bar'}, {'style': 'italic', 'weight': 400, 'asset': 'a/bar'}], 'family': 'foo'}]; // ignore: always_specify_types
-      expect(flutterManifest.fontsDescriptor, expectedFontsDescriptor);
-      final List<Font> fonts = flutterManifest.fonts;
-      expect(fonts.length, 1);
-      final Font fooFont = fonts[0];
-      final dynamic fooFontDescriptor = {'family': 'foo', 'fonts': [{'asset': 'a/bar'}, {'weight': 400, 'style': 'italic', 'asset': 'a/bar'}]}; // ignore: always_specify_types
-      expect(fooFont.descriptor, fooFontDescriptor);
-      expect(fooFont.familyName, 'foo');
-      final List<FontAsset> fooAassets = fooFont.fontAssets;
-      expect(fooAassets.length, 2);
-      final FontAsset fooFontAsset0 = fooAassets[0];
-      expect(fooFontAsset0.assetUri.path, 'a/bar');
-      expect(fooFontAsset0.weight, isNull);
-      expect(fooFontAsset0.style, isNull);
-      final FontAsset fooFontAsset1 = fooAassets[1];
-      expect(fooFontAsset1.assetUri.path, 'a/bar');
-      expect(fooFontAsset1.weight, 400);
-      expect(fooFontAsset1.style, 'italic');
-    });
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
 
-    testUsingContext('has no font family when declaration is missing the "asset" option', () async {
-      const String manifest = '''
+    expect(flutterManifest.fonts, hasLength(1));
+    expect(flutterManifest.fonts, containsAll(<Matcher>[
+      matchesFont(
+        familyName: 'foo',
+        descriptor:  <String, Object>{
+          'family': 'foo',
+          'fonts': <Object>[
+            <String, Object>{'asset': 'a/bar'},
+            <String, Object>{'weight': 400, 'style': 'italic', 'asset': 'a/bar'},
+          ],
+        },
+        fontAssets: <Matcher>[
+          matchesFontAsset(assetUri: Uri.parse('a/bar')),
+          matchesFontAsset(assetUri: Uri.parse('a/bar'), weight: 400, style: 'italic'),
+        ],
+      ),
+    ]));
+  });
+
+  testWithoutContext('FlutterManifest has no font family when declaration is '
+    'missing the "asset" option', () async {
+    const String manifest = '''
 name: test
 dependencies:
   flutter:
@@ -339,57 +375,76 @@ flutter:
       fonts:
         - weight: 400
 ''';
-      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
 
-      expect(flutterManifest.fontsDescriptor, <dynamic>[]);
-      final List<Font> fonts = flutterManifest.fonts;
-      expect(fonts.length, 0);
-    });
+    expect(flutterManifest.fontsDescriptor, isEmpty);
+    expect(flutterManifest.fonts, isEmpty);
+  });
 
-    test('allows a blank flutter section', () async {
-      const String manifest = '''
+  testWithoutContext('FlutterManifest allows a blank flutter section', () {
+    const String manifest = '''
 name: test
 dependencies:
   flutter:
     sdk: flutter
 flutter:
 ''';
-      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
-      expect(flutterManifest.isEmpty, false);
-      expect(flutterManifest.isModule, false);
-      expect(flutterManifest.isPlugin, false);
-      expect(flutterManifest.androidPackage, null);
-      expect(flutterManifest.usesAndroidX, false);
-    });
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
 
-    test('allows a module declaration', () async {
-      const String manifest = '''
+    expect(flutterManifest.isEmpty, false);
+    expect(flutterManifest.isModule, false);
+    expect(flutterManifest.isPlugin, false);
+    expect(flutterManifest.androidPackage, null);
+    expect(flutterManifest.usesAndroidX, false);
+  });
+
+  testWithoutContext('FlutterManifest allows a module declaration', () {
+    const String manifest = '''
 name: test
 flutter:
   module:
     androidPackage: com.example
     androidX: true
 ''';
-      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
-      expect(flutterManifest.isModule, true);
-      expect(flutterManifest.androidPackage, 'com.example');
-      expect(flutterManifest.usesAndroidX, true);
-    });
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
 
-    test('allows a legacy plugin declaration', () async {
-      const String manifest = '''
+    expect(flutterManifest.isModule, true);
+    expect(flutterManifest.androidPackage, 'com.example');
+    expect(flutterManifest.usesAndroidX, true);
+  });
+
+  testWithoutContext('FlutterManifest allows a legacy plugin declaration', () {
+    const String manifest = '''
 name: test
 flutter:
   plugin:
     androidPackage: com.example
 ''';
-      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
-      expect(flutterManifest.isPlugin, true);
-      expect(flutterManifest.androidPackage, 'com.example');
-    });
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
 
-    test('allows a multi-plat plugin declaration with android only', () async {
-      const String manifest = '''
+    expect(flutterManifest.isPlugin, true);
+    expect(flutterManifest.androidPackage, 'com.example');
+  });
+
+  testWithoutContext('FlutterManifest allows a multi-plat plugin declaration '
+    'with android only', () {
+    const String manifest = '''
 name: test
 flutter:
     plugin:
@@ -398,13 +453,19 @@ flutter:
           package: com.example
           pluginClass: TestPlugin
 ''';
-      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
-      expect(flutterManifest.isPlugin, true);
-      expect(flutterManifest.androidPackage, 'com.example');
-    });
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
 
-    test('allows a multi-plat plugin declaration with ios only', () async {
-      const String manifest = '''
+    expect(flutterManifest.isPlugin, true);
+    expect(flutterManifest.androidPackage, 'com.example');
+  });
+
+  testWithoutContext('FlutterManifest allows a multi-plat plugin declaration '
+    'with ios only', () {
+    const String manifest = '''
 name: test
 flutter:
     plugin:
@@ -412,37 +473,35 @@ flutter:
         ios:
           pluginClass: HelloPlugin
 ''';
-      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
-      expect(flutterManifest.isPlugin, true);
-      expect(flutterManifest.androidPackage, isNull);
-    });
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
 
-    testUsingContext('handles an invalid plugin declaration', () async {
-      const String manifest = '''
+    expect(flutterManifest.isPlugin, true);
+    expect(flutterManifest.androidPackage, isNull);
+  });
+
+  testUsingContext('FlutterManifest handles an invalid plugin declaration', () {
+    const String manifest = '''
 name: test
 flutter:
     plugin:
 ''';
-      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
-      expect(flutterManifest, null);
-      expect(testLogger.errorText, contains('Expected "plugin" to be an object, but got null'));
-    });
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
 
+    expect(flutterManifest, null);
+    expect(logger.errorText,
+      contains('Expected "plugin" to be an object, but got null'));
+  });
 
-    Future<void> checkManifestVersion({
-      String manifest,
-      String expectedAppVersion,
-      String expectedBuildName,
-      String expectedBuildNumber,
-    }) async {
-      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
-      expect(flutterManifest.appVersion, expectedAppVersion);
-      expect(flutterManifest.buildName, expectedBuildName);
-      expect(flutterManifest.buildNumber, expectedBuildNumber);
-    }
-
-    test('parses major.minor.patch+build version clause 1', () async {
-      const String manifest = '''
+  testWithoutContext('FlutterManifest parses major.minor.patch+build version clause 1', () {
+    const String manifest = '''
 name: test
 version: 1.0.0+2
 dependencies:
@@ -450,16 +509,21 @@ dependencies:
     sdk: flutter
 flutter:
 ''';
-      await checkManifestVersion(
-        manifest: manifest,
-        expectedAppVersion: '1.0.0+2',
-        expectedBuildName: '1.0.0',
-        expectedBuildNumber: '2',
-      );
-    });
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
 
-    test('parses major.minor.patch with no build version', () async {
-      const String manifest = '''
+    expect(flutterManifest, matchesManifest(
+      appVersion: '1.0.0+2',
+      buildName: '1.0.0',
+      buildNumber: '2'),
+    );
+  });
+
+  testWithoutContext('FlutterManifest parses major.minor.patch with no build version', () {
+    const String manifest = '''
 name: test
 version: 0.0.1
 dependencies:
@@ -467,16 +531,21 @@ dependencies:
     sdk: flutter
 flutter:
 ''';
-      await checkManifestVersion(
-        manifest: manifest,
-        expectedAppVersion: '0.0.1',
-        expectedBuildName: '0.0.1',
-        expectedBuildNumber: null,
-      );
-    });
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
 
-    test('parses major.minor.patch+build version clause 2', () async {
-      const String manifest = '''
+    expect(flutterManifest, matchesManifest(
+      appVersion:  '0.0.1',
+      buildName: '0.0.1',
+      buildNumber: null),
+    );
+  });
+
+  testWithoutContext('FlutterManifest parses major.minor.patch+build version clause 2', () {
+    const String manifest = '''
 name: test
 version: 1.0.0-beta+exp.sha.5114f85
 dependencies:
@@ -484,16 +553,21 @@ dependencies:
     sdk: flutter
 flutter:
 ''';
-      await checkManifestVersion(
-        manifest: manifest,
-        expectedAppVersion: '1.0.0-beta+exp.sha.5114f85',
-        expectedBuildName: '1.0.0-beta',
-        expectedBuildNumber: 'exp.sha.5114f85',
-      );
-    });
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
 
-    test('parses major.minor+build version clause', () async {
-      const String manifest = '''
+    expect(flutterManifest, matchesManifest(
+      appVersion: '1.0.0-beta+exp.sha.5114f85',
+      buildName: '1.0.0-beta',
+      buildNumber: 'exp.sha.5114f85'),
+    );
+  });
+
+  testWithoutContext('FlutterManifest parses major.minor+build version clause', () {
+    const String manifest = '''
 name: test
 version: 1.0+2
 dependencies:
@@ -501,16 +575,21 @@ dependencies:
     sdk: flutter
 flutter:
 ''';
-      await checkManifestVersion(
-        manifest: manifest,
-        expectedAppVersion: '1.0+2',
-        expectedBuildName: '1.0',
-        expectedBuildNumber: '2',
-      );
-    });
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
 
-    test('parses empty version clause', () async {
-      const String manifest = '''
+    expect(flutterManifest, matchesManifest(
+      appVersion: '1.0+2',
+      buildName: '1.0',
+      buildNumber: '2'),
+    );
+  });
+
+  testWithoutContext('FlutterManifest parses empty version clause', () {
+    const String manifest = '''
 name: test
 version:
 dependencies:
@@ -518,33 +597,43 @@ dependencies:
     sdk: flutter
 flutter:
 ''';
-      await checkManifestVersion(
-        manifest: manifest,
-        expectedAppVersion: null,
-        expectedBuildName: null,
-        expectedBuildNumber: null,
-      );
-    });
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
 
-    test('parses no version clause', () async {
-      const String manifest = '''
+    expect(flutterManifest, matchesManifest(
+      appVersion: null,
+      buildName: null,
+      buildNumber: null),
+    );
+  });
+
+  testWithoutContext('FlutterManifest parses no version clause', () {
+    const String manifest = '''
 name: test
 dependencies:
   flutter:
     sdk: flutter
 flutter:
 ''';
-      await checkManifestVersion(
-        manifest: manifest,
-        expectedAppVersion: null,
-        expectedBuildName: null,
-        expectedBuildNumber: null,
-      );
-    });
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
+
+    expect(flutterManifest, matchesManifest(
+      appVersion: null,
+      buildName: null,
+      buildNumber: null),
+    );
+  });
 
     // Regression test for https://github.com/flutter/flutter/issues/31764
-    testUsingContext('Returns proper error when font detail is malformed', () async {
-      const String manifest = '''
+  testWithoutContext('FlutterManifest returns proper error when font detail is malformed', () {
+    const String manifest = '''
 name: test
 dependencies:
   flutter:
@@ -555,14 +644,20 @@ flutter:
       fonts:
         -asset: a/bar
 ''';
-      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
 
-      expect(flutterManifest, null);
-      expect(testLogger.errorText, contains('Expected "fonts" to either be null or a list.'));
-    });
+    expect(flutterManifest, null);
+    expect(logger.errorText,
+      contains('Expected "fonts" to either be null or a list.'));
+  });
 
-    testUsingContext('Returns proper error when font detail is not a list of maps', () async {
-      const String manifest = '''
+  testWithoutContext('FlutterManifest returns proper error when font detail is '
+    'not a list of maps', () {
+    const String manifest = '''
 name: test
 dependencies:
   flutter:
@@ -573,14 +668,20 @@ flutter:
       fonts:
         - asset
 ''';
-      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
 
-      expect(flutterManifest, null);
-      expect(testLogger.errorText, contains('Expected "fonts" to be a list of maps.'));
-    });
+    expect(flutterManifest, null);
+    expect(logger.errorText,
+      contains('Expected "fonts" to be a list of maps.'));
+  });
 
-    testUsingContext('Returns proper error when font is a map instead of a list', () async {
-      const String manifest = '''
+  testWithoutContext('FlutterManifest returns proper error when font is a map '
+    'instead of a list', () {
+    const String manifest = '''
 name: test
 dependencies:
   flutter:
@@ -591,14 +692,19 @@ flutter:
     fonts:
       -asset: a/bar
 ''';
-      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
 
-      expect(flutterManifest, null);
-      expect(testLogger.errorText, contains('Expected "fonts" to be a list'));
-    });
+    expect(flutterManifest, null);
+    expect(logger.errorText, contains('Expected "fonts" to be a list'));
+  });
 
-    testUsingContext('Returns proper error when second font family is invalid', () async {
-      const String manifest = '''
+  testWithoutContext('FlutterManifest returns proper error when second font '
+    'family is invalid', () {
+    const String manifest = '''
 name: test
 dependencies:
   flutter:
@@ -611,13 +717,18 @@ flutter:
         - asset: a/bar
     - string
 ''';
-      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
-      expect(flutterManifest, null);
-      expect(testLogger.errorText, contains('Expected a map.'));
-    });
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
 
-    testUsingContext('Does not crash on empty entry', () async {
-      const String manifest = '''
+    expect(flutterManifest, null);
+    expect(logger.errorText, contains('Expected a map.'));
+  });
+
+  testWithoutContext('FlutterManifest does not crash on empty entry', () {
+    const String manifest = '''
 name: test
 dependencies:
   flutter:
@@ -628,15 +739,19 @@ flutter:
     - lib/gallery/example_code.dart
     -
 ''';
-      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
-      final List<Uri> assets = flutterManifest.assets;
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
+    final List<Uri> assets = flutterManifest.assets;
 
-      expect(testLogger.errorText, contains('Asset manifest contains a null or empty uri.'));
-      expect(assets.length, 1);
-    });
+    expect(logger.errorText, contains('Asset manifest contains a null or empty uri.'));
+    expect(assets, hasLength(1));
+  });
 
-    testUsingContext('Special characters in asset URIs', () async {
-      const String manifest = '''
+  testWithoutContext('FlutterManifest handles special characters in asset URIs', () {
+    const String manifest = '''
 name: test
 dependencies:
   flutter:
@@ -648,17 +763,24 @@ flutter:
     - lib/gallery/abc?xyz
     - lib/gallery/aaa bbb
 ''';
-      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
-      final List<Uri> assets = flutterManifest.assets;
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
+    final List<Uri> assets = flutterManifest.assets;
 
-      expect(assets.length, 3);
-      expect(assets[0].path, 'lib/gallery/abc%23xyz');
-      expect(assets[1].path, 'lib/gallery/abc%3Fxyz');
-      expect(assets[2].path, 'lib/gallery/aaa%20bbb');
-    });
+    expect(assets, hasLength(3));
+    expect(assets, <Uri>[
+      Uri.parse('lib/gallery/abc%23xyz'),
+      Uri.parse('lib/gallery/abc%3Fxyz'),
+      Uri.parse('lib/gallery/aaa%20bbb'),
+    ]);
+  });
 
-    testUsingContext('Returns proper error when flutter is a list instead of a map', () async {
-      const String manifest = '''
+  testWithoutContext('FlutterManifest returns proper error when flutter is a '
+    'list instead of a map', () {
+    const String manifest = '''
 name: test
 dependencies:
   flutter:
@@ -666,16 +788,43 @@ dependencies:
 flutter:
   - uses-material-design: true
 ''';
-      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
 
-      expect(flutterManifest, null);
-      expect(testLogger.errorText, contains('Expected "flutter" section to be an object or null, but got [{uses-material-design: true}].'));
-    });
+    expect(flutterManifest, null);
+    expect(logger.errorText,
+      contains(
+        'Expected "flutter" section to be an object or null, but got '
+        '[{uses-material-design: true}].',
+      ),
+    );
   });
 
-  group('FlutterManifest with MemoryFileSystem', () {
-    Future<void> assertSchemaIsReadable() async {
-      const String manifest = '''
+  testWithoutContext('FlutterManifest with MemoryFileSystem', () {
+    const String manifest = '''
+name: test
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+''';
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    fileSystem.file('pubspec.yaml').writeAsStringSync(manifest);
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromPath(
+       'pubspec.yaml',
+      fileSystem: fileSystem,
+      logger: logger,
+    );
+
+    expect(flutterManifest.isEmpty, false);
+  });
+
+  testWithoutContext('FlutterManifest can parse manifest on posix filesystem', () {
+    const String manifest = '''
 name: test
 dependencies:
   flutter:
@@ -683,47 +832,48 @@ dependencies:
 flutter:
 ''';
 
-      final FlutterManifest flutterManifest = FlutterManifest.createFromString(manifest);
-      expect(flutterManifest.isEmpty, false);
-    }
-
-    void testUsingContextAndFs(
-      String description,
-      FileSystem filesystem,
-      dynamic testMethod(),
-    ) {
-      testUsingContext(
-        description,
-        () async {
-          writeEmptySchemaFile(filesystem);
-          testMethod();
-        },
-        overrides: <Type, Generator>{
-          FileSystem: () => filesystem,
-          ProcessManager: () => FakeProcessManager.any(),
-        },
-      );
-    }
-
-    testUsingContext('Validate manifest on original fs', () {
-      assertSchemaIsReadable();
-    });
-
-    testUsingContextAndFs(
-      'Validate manifest on Posix FS',
-      MemoryFileSystem(style: FileSystemStyle.posix),
-      () {
-        assertSchemaIsReadable();
-      },
+    final FileSystem fileSystem = MemoryFileSystem.test(style: FileSystemStyle.windows);
+    fileSystem.file('pubspec.yaml').writeAsStringSync(manifest);
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromPath(
+      'pubspec.yaml',
+      fileSystem: fileSystem,
+      logger: logger,
     );
 
-    testUsingContextAndFs(
-      'Validate manifest on Windows FS',
-      MemoryFileSystem(style: FileSystemStyle.windows),
-      () {
-        assertSchemaIsReadable();
-      },
-    );
-
+    expect(flutterManifest.isEmpty, false);
   });
+}
+
+Matcher matchesManifest({
+  String appVersion,
+  String buildName,
+  String buildNumber,
+}) {
+  return isA<FlutterManifest>()
+    .having((FlutterManifest manifest) => manifest.appVersion, 'appVersion', appVersion)
+    .having((FlutterManifest manifest) => manifest.buildName, 'buildName', buildName)
+    .having((FlutterManifest manifest) => manifest.buildNumber, 'buildNumber', buildNumber);
+}
+
+Matcher matchesFontAsset({
+  Uri assetUri,
+  int weight,
+  String style,
+}) {
+  return isA<FontAsset>()
+    .having((FontAsset fontAsset) => fontAsset.assetUri, 'assetUri', assetUri)
+    .having((FontAsset fontAsset) => fontAsset.weight, 'weight', weight)
+    .having((FontAsset fontAsset) => fontAsset.style, 'style', style);
+}
+
+Matcher matchesFont({
+  Map<String, Object> descriptor,
+  String familyName,
+  List<Matcher> fontAssets,
+}) {
+  return isA<Font>()
+    .having((Font font) => font.descriptor, 'descriptor', descriptor)
+    .having((Font font) => font.familyName, 'familyName', familyName)
+    .having((Font font) => font.fontAssets, 'fontAssets', containsAll(fontAssets));
 }

--- a/packages/flutter_tools/test/general.shard/github_template_test.dart
+++ b/packages/flutter_tools/test/general.shard/github_template_test.dart
@@ -160,7 +160,10 @@ void main() {
           fileSystem: fs,
           logger: logger,
           client: SuccessShortenURLFakeHttpClient(),
-          flutterProjectFactory: FlutterProjectFactory(),
+          flutterProjectFactory: FlutterProjectFactory(
+            fileSystem: fs,
+            logger: logger,
+          ),
         );
         expect(
             await creator.toolCrashIssueTemplateGitHubURL(command, error, stackTrace, doctorText),
@@ -176,7 +179,10 @@ void main() {
           fileSystem: fs,
           logger: logger,
           client: FakeHttpClient(),
-          flutterProjectFactory: FlutterProjectFactory(),
+          flutterProjectFactory: FlutterProjectFactory(
+            fileSystem: fs,
+            logger: logger,
+          ),
         );
         expect(
             await creator.toolCrashIssueTemplateGitHubURL(command, error, stackTrace, doctorText),
@@ -199,7 +205,10 @@ void main() {
           fileSystem: fs,
           logger: logger,
           client: FakeHttpClient(),
-          flutterProjectFactory: FlutterProjectFactory(),
+          flutterProjectFactory: FlutterProjectFactory(
+            fileSystem: fs,
+            logger: logger,
+          ),
         );
         final Directory projectDirectory = fs.currentDirectory;
 

--- a/packages/flutter_tools/test/src/android_common.dart
+++ b/packages/flutter_tools/test/src/android_common.dart
@@ -4,6 +4,7 @@
 
 import 'package:meta/meta.dart';
 
+import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/android/android_builder.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/build_info.dart';
@@ -39,7 +40,11 @@ class FakeAndroidBuilder implements AndroidBuilder {
 /// within [directoryOverride].
 class FakeFlutterProjectFactory extends FlutterProjectFactory {
   FakeFlutterProjectFactory(this.directoryOverride) :
-    assert(directoryOverride != null);
+    assert(directoryOverride != null),
+    super(
+      fileSystem: globals.fs,
+      logger: globals.logger,
+    );
 
   final Directory directoryOverride;
 


### PR DESCRIPTION
## Description

Refactors `FlutterManifest` and `FlutterProjectFactory` to no longer use globals.
Refactors flutter_manifest_test.dart to be more idiomatic and use `testWithoutContext`