### PR TITLE
Revert "[devicelab] Do not wait for connections after process has exited"

### DIFF
--- a/dev/devicelab/test/run_test.dart
+++ b/dev/devicelab/test/run_test.dart
@@ -24,43 +24,43 @@ void main() {
       return scriptProcess;
     }
 
-    Future<void> expectScriptResult(List<String> testNames, { bool expectSuccess }) async {
+    Future<void> expectScriptResult(List<String> testNames, int expectedExitCode) async {
       final ProcessResult result = await runScript(testNames);
-      expect(result.exitCode, expectSuccess ? 0 : isNot(equals(0)),
+      expect(result.exitCode, expectedExitCode,
           reason: '[ stderr from test process ]\n\n${result.stderr}\n\n[ end of stderr ]'
           '\n\n[ stdout from test process ]\n\n${result.stdout}\n\n[ end of stdout ]');
     }
 
     test('exits with code 0 when succeeds', () async {
-      await expectScriptResult(<String>['smoke_test_success'], expectSuccess: true);
+      await expectScriptResult(<String>['smoke_test_success'], 0);
     });
 
     test('accepts file paths', () async {
-      await expectScriptResult(<String>['bin/tasks/smoke_test_success.dart'], expectSuccess: true);
+      await expectScriptResult(<String>['bin/tasks/smoke_test_success.dart'], 0);
     });
 
     test('rejects invalid file paths', () async {
-      await expectScriptResult(<String>['lib/framework/adb.dart'], expectSuccess: false);
+      await expectScriptResult(<String>['lib/framework/adb.dart'], 1);
     });
 
     test('exits with code 1 when task throws', () async {
-      await expectScriptResult(<String>['smoke_test_throws'], expectSuccess: false);
+      await expectScriptResult(<String>['smoke_test_throws'], 1);
     });
 
     test('exits with code 1 when fails', () async {
-      await expectScriptResult(<String>['smoke_test_failure'], expectSuccess: false);
+      await expectScriptResult(<String>['smoke_test_failure'], 1);
     });
 
     test('exits with code 1 when fails to connect', () async {
-      await expectScriptResult(<String>['smoke_test_setup_failure'], expectSuccess: false);
-    });
+      await expectScriptResult(<String>['smoke_test_setup_failure'], 1);
+    }, skip: true); // https://github.com/flutter/flutter/issues/53707
 
     test('exits with code 1 when results are mixed', () async {
       await expectScriptResult(<String>[
           'smoke_test_failure',
           'smoke_test_success',
         ],
-        expectSuccess: false,
+        1,
       );
     });
   });


### PR DESCRIPTION
Reverts flutter/flutter#54497

This change has led to a new flake:

```
01:08 +37 -1: test\run_test.dart: run.dart script exits with code 1 when fails to connect [E]                                                                                                          
  Expected: not <0>
    Actual: <0>
  [ stderr from test process ]
  
  
  
  [ end of stderr ]
  
  [ stdout from test process ]
  
  
  
  â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•¡ â€¢â€¢â€¢ Running task "smoke_test_setup_failure" â€¢â€¢â€¢ â•žâ•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
  
  
  Executing: C:\b\s\w\ir\k\flutter\bin\cache\dart-sdk\bin\dart --enable-vm-service=0 --no-pause-isolates-on-exit bin/tasks/smoke_test_setup_failure.dart in C:\b\s\w\ir\k\flutter\dev\devicelab
  [smoke_test_setup_failure] [STDOUT] Observatory listening on http://127.0.0.1:58612/1bRsp3TbNHI=/
  "C:\b\s\w\ir\k\flutter\bin\cache\dart-sdk\bin\dart" exit code: 0
  
  
  [ end of stdout ]
  
  package:test_api         expect
  test\run_test.dart 29:7  main.<fn>.expectScriptResult
  

01:08 +37 -1: test\run_test.dart: run.dart script exits with code 1 when results are mixed     
```