### PR TITLE
fixed flutter run for projects containing a watchOS companion

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -256,7 +256,11 @@ Future<XcodeBuildResult> buildXcodeProject({
     final String activeArchName = getNameForDarwinArch(activeArch);
     if (activeArchName != null) {
       buildCommands.add('ONLY_ACTIVE_ARCH=YES');
-      buildCommands.add('ARCHS=$activeArchName');
+      // Setting ARCHS to $activeArchName will break the build if a watchOS companion app exists,
+      // as it cannot be build for the architecture of the flutter app.
+      if (!hasWatchCompanion) {
+        buildCommands.add('ARCHS=$activeArchName');
+      }
     }
   }
 


### PR DESCRIPTION
## Description

As reported by @Henrik-glt in #51126 , when running a flutter app with a watchOS companion app on a physical iOS device using the `flutter run` command, the build currently breaks, although it works for simulated devices. The reason for this behaviour is, that when building for a physical device, the following parameters are set for xcodebuild:

> ONLY_ACTIVE_ARCH=YES
> ARCHS=$activeArchName //$activeArchName is the architecture of the iOS device.

Consequently `xcodebuild` will attempt to build the watchOS companion for the architecture of the iOS device, which is not possible. This PR fixes the issue by not setting the ARCHS parameter if a watchOS companion app is detected in the ios project.

Upon further investigation it seems that using `ONLY_ACTIVE_ARCH=YES` in combination with ARCHS is not an intended use case. See also the [xcode build system guide](https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/XcodeBuildSettingRef/1-Build_Setting_Reference/build_setting_ref.html#//apple_ref/doc/uid/TP40003931-CH3-SW157). So I would propose to drop setting ARCHS for the build path having `ONLY_ACTIVE_ARCH=YES`. I performed just a few tests, but so far setting `ONLY_ACTIVE_ARCH=YES` was sufficient to limit the build to the architecture of the target device. Because more intensive tests might be required for this change, it could also be made in a separate PR.

## Tests

I added the following tests:
   * none

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
