### PR TITLE
Ignore the SceneDisplayLag end events that are missing the vsync data

### DIFF
--- a/packages/flutter_driver/lib/src/driver/scene_display_lag_summarizer.dart
+++ b/packages/flutter_driver/lib/src/driver/scene_display_lag_summarizer.dart
@@ -58,7 +58,9 @@ class SceneDisplayLagSummarizer {
     final double total = sceneDisplayLagEvents
         .map(_getVsyncTransitionsMissed)
         .reduce((double a, double b) => a + b);
-    return total * 2 / sceneDisplayLagEvents.length;
+    // Note that the length here counts both begin and end events which means
+    // the average is half of what it should be...
+    return total / sceneDisplayLagEvents.length;
   }
 
   /// The [percentile]-th percentile `vsync_transitions_missed` over the lag events.
@@ -76,7 +78,9 @@ class SceneDisplayLagSummarizer {
     assert(e.name == kSceneDisplayLagEvent);
     assert(e.arguments.containsKey(_kVsyncTransitionsMissed));
     final dynamic transitionsMissed = e.arguments[_kVsyncTransitionsMissed];
-    if (transitionsMissed == null) return 0.0;
+    if (transitionsMissed == null) {
+      return 0.0;
+    }
     assert(transitionsMissed is String);
     return double.parse(transitionsMissed as String);
   }

--- a/packages/flutter_driver/lib/src/driver/scene_display_lag_summarizer.dart
+++ b/packages/flutter_driver/lib/src/driver/scene_display_lag_summarizer.dart
@@ -58,7 +58,7 @@ class SceneDisplayLagSummarizer {
     final double total = sceneDisplayLagEvents
         .map(_getVsyncTransitionsMissed)
         .reduce((double a, double b) => a + b);
-    return total / sceneDisplayLagEvents.length;
+    return total * 2 / sceneDisplayLagEvents.length;
   }
 
   /// The [percentile]-th percentile `vsync_transitions_missed` over the lag events.
@@ -76,6 +76,7 @@ class SceneDisplayLagSummarizer {
     assert(e.name == kSceneDisplayLagEvent);
     assert(e.arguments.containsKey(_kVsyncTransitionsMissed));
     final dynamic transitionsMissed = e.arguments[_kVsyncTransitionsMissed];
+    if (transitionsMissed == null) return 0.0;
     assert(transitionsMissed is String);
     return double.parse(transitionsMissed as String);
   }


### PR DESCRIPTION
This is a quick fix to get the benchmarks back up and running, but a real fix would be to filter the event stream better. I'll leave it to @iskakaushik to work on the better fix later.