### PR TITLE
Add onSecondaryTap to gesture recognizer and gesture detector.

### DIFF
--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -30,7 +30,7 @@ const int kPrimaryButton = 0x01;
 /// It is equivalent to:
 ///
 ///  * [kPrimaryStylusButton]: The stylus contacts the screen.
-///  * [kSecondaryMouseButton]: The primary mouse button.
+///  * [kSecondaryMouseButton]: The secondary mouse button.
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/gestures/long_press.dart
+++ b/packages/flutter/lib/src/gestures/long_press.dart
@@ -408,8 +408,9 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
 
   void _checkLongPressEnd(PointerEvent event) {
     final VelocityEstimate estimate = _velocityTracker.getVelocityEstimate();
-    final Velocity velocity =
-    estimate == null ? Velocity.zero : Velocity(pixelsPerSecond: estimate.pixelsPerSecond);
+    final Velocity velocity = estimate == null
+        ? Velocity.zero
+        : Velocity(pixelsPerSecond: estimate.pixelsPerSecond);
     final LongPressEndDetails details = LongPressEndDetails(
       globalPosition: event.position,
       localPosition: event.localPosition,

--- a/packages/flutter/lib/src/gestures/long_press.dart
+++ b/packages/flutter/lib/src/gestures/long_press.dart
@@ -141,9 +141,9 @@ class LongPressEndDetails {
 /// moved, triggering [onLongPressMoveUpdate] callbacks, unless the
 /// [postAcceptSlopTolerance] constructor argument is specified.
 ///
-/// [LongPressGestureRecognizer] competes on pointer events of [kPrimaryButton]
-/// or [kSecondaryButton] only when it has at least one non-null callback. If it
-/// has no callbacks, it is a no-op.
+/// [LongPressGestureRecognizer] may compete on pointer events of
+/// [kPrimaryButton] and/or [kSecondaryButton] if at least one corresponding
+/// callback is non-null. If it has no callbacks, it is a no-op.
 class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
   /// Creates a long-press gesture recognizer.
   ///
@@ -350,58 +350,66 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
   }
 
   void _checkLongPressStart() {
-    assert(_initialButtons == kPrimaryButton || _initialButtons == kSecondaryButton);
-    if (_initialButtons == kPrimaryButton) {
-      if (onLongPressStart != null) {
-        final LongPressStartDetails details = LongPressStartDetails(
-          globalPosition: _longPressOrigin.global,
-          localPosition: _longPressOrigin.local,
-        );
-        invokeCallback<void>('onLongPressStart',
-          () => onLongPressStart(details));
-      }
-      if (onLongPress != null) {
-        invokeCallback<void>('onLongPress', onLongPress);
-      }
-    }
-    if (_initialButtons == kSecondaryButton) {
-      if (onSecondaryLongPressStart != null) {
-        final LongPressStartDetails details = LongPressStartDetails(
-          globalPosition: _longPressOrigin.global,
-          localPosition: _longPressOrigin.local,
-        );
-        invokeCallback<void>('onSecondaryLongPressStart',
-                () => onSecondaryLongPressStart(details));
-      }
-      if (onSecondaryLongPress != null) {
-        invokeCallback<void>('onSecondaryLongPress', onSecondaryLongPress);
-      }
+    switch (_initialButtons) {
+      case kPrimaryButton:
+        if (onLongPressStart != null) {
+          final LongPressStartDetails details = LongPressStartDetails(
+            globalPosition: _longPressOrigin.global,
+            localPosition: _longPressOrigin.local,
+          );
+          invokeCallback<void>('onLongPressStart', () => onLongPressStart(details));
+        }
+        if (onLongPress != null) {
+          invokeCallback<void>('onLongPress', onLongPress);
+        }
+        break;
+      case kSecondaryButton:
+        if (onSecondaryLongPressStart != null) {
+          final LongPressStartDetails details = LongPressStartDetails(
+            globalPosition: _longPressOrigin.global,
+            localPosition: _longPressOrigin.local,
+          );
+          invokeCallback<void>(
+              'onSecondaryLongPressStart', () => onSecondaryLongPressStart(details));
+        }
+        if (onSecondaryLongPress != null) {
+          invokeCallback<void>('onSecondaryLongPress', onSecondaryLongPress);
+        }
+        break;
+      default:
+        assert(false, 'Unhandled button $_initialButtons');
     }
   }
 
   void _checkLongPressMoveUpdate(PointerEvent event) {
-    assert(_initialButtons == kPrimaryButton || _initialButtons == kSecondaryButton);
     final LongPressMoveUpdateDetails details = LongPressMoveUpdateDetails(
       globalPosition: event.position,
       localPosition: event.localPosition,
       offsetFromOrigin: event.position - _longPressOrigin.global,
       localOffsetFromOrigin: event.localPosition - _longPressOrigin.local,
     );
-    if (_initialButtons == kPrimaryButton && onLongPressMoveUpdate != null) {
-      invokeCallback<void>('onLongPressMoveUpdate',
-        () => onLongPressMoveUpdate(details));
-    }
-    if (_initialButtons == kSecondaryButton && onSecondaryLongPressMoveUpdate != null) {
-      invokeCallback<void>('onSecondaryLongPressMoveUpdate',
-        () => onSecondaryLongPressMoveUpdate(details));
+    switch (_initialButtons) {
+      case kPrimaryButton:
+        if (onLongPressMoveUpdate != null) {
+          invokeCallback<void>('onLongPressMoveUpdate',
+            () => onLongPressMoveUpdate(details));
+        }
+        break;
+      case kSecondaryButton:
+        if (onSecondaryLongPressMoveUpdate != null) {
+          invokeCallback<void>('onSecondaryLongPressMoveUpdate',
+            () => onSecondaryLongPressMoveUpdate(details));
+        }
+        break;
+      default:
+        assert(false, 'Unhandled button $_initialButtons');
     }
   }
 
   void _checkLongPressEnd(PointerEvent event) {
-    assert(_initialButtons == kPrimaryButton || _initialButtons == kSecondaryButton);
-
     final VelocityEstimate estimate = _velocityTracker.getVelocityEstimate();
-    final Velocity velocity = estimate == null ? Velocity.zero : Velocity(pixelsPerSecond: estimate.pixelsPerSecond);
+    final Velocity velocity =
+    estimate == null ? Velocity.zero : Velocity(pixelsPerSecond: estimate.pixelsPerSecond);
     final LongPressEndDetails details = LongPressEndDetails(
       globalPosition: event.position,
       localPosition: event.localPosition,
@@ -409,21 +417,25 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
     );
 
     _velocityTracker = null;
-    if (_initialButtons == kPrimaryButton) {
-      if (onLongPressEnd != null) {
-        invokeCallback<void>('onLongPressEnd', () => onLongPressEnd(details));
-      }
-      if (onLongPressUp != null) {
-        invokeCallback<void>('onLongPressUp', onLongPressUp);
-      }
-    }
-    if (_initialButtons == kSecondaryButton) {
-      if (onSecondaryLongPressEnd != null) {
-        invokeCallback<void>('onSecondaryLongPressEnd', () => onSecondaryLongPressEnd(details));
-      }
-      if (onSecondaryLongPressUp != null) {
-        invokeCallback<void>('onSecondaryLongPressUp', onSecondaryLongPressUp);
-      }
+    switch (_initialButtons) {
+      case kPrimaryButton:
+        if (onLongPressEnd != null) {
+          invokeCallback<void>('onLongPressEnd', () => onLongPressEnd(details));
+        }
+        if (onLongPressUp != null) {
+          invokeCallback<void>('onLongPressUp', onLongPressUp);
+        }
+        break;
+      case kSecondaryButton:
+        if (onSecondaryLongPressEnd != null) {
+          invokeCallback<void>('onSecondaryLongPressEnd', () => onSecondaryLongPressEnd(details));
+        }
+        if (onSecondaryLongPressUp != null) {
+          invokeCallback<void>('onSecondaryLongPressUp', onSecondaryLongPressUp);
+        }
+        break;
+      default:
+        assert(false, 'Unhandled button $_initialButtons');
     }
   }
 

--- a/packages/flutter/lib/src/gestures/tap.dart
+++ b/packages/flutter/lib/src/gestures/tap.dart
@@ -440,6 +440,8 @@ class TapGestureRecognizer extends BaseTapGestureRecognizer {
   ///
   /// See also:
   ///
+  ///  * [onSecondaryTap], a handler triggered right after this one that doesn't
+  ///    pass any details about the tap.
   ///  * [kSecondaryButton], the button this callback responds to.
   ///  * [onTapUp], a similar callback but for a primary button.
   ///  * [TapUpDetails], which is passed as an argument to this callback.

--- a/packages/flutter/lib/src/gestures/tap.dart
+++ b/packages/flutter/lib/src/gestures/tap.dart
@@ -369,7 +369,7 @@ class TapGestureRecognizer extends BaseTapGestureRecognizer {
   /// of a primary button.
   ///
   /// This triggers on the up event, if the recognizer wins the arena with it
-  /// or has previously won, immediately following [onTap].
+  /// or has previously won, immediately following [onTapUp].
   ///
   /// If this recognizer doesn't win the arena, [onTapCancel] is called instead.
   ///
@@ -395,6 +395,22 @@ class TapGestureRecognizer extends BaseTapGestureRecognizer {
   ///  * [onSecondaryTapCancel], a similar callback but for a secondary button.
   ///  * [GestureDetector.onTapCancel], which exposes this callback.
   GestureTapCancelCallback onTapCancel;
+
+  /// A pointer has stopped contacting the screen, which is recognized as a tap
+  /// of a secondary button.
+  ///
+  /// This triggers on the up event, if the recognizer wins the arena with it or
+  /// has previously won, immediately following [onSecondaryTapUp].
+  ///
+  /// If this recognizer doesn't win the arena, [onSecondaryTapCancel] is called
+  /// instead.
+  ///
+  /// See also:
+  ///
+  ///  * [kSecondaryButton], the button this callback responds to.
+  ///  * [onSecondaryTapUp], which has the same timing but with details.
+  ///  * [GestureDetector.onSecondaryTap], which exposes this callback.
+  GestureTapCallback onSecondaryTap;
 
   /// A pointer has contacted the screen at a particular location with a
   /// secondary button, which might be the start of a secondary tap.
@@ -456,7 +472,8 @@ class TapGestureRecognizer extends BaseTapGestureRecognizer {
           return false;
         break;
       case kSecondaryButton:
-        if (onSecondaryTapDown == null &&
+        if (onSecondaryTap == null &&
+            onSecondaryTapDown == null &&
             onSecondaryTapUp == null &&
             onSecondaryTapCancel == null)
           return false;
@@ -482,8 +499,7 @@ class TapGestureRecognizer extends BaseTapGestureRecognizer {
         break;
       case kSecondaryButton:
         if (onSecondaryTapDown != null)
-          invokeCallback<void>('onSecondaryTapDown',
-            () => onSecondaryTapDown(details));
+          invokeCallback<void>('onSecondaryTapDown', () => onSecondaryTapDown(details));
         break;
       default:
     }
@@ -505,8 +521,9 @@ class TapGestureRecognizer extends BaseTapGestureRecognizer {
         break;
       case kSecondaryButton:
         if (onSecondaryTapUp != null)
-          invokeCallback<void>('onSecondaryTapUp',
-            () => onSecondaryTapUp(details));
+          invokeCallback<void>('onSecondaryTapUp', () => onSecondaryTapUp(details));
+        if (onSecondaryTap != null)
+          invokeCallback<void>('onSecondaryTap', () => onSecondaryTap());
         break;
       default:
     }
@@ -523,8 +540,7 @@ class TapGestureRecognizer extends BaseTapGestureRecognizer {
         break;
       case kSecondaryButton:
         if (onSecondaryTapCancel != null)
-          invokeCallback<void>('${note}onSecondaryTapCancel',
-            onSecondaryTapCancel);
+          invokeCallback<void>('${note}onSecondaryTapCancel', onSecondaryTapCancel);
         break;
       default:
     }

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -199,6 +199,11 @@ class GestureDetector extends StatelessWidget {
     this.onLongPressMoveUpdate,
     this.onLongPressUp,
     this.onLongPressEnd,
+    this.onSecondaryLongPress,
+    this.onSecondaryLongPressStart,
+    this.onSecondaryLongPressMoveUpdate,
+    this.onSecondaryLongPressUp,
+    this.onSecondaryLongPressEnd,
     this.onVerticalDragDown,
     this.onVerticalDragStart,
     this.onVerticalDragUpdate,
@@ -308,7 +313,7 @@ class GestureDetector extends StatelessWidget {
   /// A tap with a secondary button has occurred.
   ///
   /// This triggers when the tap gesture wins. If the tap gesture did not win,
-  /// [onTapCancel] is called instead.
+  /// [onSecondaryTapCancel] is called instead.
   ///
   /// See also:
   ///
@@ -406,6 +411,59 @@ class GestureDetector extends StatelessWidget {
   ///  * [onLongPressUp], which has the same timing but without the gesture
   ///    details.
   final GestureLongPressEndCallback onLongPressEnd;
+
+  /// Called when a long press gesture with a secondary button has been
+  /// recognized.
+  ///
+  /// Triggered when a pointer has remained in contact with the screen at the
+  /// same location for a long period of time.
+  ///
+  /// See also:
+  ///
+  ///  * [kSecondaryButton], the button this callback responds to.
+  ///  * [onSecondaryLongPressStart], which has the same timing but has gesture
+  ///    details.
+  final GestureLongPressCallback onSecondaryLongPress;
+
+  /// Called when a long press gesture with a secondary button has been
+  /// recognized.
+  ///
+  /// Triggered when a pointer has remained in contact with the screen at the
+  /// same location for a long period of time.
+  ///
+  /// See also:
+  ///
+  ///  * [kSecondaryButton], the button this callback responds to.
+  ///  * [onSecondaryLongPress], which has the same timing but without the
+  ///    gesture details.
+  final GestureLongPressStartCallback onSecondaryLongPressStart;
+
+  /// A pointer has been drag-moved after a long press with a secondary button.
+  ///
+  /// See also:
+  ///
+  ///  * [kSecondaryButton], the button this callback responds to.
+  final GestureLongPressMoveUpdateCallback onSecondaryLongPressMoveUpdate;
+
+  /// A pointer that has triggered a long-press with a secondary button has
+  /// stopped contacting the screen.
+  ///
+  /// See also:
+  ///
+  ///  * [kSecondaryButton], the button this callback responds to.
+  ///  * [onSecondaryLongPressEnd], which has the same timing but has gesture
+  ///    details.
+  final GestureLongPressUpCallback onSecondaryLongPressUp;
+
+  /// A pointer that has triggered a long-press with a secondary button has
+  /// stopped contacting the screen.
+  ///
+  /// See also:
+  ///
+  ///  * [kSecondaryButton], the button this callback responds to.
+  ///  * [onSecondaryLongPressUp], which has the same timing but without the
+  ///    gesture details.
+  final GestureLongPressEndCallback onSecondaryLongPressEnd;
 
   /// A pointer has contacted the screen with a primary button and might begin
   /// to move vertically.
@@ -658,6 +716,24 @@ class GestureDetector extends StatelessWidget {
             ..onLongPressMoveUpdate = onLongPressMoveUpdate
             ..onLongPressEnd =onLongPressEnd
             ..onLongPressUp = onLongPressUp;
+        },
+      );
+    }
+
+    if (onSecondaryLongPress != null ||
+        onSecondaryLongPressUp != null ||
+        onSecondaryLongPressStart != null ||
+        onSecondaryLongPressMoveUpdate != null ||
+        onSecondaryLongPressEnd != null) {
+      gestures[LongPressGestureRecognizer] = GestureRecognizerFactoryWithHandlers<LongPressGestureRecognizer>(
+        () => LongPressGestureRecognizer(debugOwner: this),
+        (LongPressGestureRecognizer instance) {
+          instance
+            ..onSecondaryLongPress = onSecondaryLongPress
+            ..onSecondaryLongPressStart = onSecondaryLongPressStart
+            ..onSecondaryLongPressMoveUpdate = onSecondaryLongPressMoveUpdate
+            ..onSecondaryLongPressEnd =onSecondaryLongPressEnd
+            ..onSecondaryLongPressUp = onSecondaryLongPressUp;
         },
       );
     }
@@ -1125,7 +1201,7 @@ abstract class SemanticsGestureDelegate {
 // For readers who come here to learn how to write custom semantics delegates:
 // this is not a proper sample code. It has access to the detector state as well
 // as its private properties, which are inaccessible normally. It is designed
-// this way in order to work independenly in a [RawGestureRecognizer] to
+// this way in order to work independently in a [RawGestureRecognizer] to
 // preserve existing behavior.
 //
 // Instead, a normal delegate will store callbacks as properties, and use them
@@ -1178,6 +1254,14 @@ class _DefaultSemanticsGestureDelegate extends SemanticsGestureDelegate {
         longPress.onLongPressEnd(const LongPressEndDetails());
       if (longPress.onLongPressUp != null)
         longPress.onLongPressUp();
+      if (longPress.onSecondaryLongPressStart != null)
+        longPress.onSecondaryLongPressStart(const LongPressStartDetails());
+      if (longPress.onSecondaryLongPress != null)
+        longPress.onSecondaryLongPress();
+      if (longPress.onSecondaryLongPressEnd != null)
+        longPress.onSecondaryLongPressEnd(const LongPressEndDetails());
+      if (longPress.onSecondaryLongPressUp != null)
+        longPress.onSecondaryLongPressUp();
     };
   }
 

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -1254,14 +1254,6 @@ class _DefaultSemanticsGestureDelegate extends SemanticsGestureDelegate {
         longPress.onLongPressEnd(const LongPressEndDetails());
       if (longPress.onLongPressUp != null)
         longPress.onLongPressUp();
-      if (longPress.onSecondaryLongPressStart != null)
-        longPress.onSecondaryLongPressStart(const LongPressStartDetails());
-      if (longPress.onSecondaryLongPress != null)
-        longPress.onSecondaryLongPress();
-      if (longPress.onSecondaryLongPressEnd != null)
-        longPress.onSecondaryLongPressEnd(const LongPressEndDetails());
-      if (longPress.onSecondaryLongPressUp != null)
-        longPress.onSecondaryLongPressUp();
     };
   }
 

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -342,6 +342,8 @@ class GestureDetector extends StatelessWidget {
   ///
   /// See also:
   ///
+  ///  * [onSecondaryTap], a handler triggered right after this one that doesn't
+  ///    pass any details about the tap.
   ///  * [kSecondaryButton], the button this callback responds to.
   final GestureTapUpCallback onSecondaryTapUp;
 

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -189,6 +189,7 @@ class GestureDetector extends StatelessWidget {
     this.onTapUp,
     this.onTap,
     this.onTapCancel,
+    this.onSecondaryTap,
     this.onSecondaryTapDown,
     this.onSecondaryTapUp,
     this.onSecondaryTapCancel,
@@ -303,6 +304,18 @@ class GestureDetector extends StatelessWidget {
   ///
   ///  * [kPrimaryButton], the button this callback responds to.
   final GestureTapCancelCallback onTapCancel;
+
+  /// A tap with a secondary button has occurred.
+  ///
+  /// This triggers when the tap gesture wins. If the tap gesture did not win,
+  /// [onTapCancel] is called instead.
+  ///
+  /// See also:
+  ///
+  ///  * [kSecondaryButton], the button this callback responds to.
+  ///  * [onSecondaryTapUp], which is called at the same time but includes details
+  ///    regarding the pointer position.
+  final GestureTapCallback onSecondaryTap;
 
   /// A pointer that might cause a tap with a secondary button has contacted the
   /// screen at a particular location.
@@ -601,6 +614,7 @@ class GestureDetector extends StatelessWidget {
       onTapUp != null ||
       onTap != null ||
       onTapCancel != null ||
+      onSecondaryTap != null ||
       onSecondaryTapDown != null ||
       onSecondaryTapUp != null ||
       onSecondaryTapCancel != null
@@ -613,6 +627,7 @@ class GestureDetector extends StatelessWidget {
             ..onTapUp = onTapUp
             ..onTap = onTap
             ..onTapCancel = onTapCancel
+            ..onSecondaryTap = onSecondaryTap
             ..onSecondaryTapDown = onSecondaryTapDown
             ..onSecondaryTapUp = onSecondaryTapUp
             ..onSecondaryTapCancel = onSecondaryTapCancel;

--- a/packages/flutter/test/widgets/gesture_detector_test.dart
+++ b/packages/flutter/test/widgets/gesture_detector_test.dart
@@ -126,21 +126,12 @@ void main() {
   });
 
   group('Tap', () {
-    int button = 0x0;
-    void setButton(int value) {
-      button = value;
-    }
-
-    final ListVariant<int> buttonVariant = ListVariant<int>(
+    final ButtonVariant buttonVariant = ButtonVariant(
       values: <int>[kPrimaryButton, kSecondaryButton],
-      initialValue: 0x0,
-      onVariant: setButton,
-      valueToString: (int value) {
-        if (value == kSecondaryButton) {
-          return 'secondary';
-        }
-        return 'primary';
-      }
+      descriptions: <int, String>{
+        kPrimaryButton: 'primary',
+        kSecondaryButton: 'secondary',
+      },
     );
 
     testWidgets('Translucent', (WidgetTester tester) async {
@@ -167,10 +158,10 @@ void main() {
                   width: 100.0,
                   height: 100.0,
                   child: GestureDetector(
-                    onTap: button == kPrimaryButton ? () {
+                    onTap: ButtonVariant.button == kPrimaryButton ? () {
                       didTap = true;
                     } : null,
-                    onSecondaryTap: button == kSecondaryButton ? () {
+                    onSecondaryTap: ButtonVariant.button == kSecondaryButton ? () {
                       didTap = true;
                     } : null,
                     behavior: behavior,
@@ -185,28 +176,28 @@ void main() {
       didReceivePointerDown = false;
       didTap = false;
       await pumpWidgetTree(null);
-      await tester.tapAt(const Offset(10.0, 10.0), buttons: button);
+      await tester.tapAt(const Offset(10.0, 10.0), buttons: ButtonVariant.button);
       expect(didReceivePointerDown, isTrue);
       expect(didTap, isTrue);
 
       didReceivePointerDown = false;
       didTap = false;
       await pumpWidgetTree(HitTestBehavior.deferToChild);
-      await tester.tapAt(const Offset(10.0, 10.0), buttons: button);
+      await tester.tapAt(const Offset(10.0, 10.0), buttons: ButtonVariant.button);
       expect(didReceivePointerDown, isTrue);
       expect(didTap, isFalse);
 
       didReceivePointerDown = false;
       didTap = false;
       await pumpWidgetTree(HitTestBehavior.opaque);
-      await tester.tapAt(const Offset(10.0, 10.0), buttons: button);
+      await tester.tapAt(const Offset(10.0, 10.0), buttons: ButtonVariant.button);
       expect(didReceivePointerDown, isFalse);
       expect(didTap, isTrue);
 
       didReceivePointerDown = false;
       didTap = false;
       await pumpWidgetTree(HitTestBehavior.translucent);
-      await tester.tapAt(const Offset(10.0, 10.0), buttons: button);
+      await tester.tapAt(const Offset(10.0, 10.0), buttons: ButtonVariant.button);
       expect(didReceivePointerDown, isTrue);
       expect(didTap, isTrue);
     }, variant: buttonVariant);
@@ -216,17 +207,17 @@ void main() {
       await tester.pumpWidget(
         Center(
           child: GestureDetector(
-            onTap: button == kPrimaryButton ? () {
+            onTap: ButtonVariant.button == kPrimaryButton ? () {
               didTap = true;
             } : null,
-            onSecondaryTap: button == kSecondaryButton ? () {
+            onSecondaryTap: ButtonVariant.button == kSecondaryButton ? () {
               didTap = true;
             } : null,
           ),
         ),
       );
       expect(didTap, isFalse);
-      await tester.tapAt(const Offset(10.0, 10.0), buttons: button);
+      await tester.tapAt(const Offset(10.0, 10.0), buttons: ButtonVariant.button);
       expect(didTap, isTrue);
     }, variant: buttonVariant);
 
@@ -235,10 +226,10 @@ void main() {
       await tester.pumpWidget(
         Center(
           child: GestureDetector(
-            onTap: button == kPrimaryButton ? () {
+            onTap: ButtonVariant.button == kPrimaryButton ? () {
               didTap = true;
             } : null,
-            onSecondaryTap: button == kSecondaryButton ? () {
+            onSecondaryTap: ButtonVariant.button == kSecondaryButton ? () {
               didTap = true;
             } : null,
             child: Container(),
@@ -256,8 +247,8 @@ void main() {
       await tester.pumpWidget(
         Center(
           child: GestureDetector(
-            onTap: button == kPrimaryButton ? inputCallback : null,
-            onSecondaryTap: button == kSecondaryButton ? inputCallback : null,
+            onTap: ButtonVariant.button == kPrimaryButton ? inputCallback : null,
+            onSecondaryTap: ButtonVariant.button == kSecondaryButton ? inputCallback : null,
             child: Container(),
           ),
         ),
@@ -268,8 +259,8 @@ void main() {
       await tester.pumpWidget(
         Center(
           child: GestureDetector(
-            onTap: button == kPrimaryButton ? inputCallback : null,
-            onSecondaryTap: button == kSecondaryButton ? inputCallback : null,
+            onTap: ButtonVariant.button == kPrimaryButton ? inputCallback : null,
+            onSecondaryTap: ButtonVariant.button == kSecondaryButton ? inputCallback : null,
             child: Container(),
           ),
         ),
@@ -294,28 +285,28 @@ void main() {
             height: 100.0,
             color: const Color(0xFF00FF00),
             child: GestureDetector(
-              onTapDown: button == kPrimaryButton ? (TapDownDetails details) {
+              onTapDown: ButtonVariant.button == kPrimaryButton ? (TapDownDetails details) {
                 tapDown += 1;
               } : null,
-              onSecondaryTapDown: button == kSecondaryButton ? (TapDownDetails details) {
+              onSecondaryTapDown: ButtonVariant.button == kSecondaryButton ? (TapDownDetails details) {
                 tapDown += 1;
               } : null,
-              onTap: button == kPrimaryButton ? () {
+              onTap: ButtonVariant.button == kPrimaryButton ? () {
                 tap += 1;
               } : null,
-              onSecondaryTap: button == kSecondaryButton ? () {
+              onSecondaryTap: ButtonVariant.button == kSecondaryButton ? () {
                 tap += 1;
               } : null,
-              onTapCancel: button == kPrimaryButton ? () {
+              onTapCancel: ButtonVariant.button == kPrimaryButton ? () {
                 tapCancel += 1;
               } : null,
-              onSecondaryTapCancel: button == kSecondaryButton ? () {
+              onSecondaryTapCancel: ButtonVariant.button == kSecondaryButton ? () {
                 tapCancel += 1;
               } : null,
-              onLongPress: button == kPrimaryButton ? () {
+              onLongPress: ButtonVariant.button == kPrimaryButton ? () {
                 longPress += 1;
               } : null,
-              onSecondaryLongPress: button == kSecondaryButton ? () {
+              onSecondaryLongPress: ButtonVariant.button == kSecondaryButton ? () {
                 longPress += 1;
               } : null,
             ),
@@ -327,7 +318,7 @@ void main() {
       // to a point (400,300) below it. This should never call onTap.
       Future<void> dragOut(Duration timeout) async {
         final TestGesture gesture =
-        await tester.startGesture(const Offset(400.0, 50.0), buttons: button);
+        await tester.startGesture(const Offset(400.0, 50.0), buttons: ButtonVariant.button);
         // If the timeout is less than kPressTimeout the recognizer will not
         // trigger any callbacks. If the timeout is greater than kLongPressTimeout
         // then onTapDown, onLongPress, and onCancel will be called.
@@ -366,10 +357,10 @@ void main() {
             height: 100.0,
             color: const Color(0xFF00FF00),
             child: GestureDetector(
-              onLongPressUp: button == kPrimaryButton ? () {
+              onLongPressUp: ButtonVariant.button == kPrimaryButton ? () {
                 longPressUp += 1;
               } : null,
-              onSecondaryLongPressUp: button == kSecondaryButton ? () {
+              onSecondaryLongPressUp: ButtonVariant.button == kSecondaryButton ? () {
                 longPressUp += 1;
               } : null,
             ),
@@ -378,7 +369,7 @@ void main() {
       );
 
       Future<void> longPress(Duration timeout) async {
-        final TestGesture gesture = await tester.startGesture(const Offset(400.0, 50.0), buttons: button);
+        final TestGesture gesture = await tester.startGesture(const Offset(400.0, 50.0), buttons: ButtonVariant.button);
         await tester.pump(timeout);
         await gesture.up();
       }
@@ -750,5 +741,38 @@ void main() {
 class _EmptySemanticsGestureDelegate extends SemanticsGestureDelegate {
   @override
   void assignSemantics(RenderSemanticsGestureHandler renderObject) {
+  }
+}
+
+/// A [TestVariant] that runs tests multiple times with different buttons.
+class ButtonVariant extends TestVariant<int> {
+  const ButtonVariant({
+    @required this.values,
+    @required this.descriptions,
+  }) : assert(values.length != 0); // ignore: prefer_is_empty
+
+  @override
+  final List<int> values;
+
+  final Map<int, String> descriptions;
+
+  static int button;
+
+  @override
+  String describeValue(int value) {
+    assert(descriptions.containsKey(value), 'Unknown button');
+    return descriptions[value];
+  }
+
+  @override
+  Future<int> setUp(int value) async {
+    final int oldValue = button;
+    button = value;
+    return oldValue;
+  }
+
+  @override
+  Future<void> tearDown(int value, int memento) async {
+    button = memento;
   }
 }

--- a/packages/flutter/test/widgets/gesture_detector_test.dart
+++ b/packages/flutter/test/widgets/gesture_detector_test.dart
@@ -312,9 +312,12 @@ void main() {
               onSecondaryTapCancel: button == kSecondaryButton ? () {
                 tapCancel += 1;
               } : null,
-              onLongPress: () {
+              onLongPress: button == kPrimaryButton ? () {
                 longPress += 1;
-              },
+              } : null,
+              onSecondaryLongPress: button == kSecondaryButton ? () {
+                longPress += 1;
+              } : null,
             ),
           ),
         ),
@@ -333,14 +336,11 @@ void main() {
         await gesture.up();
       }
 
-      // TODO(gspencergoog): This should probably also be run for secondary
-      if (button == kPrimaryButton) {
-        await dragOut(kPressTimeout * 0.5); // generates nothing
-        expect(tapDown, 0);
-        expect(tapCancel, 0);
-        expect(tap, 0);
-        expect(longPress, 0);
-      }
+      await dragOut(kPressTimeout * 0.5); // generates nothing
+      expect(tapDown, 0);
+      expect(tapCancel, 0);
+      expect(tap, 0);
+      expect(longPress, 0);
 
       await dragOut(kPressTimeout); // generates tapDown, tapCancel
       expect(tapDown, 1);
@@ -352,37 +352,40 @@ void main() {
       expect(tapDown, 2);
       expect(tapCancel, 2);
       expect(tap, 0);
-      expect(longPress, button == kPrimaryButton ? 1 : 0);
+      expect(longPress, 1);
     }, variant: buttonVariant);
-  });
 
-  testWidgets('Long Press Up Callback called after long press', (WidgetTester tester) async {
-    int longPressUp = 0;
+    testWidgets('Long Press Up Callback called after long press', (WidgetTester tester) async {
+      int longPressUp = 0;
 
-    await tester.pumpWidget(
-      Container(
-        alignment: Alignment.topLeft,
-        child: Container(
-          alignment: Alignment.center,
-          height: 100.0,
-          color: const Color(0xFF00FF00),
-          child: GestureDetector(
-            onLongPressUp: () {
-              longPressUp += 1;
-            },
+      await tester.pumpWidget(
+        Container(
+          alignment: Alignment.topLeft,
+          child: Container(
+            alignment: Alignment.center,
+            height: 100.0,
+            color: const Color(0xFF00FF00),
+            child: GestureDetector(
+              onLongPressUp: button == kPrimaryButton ? () {
+                longPressUp += 1;
+              } : null,
+              onSecondaryLongPressUp: button == kSecondaryButton ? () {
+                longPressUp += 1;
+              } : null,
+            ),
           ),
         ),
-      ),
-    );
+      );
 
-    Future<void> longPress(Duration timeout) async {
-      final TestGesture gesture = await tester.startGesture(const Offset(400.0, 50.0));
-      await tester.pump(timeout);
-      await gesture.up();
-    }
+      Future<void> longPress(Duration timeout) async {
+        final TestGesture gesture = await tester.startGesture(const Offset(400.0, 50.0), buttons: button);
+        await tester.pump(timeout);
+        await gesture.up();
+      }
 
-    await longPress(kLongPressTimeout + const Duration(seconds: 1)); // To make sure the time for long press has occurred
-    expect(longPressUp, 1);
+      await longPress(kLongPressTimeout + const Duration(seconds: 1)); // To make sure the time for long press has occurred
+      expect(longPressUp, 1);
+    }, variant: buttonVariant);
   });
 
   testWidgets('Force Press Callback called after force press', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/gesture_detector_test.dart
+++ b/packages/flutter/test/widgets/gesture_detector_test.dart
@@ -125,193 +125,235 @@ void main() {
     expect(didEndPan, isTrue);
   });
 
-  testWidgets('Translucent', (WidgetTester tester) async {
-    bool didReceivePointerDown;
-    bool didTap;
+  group('Tap', () {
+    int button = 0x0;
+    void setButton(int value) {
+      button = value;
+    }
 
-    Future<void> pumpWidgetTree(HitTestBehavior behavior) {
-      return tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: Stack(
-            children: <Widget>[
-              Listener(
-                onPointerDown: (_) {
-                  didReceivePointerDown = true;
-                },
-                child: Container(
+    final ListVariant<int> buttonVariant = ListVariant<int>(
+      values: <int>[kPrimaryButton, kSecondaryButton],
+      initialValue: 0x0,
+      onVariant: setButton,
+      valueToString: (int value) {
+        if (value == kSecondaryButton) {
+          return 'secondary';
+        }
+        return 'primary';
+      }
+    );
+
+    testWidgets('Translucent', (WidgetTester tester) async {
+      bool didReceivePointerDown;
+      bool didTap;
+
+      Future<void> pumpWidgetTree(HitTestBehavior behavior) {
+        return tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: Stack(
+              children: <Widget>[
+                Listener(
+                  onPointerDown: (_) {
+                    didReceivePointerDown = true;
+                  },
+                  child: Container(
+                    width: 100.0,
+                    height: 100.0,
+                    color: const Color(0xFF00FF00),
+                  ),
+                ),
+                Container(
                   width: 100.0,
                   height: 100.0,
-                  color: const Color(0xFF00FF00),
+                  child: GestureDetector(
+                    onTap: button == kPrimaryButton ? () {
+                      didTap = true;
+                    } : null,
+                    onSecondaryTap: button == kSecondaryButton ? () {
+                      didTap = true;
+                    } : null,
+                    behavior: behavior,
+                  ),
                 ),
-              ),
-              Container(
-                width: 100.0,
-                height: 100.0,
-                child: GestureDetector(
-                  onTap: () {
-                    didTap = true;
-                  },
-                  behavior: behavior,
-                ),
-              ),
-            ],
+              ],
+            ),
+          ),
+        );
+      }
+
+      didReceivePointerDown = false;
+      didTap = false;
+      await pumpWidgetTree(null);
+      await tester.tapAt(const Offset(10.0, 10.0), buttons: button);
+      expect(didReceivePointerDown, isTrue);
+      expect(didTap, isTrue);
+
+      didReceivePointerDown = false;
+      didTap = false;
+      await pumpWidgetTree(HitTestBehavior.deferToChild);
+      await tester.tapAt(const Offset(10.0, 10.0), buttons: button);
+      expect(didReceivePointerDown, isTrue);
+      expect(didTap, isFalse);
+
+      didReceivePointerDown = false;
+      didTap = false;
+      await pumpWidgetTree(HitTestBehavior.opaque);
+      await tester.tapAt(const Offset(10.0, 10.0), buttons: button);
+      expect(didReceivePointerDown, isFalse);
+      expect(didTap, isTrue);
+
+      didReceivePointerDown = false;
+      didTap = false;
+      await pumpWidgetTree(HitTestBehavior.translucent);
+      await tester.tapAt(const Offset(10.0, 10.0), buttons: button);
+      expect(didReceivePointerDown, isTrue);
+      expect(didTap, isTrue);
+    }, variant: buttonVariant);
+
+    testWidgets('Empty', (WidgetTester tester) async {
+      bool didTap = false;
+      await tester.pumpWidget(
+        Center(
+          child: GestureDetector(
+            onTap: button == kPrimaryButton ? () {
+              didTap = true;
+            } : null,
+            onSecondaryTap: button == kSecondaryButton ? () {
+              didTap = true;
+            } : null,
           ),
         ),
       );
-    }
+      expect(didTap, isFalse);
+      await tester.tapAt(const Offset(10.0, 10.0), buttons: button);
+      expect(didTap, isTrue);
+    }, variant: buttonVariant);
 
-    didReceivePointerDown = false;
-    didTap = false;
-    await pumpWidgetTree(null);
-    await tester.tapAt(const Offset(10.0, 10.0));
-    expect(didReceivePointerDown, isTrue);
-    expect(didTap, isTrue);
-
-    didReceivePointerDown = false;
-    didTap = false;
-    await pumpWidgetTree(HitTestBehavior.deferToChild);
-    await tester.tapAt(const Offset(10.0, 10.0));
-    expect(didReceivePointerDown, isTrue);
-    expect(didTap, isFalse);
-
-    didReceivePointerDown = false;
-    didTap = false;
-    await pumpWidgetTree(HitTestBehavior.opaque);
-    await tester.tapAt(const Offset(10.0, 10.0));
-    expect(didReceivePointerDown, isFalse);
-    expect(didTap, isTrue);
-
-    didReceivePointerDown = false;
-    didTap = false;
-    await pumpWidgetTree(HitTestBehavior.translucent);
-    await tester.tapAt(const Offset(10.0, 10.0));
-    expect(didReceivePointerDown, isTrue);
-    expect(didTap, isTrue);
-
-  });
-
-  testWidgets('Empty', (WidgetTester tester) async {
-    bool didTap = false;
-    await tester.pumpWidget(
-      Center(
-        child: GestureDetector(
-          onTap: () {
-            didTap = true;
-          },
-        ),
-      ),
-    );
-    expect(didTap, isFalse);
-    await tester.tapAt(const Offset(10.0, 10.0));
-    expect(didTap, isTrue);
-  });
-
-  testWidgets('Only container', (WidgetTester tester) async {
-    bool didTap = false;
-    await tester.pumpWidget(
-      Center(
-        child: GestureDetector(
-          onTap: () {
-            didTap = true;
-          },
-          child: Container(),
-        ),
-      ),
-    );
-    expect(didTap, isFalse);
-    await tester.tapAt(const Offset(10.0, 10.0));
-    expect(didTap, isFalse);
-  });
-
-  testWidgets('cache render object', (WidgetTester tester) async {
-    final GestureTapCallback inputCallback = () { };
-
-    await tester.pumpWidget(
-      Center(
-        child: GestureDetector(
-          onTap: inputCallback,
-          child: Container(),
-        ),
-      ),
-    );
-
-    final RenderSemanticsGestureHandler renderObj1 = tester.renderObject(find.byType(GestureDetector));
-
-    await tester.pumpWidget(
-      Center(
-        child: GestureDetector(
-          onTap: inputCallback,
-          child: Container(),
-        ),
-      ),
-    );
-
-    final RenderSemanticsGestureHandler renderObj2 = tester.renderObject(find.byType(GestureDetector));
-
-    expect(renderObj1, same(renderObj2));
-  });
-
-  testWidgets('Tap down occurs after kPressTimeout', (WidgetTester tester) async {
-    int tapDown = 0;
-    int tap = 0;
-    int tapCancel = 0;
-    int longPress = 0;
-
-    await tester.pumpWidget(
-      Container(
-        alignment: Alignment.topLeft,
-        child: Container(
-          alignment: Alignment.center,
-          height: 100.0,
-          color: const Color(0xFF00FF00),
+    testWidgets('Only container', (WidgetTester tester) async {
+      bool didTap = false;
+      await tester.pumpWidget(
+        Center(
           child: GestureDetector(
-            onTapDown: (TapDownDetails details) {
-              tapDown += 1;
-            },
-            onTap: () {
-              tap += 1;
-            },
-            onTapCancel: () {
-              tapCancel += 1;
-            },
-            onLongPress: () {
-              longPress += 1;
-            },
+            onTap: button == kPrimaryButton ? () {
+              didTap = true;
+            } : null,
+            onSecondaryTap: button == kSecondaryButton ? () {
+              didTap = true;
+            } : null,
+            child: Container(),
           ),
         ),
-      ),
-    );
+      );
+      expect(didTap, isFalse);
+      await tester.tapAt(const Offset(10.0, 10.0));
+      expect(didTap, isFalse);
+    }, variant: buttonVariant);
 
-    // Pointer is dragged from the center of the 800x100 gesture detector
-    // to a point (400,300) below it. This should never call onTap.
-    Future<void> dragOut(Duration timeout) async {
-      final TestGesture gesture = await tester.startGesture(const Offset(400.0, 50.0));
-      // If the timeout is less than kPressTimeout the recognizer will not
-      // trigger any callbacks. If the timeout is greater than kLongPressTimeout
-      // then onTapDown, onLongPress, and onCancel will be called.
-      await tester.pump(timeout);
-      await gesture.moveTo(const Offset(400.0, 300.0));
-      await gesture.up();
-    }
+    testWidgets('cache render object', (WidgetTester tester) async {
+      final GestureTapCallback inputCallback = () { };
 
-    await dragOut(kPressTimeout * 0.5); // generates nothing
-    expect(tapDown, 0);
-    expect(tapCancel, 0);
-    expect(tap, 0);
-    expect(longPress, 0);
+      await tester.pumpWidget(
+        Center(
+          child: GestureDetector(
+            onTap: button == kPrimaryButton ? inputCallback : null,
+            onSecondaryTap: button == kSecondaryButton ? inputCallback : null,
+            child: Container(),
+          ),
+        ),
+      );
 
-    await dragOut(kPressTimeout); // generates tapDown, tapCancel
-    expect(tapDown, 1);
-    expect(tapCancel, 1);
-    expect(tap, 0);
-    expect(longPress, 0);
+      final RenderSemanticsGestureHandler renderObj1 = tester.renderObject(find.byType(GestureDetector));
 
-    await dragOut(kLongPressTimeout); // generates tapDown, longPress, tapCancel
-    expect(tapDown, 2);
-    expect(tapCancel, 2);
-    expect(tap, 0);
-    expect(longPress, 1);
+      await tester.pumpWidget(
+        Center(
+          child: GestureDetector(
+            onTap: button == kPrimaryButton ? inputCallback : null,
+            onSecondaryTap: button == kSecondaryButton ? inputCallback : null,
+            child: Container(),
+          ),
+        ),
+      );
+
+      final RenderSemanticsGestureHandler renderObj2 = tester.renderObject(find.byType(GestureDetector));
+
+      expect(renderObj1, same(renderObj2));
+    }, variant: buttonVariant);
+
+    testWidgets('Tap down occurs after kPressTimeout', (WidgetTester tester) async {
+      int tapDown = 0;
+      int tap = 0;
+      int tapCancel = 0;
+      int longPress = 0;
+
+      await tester.pumpWidget(
+        Container(
+          alignment: Alignment.topLeft,
+          child: Container(
+            alignment: Alignment.center,
+            height: 100.0,
+            color: const Color(0xFF00FF00),
+            child: GestureDetector(
+              onTapDown: button == kPrimaryButton ? (TapDownDetails details) {
+                tapDown += 1;
+              } : null,
+              onSecondaryTapDown: button == kSecondaryButton ? (TapDownDetails details) {
+                tapDown += 1;
+              } : null,
+              onTap: button == kPrimaryButton ? () {
+                tap += 1;
+              } : null,
+              onSecondaryTap: button == kSecondaryButton ? () {
+                tap += 1;
+              } : null,
+              onTapCancel: button == kPrimaryButton ? () {
+                tapCancel += 1;
+              } : null,
+              onSecondaryTapCancel: button == kSecondaryButton ? () {
+                tapCancel += 1;
+              } : null,
+              onLongPress: () {
+                longPress += 1;
+              },
+            ),
+          ),
+        ),
+      );
+
+      // Pointer is dragged from the center of the 800x100 gesture detector
+      // to a point (400,300) below it. This should never call onTap.
+      Future<void> dragOut(Duration timeout) async {
+        final TestGesture gesture =
+        await tester.startGesture(const Offset(400.0, 50.0), buttons: button);
+        // If the timeout is less than kPressTimeout the recognizer will not
+        // trigger any callbacks. If the timeout is greater than kLongPressTimeout
+        // then onTapDown, onLongPress, and onCancel will be called.
+        await tester.pump(timeout);
+        await gesture.moveTo(const Offset(400.0, 300.0));
+        await gesture.up();
+      }
+
+      // TODO(gspencergoog): This should probably also be run for secondary
+      if (button == kPrimaryButton) {
+        await dragOut(kPressTimeout * 0.5); // generates nothing
+        expect(tapDown, 0);
+        expect(tapCancel, 0);
+        expect(tap, 0);
+        expect(longPress, 0);
+      }
+
+      await dragOut(kPressTimeout); // generates tapDown, tapCancel
+      expect(tapDown, 1);
+      expect(tapCancel, 1);
+      expect(tap, 0);
+      expect(longPress, 0);
+
+      await dragOut(kLongPressTimeout); // generates tapDown, longPress, tapCancel
+      expect(tapDown, 2);
+      expect(tapCancel, 2);
+      expect(tap, 0);
+      expect(longPress, button == kPrimaryButton ? 1 : 0);
+    }, variant: buttonVariant);
   });
 
   testWidgets('Long Press Up Callback called after long press', (WidgetTester tester) async {

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -220,6 +220,58 @@ class DefaultTestVariant extends TestVariant<void> {
   Future<void> tearDown(void value, void memento) async {}
 }
 
+typedef ListVariantValueToString<T> = String Function(T value);
+
+/// A [TestVariant] that runs tests with [debugDefaultTargetPlatformOverride]
+/// set to different values of [TargetPlatform].
+class ListVariant<T> extends TestVariant<T> {
+  /// Creates a [TargetPlatformVariant] that tests the given [values].
+  const ListVariant({
+    @required this.values,
+    @required this.onVariant,
+    this.initialValue,
+    this.valueToString,
+  }) : assert(onVariant != null),
+       assert(values.length != 0); // ignore: prefer_is_empty
+
+  @override
+  final List<T> values;
+
+  /// A closure that will set the variable to a given value.
+  ///
+  /// This will be called each time a test is run, once at the beginning of the
+  /// test with the value used for the test, and once after the test has run,
+  /// giving it the [initialValue] again.
+  final ValueChanged<T> onVariant;
+
+  /// The value to call [onVariant] with once the test is finished.
+  final T initialValue;
+
+  /// If set, is used to describe the value for each test description.
+  ///
+  /// If not set, will default to the value's `toString` method.
+  final ListVariantValueToString<T> valueToString;
+
+  @override
+  String describeValue(T value) {
+    if (valueToString != null) {
+      return valueToString(value);
+    }
+    return value.toString();
+  }
+
+  @override
+  Future<T> setUp(T value) async {
+    onVariant(value);
+    return initialValue;
+  }
+
+  @override
+  Future<void> tearDown(T value, T memento) async {
+    onVariant(memento);
+  }
+}
+
 /// A [TestVariant] that runs tests with [debugDefaultTargetPlatformOverride]
 /// set to different values of [TargetPlatform].
 class TargetPlatformVariant extends TestVariant<TargetPlatform> {

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -222,8 +222,8 @@ class DefaultTestVariant extends TestVariant<void> {
 
 typedef ListVariantValueToString<T> = String Function(T value);
 
-/// A [TestVariant] that runs tests with [debugDefaultTargetPlatformOverride]
-/// set to different values of [TargetPlatform].
+/// A [TestVariant] that runs tests with various different values from a list,
+/// and resets to the initial value when done.
 class ListVariant<T> extends TestVariant<T> {
   /// Creates a [TargetPlatformVariant] that tests the given [values].
   const ListVariant({

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -220,58 +220,6 @@ class DefaultTestVariant extends TestVariant<void> {
   Future<void> tearDown(void value, void memento) async {}
 }
 
-typedef ListVariantValueToString<T> = String Function(T value);
-
-/// A [TestVariant] that runs tests with various different values from a list,
-/// and resets to the initial value when done.
-class ListVariant<T> extends TestVariant<T> {
-  /// Creates a [TargetPlatformVariant] that tests the given [values].
-  const ListVariant({
-    @required this.values,
-    @required this.onVariant,
-    this.initialValue,
-    this.valueToString,
-  }) : assert(onVariant != null),
-       assert(values.length != 0); // ignore: prefer_is_empty
-
-  @override
-  final List<T> values;
-
-  /// A closure that will set the variable to a given value.
-  ///
-  /// This will be called each time a test is run, once at the beginning of the
-  /// test with the value used for the test, and once after the test has run,
-  /// giving it the [initialValue] again.
-  final ValueChanged<T> onVariant;
-
-  /// The value to call [onVariant] with once the test is finished.
-  final T initialValue;
-
-  /// If set, is used to describe the value for each test description.
-  ///
-  /// If not set, will default to the value's `toString` method.
-  final ListVariantValueToString<T> valueToString;
-
-  @override
-  String describeValue(T value) {
-    if (valueToString != null) {
-      return valueToString(value);
-    }
-    return value.toString();
-  }
-
-  @override
-  Future<T> setUp(T value) async {
-    onVariant(value);
-    return initialValue;
-  }
-
-  @override
-  Future<void> tearDown(T value, T memento) async {
-    onVariant(memento);
-  }
-}
-
 /// A [TestVariant] that runs tests with [debugDefaultTargetPlatformOverride]
 /// set to different values of [TargetPlatform].
 class TargetPlatformVariant extends TestVariant<TargetPlatform> {


### PR DESCRIPTION
## Description

This adds `onSecondaryTap` to the `GestureDetector` and `GestureRecognizer`.

Also added a `ListVariant` (`TestVariant` subclass in widget_tester) that lets tests run multiple times with a list of values.

## Related Issues

- https://github.com/flutter/flutter/issues/55423

## Tests

- Added tests for all secondary taps using new ListVariant.

## Breaking Change

- [X] No, this is *not* a breaking change.