### PR TITLE
Add DragTarget callback onAcceptDetails, plus helper class DragTarget…

### DIFF
--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -583,7 +583,7 @@ class _DragTargetState<T> extends State<DragTarget<T>> {
     if (widget.onAccept != null)
       widget.onAccept(avatar.data as T);
     if (widget.onAcceptWithDetails != null)
-      widget.onAcceptWithDetails(DragTargetDetails(data: avatar.data as T, offset: avatar._lastOffset));
+      widget.onAcceptWithDetails(DragTargetDetails<T>(data: avatar.data as T, offset: avatar._lastOffset));
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -21,6 +21,11 @@ typedef DragTargetWillAccept<T> = bool Function(T data);
 /// Used by [DragTarget.onAccept].
 typedef DragTargetAccept<T> = void Function(T data);
 
+/// Signature for determining information about the acceptance by a [DragTarget].
+///
+/// Used by [DragTarget.onAcceptWithDetails].
+typedef DragTargetAcceptWithDetails<T> = void Function(DragTargetDetails<T> details);
+
 /// Signature for building children of a [DragTarget].
 ///
 /// The `candidateData` argument contains the list of drag data that is hovering
@@ -459,6 +464,21 @@ class DraggableDetails {
   final Offset offset;
 }
 
+/// Represents the details when a pointer event occurred on the [DragTarget].
+class DragTargetDetails<T> {
+  /// Creates details for a [DragTarget] callback.
+  ///
+  /// The [offset] must not be null.
+  DragTargetDetails({@required this.data, @required this.offset}) : assert(offset != null);
+
+  /// The data that was dropped onto this [DragTarget].
+  final T data;
+
+  /// The global position when the specific pointer event occurred on
+  /// the draggable.
+  final Offset offset;
+}
+
 /// A widget that receives data when a [Draggable] widget is dropped.
 ///
 /// When a draggable is dragged on top of a drag target, the drag target is
@@ -480,6 +500,7 @@ class DragTarget<T> extends StatefulWidget {
     @required this.builder,
     this.onWillAccept,
     this.onAccept,
+    this.onAcceptWithDetails,
     this.onLeave,
   }) : super(key: key);
 
@@ -493,12 +514,20 @@ class DragTarget<T> extends StatefulWidget {
   /// piece of data being dragged over this drag target.
   ///
   /// Called when a piece of data enters the target. This will be followed by
-  /// either [onAccept], if the data is dropped, or [onLeave], if the drag
-  /// leaves the target.
+  /// either [onAccept] and [onAcceptWithDetails], if the data is dropped, or
+  /// [onLeave], if the drag leaves the target.
   final DragTargetWillAccept<T> onWillAccept;
 
   /// Called when an acceptable piece of data was dropped over this drag target.
+  ///
+  /// Equivalent to [onAcceptWithDetails], but only includes the data.
   final DragTargetAccept<T> onAccept;
+
+  /// Called when an acceptable piece of data was dropped over this drag target.
+  ///
+  /// Equivalent to [onAccept], but with information, including the data, in a
+  /// [DragTargetDetails].
+  final DragTargetAcceptWithDetails<T> onAcceptWithDetails;
 
   /// Called when a given piece of data being dragged over this target leaves
   /// the target.
@@ -553,6 +582,8 @@ class _DragTargetState<T> extends State<DragTarget<T>> {
     });
     if (widget.onAccept != null)
       widget.onAccept(avatar.data as T);
+    if (widget.onAcceptWithDetails != null)
+      widget.onAcceptWithDetails(DragTargetDetails(data:avatar.data as T, offset:avatar._lastOffset));
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -583,7 +583,7 @@ class _DragTargetState<T> extends State<DragTarget<T>> {
     if (widget.onAccept != null)
       widget.onAccept(avatar.data as T);
     if (widget.onAcceptWithDetails != null)
-      widget.onAcceptWithDetails(DragTargetDetails(data:avatar.data as T, offset:avatar._lastOffset));
+      widget.onAcceptWithDetails(DragTargetDetails(data: avatar.data as T, offset: avatar._lastOffset));
   }
 
   @override

