### PR TITLE
[flutter_tools] switch default package path to new package_config

### DIFF
--- a/packages/flutter_tools/lib/src/dart/package_map.dart
+++ b/packages/flutter_tools/lib/src/dart/package_map.dart
@@ -10,8 +10,9 @@ import 'package:package_config/package_config.dart';
 import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/logger.dart';
+import '../globals.dart' as globals;
 
-const String kPackagesFileName = '.packages';
+final String kPackagesFileName = globals.fs.path.join('.dart_tool/package_config.json');
 
 String get globalPackagesPath => _globalPackagesPath ?? kPackagesFileName;
 


### PR DESCRIPTION
## Description

Switch the default package configuration path from `.packages` to `.dart_tool/package_config.json`

Fixes https://github.com/flutter/flutter/issues/55249
Fixes https://github.com/flutter/flutter/issues/55237