### PR TITLE
Sync macOS VMs to time server

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -500,6 +500,7 @@ task:
     CPU: 2
     MEMORY: 8G
   setup_script:
+    - sudo sntp -sS time.apple.com
     - date
     - which flutter
     - bundle --version


### PR DESCRIPTION
## Description

Force the newly-created VM to sync to Apple's time server.

```
01:26 +30: test/commands.shard/permeable/create_test.dart: (setUpAll)                                                                                                                                  Expected: ''
  Actual: 'Warning: File "/private/tmp/flutter sdk/dev/automated_tests/pubspec.yaml" was created in the future. Optimizations that rely on comparing time stamps will be unreliable. Check your system clock for accuracy.\n'
            'The timestamp was: 2020-04-27 07:23:07.000\n'
            'The time now is: 2020-04-20 07:30:13.981602\n'
            'Warning: File "/private/tmp/flutter sdk/dev/automated_tests/pubspec.yaml" was created in the future. Optimizations that rely on comparing time stamps will be unreliable. Check your system clock for accuracy.\n'
            'The timestamp was: 2020-04-27 07:23:07.000\n'
            'The time now is: 2020-04-20 07:30:14.449133\n'
            ''
```
Still unclear how Dart's filesystem could have the right date if the system clock is wrong...

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*