### PR TITLE
[benchmarks] Use synchronous num_vsync_transitions_missed

### DIFF
--- a/packages/flutter_driver/lib/src/driver/scene_display_lag_summarizer.dart
+++ b/packages/flutter_driver/lib/src/driver/scene_display_lag_summarizer.dart
@@ -7,7 +7,8 @@ import 'timeline.dart';
 /// Key for SceneDisplayLag timeline events.
 const String kSceneDisplayLagEvent = 'SceneDisplayLag';
 
-const String _kVsyncTransitionsMissed = 'vsync_transitions_missed';
+/// Argument Key for SceneDisplayLag transitions missed.
+const String kVsyncTransitionsMissed = 'num_vsync_transitions_missed';
 
 /// Returns the [p]-th percentile element from the [doubles].
 ///
@@ -74,8 +75,8 @@ class SceneDisplayLagSummarizer {
 
   double _getVsyncTransitionsMissed(TimelineEvent e) {
     assert(e.name == kSceneDisplayLagEvent);
-    assert(e.arguments.containsKey(_kVsyncTransitionsMissed));
-    final dynamic transitionsMissed = e.arguments[_kVsyncTransitionsMissed];
+    assert(e.arguments.containsKey(kVsyncTransitionsMissed));
+    final dynamic transitionsMissed = e.arguments[kVsyncTransitionsMissed];
     assert(transitionsMissed is String);
     return double.parse(transitionsMissed as String);
   }

--- a/packages/flutter_driver/test/src/real_tests/timeline_summary_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/timeline_summary_test.dart
@@ -50,7 +50,7 @@ void main() {
       'ph': 'b',
       'ts': timeStamp,
       'args': <String, String>{
-        'vsync_transitions_missed': vsyncsMissed.toString()
+        'num_vsync_transitions_missed': vsyncsMissed.toString()
       }
     };
 
@@ -59,7 +59,7 @@ void main() {
       'ph': 'e',
       'ts': timeStamp,
       'args': <String, String>{
-        'vsync_transitions_missed': vsyncsMissed.toString()
+        'num_vsync_transitions_missed': vsyncsMissed.toString()
       }
     };
 


### PR DESCRIPTION
This works around the issue where we were tracing
async events and this results in issues like:

https://github.com/flutter/flutter/issues/54629
