### PR TITLE
Update dartdoc version to 0.31.0

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -111,7 +111,7 @@ if [[ -d "$FLUTTER_PUB_CACHE" ]]; then
 fi
 
 # Install and activate dartdoc.
-"$PUB" global activate dartdoc 0.30.4
+"$PUB" global activate dartdoc 0.31.0
 
 # This script generates a unified doc set, and creates
 # a custom index.html, placing everything into dev/docs/doc.


### PR DESCRIPTION
This version update is needed mostly due to a bug parsing the new version number syntax used in Dart SDKs; it doesn't have an effect on Flutter doc generation but updating here to keep pace.

Release notes:  https://github.com/dart-lang/dartdoc/releases/tag/v0.31.0