### PR TITLE
Specify the devicelab task simulator runtime to support <Xcode 11.4

### DIFF
--- a/dev/devicelab/bin/tasks/ios_app_with_watch_companion.dart
+++ b/dev/devicelab/bin/tasks/ios_app_with_watch_companion.dart
@@ -82,6 +82,7 @@ Future<void> main() async {
           'create',
           'TestFlutteriPhoneWithWatch',
           'com.apple.CoreSimulator.SimDeviceType.iPhone-11',
+          'com.apple.CoreSimulator.SimRuntime.iOS-13-2',
         ],
         canFail: false,
         workingDirectory: flutterDirectory.path,
@@ -94,6 +95,7 @@ Future<void> main() async {
           'create',
           'TestFlutterWatch',
           'com.apple.CoreSimulator.SimDeviceType.Apple-Watch-Series-5-44mm',
+          'com.apple.CoreSimulator.SimRuntime.watchOS-6-1'
         ],
         canFail: false,
         workingDirectory: flutterDirectory.path,


### PR DESCRIPTION
## Description

https://github.com/flutter/flutter/pull/51126 added a devicelab test that made an iOS and watchOS simulator, and paired them.  It worked on Xcode 11.4, but Xcode 11 running in the devicelab requires the rumtime to be specified.

## Related Issues

https://github.com/flutter/flutter/pull/51126

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*