### PR TITLE
flutter_gallery__memory_nav and flutter_gallery__back_button_memory are flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -729,12 +729,14 @@ tasks:
       Measures memory usage after repeated navigation in Gallery.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
+    flaky: true
 
   flutter_gallery__back_button_memory:
     description: >
       Measures memory usage after Android app suspend and resume.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
+    flaky: true
 
   flutter_gallery__image_cache_memory:
     description: >


### PR DESCRIPTION
Mark `flutter_gallery__memory_nav` and `flutter_gallery__back_button_memory` as flaky, because they have been for the past few hundreds of commits.