### PR TITLE
[flutter_tools] fix version tag `v` stripping

### DIFF
--- a/packages/flutter_tools/lib/src/commands/version.dart
+++ b/packages/flutter_tools/lib/src/commands/version.dart
@@ -87,7 +87,7 @@ class VersionCommand extends FlutterCommand {
       }
     }
 
-    final String version = argResults.rest[0].replaceFirst(RegExp('^v'), '');
+    final String version = argResults.rest[0].replaceFirst('v', '');
     final List<String> matchingTags = tags.where((String tag) => tag.contains(version)).toList();
     String matchingTag;
     // TODO(fujino): make this a tool exit and fix tests

--- a/packages/flutter_tools/lib/src/commands/version.dart
+++ b/packages/flutter_tools/lib/src/commands/version.dart
@@ -87,7 +87,7 @@ class VersionCommand extends FlutterCommand {
       }
     }
 
-    final String version = argResults.rest[0].replaceFirst('v', '');
+    final String version = argResults.rest[0].replaceFirst(RegExp('^v'), '');
     final List<String> matchingTags = tags.where((String tag) => tag.contains(version)).toList();
     String matchingTag;
     // TODO(fujino): make this a tool exit and fix tests

--- a/packages/flutter_tools/test/commands.shard/hermetic/version_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/version_test.dart
@@ -71,6 +71,27 @@ void main() {
       FlutterVersion: () => mockVersion,
     });
 
+    testUsingContext('dev version switch prompt is accepted', () async {
+      when(mockStdio.stdinHasTerminal).thenReturn(true);
+      const String version = '30.0.0-dev.0.0';
+      final VersionCommand command = VersionCommand();
+      when(globals.terminal.promptForCharInput(<String>['y', 'n'],
+              logger: anyNamed('logger'), prompt: 'Are you sure you want to proceed?'))
+          .thenAnswer((Invocation invocation) async => 'y');
+
+      await createTestCommandRunner(command).run(<String>[
+        'version',
+        '--no-pub',
+        version,
+      ]);
+      expect(testLogger.statusText, contains('Switching Flutter to version $version'));
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => MockProcessManager(),
+      Stdio: () => mockStdio,
+      AnsiTerminal: () => MockTerminal(),
+      FlutterVersion: () => mockVersion,
+    });
+
     testUsingContext('version switch prompt is declined', () async {
       when(mockStdio.stdinHasTerminal).thenReturn(true);
       const String version = '10.0.0';

--- a/packages/flutter_tools/test/commands.shard/hermetic/version_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/version_test.dart
@@ -260,7 +260,7 @@ class MockProcessManager extends Mock implements ProcessManager {
       return ProcessResult(0, 0, 'v10.0.0\r\nv20.0.0\r\n30.0.0-dev.0.0', '');
     }
     if (command[0] == 'git' && command[1] == 'checkout') {
-      version = (command[2] as String).replaceFirst('v', '');
+      version = (command[2] as String).replaceFirst(RegExp('^v'), '');
     }
     return ProcessResult(0, 0, '', '');
   }

--- a/packages/flutter_tools/test/commands.shard/hermetic/version_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/version_test.dart
@@ -76,8 +76,9 @@ void main() {
       const String version = '30.0.0-dev.0.0';
       final VersionCommand command = VersionCommand();
       when(globals.terminal.promptForCharInput(<String>['y', 'n'],
-              logger: anyNamed('logger'), prompt: 'Are you sure you want to proceed?'))
-          .thenAnswer((Invocation invocation) async => 'y');
+        logger: anyNamed('logger'),
+        prompt: 'Are you sure you want to proceed?')
+      ).thenAnswer((Invocation invocation) async => 'y');
 
       await createTestCommandRunner(command).run(<String>[
         'version',


### PR DESCRIPTION
## Description

This fixes an incorrect string replacement that is intended to strip the first v, for example:

v1.0.0 => 1.0.0
1.0.0.dev.0 => 1.0.0.dev.0 (actual 1.0.0.de.0)

## Related Issues

Fixes https://github.com/flutter/flutter/issues/55421 and https://github.com/flutter/flutter/issues/55383

## Tests

Added test "dev version switch prompt is accepted" that checks that dev versions can be requested in the **flutter version** command.

Also fixed the test it self, as it had the same defect as the implementation it self.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.


<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
