### PR TITLE
Wrap PopupMenuButton in SafeArea to prevent overlap on status bar

### DIFF
--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -732,12 +732,7 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
         menu = Theme(data: theme, child: menu);
     }
 
-    return MediaQuery.removePadding(
-      context: context,
-      removeTop: true,
-      removeBottom: true,
-      removeLeft: true,
-      removeRight: true,
+    return SafeArea(
       child: Builder(
         builder: (BuildContext context) {
           return CustomSingleChildLayout(


### PR DESCRIPTION
## Description

Currently, if one use a `PopupMenuButton`, the widget won't respect the status bar of the device. This is due to the usage of `MediaQuery.removePadding` in one of the inner widgets. Replacing this with a `SafeArea` solves the issue. See screenshots below.

### Android

- Current behavior with few items:

![current_behavior_few_items](https://user-images.githubusercontent.com/13774309/80142720-ef5d6a80-85ab-11ea-82c9-a61c73a8e9f6.png)

- Current behavior with many items:

![current_behavior_many_items](https://user-images.githubusercontent.com/13774309/80142724-eff60100-85ab-11ea-9b63-57223118840f.png)

- Proposed behavior with few items:

![proposed_behavior_few_items](https://user-images.githubusercontent.com/13774309/80142725-eff60100-85ab-11ea-922b-6c2dd23f1990.png)

- Proposed behavior with many items:

![proposed_behavior_many_items](https://user-images.githubusercontent.com/13774309/80142726-f08e9780-85ab-11ea-8167-6ad550bc04bb.png)

---

### iOS

- Current behavior with few items:

![current_behavior_few_items](https://user-images.githubusercontent.com/13774309/80142846-2469bd00-85ac-11ea-9a92-044c97d838a9.png)

- Current behavior with many items:

![current_behavior_many_items](https://user-images.githubusercontent.com/13774309/80142848-259aea00-85ac-11ea-87ea-85ca36142702.png)

- Proposed behavior with few items:

![proposed_behavior_few_items](https://user-images.githubusercontent.com/13774309/80142849-259aea00-85ac-11ea-9081-4af5ec0c826d.png)

- Proposed behavior with many items:

![proposed_behavior_many_items](https://user-images.githubusercontent.com/13774309/80142851-26338080-85ac-11ea-9bf7-526eeb22bffa.png)

## Related Issues

Closes #19954.

## Tests

All current tests are passing - some of them assert positioning.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
