### PR TITLE
flutter_tools: Move _informUserOfCrash into the CrashReportSender class

### DIFF
--- a/packages/flutter_tools/lib/src/reporting/reporting.dart
+++ b/packages/flutter_tools/lib/src/reporting/reporting.dart
@@ -10,14 +10,19 @@ import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 import 'package:usage/usage_io.dart';
 
+import '../base/context.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
+import '../base/logger.dart';
+import '../base/net.dart';
 import '../base/time.dart';
 import '../doctor.dart';
 import '../features.dart';
 import '../globals.dart' as globals;
 import '../runner/flutter_command.dart';
 import '../version.dart';
+
+import 'github_template.dart';
 
 part 'crash_reporting.dart';
 part 'disabled_usage.dart';

--- a/packages/flutter_tools/test/general.shard/crash_reporting_test.dart
+++ b/packages/flutter_tools/test/general.shard/crash_reporting_test.dart
@@ -32,13 +32,13 @@ void main() {
     });
 
     setUp(() async {
-      tools.crashFileSystem = MemoryFileSystem();
+      CrashReportSender.crashFileSystem = MemoryFileSystem();
       setExitFunctionForTests((_) { });
       MockCrashReportSender.sendCalls = 0;
     });
 
     tearDown(() {
-      tools.crashFileSystem = const LocalFileSystem();
+      CrashReportSender.crashFileSystem = const LocalFileSystem();
       restoreExitFunction();
     });
 
@@ -264,7 +264,7 @@ Future<void> verifyCrashReportSent(RequestInfo crashInfo, {
 
   // Verify that we've written the crash report to disk.
   final List<String> writtenFiles =
-  (await tools.crashFileSystem.directory('/').list(recursive: true).toList())
+    CrashReportSender.crashFileSystem.directory('/').listSync(recursive: true)
       .map((FileSystemEntity e) => e.path).toList();
   expect(writtenFiles, hasLength(crashes));
   expect(writtenFiles, contains('flutter_01.log'));

--- a/packages/flutter_tools/test/general.shard/runner/runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/runner_test.dart
@@ -25,7 +25,7 @@ void main() {
     MockGitHubTemplateCreator mockGitHubTemplateCreator;
     setUp(() {
       mockGitHubTemplateCreator = MockGitHubTemplateCreator();
-      runner.crashFileSystem = MemoryFileSystem();
+      CrashReportSender.crashFileSystem = MemoryFileSystem();
       // Instead of exiting with dart:io exit(), this causes an exception to
       // be thrown, which we catch with the onError callback in the zone below.
       io.setExitFunctionForTests((int _) { throw 'test exit';});
@@ -33,7 +33,7 @@ void main() {
     });
 
     tearDown(() {
-      runner.crashFileSystem = const LocalFileSystem();
+      CrashReportSender.crashFileSystem = const LocalFileSystem();
       io.restoreExitFunction();
       Cache.enableLocking();
     });


### PR DESCRIPTION
I intend to override `_informUserOfCrash` in google3.  Move it to
`CrashReportSender` and make it public in preparation for this.

This change is almost entirely code motion.  The only changes to the
moved code are:
* Rename `_informUserOfCrash` to `informUserOfCrash`.
* Made `crashFileSystem` `static` so that it can be associated with
  `CrashReportSender` while still being easily settable by tests.

## Related Issues
* See https://github.com/jamesderlin/flutter/pull/1 for the follow-on work to make `CrashReportSender` overridable via `AppContext`.
* https://github.com/flutter/flutter/issues/53766


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

I did need to modify existing tests, but my understanding is that flutter_tools does not strictly follow the breaking change policy.