### PR TITLE
benchmark animation performance of Opacity widget

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/common.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/common.dart
@@ -12,3 +12,4 @@ const String kLargeImagesRouteName = '/large_images';
 const String kTextRouteName = '/text';
 const String kAnimatedPlaceholderRouteName = '/animated_placeholder';
 const String kColorFilterAndFadeRouteName = '/color_filter_and_fade';
+const String kFadingChildAnimationRouteName = '/fading_child_animation';

--- a/dev/benchmarks/macrobenchmarks/lib/main.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/main.dart
@@ -41,7 +41,7 @@ class MacrobenchmarksApp extends StatelessWidget {
         kTextRouteName: (BuildContext context) => TextPage(),
         kAnimatedPlaceholderRouteName: (BuildContext context) => AnimatedPlaceholderPage(),
         kColorFilterAndFadeRouteName: (BuildContext context) => ColorFilterAndFadePage(),
-        kFadingChildAnimationRouteName: (BuildContext context) => const FilteredChildAnimationPage(FilterType.OPACITY),
+        kFadingChildAnimationRouteName: (BuildContext context) => const FilteredChildAnimationPage(FilterType.opacity),
       },
     );
   }

--- a/dev/benchmarks/macrobenchmarks/lib/main.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/main.dart
@@ -12,6 +12,7 @@ import 'src/animated_placeholder.dart';
 import 'src/backdrop_filter.dart';
 import 'src/cubic_bezier.dart';
 import 'src/cull_opacity.dart';
+import 'src/filtered_child_animation.dart';
 import 'src/post_backdrop_filter.dart';
 import 'src/simple_animation.dart';
 import 'src/text.dart';
@@ -40,6 +41,7 @@ class MacrobenchmarksApp extends StatelessWidget {
         kTextRouteName: (BuildContext context) => TextPage(),
         kAnimatedPlaceholderRouteName: (BuildContext context) => AnimatedPlaceholderPage(),
         kColorFilterAndFadeRouteName: (BuildContext context) => ColorFilterAndFadePage(),
+        kFadingChildAnimationRouteName: (BuildContext context) => const FilteredChildAnimationPage(FilterType.OPACITY),
       },
     );
   }
@@ -122,6 +124,13 @@ class HomePage extends StatelessWidget {
             child: const Text('Color Filter and Fade'),
             onPressed: () {
               Navigator.pushNamed(context, kColorFilterAndFadeRouteName);
+            },
+          ),
+          RaisedButton(
+            key: const Key(kFadingChildAnimationRouteName),
+            child: const Text('Fading Child Animation'),
+            onPressed: () {
+              Navigator.pushNamed(context, kFadingChildAnimationRouteName);
             },
           ),
         ],

