### PR TITLE
remove intellij references to the v1 embedding jars now that the v2 embeddings are referenced via maven

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -605,7 +605,6 @@ To edit platform code in an IDE see https://flutter.dev/developing-packages/#edi
       'useAndroidEmbeddingV2': featureFlags.isAndroidEmbeddingV2Enabled,
       'androidMinApiLevel': android.minApiLevel,
       'androidSdkVersion': android_sdk.minimumAndroidSdkVersion,
-      'androidFlutterJar': '$flutterRoot/bin/cache/artifacts/engine/android-arm/flutter.jar',
       'withDriverTest': renderDriverTest,
       'pluginClass': pluginClass,
       'pluginDartClass': pluginDartClass,

--- a/packages/flutter_tools/templates/app/.idea/libraries/Flutter_for_Android.xml.tmpl
+++ b/packages/flutter_tools/templates/app/.idea/libraries/Flutter_for_Android.xml.tmpl
@@ -1,9 +1,0 @@
-<component name="libraryTable">
-  <library name="Flutter for Android">
-    <CLASSES>
-      <root url="jar://{{{androidFlutterJar}}}!/" />
-    </CLASSES>
-    <JAVADOC />
-    <SOURCES />
-  </library>
-</component>

--- a/packages/flutter_tools/templates/module/common/.idea/libraries/Flutter_for_Android.xml.tmpl
+++ b/packages/flutter_tools/templates/module/common/.idea/libraries/Flutter_for_Android.xml.tmpl
@@ -1,9 +1,0 @@
-<component name="libraryTable">
-  <library name="Flutter for Android">
-    <CLASSES>
-      <root url="jar://{{{androidFlutterJar}}}!/" />
-    </CLASSES>
-    <JAVADOC />
-    <SOURCES />
-  </library>
-</component>

--- a/packages/flutter_tools/templates/plugin/.idea/libraries/Flutter_for_Android.xml.tmpl
+++ b/packages/flutter_tools/templates/plugin/.idea/libraries/Flutter_for_Android.xml.tmpl
@@ -1,9 +1,0 @@
-<component name="libraryTable">
-  <library name="Flutter for Android">
-    <CLASSES>
-      <root url="jar://{{{androidFlutterJar}}}!/" />
-    </CLASSES>
-    <JAVADOC />
-    <SOURCES />
-  </library>
-</component>


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter-intellij/issues/4491