### PR TITLE
Expose current day as a parameter to showDatePicker.

### DIFF
--- a/packages/flutter/lib/src/material/pickers/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/pickers/calendar_date_picker.dart
@@ -77,6 +77,10 @@ class CalendarDatePicker extends StatefulWidget {
   /// [initialDate] must be between [firstDate] and [lastDate] or equal to
   /// one of them.
   ///
+  /// [currentDate] if not null represents the current day (i.e. today). This
+  /// date will be highlighted in the day grid. If null, the date of
+  /// `DateTime.now()` will be used.
+  ///
   /// If [selectableDayPredicate] is non-null, it must return `true` for the
   /// [initialDate].
   CalendarDatePicker({
@@ -84,6 +88,7 @@ class CalendarDatePicker extends StatefulWidget {
     @required DateTime initialDate,
     @required DateTime firstDate,
     @required DateTime lastDate,
+    DateTime currentDate,
     @required this.onDateChanged,
     this.onDisplayedMonthChanged,
     this.initialCalendarMode = DatePickerMode.day,
@@ -94,6 +99,7 @@ class CalendarDatePicker extends StatefulWidget {
        initialDate = utils.dateOnly(initialDate),
        firstDate = utils.dateOnly(firstDate),
        lastDate = utils.dateOnly(lastDate),
+       currentDate = utils.dateOnly(currentDate ?? DateTime.now()),
        assert(onDateChanged != null),
        assert(initialCalendarMode != null),
        super(key: key) {
@@ -123,6 +129,9 @@ class CalendarDatePicker extends StatefulWidget {
 
   /// The latest allowable [DateTime] that the user can select.
   final DateTime lastDate;
+
+  /// The [DateTime] representing today. It will be highlighted in the day grid.
+  final DateTime currentDate;
 
   /// Called when the user selects a date in the picker.
   final ValueChanged<DateTime> onDateChanged;
@@ -243,7 +252,7 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
         return _MonthPicker(
           key: _monthPickerKey,
           initialMonth: _currentDisplayedMonthDate,
-          currentDate: DateTime.now(),
+          currentDate: widget.currentDate,
           firstDate: widget.firstDate,
           lastDate: widget.lastDate,
           selectedDate: _selectedDate,
@@ -256,7 +265,7 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
           padding: const EdgeInsets.only(top: _subHeaderHeight),
           child: _YearPicker(
             key: _yearPickerKey,
-            currentDate: DateTime.now(),
+            currentDate: widget.currentDate,
             firstDate: widget.firstDate,
             lastDate: widget.lastDate,
             initialDate: _currentDisplayedMonthDate,

--- a/packages/flutter/lib/src/material/pickers/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/pickers/calendar_date_picker.dart
@@ -77,7 +77,7 @@ class CalendarDatePicker extends StatefulWidget {
   /// [initialDate] must be between [firstDate] and [lastDate] or equal to
   /// one of them.
   ///
-  /// [currentDate] if not null represents the current day (i.e. today). This
+  /// [currentDate] represents the current day (i.e. today). This
   /// date will be highlighted in the day grid. If null, the date of
   /// `DateTime.now()` will be used.
   ///

--- a/packages/flutter/lib/src/material/pickers/date_picker_dialog.dart
+++ b/packages/flutter/lib/src/material/pickers/date_picker_dialog.dart
@@ -45,6 +45,10 @@ const Duration _dialogSizeAnimationDuration = Duration(milliseconds: 200);
 /// their dates are considered. Their time fields are ignored. They must all
 /// be non-null.
 ///
+/// The [currentDate] represents the current day (i.e. today). This
+/// date will be highlighted in the day grid. If null, the date of
+/// `DateTime.now()` will be used.
+///
 /// An optional [initialEntryMode] argument can be used to display the date
 /// picker in the [DatePickerEntryMode.calendar] (a calendar month grid)
 /// or [DatePickerEntryMode.input] (a text input field) mode.

--- a/packages/flutter/lib/src/material/pickers/date_picker_dialog.dart
+++ b/packages/flutter/lib/src/material/pickers/date_picker_dialog.dart
@@ -93,6 +93,7 @@ Future<DateTime> showDatePicker({
   @required DateTime initialDate,
   @required DateTime firstDate,
   @required DateTime lastDate,
+  DateTime currentDate,
   DatePickerEntryMode initialEntryMode = DatePickerEntryMode.calendar,
   SelectableDayPredicate selectableDayPredicate,
   String helpText,
@@ -141,6 +142,7 @@ Future<DateTime> showDatePicker({
     initialDate: initialDate,
     firstDate: firstDate,
     lastDate: lastDate,
+    currentDate: currentDate,
     initialEntryMode: initialEntryMode,
     selectableDayPredicate: selectableDayPredicate,
     helpText: helpText,
@@ -184,6 +186,7 @@ class _DatePickerDialog extends StatefulWidget {
     @required DateTime initialDate,
     @required DateTime firstDate,
     @required DateTime lastDate,
+    DateTime currentDate,
     this.initialEntryMode = DatePickerEntryMode.calendar,
     this.selectableDayPredicate,
     this.cancelText,
@@ -200,6 +203,7 @@ class _DatePickerDialog extends StatefulWidget {
        initialDate = utils.dateOnly(initialDate),
        firstDate = utils.dateOnly(firstDate),
        lastDate = utils.dateOnly(lastDate),
+       currentDate = utils.dateOnly(currentDate ?? DateTime.now()),
        assert(initialEntryMode != null),
        assert(initialCalendarMode != null),
        super(key: key) {
@@ -229,6 +233,9 @@ class _DatePickerDialog extends StatefulWidget {
 
   /// The latest allowable [DateTime] that the user can select.
   final DateTime lastDate;
+
+  /// The [DateTime] representing today. It will be highlighted in the day grid.
+  final DateTime currentDate;
 
   final DatePickerEntryMode initialEntryMode;
 
@@ -382,6 +389,7 @@ class _DatePickerDialogState extends State<_DatePickerDialog> {
           initialDate: _selectedDate,
           firstDate: widget.firstDate,
           lastDate: widget.lastDate,
+          currentDate: widget.currentDate,
           onDateChanged: _handleDateChanged,
           selectableDayPredicate: widget.selectableDayPredicate,
           initialCalendarMode: widget.initialCalendarMode,

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../rendering/mock_canvas.dart';
 import 'feedback_tester.dart';
 
 void main() {
@@ -12,6 +13,7 @@ void main() {
   DateTime firstDate;
   DateTime lastDate;
   DateTime initialDate;
+  DateTime today;
   SelectableDayPredicate selectableDayPredicate;
   DatePickerEntryMode initialEntryMode;
   DatePickerMode initialCalendarMode;
@@ -37,6 +39,7 @@ void main() {
     firstDate = DateTime(2001, DateTime.january, 1);
     lastDate = DateTime(2031, DateTime.december, 31);
     initialDate = DateTime(2016, DateTime.january, 15);
+    today = DateTime(2016, DateTime.january, 3);
     selectableDayPredicate = null;
     initialEntryMode = DatePickerEntryMode.calendar;
     initialCalendarMode = DatePickerMode.day;
@@ -75,6 +78,7 @@ void main() {
       initialDate: initialDate,
       firstDate: firstDate,
       lastDate: lastDate,
+      currentDate: today,
       selectableDayPredicate: selectableDayPredicate,
       initialDatePickerMode: initialCalendarMode,
       initialEntryMode: initialEntryMode,
@@ -504,7 +508,7 @@ void main() {
       });
     });
 
-    testWidgets('Can select initial date picker mode', (WidgetTester tester) async {
+    testWidgets('Can select initial calendar picker mode', (WidgetTester tester) async {
       initialDate = DateTime(2014, DateTime.january, 15);
       initialCalendarMode = DatePickerMode.year;
       await prepareDatePicker(tester, (Future<DateTime> date) async {
@@ -517,6 +521,18 @@ void main() {
       });
     });
 
+    testWidgets('currentDate is highlighted', (WidgetTester tester) async {
+      today = DateTime(2016, 1, 2);
+      await prepareDatePicker(tester, (Future<DateTime> date) async {
+        await tester.pump();
+        const Color todayColor = Color(0xff2196f3); // default primary color
+        expect(
+          Material.of(tester.element(find.text('2'))),
+          // The current day should be painted with a circle outline
+          paints..circle(color: todayColor, style: PaintingStyle.stroke, strokeWidth: 1.0)
+        );
+      });
+    });
   });
 
   group('Input mode', () {


### PR DESCRIPTION
## Description

The current implementation of the Date Picker always displays the current day (denoted by a circular outline around the day) based on the device's current date (`DateTime.now()`). However, for apps that need to configure the current date, this PR adds a new `currentDate` parameter to the `showDatePicker` as well as the `CalendarDatePicker` component.

## Related Issues

Fixes: #54526

## Tests

I added a new test that checks to see if the provided current date is displayed highlighted.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them?

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
