### PR TITLE
Step 3: Removes temporary flag for SnackBarBehavior.floating offset fix

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -1325,17 +1325,6 @@ class Scaffold extends StatefulWidget {
   /// By default, the drag gesture is enabled.
   final bool endDrawerEnableOpenDragGesture;
 
-  /// This flag is deprecated and fixes and issue with incorrect clipping
-  /// and positioning of the [SnackBar] set to [SnackBarBehavior.floating].
-  @Deprecated(
-    'This property controls whether to clip and position the snackbar as '
-    'if there is always a floating action button, even if one is not present. '
-    'It exists to provide backwards compatibility to ease migrations, and will '
-    'eventually be removed. '
-    'This feature was deprecated after v1.15.3.'
-  )
-  static bool shouldSnackBarIgnoreFABRect = true;
-
   /// The state from the closest instance of this class that encloses the given context.
   ///
   /// {@tool dartpad --template=freeform}

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -2,10 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(shihaohong): remove ignoring deprecated member use analysis
-// when Scaffold.shouldSnackBarIgnoreFABRect parameter is removed.
-// ignore_for_file: deprecated_member_use_from_same_package
-
 import 'dart:async';
 import 'dart:collection';
 import 'dart:math' as math;
@@ -556,15 +552,10 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
       }
 
       double snackBarYOffsetBase;
-      if (Scaffold.shouldSnackBarIgnoreFABRect) {
-        if (floatingActionButtonRect.size != Size.zero && isSnackBarFloating)
-          snackBarYOffsetBase = floatingActionButtonRect.top;
-        else
-          snackBarYOffsetBase = contentBottom;
+      if (floatingActionButtonRect.size != Size.zero && isSnackBarFloating) {
+        snackBarYOffsetBase = floatingActionButtonRect.top;
       } else {
-        snackBarYOffsetBase = floatingActionButtonRect != null && isSnackBarFloating
-          ? floatingActionButtonRect.top
-          : contentBottom;
+        snackBarYOffsetBase = contentBottom;
       }
 
       positionChild(_ScaffoldSlot.snackBar, Offset(0.0, snackBarYOffsetBase - snackBarSize.height));

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -2,10 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(shihaohong): remove ignoring deprecated member use analysis
-// when Scaffold.shouldSnackBarIgnoreFABRect parameter is removed.
-// ignore_for_file: deprecated_member_use_from_same_package
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
## Description

Removes the temporary flag, making the offset fix the default and only behavior for SnackBarBehavior.floating.

Part 1: https://github.com/flutter/flutter/pull/50597
Part 2: https://github.com/flutter/flutter/pull/54985

## Related Issues

Fixes https://github.com/flutter/flutter/issues/47202
Fixes https://github.com/flutter/flutter/issues/43716

### Screenshots
#### Before fix
<img width="200" src="https://user-images.githubusercontent.com/17338801/72678400-15203280-3ad8-11ea-8f0c-106b64f500f9.png">
<img width="200" src="https://user-images.githubusercontent.com/17338801/72678404-223d2180-3ad8-11ea-878a-b898c94dc7d4.png">

#### After fix
<img width="200" src="https://user-images.githubusercontent.com/17338801/72678418-4567d100-3ad8-11ea-9326-ddaca97a59b9.png">
<img width="200" src="https://user-images.githubusercontent.com/17338801/72678421-48fb5800-3ad8-11ea-989f-1f1373851a6e.png">

## Migration guide
1. Set all instances of `Scaffold.shouldSnackBarIgnoreFABRect` to `true` after this PR is merged.
2. Fix all failing tests. There are likely two main types:
a) Fix all golden tests to expect the new change. 
b) Fix any widget tests that expect the SnackBar to appear higher than it should. The difference should simply be the size of the floating action button's rect.
3. Once `Scaffold.shouldSnackBarIgnoreFABRect` is set to true by default (in a subsequent PR), remove the parameter from all instances of `Scaffold`.

## Tests

n/a, but in hindsight, I should have added some tests testing the previous offset behavior so ensure that the removed behavior is properly documented somewhere.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [x] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
