### PR TITLE
Support armv7s architecture

### DIFF
--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -400,6 +400,7 @@ DarwinArch getIOSArchForName(String arch) {
   switch (arch) {
     case 'armv7':
     case 'armv7f': // iPhone 4S.
+    case 'armv7s': // iPad 4.
       return DarwinArch.armv7;
     case 'arm64':
     case 'arm64e': // iPhone XS/XS Max/XR and higher. arm64 runs on arm64e devices.

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -435,8 +435,13 @@ class XCDevice {
       } on Exception {
         // Fallback to default iOS architecture. Future-proof against a
         // theoretical version of Xcode that changes this string to something
-        // slightly different like "ARM64".
-        cpuArchitecture ??= defaultIOSArchs.first;
+        // slightly different like "ARM64", or armv7 variations like
+        // armv7s and armv7f.
+        if (architecture.startsWith('armv7')) {
+          cpuArchitecture = DarwinArch.armv7;
+        } else {
+          cpuArchitecture = defaultIOSArchs.first;
+        }
         _logger.printError(
           'Unknown architecture $architecture, defaulting to '
           '${getNameForDarwinArch(cpuArchitecture)}',

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -474,7 +474,7 @@ void main() {
     "identifier" : "d83d5bc53967baa0ee18626ba87b6254b2ab5418",
     "architecture" : "BOGUS",
     "modelName" : "Future iPad",
-    "name" : "iPad" 
+    "name" : "iPad"
   }
 ]
 ''';

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -443,6 +443,50 @@ void main() {
       }, overrides: <Type, Generator>{
         Platform: () => macPlatform,
       });
+
+      testUsingContext('handles unknown architectures', () async {
+        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
+
+        when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
+          .thenReturn(ProcessResult(1, 0, '/path/to/xcdevice', ''));
+
+        const String devicesOutput = '''
+[
+  {
+    "simulator" : false,
+    "operatingSystemVersion" : "13.3 (17C54)",
+    "interface" : "usb",
+    "available" : true,
+    "platform" : "com.apple.platform.iphoneos",
+    "modelCode" : "iPhone8,1",
+    "identifier" : "d83d5bc53967baa0ee18626ba87b6254b2ab5418",
+    "architecture" : "armv7x",
+    "modelName" : "iPad 3 BOGUS",
+    "name" : "iPad"
+  },
+  {
+    "simulator" : false,
+    "operatingSystemVersion" : "13.3 (17C54)",
+    "interface" : "usb",
+    "available" : true,
+    "platform" : "com.apple.platform.iphoneos",
+    "modelCode" : "iPhone8,1",
+    "identifier" : "d83d5bc53967baa0ee18626ba87b6254b2ab5418",
+    "architecture" : "BOGUS",
+    "modelName" : "Future iPad",
+    "name" : "iPad" 
+  }
+]
+''';
+
+        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '2']))
+          .thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 0, devicesOutput, '')));
+        final List<IOSDevice> devices = await xcdevice.getAvailableTetheredIOSDevices();
+        expect(devices[0].cpuArchitecture, DarwinArch.armv7);
+        expect(devices[1].cpuArchitecture, DarwinArch.arm64);
+      }, overrides: <Type, Generator>{
+        Platform: () => macPlatform,
+      });
     });
 
     group('diagnostics', () {


### PR DESCRIPTION
## Description

Support iPad 4 armv7 architecture variant.  Prefer armv7 architecture for default fallback when the string starts with "armv7" instead of chasing every variants (though [I think we have them all now](https://iphonedevwiki.net/index.php/On-device_toolchains)).

## Related Issues

Fixes https://github.com/flutter/flutter/issues/54477

## Tests

xcode_test

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*