### PR TITLE
Support tags in testWidgets

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -53,3 +53,4 @@ Efthymios Sarpmpanis <e.sarbanis@gmail.com>
 Cédric Wyss <cedi.wyss@gmail.com>
 Michel Feinstein <michel@feinstein.com.br>
 Michael Lee <ckmichael8@gmail.com>
+Katarina Sheremet <katarina@sheremet.ch>

--- a/dev/automated_tests/flutter_test/filtering_tag_widget_test.dart
+++ b/dev/automated_tests/flutter_test/filtering_tag_widget_test.dart
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('included', (WidgetTester tester) async {
+    expect(2 + 2, 4);
+  }, tags: <String>['include-tag']);
+  testWidgets('excluded', (WidgetTester tester) async {
+    throw 'this test should have been filtered out';
+  }, tags: <String>['exclude-tag']);
+}

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -89,7 +89,7 @@ typedef WidgetTesterCallback = Future<void> Function(WidgetTester widgetTester);
 /// each value of the [TestVariant.values]. If [variant] is not set, the test
 /// will be run once using the base test environment.
 ///
-/// If [tags] is passed, it declares user-defined tags that are implemented by
+/// If the [tags] are passed, they declare user-defined tags that are implemented by
 /// the `test` package.
 ///
 /// See also:

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -89,6 +89,9 @@ typedef WidgetTesterCallback = Future<void> Function(WidgetTester widgetTester);
 /// each value of the [TestVariant.values]. If [variant] is not set, the test
 /// will be run once using the base test environment.
 ///
+/// If [tags] is passed, it declares user-defined tags that are implemented by
+/// the `test` package.
+///
 /// See also:
 ///
 ///  * [AutomatedTestWidgetsFlutterBinding.addTime] to learn more about
@@ -112,6 +115,7 @@ void testWidgets(
   Duration initialTimeout,
   bool semanticsEnabled = true,
   TestVariant<Object> variant = const DefaultTestVariant(),
+  dynamic tags,
 }) {
   assert(variant != null);
   assert(variant.values.isNotEmpty, 'There must be at least on value to test in the testing variant');
@@ -150,6 +154,7 @@ void testWidgets(
       },
       skip: skip,
       timeout: timeout ?? binding.defaultTestTimeout,
+      tags: tags,
     );
   }
 }

--- a/packages/flutter_tools/test/commands.shard/permeable/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/test_test.dart
@@ -125,6 +125,35 @@ void main() {
     expect(result.exitCode, 1);
   });
 
+  testUsingContext('flutter test should run a widgetTest with a given tag', () async {
+    Cache.flutterRoot = '../..';
+    final ProcessResult result = await _runFlutterTest('filtering_tag_widget', automatedTestsDirectory, flutterTestDirectory,
+        extraArguments: const <String>['--tags', 'include-tag']);
+    if (!(result.stdout as String).contains('+1: All tests passed')) {
+      fail('unexpected output from test:\n\n${result.stdout}\n-- end stdout --\n\n');
+    }
+    expect(result.exitCode, 0);
+  });
+
+  testUsingContext('flutter test should not run a widgetTest with excluded tag', () async {
+    Cache.flutterRoot = '../..';
+    final ProcessResult result = await _runFlutterTest('filtering_tag_widget', automatedTestsDirectory, flutterTestDirectory,
+        extraArguments: const <String>['--exclude-tags', 'exclude-tag']);
+    if (!(result.stdout as String).contains('+1: All tests passed')) {
+      fail('unexpected output from test:\n\n${result.stdout}\n-- end stdout --\n\n');
+    }
+    expect(result.exitCode, 0);
+  });
+
+  testUsingContext('flutter test should run all widgetTest when tags are unspecified', () async {
+    Cache.flutterRoot = '../..';
+    final ProcessResult result = await _runFlutterTest('filtering_tag_widget', automatedTestsDirectory, flutterTestDirectory);
+    if (!(result.stdout as String).contains('+1 -1: Some tests failed')) {
+      fail('unexpected output from test:\n\n${result.stdout}\n-- end stdout --\n\n');
+    }
+    expect(result.exitCode, 1);
+  });
+
   testUsingContext('flutter test should test runs to completion', () async {
     Cache.flutterRoot = '../..';
     final ProcessResult result = await _runFlutterTest('trivial', automatedTestsDirectory, flutterTestDirectory,


### PR DESCRIPTION
## Description

Support `tags` in `testWidgets`. 

## Related Issues

https://github.com/flutter/flutter/issues/32836

## Tests

Tested manually.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
