### PR TITLE
Update dartdoc to 0.30.4.

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -111,7 +111,7 @@ if [[ -d "$FLUTTER_PUB_CACHE" ]]; then
 fi
 
 # Install and activate dartdoc.
-"$PUB" global activate dartdoc 0.30.2
+"$PUB" global activate dartdoc 0.30.4
 
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc.


### PR DESCRIPTION
Upgrade dartdoc to 0.30.4.

Release notes for 0.30.4:  https://github.com/dart-lang/dartdoc/releases/tag/v0.30.4
Release notes for 0.30.3:  https://github.com/dart-lang/dartdoc/releases/tag/v0.30.3

The main impacting bugfixes for Flutter are dart-lang/dartdoc#1949 and dart-lang/dartdoc#2099.

Tested with dartdoc's compare-flutter-warnings grinder; this version eliminates ~600 no canonical found warnings.