### PR TITLE
Prioritize scrolling away nested overscroll

### DIFF
--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -910,7 +910,7 @@ class _NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldCont
       _outerPosition.applyFullDragUpdate(delta);
     } else if (delta < 0.0) {
       // dragging "up"
-      // Prioritize getting rid of any inner overscroll, then and then the outer
+      // Prioritize getting rid of any inner overscroll, and then the outer
       // view, so that the app bar will scroll out of the way asap.
       double outerDelta = delta;
       for (final _NestedScrollPosition position in _innerPositions) {

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -910,20 +910,30 @@ class _NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldCont
       _outerPosition.applyFullDragUpdate(delta);
     } else if (delta < 0.0) {
       // dragging "up"
-      // TODO(ianh): prioritize first getting rid of overscroll, and then the
-      // outer view, so that the app bar will scroll out of the way asap.
-      // Right now we ignore overscroll. This works fine on Android but looks
-      // weird on iOS if you fling down then up. The problem is it's not at all
-      // clear what this should do when you have multiple inner positions at
-      // different levels of overscroll.
-      final double innerDelta = _outerPosition.applyClampedDragUpdate(delta);
-      if (innerDelta != 0.0) {
-        for (final _NestedScrollPosition position in _innerPositions)
-          position.applyFullDragUpdate(innerDelta);
+      // Prioritize getting rid of any inner overscroll, then and then the outer
+      // view, so that the app bar will scroll out of the way asap.
+      double outerDelta = delta;
+      for (final _NestedScrollPosition position in _innerPositions) {
+        if (position.pixels < 0.0) { // This inner position is in overscroll.
+          final double potentialOuterDelta = position.applyClampedDragUpdate(delta);
+          // In case there are multiple positions in varying states of
+          // overscroll, the first to 'reach' the outer view above takes
+          // precedence.
+          outerDelta = math.max(outerDelta, potentialOuterDelta);
+        }
+      }
+      if (outerDelta != 0.0) {
+        final double innerDelta = _outerPosition.applyClampedDragUpdate(
+          outerDelta
+        );
+        if (innerDelta != 0.0) {
+          for (final _NestedScrollPosition position in _innerPositions)
+            position.applyFullDragUpdate(innerDelta);
+        }
       }
     } else {
       // dragging "down" - delta is positive
-      // prioritize the inner views, so that the inner content will move before
+      // Prioritize the inner views, so that the inner content will move before
       // the app bar grows
       double outerDelta = 0.0; // it will go positive if it changes
       final List<double> overscrolls = <double>[];

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -909,7 +909,7 @@ class _NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldCont
     if (_innerPositions.isEmpty) {
       _outerPosition.applyFullDragUpdate(delta);
     } else if (delta < 0.0) {
-      // dragging "up"
+      // Dragging "up"
       // Prioritize getting rid of any inner overscroll, then and then the outer
       // view, so that the app bar will scroll out of the way asap.
       double outerDelta = delta;
@@ -932,7 +932,7 @@ class _NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldCont
         }
       }
     } else {
-      // dragging "down" - delta is positive
+      // Dragging "down" - delta is positive
       // Prioritize the inner views, so that the inner content will move before
       // the app bar grows
       double outerDelta = 0.0; // it will go positive if it changes

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -27,7 +27,6 @@ Widget buildTest({
   String title = 'TTTTTTTT',
   Key key,
   bool expanded = true,
-  ScrollPhysics physics,
 }) {
   return Localizations(
     locale: const Locale('en', 'US'),
@@ -45,7 +44,6 @@ Widget buildTest({
             length: 4,
             child: NestedScrollView(
               key: key,
-              physics: physics,
               dragStartBehavior: DragStartBehavior.down,
               controller: controller,
               headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -27,6 +27,7 @@ Widget buildTest({
   String title = 'TTTTTTTT',
   Key key,
   bool expanded = true,
+  ScrollPhysics physics,
 }) {
   return Localizations(
     locale: const Locale('en', 'US'),
@@ -44,6 +45,7 @@ Widget buildTest({
             length: 4,
             child: NestedScrollView(
               key: key,
+              physics: physics,
               dragStartBehavior: DragStartBehavior.down,
               controller: controller,
               headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
@@ -133,9 +135,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 20));
     final Offset point2 = tester.getCenter(find.text('aaa1'));
     expect(point2.dy, greaterThan(point1.dy));
-    // TODO(ianh): Once we improve how we handle scrolling down from overscroll,
-    // the following expectation should switch to 200.0.
-    expect(tester.renderObject<RenderBox>(find.byType(AppBar)).size.height, 120.0);
+    expect(tester.renderObject<RenderBox>(find.byType(AppBar)).size.height, 200.0);
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
   testWidgets('NestedScrollView overscroll and release and hold', (WidgetTester tester) async {
@@ -173,7 +173,6 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('aaa2'), findsOneWidget);
   },
-  skip: true,  // https://github.com/flutter/flutter/issues/9040
   variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
   testWidgets('NestedScrollView', (WidgetTester tester) async {
@@ -780,7 +779,7 @@ void main() {
     await tester.pump();
     expect(
       tester.getRect(find.byKey(key1)),
-      const Rect.fromLTWH(0.0, -1.0, 800.0, 100.0),
+      const Rect.fromLTWH(0.0, 0.0, 800.0, 100.0),
     );
     expect(tester.getRect(find.byKey(key2)).top, greaterThan(100.0));
     expect(tester.getRect(find.byKey(key2)).top, lessThan(129.0));
@@ -788,7 +787,7 @@ void main() {
     await tester.pump();
     expect(
       tester.getRect(find.byKey(key1)),
-      const Rect.fromLTWH(0.0, -11.0, 800.0, 100.0),
+      const Rect.fromLTWH(0.0, 0.0, 800.0, 100.0),
     );
     await gesture.moveBy(const Offset(0.0, 20.0)); // overscroll again
     await tester.pump();


### PR DESCRIPTION
## Description

This PR updates the `NestedScrollCoordinator` to prioritize scrolling 'away' any inner overscroll before any of the outer/inner positions. Previously, if you did not lift your finger from the screen and allow the overscroll to bounce back, the overscroll would stick and scroll in between the inner and outer scrollables.

*Bug behavior:*

![ezgif com-video-to-gif (5)](https://user-images.githubusercontent.com/16964204/79784370-fb6cd200-82f6-11ea-8994-86473c3340a7.gif)

*Fixed behavior:*

![Fixed](https://user-images.githubusercontent.com/16964204/79784387-03c50d00-82f7-11ea-807e-eb086b2d2416.gif)

## Related Issues

#29264 
#17518

## Tests

I updated the nested overscroll related tests. This is not being considered a breaking change. Although existing tests needed to be changed, there was a `TODO` stating these expectations when this was fixed. The comments around these tests were acknowledging that the expected behavior was bad. Ran through internal tests and everything passed, customer tests are passing as well. :) 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, this is not a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
