### PR TITLE
[ExpansionTile] adds padding property

### DIFF
--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -41,7 +41,7 @@ class ExpansionTile extends StatefulWidget {
     this.children = const <Widget>[],
     this.trailing,
     this.initiallyExpanded = false,
-    this.padding,
+    this.tilePadding,
   }) : assert(initiallyExpanded != null),
        super(key: key);
 
@@ -81,10 +81,14 @@ class ExpansionTile extends StatefulWidget {
   /// Specifies if the list tile is initially expanded (true) or collapsed (false, the default).
   final bool initiallyExpanded;
 
-  /// Specifies padding for [title].
+  /// Specifies padding for the [ListTile].
   ///
-  /// When the value is null, padding is `EdgeInsets.symmetric(horizontal: 16.0)`.
-  final EdgeInsetsGeometry padding;
+  /// Analogous to [ListTile.contentPadding], this property defines the insets for
+  /// the [leading], [title], [subtitle] and [trailing] widgets. It does not inset
+  /// the expanded [children] widgets.
+  ///
+  /// When the value is null, the tile's padding is `EdgeInsets.symmetric(horizontal: 16.0)`.
+  final EdgeInsetsGeometry tilePadding;
 
   @override
   _ExpansionTileState createState() => _ExpansionTileState();
@@ -169,6 +173,7 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
           ListTileTheme.merge(
             iconColor: _iconColor.value,
             textColor: _headerColor.value,
+            contentPadding: widget.tilePadding,
             child: ListTile(
               onTap: _handleTap,
               leading: widget.leading,
@@ -178,7 +183,6 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
                 turns: _iconTurns,
                 child: const Icon(Icons.expand_more),
               ),
-              contentPadding: widget.padding,
             ),
           ),
           ClipRect(

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -173,9 +173,9 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
           ListTileTheme.merge(
             iconColor: _iconColor.value,
             textColor: _headerColor.value,
-            contentPadding: widget.tilePadding,
             child: ListTile(
               onTap: _handleTap,
+              contentPadding: widget.tilePadding,
               leading: widget.leading,
               title: widget.title,
               subtitle: widget.subtitle,

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -41,6 +41,7 @@ class ExpansionTile extends StatefulWidget {
     this.children = const <Widget>[],
     this.trailing,
     this.initiallyExpanded = false,
+    this.padding,
   }) : assert(initiallyExpanded != null),
        super(key: key);
 
@@ -79,6 +80,11 @@ class ExpansionTile extends StatefulWidget {
 
   /// Specifies if the list tile is initially expanded (true) or collapsed (false, the default).
   final bool initiallyExpanded;
+
+  /// Specifies padding for [title].
+  ///
+  /// When the value is null, padding is `EdgeInsets.symmetric(horizontal: 16.0)`.
+  final EdgeInsetsGeometry padding;
 
   @override
   _ExpansionTileState createState() => _ExpansionTileState();
@@ -172,6 +178,7 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
                 turns: _iconTurns,
                 child: const Icon(Icons.expand_more),
               ),
+              contentPadding: widget.padding,
             ),
           ),
           ClipRect(

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -250,8 +250,8 @@ void main() {
     expect(expansionTileRect.left, titleRect.left - 8);
     expect(expansionTileRect.right, trailingRect.right + 4);
 
-    // Default height of ListTile is 56.0, top and bottom padding are 12.0 and 10.0
-    // respectively.
+    // The height of ListTile should be 78.0, considering the default height of
+    // ListTile is 56.0, and top and bottom padding are 12.0 and 10.0 respectively.
     expect(tester.getRect(find.byType(ListTile)).height, 78.0);
   });
 }

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -236,7 +236,7 @@ void main() {
         child: Center(
           child: ExpansionTile(
             title: Text('Hello'),
-            padding: EdgeInsets.fromLTRB(8, 12, 4, 10),
+            tilePadding: EdgeInsets.fromLTRB(8, 12, 4, 10),
           ),
         ),
       ),
