### PR TITLE
LayoutBuilder: skip calling builder when constraints are the same

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/gallery/backdrop.dart
+++ b/dev/integration_tests/flutter_gallery/lib/gallery/backdrop.dart
@@ -249,9 +249,11 @@ class _BackdropState extends State<Backdrop> with SingleTickerProviderStateMixin
   }
 
   void _toggleFrontLayer() {
-    final AnimationStatus status = _controller.status;
-    final bool isOpen = status == AnimationStatus.completed || status == AnimationStatus.forward;
-    _controller.fling(velocity: isOpen ? -2.0 : 2.0);
+    setState(() {
+      final AnimationStatus status = _controller.status;
+      final bool isOpen = status == AnimationStatus.completed || status == AnimationStatus.forward;
+      _controller.fling(velocity: isOpen ? -2.0 : 2.0);
+    });
   }
 
   Widget _buildStack(BuildContext context, BoxConstraints constraints) {

--- a/dev/integration_tests/flutter_gallery/lib/gallery/backdrop.dart
+++ b/dev/integration_tests/flutter_gallery/lib/gallery/backdrop.dart
@@ -215,6 +215,14 @@ class _BackdropState extends State<Backdrop> with SingleTickerProviderStateMixin
       value: 1.0,
       vsync: this,
     );
+    _controller.addStatusListener((AnimationStatus status) {
+      setState(() {
+        // This is intentionally left empty. The state change itself takes
+        // place inside the AnimationController, so there's nothing to update.
+        // All we want is for the widget to rebuild and read the new animation
+        // state from the AnimationController.
+      });
+    });
     _frontOpacity = _controller.drive(_frontOpacityTween);
   }
 
