### PR TITLE
actions required for CupertinoAlertDialog

### DIFF
--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -126,7 +126,7 @@ class CupertinoAlertDialog extends StatelessWidget {
     Key key,
     this.title,
     this.content,
-    this.actions = const <Widget>[],
+    @required this.actions,
     this.scrollController,
     this.actionScrollController,
     this.insetAnimationDuration = const Duration(milliseconds: 100),

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -97,7 +97,7 @@ bool _isInAccessibilityMode(BuildContext context) {
 ///
 /// An alert dialog informs the user about situations that require
 /// acknowledgement. An alert dialog has an optional title, optional content,
-/// and an optional list of actions. The title is displayed above the content
+/// and an optional list of actions (required in [CupertinoDialogAction]). The title is displayed above the content
 /// and the actions are displayed below the content.
 ///
 /// This dialog styles its title and content (typically a message) to match the

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -432,6 +432,7 @@ void main() {
               title: const Text('The title'),
               content: const Text('The content.'),
               scrollController: scrollController,
+              actions: const <Widget>[],
             ),
           );
         },
@@ -1061,7 +1062,10 @@ void main() {
       const MaterialApp(
         home: MediaQuery(
           data: MediaQueryData(viewInsets: EdgeInsets.zero),
-          child: CupertinoAlertDialog(content: Placeholder(fallbackHeight: 200.0)),
+          child: CupertinoAlertDialog(
+            content: Placeholder(fallbackHeight: 200.0),
+            actions: <Widget>[],
+            ),
         ),
       ),
     );
@@ -1072,7 +1076,10 @@ void main() {
       const MaterialApp(
         home: MediaQuery(
           data: MediaQueryData(viewInsets: EdgeInsets.fromLTRB(40.0, 30.0, 20.0, 10.0)),
-          child: CupertinoAlertDialog(content: Placeholder(fallbackHeight: 200.0)),
+          child: CupertinoAlertDialog(
+            content: Placeholder(fallbackHeight: 200.0),
+            actions: <Widget>[],
+            ),
         ),
       ),
     );


### PR DESCRIPTION
## Description

`CupertinoAlertDialog` shouldn't be created with actions as null, it makes it impossible to close the dialog

## Related Issues

Fixes [#49660](https://github.com/flutter/flutter/issues/49660)

## Tests



## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [x] Yes, this is a breaking change. *If not, delete the remainder of this section.*