### PR TITLE
Mark ios_app_with_watch_companion as flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -644,6 +644,7 @@ tasks:
       Checks that an iOS app with a watchOS companion can be build for physical and simulated devices.
     stage: devicelab
     required_agent_capabilities: ["mac/ios"]
+    flaky: true
 
   # Tests running on Windows host
 


### PR DESCRIPTION
## Description

Mark as flaky while I investigate the runtime installed on all the devicelab machines.

## Related Issues
https://github.com/flutter/flutter/pull/54887
https://github.com/flutter/flutter/pull/51126