### PR TITLE
FlutterErrorDetails.context docs fix

### DIFF
--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -10,6 +10,9 @@ import 'diagnostics.dart';
 import 'print.dart';
 import 'stack_frame.dart';
 
+// Examples can assume:
+// String runtimeType;
+
 /// Signature for [FlutterError.onError] handler.
 typedef FlutterExceptionHandler = void Function(FlutterErrorDetails details);
 
@@ -325,7 +328,7 @@ class ErrorSpacer extends DiagnosticsProperty<void> {
 
 /// Class for information provided to [FlutterExceptionHandler] callbacks.
 ///
-///  {@tool --snippet}
+///  {@tool snippet}
 /// This is an example of using [FlutterErrorDetails] when calling
 /// [FlutterError.reportError].
 ///
@@ -333,7 +336,7 @@ class ErrorSpacer extends DiagnosticsProperty<void> {
 /// void main() {
 ///   try {
 ///     // Try to do something!
-///   } catch (error, stack) {
+///   } catch (error) {
 ///     // Catch & report error.
 ///     FlutterError.reportError(FlutterErrorDetails(
 ///       exception: error,
@@ -413,15 +416,15 @@ class FlutterErrorDetails with Diagnosticable {
   /// obtaining the image from the network" (for the context "while obtaining
   /// the image from the network").
   ///
-  ///  {@tool --snippet}
+  /// {@tool snippet}
   /// This is an example of using and [ErrorDescription] as the
   /// [FlutterErrorDetails.context] when calling [FlutterError.reportError].
   ///
   /// ```dart
-  /// void main() {
+  /// void maybeDoSomething() {
   ///   try {
   ///     // Try to do something!
-  ///   } catch (error, stack) {
+  ///   } catch (error) {
   ///     // Catch & report error.
   ///     FlutterError.reportError(FlutterErrorDetails(
   ///       exception: error,

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -330,19 +330,15 @@ class ErrorSpacer extends DiagnosticsProperty<void> {
 /// [FlutterError.reportError].
 ///
 /// ```dart
-/// _runningAsyncTasks = true;
 /// try {
-///   return await callback();
+///   // Try to do something!
 /// } catch (error, stack) {
+///   // Catch & report error.
 ///   FlutterError.reportError(FlutterErrorDetails(
 ///     exception: error,
-///     stack: stack,
 ///     library: 'Flutter test framework',
 ///     context: ErrorSummary('while running async test code'),
 ///   ));
-///   return null;
-/// } finally {
-///   _runningAsyncTasks = false;
 /// }
 /// ```
 /// {@end-tool}
@@ -421,6 +417,7 @@ class FlutterErrorDetails with Diagnosticable {
   /// ```
   ///
   /// See also:
+  ///
   ///   * [ErrorDescription], which provides an explanation of the problem and its
   ///    cause, any information that may help track down the problem, background
   ///    information, etc.

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -325,7 +325,6 @@ class ErrorSpacer extends DiagnosticsProperty<void> {
 
 /// Class for information provided to [FlutterExceptionHandler] callbacks.
 ///
-/// {@tool snippet}
 /// This is an example of using [FlutterErrorDetails] when calling
 /// [FlutterError.reportError].
 ///
@@ -341,7 +340,6 @@ class ErrorSpacer extends DiagnosticsProperty<void> {
 ///   ));
 /// }
 /// ```
-/// {@end-tool}
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -325,27 +325,30 @@ class ErrorSpacer extends DiagnosticsProperty<void> {
 
 /// Class for information provided to [FlutterExceptionHandler] callbacks.
 ///
+///  {@tool --snippet}
 /// This is an example of using [FlutterErrorDetails] when calling
 /// [FlutterError.reportError].
 ///
 /// ```dart
-/// try {
-///   // Try to do something!
-/// } catch (error, stack) {
-///   // Catch & report error.
-///   FlutterError.reportError(FlutterErrorDetails(
-///     exception: error,
-///     library: 'Flutter test framework',
-///     context: ErrorSummary('while running async test code'),
-///   ));
+/// void main() {
+///   try {
+///     // Try to do something!
+///   } catch (error, stack) {
+///     // Catch & report error.
+///     FlutterError.reportError(FlutterErrorDetails(
+///       exception: error,
+///       library: 'Flutter test framework',
+///       context: ErrorSummary('while running async test code'),
+///     ));
+///   }
 /// }
 /// ```
+/// {@end-tool}
 ///
 /// See also:
 ///
 ///   * [FlutterError.onError], which is called whenever the Flutter framework
 ///     catches an error
-
 class FlutterErrorDetails with Diagnosticable {
   /// Creates a [FlutterErrorDetails] object with the given arguments setting
   /// the object's properties.
@@ -410,15 +413,31 @@ class FlutterErrorDetails with Diagnosticable {
   /// obtaining the image from the network" (for the context "while obtaining
   /// the image from the network").
   ///
+  ///  {@tool --snippet}
+  /// This is an example of using and [ErrorDescription] as the
+  /// [FlutterErrorDetails.context] when calling [FlutterError.reportError].
+  ///
   /// ```dart
-  /// ErrorDescription('while running async test code');
+  /// void main() {
+  ///   try {
+  ///     // Try to do something!
+  ///   } catch (error, stack) {
+  ///     // Catch & report error.
+  ///     FlutterError.reportError(FlutterErrorDetails(
+  ///       exception: error,
+  ///       library: 'Flutter test framework',
+  ///       context: ErrorDescription('while dispatching notifications for $runtimeType'),
+  ///     ));
+  ///   }
+  /// }
   /// ```
+  /// {@end-tool}
   ///
   /// See also:
   ///
-  ///   * [ErrorDescription], which provides an explanation of the problem and its
-  ///    cause, any information that may help track down the problem, background
-  ///    information, etc.
+  ///  * [ErrorDescription], which provides an explanation of the problem and
+  ///    its cause, any information that may help track down the problem,
+  ///    background information, etc.
   ///  * [ErrorSummary], which provides a short (one line) description of the
   ///    problem that was detected.
   ///  * [ErrorHint], which provides specific, non-obvious advice that may be

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -330,7 +330,7 @@ class ErrorSpacer extends DiagnosticsProperty<void> {
 /// [FlutterError.reportError].
 ///
 /// ```dart
-/// _runningAsyncTasks = true;
+/// final bool _runningAsyncTasks = true;
 /// try {
 ///   return await callback();
 /// } catch (error, stack) {

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -330,7 +330,7 @@ class ErrorSpacer extends DiagnosticsProperty<void> {
 /// [FlutterError.reportError].
 ///
 /// ```dart
-/// final bool _runningAsyncTasks = true;
+/// bool _runningAsyncTasks = true;
 /// try {
 ///   return await callback();
 /// } catch (error, stack) {

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -281,7 +281,7 @@ class ErrorSummary extends _ErrorDiagnostic {
 
 /// An [ErrorHint] provides specific, non-obvious advice that may be applicable.
 ///
-/// If your message provides obvious advice that is always applicable it is an
+/// If your message provides obvious advice that is always applicable, it is an
 /// [ErrorDescription] not a hint.
 ///
 /// See also:
@@ -325,7 +325,33 @@ class ErrorSpacer extends DiagnosticsProperty<void> {
 
 /// Class for information provided to [FlutterExceptionHandler] callbacks.
 ///
-/// See [FlutterError.onError].
+/// {@tool snippet}
+/// This is an example of using [FlutterErrorDetails] when calling
+/// [FlutterError.reportError].
+///
+/// ```dart
+/// _runningAsyncTasks = true;
+/// try {
+///   return await callback();
+/// } catch (error, stack) {
+///   FlutterError.reportError(FlutterErrorDetails(
+///     exception: error,
+///     stack: stack,
+///     library: 'Flutter test framework',
+///     context: ErrorSummary('while running async test code'),
+///   ));
+///   return null;
+/// } finally {
+///   _runningAsyncTasks = false;
+/// }
+/// ```
+/// {@end-tool}
+///
+/// See also:
+///
+///   * [FlutterError.onError], which is called whenever the Flutter framework
+///     catches an error
+
 class FlutterErrorDetails with Diagnosticable {
   /// Creates a [FlutterErrorDetails] object with the given arguments setting
   /// the object's properties.
@@ -382,13 +408,28 @@ class FlutterErrorDetails with Diagnosticable {
   /// the console.
   final String library;
 
-  /// A human-readable description of where the error was caught (as opposed to
-  /// where it was thrown).
+  /// A [DiagnosticsNode] that provides a human-readable description of where
+  /// the error was caught (as opposed to where it was thrown).
   ///
-  /// The string should be in a form that will make sense in English when
-  /// following the word "thrown", as in "thrown while obtaining the image from
-  /// the network" (for the context "while obtaining the image from the
-  /// network").
+  /// The node, e.g. an [ErrorDescription], should be in a form that will make
+  /// sense in English when following the word "thrown", as in "thrown while
+  /// obtaining the image from the network" (for the context "while obtaining
+  /// the image from the network").
+  ///
+  /// ```dart
+  /// ErrorDescription('while running async test code');
+  /// ```
+  ///
+  /// See also:
+  ///   * [ErrorDescription], which provides an explanation of the problem and its
+  ///    cause, any information that may help track down the problem, background
+  ///    information, etc.
+  ///  * [ErrorSummary], which provides a short (one line) description of the
+  ///    problem that was detected.
+  ///  * [ErrorHint], which provides specific, non-obvious advice that may be
+  ///    applicable.
+  ///  * [FlutterError], which is the most common place to use
+  ///    [FlutterErrorDetails].
   final DiagnosticsNode context;
 
   /// A callback which filters the [stack] trace. Receives an iterable of


### PR DESCRIPTION
## Description

Fixes a doc regression where FlutterErrorDetails.context is described as a String. Also added some examples as recommended in the bug.

## Related Issues

Fixes #47063

## Tests

N/A

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
