### PR TITLE
[flutter_tools] Provide global options with subcommand help text

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -845,6 +845,23 @@ abstract class FlutterCommand extends Command<void> {
     }
   }
 
+  @override
+  String get usage {
+    final String usageWithoutDescription = super.usage.substring(
+      // The description plus two newlines.
+      description.length + 2,
+    );
+    final String help = <String>[
+      description,
+      '',
+      'Global options:',
+      runner.argParser.usage,
+      '',
+      usageWithoutDescription,
+    ].join('\n');
+    return help;
+  }
+
   ApplicationPackageStore applicationPackages;
 
   /// Gets the parsed command-line option named [name] as `bool`.

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -42,6 +42,12 @@ void main() {
       when(mockProcessInfo.maxRss).thenReturn(10);
     });
 
+    testUsingContext('help text contains global options', () {
+      final FakeCommand fake = FakeCommand();
+      createTestCommandRunner(fake);
+      expect(fake.usage, contains('Global options:\n'));
+    });
+
     testUsingContext('honors shouldUpdateCache false', () async {
       final DummyFlutterCommand flutterCommand = DummyFlutterCommand(shouldUpdateCache: false);
       await flutterCommand.run();
@@ -423,10 +429,9 @@ void main() {
   });
 }
 
-
 class FakeCommand extends FlutterCommand {
   @override
-  String get description => null;
+  String get description => 'A fake command';
 
   @override
   String get name => 'fake';


### PR DESCRIPTION
## Description

E.g.
```
$ flutter run --help
Run your Flutter app on an attached device.

Global options:
-h, --help                  Print this usage information.
-v, --verbose               Noisy logging, including all shell commands executed.
                            If used with --help, shows hidden options.
-d, --device-id             Target device id or name (prefixes allowed).
    --version               Reports the version of this tool.
    --suppress-analytics    Suppress analytics reporting when this command runs.

Usage: flutter run [arguments]
-h, --help                                            Print this usage information.
    --debug                                           Build a debug version of your app (default mode).
    --profile                                         Build a version of your app specialized for performance profiling.
    --release                                         Build a release version of your app.
...
```

## Related Issues

https://github.com/flutter/flutter/issues/10253
https://github.com/flutter/flutter/issues/43191

## Tests

I added the following tests:

A new test in flutter_command_test.dart

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
