### PR TITLE
[flutter_tools] fix type error in symbolize

### DIFF
--- a/packages/flutter_tools/lib/src/commands/symbolize.dart
+++ b/packages/flutter_tools/lib/src/commands/symbolize.dart
@@ -145,6 +145,7 @@ class DwarfSymbolizationService {
   }) : _transformer = symbolsTransformer;
 
   /// Create a DwarfSymbolizationService with a no-op transformer for testing.
+  @visibleForTesting
   factory DwarfSymbolizationService.test() {
     return const DwarfSymbolizationService(
       symbolsTransformer: _testTransformer

--- a/packages/flutter_tools/lib/src/commands/symbolize.dart
+++ b/packages/flutter_tools/lib/src/commands/symbolize.dart
@@ -123,11 +123,33 @@ StreamTransformer<String, String> _defaultTransformer(Uint8List symbols) {
   return DwarfStackTraceDecoder(dwarf, includeInternalFrames: true);
 }
 
+// A no-op transformer for `DwarfSymbolizationService.test`
+StreamTransformer<String, String> _testTransformer(Uint8List buffer) {
+  return StreamTransformer<String, String>.fromHandlers(
+    handleData: (String data, EventSink<String> sink) {
+      sink.add(data);
+    },
+    handleDone: (EventSink<String> sink) {
+      sink.close();
+    },
+    handleError: (dynamic error, StackTrace stackTrace, EventSink<String> sink) {
+      sink.addError(error, stackTrace);
+    }
+  );
+}
+
 /// A service which decodes stack traces from Dart applications.
 class DwarfSymbolizationService {
   const DwarfSymbolizationService({
     SymbolsTransformer symbolsTransformer = _defaultTransformer,
   }) : _transformer = symbolsTransformer;
+
+  /// Create a DwarfSymbolizationService with a no-op transformer for testing.
+  factory DwarfSymbolizationService.test() {
+    return const DwarfSymbolizationService(
+      symbolsTransformer: _testTransformer
+    );
+  }
 
   final SymbolsTransformer _transformer;
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/symbolize_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/symbolize_test.dart
@@ -119,4 +119,4 @@ void main() {
   });
 }
 
-class MockDwarfSymboliztionService extends Mock implements DwarfSymbolizationService {}
+class MockDwarfSymbolizationService extends Mock implements DwarfSymbolizationService {}

--- a/packages/flutter_tools/test/commands.shard/hermetic/symbolize_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/symbolize_test.dart
@@ -2,10 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/common.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/symbolize.dart';
 import 'package:flutter_tools/src/convert.dart';
@@ -36,6 +38,39 @@ void main() {
       dwarfSymbolizationService: mockDwarfSymbolizationService,
     );
     applyMocksToCommand(command);
+  });
+
+  testUsingContext('Regression test for type error in codec', () async {
+    StreamTransformer<String, String> testTransformer(Uint8List buffer) {
+      return StreamTransformer<String, String>.fromHandlers(
+        handleData: (String data, EventSink<String> sink) {
+          sink.add(data);
+        },
+        handleDone: (EventSink<String> sink) {
+          sink.close();
+        },
+        handleError: (dynamic error, StackTrace stackTrace, EventSink<String> sink) {
+          sink.addError(error, stackTrace);
+        }
+      );
+    }
+    final DwarfSymbolizationService symbolizationService = DwarfSymbolizationService(
+      symbolsTransformer: testTransformer,
+    );
+    final StreamController<List<int>> output = StreamController<List<int>>();
+
+    unawaited(symbolizationService.decode(
+      input: Stream<Uint8List>.fromIterable(<Uint8List>[
+        utf8.encode('Hello, World\n') as Uint8List,
+      ]),
+      symbols: Uint8List(0),
+      output: IOSink(output.sink),
+    ));
+
+    await expectLater(
+      output.stream.transform(utf8.decoder),
+      emits('Hello, World'),
+    );
   });
 
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/symbolize_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/symbolize_test.dart
@@ -118,3 +118,5 @@ void main() {
     );
   });
 }
+
+class MockDwarfSymboliztionService extends Mock implements DwarfSymbolizationService {}

--- a/packages/flutter_tools/test/commands.shard/hermetic/symbolize_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/symbolize_test.dart
@@ -41,22 +41,7 @@ void main() {
   });
 
   testUsingContext('Regression test for type error in codec', () async {
-    StreamTransformer<String, String> testTransformer(Uint8List buffer) {
-      return StreamTransformer<String, String>.fromHandlers(
-        handleData: (String data, EventSink<String> sink) {
-          sink.add(data);
-        },
-        handleDone: (EventSink<String> sink) {
-          sink.close();
-        },
-        handleError: (dynamic error, StackTrace stackTrace, EventSink<String> sink) {
-          sink.addError(error, stackTrace);
-        }
-      );
-    }
-    final DwarfSymbolizationService symbolizationService = DwarfSymbolizationService(
-      symbolsTransformer: testTransformer,
-    );
+    final DwarfSymbolizationService symbolizationService = DwarfSymbolizationService.test();
     final StreamController<List<int>> output = StreamController<List<int>>();
 
     unawaited(symbolizationService.decode(
@@ -133,5 +118,3 @@ void main() {
     );
   });
 }
-
-class MockDwarfSymbolizationService extends Mock implements DwarfSymbolizationService {}


### PR DESCRIPTION
## Description

Symbolize had a type error, probably introduced some time after I stopped manually testing and started doing some refactoring on the code. Something, Something contravariance instead of covariance

Fixes https://github.com/flutter/flutter/issues/55214