### PR TITLE
Add a property to Material icon button to customize the splash radius

### DIFF
--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -206,7 +206,7 @@ class IconButton extends StatelessWidget {
 
   /// The splash radius.
   ///
-  /// If nil, default splash radius of [Material.defaultSplashRadius] is used.
+  /// If null, default splash radius of [Material.defaultSplashRadius] is used.
   final double splashRadius;
 
   /// The icon to display inside the button.

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -131,7 +131,7 @@ class IconButton extends StatelessWidget {
   ///
   /// Requires one of its ancestors to be a [Material] widget.
   ///
-  /// The [iconSize], [padding], [autofocus], [minSplashRadius] and [alignment] arguments must not  
+  /// The [iconSize], [padding], [autofocus], [minSplashRadius] and [alignment] arguments must not
   /// be null (though they each have default values).
   ///
   /// The [icon] argument must be specified, and is typically either an [Icon]
@@ -142,7 +142,7 @@ class IconButton extends StatelessWidget {
     this.visualDensity,
     this.padding = const EdgeInsets.all(8.0),
     this.alignment = Alignment.center,
-    this.minSplashRadius = Material.defaultSplashRadius,    
+    this.minSplashRadius = Material.defaultSplashRadius,
     @required this.icon,
     this.color,
     this.focusColor,
@@ -159,7 +159,7 @@ class IconButton extends StatelessWidget {
   }) : assert(iconSize != null),
        assert(padding != null),
        assert(alignment != null),
-       assert(minSplashRadius != null),   
+       assert(minSplashRadius != null),
        assert(autofocus != null),
        assert(icon != null),
        super(key: key);

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -205,6 +205,7 @@ class IconButton extends StatelessWidget {
   final AlignmentGeometry alignment;
 
   /// Defines the minimum splash radius on interaction.
+  ///
   /// This property must not be null. It defaults to [Material.defaultSplashRadius].
   final double minSplashRadius;
 

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -131,7 +131,7 @@ class IconButton extends StatelessWidget {
   ///
   /// Requires one of its ancestors to be a [Material] widget.
   ///
-  /// The [iconSize], [padding], [autofocus] and [alignment] arguments must not
+  /// The [iconSize], [padding], [autofocus], and [alignment] arguments must not
   /// be null (though they each have default values).
   ///
   /// The [icon] argument must be specified, and is typically either an [Icon]
@@ -206,7 +206,7 @@ class IconButton extends StatelessWidget {
 
   /// The splash radius.
   ///
-  /// If nil, default splash value of [Material.defaultSplashRadius] is used.
+  /// If nil, default splash radius of [Material.defaultSplashRadius] is used.
   final double splashRadius;
 
   /// The icon to display inside the button.

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -131,7 +131,7 @@ class IconButton extends StatelessWidget {
   ///
   /// Requires one of its ancestors to be a [Material] widget.
   ///
-  /// The [iconSize], [padding], [autofocus], and [alignment] arguments must not
+  /// The [iconSize], [padding], [autofocus], [minSplashRadius] and [alignment] arguments must not  
   /// be null (though they each have default values).
   ///
   /// The [icon] argument must be specified, and is typically either an [Icon]
@@ -142,6 +142,7 @@ class IconButton extends StatelessWidget {
     this.visualDensity,
     this.padding = const EdgeInsets.all(8.0),
     this.alignment = Alignment.center,
+    this.minSplashRadius = Material.defaultSplashRadius,    
     @required this.icon,
     this.color,
     this.focusColor,
@@ -158,6 +159,7 @@ class IconButton extends StatelessWidget {
   }) : assert(iconSize != null),
        assert(padding != null),
        assert(alignment != null),
+       assert(minSplashRadius != null),   
        assert(autofocus != null),
        assert(icon != null),
        super(key: key);
@@ -201,6 +203,10 @@ class IconButton extends StatelessWidget {
   ///  * [AlignmentDirectional], like [Alignment] for specifying alignments
   ///    relative to text direction.
   final AlignmentGeometry alignment;
+
+  /// Defines the minimum splash radius on interaction.
+  /// This property must not be null. It defaults to [Material.defaultSplashRadius].
+  final double minSplashRadius;
 
   /// The icon to display inside the button.
   ///
@@ -370,7 +376,7 @@ class IconButton extends StatelessWidget {
         highlightColor: highlightColor ?? Theme.of(context).highlightColor,
         splashColor: splashColor ?? Theme.of(context).splashColor,
         radius: math.max(
-          Material.defaultSplashRadius,
+          minSplashRadius,
           (iconSize + math.min(padding.horizontal, padding.vertical)) * 0.7,
           // x 0.5 for diameter -> radius and + 40% overflow derived from other Material apps.
         ),

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -376,7 +376,7 @@ class IconButton extends StatelessWidget {
         hoverColor: hoverColor ?? Theme.of(context).hoverColor,
         highlightColor: highlightColor ?? Theme.of(context).highlightColor,
         splashColor: splashColor ?? Theme.of(context).splashColor,
-        radius: splashRadius != null ? splashRadius : math.max(
+        radius: splashRadius ?? math.max(
           Material.defaultSplashRadius,
           (iconSize + math.min(padding.horizontal, padding.vertical)) * 0.7,
           // x 0.5 for diameter -> radius and + 40% overflow derived from other Material apps.

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -131,7 +131,7 @@ class IconButton extends StatelessWidget {
   ///
   /// Requires one of its ancestors to be a [Material] widget.
   ///
-  /// The [iconSize], [padding], [autofocus], [minSplashRadius] and [alignment] arguments must not
+  /// The [iconSize], [padding], [autofocus] and [alignment] arguments must not
   /// be null (though they each have default values).
   ///
   /// The [icon] argument must be specified, and is typically either an [Icon]
@@ -142,7 +142,7 @@ class IconButton extends StatelessWidget {
     this.visualDensity,
     this.padding = const EdgeInsets.all(8.0),
     this.alignment = Alignment.center,
-    this.minSplashRadius = Material.defaultSplashRadius,
+    this.splashRadius,
     @required this.icon,
     this.color,
     this.focusColor,
@@ -159,7 +159,7 @@ class IconButton extends StatelessWidget {
   }) : assert(iconSize != null),
        assert(padding != null),
        assert(alignment != null),
-       assert(minSplashRadius != null),
+       assert(splashRadius == null || splashRadius > 0),
        assert(autofocus != null),
        assert(icon != null),
        super(key: key);
@@ -204,10 +204,10 @@ class IconButton extends StatelessWidget {
   ///    relative to text direction.
   final AlignmentGeometry alignment;
 
-  /// Defines the minimum splash radius on interaction.
+  /// The splash radius.
   ///
-  /// This property must not be null. It defaults to [Material.defaultSplashRadius].
-  final double minSplashRadius;
+  /// If nil, default splash value of [Material.defaultSplashRadius] is used.
+  final double splashRadius;
 
   /// The icon to display inside the button.
   ///
@@ -376,8 +376,8 @@ class IconButton extends StatelessWidget {
         hoverColor: hoverColor ?? Theme.of(context).hoverColor,
         highlightColor: highlightColor ?? Theme.of(context).highlightColor,
         splashColor: splashColor ?? Theme.of(context).splashColor,
-        radius: math.max(
-          minSplashRadius,
+        radius: splashRadius != null ? splashRadius : math.max(
+          Material.defaultSplashRadius,
           (iconSize + math.min(padding.horizontal, padding.vertical)) * 0.7,
           // x 0.5 for diameter -> radius and + 40% overflow derived from other Material apps.
         ),

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -339,12 +339,12 @@ void main() {
 
   testWidgets('IconButton with explicit min splash radius',
       (WidgetTester tester) async {
-    const double minSplashRadius = 10.0;
+    const double splashRadius = 30.0;
 
     final Widget buttonWidget = wrap(
       child: IconButton(
         icon: const Icon(Icons.android),
-        minSplashRadius: minSplashRadius,
+        splashRadius: splashRadius,
         onPressed: () {/* Enable the button. */},
       ),
     );
@@ -364,7 +364,7 @@ void main() {
     expect(
       Material.of(tester.element(find.byType(IconButton))),
       paints
-        ..circle(radius: minSplashRadius)
+        ..circle(radius: splashRadius)
     );
 
     await gesture.up();

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -341,7 +341,7 @@ void main() {
       (WidgetTester tester) async {
     const double minSplashRadius = 10.0;
 
-    Widget buttonWidget = wrap(
+    final buttonWidget = wrap(
       child: IconButton(
         icon: const Icon(Icons.android),
         minSplashRadius: minSplashRadius,

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -371,7 +371,6 @@ void main() {
     await gesture.up();
   });
 
-
   testWidgets('IconButton Semantics (enabled)', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
 

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -359,8 +359,7 @@ void main() {
     final Offset center = tester.getCenter(find.byType(IconButton));
     final TestGesture gesture = await tester.startGesture(center);
     await tester.pump(); // Start gesture.
-    await tester.pump(const Duration(
-        milliseconds: 1000)); // Wait for splash to be well under way.
+    await tester.pump(const Duration(milliseconds: 1000)); // Wait for splash to be well under way.
 
     expect(
       Material.of(tester.element(find.byType(IconButton))),

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -337,6 +337,41 @@ void main() {
     await gesture.up();
   });
 
+  testWidgets('IconButton with explicit min splash radius',
+      (WidgetTester tester) async {
+    const double minSplashRadius = 10.0;
+
+    Widget buttonWidget = wrap(
+      child: IconButton(
+        icon: const Icon(Icons.android),
+        minSplashRadius: minSplashRadius,
+        onPressed: () {/* enable the button */},
+      ),
+    );
+
+    await tester.pumpWidget(
+      Theme(
+        data: ThemeData(),
+        child: buttonWidget,
+      ),
+    );
+
+    final Offset center = tester.getCenter(find.byType(IconButton));
+    final TestGesture gesture = await tester.startGesture(center);
+    await tester.pump(); // start gesture
+    await tester.pump(const Duration(
+        milliseconds: 200)); // wait for splash to be well under way
+
+    expect(
+      Material.of(tester.element(find.byType(IconButton))),
+      paints
+        ..circle(radius: minSplashRadius)
+    );
+
+    await gesture.up();
+  });
+
+
   testWidgets('IconButton Semantics (enabled)', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
 

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -360,7 +360,7 @@ void main() {
     final TestGesture gesture = await tester.startGesture(center);
     await tester.pump(); // start gesture
     await tester.pump(const Duration(
-        milliseconds: 1000)); // wait for splash to be well under way
+        milliseconds: 1000)); // Wait for splash to be well under way.
 
     expect(
       Material.of(tester.element(find.byType(IconButton))),

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -337,7 +337,7 @@ void main() {
     await gesture.up();
   });
 
-  testWidgets('IconButton with explicit min splash radius',
+  testWidgets('IconButton with explicit splash radius',
       (WidgetTester tester) async {
     const double splashRadius = 30.0;
 

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -345,7 +345,7 @@ void main() {
       child: IconButton(
         icon: const Icon(Icons.android),
         minSplashRadius: minSplashRadius,
-        onPressed: () {/* enable the button */},
+        onPressed: () {/* Enable the button. */},
       ),
     );
 

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -360,7 +360,7 @@ void main() {
     final TestGesture gesture = await tester.startGesture(center);
     await tester.pump(); // start gesture
     await tester.pump(const Duration(
-        milliseconds: 200)); // wait for splash to be well under way
+        milliseconds: 1000)); // wait for splash to be well under way
 
     expect(
       Material.of(tester.element(find.byType(IconButton))),

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -341,7 +341,7 @@ void main() {
       (WidgetTester tester) async {
     const double minSplashRadius = 10.0;
 
-    final buttonWidget = wrap(
+    final Widget buttonWidget = wrap(
       child: IconButton(
         icon: const Icon(Icons.android),
         minSplashRadius: minSplashRadius,

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -344,7 +344,7 @@ void main() {
       MaterialApp(
         home: Material(
           child: Center(
-            IconButton(
+            child: IconButton(
               icon: const Icon(Icons.android),
               splashRadius: splashRadius,
               onPressed: () { /* enable the button */ },

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -340,19 +340,17 @@ void main() {
   testWidgets('IconButton with explicit splash radius',
       (WidgetTester tester) async {
     const double splashRadius = 30.0;
-
-    final Widget buttonWidget = wrap(
-      child: IconButton(
-        icon: const Icon(Icons.android),
-        splashRadius: splashRadius,
-        onPressed: () {/* Enable the button. */},
-      ),
-    );
-
     await tester.pumpWidget(
-      Theme(
-        data: ThemeData(),
-        child: buttonWidget,
+      MaterialApp(
+        home: Material(
+          child: Center(
+            IconButton(
+              icon: const Icon(Icons.android),
+              splashRadius: splashRadius,
+              onPressed: () { /* enable the button */ },
+            ),
+          ),
+        ),
       ),
     );
 

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -358,7 +358,7 @@ void main() {
 
     final Offset center = tester.getCenter(find.byType(IconButton));
     final TestGesture gesture = await tester.startGesture(center);
-    await tester.pump(); // start gesture
+    await tester.pump(); // Start gesture.
     await tester.pump(const Duration(
         milliseconds: 1000)); // Wait for splash to be well under way.
 


### PR DESCRIPTION
## Description

Add a property to Material icon button to customize the splash radius.

## Tests

I added the following tests:
* IconButton with explicit min splash radius.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [?] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
