### PR TITLE
[flutter_tools] ensure EventPrinter handles a null parent

### DIFF
--- a/packages/flutter_tools/lib/src/test/event_printer.dart
+++ b/packages/flutter_tools/lib/src/test/event_printer.dart
@@ -24,17 +24,17 @@ class EventPrinter extends TestWatcher {
 
   @override
   Future<void> handleTestCrashed(ProcessEvent event) async {
-    return _parent.handleTestCrashed(event);
+    return _parent?.handleTestCrashed(event);
   }
 
   @override
   Future<void> handleTestTimedOut(ProcessEvent event) async {
-    return _parent.handleTestTimedOut(event);
+    return _parent?.handleTestTimedOut(event);
   }
 
   @override
   Future<void> handleFinishedTest(ProcessEvent event) async {
-    return _parent.handleFinishedTest(event);
+    return _parent?.handleFinishedTest(event);
   }
 
   void _sendEvent(String name, [ dynamic params ]) {

--- a/packages/flutter_tools/test/general.shard/tester/event_printer_test.dart
+++ b/packages/flutter_tools/test/general.shard/tester/event_printer_test.dart
@@ -1,0 +1,21 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tools/src/test/event_printer.dart';
+import 'package:flutter_tools/src/test/watcher.dart';
+
+import '../../src/common.dart';
+import '../../src/mocks.dart';
+
+void main() {
+  testWithoutContext('EventPrinter handles a null parent', () {
+    final EventPrinter eventPrinter = EventPrinter(out: StringBuffer());
+    final ProcessEvent processEvent = ProcessEvent(0, FakeProcess());
+
+    expect(() => eventPrinter.handleFinishedTest(processEvent), returnsNormally);
+    expect(() => eventPrinter.handleStartedProcess(processEvent), returnsNormally);
+    expect(() => eventPrinter.handleTestCrashed(processEvent), returnsNormally);
+    expect(() => eventPrinter.handleTestTimedOut(processEvent), returnsNormally);
+  });
+}


### PR DESCRIPTION
## Description

null safety pls!

Fixes https://github.com/flutter/flutter/issues/54917
