### PR TITLE
[flutter_tools] dont suppress analytics from re-entrant macos build

### DIFF
--- a/packages/flutter_tools/bin/macos_assemble.sh
+++ b/packages/flutter_tools/bin/macos_assemble.sh
@@ -72,7 +72,7 @@ if [[ -n "$DART_OBFUSCATION" ]]; then
   dart_obfuscation_flag="true"
 fi
 
-RunCommand "${FLUTTER_ROOT}/bin/flutter" --suppress-analytics               \
+RunCommand "${FLUTTER_ROOT}/bin/flutter"                                    \
     ${verbose_flag}                                                         \
     ${flutter_engine_flag}                                                  \
     ${local_engine_flag}                                                    \


### PR DESCRIPTION
## Description

We don't suppress this in Android or iOS, don't do it for macOS.