### PR TITLE
[flutter_tools] enable `flutter upgrade` to support force pushed branches

### DIFF
--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -206,9 +206,9 @@ class UpgradeCommandRunner {
   Future<String> fetchRemoteRevision() async {
     String revision;
     try {
-      // Make sure upstream is up to date
+      // Fetch upstream branch's commits and tags
       await processUtils.run(
-        <String>['git', 'fetch'],
+        <String>['git', 'fetch', '--tags'],
         throwOnError: true,
         workingDirectory: workingDirectory,
       );

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -5,7 +5,6 @@
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 
-import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/upgrade.dart';
 import 'package:flutter_tools/src/convert.dart';
@@ -294,58 +293,6 @@ void main() {
           directory: tempDir,
           logger: testLogger,
         ),
-      });
-    });
-  });
-
-  group('matchesGitLine', () {
-    setUpAll(() {
-      Cache.disableLocking();
-    });
-
-    bool _match(String line) => UpgradeCommandRunner.matchesGitLine(line);
-
-    test('regex match', () {
-      expect(_match(' .../flutter_gallery/lib/demo/buttons_demo.dart    | 10 +--'), true);
-      expect(_match(' dev/benchmarks/complex_layout/lib/main.dart        |  24 +-'), true);
-
-      expect(_match(' rename {packages/flutter/doc => dev/docs}/styles.html (92%)'), true);
-      expect(_match(' delete mode 100644 doc/index.html'), true);
-      expect(_match(' create mode 100644 dev/integration_tests/flutter_gallery/lib/gallery/demo.dart'), true);
-
-      expect(_match('Fast-forward'), true);
-    });
-
-    test("regex doesn't match", () {
-      expect(_match('Updating 79cfe1e..5046107'), false);
-      expect(_match('229 files changed, 6179 insertions(+), 3065 deletions(-)'), false);
-    });
-
-    group('findProjectRoot', () {
-      Directory tempDir;
-
-      setUp(() async {
-        tempDir = globals.fs.systemTempDirectory.createTempSync('flutter_tools_upgrade_test.');
-      });
-
-      tearDown(() {
-        tryToDelete(tempDir);
-      });
-
-      testUsingContext('in project', () async {
-        final String projectPath = await createProject(tempDir);
-        expect(findProjectRoot(projectPath), projectPath);
-        expect(findProjectRoot(globals.fs.path.join(projectPath, 'lib')), projectPath);
-
-        final String hello = globals.fs.path.join(Cache.flutterRoot, 'examples', 'hello_world');
-        expect(findProjectRoot(hello), hello);
-        expect(findProjectRoot(globals.fs.path.join(hello, 'lib')), hello);
-      });
-
-      testUsingContext('outside project', () async {
-        final String projectPath = await createProject(tempDir);
-        expect(findProjectRoot(globals.fs.directory(projectPath).parent.path), null);
-        expect(findProjectRoot(Cache.flutterRoot), null);
       });
     });
   });

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -164,7 +164,7 @@ void main() {
     testUsingContext('fetchRemoteRevision', () async {
       const String revision = 'abc123';
       when(processManager.run(
-        <String>['git', 'fetch'],
+        <String>['git', 'fetch', '--tags'],
         environment:anyNamed('environment'),
         workingDirectory: anyNamed('workingDirectory')),
       ).thenAnswer((Invocation invocation) async {

--- a/packages/flutter_tools/test/integration.shard/downgrade_upgrade_integration_test.dart
+++ b/packages/flutter_tools/test/integration.shard/downgrade_upgrade_integration_test.dart
@@ -57,8 +57,7 @@ void main() {
       'git', 'config', '--system', 'core.longpaths', 'true',
     ]);
 
-    print('Step 1');
-    // Step 1. Clone the dev branch of flutter into the test directory.
+    print('Step 1 - clone the $_kBranch of flutter into the test directory');
     exitCode = await processUtils.stream(<String>[
       'git',
       'clone',
@@ -66,8 +65,7 @@ void main() {
     ], workingDirectory: parentDirectory.path, trace: true);
     expect(exitCode, 0);
 
-    print('Step 2');
-    // Step 2. Switch to the dev branch.
+    print('Step 2 - switch to the $_kBranch');
     exitCode = await processUtils.stream(<String>[
       'git',
       'checkout',
@@ -78,8 +76,7 @@ void main() {
     ], workingDirectory: testDirectory.path, trace: true);
     expect(exitCode, 0);
 
-    print('Step 3');
-    // Step 3. Revert to a prior version.
+    print('Step 3 - revert back to $_kInitialVersion');
     exitCode = await processUtils.stream(<String>[
       'git',
       'reset',
@@ -88,9 +85,8 @@ void main() {
     ], workingDirectory: testDirectory.path, trace: true);
     expect(exitCode, 0);
 
-    print('Step 4');
-    // Step 4. Upgrade to the newest stable. This should update the persistent
-    // tool state with the sha for v1.14.3
+    print('Step 4 - upgrade to the newest $_kBranch');
+    // This should update the persistent tool state with the sha for HEAD
     exitCode = await processUtils.stream(<String>[
       flutterBin,
       'upgrade',
@@ -99,8 +95,7 @@ void main() {
     ], workingDirectory: testDirectory.path, trace: true);
     expect(exitCode, 0);
 
-    print('Step 5');
-    // Step 5. Verify that the version is different.
+    print('Step 5 - verify that the version is different');
     final RunResult versionResult = await processUtils.run(<String>[
       'git',
       'describe',
@@ -111,8 +106,9 @@ void main() {
       '--tags',
     ], workingDirectory: testDirectory.path);
     expect(versionResult.stdout, isNot(contains(_kInitialVersion)));
+    print('current version is ${versionResult.stdout.trim()}\ninitial was $_kInitialVersion');
 
-    print('Step 6');
+    print('Step 6 - downgrade back to the initial version');
     // Step 6. Downgrade back to initial version.
     exitCode = await processUtils.stream(<String>[
        flutterBin,
@@ -122,7 +118,7 @@ void main() {
     ], workingDirectory: testDirectory.path, trace: true);
     expect(exitCode, 0);
 
-    print('Step 7');
+    print('Step 7 - verify downgraded version matches original version');
     // Step 7. Verify downgraded version matches original version.
     final RunResult oldVersionResult = await processUtils.run(<String>[
       'git',
@@ -134,5 +130,6 @@ void main() {
       '--tags',
     ], workingDirectory: testDirectory.path);
     expect(oldVersionResult.stdout, contains(_kInitialVersion));
+    print('current version is ${oldVersionResult.stdout.trim()}\ninitial was $_kInitialVersion');
   });
 }


### PR DESCRIPTION
## Description

In https://github.com/flutter/flutter/pull/53715 I removed support for `flutter upgrade`-ing forward through a force pushed branch assuming that we would not be force pushing in the future, and to allow the `downgrade_upgrade_integration_test` to properly test upgrading.

However, because of #55576, we will have to again force push past hotfixes. The way upgrading from hotfixed branches *previously* worked was:

1. reset backward to the last non-hotfix tag on the branch (e.g. `v1.2.3+hotfix.4 -> v1.2.3`)
1. do a `git pull --ff` fast forward to the tip of the branch (e.g. `v1.2.3 -> 1.3.0`).

However, with the new release scheme, finding the point to reset to is not as simple as stripping out the `+hotfix.x` from the tag (I'm guessing we could use `git merge-base master <channel>`. However this would regress the `downgrade_upgrade_integration_test`, and since we're doing a hard reset, we might as well just hard reset to the upstream HEAD:

1. fetch the upstream version of the branch, `git fetch`
1. retrieve the revision of the upstream HEAD, `git rev-parse --verify @{u}`
1. hard reset to the upstream HEAD, `git reset --hard <revision from last step>`

## Related Issues

Fixes https://github.com/flutter/flutter/issues/55576.

## Tests

I updated mocks to the unit tests and the `downgrade_upgrade_integration_test` still passes.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*
