### PR TITLE
[web] Enable SelectableText on web [WIP]

### DIFF
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -528,9 +528,28 @@ class PictureLayer extends Layer {
     }
   }
 
+  /// Hints that any text painted in the current layer is selectable.
+  ///
+  /// The scene must be explicitly recomposited after this property is changed
+  /// (as described at [Layer]).
+  bool get isSelectableHint => _isSelectableHint;
+  bool _isSelectableHint = false;
+  set isSelectableHint(bool value) {
+    if (value != _isSelectableHint) {
+      _isSelectableHint = value;
+      markNeedsAddToScene();
+    }
+  }
+
   @override
   void addToScene(ui.SceneBuilder builder, [ Offset layerOffset = Offset.zero ]) {
-    builder.addPicture(layerOffset, picture, isComplexHint: isComplexHint, willChangeHint: willChangeHint);
+    builder.addPicture(
+      layerOffset,
+      picture,
+      isComplexHint: isComplexHint,
+      willChangeHint: willChangeHint,
+      isSelectableHint: isSelectableHint,
+    );
   }
 
   @override
@@ -540,7 +559,7 @@ class PictureLayer extends Layer {
     properties.add(DiagnosticsProperty<String>('picture', describeIdentity(_picture)));
     properties.add(DiagnosticsProperty<String>(
       'raster cache hints',
-      'isComplex = $isComplexHint, willChange = $willChangeHint'),
+      'isComplex = $isComplexHint, willChange = $willChangeHint, isSelectable = $isSelectableHint'),
     );
   }
 

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -332,6 +332,11 @@ class PaintingContext extends ClipContext {
     _currentLayer?.willChangeHint = true;
   }
 
+  /// Hints that any text painted in the current layer is selectable.
+  void setIsSelectableHint() {
+    _currentLayer?.isSelectableHint = true;
+  }
+
   /// Adds a composited leaf layer to the recording.
   ///
   /// After calling this function, the [canvas] property will change to refer to


### PR DESCRIPTION
## Description

Enables SelectableText widget on web by setting the `user-select` and `pointer-events` on the generated picture layers where-in exists the paragraph tags. This works by applying the change as a hint. The notion here is to eventually enable whole layers to have selectability. 

* Engine PR required for this change: https://github.com/flutter/engine/pull/17888 - [web] Enable selectable text in PictureLayer.

## Related Issues

* https://github.com/flutter/flutter/issues/47234 - SelectableText can't be copied on web

## Tests

* Tests to follow if PR approach is approved.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
