### PR TITLE
[flutter_tools] Add experimental path-based browser location handling for Flutter Web.

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -421,6 +421,7 @@ class _ResidentWebRunner extends ResidentWebRunner {
           entrypoint: globals.fs.file(target).uri,
           expressionCompiler: expressionCompiler,
           chromiumLauncher: _chromiumLauncher,
+          dartDefines: debuggingOptions.buildInfo.dartDefines,
         );
         final Uri url = await device.devFS.create();
         if (debuggingOptions.buildInfo.isDebug) {

--- a/packages/flutter_tools/lib/src/build_system/targets/dart.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/dart.dart
@@ -60,6 +60,9 @@ const String kFileSystemRoots = 'FileSystemRoots';
 /// Defines specified via the `--dart-define` command-line option.
 const String kDartDefines = 'DartDefines';
 
+/// Use Path Strategy name that can be specified as a dart-define
+const String kUsePathStrategy = 'flutter.web.usePathStrategy';
+
 /// The define to control what iOS architectures are built for.
 ///
 /// This is expected to be a comma-separated list of architectures. If not


### PR DESCRIPTION
## Description

This enables the `flutter run` to start a local web-server that hosts index.html for unknown pages and thus allowing the Flutter Web JavaScript to detect the correct URL when using the new path location strategy.

This patch depends on my other PR for the engine here: https://github.com/flutter/engine/pull/17829

### Example usage

`flutter run -d chrome --dart-define=flutter.web.usePathStrategy=true`
`flutter run -d chrome --release --dart-define=flutter.web.usePathStrategy=true`
`flutter build web --dart-define=flutter.web.usePathStrategy=true`

## Related Issues

Closes: https://github.com/flutter/flutter/issues/33245 - *Flutter_web navigation should provide a way to remove hash symbol(#)*

## Tests

Tests added.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

/cc @jonahwilliams @yjbanov 