### PR TITLE
Make Web shard count configurable via WEB_SHARD_COUNT

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,6 +5,7 @@ web_shard_template: &WEB_SHARD_TEMPLATE
   only_if: "changesInclude('.cirrus.yml', 'dev/**', 'packages/flutter/**', 'packages/flutter_test/**', 'packages/flutter_tools/lib/src/test/**', 'packages/flutter_web_plugins/**', 'bin/internal/**') || $CIRRUS_PR == ''"
   environment:
     # As of March 2020, the Web shards needed 16G of RAM and 4 CPUs to run all framework tests with goldens without flaking.
+    WEB_SHARD_COUNT: 8
     CPU: 4
     MEMORY: 16G
     CHROME_NO_SANDBOX: true


### PR DESCRIPTION
## Description

Make Web shard count configurable via the `WEB_SHARD_COUNT` environment variable. This way the engine repo can use a different number of shards from the framework repo.
