### PR TITLE
Animation sheet golden test

### DIFF
--- a/packages/flutter_test/lib/flutter_test.dart
+++ b/packages/flutter_test/lib/flutter_test.dart
@@ -57,6 +57,7 @@ export 'src/goldens.dart';
 export 'src/matchers.dart';
 export 'src/nonconst.dart';
 export 'src/platform.dart';
+export 'src/sheet_display.dart';
 export 'src/stack_manipulation.dart';
 export 'src/test_async_utils.dart';
 export 'src/test_compat.dart';

--- a/packages/flutter_test/lib/src/sheet_display.dart
+++ b/packages/flutter_test/lib/src/sheet_display.dart
@@ -7,13 +7,15 @@ import 'package:flutter/widgets.dart';
 
 /// Place `cellNum` number of the target widget in a grid sheet.
 /// 
-/// Each target widget is placed in a cell of size `cellSize`. Cells are placed
-/// from top left to bottom right, horizontal first.
+/// The [SheetDisplay] tries to fill as much space as the parent allows, then
+/// display clones of the target widget in cells of size `cellSize`, placing
+/// cells from top left to bottom right, horizontal first. Cells are keyed from
+/// the tail to the front, meaning new clones are added to the front of the list.
 /// 
-/// Cells are keyed from the tail to the front, meaning new clones are added to
-/// the front of the list.
+/// See also:
 /// 
-/// This class is useful to display the frame-by-frame animation of a widget.
+///  * [WidgetTester.pumpFrames], which is often used together to display the
+///    frame-by-frame animation of a widget in a test.
 class SheetDisplay extends StatelessWidget {
   /// Create an [SheetDisplay] using a fixed `target` widget.
   /// 
@@ -35,9 +37,7 @@ class SheetDisplay extends StatelessWidget {
   /// Should not change throughout the test.
   final Size cellSize;
 
-  /// An increasing integer that starts from 0.
-  /// 
-  /// At the [cellNum]'th frame, [cellNum] clones will be displayed.
+  /// The number of clones to be displayed.
   final int cellNum;
 
   @override

--- a/packages/flutter_test/lib/src/sheet_display.dart
+++ b/packages/flutter_test/lib/src/sheet_display.dart
@@ -1,0 +1,153 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+
+/// Place `cellNum` number of the target widget in a grid sheet.
+/// 
+/// Each target widget is placed in a cell of size `cellSize`. Cells are placed
+/// from top left to bottom right, horizontal first.
+/// 
+/// Cells are keyed from the tail to the front, meaning new clones are added to
+/// the front of the list.
+/// 
+/// This class is useful to display the frame-by-frame animation of a widget.
+class SheetDisplay extends StatelessWidget {
+  /// Create an [SheetDisplay] using a fixed `target` widget.
+  /// 
+  /// The `cellSize` and `frameIndex` are required.
+  const SheetDisplay({
+    Key key,
+    this.target, 
+    @required this.cellSize,
+    @required this.cellNum,
+  }) : assert(cellSize != null),
+       assert(cellNum != null),
+       super(key: key);
+
+  /// The widget to show animation of.
+  final Widget target;
+
+  /// The size of a cell. Should contain a widget.
+  /// 
+  /// Should not change throughout the test.
+  final Size cellSize;
+
+  /// An increasing integer that starts from 0.
+  /// 
+  /// At the [cellNum]'th frame, [cellNum] clones will be displayed.
+  final int cellNum;
+
+  @override
+  Widget build(BuildContext context) {
+    return RepaintBoundary(
+      child: _CellGrid(
+        cellSize: cellSize,
+        children: List<Widget>.generate(cellNum + 1, (int index) {
+          final int i = cellNum - index;
+          return Container(
+            key: ValueKey<int>(i),
+            child: target,
+          );
+        }),
+      )
+    );
+  }
+}
+
+// A grid of fixed-sized cells that are positioned from top left, horizontal-first,
+// until the the entire grid is filled, discarding the remaining children.
+class _CellGrid extends MultiChildRenderObjectWidget {
+  _CellGrid({
+    Key key,
+    @required this.cellSize,
+    List<Widget> children = const <Widget>[],
+  }) : assert(cellSize != null),
+       super(key: key, children: children);
+
+  final Size cellSize;
+
+  @override
+  _RenderCellGrid createRenderObject(BuildContext context) {
+    return _RenderCellGrid(
+      cellSize: cellSize,
+    );
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, covariant _RenderCellGrid renderObject) {
+    renderObject
+      .cellSize = cellSize;
+  }
+}
+
+class _CellGridParentData extends ContainerBoxParentData<RenderBox>{
+}
+
+class _RenderCellGrid extends RenderBox with ContainerRenderObjectMixin<RenderBox, _CellGridParentData>,
+                                             RenderBoxContainerDefaultsMixin<RenderBox, _CellGridParentData> {
+  _RenderCellGrid({
+    List<RenderBox> children,
+    Size cellSize,
+  }) : _cellSize = cellSize {
+    addAll(children);
+  }
+
+  Size get cellSize => _cellSize;
+  Size _cellSize;
+  set cellSize(Size value) {
+    _cellSize = value;
+    markNeedsLayout();
+  }
+
+  int get _columnNum {
+    assert(size != null);
+    return (size.width / cellSize.width).floor();
+  }
+
+  int get _rowNum {
+    assert(size != null);
+    return (size.height / cellSize.height).floor();
+  }
+
+  @override
+  void setupParentData(RenderBox child) {
+    if (child.parentData is! _CellGridParentData)
+      child.parentData = _CellGridParentData();
+  }
+
+  @override
+  void performResize() {
+    size = constraints.biggest;
+    final int maxChildrenNum = _columnNum * _rowNum;
+    int childrenNum = 0;
+    RenderBox child = firstChild;
+    double x = 0;
+    double y = 0;
+    while (child != null && childrenNum < maxChildrenNum) {
+      assert(y + cellSize.height < size.height);
+      assert(x + cellSize.width < size.width);
+      final _CellGridParentData childParentData = child.parentData as _CellGridParentData;
+      child.layout(BoxConstraints.tight(cellSize), parentUsesSize: false);
+      childParentData.offset = Offset(x, y);
+      childrenNum += 1;
+      x += cellSize.width;
+      if (x >= size.width - cellSize.width) {
+        x = 0;
+        y += cellSize.height;
+      }
+      child = childParentData.nextSibling;
+    }
+  }
+
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    defaultPaint(context, offset);
+    return;
+  }
+
+  @override
+  bool get sizedByParent => true;
+}

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -48,6 +48,9 @@ export 'package:test_api/test_api.dart' hide
 /// Signature for callback to [testWidgets] and [benchmarkWidgets].
 typedef WidgetTesterCallback = Future<void> Function(WidgetTester widgetTester);
 
+/// Signature for callback to [WidgetTester.pumpFrames].
+typedef FrameGetter = Widget Function(int frameIndex);
+
 /// Runs the [callback] inside the Flutter test environment.
 ///
 /// Use this function for testing custom [StatelessWidget]s and
@@ -543,6 +546,24 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
         count += 1;
       } while (binding.hasScheduledFrame);
     }).then<int>((_) => count);
