### PR TITLE
Pass in runtime to ios_app_with_watch_companion simctl create

### DIFF
--- a/dev/devicelab/bin/tasks/ios_app_with_watch_companion.dart
+++ b/dev/devicelab/bin/tasks/ios_app_with_watch_companion.dart
@@ -112,11 +112,16 @@ Future<void> main() async {
           watchSimRuntime = watchOSRuntimeMatch.group(1).trim();
         }
       }
-      if (iOSSimRuntime == null) {
-        return TaskResult.failure('No iOS Simulator runtime found, available runtimes:\n$availableRuntimes');
-      }
-      if (watchSimRuntime == null) {
-        return TaskResult.failure('No watchOS Simulator runtime found, available runtimes:\n$availableRuntimes');
+      if (iOSSimRuntime == null || watchSimRuntime == null) {
+        String message;
+        if (iOSSimRuntime != null) {
+          message = 'Found "$iOSSimRuntime", but no watchOS simulator runtime found.';
+        } else if (watchSimRuntime != null) {
+          message = 'Found "$watchSimRuntime", but no iOS simulator runtime found.';
+        } else {
+          message = 'watchOS and iOS simulator runtimes not found.';
+        }
+        return TaskResult.failure('$message Available runtimes:\n$availableRuntimes');
       }
 
       // Create iOS simulator.


### PR DESCRIPTION
## Description

The versions of `simctl` installed on the devicelab machines require a runtime argument.
Parse the output of `simctl list runtimes` and pass into `simctl create` when creating iOS and watchOS simulators.

## Related Issues

https://github.com/flutter/flutter/issues/54892

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*