### PR TITLE
[flutter_tools] Handle empty gzip file on Windows

### DIFF
--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -362,6 +362,8 @@ class _WindowsUtils extends OperatingSystemUtils {
       return false;
     } on ArchiveException catch (_) {
       return false;
+    } on RangeError catch (_) {
+      return false;
     }
     return true;
   }

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -121,6 +121,7 @@ void main() {
         platform: FakePlatform(operatingSystem: 'windows'),
         processManager: mockProcessManager,
       );
+
       expect(osUtils.verifyGzip(mockFile), isFalse);
     });
 

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -103,6 +103,7 @@ void main() {
         platform: FakePlatform(operatingSystem: 'windows'),
         processManager: mockProcessManager,
       );
+
       expect(osUtils.verifyGzip(mockFile), isFalse);
     });
 

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:typed_data';
+
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/io.dart';
@@ -87,9 +89,61 @@ void main() {
     });
   });
 
+  group('gzip on Windows:', () {
+    testWithoutContext('verifyGzip returns false on a FileSystemException', () {
+      final MockFileSystem fileSystem = MockFileSystem();
+      final MockFile mockFile = MockFile();
+      when(fileSystem.file(any)).thenReturn(mockFile);
+      when(mockFile.readAsBytesSync()).thenThrow(
+        const FileSystemException('error'),
+      );
+      final OperatingSystemUtils osUtils = OperatingSystemUtils(
+        fileSystem: fileSystem,
+        logger: BufferLogger.test(),
+        platform: FakePlatform(operatingSystem: 'windows'),
+        processManager: mockProcessManager,
+      );
+      expect(osUtils.verifyGzip(mockFile), isFalse);
+    });
+
+    testWithoutContext('verifyGzip returns false on an ArchiveException', () {
+      final MockFileSystem fileSystem = MockFileSystem();
+      final MockFile mockFile = MockFile();
+      when(fileSystem.file(any)).thenReturn(mockFile);
+      when(mockFile.readAsBytesSync()).thenReturn(Uint8List.fromList(<int>[
+        // Anything other than the magic header: 0x1f, 0x8b.
+        0x01,
+        0x02,
+      ]));
+      final OperatingSystemUtils osUtils = OperatingSystemUtils(
+        fileSystem: fileSystem,
+        logger: BufferLogger.test(),
+        platform: FakePlatform(operatingSystem: 'windows'),
+        processManager: mockProcessManager,
+      );
+      expect(osUtils.verifyGzip(mockFile), isFalse);
+    });
+
+    testWithoutContext('verifyGzip returns false on an empty file', () {
+      final MockFileSystem fileSystem = MockFileSystem();
+      final MockFile mockFile = MockFile();
+      when(fileSystem.file(any)).thenReturn(mockFile);
+      when(mockFile.readAsBytesSync()).thenReturn(Uint8List(0));
+      final OperatingSystemUtils osUtils = OperatingSystemUtils(
+        fileSystem: fileSystem,
+        logger: BufferLogger.test(),
+        platform: FakePlatform(operatingSystem: 'windows'),
+        processManager: mockProcessManager,
+      );
+      expect(osUtils.verifyGzip(mockFile), isFalse);
+    });
+  });
+
   testWithoutContext('stream compression level', () {
     expect(OperatingSystemUtils.gzipLevel1.level, equals(1));
   });
 }
 
 class MockProcessManager extends Mock implements ProcessManager {}
+class MockFileSystem extends Mock implements FileSystem {}
+class MockFile extends Mock implements File {}

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -135,6 +135,7 @@ void main() {
         platform: FakePlatform(operatingSystem: 'windows'),
         processManager: mockProcessManager,
       );
+
       expect(osUtils.verifyGzip(mockFile), isFalse);
     });
   });


### PR DESCRIPTION
## Description

`GzipDecoder` can throw a `RangeError` on an empty file. Handle like other errors and return false from `OperatingSystemUtils.verifyGzip()` on Windows.

## Related Issues

Second most frequent crash on beta/1.17.0.

## Tests

I added the following tests:

Added tests to os_test.dart.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