+  }
+
+  /// Repeatedly triggers frames with `frameDuration` amount of time in between.
+  Future<void> pumpFrames(
+    FrameGetter getFrame,
+    int frameCount, {
+    Duration frameDuration = const Duration(milliseconds: 16, microseconds: 667),
+  }) {
+    return TestAsyncUtils.guard<void>(() async {
+      for (int currentFrame = 0; currentFrame < frameCount; currentFrame++) {
+        binding.attachRootWidget(getFrame(currentFrame));
+        binding.scheduleFrame();
+        await binding.pump(
+          frameDuration,
+          currentFrame == frameCount - 1 ? EnginePhase.sendSemanticsUpdate : EnginePhase.build,
+        );
+      }
+    });
   }
 
   /// Runs a [callback] that performs real asynchronous work.


### PR DESCRIPTION
## Description

This PR adds support for golden-testing animating widgets in an animation sheet.

The change introduces 2 new APIs:
* `WidgetTester.pumpFrames`, which is like `pump` but pumps a number of frames with the specified interval of `frameDuration` 
* `SheetDisplay`, which places clones of the target widget in a grid, and assign them with keys from the tail to the front

In this way, clones of the widget will be added to the front of the sheet one every frame, so that after a number of frames, the sheet is filled with clones that show each frame of the widget.

Take `CircularProgressionIndicator` as an example. Tests such as follows:

```dart
  testWidgets('Indeterminate CircularProgressIndicator uses expected animation', (WidgetTester tester) async {
    await tester.pumpFrames(
      (int frameIndex) => SheetDisplay(
        cellNum: frameIndex + 1,
        cellSize: const Size(48, 48),
        target: const Padding(
          padding: EdgeInsets.all(4.0),
          child: CircularProgressIndicator(),
        ),
      ),
      16 * 12,
    );

    expect(
      find.byType(SheetDisplay),
      matchesGoldenFile('circular_progress_indicator.grid.png'),
    );
  });
```

Will yield a result as:

![circular_progress_indicator grid](https://user-images.githubusercontent.com/1596656/79032248-d1c6e480-7b59-11ea-9382-9a7f29f95188.png)

## Related Issues

- Blocks https://github.com/flutter/flutter/pull/50412, which needs an animation test
- Affected by https://github.com/flutter/flutter/issues/54511, golden tests yield incorrect result on chrome

## Tests

I added the following tests:

- `pumpFrames`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
