### PR TITLE
ignore .idea directory in dart analyzer and analyzer benchmark output in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@
 /dev/integration_tests/**/Pods
 /packages/flutter/coverage/
 version
+analysis_benchmark.json
 
 # packages file containing multi-root paths
 .packages.generated

--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -1147,6 +1147,8 @@ Iterable<File> _allFiles(String workingDirectory, String extension, { @required 
         continue;
       if (path.basename(entity.path) == '.git')
         continue;
+      if (path.basename(entity.path) == '.idea')
+        continue;
       if (path.basename(entity.path) == '.gradle')
         continue;
       if (path.basename(entity.path) == '.dart_tool')


### PR DESCRIPTION
I recently ran `dev/bots/analyze.dart` in my repo to check for license violations and it bombed out by trying to analyze the files in my Android Studio `.idea` directory. That directory is in the `.gitignore` file, but `analyze.dart` doesn't use `.gitignore` to prune its files so I had to add a rule to the dart code to avoid this.

Also, analyze.dart outputs a benchmark json file when it is done with information on its performance. I added this file to the `.gitignore` to keep it out of git activities.