### PR TITLE
Add `ExcludeFocus` widget, and a way to prevent focusability for a subtree.

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -1135,9 +1135,7 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<BuildContext>('context', context, defaultValue: null));
-    if (this is! FocusScopeNode) {
-      properties.add(FlagProperty('descendantsAreFocusable', value: descendantsAreFocusable, ifFalse: 'DESCENDANTS UNFOCUSABLE', defaultValue: true));
-    }
+    properties.add(FlagProperty('descendantsAreFocusable', value: descendantsAreFocusable, ifFalse: 'DESCENDANTS UNFOCUSABLE', defaultValue: true));
     properties.add(FlagProperty('canRequestFocus', value: canRequestFocus, ifFalse: 'NOT FOCUSABLE', defaultValue: true));
     properties.add(FlagProperty('hasFocus', value: hasFocus && !hasPrimaryFocus, ifTrue: 'IN FOCUS PATH', defaultValue: false));
     properties.add(FlagProperty('hasPrimaryFocus', value: hasPrimaryFocus, ifTrue: 'PRIMARY FOCUS', defaultValue: false));

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -487,10 +487,12 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
   @mustCallSuper
   set canRequestFocus(bool value) {
     if (value != _canRequestFocus) {
+      // Have to set this first before unfocusing, since it checks this to cull
+      // unfocusable, previously-focused children.
+      _canRequestFocus = value;
       if (hasFocus && !value) {
         unfocus(disposition: UnfocusDisposition.previouslyFocusedChild);
       }
-      _canRequestFocus = value;
       _manager?._markPropertiesChanged(this);
     }
   }
@@ -839,11 +841,6 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
       // If the scope is null, then this is either the root node, or a node that
       // is not yet in the tree, neither of which do anything when unfocused.
       return;
