### PR TITLE
Created method to report ImageChunkEvents

### DIFF
--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -516,7 +516,7 @@ abstract class ImageStreamCompleter with Diagnosticable {
     }
   }
 
-  /// Calls all the registered image chunk listeners (listeners with an
+  /// Calls all the registered [ImageChunkListener]s (listeners with an
   /// [ImageStreamListener.onChunk] specified) to notify them of a new
   /// [ImageChunkEvent].
   @protected

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -516,6 +516,23 @@ abstract class ImageStreamCompleter with Diagnosticable {
     }
   }
 
+  /// Calls all the registered ImageChunkListeners (listeners with an
+  /// [ImageStreamListener.onChunk] specified) to notify them of a new
+  /// [ImageChunkEvent].
+  @protected
+  void reportImageChunkEvent(ImageChunkEvent event){
+    if (hasListeners) {
+      // Make a copy to allow for concurrent modification.
+      final List<ImageChunkListener> localListeners = _listeners
+          .map<ImageChunkListener>((ImageStreamListener listener) => listener.onChunk)
+          .where((ImageChunkListener chunkListener) => chunkListener != null)
+          .toList();
+      for (final ImageChunkListener listener in localListeners) {
+        listener(event);
+      }
+    }
+  }
+
   /// Accumulates a list of strings describing the object's state. Subclasses
   /// should override this to have their information included in [toString].
   @override