--- a/packages/flutter/test/widgets/draggable_test.dart
+++ b/packages/flutter/test/widgets/draggable_test.dart
@@ -13,7 +13,7 @@ import 'semantics_tester.dart';
 void main() {
   testWidgets('Drag and drop - control test', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
-    final List<DragTargetDetails> acceptedDetails = <DragTargetDetails>[];
+    final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
     int dragStartedCount = 0;
 
     await tester.pumpWidget(MaterialApp(
@@ -186,7 +186,7 @@ void main() {
                 onAccept: (int data) {
                   events.add('drop');
                 },
-                onAcceptWithDetails: (DragTargetDetails _) {
+                onAcceptWithDetails: (DragTargetDetails<int> _) {
                   events.add('details');
                 },
               ),
@@ -274,7 +274,7 @@ void main() {
             onAccept: (int data) {
               events.add('drop');
             },
-            onAcceptWithDetails: (DragTargetDetails _) {
+            onAcceptWithDetails: (DragTargetDetails<int> _) {
               events.add('details');
             },
           ),
@@ -325,7 +325,7 @@ void main() {
             onAccept: (int data) {
               events.add('drop');
             },
-            onAcceptWithDetails: (DragTargetDetails _) {
+            onAcceptWithDetails: (DragTargetDetails<int> _) {
               events.add('details');
             },
           ),
@@ -374,7 +374,7 @@ void main() {
             onAccept: (int data) {
               events.add('drop');
             },
-            onAcceptWithDetails: (DragTargetDetails _) {
+            onAcceptWithDetails: (DragTargetDetails<int> _) {
               events.add('details');
             },
           ),
@@ -421,7 +421,7 @@ void main() {
             onAccept: (int data) {
               events.add('drop $data');
             },
-            onAcceptWithDetails: (DragTargetDetails _) {
+            onAcceptWithDetails: (DragTargetDetails<int> _) {
               events.add('details');
             },
           ),
@@ -532,7 +532,7 @@ void main() {
             onAccept: (int data) {
               events.add('drop $data');
             },
-            onAcceptWithDetails: (DragTargetDetails _) {
+            onAcceptWithDetails: (DragTargetDetails<int> _) {
               events.add('details');
             },
           ),
@@ -642,7 +642,7 @@ void main() {
               onAccept: (int data) {
                 events.add('drop $data');
               },
-              onAcceptWithDetails: (DragTargetDetails _) {
+              onAcceptWithDetails: (DragTargetDetails<int> _) {
                 events.add('details');
               },
             ),
@@ -760,7 +760,7 @@ void main() {
 
   testWidgets('Drag and drop - onDraggableCanceled not called if dropped on accepting target', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
-    final List<DragTargetDetails> acceptedDetails = <DragTargetDetails>[];
+    final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
     bool onDraggableCanceledCalled = false;
 
     await tester.pumpWidget(MaterialApp(
@@ -828,7 +828,7 @@ void main() {
 
   testWidgets('Drag and drop - onDraggableCanceled called if dropped on non-accepting target', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
-    final List<DragTargetDetails> acceptedDetails = <DragTargetDetails>[];
+    final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
     bool onDraggableCanceledCalled = false;
     Velocity onDraggableCanceledVelocity;
     Offset onDraggableCanceledOffset;
@@ -905,7 +905,7 @@ void main() {
 
   testWidgets('Drag and drop - onDraggableCanceled called if dropped on non-accepting target with correct velocity', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
-    final List<DragTargetDetails> acceptedDetails = <DragTargetDetails>[];
+    final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
     bool onDraggableCanceledCalled = false;
     Velocity onDraggableCanceledVelocity;
     Offset onDraggableCanceledOffset;
@@ -960,7 +960,7 @@ void main() {
 
   testWidgets('Drag and drop - onDragEnd not called if dropped on non-accepting target', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
-    final List<DragTargetDetails> acceptedDetails = <DragTargetDetails>[];
+    final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
     bool onDragEndCalled = false;
     DraggableDetails onDragEndDraggableDetails;
     await tester.pumpWidget(MaterialApp(
@@ -1174,7 +1174,7 @@ void main() {
 
   testWidgets('Drag and drop - onDragCompleted not called if dropped on non-accepting target', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
-    final List<DragTargetDetails> acceptedDetails = <DragTargetDetails>[];
+    final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
     bool onDragCompletedCalled = false;
 
     await tester.pumpWidget(MaterialApp(
@@ -1245,7 +1245,7 @@ void main() {
 
   testWidgets('Drag and drop - onDragEnd called if dropped on accepting target', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
-    final List<DragTargetDetails> acceptedDetails = <DragTargetDetails>[];
+    final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
     bool onDragEndCalled = false;
     DraggableDetails onDragEndDraggableDetails;
     await tester.pumpWidget(MaterialApp(
@@ -1341,7 +1341,7 @@ void main() {
             onAccept: (int data) {
               events.add('drop');
             },
-            onAcceptWithDetails: (DragTargetDetails _) {
+            onAcceptWithDetails: (DragTargetDetails<int> _) {
               events.add('details');
             },
           ),
@@ -1387,7 +1387,7 @@ void main() {
 
   testWidgets('Drag and drop - onDragCompleted called if dropped on accepting target', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
-    final List<DragTargetDetails> acceptedDetails = <DragTargetDetails>[];
+    final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
     bool onDragCompletedCalled = false;
 
     await tester.pumpWidget(MaterialApp(
@@ -1455,9 +1455,9 @@ void main() {
 
   testWidgets('Drag and drop - allow pass thru of unaccepted data test', (WidgetTester tester) async {
     final List<int> acceptedInts = <int>[];
-    final List<DragTargetDetails> acceptedIntsDetails = <DragTargetDetails>[];
+    final List<DragTargetDetails<int>> acceptedIntsDetails = <DragTargetDetails<int>>[];
     final List<double> acceptedDoubles = <double>[];
-    final List<DragTargetDetails> acceptedDoublesDetails = <DragTargetDetails>[];
+    final List<DragTargetDetails<double>> acceptedDoublesDetails = <DragTargetDetails<double>>[];
 
     await tester.pumpWidget(MaterialApp(
       home: Column(
@@ -1589,9 +1589,9 @@ void main() {
 
   testWidgets('Drag and drop - allow pass thru of unaccepted data twice test', (WidgetTester tester) async {
     final List<DragTargetData> acceptedDragTargetDatas = <DragTargetData>[];
-    final List<DragTargetDetails> acceptedDragTargetDataDetails = <DragTargetDetails>[];
+    final List<DragTargetDetails<DragTargetData>> acceptedDragTargetDataDetails = <DragTargetDetails<DragTargetData>>[];
     final List<ExtendedDragTargetData> acceptedExtendedDragTargetDatas = <ExtendedDragTargetData>[];
-    final List<DragTargetDetails> acceptedExtendedDragTargetDataDetails = <DragTargetDetails>[];
+    final List<DragTargetDetails<ExtendedDragTargetData>> acceptedExtendedDragTargetDataDetails = <DragTargetDetails<ExtendedDragTargetData>>[];
     final DragTargetData dragTargetData = DragTargetData();
     await tester.pumpWidget(MaterialApp(
       home: Column(
@@ -1657,7 +1657,7 @@ void main() {
 
   testWidgets('Drag and drop - maxSimultaneousDrags', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
-    final List<DragTargetDetails> acceptedDetails = <DragTargetDetails>[];
+    final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
 
     Widget build(int maxSimultaneousDrags) {
       return MaterialApp(
@@ -1873,7 +1873,7 @@ void main() {
             onAccept: (int data) {
               events.add('drop');
             },
-            onAcceptWithDetails: (DragTargetDetails _) {
+            onAcceptWithDetails: (DragTargetDetails<int> _) {
               events.add('details');
             },
           ),
@@ -1918,7 +1918,7 @@ void main() {
 
   testWidgets('Drag and drop - remove draggable', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
-    final List<DragTargetDetails> acceptedDetails = <DragTargetDetails>[];
+    final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
 
     await tester.pumpWidget(MaterialApp(
       home: Column(
@@ -2022,7 +2022,7 @@ void main() {
 
   testWidgets('long-press draggable calls onDragEnd called if dropped on accepting target', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
-    final List<DragTargetDetails> acceptedDetails = <DragTargetDetails>[];
+    final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
     bool onDragEndCalled = false;
     DraggableDetails onDragEndDraggableDetails;
 
@@ -2109,7 +2109,7 @@ void main() {
 
   testWidgets('long-press draggable calls onDragCompleted called if dropped on accepting target', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
-    final List<DragTargetDetails> acceptedDetails = <DragTargetDetails>[];
+    final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
     bool onDragCompletedCalled = false;
 
     await tester.pumpWidget(MaterialApp(
@@ -2429,7 +2429,7 @@ Future<void> _testLongPressDraggableHapticFeedback({ WidgetTester tester, bool h
 
 Future<void> _testChildAnchorFeedbackPosition({ WidgetTester tester, double top = 0.0, double left = 0.0 }) async {
   final List<int> accepted = <int>[];
-  final List<DragTargetDetails> acceptedDetails = <DragTargetDetails>[];
+  final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
   int dragStartedCount = 0;
 
   await tester.pumpWidget(

--- a/packages/flutter/test/widgets/draggable_test.dart
+++ b/packages/flutter/test/widgets/draggable_test.dart
@@ -13,6 +13,7 @@ import 'semantics_tester.dart';
 void main() {
   testWidgets('Drag and drop - control test', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
+    final List<DragTargetDetails> acceptedDetails = <DragTargetDetails>[];
     int dragStartedCount = 0;
 
     await tester.pumpWidget(MaterialApp(
@@ -31,12 +32,14 @@ void main() {
               return Container(height: 100.0, child: const Text('Target'));
             },
             onAccept: accepted.add,
+            onAcceptWithDetails: acceptedDetails.add,
           ),
         ],
       ),
     ));
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -47,6 +50,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsOneWidget);
     expect(find.text('Target'), findsOneWidget);
@@ -57,6 +61,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsOneWidget);
     expect(find.text('Target'), findsOneWidget);
@@ -66,6 +71,8 @@ void main() {
     await tester.pump();
 
     expect(accepted, equals(<int>[1]));
+    expect(acceptedDetails, hasLength(1));
+    expect(acceptedDetails.first.offset, const Offset(256.0, 74.0));
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -179,6 +186,9 @@ void main() {
                 onAccept: (int data) {
                   events.add('drop');
                 },
+                onAcceptWithDetails: (DragTargetDetails _) {
+                  events.add('details');
+                },
               ),
             ],
           ),
@@ -217,7 +227,7 @@ void main() {
     expect(events, isEmpty);
     await gesture.up();
     await tester.pump();
-    expect(events, equals(<String>['drop']));
+    expect(events, equals(<String>['drop', 'details']));
     events.clear();
 
     // drag and tap and drop
@@ -235,7 +245,7 @@ void main() {
     await tester.tap(find.text('Target'));
     await gesture.up();
     await tester.pump();
-    expect(events, equals(<String>['tap', 'tap', 'drop']));
+    expect(events, equals(<String>['tap', 'tap', 'drop', 'details']));
     events.clear();
   });
 
@@ -264,6 +274,9 @@ void main() {
             onAccept: (int data) {
               events.add('drop');
             },
+            onAcceptWithDetails: (DragTargetDetails _) {
+              events.add('details');
+            },
           ),
         ],
       ),
@@ -289,7 +302,7 @@ void main() {
     expect(events, isEmpty);
     await gesture.up();
     await tester.pump();
-    expect(events, equals(<String>['drop']));
+    expect(events, equals(<String>['drop', 'details']));
     events.clear();
   });
 
@@ -311,6 +324,9 @@ void main() {
             },
             onAccept: (int data) {
               events.add('drop');
+            },
+            onAcceptWithDetails: (DragTargetDetails _) {
+              events.add('details');
             },
           ),
         ],
@@ -358,6 +374,9 @@ void main() {
             onAccept: (int data) {
               events.add('drop');
             },
+            onAcceptWithDetails: (DragTargetDetails _) {
+              events.add('details');
+            },
           ),
         ],
       ),
@@ -384,7 +403,7 @@ void main() {
     expect(events, isEmpty);
     await gesture.up();
     await tester.pump();
-    expect(events, equals(<String>['drop']));
+    expect(events, equals(<String>['drop', 'details']));
   });
 
   testWidgets('Drag and drop - horizontal and vertical draggables in vertical block', (WidgetTester tester) async {
@@ -401,6 +420,9 @@ void main() {
             },
             onAccept: (int data) {
               events.add('drop $data');
+            },
+            onAcceptWithDetails: (DragTargetDetails _) {
+              events.add('details');
             },
           ),
           Container(height: 400.0),
@@ -439,7 +461,7 @@ void main() {
     await tester.pump();
     await gesture.up();
     await tester.pump();
-    expect(events, equals(<String>['drop 2']));
+    expect(events, equals(<String>['drop 2', 'details']));
     expect(tester.getCenter(find.text('Target')).dy, greaterThan(0.0));
     events.clear();
 
@@ -456,7 +478,7 @@ void main() {
     await tester.pump();
     await gesture.up();
     await tester.pump();
-    expect(events, equals(<String>['drop 1']));
+    expect(events, equals(<String>['drop 1', 'details']));
     expect(tester.getCenter(find.text('Target')).dy, greaterThan(0.0));
     events.clear();
 
@@ -474,7 +496,7 @@ void main() {
     await tester.pump();
     await gesture.up();
     await tester.pump();
-    expect(events, equals(<String>['drop 2']));
+    expect(events, equals(<String>['drop 2', 'details']));
     expect(tester.getCenter(find.text('Target')).dy, greaterThan(0.0));
     events.clear();
 
@@ -509,6 +531,9 @@ void main() {
             },
             onAccept: (int data) {
               events.add('drop $data');
+            },
+            onAcceptWithDetails: (DragTargetDetails _) {
+              events.add('details');
             },
           ),
           Container(width: 400.0),
@@ -547,7 +572,7 @@ void main() {
     await tester.pump();
     await gesture.up();
     await tester.pump();
-    expect(events, equals(<String>['drop 1']));
+    expect(events, equals(<String>['drop 1', 'details']));
     expect(tester.getCenter(find.text('Target')).dx, greaterThan(0.0));
     events.clear();
 
@@ -564,7 +589,7 @@ void main() {
     await tester.pump();
     await gesture.up();
     await tester.pump();
-    expect(events, equals(<String>['drop 2']));
+    expect(events, equals(<String>['drop 2', 'details']));
     expect(tester.getCenter(find.text('Target')).dx, greaterThan(0.0));
     events.clear();
 
@@ -582,7 +607,7 @@ void main() {
     await tester.pump();
     await gesture.up();
     await tester.pump();
-    expect(events, equals(<String>['drop 1']));
+    expect(events, equals(<String>['drop 1', 'details']));
     expect(tester.getCenter(find.text('Target')).dx, greaterThan(0.0));
     events.clear();
 
@@ -616,6 +641,9 @@ void main() {
               },
               onAccept: (int data) {
                 events.add('drop $data');
+              },
+              onAcceptWithDetails: (DragTargetDetails _) {
+                events.add('details');
               },
             ),
             Container(width: 400.0),
@@ -732,6 +760,7 @@ void main() {
 
   testWidgets('Drag and drop - onDraggableCanceled not called if dropped on accepting target', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
+    final List<DragTargetDetails> acceptedDetails = <DragTargetDetails>[];
     bool onDraggableCanceledCalled = false;
 
     await tester.pumpWidget(MaterialApp(
@@ -750,12 +779,14 @@ void main() {
               return Container(height: 100.0, child: const Text('Target'));
             },
             onAccept: accepted.add,
+            onAcceptWithDetails: acceptedDetails.add,
           ),
         ],
       ),
     ));
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -766,6 +797,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsOneWidget);
     expect(find.text('Target'), findsOneWidget);
@@ -776,6 +808,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsOneWidget);
     expect(find.text('Target'), findsOneWidget);
@@ -785,6 +818,8 @@ void main() {
     await tester.pump();
 
     expect(accepted, equals(<int>[1]));
+    expect(acceptedDetails, hasLength(1));
+    expect(acceptedDetails.first.offset, const Offset(256.0, 74.0));
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -793,6 +828,7 @@ void main() {
 
   testWidgets('Drag and drop - onDraggableCanceled called if dropped on non-accepting target', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
+    final List<DragTargetDetails> acceptedDetails = <DragTargetDetails>[];
     bool onDraggableCanceledCalled = false;
     Velocity onDraggableCanceledVelocity;
     Offset onDraggableCanceledOffset;
@@ -818,12 +854,15 @@ void main() {
               );
             },
             onWillAccept: (int data) => false,
+            onAccept: accepted.add,
+            onAcceptWithDetails: acceptedDetails.add,
           ),
         ],
       ),
     ));
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -834,6 +873,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsOneWidget);
     expect(find.text('Target'), findsOneWidget);
@@ -844,6 +884,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsOneWidget);
     expect(find.text('Target'), findsOneWidget);
@@ -853,6 +894,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -863,6 +905,7 @@ void main() {
 
   testWidgets('Drag and drop - onDraggableCanceled called if dropped on non-accepting target with correct velocity', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
+    final List<DragTargetDetails> acceptedDetails = <DragTargetDetails>[];
     bool onDraggableCanceledCalled = false;
     Velocity onDraggableCanceledVelocity;
     Offset onDraggableCanceledOffset;
@@ -886,12 +929,15 @@ void main() {
               child: const Text('Target'),
             );
           },
-          onWillAccept: (int data) => false),
-        ],
-      ),
-    ));
+          onWillAccept: (int data) => false,
+          onAccept: accepted.add,
+          onAcceptWithDetails: acceptedDetails.add,
+        ),
+      ],
+    )));
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -902,6 +948,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -913,6 +960,7 @@ void main() {
 
   testWidgets('Drag and drop - onDragEnd not called if dropped on non-accepting target', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
+    final List<DragTargetDetails> acceptedDetails = <DragTargetDetails>[];
     bool onDragEndCalled = false;
     DraggableDetails onDragEndDraggableDetails;
     await tester.pumpWidget(MaterialApp(
@@ -935,12 +983,15 @@ void main() {
               );
             },
             onWillAccept: (int data) => false,
+            onAccept: accepted.add,
+            onAcceptWithDetails: acceptedDetails.add,
           ),
         ],
       ),
     ));
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -951,6 +1002,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsOneWidget);
     expect(find.text('Target'), findsOneWidget);
@@ -961,6 +1013,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsOneWidget);
     expect(find.text('Target'), findsOneWidget);
@@ -970,6 +1023,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -1120,6 +1174,7 @@ void main() {
 
   testWidgets('Drag and drop - onDragCompleted not called if dropped on non-accepting target', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
+    final List<DragTargetDetails> acceptedDetails = <DragTargetDetails>[];
     bool onDragCompletedCalled = false;
 
     await tester.pumpWidget(MaterialApp(
@@ -1141,12 +1196,15 @@ void main() {
               );
             },
             onWillAccept: (int data) => false,
+            onAccept: accepted.add,
+            onAcceptWithDetails: acceptedDetails.add,
           ),
         ],
       ),
     ));
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -1157,6 +1215,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsOneWidget);
     expect(find.text('Target'), findsOneWidget);
@@ -1167,6 +1226,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsOneWidget);
     expect(find.text('Target'), findsOneWidget);
@@ -1176,6 +1236,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -1184,6 +1245,7 @@ void main() {
 
   testWidgets('Drag and drop - onDragEnd called if dropped on accepting target', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
+    final List<DragTargetDetails> acceptedDetails = <DragTargetDetails>[];
     bool onDragEndCalled = false;
     DraggableDetails onDragEndDraggableDetails;
     await tester.pumpWidget(MaterialApp(
@@ -1203,12 +1265,14 @@ void main() {
               return Container(height: 100.0, child: const Text('Target'));
             },
             onAccept: accepted.add,
+            onAcceptWithDetails: acceptedDetails.add,
           ),
         ],
       ),
     ));
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -1219,6 +1283,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsOneWidget);
     expect(find.text('Target'), findsOneWidget);
@@ -1229,6 +1294,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsOneWidget);
     expect(find.text('Target'), findsOneWidget);
@@ -1238,7 +1304,11 @@ void main() {
     await tester.pump();
 
     final Offset droppedLocation = tester.getTopLeft(find.text('Target'));
+    final Offset expectedDropOffset = Offset(droppedLocation.dx, secondLocation.dy - firstLocation.dy);
+
     expect(accepted, equals(<int>[1]));
+    expect(acceptedDetails, hasLength(1));
+    expect(acceptedDetails.first.offset, const Offset(256.0, 74.0));
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -1246,9 +1316,7 @@ void main() {
     expect(onDragEndDraggableDetails, isNotNull);
     expect(onDragEndDraggableDetails.wasAccepted, isTrue);
     expect(onDragEndDraggableDetails.velocity, equals(Velocity.zero));
-    expect(onDragEndDraggableDetails.offset,
-        equals(
-            Offset(droppedLocation.dx, secondLocation.dy - firstLocation.dy)));
+    expect(onDragEndDraggableDetails.offset, equals(expectedDropOffset));
   });
 
   testWidgets('DragTarget does not call onDragEnd when remove from the tree', (WidgetTester tester) async {
@@ -1272,6 +1340,9 @@ void main() {
             },
             onAccept: (int data) {
               events.add('drop');
+            },
+            onAcceptWithDetails: (DragTargetDetails _) {
+              events.add('details');
             },
           ),
         ],
@@ -1316,6 +1387,7 @@ void main() {
 
   testWidgets('Drag and drop - onDragCompleted called if dropped on accepting target', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
+    final List<DragTargetDetails> acceptedDetails = <DragTargetDetails>[];
     bool onDragCompletedCalled = false;
 
     await tester.pumpWidget(MaterialApp(
@@ -1334,12 +1406,14 @@ void main() {
               return Container(height: 100.0, child: const Text('Target'));
             },
             onAccept: accepted.add,
+            onAcceptWithDetails: acceptedDetails.add,
           ),
         ],
       ),
     ));
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -1350,6 +1424,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsOneWidget);
     expect(find.text('Target'), findsOneWidget);
@@ -1360,6 +1435,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsOneWidget);
     expect(find.text('Target'), findsOneWidget);
@@ -1369,6 +1445,8 @@ void main() {
     await tester.pump();
 
     expect(accepted, equals(<int>[1]));
+    expect(acceptedDetails, hasLength(1));
+    expect(acceptedDetails.first.offset, const Offset(256.0, 74.0));
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -1377,7 +1455,9 @@ void main() {
 
   testWidgets('Drag and drop - allow pass thru of unaccepted data test', (WidgetTester tester) async {
     final List<int> acceptedInts = <int>[];
+    final List<DragTargetDetails> acceptedIntsDetails = <DragTargetDetails>[];
     final List<double> acceptedDoubles = <double>[];
+    final List<DragTargetDetails> acceptedDoublesDetails = <DragTargetDetails>[];
 
     await tester.pumpWidget(MaterialApp(
       home: Column(
@@ -1404,6 +1484,7 @@ void main() {
                   );
                 },
                 onAccept: acceptedInts.add,
+                onAcceptWithDetails: acceptedIntsDetails.add,
               ),
               DragTarget<double>(
                 builder: (BuildContext context, List<double> data, List<dynamic> rejects) {
@@ -1415,6 +1496,7 @@ void main() {
                   );
                 },
                 onAccept: acceptedDoubles.add,
+                onAcceptWithDetails: acceptedDoublesDetails.add,
               ),
             ],
           ),
@@ -1423,7 +1505,9 @@ void main() {
     ));
 
     expect(acceptedInts, isEmpty);
+    expect(acceptedIntsDetails, isEmpty);
     expect(acceptedDoubles, isEmpty);
+    expect(acceptedDoublesDetails, isEmpty);
     expect(find.text('IntSource'), findsOneWidget);
     expect(find.text('IntDragging'), findsNothing);
     expect(find.text('DoubleSource'), findsOneWidget);
@@ -1440,7 +1524,9 @@ void main() {
     await tester.pump();
 
     expect(acceptedInts, isEmpty);
+    expect(acceptedIntsDetails, isEmpty);
     expect(acceptedDoubles, isEmpty);
+    expect(acceptedDoublesDetails, isEmpty);
     expect(find.text('IntDragging'), findsNothing);
     expect(find.text('DoubleDragging'), findsOneWidget);
 
@@ -1448,7 +1534,9 @@ void main() {
     await tester.pump();
 
     expect(acceptedInts, isEmpty);
+    expect(acceptedIntsDetails, isEmpty);
     expect(acceptedDoubles, isEmpty);
+    expect(acceptedDoublesDetails, isEmpty);
     expect(find.text('IntDragging'), findsNothing);
     expect(find.text('DoubleDragging'), findsOneWidget);
 
@@ -1456,18 +1544,24 @@ void main() {
     await tester.pump();
 
     expect(acceptedInts, isEmpty);
+    expect(acceptedIntsDetails, isEmpty);
     expect(acceptedDoubles, equals(<double>[1.0]));
+    expect(acceptedDoublesDetails, hasLength(1));
+    expect(acceptedDoublesDetails.first.offset, const Offset(112.0, 122.0));
     expect(find.text('IntDragging'), findsNothing);
     expect(find.text('DoubleDragging'), findsNothing);
 
     acceptedDoubles.clear();
+    acceptedDoublesDetails.clear();
 
     // Drag the int draggable.
     final TestGesture intGesture = await tester.startGesture(intLocation, pointer: 7);
     await tester.pump();
 
     expect(acceptedInts, isEmpty);
+    expect(acceptedIntsDetails, isEmpty);
     expect(acceptedDoubles, isEmpty);
+    expect(acceptedDoublesDetails, isEmpty);
     expect(find.text('IntDragging'), findsOneWidget);
     expect(find.text('DoubleDragging'), findsNothing);
 
@@ -1475,7 +1569,9 @@ void main() {
     await tester.pump();
 
     expect(acceptedInts, isEmpty);
+    expect(acceptedIntsDetails, isEmpty);
     expect(acceptedDoubles, isEmpty);
+    expect(acceptedDoublesDetails, isEmpty);
     expect(find.text('IntDragging'), findsOneWidget);
     expect(find.text('DoubleDragging'), findsNothing);
 
@@ -1483,14 +1579,19 @@ void main() {
     await tester.pump();
 
     expect(acceptedInts, equals(<int>[1]));
+    expect(acceptedIntsDetails, hasLength(1));
+    expect(acceptedIntsDetails.first.offset, const Offset(184.0, 122.0));
     expect(acceptedDoubles, isEmpty);
+    expect(acceptedDoublesDetails, isEmpty);
     expect(find.text('IntDragging'), findsNothing);
     expect(find.text('DoubleDragging'), findsNothing);
   });
 
   testWidgets('Drag and drop - allow pass thru of unaccepted data twice test', (WidgetTester tester) async {
     final List<DragTargetData> acceptedDragTargetDatas = <DragTargetData>[];
+    final List<DragTargetDetails> acceptedDragTargetDataDetails = <DragTargetDetails>[];
     final List<ExtendedDragTargetData> acceptedExtendedDragTargetDatas = <ExtendedDragTargetData>[];
+    final List<DragTargetDetails> acceptedExtendedDragTargetDataDetails = <DragTargetDetails>[];
     final DragTargetData dragTargetData = DragTargetData();
     await tester.pumpWidget(MaterialApp(
       home: Column(
@@ -1511,6 +1612,7 @@ void main() {
                     ),
                   );
                 }, onAccept: acceptedDragTargetDatas.add,
+                onAcceptWithDetails: acceptedDragTargetDataDetails.add,
               ),
               DragTarget<ExtendedDragTargetData>(
                 builder: (BuildContext context, List<ExtendedDragTargetData> data, List<dynamic> rejects) {
@@ -1522,6 +1624,7 @@ void main() {
                   );
                 },
                 onAccept: acceptedExtendedDragTargetDatas.add,
+                onAcceptWithDetails: acceptedExtendedDragTargetDataDetails.add,
               ),
             ],
           ),
@@ -1541,15 +1644,20 @@ void main() {
       await tester.pump();
 
       expect(acceptedDragTargetDatas, equals(<DragTargetData>[dragTargetData]));
+      expect(acceptedDragTargetDataDetails, hasLength(1));
+      expect(acceptedDragTargetDataDetails.first.offset, const Offset(256.0, 74.0));
       expect(acceptedExtendedDragTargetDatas, isEmpty);
+      expect(acceptedExtendedDragTargetDataDetails, isEmpty);
 
       acceptedDragTargetDatas.clear();
+      acceptedDragTargetDataDetails.clear();
       await tester.pump();
     }
   });
 
   testWidgets('Drag and drop - maxSimultaneousDrags', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
+    final List<DragTargetDetails> acceptedDetails = <DragTargetDetails>[];
 
     Widget build(int maxSimultaneousDrags) {
       return MaterialApp(
@@ -1566,6 +1674,7 @@ void main() {
                 return Container(height: 100.0, child: const Text('Target'));
               },
               onAccept: accepted.add,
+              onAcceptWithDetails: acceptedDetails.add,
             ),
           ],
         ),
@@ -1578,6 +1687,7 @@ void main() {
     final Offset secondLocation = tester.getCenter(find.text('Target'));
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -1586,6 +1696,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -1595,6 +1706,7 @@ void main() {
     await tester.pumpWidget(build(2));
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -1603,6 +1715,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsOneWidget);
     expect(find.text('Target'), findsOneWidget);
@@ -1611,6 +1724,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNWidgets(2));
     expect(find.text('Target'), findsOneWidget);
@@ -1619,6 +1733,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNWidgets(2));
     expect(find.text('Target'), findsOneWidget);
@@ -1629,6 +1744,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNWidgets(2));
     expect(find.text('Target'), findsOneWidget);
@@ -1637,6 +1753,8 @@ void main() {
     await tester.pump();
 
     expect(accepted, equals(<int>[1]));
+    expect(acceptedDetails, hasLength(1));
+    expect(acceptedDetails.first.offset, const Offset(256.0, 74.0));
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsOneWidget);
     expect(find.text('Target'), findsOneWidget);
@@ -1645,6 +1763,9 @@ void main() {
     await tester.pump();
 
     expect(accepted, equals(<int>[1, 1]));
+    expect(acceptedDetails, hasLength(2));
+    expect(acceptedDetails[0].offset, const Offset(256.0, 74.0));
+    expect(acceptedDetails[1].offset, const Offset(256.0, 74.0));
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -1653,6 +1774,9 @@ void main() {
     await tester.pump();
 
     expect(accepted, equals(<int>[1, 1]));
+    expect(acceptedDetails, hasLength(2));
+    expect(acceptedDetails[0].offset, const Offset(256.0, 74.0));
+    expect(acceptedDetails[1].offset, const Offset(256.0, 74.0));
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -1749,6 +1873,9 @@ void main() {
             onAccept: (int data) {
               events.add('drop');
             },
+            onAcceptWithDetails: (DragTargetDetails _) {
+              events.add('details');
+            },
           ),
         ],
       ),
@@ -1791,6 +1918,7 @@ void main() {
 
   testWidgets('Drag and drop - remove draggable', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
+    final List<DragTargetDetails> acceptedDetails = <DragTargetDetails>[];
 
     await tester.pumpWidget(MaterialApp(
       home: Column(
@@ -1805,12 +1933,14 @@ void main() {
               return Container(height: 100.0, child: const Text('Target'));
             },
             onAccept: accepted.add,
+            onAcceptWithDetails: acceptedDetails.add,
           ),
         ],
       ),
     ));
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -1820,6 +1950,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsOneWidget);
     expect(find.text('Target'), findsOneWidget);
@@ -1832,12 +1963,14 @@ void main() {
               return Container(height: 100.0, child: const Text('Target'));
             },
             onAccept: accepted.add,
+            onAcceptWithDetails: acceptedDetails.add,
           ),
         ],
       ),
     ));
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsNothing);
     expect(find.text('Dragging'), findsOneWidget);
     expect(find.text('Target'), findsOneWidget);
@@ -1847,6 +1980,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsNothing);
     expect(find.text('Dragging'), findsOneWidget);
     expect(find.text('Target'), findsOneWidget);
@@ -1855,6 +1989,8 @@ void main() {
     await tester.pump();
 
     expect(accepted, equals(<int>[1]));
+    expect(acceptedDetails, hasLength(1));
+    expect(acceptedDetails.first.offset, const Offset(256.0, 26.0));
     expect(find.text('Source'), findsNothing);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -1886,6 +2022,7 @@ void main() {
 
   testWidgets('long-press draggable calls onDragEnd called if dropped on accepting target', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
+    final List<DragTargetDetails> acceptedDetails = <DragTargetDetails>[];
     bool onDragEndCalled = false;
     DraggableDetails onDragEndDraggableDetails;
 
@@ -1906,12 +2043,14 @@ void main() {
               return Container(height: 100.0, child: const Text('Target'));
             },
             onAccept: accepted.add,
+            onAcceptWithDetails: acceptedDetails.add,
           ),
         ],
       ),
     ));
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -1922,6 +2061,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -1930,6 +2070,7 @@ void main() {
     await tester.pump(kLongPressTimeout);
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsOneWidget);
     expect(find.text('Target'), findsOneWidget);
@@ -1941,6 +2082,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsOneWidget);
     expect(find.text('Target'), findsOneWidget);
@@ -1950,7 +2092,11 @@ void main() {
     await tester.pump();
 
     final Offset droppedLocation = tester.getTopLeft(find.text('Target'));
+    final Offset expectedDropOffset = Offset(droppedLocation.dx, secondLocation.dy - firstLocation.dy);
+
     expect(accepted, equals(<int>[1]));
+    expect(acceptedDetails, hasLength(1));
+    expect(acceptedDetails.first.offset, expectedDropOffset);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -1958,13 +2104,12 @@ void main() {
     expect(onDragEndDraggableDetails, isNotNull);
     expect(onDragEndDraggableDetails.wasAccepted, isTrue);
     expect(onDragEndDraggableDetails.velocity, equals(Velocity.zero));
-    expect(onDragEndDraggableDetails.offset,
-        equals(
-            Offset(droppedLocation.dx, secondLocation.dy - firstLocation.dy)));
+    expect(onDragEndDraggableDetails.offset, equals(expectedDropOffset));
   });
 
   testWidgets('long-press draggable calls onDragCompleted called if dropped on accepting target', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
+    final List<DragTargetDetails> acceptedDetails = <DragTargetDetails>[];
     bool onDragCompletedCalled = false;
 
     await tester.pumpWidget(MaterialApp(
@@ -1983,12 +2128,14 @@ void main() {
               return Container(height: 100.0, child: const Text('Target'));
             },
             onAccept: accepted.add,
+            onAcceptWithDetails: acceptedDetails.add,
           ),
         ],
       ),
     ));
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -1999,6 +2146,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -2007,6 +2155,7 @@ void main() {
     await tester.pump(kLongPressTimeout);
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsOneWidget);
     expect(find.text('Target'), findsOneWidget);
@@ -2018,6 +2167,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, isEmpty);
+    expect(acceptedDetails, isEmpty);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsOneWidget);
     expect(find.text('Target'), findsOneWidget);
@@ -2027,6 +2177,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, equals(<int>[1]));
+    expect(acceptedDetails.first.offset, const Offset(256.0, 74.0));
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -2278,6 +2429,7 @@ Future<void> _testLongPressDraggableHapticFeedback({ WidgetTester tester, bool h
 
 Future<void> _testChildAnchorFeedbackPosition({ WidgetTester tester, double top = 0.0, double left = 0.0 }) async {
   final List<int> accepted = <int>[];
+  final List<DragTargetDetails> acceptedDetails = <DragTargetDetails>[];
   int dragStartedCount = 0;
 
   await tester.pumpWidget(
@@ -2305,6 +2457,7 @@ Future<void> _testChildAnchorFeedbackPosition({ WidgetTester tester, double top 
                     return Container(height: 100.0, child: const Text('Target'));
                   },
                   onAccept: accepted.add,
+                  onAcceptWithDetails: acceptedDetails.add,
                 ),
               ],
             ),
@@ -2315,6 +2468,7 @@ Future<void> _testChildAnchorFeedbackPosition({ WidgetTester tester, double top 
   );
 
   expect(accepted, isEmpty);
+  expect(acceptedDetails, isEmpty);
   expect(find.text('Source'), findsOneWidget);
   expect(find.text('Dragging'), findsNothing);
   expect(find.text('Target'), findsOneWidget);
@@ -2325,6 +2479,7 @@ Future<void> _testChildAnchorFeedbackPosition({ WidgetTester tester, double top 
   await tester.pump();
 
   expect(accepted, isEmpty);
+  expect(acceptedDetails, isEmpty);
   expect(find.text('Source'), findsOneWidget);
   expect(find.text('Dragging'), findsOneWidget);
   expect(find.text('Target'), findsOneWidget);
@@ -2336,6 +2491,7 @@ Future<void> _testChildAnchorFeedbackPosition({ WidgetTester tester, double top 
   await tester.pump();
 
   expect(accepted, isEmpty);
+  expect(acceptedDetails, isEmpty);
   expect(find.text('Source'), findsOneWidget);
   expect(find.text('Dragging'), findsOneWidget);
   expect(find.text('Target'), findsOneWidget);


### PR DESCRIPTION
…Details, to report offset on drop

## Description

Adds the ability for DragTarget to get the drop offset. Adds a new onAcceptDetails callback, and helper class DragTargetDetails. 

## Related Issues

* Fixes #55184 

## Tests

draggable_test.dart has been updated

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.

