### PR TITLE
prettify the flutter web bootstrap file

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -584,18 +584,23 @@ class _ResidentWebRunner extends ResidentWebRunner {
       }
 
       final String entrypoint = <String>[
-        'import "$importedEntrypoint" as entrypoint;',
-        'import "dart:ui" as ui;',
+        '// Flutter web bootstrap script for $importedEntrypoint.',
+        '',
+        "import 'dart:ui' as ui;",
+        '',
+        "import '$importedEntrypoint' as entrypoint;",
         if (hasWebPlugins)
-          'import "package:flutter_web_plugins/flutter_web_plugins.dart";',
+          "import 'package:flutter_web_plugins/flutter_web_plugins.dart';",
         if (hasWebPlugins)
-          'import "$generatedImport";',
+          "import '$generatedImport';",
+        '',
         'Future<void> main() async {',
         if (hasWebPlugins)
           '  registerPlugins(webPluginRegistry);',
         '  await ui.webOnlyInitializePlatform();',
         '  entrypoint.main();',
         '}',
+        '',
       ].join('\n');
       result.writeAsStringSync(entrypoint);
     }

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/build_runner/devfs_web.dart';
 import 'package:flutter_tools/src/build_runner/resident_web_runner.dart';
 import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
@@ -21,7 +22,6 @@ import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:flutter_tools/src/web/chrome.dart';
-import 'package:flutter_tools/src/build_runner/devfs_web.dart';
 import 'package:flutter_tools/src/web/web_device.dart';
 import 'package:mockito/mockito.dart';
 import 'package:platform/platform.dart';
@@ -390,9 +390,10 @@ void main() {
 
     // Ensure that generated entrypoint is generated correctly.
     expect(entrypointFileName, isNotNull);
-    expect(globals.fs.file(entrypointFileName).readAsStringSync(), contains(
-      'await ui.webOnlyInitializePlatform();'
-    ));
+    final String entrypointContents = globals.fs.file(entrypointFileName).readAsStringSync();
+    expect(entrypointContents, contains('// Flutter web bootstrap script'));
+    expect(entrypointContents, contains("import 'dart:ui' as ui;"));
+    expect(entrypointContents, contains('await ui.webOnlyInitializePlatform();'));
 
     expect(testLogger.statusText, contains('Restarted application in'));
     expect(result.code, 0);


### PR DESCRIPTION
## Description

This PR makes the flutter web bootstrap file (`org-dartlang-app:///web_entrypoint.dart`) adhere more closely to dart formatting norms. The `dart:` imports appear first, there's a blank line between different groups of imports, and the file ends in a blank line.

The bootstrap file is the first seen when debugging apps in some debuggers (like DevTools), so it's useful for it to look reasonably clean (even if it is generated code).

After this change:

<img width="639" alt="Screen Shot 2020-04-18 at 1 40 31 PM" src="https://user-images.githubusercontent.com/1269969/79672919-d6f3e700-818a-11ea-95d3-d092f59b4d5f.png">

## Related Issues

none

## Tests

I added the following tests:

Updated the relevant test in `test/general.shard/resident_web_runner_test.dart`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