--- a/dev/benchmarks/macrobenchmarks/lib/src/filtered_child_animation.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/filtered_child_animation.dart
@@ -1,0 +1,216 @@
+import 'dart:math';
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+enum FilterType {
+  OPACITY, ROTATE_TRANSFORM, ROTATE_FILTER,
+}
+
+class FilteredChildAnimationPage extends StatefulWidget {
+  const FilteredChildAnimationPage(
+      this._filterType,
+      [
+        this._complexChild = true,
+        this._useRepaintBoundary = true,
+      ]);
+
+  final FilterType _filterType;
+  final bool _complexChild;
+  final bool _useRepaintBoundary;
+
+  @override
+  _FilteredChildAnimationPageState createState() => _FilteredChildAnimationPageState(_filterType, _complexChild, _useRepaintBoundary);
+}
+
+class _FilteredChildAnimationPageState extends State<FilteredChildAnimationPage> with SingleTickerProviderStateMixin {
+  _FilteredChildAnimationPageState(this._filterType, this._complexChild, this._useRepaintBoundary);
+
+  AnimationController _controller;
+  bool _useRepaintBoundary;
+  bool _complexChild;
+  FilterType _filterType;
+  final GlobalKey _childKey = GlobalKey(debugLabel: 'child to animate');
+  Offset _childCenter = Offset.zero;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final RenderBox childBox = _childKey.currentContext.findRenderObject() as RenderBox;
+      final Offset localCenter = childBox.paintBounds.center;
+      _childCenter = childBox.localToGlobal(localCenter);
+    });
+    _controller = AnimationController(vsync: this, duration: const Duration(seconds: 2));
+    _controller.repeat();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _setFilterType(FilterType type, bool selected) {
+    setState(() => _filterType = selected ? type : null);
+  }
+
+  List<Widget> makeComplexChildList(int rows, int cols, double w, double h) {
+    final List<Widget> children = <Widget>[];
+    final double sx = w / cols;
+    final double sy = h / rows;
+    final double tx = - sx * cols / 2.0;
+    final double ty = - sy * rows / 2.0;
+    for (int r = 0; r < rows; r++) {
+      for (int c = 0; c < cols; c++) {
+        children.add(RepaintBoundary(child: Transform(
+          child: const Text('text'),
+          transform: Matrix4.translationValues(c * sx + tx, r * sy + ty, 0.0),
+        )));
+      }
+    }
+    return children;
+  }
+
+  static Widget _makeChild(int rows, int cols, double fontSize, bool complex) {
+    final BoxDecoration decoration = BoxDecoration(
+      color: Colors.green,
+      boxShadow: complex ? <BoxShadow>[
+        const BoxShadow(
+          color: Colors.black,
+          blurRadius: 10.0,
+        ),
+      ] : null,
+      borderRadius: BorderRadius.circular(10.0),
+    );
+    return Stack(
+      alignment: Alignment.center,
+      children: <Widget>[
+        Column(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: List<Widget>.generate(rows, (int r) => Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: List<Widget>.generate(cols, (int c) => Container(
+              child: Text('text', style: TextStyle(fontSize: fontSize)),
+              decoration: decoration,
+            )),
+          )),
+        ),
+        const Text('child',
+          style: TextStyle(
+            color: Colors.blue,
+            fontSize: 36,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _animate({Widget child, bool protectChild}) {
+    if (_filterType == null) {
+      _controller.reset();
+      return child;
+    }
+    _controller.repeat();
+    Widget Function(BuildContext, Widget) builder;
+    switch (_filterType) {
+      case FilterType.OPACITY:
+        builder = (BuildContext context, Widget child) => Opacity(
+          opacity: (_controller.value * 2.0 - 1.0).abs(),
+          child: child,
+        );
+        break;
+      case FilterType.ROTATE_TRANSFORM:
+        builder = (BuildContext context, Widget child) => Transform(
+          transform: Matrix4.rotationZ(_controller.value * 2.0 * pi),
+          alignment: Alignment.center,
+          child: child,
+        );
+        break;
+      case FilterType.ROTATE_FILTER:
+        builder = (BuildContext context, Widget child) => ImageFiltered(
+          imageFilter: ImageFilter.matrix((
+              Matrix4.identity()
+                ..translate(_childCenter.dx, _childCenter.dy)
+                ..rotateZ(_controller.value * 2.0 * pi)
+                ..translate(- _childCenter.dx, - _childCenter.dy)
+          ).storage),
+          child: child,
+        );
+        break;
+    }
+    return RepaintBoundary(
+      child: AnimatedBuilder(
+        animation: _controller,
+        child: protectChild ? RepaintBoundary(child: child) : child,
+        builder: builder,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Filtered Child Animation'),
+      ),
+      body: Center(
+        child: _animate(
+          child: Container(
+            key: _childKey,
+            color: Colors.yellow,
+            width: 300,
+            height: 300,
+            child: Center(
+              child: _makeChild(4, 3, 24.0, _complexChild),
+            ),
+          ),
+          protectChild: _useRepaintBoundary,
+        ),
+      ),
+      bottomNavigationBar: BottomAppBar(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                const Text('Opacity:'),
+                Checkbox(
+                  value: _filterType == FilterType.OPACITY,
+                  onChanged: (bool b) => _setFilterType(FilterType.OPACITY, b),
+                ),
+                const Text('Tx Rotate:'),
+                Checkbox(
+                  value: _filterType == FilterType.ROTATE_TRANSFORM,
+                  onChanged: (bool b) => _setFilterType(FilterType.ROTATE_TRANSFORM, b),
+                ),
+                const Text('IF Rotate:'),
+                Checkbox(
+                  value: _filterType == FilterType.ROTATE_FILTER,
+                  onChanged: (bool b) => _setFilterType(FilterType.ROTATE_FILTER, b),
+                ),
+              ],
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                const Text('Complex child:'),
+                Checkbox(
+                  value: _complexChild,
+                  onChanged: (bool b) => setState(() => _complexChild = b),
+                ),
+                const Text('RPB on child:'),
+                Checkbox(
+                  value: _useRepaintBoundary,
+                  onChanged: (bool b) => setState(() => _useRepaintBoundary = b),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/dev/benchmarks/macrobenchmarks/lib/src/filtered_child_animation.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/filtered_child_animation.dart
@@ -4,7 +4,7 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 
 enum FilterType {
-  OPACITY, ROTATE_TRANSFORM, ROTATE_FILTER,
+  opacity, rotateTransform, rotateFilter,
 }
 
 class FilteredChildAnimationPage extends StatefulWidget {
@@ -55,21 +55,13 @@ class _FilteredChildAnimationPageState extends State<FilteredChildAnimationPage>
     setState(() => _filterType = selected ? type : null);
   }
 
-  List<Widget> makeComplexChildList(int rows, int cols, double w, double h) {
-    final List<Widget> children = <Widget>[];
-    final double sx = w / cols;
-    final double sy = h / rows;
-    final double tx = - sx * cols / 2.0;
-    final double ty = - sy * rows / 2.0;
-    for (int r = 0; r < rows; r++) {
-      for (int c = 0; c < cols; c++) {
-        children.add(RepaintBoundary(child: Transform(
-          child: const Text('text'),
-          transform: Matrix4.translationValues(c * sx + tx, r * sy + ty, 0.0),
-        )));
-      }
+  String get _title {
+    switch (_filterType) {
+      case FilterType.opacity: return 'Fading Child Animation';
+      case FilterType.rotateTransform: return 'Transformed Child Animation';
+      case FilterType.rotateFilter: return 'Matrix Filtered Child Animation';
+      default: return 'Static Child';
     }
-    return children;
   }
 
   static Widget _makeChild(int rows, int cols, double fontSize, bool complex) {
@@ -114,20 +106,20 @@ class _FilteredChildAnimationPageState extends State<FilteredChildAnimationPage>
     _controller.repeat();
     Widget Function(BuildContext, Widget) builder;
     switch (_filterType) {
-      case FilterType.OPACITY:
+      case FilterType.opacity:
         builder = (BuildContext context, Widget child) => Opacity(
           opacity: (_controller.value * 2.0 - 1.0).abs(),
           child: child,
         );
         break;
-      case FilterType.ROTATE_TRANSFORM:
+      case FilterType.rotateTransform:
         builder = (BuildContext context, Widget child) => Transform(
           transform: Matrix4.rotationZ(_controller.value * 2.0 * pi),
           alignment: Alignment.center,
           child: child,
         );
         break;
-      case FilterType.ROTATE_FILTER:
+      case FilterType.rotateFilter:
         builder = (BuildContext context, Widget child) => ImageFiltered(
           imageFilter: ImageFilter.matrix((
               Matrix4.identity()
@@ -152,7 +144,7 @@ class _FilteredChildAnimationPageState extends State<FilteredChildAnimationPage>
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Filtered Child Animation'),
+        title: Text(_title),
       ),
       body: Center(
         child: _animate(
@@ -178,18 +170,18 @@ class _FilteredChildAnimationPageState extends State<FilteredChildAnimationPage>
               children: <Widget>[
                 const Text('Opacity:'),
                 Checkbox(
-                  value: _filterType == FilterType.OPACITY,
-                  onChanged: (bool b) => _setFilterType(FilterType.OPACITY, b),
+                  value: _filterType == FilterType.opacity,
+                  onChanged: (bool b) => _setFilterType(FilterType.opacity, b),
                 ),
                 const Text('Tx Rotate:'),
                 Checkbox(
-                  value: _filterType == FilterType.ROTATE_TRANSFORM,
-                  onChanged: (bool b) => _setFilterType(FilterType.ROTATE_TRANSFORM, b),
+                  value: _filterType == FilterType.rotateTransform,
+                  onChanged: (bool b) => _setFilterType(FilterType.rotateTransform, b),
                 ),
                 const Text('IF Rotate:'),
                 Checkbox(
-                  value: _filterType == FilterType.ROTATE_FILTER,
-                  onChanged: (bool b) => _setFilterType(FilterType.ROTATE_FILTER, b),
+                  value: _filterType == FilterType.rotateFilter,
+                  onChanged: (bool b) => _setFilterType(FilterType.rotateFilter, b),
                 ),
               ],
             ),

--- a/dev/benchmarks/macrobenchmarks/lib/src/filtered_child_animation.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/filtered_child_animation.dart
@@ -1,3 +1,7 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'dart:math';
 import 'dart:ui';
 

--- a/dev/benchmarks/macrobenchmarks/test_driver/fading_child_animation_perf.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/fading_child_animation_perf.dart
@@ -1,0 +1,11 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_driver/driver_extension.dart';
+import 'package:macrobenchmarks/main.dart' as app;
+
+void main() {
+  enableFlutterDriverExtension();
+  app.main();
+}

--- a/dev/benchmarks/macrobenchmarks/test_driver/fading_child_animation_perf_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/fading_child_animation_perf_test.dart
@@ -1,0 +1,16 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:macrobenchmarks/common.dart';
+
+import 'util.dart';
+
+void main() {
+  macroPerfTest(
+    'fading_child_animation_perf',
+    kFadingChildAnimationRouteName,
+    pageDelay: const Duration(seconds: 1),
+    duration: const Duration(seconds: 10),
+  );
+}

--- a/dev/devicelab/bin/tasks/fading_child_animation_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/fading_child_animation_perf__timeline_summary.dart
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+import 'package:flutter_devicelab/framework/adb.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.android;
+  await task(createFadingChildAnimationPerfTest());
+}

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -189,6 +189,14 @@ TaskFunction createColorFilterAndFadePerfTest() {
   ).run;
 }
 
+TaskFunction createFadingChildAnimationPerfTest() {
+  return PerfTest(
+    '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
+    'test_driver/fading_child_animation_perf.dart',
+    'fading_child_animation_perf',
+  ).run;
+}
+
 /// Measure application startup performance.
 class StartupTest {
   const StartupTest(this.testDirectory, { this.reportMetrics = true });

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -201,6 +201,12 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
 
+  fading_child_animation_perf__timeline_summary:
+    description: >
+      Measures the runtime performance of opacity filter with fade on Android.
+    stage: devicelab
+    required_agent_capabilities: ["mac/android"]
+
   flavors_test:
     description: >
       Checks that flavored builds work on Android.


### PR DESCRIPTION
Adding a benchmark to measure the performance of using an Opacity widget to animate fading.

This benchmark will help measure the impact of https://github.com/flutter/flutter/issues/52864 and the impending fix for it more directly and precisely.

Here is an example of the results of this benchmark showing improvements from a local engine build that fixes that bug:
```
                   Score                   Average A (noise)  Average B (noise)   Speed-up
average_frame_build_time_millis                 1.76 (3.59%)       1.89 (4.21%)     0.93x	
worst_frame_build_time_millis                   5.89 (11.51%)      8.16 (36.16%)    0.72x	
90th_percentile_frame_build_time_millis.        2.57 (2.24%)       2.61 (10.15%)    0.98x	
99th_percentile_frame_build_time_millis         4.64 (4.20%)       5.29 (7.32%)     0.88x	
average_frame_rasterizer_time_millis            4.66 (1.83%)       3.75 (1.35%)     1.24x	
worst_frame_rasterizer_time_millis             12.86 (61.69%)     10.18 (22.62%)    1.26x	
90th_percentile_frame_rasterizer_time_millis    5.08 (2.72%)       4.05 (2.19%)     1.25x	
99th_percentile_frame_rasterizer_time_millis    6.85 (10.99%)      6.51 (8.28%)     1.05x	
average_vsync_transitions_missed                0.80 (50.00%)      0.40 (122.47%)   2.00x	
90th_percentile_vsync_transitions_missed        0.80 (50.00%)      0.40 (122.47%)   2.00x	
99th_percentile_vsync_transitions_missed        0.80 (50.00%)      0.40 (122.47%)   2.00x	
```

Approximately a 20% improvement for all rasterizer times except for 99th percentile.