-    }
-    if (overrideFocusability) {
-      for (final FocusNode child in children) {
-        child.unfocus(disposition: disposition);
-      }
     }
     switch (disposition) {
       case UnfocusDisposition.scope:

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -17,7 +17,7 @@ import 'framework.dart';
 
 // Used for debugging focus code. Set to true to see highly verbose debug output
 // when focus changes occur.
-const bool _kDebugFocus = true;
+const bool _kDebugFocus = false;
 
 bool _focusDebug(String message, [Iterable<String> details]) {
   if (_kDebugFocus) {
@@ -413,13 +413,13 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
     FocusOnKeyCallback onKey,
     bool skipTraversal = false,
     bool canRequestFocus = true,
-    bool overrideChildren = false,
+    bool overrideFocusability = false,
   })  : assert(skipTraversal != null),
         assert(canRequestFocus != null),
-        assert(overrideChildren != null),
+        assert(overrideFocusability != null),
         _skipTraversal = skipTraversal,
         _canRequestFocus = canRequestFocus,
-        _overrideChildren = overrideChildren,
+        _overrideFocusability = overrideFocusability,
         _onKey = onKey {
     // Set it via the setter so that it does nothing on release builds.
     this.debugLabel = debugLabel;
@@ -476,7 +476,7 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
       return false;
     }
     for (final FocusNode ancestor in ancestors) {
-      if (ancestor.overrideChildren && !ancestor._canRequestFocus) {
+      if (ancestor.overrideFocusability && !ancestor._canRequestFocus) {
         return false;
       }
     }
@@ -496,27 +496,29 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
   }
 
   /// If true, setting [canRequestFocus] on this focus node to false will
-  /// disable focus for its children.
+  /// disable focus for its descendants.
   ///
   /// Defaults to false.  Set to true if you want this node's descendants to
   /// be unfocusable when this node's [canRequestFocus] is false.
   ///
-  /// If any children are focused when this is set and [canRequestFocus] is
-  /// false, they will be unfocused. When `overrideChildren` is set to false
+  /// If any descendants are focused when this is set and [canRequestFocus] is
+  /// false, they will be unfocused. When `overrideFocusability` is set to false
   /// again, they will not be refocused, although they will be able to accept
   /// focus again.
   ///
   /// See also:
   ///
+  ///  * [ExcludeFocus], a widget that uses this property to conditionally
+  ///    exclude focus for a subtree.
   ///  * [Focus], a widget that exposes this setting as a parameter.
   ///  * [FocusTraversalGroup], a widget used to group together and configure
   ///    the focus traversal policy for a widget subtree that also has an
   ///    `excludeFocus` parameter that prevents its children from being focused.
-  bool get overrideChildren => _overrideChildren;
-  bool _overrideChildren;
+  bool get overrideFocusability => _overrideFocusability;
+  bool _overrideFocusability;
   @mustCallSuper
-  set overrideChildren(bool value) {
-    if (value == _overrideChildren) {
+  set overrideFocusability(bool value) {
+    if (value == _overrideFocusability) {
       return;
     }
     if (!canRequestFocus && hasFocus) {
@@ -524,7 +526,7 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
         child.unfocus(disposition: UnfocusDisposition.previouslyFocusedChild);
       }
     }
-    _overrideChildren = value;
+    _overrideFocusability = value;
     _manager?._markPropertiesChanged(this);
   }
 
@@ -838,7 +840,7 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
       // is not yet in the tree, neither of which do anything when unfocused.
       return;
     }
-    if (overrideChildren) {
+    if (overrideFocusability) {
       for (final FocusNode child in children) {
         child.unfocus(disposition: disposition);
       }
@@ -1131,7 +1133,7 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<BuildContext>('context', context, defaultValue: null));
     if (this is! FocusScopeNode) {
-      properties.add(FlagProperty('overrideChildren', value: overrideChildren, ifTrue: 'OVERRIDE', defaultValue: false));
+      properties.add(FlagProperty('overrideFocusability', value: overrideFocusability, ifTrue: 'OVERRIDE', defaultValue: false));
     }
     properties.add(FlagProperty('canRequestFocus', value: canRequestFocus, ifFalse: 'NOT FOCUSABLE', defaultValue: true));
     properties.add(FlagProperty('hasFocus', value: hasFocus && !hasPrimaryFocus, ifTrue: 'IN FOCUS PATH', defaultValue: false));
@@ -1198,7 +1200,7 @@ class FocusScopeNode extends FocusNode {
           debugLabel: debugLabel,
           onKey: onKey,
           canRequestFocus: canRequestFocus,
-          overrideChildren: true,
+          overrideFocusability: true,
           skipTraversal: skipTraversal,
         );
 

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -402,11 +402,10 @@ class Focus extends StatefulWidget {
   final bool canRequestFocus;
 
   /// {@template flutter.widgets.Focus.descendantsAreFocusable}
-  /// If false, will make this widget's focus node and its descendants
-  /// unfocusable.
+  /// If false, will make this widget's descendants unfocusable.
   ///
-  /// Defaults to true. Does not affect focusability of this node: for that,
-  /// use [canRequestFocus].
+  /// Defaults to true. Does not affect focusability of this node (just its
+  /// descendants): for that, use [canRequestFocus].
   ///
   /// If any descendants are focused when this is set to false, they will be
   /// unfocused. When `descendantsAreFocusable` is set to true again, they will
@@ -419,7 +418,7 @@ class Focus extends StatefulWidget {
   ///  * [ExcludeFocus], a widget that uses this property to conditionally
   ///    exclude focus for a subtree.
   ///  * [FocusTraversalGroup], a widget used to group together and configure
-  ///    the focus traversal policy for a widget subtree that has an
+  ///    the focus traversal policy for a widget subtree that has a
   ///    `descendantsAreFocusable` parameter to conditionally block focus for a
   ///    subtree.
   /// {@endtemplate}
@@ -949,26 +948,44 @@ class _FocusMarker extends InheritedNotifier<FocusNode> {
 /// Does not affect the value of [canRequestFocus] on the descendants.
 ///
 /// See also:
-///  - [Focus], a widget for adding and managing a [FocusNode] in the widget tree.
-///  - [FocusTraversalGroup], a widget that groups widgets for focus traversal,
+///
+///  * [Focus], a widget for adding and managing a [FocusNode] in the widget tree.
+///  * [FocusTraversalGroup], a widget that groups widgets for focus traversal,
 ///    and can also be used in the same way as this widget by setting its
 ///    `descendantsAreFocusable` attribute.
 class ExcludeFocus extends StatelessWidget {
   /// Const constructor for [ExcludeFocus] widget.
   ///
-  /// The [descendantsAreFocusable] argument must not be null.
+  /// The [excluding] argument must not be null.
   ///
   /// The [child] argument is required, and must not be null.
   const ExcludeFocus({
     Key key,
-    this.descendantsAreFocusable = false,
+    this.excluding = true,
     @required this.child,
-  })  : assert(descendantsAreFocusable != null),
+  })  : assert(excluding != null),
         assert(child != null),
         super(key: key);
 
-  /// {@macro flutter.widgets.Focus.descendantsAreFocusable}
-  final bool descendantsAreFocusable;
+  /// If true, will make this widget's descendants unfocusable.
+  ///
+  /// Defaults to true.
+  ///
+  /// If any descendants are focused when this is set to true, they will be
+  /// unfocused. When `excluding` is set to false again, they will not be
+  /// refocused, although they will be able to accept focus again.
+  ///
+  /// Does not affect the value of [canRequestFocus] on the descendants.
+  ///
+  /// See also:
+  ///
+  ///  * [Focus.descendantsAreFocusable], the attribute of a [Focus] widget that
+  ///    controls this same property for focus widgets.
+  ///  * [FocusTraversalGroup], a widget used to group together and configure
+  ///    the focus traversal policy for a widget subtree that has a
+  ///    `descendantsAreFocusable` parameter to conditionally block focus for a
+  ///    subtree.
+  final bool excluding;
 
   /// The child widget of this [ExcludeFocus].
   ///
@@ -980,7 +997,7 @@ class ExcludeFocus extends StatelessWidget {
     return Focus(
       canRequestFocus: false,
       skipTraversal: true,
-      descendantsAreFocusable: descendantsAreFocusable,
+      descendantsAreFocusable: !excluding,
       child: child,
     );
   }

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -1583,13 +1583,14 @@ class FocusTraversalOrder extends InheritedWidget {
 class FocusTraversalGroup extends StatefulWidget {
   /// Creates a [FocusTraversalGroup] object.
   ///
-  /// The [child] argument must not be null.
+  /// The [child] and [excludeFocus] arguments must not be null.
   FocusTraversalGroup({
     Key key,
     FocusTraversalPolicy policy,
-    this.excludeFocus,
+    this.excludeFocus = false,
     @required this.child,
-  })  : policy = policy ?? ReadingOrderTraversalPolicy(),
+  })  : assert(excludeFocus != null),
+        policy = policy ?? ReadingOrderTraversalPolicy(),
         super(key: key);
 
   /// The policy used to move the focus from one focus node to another when
@@ -1611,7 +1612,10 @@ class FocusTraversalGroup extends StatefulWidget {
 
   /// If true, then the children of this group will be marked as not focusable.
   ///
-  /// If any children of this group are currently focused, they will lose focus.
+  /// If any children of this group are currently focused when this is set to
+  /// true, they will lose focus.
+  ///
+  /// Defaults to false. Must not be null.
   final bool excludeFocus;
 
   /// The child widget of this [FocusTraversalGroup].

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -1587,14 +1587,10 @@ class FocusTraversalGroup extends StatefulWidget {
   FocusTraversalGroup({
     Key key,
     FocusTraversalPolicy policy,
+    this.excludeFocus,
     @required this.child,
   })  : policy = policy ?? ReadingOrderTraversalPolicy(),
         super(key: key);
-
-  /// The child widget of this [FocusTraversalGroup].
-  ///
-  /// {@macro flutter.widgets.child}
-  final Widget child;
 
   /// The policy used to move the focus from one focus node to another when
   /// traversing them using a keyboard.
@@ -1612,6 +1608,16 @@ class FocusTraversalGroup extends StatefulWidget {
   ///    nodes in the reading order defined in the widget tree, and then top to
   ///    bottom.
   final FocusTraversalPolicy policy;
+
+  /// If true, then the children of this group will be marked as not focusable.
+  ///
+  /// If any children of this group are currently focused, they will lose focus.
+  final bool excludeFocus;
+
+  /// The child widget of this [FocusTraversalGroup].
+  ///
+  /// {@macro flutter.widgets.child}
+  final Widget child;
 
   /// Returns the focus policy set by the [FocusTraversalGroup] that most
   /// tightly encloses the given [BuildContext].
@@ -1691,6 +1697,7 @@ class _FocusTraversalGroupState extends State<FocusTraversalGroup> {
         canRequestFocus: false,
         skipTraversal: true,
         includeSemantics: false,
+        overrideChildren: widget.excludeFocus,
         child: widget.child,
       ),
     );

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -1421,6 +1421,9 @@ class FocusTraversalOrder extends InheritedWidget {
 ///
 /// By default, traverses in reading order using [ReadingOrderTraversalPolicy].
 ///
+/// To prevent the members of the group from being focused, set the
+/// [descendantsAreFocusable] attribute to true.
+///
 /// {@tool dartpad --template=stateless_widget_material}
 /// This sample shows three rows of buttons, each grouped by a
 /// [FocusTraversalGroup], each with different traversal order policies. Use tab
@@ -1583,13 +1586,13 @@ class FocusTraversalOrder extends InheritedWidget {
 class FocusTraversalGroup extends StatefulWidget {
   /// Creates a [FocusTraversalGroup] object.
   ///
-  /// The [child] and [excludeFocus] arguments must not be null.
+  /// The [child] and [descendantsAreFocusable] arguments must not be null.
   FocusTraversalGroup({
     Key key,
     FocusTraversalPolicy policy,
-    this.excludeFocus = false,
+    this.descendantsAreFocusable = true,
     @required this.child,
-  })  : assert(excludeFocus != null),
+  })  : assert(descendantsAreFocusable != null),
         policy = policy ?? ReadingOrderTraversalPolicy(),
         super(key: key);
 
@@ -1610,13 +1613,8 @@ class FocusTraversalGroup extends StatefulWidget {
   ///    bottom.
   final FocusTraversalPolicy policy;
 
-  /// If true, then the children of this group will be marked as not focusable.
-  ///
-  /// If any children of this group are currently focused when this is set to
-  /// true, they will lose focus.
-  ///
-  /// Defaults to false. Must not be null.
-  final bool excludeFocus;
+  /// {@macro flutter.widgets.Focus.descendantsAreFocusable}
+  final bool descendantsAreFocusable;
 
   /// The child widget of this [FocusTraversalGroup].
   ///
@@ -1701,7 +1699,7 @@ class _FocusTraversalGroupState extends State<FocusTraversalGroup> {
         canRequestFocus: false,
         skipTraversal: true,
         includeSemantics: false,
-        overrideFocusability: widget.excludeFocus,
+        descendantsAreFocusable: widget.descendantsAreFocusable,
         child: widget.child,
       ),
     );

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -1697,7 +1697,7 @@ class _FocusTraversalGroupState extends State<FocusTraversalGroup> {
         canRequestFocus: false,
         skipTraversal: true,
         includeSemantics: false,
-        overrideChildren: widget.excludeFocus,
+        overrideFocusability: widget.excludeFocus,
         child: widget.child,
       ),
     );

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -997,6 +997,7 @@ void main() {
       final List<String> description = builder.properties.map((DiagnosticsNode n) => n.toString()).toList();
       expect(description, <String>[
         'context: null',
+        'descendantsAreFocusable: true',
         'canRequestFocus: true',
         'hasFocus: false',
         'hasPrimaryFocus: false'

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -64,7 +64,6 @@ void main() {
       expect(child2.parent, isNull);
       expect(parent.children, isEmpty);
     });
-    testWidgets('canRequestFocus affects descendants when overriding.', (WidgetTester tester) async {
     testWidgets('Geometry is transformed properly.', (WidgetTester tester) async {
       final FocusNode focusNode1 = FocusNode(debugLabel: 'Test Node 1');
       final FocusNode focusNode2 = FocusNode(debugLabel: 'Test Node 2');
@@ -98,7 +97,7 @@ void main() {
       expect(focusNode1.offset, equals(const Offset(300.0, 8.0)));
       expect(focusNode2.offset, equals(const Offset(443.0, 194.5)));
     });
-    testWidgets('canRequestFocus affects children when overriding.', (WidgetTester tester) async {
+    testWidgets('canRequestFocus affects descendants when overriding.', (WidgetTester tester) async {
       final BuildContext context = await setupWidget(tester);
       final FocusScopeNode scope = FocusScopeNode(debugLabel: 'Scope', canRequestFocus: true);
       final FocusAttachment scopeAttachment = scope.attach(context);

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -97,13 +97,13 @@ void main() {
       expect(focusNode1.offset, equals(const Offset(300.0, 8.0)));
       expect(focusNode2.offset, equals(const Offset(443.0, 194.5)));
     });
-    testWidgets('canRequestFocus affects descendants when overriding.', (WidgetTester tester) async {
+    testWidgets('descendantsAreFocusable disables focus for descendants.', (WidgetTester tester) async {
       final BuildContext context = await setupWidget(tester);
-      final FocusScopeNode scope = FocusScopeNode(debugLabel: 'Scope', canRequestFocus: true);
+      final FocusScopeNode scope = FocusScopeNode(debugLabel: 'Scope');
       final FocusAttachment scopeAttachment = scope.attach(context);
-      final FocusNode parent1 = FocusNode(debugLabel: 'Parent 1', overrideFocusability: true);
+      final FocusNode parent1 = FocusNode(debugLabel: 'Parent 1');
       final FocusAttachment parent1Attachment = parent1.attach(context);
-      final FocusNode parent2 = FocusNode(debugLabel: 'Parent 2', overrideFocusability: true);
+      final FocusNode parent2 = FocusNode(debugLabel: 'Parent 2');
       final FocusAttachment parent2Attachment = parent2.attach(context);
       final FocusNode child1 = FocusNode(debugLabel: 'Child 1');
       final FocusAttachment child1Attachment = child1.attach(context);
@@ -122,21 +122,25 @@ void main() {
       expect(scope.traversalDescendants.contains(child1), isTrue);
       expect(scope.traversalDescendants.contains(child2), isTrue);
 
-      parent2.canRequestFocus = false;
+      parent2.descendantsAreFocusable = false;
+      // Node should still be focusable, even if descendants are not.
+      parent2.requestFocus();
       await tester.pump();
+      expect(parent2.hasPrimaryFocus, isTrue);
+
       child2.requestFocus();
       await tester.pump();
       expect(tester.binding.focusManager.primaryFocus, isNot(equals(child2)));
-      expect(tester.binding.focusManager.primaryFocus, equals(child1));
-      expect(scope.focusedChild, equals(child1));
+      expect(tester.binding.focusManager.primaryFocus, equals(parent2));
+      expect(scope.focusedChild, equals(parent2));
       expect(scope.traversalDescendants.contains(child1), isTrue);
       expect(scope.traversalDescendants.contains(child2), isFalse);
 
-      parent1.canRequestFocus = false;
+      parent1.descendantsAreFocusable = false;
       await tester.pump();
       expect(tester.binding.focusManager.primaryFocus, isNot(equals(child2)));
       expect(tester.binding.focusManager.primaryFocus, isNot(equals(child1)));
-      expect(scope.focusedChild, isNull);
+      expect(scope.focusedChild, equals(parent2));
       expect(scope.traversalDescendants.contains(child1), isFalse);
       expect(scope.traversalDescendants.contains(child2), isFalse);
     });
@@ -148,7 +152,7 @@ void main() {
       final List<String> description = builder.properties.map((DiagnosticsNode n) => n.toString()).toList();
       expect(description, <String>[
         'context: null',
-        'overrideFocusability: false',
+        'descendantsAreFocusable: true',
         'canRequestFocus: true',
         'hasFocus: false',
         'hasPrimaryFocus: false',

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -64,6 +64,7 @@ void main() {
       expect(child2.parent, isNull);
       expect(parent.children, isEmpty);
     });
+    testWidgets('canRequestFocus affects descendants when overriding.', (WidgetTester tester) async {
     testWidgets('Geometry is transformed properly.', (WidgetTester tester) async {
       final FocusNode focusNode1 = FocusNode(debugLabel: 'Test Node 1');
       final FocusNode focusNode2 = FocusNode(debugLabel: 'Test Node 2');
@@ -101,9 +102,9 @@ void main() {
       final BuildContext context = await setupWidget(tester);
       final FocusScopeNode scope = FocusScopeNode(debugLabel: 'Scope', canRequestFocus: true);
       final FocusAttachment scopeAttachment = scope.attach(context);
-      final FocusNode parent1 = FocusNode(debugLabel: 'Parent 1', overrideChildren: true);
+      final FocusNode parent1 = FocusNode(debugLabel: 'Parent 1', overrideFocusability: true);
       final FocusAttachment parent1Attachment = parent1.attach(context);
-      final FocusNode parent2 = FocusNode(debugLabel: 'Parent 2', overrideChildren: true);
+      final FocusNode parent2 = FocusNode(debugLabel: 'Parent 2', overrideFocusability: true);
       final FocusAttachment parent2Attachment = parent2.attach(context);
       final FocusNode child1 = FocusNode(debugLabel: 'Child 1');
       final FocusAttachment child1Attachment = child1.attach(context);
@@ -148,7 +149,7 @@ void main() {
       final List<String> description = builder.properties.map((DiagnosticsNode n) => n.toString()).toList();
       expect(description, <String>[
         'context: null',
-        'overrideChildren: false',
+        'overrideFocusability: false',
         'canRequestFocus: true',
         'hasFocus: false',
         'hasPrimaryFocus: false',

--- a/packages/flutter/test/widgets/focus_scope_test.dart
+++ b/packages/flutter/test/widgets/focus_scope_test.dart
@@ -990,6 +990,7 @@ void main() {
       expect(keyB.currentState.focusNode.hasFocus, isFalse);
       expect(find.text('b'), findsOneWidget);
     });
+
     testWidgets('Can focus root node.', (WidgetTester tester) async {
       final GlobalKey key1 = GlobalKey(debugLabel: '1');
       await tester.pumpWidget(
@@ -1008,6 +1009,7 @@ void main() {
       expect(rootNode.hasFocus, isTrue);
       expect(rootNode, equals(firstElement.owner.focusManager.rootScope));
     });
+
     testWidgets('Can autofocus a node.', (WidgetTester tester) async {
       final FocusNode focusNode = FocusNode(debugLabel: 'Test Node');
       await tester.pumpWidget(
@@ -1031,6 +1033,7 @@ void main() {
       await tester.pump();
       expect(focusNode.hasPrimaryFocus, isTrue);
     });
+
     testWidgets("Won't autofocus a node if one is already focused.", (WidgetTester tester) async {
       final FocusNode focusNodeA = FocusNode(debugLabel: 'Test Node A');
       final FocusNode focusNodeB = FocusNode(debugLabel: 'Test Node B');
@@ -1070,6 +1073,7 @@ void main() {
       expect(focusNodeA.hasPrimaryFocus, isTrue);
     });
   });
+
   group(Focus, () {
     testWidgets('Focus.of stops at the nearest Focus widget.', (WidgetTester tester) async {
       final GlobalKey key1 = GlobalKey(debugLabel: '1');
@@ -1195,6 +1199,7 @@ void main() {
       expect(nodes.length, equals(2));
       expect(keys, equals(<Key>[key7, key8]));
     });
+
     testWidgets('Can set focus.', (WidgetTester tester) async {
       final GlobalKey key1 = GlobalKey(debugLabel: '1');
       bool gotFocus;
@@ -1214,6 +1219,7 @@ void main() {
       expect(gotFocus, isTrue);
       expect(node.hasFocus, isTrue);
     });
+
     testWidgets('Focus is ignored when set to not focusable.', (WidgetTester tester) async {
       final GlobalKey key1 = GlobalKey(debugLabel: '1');
       bool gotFocus;
@@ -1234,6 +1240,7 @@ void main() {
       expect(gotFocus, isNull);
       expect(node.hasFocus, isFalse);
     });
+
     testWidgets('Focus is lost when set to not focusable.', (WidgetTester tester) async {
       final GlobalKey key1 = GlobalKey(debugLabel: '1');
       bool gotFocus;
@@ -1273,6 +1280,7 @@ void main() {
       expect(gotFocus, false);
       expect(node.hasFocus, isFalse);
     });
+
     testWidgets('Child of unfocusable Focus can get focus.', (WidgetTester tester) async {
       final GlobalKey key1 = GlobalKey(debugLabel: '1');
       final GlobalKey key2 = GlobalKey(debugLabel: '2');
@@ -1304,237 +1312,318 @@ void main() {
       expect(gotFocus, isTrue);
       expect(unfocusableNode.hasFocus, isTrue);
     });
-  });
-  testWidgets('Nodes are removed when all Focuses are removed.', (WidgetTester tester) async {
-    final GlobalKey key1 = GlobalKey(debugLabel: '1');
-    bool gotFocus;
-    await tester.pumpWidget(
-      FocusScope(
-        child: Focus(
-          onFocusChange: (bool focused) => gotFocus = focused,
-          child: Container(key: key1),
-        ),
-      ),
-    );
 
-    final Element firstNode = tester.element(find.byKey(key1));
-    final FocusNode node = Focus.of(firstNode);
-    node.requestFocus();
-
-    await tester.pump();
-
-    expect(gotFocus, isTrue);
-    expect(node.hasFocus, isTrue);
-
-    await tester.pumpWidget(Container());
-
-    expect(FocusManager.instance.rootScope.descendants, isEmpty);
-  });
-  testWidgets('Focus widgets set Semantics information about focus', (WidgetTester tester) async {
-    final GlobalKey<TestFocusState> key = GlobalKey();
-
-    await tester.pumpWidget(
-      TestFocus(key: key, name: 'a'),
-    );
-
-    final SemanticsNode semantics = tester.getSemantics(find.byKey(key));
-
-    expect(key.currentState.focusNode.hasFocus, isFalse);
-    expect(semantics.hasFlag(SemanticsFlag.isFocused), isFalse);
-    expect(semantics.hasFlag(SemanticsFlag.isFocusable), isTrue);
-
-    FocusScope.of(key.currentContext).requestFocus(key.currentState.focusNode);
-    await tester.pumpAndSettle();
-
-    expect(key.currentState.focusNode.hasFocus, isTrue);
-    expect(semantics.hasFlag(SemanticsFlag.isFocused), isTrue);
-    expect(semantics.hasFlag(SemanticsFlag.isFocusable), isTrue);
-
-    key.currentState.focusNode.canRequestFocus = false;
-    await tester.pumpAndSettle();
-
-    expect(key.currentState.focusNode.hasFocus, isFalse);
-    expect(key.currentState.focusNode.canRequestFocus, isFalse);
-    expect(semantics.hasFlag(SemanticsFlag.isFocused), isFalse);
-    expect(semantics.hasFlag(SemanticsFlag.isFocusable), isFalse);
-  });
-  testWidgets('Setting canRequestFocus on focus node causes update.', (WidgetTester tester) async {
-    final GlobalKey<TestFocusState> key = GlobalKey();
-
-    final TestFocus testFocus = TestFocus(key: key, name: 'a');
-    await tester.pumpWidget(
-      testFocus,
-    );
-
-    await tester.pumpAndSettle();
-    key.currentState.built = false;
-    key.currentState.focusNode.canRequestFocus = false;
-    await tester.pumpAndSettle();
-    key.currentState.built = true;
-
-    expect(key.currentState.focusNode.canRequestFocus, isFalse);
-  });
-
-  testWidgets('canRequestFocus causes descendants of scope to be skipped.', (WidgetTester tester) async {
-    final GlobalKey scope1 = GlobalKey(debugLabel: 'scope1');
-    final GlobalKey scope2 = GlobalKey(debugLabel: 'scope2');
-    final GlobalKey focus1 = GlobalKey(debugLabel: 'focus1');
-    final GlobalKey focus2 = GlobalKey(debugLabel: 'focus2');
-    final GlobalKey container1 = GlobalKey(debugLabel: 'container');
-    Future<void> pumpTest({
-      bool allowScope1 = true,
-      bool allowScope2 = true,
-      bool allowFocus1 = true,
-      bool allowFocus2 = true,
-    }) async {
+    testWidgets('Nodes are removed when all Focuses are removed.', (WidgetTester tester) async {
+      final GlobalKey key1 = GlobalKey(debugLabel: '1');
+      bool gotFocus;
       await tester.pumpWidget(
         FocusScope(
-          key: scope1,
-          canRequestFocus: allowScope1,
-          child: FocusScope(
-            key: scope2,
-            canRequestFocus: allowScope2,
-            child: Focus(
-              key: focus1,
-              canRequestFocus: allowFocus1,
+          child: Focus(
+            onFocusChange: (bool focused) => gotFocus = focused,
+            child: Container(key: key1),
+          ),
+        ),
+      );
+
+      final Element firstNode = tester.element(find.byKey(key1));
+      final FocusNode node = Focus.of(firstNode);
+      node.requestFocus();
+
+      await tester.pump();
+
+      expect(gotFocus, isTrue);
+      expect(node.hasFocus, isTrue);
+
+      await tester.pumpWidget(Container());
+
+      expect(FocusManager.instance.rootScope.descendants, isEmpty);
+    });
+
+    testWidgets('Focus widgets set Semantics information about focus', (WidgetTester tester) async {
+      final GlobalKey<TestFocusState> key = GlobalKey();
+
+      await tester.pumpWidget(
+        TestFocus(key: key, name: 'a'),
+      );
+
+      final SemanticsNode semantics = tester.getSemantics(find.byKey(key));
+
+      expect(key.currentState.focusNode.hasFocus, isFalse);
+      expect(semantics.hasFlag(SemanticsFlag.isFocused), isFalse);
+      expect(semantics.hasFlag(SemanticsFlag.isFocusable), isTrue);
+
+      FocusScope.of(key.currentContext).requestFocus(key.currentState.focusNode);
+      await tester.pumpAndSettle();
+
+      expect(key.currentState.focusNode.hasFocus, isTrue);
+      expect(semantics.hasFlag(SemanticsFlag.isFocused), isTrue);
+      expect(semantics.hasFlag(SemanticsFlag.isFocusable), isTrue);
+
+      key.currentState.focusNode.canRequestFocus = false;
+      await tester.pumpAndSettle();
+
+      expect(key.currentState.focusNode.hasFocus, isFalse);
+      expect(key.currentState.focusNode.canRequestFocus, isFalse);
+      expect(semantics.hasFlag(SemanticsFlag.isFocused), isFalse);
+      expect(semantics.hasFlag(SemanticsFlag.isFocusable), isFalse);
+    });
+
+    testWidgets('Setting canRequestFocus on focus node causes update.', (WidgetTester tester) async {
+      final GlobalKey<TestFocusState> key = GlobalKey();
+
+      final TestFocus testFocus = TestFocus(key: key, name: 'a');
+      await tester.pumpWidget(
+        testFocus,
+      );
+
+      await tester.pumpAndSettle();
+      key.currentState.built = false;
+      key.currentState.focusNode.canRequestFocus = false;
+      await tester.pumpAndSettle();
+      key.currentState.built = true;
+
+      expect(key.currentState.focusNode.canRequestFocus, isFalse);
+    });
+
+    testWidgets('canRequestFocus causes descendants of scope to be skipped.', (WidgetTester tester) async {
+      final GlobalKey scope1 = GlobalKey(debugLabel: 'scope1');
+      final GlobalKey scope2 = GlobalKey(debugLabel: 'scope2');
+      final GlobalKey focus1 = GlobalKey(debugLabel: 'focus1');
+      final GlobalKey focus2 = GlobalKey(debugLabel: 'focus2');
+      final GlobalKey container1 = GlobalKey(debugLabel: 'container');
+      Future<void> pumpTest({
+        bool allowScope1 = true,
+        bool allowScope2 = true,
+        bool allowFocus1 = true,
+        bool allowFocus2 = true,
+      }) async {
+        await tester.pumpWidget(
+          FocusScope(
+            key: scope1,
+            canRequestFocus: allowScope1,
+            child: FocusScope(
+              key: scope2,
+              canRequestFocus: allowScope2,
               child: Focus(
-                key: focus2,
-                canRequestFocus: allowFocus2,
-                child: Container(
-                  key: container1,
+                key: focus1,
+                canRequestFocus: allowFocus1,
+                child: Focus(
+                  key: focus2,
+                  canRequestFocus: allowFocus2,
+                  child: Container(
+                    key: container1,
+                  ),
                 ),
               ),
             ),
           ),
-        ),
-      );
+        );
+        await tester.pump();
+      }
+
+      // Check childless node (focus2).
+      await pumpTest();
+      Focus.of(container1.currentContext).requestFocus();
       await tester.pump();
-    }
+      expect(Focus.of(container1.currentContext).hasFocus, isTrue);
+      await pumpTest(allowFocus2: false);
+      expect(Focus.of(container1.currentContext).hasFocus, isFalse);
+      Focus.of(container1.currentContext).requestFocus();
+      await tester.pump();
+      expect(Focus.of(container1.currentContext).hasFocus, isFalse);
+      await pumpTest();
+      Focus.of(container1.currentContext).requestFocus();
+      await tester.pump();
+      expect(Focus.of(container1.currentContext).hasFocus, isTrue);
 
-    // Check childless node (focus2).
-    await pumpTest();
-    Focus.of(container1.currentContext).requestFocus();
-    await tester.pump();
-    expect(Focus.of(container1.currentContext).hasFocus, isTrue);
-    await pumpTest(allowFocus2: false);
-    expect(Focus.of(container1.currentContext).hasFocus, isFalse);
-    Focus.of(container1.currentContext).requestFocus();
-    await tester.pump();
-    expect(Focus.of(container1.currentContext).hasFocus, isFalse);
-    await pumpTest();
-    Focus.of(container1.currentContext).requestFocus();
-    await tester.pump();
-    expect(Focus.of(container1.currentContext).hasFocus, isTrue);
+      // Check FocusNode with child (focus1). Shouldn't affect children.
+      await pumpTest(allowFocus1: false);
+      expect(Focus.of(container1.currentContext).hasFocus, isTrue); // focus2 has focus.
+      Focus.of(focus2.currentContext).requestFocus(); // Try to focus focus1
+      await tester.pump();
+      expect(Focus.of(container1.currentContext).hasFocus, isTrue); // focus2 still has focus.
+      Focus.of(container1.currentContext).requestFocus(); // Now try to focus focus2
+      await tester.pump();
+      expect(Focus.of(container1.currentContext).hasFocus, isTrue);
+      await pumpTest();
+      // Try again, now that we've set focus1's canRequestFocus to true again.
+      Focus.of(container1.currentContext).unfocus();
+      await tester.pump();
+      expect(Focus.of(container1.currentContext).hasFocus, isFalse);
+      Focus.of(container1.currentContext).requestFocus();
+      await tester.pump();
+      expect(Focus.of(container1.currentContext).hasFocus, isTrue);
 
-    // Check FocusNode with child (focus1). Shouldn't affect children.
-    await pumpTest(allowFocus1: false);
-    expect(Focus.of(container1.currentContext).hasFocus, isTrue); // focus2 has focus.
-    Focus.of(focus2.currentContext).requestFocus(); // Try to focus focus1
-    await tester.pump();
-    expect(Focus.of(container1.currentContext).hasFocus, isTrue); // focus2 still has focus.
-    Focus.of(container1.currentContext).requestFocus(); // Now try to focus focus2
-    await tester.pump();
-    expect(Focus.of(container1.currentContext).hasFocus, isTrue);
-    await pumpTest();
-    // Try again, now that we've set focus1's canRequestFocus to true again.
-    Focus.of(container1.currentContext).unfocus();
-    await tester.pump();
-    expect(Focus.of(container1.currentContext).hasFocus, isFalse);
-    Focus.of(container1.currentContext).requestFocus();
-    await tester.pump();
-    expect(Focus.of(container1.currentContext).hasFocus, isTrue);
+      // Check FocusScopeNode with only FocusNode children (scope2). Should affect children.
+      await pumpTest(allowScope2: false);
+      expect(Focus.of(container1.currentContext).hasFocus, isFalse);
+      FocusScope.of(focus1.currentContext).requestFocus(); // Try to focus scope2
+      await tester.pump();
+      expect(Focus.of(container1.currentContext).hasFocus, isFalse);
+      Focus.of(focus2.currentContext).requestFocus(); // Try to focus focus1
+      await tester.pump();
+      expect(Focus.of(container1.currentContext).hasFocus, isFalse);
+      Focus.of(container1.currentContext).requestFocus(); // Try to focus focus2
+      await tester.pump();
+      expect(Focus.of(container1.currentContext).hasFocus, isFalse);
+      await pumpTest();
+      // Try again, now that we've set scope2's canRequestFocus to true again.
+      Focus.of(container1.currentContext).requestFocus();
+      await tester.pump();
+      expect(Focus.of(container1.currentContext).hasFocus, isTrue);
 
-    // Check FocusScopeNode with only FocusNode children (scope2). Should affect children.
-    await pumpTest(allowScope2: false);
-    expect(Focus.of(container1.currentContext).hasFocus, isFalse);
-    FocusScope.of(focus1.currentContext).requestFocus(); // Try to focus scope2
-    await tester.pump();
-    expect(Focus.of(container1.currentContext).hasFocus, isFalse);
-    Focus.of(focus2.currentContext).requestFocus(); // Try to focus focus1
-    await tester.pump();
-    expect(Focus.of(container1.currentContext).hasFocus, isFalse);
-    Focus.of(container1.currentContext).requestFocus(); // Try to focus focus2
-    await tester.pump();
-    expect(Focus.of(container1.currentContext).hasFocus, isFalse);
-    await pumpTest();
-    // Try again, now that we've set scope2's canRequestFocus to true again.
-    Focus.of(container1.currentContext).requestFocus();
-    await tester.pump();
-    expect(Focus.of(container1.currentContext).hasFocus, isTrue);
+      // Check FocusScopeNode with both FocusNode children and FocusScope children (scope1). Should affect children.
+      await pumpTest(allowScope1: false);
+      expect(Focus.of(container1.currentContext).hasFocus, isFalse);
+      FocusScope.of(scope2.currentContext).requestFocus(); // Try to focus scope1
+      await tester.pump();
+      expect(Focus.of(container1.currentContext).hasFocus, isFalse);
+      FocusScope.of(focus1.currentContext).requestFocus(); // Try to focus scope2
+      await tester.pump();
+      expect(Focus.of(container1.currentContext).hasFocus, isFalse);
+      Focus.of(focus2.currentContext).requestFocus(); // Try to focus focus1
+      await tester.pump();
+      expect(Focus.of(container1.currentContext).hasFocus, isFalse);
+      Focus.of(container1.currentContext).requestFocus(); // Try to focus focus2
+      await tester.pump();
+      expect(Focus.of(container1.currentContext).hasFocus, isFalse);
+      await pumpTest();
+      // Try again, now that we've set scope1's canRequestFocus to true again.
+      Focus.of(container1.currentContext).requestFocus();
+      await tester.pump();
+      expect(Focus.of(container1.currentContext).hasFocus, isTrue);
+    });
 
-    // Check FocusScopeNode with both FocusNode children and FocusScope children (scope1). Should affect children.
-    await pumpTest(allowScope1: false);
-    expect(Focus.of(container1.currentContext).hasFocus, isFalse);
-    FocusScope.of(scope2.currentContext).requestFocus(); // Try to focus scope1
-    await tester.pump();
-    expect(Focus.of(container1.currentContext).hasFocus, isFalse);
-    FocusScope.of(focus1.currentContext).requestFocus(); // Try to focus scope2
-    await tester.pump();
-    expect(Focus.of(container1.currentContext).hasFocus, isFalse);
-    Focus.of(focus2.currentContext).requestFocus(); // Try to focus focus1
-    await tester.pump();
-    expect(Focus.of(container1.currentContext).hasFocus, isFalse);
-    Focus.of(container1.currentContext).requestFocus(); // Try to focus focus2
-    await tester.pump();
-    expect(Focus.of(container1.currentContext).hasFocus, isFalse);
-    await pumpTest();
-    // Try again, now that we've set scope1's canRequestFocus to true again.
-    Focus.of(container1.currentContext).requestFocus();
-    await tester.pump();
-    expect(Focus.of(container1.currentContext).hasFocus, isTrue);
-  });
+    testWidgets('skipTraversal works as expected.', (WidgetTester tester) async {
+      final FocusScopeNode scope1 = FocusScopeNode(debugLabel: 'scope1');
+      final FocusScopeNode scope2 = FocusScopeNode(debugLabel: 'scope2');
+      final FocusNode focus1 = FocusNode(debugLabel: 'focus1');
+      final FocusNode focus2 = FocusNode(debugLabel: 'focus2');
 
-  testWidgets('skipTraversal works as expected.', (WidgetTester tester) async {
-    final FocusScopeNode scope1 = FocusScopeNode(debugLabel: 'scope1');
-    final FocusScopeNode scope2 = FocusScopeNode(debugLabel: 'scope2');
-    final FocusNode focus1 = FocusNode(debugLabel: 'focus1');
-    final FocusNode focus2 = FocusNode(debugLabel: 'focus2');
-
-    Future<void> pumpTest({
-      bool traverseScope1 = false,
-      bool traverseScope2 = false,
-      bool traverseFocus1 = false,
-      bool traverseFocus2 = false,
-    }) async {
-      await tester.pumpWidget(
-        FocusScope(
-          node: scope1,
-          skipTraversal: traverseScope1,
-          child: FocusScope(
-            node: scope2,
-            skipTraversal: traverseScope2,
-            child: Focus(
-              focusNode: focus1,
-              skipTraversal: traverseFocus1,
+      Future<void> pumpTest({
+        bool traverseScope1 = false,
+        bool traverseScope2 = false,
+        bool traverseFocus1 = false,
+        bool traverseFocus2 = false,
+      }) async {
+        await tester.pumpWidget(
+          FocusScope(
+            node: scope1,
+            skipTraversal: traverseScope1,
+            child: FocusScope(
+              node: scope2,
+              skipTraversal: traverseScope2,
               child: Focus(
-                focusNode: focus2,
-                skipTraversal: traverseFocus2,
-                child: Container(),
+                focusNode: focus1,
+                skipTraversal: traverseFocus1,
+                child: Focus(
+                  focusNode: focus2,
+                  skipTraversal: traverseFocus2,
+                  child: Container(),
+                ),
               ),
+            ),
+          ),
+        );
+        await tester.pump();
+      }
+
+      await pumpTest();
+      expect(scope1.traversalDescendants, equals(<FocusNode>[focus2, focus1, scope2]));
+
+      // Check childless node (focus2).
+      await pumpTest(traverseFocus2: true);
+      expect(scope1.traversalDescendants, equals(<FocusNode>[focus1, scope2]));
+
+      // Check FocusNode with child (focus1). Shouldn't affect children.
+      await pumpTest(traverseFocus1: true);
+      expect(scope1.traversalDescendants, equals(<FocusNode>[focus2, scope2]));
+
+      // Check FocusScopeNode with only FocusNode children (scope2). Should affect children.
+      await pumpTest(traverseScope2: true);
+      expect(scope1.traversalDescendants, equals(<FocusNode>[focus2, focus1]));
+
+      // Check FocusScopeNode with both FocusNode children and FocusScope children (scope1). Should affect children.
+      await pumpTest(traverseScope1: true);
+      expect(scope1.traversalDescendants, equals(<FocusNode>[focus2, focus1, scope2]));
+    });
+    testWidgets('descendantsAreFocusable works as expected.', (WidgetTester tester) async {
+      final GlobalKey key1 = GlobalKey(debugLabel: '1');
+      final GlobalKey key2 = GlobalKey(debugLabel: '2');
+      final FocusNode focusNode = FocusNode();
+      bool gotFocus;
+      await tester.pumpWidget(
+        Focus(
+          descendantsAreFocusable: false,
+          child: Focus(
+            onFocusChange: (bool focused) => gotFocus = focused,
+            child: Focus(
+              key: key1,
+              focusNode: focusNode,
+              child: Container(key: key2),
             ),
           ),
         ),
       );
+
+      final Element childWidget = tester.element(find.byKey(key1));
+      final FocusNode unfocusableNode = Focus.of(childWidget);
+      final Element containerWidget = tester.element(find.byKey(key2));
+      final FocusNode containerNode = Focus.of(containerWidget);
+
+      unfocusableNode.requestFocus();
       await tester.pump();
-    }
 
-    await pumpTest();
-    expect(scope1.traversalDescendants, equals(<FocusNode>[focus2, focus1, scope2]));
+      expect(gotFocus, isNull);
+      expect(containerNode.hasFocus, isFalse);
+      expect(unfocusableNode.hasFocus, isFalse);
 
-    // Check childless node (focus2).
-    await pumpTest(traverseFocus2: true);
-    expect(scope1.traversalDescendants, equals(<FocusNode>[focus1, scope2]));
+      containerNode.requestFocus();
+      await tester.pump();
 
-    // Check FocusNode with child (focus1). Shouldn't affect children.
-    await pumpTest(traverseFocus1: true);
-    expect(scope1.traversalDescendants, equals(<FocusNode>[focus2, scope2]));
+      expect(gotFocus, isNull);
+      expect(containerNode.hasFocus, isFalse);
+      expect(unfocusableNode.hasFocus, isFalse);
+    });
+  });
+  group(ExcludeFocus, () {
+    testWidgets("Descendants of ExcludeFocus aren't focusable.", (WidgetTester tester) async {
+      final GlobalKey key1 = GlobalKey(debugLabel: '1');
+      final GlobalKey key2 = GlobalKey(debugLabel: '2');
+      final FocusNode focusNode = FocusNode();
+      bool gotFocus;
+      await tester.pumpWidget(
+        ExcludeFocus(
+          excluding: true,
+          child: Focus(
+            onFocusChange: (bool focused) => gotFocus = focused,
+            child: Focus(
+              key: key1,
+              focusNode: focusNode,
+              child: Container(key: key2),
+            ),
+          ),
+        ),
+      );
 
-    // Check FocusScopeNode with only FocusNode children (scope2). Should affect children.
-    await pumpTest(traverseScope2: true);
-    expect(scope1.traversalDescendants, equals(<FocusNode>[focus2, focus1]));
+      final Element childWidget = tester.element(find.byKey(key1));
+      final FocusNode unfocusableNode = Focus.of(childWidget);
+      final Element containerWidget = tester.element(find.byKey(key2));
+      final FocusNode containerNode = Focus.of(containerWidget);
 
-    // Check FocusScopeNode with both FocusNode children and FocusScope children (scope1). Should affect children.
-    await pumpTest(traverseScope1: true);
-    expect(scope1.traversalDescendants, equals(<FocusNode>[focus2, focus1, scope2]));
+      unfocusableNode.requestFocus();
+      await tester.pump();
+
+      expect(gotFocus, isNull);
+      expect(containerNode.hasFocus, isFalse);
+      expect(unfocusableNode.hasFocus, isFalse);
+
+      containerNode.requestFocus();
+      await tester.pump();
+
+      expect(gotFocus, isNull);
+      expect(containerNode.hasFocus, isFalse);
+      expect(unfocusableNode.hasFocus, isFalse);
+    });
   });
 }

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -1962,6 +1962,44 @@ void main() {
       final TestSemantics expectedSemantics = TestSemantics.root();
       expect(semantics, hasSemantics(expectedSemantics));
     });
+    testWidgets("Descendants of FocusTraversalGroup aren't focusable if descendantsAreFocusable is false.", (WidgetTester tester) async {
+      final GlobalKey key1 = GlobalKey(debugLabel: '1');
+      final GlobalKey key2 = GlobalKey(debugLabel: '2');
+      final FocusNode focusNode = FocusNode();
+      bool gotFocus;
+      await tester.pumpWidget(
+        FocusTraversalGroup(
+          descendantsAreFocusable: false,
+          child: Focus(
+            onFocusChange: (bool focused) => gotFocus = focused,
+            child: Focus(
+              key: key1,
+              focusNode: focusNode,
+              child: Container(key: key2),
+            ),
+          ),
+        ),
+      );
+
+      final Element childWidget = tester.element(find.byKey(key1));
+      final FocusNode unfocusableNode = Focus.of(childWidget);
+      final Element containerWidget = tester.element(find.byKey(key2));
+      final FocusNode containerNode = Focus.of(containerWidget);
+
+      unfocusableNode.requestFocus();
+      await tester.pump();
+
+      expect(gotFocus, isNull);
+      expect(containerNode.hasFocus, isFalse);
+      expect(unfocusableNode.hasFocus, isFalse);
+
+      containerNode.requestFocus();
+      await tester.pump();
+
+      expect(gotFocus, isNull);
+      expect(containerNode.hasFocus, isFalse);
+      expect(unfocusableNode.hasFocus, isFalse);
+    });
   });
 }
 


### PR DESCRIPTION
## Description

This adds an `ExcludeFocus` widget that prevents widgets in a subtree from having or obtaining focus.  It also adds the ability for a `FocusNode` to conditionally prevent its children from being focusable when it isn't focusable (i.e. when `canRequestFocus` is false).

It does this by adding a `descendantsAreFocusable` attribute to the `FocusNode`, which, when false, prevents the descendants of the node from being focusable (and removes focus from them if they are currently focused).

The `FocusScopeNode` already had this ability, although it was implemented differently.

## Related Issues

 - https://github.com/flutter/flutter/issues/55452

## Tests

 - Added a test to make sure that focusability can be overridden.

## Breaking Change

- [X] No, this is *not* a breaking change.