### PR TITLE
[flutter_tools] remove trailing eth info from fuchsia package server

### DIFF
--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_pm.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_pm.dart
@@ -180,7 +180,14 @@ class FuchsiaPM {
 ///   server.stop();
 /// }
 class FuchsiaPackageServer {
-  FuchsiaPackageServer(this._repo, this.name, this._host, this._port);
+  factory FuchsiaPackageServer(String repo, String name, String host, int port) {
+    if (host.contains('%')) {
+      host = host.split('%').first;
+    }
+    return FuchsiaPackageServer._(repo, name, host, port);
+  }
+
+  FuchsiaPackageServer._(this._repo, this.name, this._host, this._port);
 
   static const String deviceHost = 'fuchsia.com';
   static const String toolHost = 'flutter_tool';

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_pm.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_pm.dart
@@ -181,6 +181,9 @@ class FuchsiaPM {
 /// }
 class FuchsiaPackageServer {
   factory FuchsiaPackageServer(String repo, String name, String host, int port) {
+    // TODO(jonahwilliams): ensure we only receive valid ipv4 or ipv6 InternetAddresses.
+    // Temporary work around to receiving ipv6 addresses with trailing information:
+    // fe80::ec4:7aff:fecc:ea8f%eno2
     if (host.contains('%')) {
       host = host.split('%').first;
     }

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_pm_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_pm_test.dart
@@ -78,7 +78,7 @@ void main() {
 
       expect(
         FuchsiaPackageServer('a', 'b', host, port).url,
-        'http://[fe80::ec4:7aff:fecc:ea8f%25eno2]:23',
+        'http://[fe80::ec4:7aff:fecc:ea8f]:23',
       );
     });
   });


### PR DESCRIPTION
## Description

This is not valid ipv6