@@ -628,16 +645,7 @@ class MultiFrameImageStreamCompleter extends ImageStreamCompleter {
     if (chunkEvents != null) {
       chunkEvents.listen(
         (ImageChunkEvent event) {
-          if (hasListeners) {
-            // Make a copy to allow for concurrent modification.
-            final List<ImageChunkListener> localListeners = _listeners
-                .map<ImageChunkListener>((ImageStreamListener listener) => listener.onChunk)
-                .where((ImageChunkListener chunkListener) => chunkListener != null)
-                .toList();
-            for (final ImageChunkListener listener in localListeners) {
-              listener(event);
-            }
-          }
+          reportImageChunkEvent(event);
         }, onError: (dynamic error, StackTrace stack) {
           reportError(
             context: ErrorDescription('loading an image'),

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -516,7 +516,7 @@ abstract class ImageStreamCompleter with Diagnosticable {
     }
   }
 
-  /// Calls all the registered ImageChunkListeners (listeners with an
+  /// Calls all the registered image chunk listeners (listeners with an
   /// [ImageStreamListener.onChunk] specified) to notify them of a new
   /// [ImageChunkEvent].
   @protected
@@ -643,10 +643,8 @@ class MultiFrameImageStreamCompleter extends ImageStreamCompleter {
       );
     });
     if (chunkEvents != null) {
-      chunkEvents.listen(
-        (ImageChunkEvent event) {
-          reportImageChunkEvent(event);
-        }, onError: (dynamic error, StackTrace stack) {
+      chunkEvents.listen(reportImageChunkEvent,
+        onError: (dynamic error, StackTrace stack) {
           reportError(
             context: ErrorDescription('loading an image'),
             exception: error,

--- a/packages/flutter/test/painting/image_stream_test.dart
+++ b/packages/flutter/test/painting/image_stream_test.dart
@@ -147,7 +147,7 @@ void main() {
     );
 
     imageStream.addListener(ImageStreamListener(
-          (ImageInfo image, bool synchronousCall) { },
+      (ImageInfo image, bool synchronousCall) { },
       onChunk: (ImageChunkEvent event) {
         chunkEvents.add(event);
       },
@@ -173,7 +173,7 @@ void main() {
     streamController.add(const ImageChunkEvent(cumulativeBytesLoaded: 1, expectedTotalBytes: 3));
     await tester.idle();
     imageStream.addListener(ImageStreamListener(
-          (ImageInfo image, bool synchronousCall) { },
+      (ImageInfo image, bool synchronousCall) { },
       onChunk: (ImageChunkEvent event) {
         chunkEvents.add(event);
       },

--- a/packages/flutter/test/painting/image_stream_test.dart
+++ b/packages/flutter/test/painting/image_stream_test.dart
@@ -78,6 +78,17 @@ class MockCodec implements Codec {
 
 }
 
+class FakeEventReportingImageStreamCompleter extends ImageStreamCompleter {
+  FakeEventReportingImageStreamCompleter({Stream<ImageChunkEvent> chunkEvents,}) {
+    if (chunkEvents != null) {
+      chunkEvents.listen((ImageChunkEvent event) {
+          reportImageChunkEvent(event);
+        },
+      );
+    }
+  }
+}
+
 void main() {
   testWidgets('Codec future fails', (WidgetTester tester) async {
     final Completer<Codec> completer = Completer<Codec>();
@@ -128,7 +139,54 @@ void main() {
     expect(mockCodec.numFramesAsked, 1);
   });
 
-  testWidgets('Chunk events are delivered', (WidgetTester tester) async {
+  testWidgets('Chunk events of base ImageStreamCompleter are delivered', (WidgetTester tester) async {
+    final List<ImageChunkEvent> chunkEvents = <ImageChunkEvent>[];
+    final StreamController<ImageChunkEvent> streamController = StreamController<ImageChunkEvent>();
+    final ImageStreamCompleter imageStream = FakeEventReportingImageStreamCompleter(
+      chunkEvents: streamController.stream,
+    );
+
+    imageStream.addListener(ImageStreamListener(
+          (ImageInfo image, bool synchronousCall) { },
+      onChunk: (ImageChunkEvent event) {
+        chunkEvents.add(event);
+      },
+    ));
+    streamController.add(const ImageChunkEvent(cumulativeBytesLoaded: 1, expectedTotalBytes: 3));
+    streamController.add(const ImageChunkEvent(cumulativeBytesLoaded: 2, expectedTotalBytes: 3));
+    await tester.idle();
+
+    expect(chunkEvents.length, 2);
+    expect(chunkEvents[0].cumulativeBytesLoaded, 1);
+    expect(chunkEvents[0].expectedTotalBytes, 3);
+    expect(chunkEvents[1].cumulativeBytesLoaded, 2);
+    expect(chunkEvents[1].expectedTotalBytes, 3);
+  });
+
+  testWidgets('Chunk events of base ImageStreamCompleter are not buffered before listener registration', (WidgetTester tester) async {
+    final List<ImageChunkEvent> chunkEvents = <ImageChunkEvent>[];
+    final StreamController<ImageChunkEvent> streamController = StreamController<ImageChunkEvent>();
+    final ImageStreamCompleter imageStream = FakeEventReportingImageStreamCompleter(
+      chunkEvents: streamController.stream,
+    );
+
+    streamController.add(const ImageChunkEvent(cumulativeBytesLoaded: 1, expectedTotalBytes: 3));
+    await tester.idle();
+    imageStream.addListener(ImageStreamListener(
+          (ImageInfo image, bool synchronousCall) { },
+      onChunk: (ImageChunkEvent event) {
+        chunkEvents.add(event);
+      },
+    ));
+    streamController.add(const ImageChunkEvent(cumulativeBytesLoaded: 2, expectedTotalBytes: 3));
+    await tester.idle();
+
+    expect(chunkEvents.length, 1);
+    expect(chunkEvents[0].cumulativeBytesLoaded, 2);
+    expect(chunkEvents[0].expectedTotalBytes, 3);
+  });
+
+  testWidgets('Chunk events of MultiFrameImageStreamCompleter are delivered', (WidgetTester tester) async {
     final List<ImageChunkEvent> chunkEvents = <ImageChunkEvent>[];
     final Completer<Codec> completer = Completer<Codec>();
     final StreamController<ImageChunkEvent> streamController = StreamController<ImageChunkEvent>();
@@ -155,7 +213,7 @@ void main() {
     expect(chunkEvents[1].expectedTotalBytes, 3);
   });
 
-  testWidgets('Chunk events are not buffered before listener registration', (WidgetTester tester) async {
+  testWidgets('Chunk events of MultiFrameImageStreamCompleter are not buffered before listener registration', (WidgetTester tester) async {
     final List<ImageChunkEvent> chunkEvents = <ImageChunkEvent>[];
     final Completer<Codec> completer = Completer<Codec>();
     final StreamController<ImageChunkEvent> streamController = StreamController<ImageChunkEvent>();


### PR DESCRIPTION
With this method custom ImageStreamCompleter implementations can also send these events.
Fixes #55040

## Description

As described in #55040 custom implementations of ImageStreamCompleter are currently unable to send report updates to the listeners. Only implementations within the same file are able to do so. The method is made in a very similar way as setImage and reportError.

## Related Issues

Fixes issue #55040 

## Tests

I could use some help with this. This method is covered by existing tests in image_stream_test.dart, for example 'Chunk events are delivered'. So I'm not sure whether I need to add new tests or how they should be made. So I guess the coverage is still 100%, but maybe we need a more specific test.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
