### PR TITLE
Relands Fix FlutterError.onError in debug mode

### DIFF
--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -715,7 +715,7 @@ class FlutterError extends Error with DiagnosticableTreeMixin implements Asserti
 
   /// Called whenever the Flutter framework catches an error.
   ///
-  /// The default behavior is to call [dumpErrorToConsole].
+  /// The default behavior is to call [presentError].
   ///
   /// You can set this to your own function to override this default behavior.
   /// For example, you could report all errors to your server.
@@ -725,7 +725,18 @@ class FlutterError extends Error with DiagnosticableTreeMixin implements Asserti
   ///
   /// Set this to null to silently catch and ignore errors. This is not
   /// recommended.
-  static FlutterExceptionHandler onError = dumpErrorToConsole;
+  static FlutterExceptionHandler onError = (FlutterErrorDetails details) => presentError(details);
+
+  /// Called whenever the Flutter framework wants to present an error to the
+  /// users.
+  ///
+  /// The default behavior is to call [dumpErrorToConsole].
+  ///
+  /// Plugins can override how an error is to be presented to the user. For
+  /// example, the structured errors service extension sets its own method when
+  /// the extension is enabled. If you want to change how Flutter responds to an
+  /// error, use [onError] instead.
+  static FlutterExceptionHandler presentError = dumpErrorToConsole;
 
   static int _errorCount = 0;
 

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -959,13 +959,13 @@ mixin WidgetInspectorService {
     SchedulerBinding.instance.addPersistentFrameCallback(_onFrameStart);
 
     final FlutterExceptionHandler structuredExceptionHandler = _reportError;
-    final FlutterExceptionHandler defaultExceptionHandler = FlutterError.onError;
+    final FlutterExceptionHandler defaultExceptionHandler = FlutterError.presentError;
 
     _registerBoolServiceExtension(
       name: 'structuredErrors',
-      getter: () async => FlutterError.onError == structuredExceptionHandler,
+      getter: () async => FlutterError.presentError == structuredExceptionHandler,
       setter: (bool value) {
-        FlutterError.onError = value ? structuredExceptionHandler : defaultExceptionHandler;
+        FlutterError.presentError = value ? structuredExceptionHandler : defaultExceptionHandler;
         return Future<void>.value();
       },
     );

--- a/packages/flutter/test/widgets/widget_inspector_structure_error_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_structure_error_test.dart
@@ -1,0 +1,91 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  StructureErrorTestWidgetInspectorService.runTests();
+}
+
+typedef InspectorServiceExtensionCallback = FutureOr<Map<String, Object>> Function(Map<String, String> parameters);
+
+class StructureErrorTestWidgetInspectorService extends Object with WidgetInspectorService {
+  final Map<String, InspectorServiceExtensionCallback> extensions = <String, InspectorServiceExtensionCallback>{};
+
+  final Map<String, List<Map<Object, Object>>> eventsDispatched = <String, List<Map<Object, Object>>>{};
+
+  @override
+  void registerServiceExtension({
+    @required String name,
+    @required FutureOr<Map<String, Object>> callback(Map<String, String> parameters),
+  }) {
+    assert(!extensions.containsKey(name));
+    extensions[name] = callback;
+  }
+
+  @override
+  void postEvent(String eventKind, Map<Object, Object> eventData) {
+    getEventsDispatched(eventKind).add(eventData);
+  }
+
+  List<Map<Object, Object>> getEventsDispatched(String eventKind) {
+    return eventsDispatched.putIfAbsent(eventKind, () => <Map<Object, Object>>[]);
+  }
+
+  Iterable<Map<Object, Object>> getServiceExtensionStateChangedEvents(String extensionName) {
+    return getEventsDispatched('Flutter.ServiceExtensionStateChanged')
+      .where((Map<Object, Object> event) => event['extension'] == extensionName);
+  }
+
+  Future<String> testBoolExtension(String name, Map<String, String> arguments) async {
+    expect(extensions, contains(name));
+    // Encode and decode to JSON to match behavior using a real service
+    // extension where only JSON is allowed.
+    return json.decode(json.encode(await extensions[name](arguments)))['enabled'] as String;
+  }
+
+
+  static void runTests() {
+    final StructureErrorTestWidgetInspectorService service = StructureErrorTestWidgetInspectorService();
+    WidgetInspectorService.instance = service;
+
+    test('ext.flutter.inspector.structuredErrors still report error to original on error', () async {
+      final FlutterExceptionHandler oldHandler = FlutterError.onError;
+
+      FlutterErrorDetails actualError;
+      // Creates a spy onError. This spy needs to be set before widgets binding
+      // initializes.
+      FlutterError.onError = (FlutterErrorDetails details) {
+        actualError = details;
+      };
+
+      WidgetsFlutterBinding.ensureInitialized();
+      try {
+        // Enables structured errors.
+        expect(await service.testBoolExtension(
+          'structuredErrors', <String, String>{'enabled': 'true'}),
+          equals('true'));
+
+        // Creates an error.
+        final FlutterErrorDetails expectedError = FlutterErrorDetailsForRendering(
+          library: 'rendering library',
+          context: ErrorDescription('during layout'),
+          exception: StackTrace.current,
+        );
+        FlutterError.reportError(expectedError);
+
+        // Validates the spy still received an error.
+        expect(actualError, expectedError);
+      } finally {
+        FlutterError.onError = oldHandler;
+      }
+    });
+  }
+}

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -2331,6 +2331,8 @@ class TestWidgetInspectorService extends Object with WidgetInspectorService {
         // The run test overrides the flutter error handler, so we should
         // restore it back for the structure error to continue working.
         FlutterError.onError = oldHandler;
+        // Cleans up the fake async so it does not bleed into next test.
+        binding.postTest();
 
         // Send another error.
         FlutterError.reportError(FlutterErrorDetailsForRendering(

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -2276,11 +2276,11 @@ class TestWidgetInspectorService extends Object with WidgetInspectorService {
       );
     }, skip: isBrowser);
 
-    testWidgets('ext.flutter.inspector.structuredErrors', (WidgetTester tester) async {
+    test('ext.flutter.inspector.structuredErrors', () async {
       List<Map<Object, Object>> flutterErrorEvents = service.getEventsDispatched('Flutter.Error');
       expect(flutterErrorEvents, isEmpty);
 
-      final FlutterExceptionHandler oldHandler = FlutterError.onError;
+      final FlutterExceptionHandler oldHandler = FlutterError.presentError;
 
       try {
         // Enable structured errors.
@@ -2320,9 +2320,17 @@ class TestWidgetInspectorService extends Object with WidgetInspectorService {
         error = flutterErrorEvents.last;
         expect(error['errorsSinceReload'], 1);
 
-        // Reload the app.
-        tester.binding.reassembleApplication();
-        await tester.pump();
+        // Reloads the app.
+        final FlutterExceptionHandler oldHandler = FlutterError.onError;
+        final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized() as TestWidgetsFlutterBinding;
+        // We need the runTest to setup the fake async in the test binding.
+        await binding.runTest(() async {
+          binding.reassembleApplication();
+          await binding.pump();
+        }, () { });
+        // The run test overrides the flutter error handler, so we should
+        // restore it back for the structure error to continue working.
+        FlutterError.onError = oldHandler;
 
         // Send another error.
         FlutterError.reportError(FlutterErrorDetailsForRendering(
@@ -2337,7 +2345,7 @@ class TestWidgetInspectorService extends Object with WidgetInspectorService {
         error = flutterErrorEvents.last;
         expect(error['errorsSinceReload'], 0);
       } finally {
-        FlutterError.onError = oldHandler;
+        FlutterError.presentError = oldHandler;
       }
     });
 


### PR DESCRIPTION
## Description

Previous PR change the way that the testWidgets intercepts error. It was a bad decision, and i updated it in this pr.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/47447

## Tests

I added the following tests:

See files

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
