### PR TITLE
[flutter_tools] skip mDNS test on windows

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -290,14 +290,9 @@ Future<void> _runToolTests() async {
       .map<String>((String name) => path.basenameWithoutExtension(name)),
     // The `dynamic` on the next line is because Map.fromIterable isn't generic.
     value: (dynamic subshard) => () async {
-      // Due to https://github.com/flutter/flutter/issues/46180, skip the hermetic directory
-      // on Windows.
-      final String suffix = Platform.isWindows && subshard == 'commands'
-        ? 'permeable'
-        : '';
       await _pubRunTest(
         toolsPath,
-        testPaths: <String>[path.join(kTest, '$subshard$kDotShard', suffix)],
+        testPaths: <String>[path.join(kTest, '$subshard$kDotShard')],
         tableData: bigqueryApi?.tabledata,
         enableFlutterToolAsserts: true,
       );
@@ -783,7 +778,6 @@ Future<void> _runFlutterWebTest(String workingDirectory, List<String> tests) asy
 Future<void> _pubRunTest(String workingDirectory, {
   List<String> testPaths,
   bool enableFlutterToolAsserts = true,
-  bool useBuildRunner = false,
   String coverage,
   bq.TabledataResourceApi tableData,
   bool forceSingleCore = false,
@@ -860,7 +854,6 @@ Future<void> _pubRunTest(String workingDirectory, {
       args,
       workingDirectory: workingDirectory,
       environment: pubEnvironment,
-      removeLine: useBuildRunner ? (String line) => line.startsWith('[INFO]') : null,
     );
   }
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io'; // ignore: dart_io_import
 
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/common.dart';
@@ -490,7 +491,7 @@ void main() {
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
-    });
+    }, skip: Platform.isWindows); // https://github.com/flutter/flutter/issues/55173
 
     group('forwarding to given port', () {
       const int devicePort = 499;


### PR DESCRIPTION
## Description

Due to https://github.com/flutter/flutter/issues/55173 , mDNS tests cannot be run on windows. Skip the test so the shard does not crash

Fixes https://github.com/flutter/flutter/issues/46180

