### PR TITLE
[flutter_tools] ensure etag headers are ascii

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
@@ -350,7 +350,8 @@ class WebAssetServer implements AssetReader {
 
     // For real files, use a serialized file stat plus path as a revision.
     // This allows us to update between canvaskit and non-canvaskit SDKs.
-    final String etag = file.lastModifiedSync().toIso8601String() + file.path;
+    final String etag = file.lastModifiedSync().toIso8601String()
+      + Uri.encodeComponent(file.path);
     if (ifNoneMatch == etag) {
       return shelf.Response.notModified();
     }

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -324,6 +324,18 @@ void main() {
     expect((await response.read().toList()).first, source.readAsBytesSync());
   }));
 
+  test('serves valid etag header for asset files with non-ascii chracters', () => testbed.run(() async {
+    globals.fs.file(globals.fs.path.join('build', 'flutter_assets', 'fooπ'))
+      ..createSync(recursive: true)
+      ..writeAsBytesSync(<int>[1, 2, 3]);
+
+    final Response response = await webAssetServer
+      .handleRequest(Request('GET', Uri.parse('http://foobar/assets/fooπ')));
+    final String etag = response.headers[HttpHeaders.etagHeader];
+
+    expect(etag.runes, everyElement(predicate((int char) => char < 255)));
+  }));
+
   test('handles serving missing asset file', () => testbed.run(() async {
     final Response response = await webAssetServer
       .handleRequest(Request('GET', Uri.parse('http://foobar/assets/foo')));


### PR DESCRIPTION
## Description

fix crasher caused by non-ascii etag header:

```
FormatException: Invalid HTTP header field value: "2020-04-25T00:13:54.000C:\\Users\\REDACTED

  | at _HttpHeaders._validateValue | (http_headers.dart:626 )
-- | -- | --
  | at _HttpHeaders._addAll | (http_headers.dart:75 )
  | at _HttpHeaders.set | (http_headers.dart:92 )
  | at _writeResponse.<anonymous closure> | (shelf_io.dart:173 )
  | at CanonicalizedMap.forEach.<anonymous closure> | (canonicalized_map.dart:93 )
  | at _LinkedHashMapMixin.forEach | (compact_hash.dart:379 )
  | at CanonicalizedMap.forEach | (canonicalized_map.dart:93 )
  | at MapView.forEach | (maps.dart:337 )
  | at _writeResponse | (shelf_io.dart:171 )
  | at handleRequest | (shelf_io.dart:119 )
  | at <asynchronous gap> | (async )
  | at serveRequests.<anonymous closure>.<anonymous closure> | (shelf_io.dart:63 )
  | at _rootRunUnary | (zone.dart:1192 )
  | at _CustomZone.runUnary | (zone.dart:1085 )
  | at _CustomZone.runUnaryGuarded | (zone.dart:987 )
  | at _BufferingStreamSubscription._sendData | (stream_impl.dart:339 )
  | at _BufferingStreamSubscription._add | (stream_impl.dart:266 )
  | at _SyncStreamControllerDispatch._sendData | (stream_controller.dart:779 )
  | at _StreamController._add | (stream_controller.dart:655 )
  | at _StreamController.add | (stream_controller.dart:597 )
  | at _HttpServer._handleRequest | (http_impl.dart:2868 )
  | at new _HttpConnection.<anonymous closure> | (http_impl.dart:2627 )
  | at _rootRunUnary | (zone.dart:1192 )
  | at _CustomZone.runUnary | (zone.dart:1085 )
  | at _CustomZone.runUnaryGuarded | (zone.dart:987 )
  | at _BufferingStreamSubscription._sendData | (stream_impl.dart:339 )
  | at _BufferingStreamSubscription._add | (stream_impl.dart:266 )
  | at _SyncStreamControllerDispatch._sendData | (stream_controller.dart:779 )
  | at _StreamController._add | (stream_controller.dart:655 )
  | at _StreamController.add | (stream_controller.dart:597 )
  | at _HttpParser._headersEnd | (http_parser.dart:399 )
  | at _HttpParser._doParse | (http_parser.dart:739 )
  | at _HttpParser._parse | (http_parser.dart:328 )
  | at _HttpParser._onData | (http_parser.dart:850 )
  | at _rootRunUnary | (zone.dart:1192 )
  | at _CustomZone.runUnary | (zone.dart:1085 )
  | at _CustomZone.runUnaryGuarded | (zone.dart:987 )
  | at _BufferingStreamSubscription._sendData | (stream_impl.dart:339 )
  | at _BufferingStreamSubscription._add | (stream_impl.dart:266 )
  | at _SyncStreamControllerDispatch._sendData | (stream_controller.dart:779 )
  | at _StreamController._add | (stream_controller.dart:655 )
  | at _StreamController.add | (stream_controller.dart:597 )
  | at _Socket._onData | (socket_patch.dart:1982 )
  | at _rootRunUnary | (zone.dart:1196 )
  | at _CustomZone.runUnary | (zone.dart:1085 )
  | at _CustomZone.runUnaryGuarded | (zone.dart:987 )
  | at _BufferingStreamSubscription._sendData | (stream_impl.dart:339 )
  | at _BufferingStreamSubscription._add | (stream_impl.dart:266 )
  | at _SyncStreamControllerDispatch._sendData | (stream_controller.dart:779 )
  | at _StreamController._add | (stream_controller.dart:655 )
  | at _StreamController.add | (stream_controller.dart:597 )
  | at new _RawSocket.<anonymous closure> | (socket_patch.dart:1527 )
  | at _NativeSocket.issueReadEvent.issue | (socket_patch.dart:1019 )
  | at _microtaskLoop | (schedule_microtask.dart:43 )
  | at _startMicrotaskLoop | (schedule_microtask.dart:52 )
  | at _runPendingImmediateCallback | (isolate_patch.dart:118 )
  | at _RawReceivePortImpl._handleMessage | (isolate_patch.dart:169 )

```