@@ -249,11 +257,9 @@ class _BackdropState extends State<Backdrop> with SingleTickerProviderStateMixin
   }
 
   void _toggleFrontLayer() {
-    setState(() {
-      final AnimationStatus status = _controller.status;
-      final bool isOpen = status == AnimationStatus.completed || status == AnimationStatus.forward;
-      _controller.fling(velocity: isOpen ? -2.0 : 2.0);
-    });
+    final AnimationStatus status = _controller.status;
+    final bool isOpen = status == AnimationStatus.completed || status == AnimationStatus.forward;
+    _controller.fling(velocity: isOpen ? -2.0 : 2.0);
   }
 
   Widget _buildStack(BuildContext context, BoxConstraints constraints) {

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -193,10 +193,11 @@ mixin RenderConstrainedLayoutBuilder<ConstraintType extends Constraints, ChildTy
   ///
   /// The layout build rebuilds automatically when layout constraints change.
   /// However, we must also rebuild when the widget updates, e.g. after
-  /// `setState`, or `didChangeDependencies`, even when the layout constraints
-  /// remain unchanged.
+  /// [State.setState], or [State.didChangeDependencies], even when the layout
+  /// constraints remain unchanged.
   ///
   /// See also:
+  ///
   ///  * [ConstrainedLayoutBuilder.builder], which is called during the rebuild.
   void markNeedsBuild() {
     // Do not call the callback directly. It must be called during the layout

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -17,6 +17,18 @@ typedef LayoutWidgetBuilder = Widget Function(BuildContext context, BoxConstrain
 /// function at layout time and provides the constraints that this widget should
 /// adhere to. This is useful when the parent constrains the child's size and layout,
 /// and doesn't depend on the child's intrinsic size.
+///
+/// {@template flutter.widgets.layoutBuilder.builderFunctionInvocation}
+/// The [builder] function is called in the following situations:
+///
+/// * The first time the widget is laid out.
+/// * When the parent widget passes different layout constraints.
+/// * When the parent widget updates this widget.
+/// * When the depedencies that the [builder] function subscribes to change.
+///
+/// The [builder] function is _not_ called during layout if the parent passes
+/// the same constraints repeatedly.
+/// {@endtemplate}
 abstract class ConstrainedLayoutBuilder<ConstraintType extends Constraints> extends RenderObjectWidget {
   /// Creates a widget that defers its building until layout.
   ///
@@ -221,11 +233,13 @@ mixin RenderConstrainedLayoutBuilder<ConstraintType extends Constraints, ChildTy
 /// the child's intrinsic size. The [LayoutBuilder]'s final size will match its
 /// child's size.
 ///
+/// {@macro flutter.widgets.layoutBuilder.builderFunctionInvocation}
+///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=IYDVcriKjsw}
 ///
 /// If the child should be smaller than the parent, consider wrapping the child
 /// in an [Align] widget. If the child might want to be bigger, consider
-/// wrapping it in a [SingleChildScrollView].
+/// wrapping it in a [SingleChildScrollView] or [OverflowBox].
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/widgets/sliver_layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/sliver_layout_builder.dart
@@ -52,7 +52,7 @@ class _RenderSliverLayoutBuilder extends RenderSliver with RenderObjectWithChild
 
   @override
   void performLayout() {
-    layoutAndBuildChild();
+    rebuildIfNecessary();
     child?.layout(constraints, parentUsesSize: true);
     geometry = child?.geometry ?? SliverGeometry.zero;
   }

--- a/packages/flutter/lib/src/widgets/sliver_layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/sliver_layout_builder.dart
@@ -19,6 +19,7 @@ typedef SliverLayoutWidgetBuilder = Widget Function(BuildContext context, Sliver
 /// The [SliverLayoutBuilder]'s final [SliverGeometry] will match the [SliverGeometry]
 /// of its child.
 ///
+/// {@macro flutter.widgets.layoutBuilder.builderFunctionInvocation}
 ///
 /// See also:
 ///

--- a/packages/flutter/test/widgets/layout_builder_test.dart
+++ b/packages/flutter/test/widgets/layout_builder_test.dart
@@ -590,11 +590,29 @@ void main() {
 
   testWidgets('LayoutBuilder does not call builder when layout happens but layout constraints do not change', (WidgetTester tester) async {
     int builderInvocationCount = 0;
-    final LayoutWidgetBuilder builder = (BuildContext context, BoxConstraints constraints) {
-      builderInvocationCount += 1;
-      return Container();
-    };
-    await tester.pumpWidget(LayoutBuilder(builder: builder));
+
+    Future<void> pumpTestWidget(Size size) async {
+      await tester.pumpWidget(
+        // Center is used to give the SizedBox the power to determine constraints for LayoutBuilder
+        Center(
+          child: SizedBox.fromSize(
+            size: size,
+            child: LayoutBuilder(builder: (BuildContext context, BoxConstraints constraints) {
+              builderInvocationCount += 1;
+              return _LayoutSpy();
+            }),
+          ),
+        ),
+      );
+    }
+
+    await pumpTestWidget(const Size(10, 10));
+
+    final _RenderLayoutSpy spy = tester.renderObject(find.byType(_LayoutSpy));
+
+    // The child is laid out once the first time.
+    expect(spy.performLayoutCount, 1);
+    expect(spy.performResizeCount, 1);
 
     // The initial `pumpWidget` will trigger `performRebuild`, asking for
     // builder invocation.
@@ -602,15 +620,72 @@ void main() {
 
     // Invalidate the layout without chaning the constraints.
     tester.renderObject(find.byType(LayoutBuilder)).markNeedsLayout();
+
     // The second pump will not go through the `performRebuild` or `update`, and
     // only judge the need for builder invocation based on constraints, which
-    // didn't change, so we don't expect the counter to go up.
+    // didn't change, so we don't expect any counters to go up.
     await tester.pump();
     expect(builderInvocationCount, 1);
+    expect(spy.performLayoutCount, 1);
+    expect(spy.performResizeCount, 1);
 
     // Cause the `update` to be called (but not `performRebuild`), triggering
     // builder invocation.
-    await tester.pumpWidget(LayoutBuilder(builder: builder));
+    await pumpTestWidget(const Size(10, 10));
     expect(builderInvocationCount, 2);
+
+    // The spy does not invalidate its layout on widget update, so no
+    // layout-related methods should be called.
+    expect(spy.performLayoutCount, 1);
+    expect(spy.performResizeCount, 1);
+
+    // Have the child request layout and verify that the child gets laid out
+    // despite layout constraints remaining constant.
+    spy.markNeedsLayout();
+    await tester.pump();
+
+    // Expect performLayout to be called.
+    expect(spy.performLayoutCount, 2);
+
+    // performResize should not be called because the spy sets sizedByParent,
+    // and the constraints did not change.
+    expect(spy.performResizeCount, 1);
+
+    // Change the parent size, triggering constraint change.
+    await pumpTestWidget(const Size(20, 20));
+    expect(builderInvocationCount, 3);
+    expect(spy.performLayoutCount, 3);
+    expect(spy.performResizeCount, 2);
   });
+}
+
+class _LayoutSpy extends LeafRenderObjectWidget {
+  @override
+  LeafRenderObjectElement createElement() => _LayoutSpyElement(this);
+
+  @override
+  RenderObject createRenderObject(BuildContext context) => _RenderLayoutSpy();
+}
+
+class _LayoutSpyElement extends LeafRenderObjectElement {
+  _LayoutSpyElement(LeafRenderObjectWidget widget) : super(widget);
+}
+
+class _RenderLayoutSpy extends RenderBox {
+  int performLayoutCount = 0;
+  int performResizeCount = 0;
+
+  @override
+  bool get sizedByParent => true;
+
+  @override
+  void performResize() {
+    performResizeCount += 1;
+    size = constraints.biggest;
+  }
+
+  @override
+  void performLayout() {
+    performLayoutCount += 1;
+  }
 }

--- a/packages/flutter/test/widgets/layout_builder_test.dart
+++ b/packages/flutter/test/widgets/layout_builder_test.dart
@@ -644,6 +644,10 @@ void main() {
     spy.markNeedsLayout();
     await tester.pump();
 
+    // Builder is not invoked. This was a layout-only pump with the same parent
+    // constraints.
+    expect(builderInvocationCount, 2);
+
     // Expect performLayout to be called.
     expect(spy.performLayoutCount, 2);
 
@@ -653,6 +657,8 @@ void main() {
 
     // Change the parent size, triggering constraint change.
     await pumpTestWidget(const Size(20, 20));
+
+    // We should see everything invoked once.
     expect(builderInvocationCount, 3);
     expect(spy.performLayoutCount, 3);
     expect(spy.performResizeCount, 2);


### PR DESCRIPTION
## Description

Avoid calling `builder` in `ConstrainedLayoutBuilder` when layout constraints are the same.

[Design doc](https://flutter.dev/go/layout-builder-optimization).

## Related Issues

Fixes https://github.com/flutter/flutter/issues/6469

## Tests

I added the following tests:

* A new test in `layout_builder_test.dart`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [x] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [x] I wrote a design doc: http://flutter.dev/go/layout-builder-optimization
   - [x] I got input from the developer relations team, specifically from: @RedBrogdon 
   - [x] I wrote a migration guide: https://github.com/flutter/website/pull/3995

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
