### PR TITLE
[flutter_tools] support any as a special web-hostname

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
@@ -136,7 +136,12 @@ class WebAssetServer implements AssetReader {
     DwdsLauncher dwdsLauncher = Dwds.start,
   }) async {
     try {
-      final InternetAddress address = (await InternetAddress.lookup(hostname)).first;
+      InternetAddress address;
+      if (hostname == 'any') {
+        address = InternetAddress.anyIPv4;
+      } else {
+        address = (await InternetAddress.lookup(hostname)).first;
+      }
       final HttpServer httpServer = await HttpServer.bind(address, port);
       final PackageConfig packageConfig = await loadPackageConfigUri(
         globals.fs.file(PackageMap.globalPackagesPath).absolute.uri,
@@ -634,7 +639,11 @@ class WebDevFS implements DevFS {
       expressionCompiler,
       testMode: testMode,
     );
-    _baseUri = Uri.parse('http://$hostname:$port');
+    if (hostname == 'any') {
+      _baseUri = Uri.http('localhost:$port', '');
+    } else {
+      _baseUri = Uri.http('$hostname:$port', '');
+    }
     return _baseUri;
   }
 

--- a/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
@@ -216,6 +216,7 @@ class WebAssetServer implements AssetReader {
           final Chrome chrome = await ChromeLauncher.connectedInstance;
           return chrome.chromeConnection;
         },
+        hostname: hostname,
         urlEncoder: urlTunneller,
         enableDebugging: true,
         useSseForDebugProxy: useSseForDebugProxy,

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -159,7 +159,11 @@ abstract class FlutterCommand extends Command<void> {
   void usesWebOptions({ bool hide = true }) {
     argParser.addOption('web-hostname',
       defaultsTo: 'localhost',
-      help: 'The hostname to serve web application on.',
+      help:
+        'The hostname that the web sever will use to resolve an IP to serve '
+        'from. The unresolved hostname is used to launch Chrome when using '
+        'the chrome Device. The name "any" may also be used to server on any '
+        'IPV4 for either the Chrome or web-server device.',
       hide: hide,
     );
     argParser.addOption('web-port',

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -162,7 +162,7 @@ abstract class FlutterCommand extends Command<void> {
       help:
         'The hostname that the web sever will use to resolve an IP to serve '
         'from. The unresolved hostname is used to launch Chrome when using '
-        'the chrome Device. The name "any" may also be used to server on any '
+        'the chrome Device. The name "any" may also be used to serve on any '
         'IPV4 for either the Chrome or web-server device.',
       hide: hide,
     );

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -481,7 +481,7 @@ void main() {
   test('Launches DWDS with the correct arguments', () => testbed.run(() async {
     globals.fs.file('.packages').writeAsStringSync('\n');
     final WebAssetServer server = await WebAssetServer.start(
-      'localhost',
+      'any',
       8123,
       (String url) => null,
       true,
@@ -509,6 +509,7 @@ void main() {
         expect(enableDebugging, true);
         expect(enableDebugExtension, true);
         expect(useSseForDebugProxy, true);
+        expect(hostname, 'any');
 
         return MockDwds();
       });

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -380,7 +380,7 @@ void main() {
     webDevFS.requireJS.createSync(recursive: true);
     webDevFS.stackTraceMapper.createSync(recursive: true);
 
-    await webDevFS.create();
+    final Uri uri = await webDevFS.create();
     webDevFS.webAssetServer.entrypointCacheDirectory = globals.fs.currentDirectory;
     globals.fs.currentDirectory
       .childDirectory('lib')
@@ -432,6 +432,49 @@ void main() {
     expect(await webDevFS.webAssetServer.dartSourceContents('web_entrypoint.dart'),
       contains('GENERATED'));
 
+    // served on localhost
+    expect(uri, Uri.http('localhost:0', ''));
+
+    await webDevFS.destroy();
+  }));
+
+  test('Can start web server with hostname any', () => testbed.run(() async {
+    globals.fs.file('.packages').writeAsStringSync('\n');
+    final File outputFile = globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
+      ..createSync(recursive: true);
+    outputFile.parent.childFile('a.sources').writeAsStringSync('');
+    outputFile.parent.childFile('a.json').writeAsStringSync('{}');
+    outputFile.parent.childFile('a.map').writeAsStringSync('{}');
+    outputFile.parent.childFile('.packages').writeAsStringSync('\n');
+
+    final ResidentCompiler residentCompiler = MockResidentCompiler();
+    when(residentCompiler.recompile(
+      any,
+      any,
+      outputPath: anyNamed('outputPath'),
+      packagesFilePath: anyNamed('packagesFilePath'),
+    )).thenAnswer((Invocation invocation) async {
+      return const CompilerOutput('a', 0, <Uri>[]);
+    });
+
+    final WebDevFS webDevFS = WebDevFS(
+      hostname: 'any',
+      port: 0,
+      packagesFilePath: '.packages',
+      urlTunneller: null,
+      useSseForDebugProxy: true,
+      buildMode: BuildMode.debug,
+      enableDwds: false,
+      entrypoint: Uri.base,
+      testMode: true,
+      expressionCompiler: null,
+    );
+    webDevFS.requireJS.createSync(recursive: true);
+    webDevFS.stackTraceMapper.createSync(recursive: true);
+
+    final Uri uri = await webDevFS.create();
+
+    expect(uri, Uri.http('localhost:0', ''));
     await webDevFS.destroy();
   }));
 


### PR DESCRIPTION
## Description

When "any" is provided as a --web-hostname, serve the app on anyipv4. Ensure that any is not used as a hostname when spawning chrome.

fyi @DanTup 