### PR TITLE
validate engine hash

### DIFF
--- a/dev/bots/run_command.dart
+++ b/dev/bots/run_command.dart
@@ -80,7 +80,7 @@ Future<void> runCommand(String executable, List<String> arguments, {
   );
 
   final String commandDescription = '${path.relative(executable, from: workingDirectory)} ${arguments.join(' ')}';
-  final String relativeWorkingDir = path.relative(workingDirectory);
+  final String relativeWorkingDir = path.relative(workingDirectory ?? Directory.current.path);
   if (skip) {
     printProgress('SKIPPING', relativeWorkingDir, commandDescription);
     return;


### PR DESCRIPTION
Fixes #27574

Validates that `flutter_tester --help` gives us a Flutter Engine Version that matches the contents of `bin/internal/engine.version`.  This is meant to guard against regressions in the recipe scripts where we accidentally upload a revision to the wrong bucket folder.