### PR TITLE
[flutter_tools] check first for stable tag, then dev tag

### DIFF
--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -783,7 +783,10 @@ class GitTagVersion {
     );
   }
 
-  /// Check for the release tag format of the forms x.y.z or x.y.z-m.n.pre
+  /// Check for the release tag format.
+  ///
+  /// Release tags can be either stable format like '1.2.3' or dev format, like
+  /// '1.2.3-4.5.pre'.
   static GitTagVersion parseTaggedVersion(String version) {
     final RegExp versionPattern = RegExp(
       r'^(\d+)\.(\d+)\.(\d+)(-\d+\.\d+\.pre)?$');
@@ -797,27 +800,30 @@ class GitTagVersion {
     final int y = matchGroups[1] == null ? null : int.tryParse(matchGroups[1]);
     final int z = matchGroups[2] == null ? null : int.tryParse(matchGroups[2]);
     final String devString = matchGroups[3];
-    int m, n;
+    int devVersion, devPatch;
     if (devString != null) {
       final Match devMatch = RegExp(r'^-(\d+)\.(\d+)\.pre')
         .firstMatch(devString);
       final List<String> devGroups = devMatch.groups(<int>[1, 2]);
-      m = devGroups[0] == null ? null : int.tryParse(devGroups[0]);
-      n = devGroups[1] == null ? null : int.tryParse(devGroups[1]);
+      devVersion = devGroups[0] == null ? null : int.tryParse(devGroups[0]);
+      devPatch = devGroups[1] == null ? null : int.tryParse(devGroups[1]);
     }
     return GitTagVersion(
       x: x,
       y: y,
       z: z,
-      devVersion: m,
-      devPatch: n,
+      devVersion: devVersion,
+      devPatch: devPatch,
       commits: 0,
       hash: '',
       gitTag: version,
     );
   }
 
-  /// Detect output of git describe, of the form x.y.z-m.n.pre-<commits>-g<hash>
+  /// Detect output of git describe
+  ///
+  /// For example, for commit abc123 that is 6 commits after tag 1.2.3-4.5.pre
+  /// git would return '1.2.3-4.5.pre-6-gabc123'.
   static GitTagVersion parseGitVersion(String version) {
     final RegExp versionPattern = RegExp(
       r'^(\d+)\.(\d+)\.(\d+)(-\d+\.\d+\.pre)?-(\d+)-g([a-f0-9]+)$');
@@ -831,13 +837,13 @@ class GitTagVersion {
     final int y = matchGroups[1] == null ? null : int.tryParse(matchGroups[1]);
     final int z = matchGroups[2] == null ? null : int.tryParse(matchGroups[2]);
     final String devString = matchGroups[3];
-    int m, n;
+    int devVersion, devPatch;
     if (devString != null) {
       final Match devMatch = RegExp(r'^-(\d+)\.(\d+)\.pre$')
         .firstMatch(devString);
       final List<String> devGroups = devMatch.groups(<int>[1, 2]);
-      m = devGroups[0] == null ? null : int.tryParse(devGroups[0]);
-      n = devGroups[1] == null ? null : int.tryParse(devGroups[1]);
+      devVersion = devGroups[0] == null ? null : int.tryParse(devGroups[0]);
+      devPatch = devGroups[1] == null ? null : int.tryParse(devGroups[1]);
     }
     // count of commits past last tagged version
     final int commits = matchGroups[4] == null ? null : int.tryParse(matchGroups[4]);
@@ -847,8 +853,8 @@ class GitTagVersion {
       x: x,
       y: y,
       z: z,
-      devVersion: m,
-      devPatch: n,
+      devVersion: devVersion,
+      devPatch: devPatch,
       commits: commits,
       hash: hash,
       gitTag: '$x.$y.$z${devString ?? ''}', // e.g. 1.2.3-4.5.pre

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -754,17 +754,20 @@ class GitTagVersion {
     }
     final List<String> tags = _runGit(
       'git tag --contains HEAD', processUtils, workingDirectory).split('\n');
+
     // Check first for a stable tag
+    final RegExp stableTagPattern = RegExp(r'^\d+\.\d+\.\d+$');
     for (final String tag in tags) {
       final String trimmedTag = tag.trim();
-      if (RegExp(r'^\d+\.\d+\.\d+$').hasMatch(trimmedTag)) {
+      if (stableTagPattern.hasMatch(trimmedTag)) {
         return parse(trimmedTag);
       }
     }
     // Next check for a dev tag
+    final RegExp devTagPattern = RegExp(r'^\d+\.\d+\.\d+-\d+\.\d+\.pre$');
     for (final String tag in tags) {
       final String trimmedTag = tag.trim();
-      if (RegExp(r'^\d+\.\d+\.\d+-\d+\.\d+\.pre$').hasMatch(trimmedTag)) {
+      if (devTagPattern.hasMatch(trimmedTag)) {
         return parse(trimmedTag);
       }
     }

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -779,6 +779,28 @@ class GitTagVersion {
     );
   }
 
+  /// Check for the release tag format of the form x.y.z
+  static GitTagVersion parseStableVersion(String version) {
+    final RegExp versionPattern = RegExp(
+      r'^(\d+)\.(\d+)\.(\d+)$');
+    final List<String> parts = versionPattern.matchAsPrefix(version)?.groups(<int>[1, 2, 3]);
+    if (parts == null) {
+      return const GitTagVersion.unknown();
+    }
+    final List<int> parsedParts = parts.map<int>(
+      (String source) => source == null ? null : int.tryParse(source)).toList();
+    return GitTagVersion(
+      x: parsedParts[0],
+      y: parsedParts[1],
+      z: parsedParts[2],
+      devVersion: null,
+      devPatch: null,
+      commits: 0,
+      hash: '',
+      gitTag: version,
+    );
+  }
+
   /// Check for the release tag format of the form x.y.z-m.n.pre
   static GitTagVersion parseVersion(String version) {
     final RegExp versionPattern = RegExp(
@@ -813,6 +835,10 @@ class GitTagVersion {
   static GitTagVersion parse(String version) {
     GitTagVersion gitTagVersion;
 
+    gitTagVersion = parseStableVersion(version);
+    if (gitTagVersion != const GitTagVersion.unknown()) {
+      return gitTagVersion;
+    }
     gitTagVersion = parseVersion(version);
     if (gitTagVersion != const GitTagVersion.unknown()) {
       return gitTagVersion;

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -769,7 +769,7 @@ class GitTagVersion {
       }
     }
 
-    // If we're not currently on a tag, 
+    // If we're not currently on a tag, use git describe
     return parse(
       _runGit(
         'git describe --match *.*.*-*.*.pre --first-parent --long --tags',

--- a/packages/flutter_tools/test/commands.shard/hermetic/version_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/version_test.dart
@@ -259,7 +259,7 @@ class MockProcessManager extends Mock implements ProcessManager {
       return ProcessResult(0, 0, '000000000000000000000', '');
     }
     if (commandStr ==
-        'git describe --match *.*.* --first-parent --long --tags') {
+        'git describe --match *.*.*-*.*.pre --first-parent --long --tags') {
       if (version.isNotEmpty) {
         return ProcessResult(0, 0, '$version-0-g00000000', '');
       }

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -238,7 +238,13 @@ void main() {
         fakeProcessManager = FakeProcessManager.list(<FakeCommand>[
           const FakeCommand(
             command: <String>[
-              'git', 'describe', '--match', '*.*.*', '--first-parent', '--long', '--tags',
+              'git', 'tag', '--contains', 'HEAD',
+            ],
+            stdout: '',
+          ),
+          const FakeCommand(
+            command: <String>[
+              'git', 'describe', '--match', '*.*.*-*.*.pre', '--first-parent', '--long', '--tags',
             ],
             stdout: 'v1.12.16-19-gb45b676af',
           ),

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
@@ -179,7 +179,9 @@ void main() {
           workingDirectory: Cache.flutterRoot)).thenReturn(result);
         when(processManager.runSync('git fetch https://github.com/flutter/flutter.git --tags'.split(' '),
           workingDirectory: Cache.flutterRoot)).thenReturn(result);
-        when(processManager.runSync('git describe --match *.*.* --first-parent --long --tags'.split(' '),
+        when(processManager.runSync('git tag --contains HEAD'.split(' '),
+          workingDirectory: Cache.flutterRoot)).thenReturn(result);
+        when(processManager.runSync('git describe --match *.*.*-*.*.pre --first-parent --long --tags'.split(' '),
           workingDirectory: Cache.flutterRoot)).thenReturn(result);
         when(processManager.runSync(FlutterVersion.gitLog('-n 1 --pretty=format:%ad --date=iso'.split(' ')),
           workingDirectory: Cache.flutterRoot)).thenReturn(result);

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -530,10 +530,18 @@ void main() {
       environment: anyNamed('environment'),
     )).thenReturn(RunResult(ProcessResult(109, 0, '', ''), <String>['git', 'fetch']));
     when(processUtils.runSync(
-      <String>['git', 'describe', '--match', '*.*.*', '--first-parent', '--long', '--tags'],
+      <String>['git', 'tag', '--contains', 'HEAD'],
       workingDirectory: anyNamed('workingDirectory'),
       environment: anyNamed('environment'),
-    )).thenReturn(RunResult(ProcessResult(110, 0, 'v0.1.2-3-1234abcd', ''), <String>['git', 'describe']));
+    )).thenReturn(
+      RunResult(ProcessResult(110, 0, '', ''),
+      <String>['git', 'tag', '--contains', 'HEAD'],
+    ));
+    when(processUtils.runSync(
+      <String>['git', 'describe', '--match', '*.*.*-*.*.pre', '--first-parent', '--long', '--tags'],
+      workingDirectory: anyNamed('workingDirectory'),
+      environment: anyNamed('environment'),
+    )).thenReturn(RunResult(ProcessResult(111, 0, 'v0.1.2-3-1234abcd', ''), <String>['git', 'describe']));
 
     GitTagVersion.determine(processUtils, workingDirectory: '.', fetchTags: true);
 
@@ -548,7 +556,7 @@ void main() {
       environment: anyNamed('environment'),
     )).called(1);
     verify(processUtils.runSync(
-      <String>['git', 'describe', '--match', '*.*.*', '--first-parent', '--long', '--tags'],
+      <String>['git', 'describe', '--match', '*.*.*-*.*.pre', '--first-parent', '--long', '--tags'],
       workingDirectory: anyNamed('workingDirectory'),
       environment: anyNamed('environment'),
     )).called(1);
@@ -669,10 +677,15 @@ void fakeData(
     environment: anyNamed('environment'),
   )).thenReturn(ProcessResult(105, 0, '', ''));
   when(pm.runSync(
-    <String>['git', 'describe', '--match', '*.*.*', '--first-parent', '--long', '--tags'],
+    <String>['git', 'tag', '--contains', 'HEAD'],
     workingDirectory: anyNamed('workingDirectory'),
     environment: anyNamed('environment'),
-  )).thenReturn(ProcessResult(106, 0, 'v0.1.2-3-1234abcd', ''));
+  )).thenReturn(ProcessResult(106, 0, '', ''));
+  when(pm.runSync(
+    <String>['git', 'describe', '--match', '*.*.*-*.*.pre', '--first-parent', '--long', '--tags'],
+    workingDirectory: anyNamed('workingDirectory'),
+    environment: anyNamed('environment'),
+  )).thenReturn(ProcessResult(107, 0, 'v0.1.2-3-1234abcd', ''));
 }
 
 class MockProcessManager extends Mock implements ProcessManager {}

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -394,11 +394,19 @@ void main() {
     const String hash = 'abcdef';
     GitTagVersion gitTagVersion;
 
+    // Master channel
     gitTagVersion = GitTagVersion.parse('1.2.3-4.5.pre-13-g$hash');
     expect(gitTagVersion.frameworkVersionFor(hash), '1.2.3-5.0.pre.13');
     expect(gitTagVersion.gitTag, '1.2.3-4.5.pre');
     expect(gitTagVersion.devVersion, 4);
     expect(gitTagVersion.devPatch, 5);
+
+    // Stable channel
+    gitTagVersion = GitTagVersion.parse('1.2.3');
+    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.3');
+    expect(gitTagVersion.gitTag, '1.2.3');
+    expect(gitTagVersion.devVersion, null);
+    expect(gitTagVersion.devPatch, null);
 
     gitTagVersion = GitTagVersion.parse('1.2.3-13-g$hash');
     expect(gitTagVersion.frameworkVersionFor(hash), '1.2.4.pre.13');

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -412,7 +412,7 @@ void main() {
 
     // Dev channel
     gitTagVersion = GitTagVersion.parse('1.2.3-4.5.pre');
-    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.3-5.0.pre');
+    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.3-4.5.pre');
     expect(gitTagVersion.gitTag, '1.2.3-4.5.pre');
     expect(gitTagVersion.devVersion, 4);
     expect(gitTagVersion.devPatch, 5);

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -404,7 +404,9 @@ void main() {
     // Stable channel
     gitTagVersion = GitTagVersion.parse('1.2.3');
     expect(gitTagVersion.frameworkVersionFor(hash), '1.2.3');
-    expect(gitTagVersion.gitTag, '1.2.3');
+    expect(gitTagVersion.x, 1);
+    expect(gitTagVersion.y, 2);
+    expect(gitTagVersion.z, 3);
     expect(gitTagVersion.devVersion, null);
     expect(gitTagVersion.devPatch, null);
 

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -410,6 +410,13 @@ void main() {
     expect(gitTagVersion.devVersion, null);
     expect(gitTagVersion.devPatch, null);
 
+    // Dev channel
+    gitTagVersion = GitTagVersion.parse('1.2.3-4.5.pre');
+    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.3-5.0.pre');
+    expect(gitTagVersion.gitTag, '1.2.3-4.5.pre');
+    expect(gitTagVersion.devVersion, 4);
+    expect(gitTagVersion.devPatch, 5);
+
     gitTagVersion = GitTagVersion.parse('1.2.3-13-g$hash');
     expect(gitTagVersion.frameworkVersionFor(hash), '1.2.4.pre.13');
     expect(gitTagVersion.gitTag, '1.2.3');

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -394,14 +394,6 @@ void main() {
     const String hash = 'abcdef';
     GitTagVersion gitTagVersion;
 
-    // legacy tag format (x.y.z-dev.m.n), master channel
-    gitTagVersion = GitTagVersion.parse('1.2.3-dev.4.5-4-g$hash');
-    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.3-5.0.pre.4');
-    expect(gitTagVersion.gitTag, '1.2.3-dev.4.5');
-    expect(gitTagVersion.devVersion, 4);
-    expect(gitTagVersion.devPatch, 5);
-
-    // new tag release format, master channel
     gitTagVersion = GitTagVersion.parse('1.2.3-4.5.pre-13-g$hash');
     expect(gitTagVersion.frameworkVersionFor(hash), '1.2.3-5.0.pre.13');
     expect(gitTagVersion.gitTag, '1.2.3-4.5.pre');
@@ -456,10 +448,18 @@ void main() {
       environment: anyNamed('environment'),
     )).thenReturn(RunResult(ProcessResult(105, 0, '', ''), <String>['git', 'fetch']));
     when(processUtils.runSync(
-      <String>['git', 'describe', '--match', '*.*.*', '--first-parent', '--long', '--tags'],
+      <String>['git', 'describe', '--match', '*.*.*-*.*.pre', '--first-parent', '--long', '--tags'],
       workingDirectory: anyNamed('workingDirectory'),
       environment: anyNamed('environment'),
     )).thenReturn(RunResult(ProcessResult(106, 0, 'v0.1.2-3-1234abcd', ''), <String>['git', 'describe']));
+    when(processUtils.runSync(
+      <String>['git', 'tag', '--contains', 'HEAD'],
+      workingDirectory: anyNamed('workingDirectory'),
+      environment: anyNamed('environment'),
+    )).thenReturn(
+      RunResult(ProcessResult(110, 0, '', ''),
+      <String>['git', 'tag', '--contains', 'HEAD'],
+    ));
 
     GitTagVersion.determine(processUtils, workingDirectory: '.');
 
@@ -474,7 +474,7 @@ void main() {
       environment: anyNamed('environment'),
     ));
     verify(processUtils.runSync(
-      <String>['git', 'describe', '--match', '*.*.*', '--first-parent', '--long', '--tags'],
+      <String>['git', 'describe', '--match', '*.*.*-*.*.pre', '--first-parent', '--long', '--tags'],
       workingDirectory: anyNamed('workingDirectory'),
       environment: anyNamed('environment'),
     )).called(1);
@@ -493,10 +493,18 @@ void main() {
       environment: anyNamed('environment'),
     )).thenReturn(RunResult(ProcessResult(106, 0, '', ''), <String>['git', 'fetch']));
     when(processUtils.runSync(
-      <String>['git', 'describe', '--match', '*.*.*', '--first-parent', '--long', '--tags'],
+      <String>['git', 'describe', '--match', '*.*.*-*.*.pre', '--first-parent', '--long', '--tags'],
       workingDirectory: anyNamed('workingDirectory'),
       environment: anyNamed('environment'),
     )).thenReturn(RunResult(ProcessResult(107, 0, 'v0.1.2-3-1234abcd', ''), <String>['git', 'describe']));
+    when(processUtils.runSync(
+      <String>['git', 'tag', '--contains', 'HEAD'],
+      workingDirectory: anyNamed('workingDirectory'),
+      environment: anyNamed('environment'),
+    )).thenReturn(
+      RunResult(ProcessResult(108, 0, '', ''),
+      <String>['git', 'tag', '--contains', 'HEAD'],
+    ));
 
     GitTagVersion.determine(processUtils, workingDirectory: '.', fetchTags: true);
 
@@ -511,7 +519,7 @@ void main() {
       environment: anyNamed('environment'),
     ));
     verify(processUtils.runSync(
-      <String>['git', 'describe', '--match', '*.*.*', '--first-parent', '--long', '--tags'],
+      <String>['git', 'describe', '--match', '*.*.*-*.*.pre', '--first-parent', '--long', '--tags'],
       workingDirectory: anyNamed('workingDirectory'),
       environment: anyNamed('environment'),
     )).called(1);


### PR DESCRIPTION
## Description

In the situation where beta release `1.2.3-4.5.pre` is promoted to the stable channel as `1.2.3`, the tool will have to disambiguate between multiple tags on the same commit. The desired outcome is to always favor the stable tag. Prior to this PR, the tool relied on `git describe ...`to pick the right tag. Testing locally, it seemed to do the right thing, but as this may not be stable (e.g. https://stackoverflow.com/questions/8089002/git-describe-with-two-tags-on-the-same-commit), this PR makes the following changes:

1. Rather than always running `git describe ...` to determine the version, first check if the current commit is already tagged (`git tag --contains HEAD`), and if it is, check first for a stable tag, then for a dev tag.
1. If no stable or dev tag is found, then run `git describe ...` as before and parse.
1. Removes support for the previous tag format `x.y.z-dev.m.n`, closing https://github.com/flutter/flutter/issues/53850.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/55332 and https://github.com/flutter/flutter/issues/53850.

## Tests

Updated test mocks to support an additional process call to git, and added additional test expectations.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*