### PR TITLE
flutter_tools: Prefer using .of() over .from() when possible

### DIFF
--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -37,7 +37,7 @@ Future<int> run(
   if (muteCommandLogging) {
     // Remove the verbose option; for help and doctor, users don't need to see
     // verbose logs.
-    args = List<String>.from(args);
+    args = List<String>.of(args);
     args.removeWhere((String option) => option == '-v' || option == '--verbose');
   }
 

--- a/packages/flutter_tools/lib/src/android/gradle_utils.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_utils.dart
@@ -21,7 +21,7 @@ import 'android_studio.dart';
 
 /// The environment variables needed to run Gradle.
 Map<String, String> get gradleEnvironment {
-  final Map<String, String> environment = Map<String, String>.from(globals.platform.environment);
+  final Map<String, String> environment = Map<String, String>.of(globals.platform.environment);
   if (javaPath != null) {
     // Use java bundled with Android Studio.
     environment['JAVA_HOME'] = javaPath;

--- a/packages/flutter_tools/lib/src/base/fingerprint.dart
+++ b/packages/flutter_tools/lib/src/base/fingerprint.dart
@@ -28,7 +28,7 @@ class Fingerprinter {
     Iterable<String> depfilePaths = const <String>[],
     FingerprintPathFilter pathFilter,
   }) : _paths = paths.toList(),
-       _properties = Map<String, String>.from(properties),
+       _properties = Map<String, String>.of(properties),
        _depfilePaths = depfilePaths.toList(),
        _pathFilter = pathFilter,
        assert(fingerprintPath != null),

--- a/packages/flutter_tools/lib/src/base/terminal.dart
+++ b/packages/flutter_tools/lib/src/base/terminal.dart
@@ -273,7 +273,7 @@ class AnsiTerminal implements Terminal {
     List<String> charactersToDisplay = acceptedCharacters;
     if (defaultChoiceIndex != null) {
       assert(defaultChoiceIndex >= 0 && defaultChoiceIndex < acceptedCharacters.length);
-      charactersToDisplay = List<String>.from(charactersToDisplay);
+      charactersToDisplay = List<String>.of(charactersToDisplay);
       charactersToDisplay[defaultChoiceIndex] = bolden(charactersToDisplay[defaultChoiceIndex]);
       acceptedCharacters.add('\n');
     }

--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -79,7 +79,7 @@ class ItemListNotifier<T> {
   }
 
   ItemListNotifier.from(List<T> items) {
-    _items = Set<T>.from(items);
+    _items = Set<T>.of(items);
   }
 
   Set<T> _items;
@@ -93,7 +93,7 @@ class ItemListNotifier<T> {
   List<T> get items => _items.toList();
 
   void updateWithNewList(List<T> updatedList) {
-    final Set<T> updatedSet = Set<T>.from(updatedList);
+    final Set<T> updatedSet = Set<T>.of(updatedList);
 
     final Set<T> addedItems = updatedSet.difference(_items);
     final Set<T> removedItems = _items.difference(updatedSet);

--- a/packages/flutter_tools/lib/src/commands/analyze_once.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_once.dart
@@ -54,7 +54,7 @@ class AnalyzeOnce extends AnalyzeBase {
         (workingDirectory ?? fileSystem.currentDirectory).path;
 
     // find directories from argResults.rest
-    final Set<String> directories = Set<String>.from(argResults.rest
+    final Set<String> directories = Set<String>.of(argResults.rest
         .map<String>((String path) => fileSystem.path.canonicalize(path)));
     if (directories.isNotEmpty) {
       for (final String directory in directories) {

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -1290,7 +1290,7 @@ class PubDependencyTree {
           dependencies = const <String>[];
         }
         _versions[package] = version;
-        _dependencyTree[package] = Set<String>.from(dependencies);
+        _dependencyTree[package] = Set<String>.of(dependencies);
       }
     }
     return null;

--- a/packages/flutter_tools/lib/src/desktop_device.dart
+++ b/packages/flutter_tools/lib/src/desktop_device.dart
@@ -139,7 +139,7 @@ abstract class DesktopDevice extends Device {
     bool succeeded = true;
     // Walk a copy of _runningProcesses, since the exit handler removes from the
     // set.
-    for (final Process process in Set<Process>.from(_runningProcesses)) {
+    for (final Process process in Set<Process>.of(_runningProcesses)) {
       succeeded &= process.kill();
     }
     return succeeded;

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -293,7 +293,7 @@ class _DevFSHttpWriter {
   Future<void> write(Map<Uri, DevFSContent> entries) async {
     _client.maxConnectionsPerHost = kMaxInFlight;
     _completer = Completer<void>();
-    _outstanding = Map<Uri, DevFSContent>.from(entries);
+    _outstanding = Map<Uri, DevFSContent>.of(entries);
     _scheduleWrites();
     await _completer.future;
   }

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_build.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_build.dart
@@ -131,7 +131,7 @@ Future<void> _buildAssets(
   );
 
   final Map<String, DevFSContent> assetEntries =
-      Map<String, DevFSContent>.from(assets.entries);
+      Map<String, DevFSContent>.of(assets.entries);
   await writeBundle(globals.fs.directory(assetDir), assetEntries);
 
   final String appName = fuchsiaProject.project.manifest.appName;

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -809,7 +809,7 @@ class _FuchsiaPortForwarder extends DevicePortForwarder {
   @override
   Future<void> dispose() async {
     final List<ForwardedPort> forwardedPortsCopy =
-      List<ForwardedPort>.from(forwardedPorts);
+      List<ForwardedPort>.of(forwardedPorts);
     for (final ForwardedPort port in forwardedPortsCopy) {
       await unforward(port);
     }

--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -47,7 +47,7 @@ class IOSDeploy {
     // Python script that uses package 'six'. LLDB.framework relies on the
     // python at the front of the path, which may not include package 'six'.
     // Ensure that we pick up the system install of python, which includes it.
-    final Map<String, String> environment = Map<String, String>.from(_platform.environment);
+    final Map<String, String> environment = Map<String, String>.of(_platform.environment);
     environment['PATH'] = '/usr/bin:${environment['PATH']}';
     environment.addEntries(<MapEntry<String, String>>[_cache.dyLdLibEntry]);
     return environment;

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -342,7 +342,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   // it a lot of wiggle room (locally on Flutter Gallery, this takes ~1s).
   // When there is a timeout, we retry once. See issue #35988.
   final List<String> showBuildSettingsCommand = (List<String>
-      .from(buildCommands)
+      .of(buildCommands)
       ..add('-showBuildSettings'))
       // Undocumented behavior: xcodebuild craps out if -showBuildSettings
       // is used together with -allowProvisioningUpdates or

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -897,7 +897,7 @@ class _IOSSimulatorDevicePortForwarder extends DevicePortForwarder {
 
   @override
   Future<void> dispose() async {
-    final List<ForwardedPort> portsCopy = List<ForwardedPort>.from(_ports);
+    final List<ForwardedPort> portsCopy = List<ForwardedPort>.of(_ports);
     for (final ForwardedPort port in portsCopy) {
       await unforward(port);
     }

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -108,7 +108,7 @@ class FlutterProject {
       example.android.applicationId,
       await example.ios.productBundleIdentifier,
     ];
-    return Set<String>.from(candidates
+    return Set<String>.of(candidates
         .map<String>(_organizationNameFromPackageName)
         .where((String name) => name != null));
   }

--- a/packages/flutter_tools/lib/src/tracing.dart
+++ b/packages/flutter_tools/lib/src/tracing.dart
@@ -102,7 +102,7 @@ Future<void> downloadStartupTrace(VMService observatory, { bool awaitFirstFrame 
 
   int extractInstantEventTimestamp(String eventName) {
     final List<Map<String, dynamic>> events =
-        List<Map<String, dynamic>>.from((timeline['traceEvents'] as List<dynamic>).cast<Map<String, dynamic>>());
+        List<Map<String, dynamic>>.from(timeline['traceEvents'] as List<dynamic>);
     final Map<String, dynamic> event = events.firstWhere(
       (Map<String, dynamic> event) => event['name'] == eventName, orElse: () => null,
     );

--- a/packages/flutter_tools/test/general.shard/base/fingerprint_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/fingerprint_test.dart
@@ -362,7 +362,7 @@ void main() {
           },
           'files': <String, dynamic>{},
         };
-        final Map<String, dynamic> b = Map<String, dynamic>.from(a);
+        final Map<String, dynamic> b = Map<String, dynamic>.of(a);
         b['properties'] = <String, String>{
           'buildMode': BuildMode.release.toString(),
         };
@@ -380,7 +380,7 @@ void main() {
             'b.dart': '6f144e08b58cd0925328610fad7ac07c',
           },
         };
-        final Map<String, dynamic> b = Map<String, dynamic>.from(a);
+        final Map<String, dynamic> b = Map<String, dynamic>.of(a);
         b['files'] = <String, dynamic>{
           'a.dart': '8a21a15fad560b799f6731d436c1b698',
           'b.dart': '6f144e08b58cd0925328610fad7ac07d',
@@ -399,7 +399,7 @@ void main() {
             'b.dart': '6f144e08b58cd0925328610fad7ac07c',
           },
         };
-        final Map<String, dynamic> b = Map<String, dynamic>.from(a);
+        final Map<String, dynamic> b = Map<String, dynamic>.of(a);
         b['files'] = <String, dynamic>{
           'a.dart': '8a21a15fad560b799f6731d436c1b698',
           'c.dart': '6f144e08b58cd0925328610fad7ac07d',

--- a/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
@@ -387,7 +387,7 @@ void main() {
       final VisualStudioFixture fixture = setUpVisualStudio();
       final VisualStudio visualStudio = fixture.visualStudio;
 
-      final Map<String, dynamic> response = Map<String, dynamic>.from(_defaultResponse)
+      final Map<String, dynamic> response = Map<String, dynamic>.of(_defaultResponse)
         ..['isPrerelease'] = true;
       setMockCompatibleVisualStudioInstallation(
         null,
@@ -448,7 +448,7 @@ void main() {
         fixture.processManager,
       );
 
-      final Map<String, dynamic> response = Map<String, dynamic>.from(_defaultResponse)
+      final Map<String, dynamic> response = Map<String, dynamic>.of(_defaultResponse)
         ..['isComplete'] = false;
       setMockAnyVisualStudioInstallation(
         response,
@@ -476,7 +476,7 @@ void main() {
         fixture.processManager,
       );
 
-      final Map<String, dynamic> response = Map<String, dynamic>.from(_defaultResponse)
+      final Map<String, dynamic> response = Map<String, dynamic>.of(_defaultResponse)
         ..['isLaunchable'] = false;
       setMockAnyVisualStudioInstallation(
         response,
@@ -503,7 +503,7 @@ void main() {
         fixture.processManager,
       );
 
-      final Map<String, dynamic> response = Map<String, dynamic>.from(_defaultResponse)
+      final Map<String, dynamic> response = Map<String, dynamic>.of(_defaultResponse)
         ..['isRebootRequired'] = true;
       setMockAnyVisualStudioInstallation(
         response,
@@ -565,7 +565,7 @@ void main() {
       final VisualStudioFixture fixture = setUpVisualStudio();
       final VisualStudio visualStudio = fixture.visualStudio;
 
-      final Map<String, dynamic> response = Map<String, dynamic>.from(_defaultResponse)
+      final Map<String, dynamic> response = Map<String, dynamic>.of(_defaultResponse)
         ..['isRebootRequired'] = true;
       setMockCompatibleVisualStudioInstallation(
         response,
@@ -585,7 +585,7 @@ void main() {
       final VisualStudioFixture fixture = setUpVisualStudio();
       final VisualStudio visualStudio = fixture.visualStudio;
 
-      final Map<String, dynamic> response = Map<String, dynamic>.from(_defaultResponse)
+      final Map<String, dynamic> response = Map<String, dynamic>.of(_defaultResponse)
         ..['isRebootRequired'] = true;
       setMockCompatibleVisualStudioInstallation(
         response,

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -585,7 +585,7 @@ class BasicMock {
   final List<String> messages = <String>[];
 
   void expectMessages(List<String> expectedMessages) {
-    final List<String> actualMessages = List<String>.from(messages);
+    final List<String> actualMessages = List<String>.of(messages);
     messages.clear();
     expect(actualMessages, unorderedEquals(expectedMessages));
   }


### PR DESCRIPTION
Prefer using `.of()` (which is statically type-checked) over `.from()` (which is dynamically type-checked) when possible.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*
