### PR TITLE
[flutter_tools] remove runFromSource, move runInView to vm_service extension

### DIFF
--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -457,14 +457,18 @@ class HotRunner extends ResidentRunner {
 
   Future<void> _launchInView(
     FlutterDevice device,
-    Uri entryUri,
-    Uri packagesUri,
-    Uri assetsDirectoryUri,
-  ) {
-    return Future.wait(<Future<void>>[
+    Uri main,
+    Uri assetsDirectory,
+  ) async {
+    await Future.wait(<Future<void>>[
       for (final FlutterView view in device.views)
-        view.runFromSource(entryUri, assetsDirectoryUri),
+        device.vmService.runInView(
+          viewId: view.id,
+          main: main,
+          assetsDirectory: assetsDirectory,
+        ),
     ]);
+    await device.refreshViews();
   }
 
   Future<void> _launchFromDevFS(String mainScript) async {
@@ -473,12 +477,10 @@ class HotRunner extends ResidentRunner {
     for (final FlutterDevice device in flutterDevices) {
       final Uri deviceEntryUri = device.devFS.baseUri.resolveUri(
         globals.fs.path.toUri(entryUri));
-      final Uri devicePackagesUri = device.devFS.baseUri.resolve('.packages');
       final Uri deviceAssetsDirectoryUri = device.devFS.baseUri.resolveUri(
         globals.fs.path.toUri(getAssetBuildDirectory()));
       futures.add(_launchInView(device,
                           deviceEntryUri,
-                          devicePackagesUri,
                           deviceAssetsDirectoryUri));
     }
     await Future.wait(futures);

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -149,9 +149,6 @@ class VMService implements vm_service.VmService {
     // TODO(jonahwilliams): this is temporary to support the current vm_service
     // semantics of update-in-place.
     secondary.listen((dynamic rawData) {
-      print('!!!');
-      print(rawData);
-      print('!!!');
       final String message = rawData as String;
       final dynamic map = json.decode(message);
       if (map != null && map['method'] == 'streamNotify') {

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -20,6 +20,7 @@ import 'version.dart';
 const String kGetSkSLsMethod = '_flutter.getSkSLs';
 const String kSetAssetBundlePathMethod = '_flutter.setAssetBundlePath';
 const String kFlushUIThreadTasksMethod = '_flutter.flushUIThreadTasks';
+const String kRunInViewMethod = '_flutter.runInView';
 
 /// Override `WebSocketConnector` in [context] to use a different constructor
 /// for [WebSocket]s (used by tests).
@@ -148,6 +149,9 @@ class VMService implements vm_service.VmService {
     // TODO(jonahwilliams): this is temporary to support the current vm_service
     // semantics of update-in-place.
     secondary.listen((dynamic rawData) {
+      print('!!!');
+      print(rawData);
+      print('!!!');
       final String message = rawData as String;
       final dynamic map = json.decode(message);
       if (map != null && map['method'] == 'streamNotify') {
@@ -1068,19 +1072,6 @@ class VM extends ServiceObjectOwner {
     return invokeRpcRaw('_deleteDevFS', params: <String, dynamic>{'fsName': fsName});
   }
 
-  Future<ServiceMap> runInView(
-    String viewId,
-    Uri main,
-    Uri assetsDirectory,
-  ) {
-    return invokeRpc<ServiceMap>('_flutter.runInView',
-      params: <String, dynamic>{
-        'viewId': viewId,
-        'mainScript': main.toString(),
-        'assetDirectory': assetsDirectory.toString(),
-    });
-  }
-
   Future<Map<String, dynamic>> clearVMTimeline() {
     return invokeRpcRaw('clearVMTimeline');
   }
@@ -1518,36 +1509,6 @@ class FlutterView extends ServiceObject {
     _uiIsolate = map['isolate'] as Isolate;
   }
 
-  // TODO(johnmccutchan): Report errors when running failed.
-  Future<void> runFromSource(
-    Uri entryUri,
-    Uri assetsDirectoryUri,
-  ) async {
-    final String viewId = id;
-    // When this completer completes the isolate is running.
-    final Completer<void> completer = Completer<void>();
-    try {
-      await owner.vm.vmService.streamListen('Isolate');
-    } on vm_service.RPCError {
-      // Do nothing, since the tool is already subscribed.
-    }
-    final StreamSubscription<vm_service.Event> subscription =
-      owner.vm.vmService.onIsolateEvent.listen((vm_service.Event event) {
-        if (event.kind == ServiceEvent.kIsolateRunnable) {
-          globals.printTrace('Isolate is runnable.');
-          if (!completer.isCompleted) {
-            completer.complete();
-          }
-        }
-      });
-    await owner.vm.runInView(viewId,
-                             entryUri,
-                             assetsDirectoryUri);
-    await completer.future;
-    await owner.vm.refreshViews(waitForViews: true);
-    await subscription.cancel();
-  }
-
   bool get hasIsolate => _uiIsolate != null;
 
   @override
@@ -1556,6 +1517,7 @@ class FlutterView extends ServiceObject {
 
 /// Flutter specific VM Service functionality.
 extension FlutterVmService on vm_service.VmService {
+
   /// Set the asset directory for the an attached Flutter view.
   Future<void> setAssetDirectory({
     @required Uri assetsDirectory,
@@ -1599,5 +1561,34 @@ extension FlutterVmService on vm_service.VmService {
         'isolateId': uiIsolateId,
       },
     );
+  }
+
+  /// Launch the Dart isolate with entrypoint [main] in the Flutter engine [viewId]
+  /// with [assetsDirectory] as the devFS.
+  ///
+  /// This method is used by the tool to hot restart an already running Flutter
+  /// engine.
+  Future<void> runInView({
+    @required String viewId,
+    @required Uri main,
+    @required Uri assetsDirectory,
+  }) async {
+    try {
+      await streamListen('Isolate');
+    } on vm_service.RPCError {
+      // Do nothing, since the tool is already subscribed.
+    }
+    final Future<void> onRunnable = onIsolateEvent.firstWhere((vm_service.Event event) {
+      return event.kind == vm_service.EventKind.kIsolateRunnable;
+    });
+    await callMethod(
+      kRunInViewMethod,
+      args: <String, Object>{
+        'viewId': viewId,
+        'mainScript': main.toString(),
+        'assetDirectory': assetsDirectory.toString(),
+      },
+    );
+    await onRunnable;
   }
 }

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -88,6 +88,8 @@ void main() {
         invalidatedSourcesCount: 0,
       );
     });
+    // TODO(jonahwilliams): replace mock with FakeVmServiceHost once all methods
+    // are moved to real vm service.
     when(mockFlutterDevice.devFS).thenReturn(mockDevFS);
     when(mockFlutterDevice.views).thenReturn(<FlutterView>[
       mockFlutterView,
@@ -97,11 +99,20 @@ void main() {
     final MockVM mockVM = MockVM();
     when(mockVMService.vm).thenReturn(mockVM);
     when(mockVM.isolates).thenReturn(<Isolate>[mockIsolate]);
-    when(mockVMService.runInView(
-      viewId: anyNamed('viewId'),
-      main: anyNamed('main'),
-      assetsDirectory: anyNamed('assetsDirectory'),
-    )).thenAnswer((Invocation invocation) async {});
+    when(mockVMService.streamListen('Isolate')).thenAnswer((Invocation invocation) async {
+      return vm_service.Success();
+    });
+    when(mockVMService.onIsolateEvent).thenAnswer((Invocation invocation) {
+      return Stream<vm_service.Event>.fromIterable(<vm_service.Event>[
+        vm_service.Event(kind: vm_service.EventKind.kIsolateRunnable, timestamp: 0),
+      ]);
+    });
+    when(mockVMService.callMethod(
+      kRunInViewMethod,
+      args: anyNamed('args'),
+    )).thenAnswer((Invocation invocation) async {
+      return vm_service.Success();
+    });
     when(mockFlutterDevice.stopEchoingDeviceLog()).thenAnswer((Invocation invocation) async { });
     when(mockFlutterDevice.observatoryUris).thenAnswer((_) => Stream<Uri>.value(testUri));
     when(mockFlutterDevice.connect(

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -97,7 +97,11 @@ void main() {
     final MockVM mockVM = MockVM();
     when(mockVMService.vm).thenReturn(mockVM);
     when(mockVM.isolates).thenReturn(<Isolate>[mockIsolate]);
-    when(mockFlutterView.runFromSource(any, any)).thenAnswer((Invocation invocation) async {});
+    when(mockVMService.runInView(
+      viewId: anyNamed('viewId'),
+      main: anyNamed('main'),
+      assetsDirectory: anyNamed('assetsDirectory'),
+    )).thenAnswer((Invocation invocation) async {});
     when(mockFlutterDevice.stopEchoingDeviceLog()).thenAnswer((Invocation invocation) async { });
     when(mockFlutterDevice.observatoryUris).thenAnswer((_) => Stream<Uri>.value(testUri));
     when(mockFlutterDevice.connect(

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -285,15 +285,15 @@ void main() {
   testWithoutContext('runInView forwards arguments correctly', () async {
     final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
       requests: <VmServiceExpectation>[
-        const FakeRequest(method: 'streamListen', id: '1', params: <String, Object>{
+        const FakeVmServiceRequest(method: 'streamListen', id: '1', params: <String, Object>{
           'streamId': 'Isolate'
         }),
-        const FakeRequest(method: kRunInViewMethod, id: '2', params: <String, Object>{
+        const FakeVmServiceRequest(method: kRunInViewMethod, id: '2', params: <String, Object>{
           'viewId': '1234',
           'mainScript': 'main.dart',
           'assetDirectory': 'flutter_assets/',
         }),
-        FakeStreamResponse(
+        FakeVmServiceStreamResponse(
           streamId: 'Isolate',
           event: vm_service.Event(
             kind: vm_service.EventKind.kIsolateRunnable,
@@ -326,11 +326,11 @@ class FakeVmServiceHost {
       if (_requests.isEmpty) {
         throw Exception('Unexpected request: $request');
       }
-      final FakeRequest fakeRequest = _requests.removeAt(0) as FakeRequest;
-      expect(fakeRequest, isA<FakeRequest>()
-        .having((FakeRequest request) => request.method, 'method', request['method'])
-        .having((FakeRequest request) => request.id, 'id', request['id'])
-        .having((FakeRequest request) => request.params, 'params', request['params'])
+      final FakeVmServiceRequest fakeRequest = _requests.removeAt(0) as FakeVmServiceRequest;
+      expect(fakeRequest, isA<FakeVmServiceRequest>()
+        .having((FakeVmServiceRequest request) => request.method, 'method', request['method'])
+        .having((FakeVmServiceRequest request) => request.id, 'id', request['id'])
+        .having((FakeVmServiceRequest request) => request.params, 'params', request['params'])
       );
       _input.add(json.encode(<String, Object>{
         'jsonrpc': '2.0',
@@ -354,7 +354,7 @@ class FakeVmServiceHost {
   // or until we hit a FakeRequest
   void _applyStreamListen() {
     while (_requests.isNotEmpty && !_requests.first.isRequest) {
-      final FakeStreamResponse response = _requests.removeAt(0) as FakeStreamResponse;
+      final FakeVmServiceStreamResponse response = _requests.removeAt(0) as FakeVmServiceStreamResponse;
       _input.add(json.encode(<String, Object>{
         'jsonrpc': '2.0',
         'method': 'streamNotify',
@@ -371,8 +371,8 @@ abstract class VmServiceExpectation {
   bool get isRequest;
 }
 
-class FakeRequest implements VmServiceExpectation {
-  const FakeRequest({
+class FakeVmServiceRequest implements VmServiceExpectation {
+  const FakeVmServiceRequest({
     @required this.method,
     @required this.id,
     @required this.params,
@@ -388,8 +388,8 @@ class FakeRequest implements VmServiceExpectation {
   bool get isRequest => true;
 }
 
-class FakeStreamResponse implements VmServiceExpectation {
-  const FakeStreamResponse({
+class FakeVmServiceStreamResponse implements VmServiceExpectation {
+  const FakeVmServiceStreamResponse({
     @required this.event,
     @required this.streamId,
   });
@@ -400,7 +400,6 @@ class FakeStreamResponse implements VmServiceExpectation {
   @override
   bool get isRequest => false;
 }
-
 
 class MockDevice extends Mock implements Device {}
 class MockVMService extends Mock implements vm_service.VmService {}


### PR DESCRIPTION
## Description

Remove runFromSource, which is just a wrapper
Move runInView to the vmService extension
Remove unused reference to .packages file

## Related Issues

Work towards https://github.com/flutter/flutter/issues/52179

## Tests

I added a new test helper for dealing with the vmservice. It is based on the FakeProcessManager, but is a tad more complex due to streamNotify, essentially responses without a corresponding request.