### PR TITLE
[flutter_tools] update coverage collector to use vmservice api

### DIFF
--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -492,6 +492,11 @@ class VMService implements vm_service.VmService {
     _getEventController(streamId).add(event);
   }
 
+  @override
+  Future<vm_service.ScriptList> getScripts(String isolateId) {
+    return _delegateService.getScripts(isolateId);
+  }
+
   /// Reloads the VM.
   Future<void> getVMOld() async => await vm.reload();
 

--- a/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
+++ b/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/test/coverage_collector.dart';
 import 'package:flutter_tools/src/vmservice.dart';
 import 'package:mockito/mockito.dart';
+import 'package:vm_service/vm_service.dart' as vm_service;
 
 import '../src/common.dart';
 
@@ -19,10 +20,8 @@ void main() {
   });
 
   test('Coverage collector Can handle coverage sentinenl data', () async {
-    when(mockVMService.vm.isolates.first.invokeRpcRaw('getScripts', params: anyNamed('params')))
-      .thenAnswer((Invocation invocation) async {
-        return <String, Object>{'type': 'Sentinel', 'kind': 'Collected', 'valueAsString': '<collected>'};
-      });
+    when(mockVMService.getScripts(any))
+      .thenThrow(vm_service.SentinelException.parse('getScripts', <String, Object>{}));
     final Map<String, Object> result = await collect(null, (String predicate) => true, connector: (Uri uri) async {
       return mockVMService;
     });


### PR DESCRIPTION
## Description

Since the update to the vmservice API, the coverage collector's request to getScripts can throw a SentinelException. Previously this code expected sentinels in the form of a sentinel object.

Update the API to the package:vm_service API, and catch the sentinel exception