### PR TITLE
[flutter_tools] catch ProcessException and throw ToolExit during upgrade

### DIFF
--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -137,7 +137,7 @@ class UpgradeCommandRunner {
     }
     recordState(flutterVersion);
     await upgradeChannel(flutterVersion);
-    await attemptReset(flutterVersion, upstreamRevision);
+    await attemptReset(upstreamRevision);
     if (!testFlow) {
       await flutterUpgradeContinue();
     }
@@ -243,14 +243,15 @@ class UpgradeCommandRunner {
   /// This is a reset instead of fast forward because if we are on a release
   /// branch with cherry picks, there may not be a direct fast-forward route
   /// to the next release.
-  Future<void> attemptReset(FlutterVersion oldFlutterVersion, String newRevision) async {
-    final RunResult result = await processUtils.run(
-      <String>['git', 'reset', '--hard', newRevision],
-      throwOnError: true,
-      workingDirectory: workingDirectory,
-    );
-    if (result.exitCode != 0) {
-      throwToolExit(null, exitCode: result.exitCode);
+  Future<void> attemptReset(String newRevision) async {
+    try {
+      await processUtils.run(
+        <String>['git', 'reset', '--hard', newRevision],
+        throwOnError: true,
+        workingDirectory: workingDirectory,
+      );
+    } on ProcessException catch (e) {
+      throwToolExit(e.message, exitCode: e.errorCode);
     }
   }
 

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -186,6 +186,25 @@ void main() {
       Platform: () => fakePlatform,
     });
 
+    testUsingContext('git exception during attemptReset throwsToolExit', () async {
+      const String revision = 'abc123';
+      const String errorMessage = 'fatal: Could not parse object ´$revision´';
+      when(processManager.run(
+        <String>['git', 'reset', '--hard', revision]
+      )).thenThrow(const ProcessException(
+        'git',
+        <String>['reset', '--hard', revision],
+        errorMessage,
+      ));
+      expect(
+        () async => await realCommandRunner.attemptReset(revision),
+        throwsToolExit(message: errorMessage),
+      );
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => processManager,
+      Platform: () => fakePlatform,
+    });
+
     testUsingContext('flutterUpgradeContinue passes env variables to child process', () async {
       await realCommandRunner.flutterUpgradeContinue();
 
@@ -315,7 +334,7 @@ class FakeUpgradeCommandRunner extends UpgradeCommandRunner {
   Future<void> upgradeChannel(FlutterVersion flutterVersion) async {}
 
   @override
-  Future<bool> attemptReset(FlutterVersion flutterVersion, String newRevision) async => alreadyUpToDate;
+  Future<void> attemptReset(String newRevision) async {}
 
   @override
   Future<void> precacheArtifacts() async {}

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -196,6 +196,7 @@ void main() {
         <String>['reset', '--hard', revision],
         errorMessage,
       ));
+
       expect(
         () async => await realCommandRunner.attemptReset(revision),
         throwsToolExit(message: errorMessage),


### PR DESCRIPTION
## Description

Previously the `attemptReset` method (of the `flutter upgrade` flow) was invoking git with `throwOnError` while also checking if the exit code was non-zero. Thus we were never actually catching the errors. This wraps the process call in a try, catching `ProcessException`s and throwing tool exits on them.

## Related Issues

Based on [this comment](https://github.com/flutter/flutter/pull/55594/files#r416029795), related to https://github.com/flutter/flutter/issues/55576

## Tests

Added a new unit test to verify this behavior.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*