### PR TITLE
Prevent use of TextInputType.text when also using TextInputAction.newLine via assert

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -310,9 +310,9 @@ class CupertinoTextField extends StatefulWidget {
            selectAll: true,
            paste: true,
          )),
-       assert(textInputAction != TextInputAction.newLine ||
+       assert(textInputAction != TextInputAction.newline ||
          maxLines == 1 ||
-         keyboardType != TextInputType.text, 'Use keyboardType TextInputType.multiline when using TextInputAction.newLine on a multiline TextField.'),
+         keyboardType != TextInputType.text, 'Use keyboardType TextInputType.multiline when using TextInputAction.newline on a multiline CupertinoTextField.'),
        super(key: key);
 
   /// Controls the text being edited.

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -310,6 +310,9 @@ class CupertinoTextField extends StatefulWidget {
            selectAll: true,
            paste: true,
          )),
+       assert(textInputAction != TextInputAction.newLine ||
+         maxLines == 1 ||
+         keyboardType != TextInputType.text, 'Use keyboardType TextInputType.multiline when using TextInputAction.newLine on a multiline TextField.'),
        super(key: key);
 
   /// Controls the text being edited.

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -299,10 +299,10 @@ class CupertinoTextField extends StatefulWidget {
        assert(prefixMode != null),
        assert(suffixMode != null),
        // Assert the following instead of setting it directly to avoid surprising the user by silently changing the value they set.
-       assert(textInputAction != TextInputAction.newline ||
+       assert(!identical(textInputAction, TextInputAction.newline) ||
          maxLines == 1 ||
-         keyboardType != TextInputType.text,
-         'Use keyboardType TextInputType.multiline when using TextInputAction.newline on a multiline CupertinoTextField.'),
+         !identical(keyboardType, TextInputType.text),
+         'Use keyboardType TextInputType.multiline when using TextInputAction.newline on a multiline TextField.'),
        keyboardType = keyboardType ?? (maxLines == 1 ? TextInputType.text : TextInputType.multiline),
        toolbarOptions = toolbarOptions ?? (obscureText ?
          const ToolbarOptions(

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -298,6 +298,11 @@ class CupertinoTextField extends StatefulWidget {
        assert(clearButtonMode != null),
        assert(prefixMode != null),
        assert(suffixMode != null),
+       // Assert the following instead of setting it directly to avoid surprising the user by silently changing the value they set.
+       assert(textInputAction != TextInputAction.newline ||
+         maxLines == 1 ||
+         keyboardType != TextInputType.text,
+         'Use keyboardType TextInputType.multiline when using TextInputAction.newline on a multiline CupertinoTextField.'),
        keyboardType = keyboardType ?? (maxLines == 1 ? TextInputType.text : TextInputType.multiline),
        toolbarOptions = toolbarOptions ?? (obscureText ?
          const ToolbarOptions(
@@ -310,9 +315,6 @@ class CupertinoTextField extends StatefulWidget {
            selectAll: true,
            paste: true,
          )),
-       assert(textInputAction != TextInputAction.newline ||
-         maxLines == 1 ||
-         keyboardType != TextInputType.text, 'Use keyboardType TextInputType.multiline when using TextInputAction.newline on a multiline CupertinoTextField.'),
        super(key: key);
 
   /// Controls the text being edited.

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -375,7 +375,7 @@ class TextField extends StatefulWidget {
        assert(!obscureText || maxLines == 1, 'Obscured fields cannot be multiline.'),
        assert(maxLength == null || maxLength == TextField.noMaxLength || maxLength > 0),
        // Assert the following instead of setting it directly to avoid surprising the user by silently changing the value they set.
-       assert(textInputAction?.index != TextInputAction.newline.index ||
+       assert(textInputAction != TextInputAction.newline ||
          maxLines == 1 ||
          keyboardType != TextInputType.text,
          'Use keyboardType TextInputType.multiline when using TextInputAction.newline on a multiline TextField.'),

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -375,9 +375,9 @@ class TextField extends StatefulWidget {
        assert(!obscureText || maxLines == 1, 'Obscured fields cannot be multiline.'),
        assert(maxLength == null || maxLength == TextField.noMaxLength || maxLength > 0),
        // Assert the following instead of setting it directly to avoid surprising the user by silently changing the value they set.
-       assert(textInputAction != TextInputAction.newline ||
+       assert(!identical(textInputAction, TextInputAction.newline) ||
          maxLines == 1 ||
-         keyboardType != TextInputType.text,
+         !identical(keyboardType, TextInputType.text),
          'Use keyboardType TextInputType.multiline when using TextInputAction.newline on a multiline TextField.'),
        keyboardType = keyboardType ?? (maxLines == 1 ? TextInputType.text : TextInputType.multiline),
        toolbarOptions = toolbarOptions ?? (obscureText ?

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -374,6 +374,11 @@ class TextField extends StatefulWidget {
        ),
        assert(!obscureText || maxLines == 1, 'Obscured fields cannot be multiline.'),
        assert(maxLength == null || maxLength == TextField.noMaxLength || maxLength > 0),
+       // Assert the following instead of setting it directly to avoid surprising the user by silently changing the value they set.
+       assert(textInputAction?.index != TextInputAction.newline.index ||
+         maxLines == 1 ||
+         keyboardType != TextInputType.text,
+         'Use keyboardType TextInputType.multiline when using TextInputAction.newline on a multiline TextField.'),
        keyboardType = keyboardType ?? (maxLines == 1 ? TextInputType.text : TextInputType.multiline),
        toolbarOptions = toolbarOptions ?? (obscureText ?
          const ToolbarOptions(
@@ -386,9 +391,6 @@ class TextField extends StatefulWidget {
            selectAll: true,
            paste: true,
          )),
-       assert(textInputAction != TextInputAction.newline ||
-         maxLines == 1 ||
-         keyboardType != TextInputType.text, 'Use keyboardType TextInputType.multiline when using TextInputAction.newline on a multiline TextField.'),
        super(key: key);
 
   /// Controls the text being edited.

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -386,9 +386,9 @@ class TextField extends StatefulWidget {
            selectAll: true,
            paste: true,
          )),
-       assert(textInputAction != TextInputAction.newLine ||
+       assert(textInputAction != TextInputAction.newline ||
          maxLines == 1 ||
-         keyboardType != TextInputType.text, 'Use keyboardType TextInputType.multiline when using TextInputAction.newLine on a multiline TextField.'),
+         keyboardType != TextInputType.text, 'Use keyboardType TextInputType.multiline when using TextInputAction.newline on a multiline TextField.'),
        super(key: key);
 
   /// Controls the text being edited.

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -386,6 +386,9 @@ class TextField extends StatefulWidget {
            selectAll: true,
            paste: true,
          )),
+       assert(textInputAction != TextInputAction.newLine ||
+         maxLines == 1 ||
+         keyboardType != TextInputType.text, 'Use keyboardType TextInputType.multiline when using TextInputAction.newLine on a multiline TextField.'),
        super(key: key);
 
   /// Controls the text being edited.


### PR DESCRIPTION
## Description

When defining a multiline textfield, we should prevent the combo of using TextInputAction.newLine and TextInputType.text because TextInputType.multiline is the proper keyboard for handling this situation. TextInputType.multiline should be strictly better compared to TextInputType.text. If the keyboard is told to handle as TextInputType.text, it may not insert the required `\n` (we see this in all Samsung keyboards as well as some languages of gboard such as korean), instead opting to trigger the key event in the input connection adaptor, which can lead to the newLine behavior to fail.

We suggest to the user to use TextInputType.multiline instead.

We also allow the other TextInputTypes as it is ambiguous whether those support multi line or not.

## Related Issues

https://github.com/flutter/flutter/issues/54745

## Tests

This just adds asserts.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
