### PR TITLE
TextField enabled fix

### DIFF
--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -797,7 +797,7 @@ class _TextFieldState extends State<TextField> implements TextSelectionGestureDe
     final InputDecoration effectiveDecoration = (widget.decoration ?? const InputDecoration())
       .applyDefaults(themeData.inputDecorationTheme)
       .copyWith(
-        enabled: widget.enabled,
+        enabled: _isEnabled,
         hintMaxLines: widget.decoration?.hintMaxLines ?? widget.maxLines,
       );
 

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -165,7 +165,7 @@ class TextFormField extends FormField<String> {
     FormFieldSetter<String> onSaved,
     FormFieldValidator<String> validator,
     List<TextInputFormatter> inputFormatters,
-    bool enabled = true,
+    bool enabled,
     double cursorWidth = 2.0,
     Radius cursorRadius,
     Color cursorColor,
@@ -205,7 +205,7 @@ class TextFormField extends FormField<String> {
     onSaved: onSaved,
     validator: validator,
     autovalidate: autovalidate,
-    enabled: enabled,
+    enabled: enabled ?? decoration?.enabled ?? true,
     builder: (FormFieldState<String> field) {
       final _TextFormFieldState state = field as _TextFormFieldState;
       final InputDecoration effectiveDecoration = (decoration ?? const InputDecoration())
@@ -248,7 +248,7 @@ class TextFormField extends FormField<String> {
         onEditingComplete: onEditingComplete,
         onSubmitted: onFieldSubmitted,
         inputFormatters: inputFormatters,
-        enabled: enabled,
+        enabled: enabled ?? decoration?.enabled ?? true,
         cursorWidth: cursorWidth,
         cursorRadius: cursorRadius,
         cursorColor: cursorColor,

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -3600,7 +3600,8 @@ void main() {
   testWidgets('Disabled text field hides helper and counter', (WidgetTester tester) async {
     const String helperText = 'helper text';
     const String counterText = 'counter text';
-    Widget buildFrame(bool enabled) {
+    const String errorText = 'error text';
+    Widget buildFrame(bool enabled, bool hasError) {
       return MaterialApp(
         home: Material(
           child: Center(
@@ -3609,6 +3610,7 @@ void main() {
                 labelText: 'label text',
                 helperText: helperText,
                 counterText: counterText,
+                errorText: hasError ? errorText : null,
                 enabled: enabled,
               ),
             ),
@@ -3617,19 +3619,28 @@ void main() {
       );
     }
 
-    // When enabled is true, the helper and counter are visible.
-    await tester.pumpWidget(buildFrame(true));
+    await tester.pumpWidget(buildFrame(true, false));
     Text helperWidget = tester.widget(find.text(helperText));
     Text counterWidget = tester.widget(find.text(counterText));
     expect(helperWidget.style.color, isNot(equals(Colors.transparent)));
     expect(counterWidget.style.color, isNot(equals(Colors.transparent)));
+    await tester.pumpWidget(buildFrame(true, true));
+    counterWidget = tester.widget(find.text(counterText));
+    Text errorWidget = tester.widget(find.text(errorText));
+    expect(helperWidget.style.color, isNot(equals(Colors.transparent)));
+    expect(errorWidget.style.color, isNot(equals(Colors.transparent)));
 
-    // When enabled is false, the helper and counter are not visible.
-    await tester.pumpWidget(buildFrame(false));
+    // When enabled is false, the helper/error and counter are not visible.
+    await tester.pumpWidget(buildFrame(false, false));
     helperWidget = tester.widget(find.text(helperText));
     counterWidget = tester.widget(find.text(counterText));
     expect(helperWidget.style.color, equals(Colors.transparent));
     expect(counterWidget.style.color, equals(Colors.transparent));
+    await tester.pumpWidget(buildFrame(false, true));
+    errorWidget = tester.widget(find.text(errorText));
+    counterWidget = tester.widget(find.text(counterText));
+    expect(counterWidget.style.color, equals(Colors.transparent));
+    expect(errorWidget.style.color, equals(Colors.transparent));
   });
 
   testWidgets('currentValueLength/maxValueLength are in the tree', (WidgetTester tester) async {

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -3597,6 +3597,41 @@ void main() {
     semantics.dispose();
   });
 
+  testWidgets('Disabled text field hides helper and counter', (WidgetTester tester) async {
+    const String helperText = 'helper text';
+    const String counterText = 'counter text';
+    Widget buildFrame(bool enabled) {
+      return MaterialApp(
+        home: Material(
+          child: Center(
+            child: TextField(
+              decoration: InputDecoration(
+                labelText: 'label text',
+                helperText: helperText,
+                counterText: counterText,
+                enabled: enabled,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    // When enabled is true, the helper and counter are visible.
+    await tester.pumpWidget(buildFrame(true));
+    Text helperWidget = tester.widget(find.text(helperText));
+    Text counterWidget = tester.widget(find.text(counterText));
+    expect(helperWidget.style.color, isNot(equals(Colors.transparent)));
+    expect(counterWidget.style.color, isNot(equals(Colors.transparent)));
+
+    // When enabled is false, the helper and counter are not visible.
+    await tester.pumpWidget(buildFrame(false));
+    helperWidget = tester.widget(find.text(helperText));
+    counterWidget = tester.widget(find.text(counterText));
+    expect(helperWidget.style.color, equals(Colors.transparent));
+    expect(counterWidget.style.color, equals(Colors.transparent));
+  });
+
   testWidgets('currentValueLength/maxValueLength are in the tree', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
     final TextEditingController controller = TextEditingController();

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -240,6 +240,42 @@ void main() {
     expect(_validateCalled, 2);
   });
 
+
+  testWidgets('Disabled field hides helper and counter', (WidgetTester tester) async {
+    const String helperText = 'helper text';
+    const String counterText = 'counter text';
+    Widget buildFrame(bool enabled) {
+      return MaterialApp(
+        home: Material(
+          child: Center(
+            child: TextFormField(
+              decoration: InputDecoration(
+                labelText: 'label text',
+                helperText: helperText,
+                counterText: counterText,
+                enabled: enabled,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    // When enabled is true, the helper and counter are visible.
+    await tester.pumpWidget(buildFrame(true));
+    Text helperWidget = tester.widget(find.text(helperText));
+    Text counterWidget = tester.widget(find.text(counterText));
+    expect(helperWidget.style.color, isNot(equals(Colors.transparent)));
+    expect(counterWidget.style.color, isNot(equals(Colors.transparent)));
+
+    // When enabled is false, the helper and counter are not visible.
+    await tester.pumpWidget(buildFrame(false));
+    helperWidget = tester.widget(find.text(helperText));
+    counterWidget = tester.widget(find.text(counterText));
+    expect(helperWidget.style.color, equals(Colors.transparent));
+    expect(counterWidget.style.color, equals(Colors.transparent));
+  });
+
   testWidgets('passing a buildCounter shows returned widget', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
       home: Material(

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -244,7 +244,8 @@ void main() {
   testWidgets('Disabled field hides helper and counter', (WidgetTester tester) async {
     const String helperText = 'helper text';
     const String counterText = 'counter text';
-    Widget buildFrame(bool enabled) {
+    const String errorText = 'error text';
+    Widget buildFrame(bool enabled, bool hasError) {
       return MaterialApp(
         home: Material(
           child: Center(
@@ -253,6 +254,7 @@ void main() {
                 labelText: 'label text',
                 helperText: helperText,
                 counterText: counterText,
+                errorText: hasError ? errorText : null,
                 enabled: enabled,
               ),
             ),
@@ -261,19 +263,29 @@ void main() {
       );
     }
 
-    // When enabled is true, the helper and counter are visible.
-    await tester.pumpWidget(buildFrame(true));
+    // When enabled is true, the helper/error and counter are visible.
+    await tester.pumpWidget(buildFrame(true, false));
     Text helperWidget = tester.widget(find.text(helperText));
     Text counterWidget = tester.widget(find.text(counterText));
     expect(helperWidget.style.color, isNot(equals(Colors.transparent)));
     expect(counterWidget.style.color, isNot(equals(Colors.transparent)));
+    await tester.pumpWidget(buildFrame(true, true));
+    counterWidget = tester.widget(find.text(counterText));
+    Text errorWidget = tester.widget(find.text(errorText));
+    expect(helperWidget.style.color, isNot(equals(Colors.transparent)));
+    expect(errorWidget.style.color, isNot(equals(Colors.transparent)));
 
-    // When enabled is false, the helper and counter are not visible.
-    await tester.pumpWidget(buildFrame(false));
+    // When enabled is false, the helper/error and counter are not visible.
+    await tester.pumpWidget(buildFrame(false, false));
     helperWidget = tester.widget(find.text(helperText));
     counterWidget = tester.widget(find.text(counterText));
     expect(helperWidget.style.color, equals(Colors.transparent));
     expect(counterWidget.style.color, equals(Colors.transparent));
+    await tester.pumpWidget(buildFrame(false, true));
+    errorWidget = tester.widget(find.text(errorText));
+    counterWidget = tester.widget(find.text(counterText));
+    expect(counterWidget.style.color, equals(Colors.transparent));
+    expect(errorWidget.style.color, equals(Colors.transparent));
   });
 
   testWidgets('passing a buildCounter shows returned widget', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

In [InputDecoration's docs for enabled](https://master-api.flutter.dev/flutter/material/InputDecoration/enabled.html), it says that setting it to false should hide helper/error and counter.  However, that was getting overridden and not working when passed as part of InputDecoration for a TextFormField.

## Related Issues

Closes https://github.com/flutter/flutter/issues/55632

For the record, enabled and its docs were originally added in https://github.com/flutter/flutter/pull/13734.

## Tests

I added a test that sets and unsets enabled and asserts the visibility of helper/error and counter are correct.