@@ -245,15 +245,13 @@ void main() {
     final Rect expansionTileRect = tester.getRect(find.byType(ExpansionTile));
     final Rect titleRect = tester.getRect(find.text('Hello'));
     final Rect trailingRect = tester.getRect(find.byIcon(Icons.expand_more));
-    final Rect tallerWidget = titleRect.height > trailingRect.height ? titleRect : trailingRect;
 
     // Check the positions of title and trailing Widgets, after padding is applied.
     expect(expansionTileRect.left, titleRect.left - 8);
     expect(expansionTileRect.right, trailingRect.right + 4);
 
-    // Height of ListTile is 56.0, Border of ExpansionTile is 1.0, and top
-    // padding is 12.0 .
-    expect(expansionTileRect.top, tallerWidget.top - (56 - tallerWidget.height) / 2 - 12 - 1);
-    expect(expansionTileRect.bottom, tallerWidget.bottom + (56 - tallerWidget.height) / 2 + 10 + 1);
+    // Default height of ListTile is 56.0, top and bottom padding are 12.0 and 10.0
+    // respectively.
+    expect(tester.getRect(find.byType(ListTile)).height, 78.0);
   });
 }

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -242,16 +242,18 @@ void main() {
       ),
     ));
 
-    final Rect expansionTileRect = tester.getRect(find.byType(ExpansionTile));
     final Rect titleRect = tester.getRect(find.text('Hello'));
     final Rect trailingRect = tester.getRect(find.byIcon(Icons.expand_more));
+    final Rect listTileRect = tester.getRect(find.byType(ListTile));
+    final Rect tallerWidget = titleRect.height > trailingRect.height ? titleRect : trailingRect;
 
     // Check the positions of title and trailing Widgets, after padding is applied.
-    expect(expansionTileRect.left, titleRect.left - 8);
-    expect(expansionTileRect.right, trailingRect.right + 4);
+    expect(listTileRect.left, titleRect.left - 8);
+    expect(listTileRect.right, trailingRect.right + 4);
 
-    // The height of ListTile should be 78.0, considering the default height of
-    // ListTile is 56.0, and top and bottom padding are 12.0 and 10.0 respectively.
-    expect(tester.getRect(find.byType(ListTile)).height, 78.0);
+    // Calculate the remaining height of ListTile from the default height.
+    final double remainingHeight = 56 - tallerWidget.height;
+    expect(listTileRect.top, tallerWidget.top - remainingHeight / 2 - 12);
+    expect(listTileRect.bottom, tallerWidget.bottom + remainingHeight / 2 + 10);
   });
 }

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -229,4 +229,31 @@ void main() {
 
     expect(find.text('Subtitle'), findsOneWidget);
   });
+
+  testWidgets('ExpansionTile padding test', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: Material(
+        child: Center(
+          child: ExpansionTile(
+            title: Text('Hello'),
+            padding: EdgeInsets.fromLTRB(8, 12, 4, 10),
+          ),
+        ),
+      ),
+    ));
+
+    final Rect expansionTileRect = tester.getRect(find.byType(ExpansionTile));
+    final Rect titleRect = tester.getRect(find.text('Hello'));
+    final Rect trailingRect = tester.getRect(find.byIcon(Icons.expand_more));
+    final Rect tallerWidget = titleRect.height > trailingRect.height ? titleRect : trailingRect;
+
+    // Check the positions of title and trailing Widgets, after padding is applied.
+    expect(expansionTileRect.left, titleRect.left - 8);
+    expect(expansionTileRect.right, trailingRect.right + 4);
+
+    // Height of ListTile is 56.0, Border of ExpansionTile is 1.0, and top
+    // padding is 12.0 .
+    expect(expansionTileRect.top, tallerWidget.top - (56 - tallerWidget.height) / 2 - 12 - 1);
+    expect(expansionTileRect.bottom, tallerWidget.bottom + (56 - tallerWidget.height) / 2 + 10 + 1);
+  });
 }


### PR DESCRIPTION
## Description
Exposes the `ListTile.contentPadding` for `title`. Users can now use padding to change the `contentPadding` of `ListTile` used for `title`.

## Related Issues
Fixes #54928

## Tests

I added test to check padding property of `ExpansionTile`.
## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
