### PR TITLE
Step 2: SnackBarBehavior.floating offset fix by default

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -1343,7 +1343,7 @@ class Scaffold extends StatefulWidget {
     'eventually be removed. '
     'This feature was deprecated after v1.15.3.'
   )
-  static bool shouldSnackBarIgnoreFABRect = false;
+  static bool shouldSnackBarIgnoreFABRect = true;
 
   /// The state from the closest instance of this class that encloses the given context.
   ///

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -1075,10 +1075,6 @@ void main() {
         '$behavior should align SnackBar with the bottom of Scaffold '
         'when Scaffold has no other elements',
         (WidgetTester tester) async {
-          // TODO(shihaohong): Remove this flag once the migration to fix
-          // SnackBarBehavior.floating is complete.
-          Scaffold.shouldSnackBarIgnoreFABRect = true;
-
           await tester.pumpWidget(
             MaterialApp(
               home: Scaffold(
@@ -1101,9 +1097,6 @@ void main() {
           final Offset scaffoldBottomLeft = tester.getBottomLeft(find.byType(Scaffold));
 
           expect(snackBarBottomLeft, equals(scaffoldBottomLeft));
-          // TODO(shihaohong): Remove this flag once the migration to fix
-          // SnackBarBehavior.floating is complete.
-          Scaffold.shouldSnackBarIgnoreFABRect = false;
         },
       );
 
@@ -1111,9 +1104,6 @@ void main() {
         '$behavior should align SnackBar with the top of BottomNavigationBar '
         'when Scaffold has no FloatingActionButton',
         (WidgetTester tester) async {
-          // TODO(shihaohong): Remove this flag once the migration to fix
-          // SnackBarBehavior.floating is complete.
-          Scaffold.shouldSnackBarIgnoreFABRect = true;
           final UniqueKey boxKey = UniqueKey();
           await tester.pumpWidget(
             MaterialApp(
@@ -1138,9 +1128,6 @@ void main() {
           final Offset bottomNavigationBarTopLeft = tester.getTopLeft(find.byKey(boxKey));
 
           expect(snackBarBottomLeft, equals(bottomNavigationBarTopLeft));
-          // TODO(shihaohong): Remove this flag once the migration to fix
-          // SnackBarBehavior.floating is complete.
-          Scaffold.shouldSnackBarIgnoreFABRect = false;
         },
       );
 


### PR DESCRIPTION
## Description
Re-attempt of https://github.com/flutter/flutter/pull/52136 due to CI failures unrelated to the PR.

Continuation from https://github.com/flutter/flutter/pull/50597, applying the offset fix by default. The PR that follows this will remove the flag altogether, making the fix a default setting and removing the previous, incorrect offset.

## Migration guide
1. Set all instances of `Scaffold.shouldSnackBarIgnoreFABRect` to `true` after this PR is merged.
2. Fix all failing tests. There are likely two main types:
a) Fix all golden tests to expect the new change. 
b) Fix any widget tests that expect the SnackBar to appear higher than it should. The difference should simply be the size of the floating action button's rect.
3. Once `Scaffold.shouldSnackBarIgnoreFABRect` is set to true by default (in a subsequent PR), remove the parameter from all instances of `Scaffold`.

## Related Issues

Addresses #47202
Addresses #43716

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [x] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [x] I wrote a design doc and migration guide: https://flutter.dev/go/floating-snackbar-offset

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
