### PR TITLE
Print stdout and stderr when the ssh command failed

### DIFF
--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -802,7 +802,10 @@ class _FuchsiaPortForwarder extends DevicePortForwarder {
     ];
     final ProcessResult result = await globals.processManager.run(command);
     if (result.exitCode != 0) {
-      throwToolExit('Unforward command failed: $result');
+      throwToolExit('Unforward command failed:\n'
+        'stdout: ${result.stdout}\n'
+        'stderr: ${result.stderr}'
+      );
     }
   }
 

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -802,7 +802,8 @@ class _FuchsiaPortForwarder extends DevicePortForwarder {
     ];
     final ProcessResult result = await globals.processManager.run(command);
     if (result.exitCode != 0) {
-      throwToolExit('Unforward command failed:\n'
+      throwToolExit(
+        'Unforward command failed:\n'
         'stdout: ${result.stdout}\n'
         'stderr: ${result.stderr}'
       );

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
@@ -563,6 +563,49 @@ void main() {
     }, testOn: 'posix');
   });
 
+  group('portForwarder', () {
+    MockProcessManager mockProcessManager;
+    MockFile sshConfig;
+
+    setUp(() {
+      mockProcessManager = MockProcessManager();
+
+      sshConfig = MockFile();
+      when(sshConfig.path).thenReturn('irrelevant');
+      when(sshConfig.existsSync()).thenReturn(true);
+      when(sshConfig.absolute).thenReturn(sshConfig);
+    });
+
+    testUsingContext('unforward prints stdout and stderror if ssh command failed', () async {
+      final FuchsiaDevice device = FuchsiaDevice('id', name: 'tester');
+
+      final MockProcessResult mockFailureProcessResult = MockProcessResult();
+      when(mockFailureProcessResult.exitCode).thenReturn(1);
+      when<String>(mockFailureProcessResult.stdout as String).thenReturn('<stdout>');
+      when<String>(mockFailureProcessResult.stderr as String).thenReturn('<stderr>');
+      when(mockProcessManager.run(<String>[
+        'ssh',
+        '-F',
+        'irrelevant',
+        '-O',
+        'cancel',
+        '-vvv',
+        '-L',
+        '0:127.0.0.1:1',
+        'id',
+      ])).thenAnswer((Invocation invocation) {
+        return Future<ProcessResult>.value(mockFailureProcessResult);
+      });
+      await expectLater(
+        () => device.portForwarder.unforward(ForwardedPort(/*hostPort=*/ 0, /*devicePort=*/ 1)),
+        throwsToolExit(message: 'Unforward command failed:\nstdout: <stdout>\nstderr: <stderr>'),
+      );
+    }, overrides: <Type, Generator>{
+      ProcessManager: () => mockProcessManager,
+      FuchsiaArtifacts: () => FuchsiaArtifacts(sshConfig: sshConfig),
+    });
+  });
+
 
   group(FuchsiaIsolateDiscoveryProtocol, () {
     MockPortForwarder portForwarder;

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
@@ -576,7 +576,7 @@ void main() {
       when(sshConfig.absolute).thenReturn(sshConfig);
     });
 
-    testUsingContext('unforward prints stdout and stderror if ssh command failed', () async {
+    testUsingContext('`unforward` prints stdout and stderr if ssh command failed', () async {
       final FuchsiaDevice device = FuchsiaDevice('id', name: 'tester');
 
       final MockProcessResult mockFailureProcessResult = MockProcessResult();


### PR DESCRIPTION
## Description

Print stdout and stderr when the ssh command failed.

## Related Issues

Helps debug https://chromium-swarm.appspot.com/task?id=4bd2da4abbe5f810

## Tests

I added the following tests: unit test

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
