### PR TITLE
Use correct path for `flutter` in `flutter_gallery_v2_chrome_run_test.dart`

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_gallery_v2_chrome_run_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_v2_chrome_run_test.dart
@@ -6,6 +6,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:path/path.dart' as path;
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
 
@@ -51,7 +53,7 @@ class NewGalleryChromeRunTest {
 
       final List<String> options = <String>['-d', 'chrome', '--verbose', '--resident'];
       final Process process = await startProcess(
-        'flutter',
+        path.join(flutterDirectory.path, 'bin', 'flutter'),
         flutterCommandArgs('run', options),
         environment: <String, String>{
           'FLUTTER_WEB': 'true',


### PR DESCRIPTION
## Description

The test `flutter_gallery_v2_chrome_run_test` is failing, because `flutter` is not on the PATH on devicelab hosts.
This PR tells the testing machine the location of `flutter` using a relative path.

## Related Issues

Closes #55479

## Tests

**No tests have been added for this change.**

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
    - This is a fix; no new documentation was needed.
- [x] All existing and new tests are passing.
    - `flutter_gallery_v2_chrome_run_test.dart` is not imported into any other files under `devicelab`, so this test **should not** affect other tests.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.


<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
