### PR TITLE
disable hit testing if the CompositedTransformFollower is hidden when…

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -4914,7 +4914,7 @@ class RenderFollowerLayer extends RenderProxyBox {
   ///
   /// When the render object is not linked, then: if [showWhenUnlinked] is true,
   /// the child is visible and not repositioned; if it is false, then child is
-  /// hidden.
+  /// hidden, and its hit testing is also disabled.
   bool get showWhenUnlinked => _showWhenUnlinked;
   bool _showWhenUnlinked;
   set showWhenUnlinked(bool value) {

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -4962,6 +4962,9 @@ class RenderFollowerLayer extends RenderProxyBox {
 
   @override
   bool hitTest(BoxHitTestResult result, { Offset position }) {
+    // Disables the hit testing if this render object is hidden.
+    if (link.leader == null && !showWhenUnlinked)
+      return false;
     // RenderFollowerLayer objects don't check if they are
     // themselves hit, because it's confusing to think about
     // how the untransformed size and the child's transformed

--- a/packages/flutter/test/rendering/proxy_box_test.dart
+++ b/packages/flutter/test/rendering/proxy_box_test.dart
@@ -493,6 +493,61 @@ void main() {
     box.translation = const Offset(0.3, 0.3);
     expect(box.markNeedsSemanticsUpdateCallCount, 3);
   });
+
+  test('RenderFollowerLayer hit test without a leader layer and the showWhenUnlinked is true', () {
+    final RenderFollowerLayer follower = RenderFollowerLayer(
+      link: LayerLink(),
+      showWhenUnlinked: true,
+      child: RenderSizedBox(const Size(1.0, 1.0)),
+    );
+    layout(follower, constraints: BoxConstraints.tight(const Size(200.0, 200.0)));
+    final BoxHitTestResult hitTestResult = BoxHitTestResult();
+    expect(follower.hitTest(hitTestResult, position: const Offset(0.0, 0.0)), isTrue);
+  });
+
+  test('RenderFollowerLayer hit test without a leader layer and the showWhenUnlinked is false', () {
+    final RenderFollowerLayer follower = RenderFollowerLayer(
+      link: LayerLink(),
+      showWhenUnlinked: false,
+      child: RenderSizedBox(const Size(1.0, 1.0)),
+    );
+    layout(follower, constraints: BoxConstraints.tight(const Size(200.0, 200.0)));
+    final BoxHitTestResult hitTestResult = BoxHitTestResult();
+    expect(follower.hitTest(hitTestResult, position: const Offset(0.0, 0.0)), isFalse);
+  });
+
+  test('RenderFollowerLayer hit test with a leader layer and the showWhenUnlinked is true', () {
+    // Creates a layer link with a leader.
+    final LayerLink link = LayerLink();
+    final LeaderLayer leader = LeaderLayer(link: link);
+    leader.attach(Object());
+
+    final RenderFollowerLayer follower = RenderFollowerLayer(
+      link: link,
+      showWhenUnlinked: true,
+      child: RenderSizedBox(const Size(1.0, 1.0)),
+    );
+    layout(follower, constraints: BoxConstraints.tight(const Size(200.0, 200.0)));
+    final BoxHitTestResult hitTestResult = BoxHitTestResult();
+    expect(follower.hitTest(hitTestResult, position: const Offset(0.0, 0.0)), isTrue);
+  });
+
+  test('RenderFollowerLayer hit test with a leader layer and the showWhenUnlinked is false', () {
+    // Creates a layer link with a leader.
+    final LayerLink link = LayerLink();
+    final LeaderLayer leader = LeaderLayer(link: link);
+    leader.attach(Object());
+
+    final RenderFollowerLayer follower = RenderFollowerLayer(
+      link: link,
+      showWhenUnlinked: false,
+      child: RenderSizedBox(const Size(1.0, 1.0)),
+    );
+    layout(follower, constraints: BoxConstraints.tight(const Size(200.0, 200.0)));
+    final BoxHitTestResult hitTestResult = BoxHitTestResult();
+    // The follower is still hit testable because there is a leader layer.
+    expect(follower.hitTest(hitTestResult, position: const Offset(0.0, 0.0)), isTrue);
+  });
 }
 
 class _TestRectClipper extends CustomClipper<Rect> {


### PR DESCRIPTION
… there is no leader layer

## Description

This PR disable hit test when there is no leader layer and showWhenUnlinked is false.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/21320

## Tests

I added the following tests:

see file change

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
