### PR TITLE
Updated Nested SingleChildScrollView test for clarity

### DIFF
--- a/packages/flutter/test/widgets/single_child_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/single_child_scroll_view_test.dart
@@ -581,9 +581,9 @@ void main() {
                   children: List<Widget>.generate(10, (int y) {
                     return Row(
                       children: children[y] = List<Widget>.generate(10, (int x) {
-                        // nonconst is used below to avoid const constructor and to force a new instance
                         return SizedBox(
-                          height: nonconst(100.0),
+                          key: UniqueKey(),
+                          height: 100.0,
                           width: 100.0,
                         );
                       }),


### PR DESCRIPTION
The original code did correctly force a new SizedBox widget to be created for each test grid cell while avoiding the const widget lint-rule, but it was a little obscure:
```dart
return SizedBox(
  height: nonconst(100.0),
  height: 100.0,
  width: 100.0,
);
```
This PR takes the more conventional approach:
```dart
return SizedBox(
  key: UniqueKey(),
  height: 100.0,
  width: 100.0,
);
```

This PR is a follow-on for https://github.com/flutter/flutter/pull/54394