### PR TITLE
[flutter_driver] Fix browser check

### DIFF
--- a/packages/flutter_driver/lib/src/driver/driver.dart
+++ b/packages/flutter_driver/lib/src/driver/driver.dart
@@ -167,7 +167,7 @@ abstract class FlutterDriver {
   ///
   ///  * [VMServiceFlutterDriver], which uses vmservice to implement.
   ///  * [WebFlutterDriver], which uses webdriver to implement.
-  Future<Map<String, dynamic>> sendCommand(Command command) => throw UnimplementedError();
+  Future<Map<String, dynamic>> sendCommand(Command command) async => throw UnimplementedError();
 
   /// Checks the status of the Flutter Driver extension.
   Future<Health> checkHealth({ Duration timeout }) async {
@@ -560,7 +560,7 @@ abstract class FlutterDriver {
   ///        In practice, sometimes the device gets really busy for a while and
   ///        even two seconds isn't enough, which means that this is still racy
   ///        and a source of flakes.
-  Future<List<int>> screenshot() {
+  Future<List<int>> screenshot() async {
     throw UnimplementedError();
   }
 
@@ -585,7 +585,7 @@ abstract class FlutterDriver {
   /// [getFlagList]: https://github.com/dart-lang/sdk/blob/master/runtime/vm/service/service.md#getflaglist
   ///
   /// Throws [UnimplementedError] on [WebFlutterDriver] instances.
-  Future<List<Map<String, dynamic>>> getVmFlags() {
+  Future<List<Map<String, dynamic>>> getVmFlags() async {
     throw UnimplementedError();
   }
   /// Starts recording performance traces.
@@ -598,7 +598,7 @@ abstract class FlutterDriver {
   Future<void> startTracing({
     List<TimelineStream> streams = const <TimelineStream>[TimelineStream.all],
     Duration timeout = kUnusuallyLongTimeout,
-  }) {
+  }) async {
     throw UnimplementedError();
   }
 
@@ -611,7 +611,7 @@ abstract class FlutterDriver {
   /// For [WebFlutterDriver], this is only supported for Chrome.
   Future<Timeline> stopTracingAndDownloadTimeline({
     Duration timeout = kUnusuallyLongTimeout,
-  }) {
+  }) async {
     throw UnimplementedError();
   }
   /// Runs [action] and outputs a performance trace for it.
@@ -637,7 +637,7 @@ abstract class FlutterDriver {
     Future<dynamic> action(), {
     List<TimelineStream> streams = const <TimelineStream>[TimelineStream.all],
     bool retainPriorEvents = false,
-  }) {
+  }) async {
     throw UnimplementedError();
   }
 
@@ -650,7 +650,7 @@ abstract class FlutterDriver {
   /// For [WebFlutterDriver], this is only supported for Chrome.
   Future<void> clearTimeline({
     Duration timeout = kUnusuallyLongTimeout,
-  }) {
+  }) async {
     throw UnimplementedError();
   }
   /// [action] will be executed with the frame sync mechanism disabled.
@@ -683,14 +683,14 @@ abstract class FlutterDriver {
   /// Force a garbage collection run in the VM.
   ///
   /// Throws [UnimplementedError] on [WebFlutterDriver] instances.
-  Future<void> forceGC() {
+  Future<void> forceGC() async {
     throw UnimplementedError();
   }
 
   /// Closes the underlying connection to the VM service.
   ///
   /// Returns a [Future] that fires once the connection has been closed.
-  Future<void> close() {
+  Future<void> close() async {
     throw UnimplementedError();
   }
 }

--- a/packages/flutter_driver/lib/src/driver/web_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/web_driver.dart
@@ -154,7 +154,7 @@ class WebFlutterDriver extends FlutterDriver {
 
   /// Checks whether browser supports Timeline related operations
   void _checkBrowserSupportsTimeline() {
-    if (_connection.supportsTimelineAction) {
+    if (!_connection.supportsTimelineAction) {
       throw UnsupportedError('Timeline action is not supported by current testing browser');
     }
   }
@@ -164,22 +164,12 @@ class WebFlutterDriver extends FlutterDriver {
 class FlutterWebConnection {
   /// Creates a FlutterWebConnection with WebDriver
   /// and whether the WebDriver supports timeline action
-  FlutterWebConnection(this._driver, this._supportsTimelineAction);
+  FlutterWebConnection(this._driver, this.supportsTimelineAction);
 
   final async_io.WebDriver _driver;
 
-
-  bool _supportsTimelineAction;
   /// Whether the connected WebDriver supports timeline action for Flutter Web Driver
-  // ignore: unnecessary_getters_setters
-  bool get supportsTimelineAction => _supportsTimelineAction;
-
-  /// Setter for _supportsTimelineAction
-  @visibleForTesting
-  // ignore: unnecessary_getters_setters
-  set supportsTimelineAction(bool value) {
-    _supportsTimelineAction = value;
-  }
+  bool supportsTimelineAction;
 
   /// Starts WebDriver with the given [settings] and
   /// establishes the connection to Flutter Web application.

--- a/packages/flutter_driver/test/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/flutter_driver_test.dart
@@ -693,7 +693,7 @@ void main() {
 
     setUp(() {
       mockConnection = MockFlutterWebConnection();
-      mockConnection.supportsTimelineAction = true;
+      when(mockConnection.supportsTimelineAction).thenReturn(true);
       driver = WebFlutterDriver.connectedTo(mockConnection);
     });
 
@@ -1033,19 +1033,19 @@ void main() {
 
     setUp(() {
       mockConnection = MockFlutterWebConnection();
-      mockConnection.supportsTimelineAction = false;
+      when(mockConnection.supportsTimelineAction).thenReturn(false);
       driver = WebFlutterDriver.connectedTo(mockConnection);
     });
 
     test('tracing', () async {
       expect(driver.traceAction(() async { return Future<dynamic>.value(); }),
-          throwsA(isA<UnimplementedError>()));
+          throwsA(isA<UnsupportedError>()));
       expect(driver.startTracing(),
-          throwsA(isA<UnimplementedError>()));
+          throwsA(isA<UnsupportedError>()));
       expect(driver.stopTracingAndDownloadTimeline(),
-          throwsA(isA<UnimplementedError>()));
+          throwsA(isA<UnsupportedError>()));
       expect(driver.clearTimeline(),
-          throwsA(isA<UnimplementedError>()));
+          throwsA(isA<UnsupportedError>()));
     });
   });
 }


### PR DESCRIPTION
## Description

Currently, using Timeline actions with a web driver (using Chrome) throws an error.

This PR
- Fixes _checkBrowserSupportsTimeline by returning the correct value
- Marks async driver methods (this fixes a couple of tests)

## Tests

Fixed existing tests. Apart from those fixed, existing failing tests are still failing.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*


<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
