### PR TITLE
[flutter_tools] detect ipv6 in fuchsia server url

### DIFF
--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -299,8 +299,9 @@ class FuchsiaDevice extends Device {
 
       // Start up a package server.
       const String packageServerName = FuchsiaPackageServer.toolHost;
+      final bool isIpv6 = InternetAddress(host).type == InternetAddressType.IPv6;
       fuchsiaPackageServer = FuchsiaPackageServer(
-          packageRepo.path, packageServerName, host, port);
+          packageRepo.path, packageServerName, host, port, isIpv6);
       if (!await fuchsiaPackageServer.start()) {
         globals.printError('Failed to start the Fuchsia package server');
         return LaunchResult.failed();

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -299,9 +299,8 @@ class FuchsiaDevice extends Device {
 
       // Start up a package server.
       const String packageServerName = FuchsiaPackageServer.toolHost;
-      final bool isIpv6 = host.contains(':');
       fuchsiaPackageServer = FuchsiaPackageServer(
-          packageRepo.path, packageServerName, host, port, isIpv6);
+          packageRepo.path, packageServerName, host, port);
       if (!await fuchsiaPackageServer.start()) {
         globals.printError('Failed to start the Fuchsia package server');
         return LaunchResult.failed();

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -299,7 +299,7 @@ class FuchsiaDevice extends Device {
 
       // Start up a package server.
       const String packageServerName = FuchsiaPackageServer.toolHost;
-      final bool isIpv6 = InternetAddress(host).type == InternetAddressType.IPv6;
+      final bool isIpv6 = host.contains(':');
       fuchsiaPackageServer = FuchsiaPackageServer(
           packageRepo.path, packageServerName, host, port, isIpv6);
       if (!await fuchsiaPackageServer.start()) {

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_pm.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_pm.dart
@@ -180,7 +180,7 @@ class FuchsiaPM {
 ///   server.stop();
 /// }
 class FuchsiaPackageServer {
-  FuchsiaPackageServer(this._repo, this.name, this._host, this._port);
+  FuchsiaPackageServer(this._repo, this.name, this._host, this._port, this._ipv6);
 
   static const String deviceHost = 'fuchsia.com';
   static const String toolHost = 'flutter_tool';
@@ -188,11 +188,14 @@ class FuchsiaPackageServer {
   final String _repo;
   final String _host;
   final int _port;
+  final bool _ipv6;
 
   Process _process;
 
   /// The URL that can be used by the device to access this package server.
-  String get url => 'http://$_host:$_port';
+  String get url => _ipv6
+    ? 'http://[$_host]:$_port'
+    : 'http://$_host:$_port';
 
   // The name used to reference the server by fuchsia-pkg:// urls.
   final String name;

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_pm.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_pm.dart
@@ -180,7 +180,7 @@ class FuchsiaPM {
 ///   server.stop();
 /// }
 class FuchsiaPackageServer {
-  FuchsiaPackageServer(this._repo, this.name, this._host, this._port, this._ipv6);
+  FuchsiaPackageServer(this._repo, this.name, this._host, this._port);
 
   static const String deviceHost = 'fuchsia.com';
   static const String toolHost = 'flutter_tool';
@@ -188,14 +188,11 @@ class FuchsiaPackageServer {
   final String _repo;
   final String _host;
   final int _port;
-  final bool _ipv6;
 
   Process _process;
 
   /// The URL that can be used by the device to access this package server.
-  String get url => _ipv6
-    ? 'http://[$_host]:$_port'
-    : 'http://$_host:$_port';
+  String get url => Uri(scheme: 'http', host: _host, port: _port).toString();
 
   // The name used to reference the server by fuchsia-pkg:// urls.
   final String name;

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_pm_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_pm_test.dart
@@ -75,12 +75,10 @@ void main() {
     testWithoutContext('ipv6 formatting logic of FuchsiaPackageServer', () {
       const String host = 'fe80::ec4:7aff:fecc:ea8f%eno2';
       const int port = 23;
-      // Test determination used in fuchsia_pm.
-      final bool isIpv6 = host.contains(':');
 
       expect(
-        FuchsiaPackageServer('a', 'b', host, port, isIpv6).url,
-        'http://[fe80::ec4:7aff:fecc:ea8f%eno2]:23',
+        FuchsiaPackageServer('a', 'b', host, port).url,
+        'http://[fe80::ec4:7aff:fecc:ea8f%25eno2]:23',
       );
     });
   });

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_pm_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_pm_test.dart
@@ -76,7 +76,7 @@ void main() {
       const String host = 'fe80::ec4:7aff:fecc:ea8f%eno2';
       const int port = 23;
       // Test determination used in fuchsia_pm.
-      final bool isIpv6 = InternetAddress(host).type == InternetAddressType.IPv6;
+      final bool isIpv6 = host.contains(':');
 
       expect(
         FuchsiaPackageServer('a', 'b', host, port, isIpv6).url,

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_pm_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_pm_test.dart
@@ -71,6 +71,18 @@ void main() {
       FuchsiaArtifacts: () => mockFuchsiaArtifacts,
       ProcessManager: () => mockProcessManager,
     });
+
+    testWithoutContext('ipv6 formatting logic of FuchsiaPackageServer', () {
+      const String host = 'fe80::ec4:7aff:fecc:ea8f%eno2';
+      const int port = 23;
+      // Test determination used in fuchsia_pm.
+      final bool isIpv6 = InternetAddress(host).type == InternetAddressType.IPv6;
+
+      expect(
+        FuchsiaPackageServer('a', 'b', host, port, isIpv6).url,
+        'http://[fe80::ec4:7aff:fecc:ea8f%eno2]:23',
+      );
+    });
   });
 }
 


### PR DESCRIPTION
## Description

We were not correctly formatting ipv6 urls in `FuchsiaPackageServer`. Parse the InternetAddress to determine if its an ipv6 type and format with braces 

Fixes https://github.com/flutter/flutter/issues/55592