### PR TITLE
Skip Audit - Painting Library

### DIFF
--- a/packages/flutter/test/painting/beveled_rectangle_border_test.dart
+++ b/packages/flutter/test/painting/beveled_rectangle_border_test.dart
@@ -42,7 +42,7 @@ void main() {
     const BorderSide side = BorderSide(width: 4.0);
     expect(const BeveledRectangleBorder(side: side).getOuterPath(rect1), looksLikeRect1);
     expect(const BeveledRectangleBorder(side: side).getInnerPath(rect1), looksLikeInnerPath);
-  }, skip: isBrowser);
+  });
 
   test('BeveledRectangleBorder non-zero BorderRadius', () {
     const Rect rect = Rect.fromLTRB(10.0, 20.0, 30.0, 40.0);
@@ -55,6 +55,6 @@ void main() {
     );
     expect(border.getOuterPath(rect), looksLikeRect);
     expect(border.getInnerPath(rect), looksLikeRect);
-  }, skip: isBrowser);
+  });
 
 }

--- a/packages/flutter/test/painting/border_rtl_test.dart
+++ b/packages/flutter/test/painting/border_rtl_test.dart
@@ -349,14 +349,14 @@ void main() {
         ],
       ),
     );
-  }, skip: isBrowser);
+  });
 
   test('BorderDirectional constructor', () {
     expect(() => BorderDirectional(top: nonconst(null)), throwsAssertionError);
     expect(() => BorderDirectional(start: nonconst(null)), throwsAssertionError);
     expect(() => BorderDirectional(end: nonconst(null)), throwsAssertionError);
     expect(() => BorderDirectional(bottom: nonconst(null)), throwsAssertionError);
-  }, skip: isBrowser);
+  });
 
   test('BorderDirectional.merge', () {
     const BorderSide magenta3 = BorderSide(color: Color(0xFFFF00FF), width: 3.0);
@@ -395,7 +395,7 @@ void main() {
       ),
       throwsAssertionError,
     );
-  }, skip: isBrowser);
+  });
 
   test('BorderDirectional.dimensions', () {
     expect(
@@ -407,7 +407,7 @@ void main() {
       ).dimensions,
       const EdgeInsetsDirectional.fromSTEB(2.0, 3.0, 7.0, 5.0),
     );
-  }, skip: isBrowser);
+  });
 
   test('BorderDirectional.isUniform', () {
     expect(
@@ -477,7 +477,7 @@ void main() {
       const BorderDirectional().isUniform,
       true,
     );
-  }, skip: isBrowser);
+  });
 
   test('BorderDirectional.add - all directional', () {
     const BorderSide magenta3 = BorderSide(color: Color(0xFFFF00FF), width: 3.0);
@@ -513,7 +513,7 @@ void main() {
     expect(bZ + bZ, bZ);
     expect(b0 + bZ, bZ);
     expect(bZ + b0, bZ);
-  }, skip: isBrowser);
+  });
 
   test('BorderDirectional.add', () {
     const BorderSide side1 = BorderSide(color: Color(0x11111111));
@@ -565,7 +565,7 @@ void main() {
     expect((borderDirectionalWithStart + borderWithoutSides).toString(), '${const BorderDirectional(start: side1, top: doubleSide2, bottom: doubleSide2)}');
     expect((borderDirectionalWithEnd + borderWithoutSides).toString(), '${const BorderDirectional(end: side1, top: doubleSide2, bottom: doubleSide2)}');
     expect((borderDirectionalWithoutSides + borderWithoutSides).toString(), '${const Border(top: doubleSide2, bottom: doubleSide2)}');
-  }, skip: isBrowser);
+  });
 
   test('BorderDirectional.scale', () {
     const BorderSide magenta3 = BorderSide(color: Color(0xFFFF00FF), width: 3.0);
@@ -579,7 +579,7 @@ void main() {
     expect(bY0.scale(3.0), bY0);
     const BorderDirectional bY2 = BorderDirectional(top: yellow2);
     expect(bY2.scale(0.0), bY0);
-  }, skip: isBrowser);
+  });
 
   test('BorderDirectional.lerp', () {
     const BorderDirectional directionalWithTop10 = BorderDirectional(top: BorderSide(width: 10.0));
@@ -653,7 +653,7 @@ void main() {
       },
       paintsAssertion, // no TextDirection
     );
-  }, skip: isBrowser);
+  });
 
   test('BorderDirectional hashCode', () {
     final BorderSide side = BorderSide(width: nonconst(2.0));
@@ -703,5 +703,5 @@ void main() {
     expect(decoration2.padding, const EdgeInsetsDirectional.fromSTEB(2.0, 0.0, 0.0, 0.0));
     expect(decoration2.scale(2.0), decoration4);
     expect(BoxDecoration.lerp(decoration2, decoration6, 0.5), decoration4);
-  }, skip: isBrowser);
+  });
 }

--- a/packages/flutter/test/painting/circle_border_test.dart
+++ b/packages/flutter/test/painting/circle_border_test.dart
@@ -26,5 +26,5 @@ void main() {
       paints
         ..circle(x: 25.0, y: 40.0, radius: 10.0, strokeWidth: 10.0),
     );
-  }, skip: isBrowser);
+  });
 }

--- a/packages/flutter/test/painting/continous_rectangle_border_test.dart
+++ b/packages/flutter/test/painting/continous_rectangle_border_test.dart
@@ -42,7 +42,7 @@ void main() {
     const BorderSide side = BorderSide(width: 4.0);
     expect(const ContinuousRectangleBorder(side: side).getOuterPath(rect1), looksLikeRect1);
     expect(const ContinuousRectangleBorder(side: side).getInnerPath(rect1), looksLikeInnerPath);
-  }, skip: isBrowser);
+  });
 
   test('ContinuousRectangleBorder non-zero BorderRadius', () {
     const Rect rect = Rect.fromLTRB(10.0, 20.0, 30.0, 40.0);
@@ -55,7 +55,7 @@ void main() {
     );
     expect(border.getOuterPath(rect), looksLikeRect);
     expect(border.getInnerPath(rect), looksLikeRect);
-  }, skip: isBrowser);
+  });
 
   testWidgets('Golden test even radii', (WidgetTester tester) async {
     await tester.pumpWidget(RepaintBoundary(
@@ -73,7 +73,7 @@ void main() {
       find.byType(RepaintBoundary),
       matchesGoldenFile('continuous_rectangle_border.golden_test_even_radii.png'),
     );
-  }, skip: isBrowser);
+  });
 
   testWidgets('Golden test varying radii', (WidgetTester tester) async {
     await tester.pumpWidget(RepaintBoundary(
@@ -96,8 +96,7 @@ void main() {
       find.byType(RepaintBoundary),
       matchesGoldenFile('continuous_rectangle_border.golden_test_varying_radii.png'),
     );
-    // TODO(Piinks): Remove skip once web goldens are supported, https://github.com/flutter/flutter/issues/40297
-  }, skip: isBrowser);
+  });
 
   testWidgets('Golden test topLeft radii', (WidgetTester tester) async {
     await tester.pumpWidget(RepaintBoundary(
@@ -117,8 +116,7 @@ void main() {
       find.byType(RepaintBoundary),
       matchesGoldenFile('continuous_rectangle_border.golden_test_topLeft_radii.png'),
     );
-    // TODO(Piinks): Remove skip once web goldens are supported, https://github.com/flutter/flutter/issues/40297
-  }, skip: isBrowser);
+  });
 
   testWidgets('Golden test topRight radii', (WidgetTester tester) async {
     await tester.pumpWidget(RepaintBoundary(
@@ -138,8 +136,7 @@ void main() {
       find.byType(RepaintBoundary),
       matchesGoldenFile('continuous_rectangle_border.golden_test_topRight_radii.png'),
     );
-    // TODO(Piinks): Remove skip once web goldens are supported, https://github.com/flutter/flutter/issues/40297
-  }, skip: isBrowser);
+  });
 
   testWidgets('Golden test bottomLeft radii', (WidgetTester tester) async {
     await tester.pumpWidget(RepaintBoundary(
@@ -159,8 +156,7 @@ void main() {
       find.byType(RepaintBoundary),
       matchesGoldenFile('continuous_rectangle_border.golden_test_bottomLeft_radii.png'),
     );
-    // TODO(Piinks): Remove skip once web goldens are supported, https://github.com/flutter/flutter/issues/40297
-  }, skip: isBrowser);
+  });
 
   testWidgets('Golden test bottomRight radii', (WidgetTester tester) async {
     await tester.pumpWidget(RepaintBoundary(
@@ -180,8 +176,7 @@ void main() {
       find.byType(RepaintBoundary),
       matchesGoldenFile('continuous_rectangle_border.golden_test_bottomRight_radii.png'),
     );
-    // TODO(Piinks): Remove skip once web goldens are supported, https://github.com/flutter/flutter/issues/40297
-  }, skip: isBrowser);
+  });
 
   testWidgets('Golden test large radii', (WidgetTester tester) async {
     await tester.pumpWidget(RepaintBoundary(
@@ -199,6 +194,6 @@ void main() {
       find.byType(RepaintBoundary),
       matchesGoldenFile('continuous_rectangle_border.golden_test_large_radii.png'),
     );
-  }, skip: isBrowser);
+  });
 
 }

--- a/packages/flutter/test/painting/gradient_test.dart
+++ b/packages/flutter/test/painting/gradient_test.dart
@@ -817,7 +817,7 @@ void main() {
       for (final Gradient gradient in gradients45) {
         testWidgets('$gradient', (WidgetTester tester) async {
           await runTest(tester, gradient, 45);
-        }, skip: isBrowser); // Reference needed
+        }, skip: isBrowser); // https://github.com/flutter/flutter/issues/41389
       }
     });
 
@@ -825,7 +825,7 @@ void main() {
       for (final Gradient gradient in gradients90) {
         testWidgets('$gradient', (WidgetTester tester) async {
           await runTest(tester, gradient, 90);
-        }, skip: isBrowser); // Reference needed
+        }, skip: isBrowser); // https://github.com/flutter/flutter/issues/41389
       }
     });
   });

--- a/packages/flutter/test/painting/gradient_test.dart
+++ b/packages/flutter/test/painting/gradient_test.dart
@@ -817,7 +817,7 @@ void main() {
       for (final Gradient gradient in gradients45) {
         testWidgets('$gradient', (WidgetTester tester) async {
           await runTest(tester, gradient, 45);
-        });
+        }, skip: isBrowser); // Reference needed
       }
     });
 
@@ -825,10 +825,10 @@ void main() {
       for (final Gradient gradient in gradients90) {
         testWidgets('$gradient', (WidgetTester tester) async {
           await runTest(tester, gradient, 90);
-        });
+        }, skip: isBrowser); // Reference needed
       }
     });
-  }, skip: isBrowser); // Reference needed
+  });
 }
 
 class GradientPainter extends CustomPainter {

--- a/packages/flutter/test/painting/gradient_test.dart
+++ b/packages/flutter/test/painting/gradient_test.dart
@@ -817,7 +817,7 @@ void main() {
       for (final Gradient gradient in gradients45) {
         testWidgets('$gradient', (WidgetTester tester) async {
           await runTest(tester, gradient, 45);
-        }, skip: isBrowser); // TODO(yjbanov): web does not support golden tests yet: https://github.com/flutter/flutter/issues/40297
+        });
       }
     });
 
@@ -825,7 +825,7 @@ void main() {
       for (final Gradient gradient in gradients90) {
         testWidgets('$gradient', (WidgetTester tester) async {
           await runTest(tester, gradient, 90);
-        }, skip: isBrowser); // TODO(yjbanov): web does not support golden tests yet: https://github.com/flutter/flutter/issues/40297
+        });
       }
     });
   });

--- a/packages/flutter/test/painting/gradient_test.dart
+++ b/packages/flutter/test/painting/gradient_test.dart
@@ -828,7 +828,7 @@ void main() {
         });
       }
     });
-  });
+  }, skip: isBrowser); // Reference needed
 }
 
 class GradientPainter extends CustomPainter {

--- a/packages/flutter/test/painting/image_provider_test.dart
+++ b/packages/flutter/test/painting/image_provider_test.dart
@@ -317,7 +317,7 @@ void main() {
         debugNetworkImageHttpClientProvider = () => client2;
         await loadNetworkImage();
         expect(capturedErrors, <dynamic>['client1', 'client2']);
-      });
+      }, skip: isBrowser); // Browser implementation does not use HTTP client but an <img> tag.
 
       test('Propagates http client errors during resolve()', () async {
         when(httpClient.getUrl(any)).thenThrow(Error());
@@ -395,7 +395,7 @@ void main() {
           expect(events[i].cumulativeBytesLoaded, math.min((i + 1) * chunkSize, kTransparentImage.length));
           expect(events[i].expectedTotalBytes, kTransparentImage.length);
         }
-      });
+      }, skip: isBrowser); // Reference needed
 
       test('NetworkImage is evicted from cache on SocketException', () async {
         final MockHttpClient mockHttpClient = MockHttpClient();
@@ -443,7 +443,7 @@ void main() {
     const ImageConfiguration resizeConfig = ImageConfiguration(size: resizeDims);
     final Size resizedImageSize = await _resolveAndGetSize(resizedImage, configuration: resizeConfig);
     expect(resizedImageSize, resizeDims);
-  });
+  }, skip: isBrowser); // Reference needed
 
   test('ResizeImage does not resize when no size is passed', () async {
     final Uint8List bytes = Uint8List.fromList(kTransparentImage);

--- a/packages/flutter/test/painting/image_provider_test.dart
+++ b/packages/flutter/test/painting/image_provider_test.dart
@@ -65,7 +65,7 @@ void main() {
 
         expect(imageCache.statusForKey(provider).untracked, true);
         expect(imageCache.pendingImageCount, 0);
-      }, skip: isBrowser); // Reference needed
+      }, skip: isBrowser); // https://github.com/flutter/flutter/issues/56314
 
       test('AssetImageProvider - evicts on null load', () async {
         final Completer<StateError> error = Completer<StateError>();
@@ -395,7 +395,7 @@ void main() {
           expect(events[i].cumulativeBytesLoaded, math.min((i + 1) * chunkSize, kTransparentImage.length));
           expect(events[i].expectedTotalBytes, kTransparentImage.length);
         }
-      }, skip: isBrowser); // Reference needed
+      }, skip: isBrowser); // https://github.com/flutter/flutter/issues/56317
 
       test('NetworkImage is evicted from cache on SocketException', () async {
         final MockHttpClient mockHttpClient = MockHttpClient();
@@ -443,7 +443,7 @@ void main() {
     const ImageConfiguration resizeConfig = ImageConfiguration(size: resizeDims);
     final Size resizedImageSize = await _resolveAndGetSize(resizedImage, configuration: resizeConfig);
     expect(resizedImageSize, resizeDims);
-  }, skip: isBrowser); // Reference needed
+  }, skip: isBrowser); // https://github.com/flutter/flutter/issues/56312
 
   test('ResizeImage does not resize when no size is passed', () async {
     final Uint8List bytes = Uint8List.fromList(kTransparentImage);

--- a/packages/flutter/test/painting/image_provider_test.dart
+++ b/packages/flutter/test/painting/image_provider_test.dart
@@ -65,7 +65,7 @@ void main() {
 
         expect(imageCache.statusForKey(provider).untracked, true);
         expect(imageCache.pendingImageCount, 0);
-      }, skip: isBrowser);
+      });
 
       test('AssetImageProvider - evicts on null load', () async {
         final Completer<StateError> error = Completer<StateError>();
@@ -87,7 +87,7 @@ void main() {
 
         expect(imageCache.statusForKey(provider).untracked, true);
         expect(imageCache.pendingImageCount, 0);
-      }, skip: isBrowser);
+      });
 
       test('ImageProvider can evict images', () async {
         final Uint8List bytes = Uint8List.fromList(kTransparentImage);
@@ -286,7 +286,7 @@ void main() {
             .having((NetworkImageLoadException e) => e.statusCode, 'statusCode', errorStatusCode)
             .having((NetworkImageLoadException e) => e.uri, 'uri', Uri.base.resolve(requestUrl)),
         );
-      }, skip: isBrowser);  // Browser implementation does not use HTTP client but a <img> tag.
+      }, skip: isBrowser);  // Browser implementation does not use HTTP client but an <img> tag.
 
       test('Disallows null urls', () {
         expect(() {
@@ -317,7 +317,7 @@ void main() {
         debugNetworkImageHttpClientProvider = () => client2;
         await loadNetworkImage();
         expect(capturedErrors, <dynamic>['client1', 'client2']);
-      }, skip: isBrowser);
+      });
 
       test('Propagates http client errors during resolve()', () async {
         when(httpClient.getUrl(any)).thenThrow(Error());
@@ -395,7 +395,7 @@ void main() {
           expect(events[i].cumulativeBytesLoaded, math.min((i + 1) * chunkSize, kTransparentImage.length));
           expect(events[i].expectedTotalBytes, kTransparentImage.length);
         }
-      }, skip: isBrowser);
+      });
 
       test('NetworkImage is evicted from cache on SocketException', () async {
         final MockHttpClient mockHttpClient = MockHttpClient();
@@ -443,7 +443,7 @@ void main() {
     const ImageConfiguration resizeConfig = ImageConfiguration(size: resizeDims);
     final Size resizedImageSize = await _resolveAndGetSize(resizedImage, configuration: resizeConfig);
     expect(resizedImageSize, resizeDims);
-  }, skip: isBrowser);
+  });
 
   test('ResizeImage does not resize when no size is passed', () async {
     final Uint8List bytes = Uint8List.fromList(kTransparentImage);
@@ -456,7 +456,7 @@ void main() {
     final MemoryImage resizedImage = MemoryImage(bytes);
     final Size resizedImageSize = await _resolveAndGetSize(resizedImage);
     expect(resizedImageSize, const Size(1, 1));
-  }, skip: isBrowser);
+  });
 
   test('ResizeImage stores values', () async {
     final Uint8List bytes = Uint8List.fromList(kTransparentImage);

--- a/packages/flutter/test/painting/image_provider_test.dart
+++ b/packages/flutter/test/painting/image_provider_test.dart
@@ -65,7 +65,7 @@ void main() {
 
         expect(imageCache.statusForKey(provider).untracked, true);
         expect(imageCache.pendingImageCount, 0);
-      });
+      }, skip: isBrowser); // Reference needed
 
       test('AssetImageProvider - evicts on null load', () async {
         final Completer<StateError> error = Completer<StateError>();

--- a/packages/flutter/test/painting/image_resolution_test.dart
+++ b/packages/flutter/test/painting/image_resolution_test.dart
@@ -145,7 +145,7 @@ void main() {
         expect(bundleKey.scale, 1.0);
       }));
     });
-  }, skip: isBrowser);
+  });
 
   group('Regression - When assets available are 1.0 and 3.0 check devices with a range of scales', () {
     const String mainAssetPath = 'assets/normalFolder/normalFile.png';
@@ -201,6 +201,6 @@ void main() {
     test('Typical case 4.0', () {
       _buildBundleAndTestVariantLogic(4.0, 3.0, variantPath);
     });
-  }, skip: isBrowser);
+  });
 
 }

--- a/packages/flutter/test/painting/notched_shapes_test.dart
+++ b/packages/flutter/test/painting/notched_shapes_test.dart
@@ -81,7 +81,7 @@ void main() {
           sampleSize: 100,
         ),
       );
-    }, skip: isBrowser);
+    });
 
     test('AutomaticNotchedShape - no guest', () {
       expect(

--- a/packages/flutter/test/painting/notched_shapes_test.dart
+++ b/packages/flutter/test/painting/notched_shapes_test.dart
@@ -81,7 +81,7 @@ void main() {
           sampleSize: 100,
         ),
       );
-    }, skip: isBrowser); // Reference needed
+    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/44572
 
     test('AutomaticNotchedShape - no guest', () {
       expect(

--- a/packages/flutter/test/painting/notched_shapes_test.dart
+++ b/packages/flutter/test/painting/notched_shapes_test.dart
@@ -81,7 +81,7 @@ void main() {
           sampleSize: 100,
         ),
       );
-    });
+    }, skip: isBrowser); // Reference needed
 
     test('AutomaticNotchedShape - no guest', () {
       expect(

--- a/packages/flutter/test/painting/rounded_rectangle_border_test.dart
+++ b/packages/flutter/test/painting/rounded_rectangle_border_test.dart
@@ -91,5 +91,5 @@ void main() {
     expect(direct50, indirect50);
     expect(direct50.hashCode, indirect50.hashCode);
     expect(direct50.toString(), indirect50.toString());
-  }, skip: isBrowser);
+  });
 }

--- a/packages/flutter/test/painting/stadium_border_test.dart
+++ b/packages/flutter/test/painting/stadium_border_test.dart
@@ -84,7 +84,7 @@ void main() {
     expect(direct50, indirect50);
     expect(direct50.hashCode, indirect50.hashCode);
     expect(direct50.toString(), indirect50.toString());
-  }, skip: isBrowser);
+  });
 
   test('StadiumBorder and RoundedRectBorder', () {
     const StadiumBorder stadium = StadiumBorder(side: BorderSide.none);

--- a/packages/flutter/test/painting/text_painter_rtl_test.dart
+++ b/packages/flutter/test/painting/text_painter_rtl_test.dart
@@ -322,7 +322,7 @@ void main() {
         TextBox.fromLTRBD(0.0, 10.0, 10.0, 20.0, TextDirection.rtl), // Alef
       ],
     );
-  }, skip: isBrowser); // Reference needed
+  }, skip: isBrowser); // https://github.com/flutter/flutter/issues/32238
 
   test('TextPainter - line wrap mid-word', () {
     final TextPainter painter = TextPainter()

--- a/packages/flutter/test/painting/text_painter_rtl_test.dart
+++ b/packages/flutter/test/painting/text_painter_rtl_test.dart
@@ -322,7 +322,7 @@ void main() {
         TextBox.fromLTRBD(0.0, 10.0, 10.0, 20.0, TextDirection.rtl), // Alef
       ],
     );
-  });
+  }, skip: isBrowser); // Reference needed
 
   test('TextPainter - line wrap mid-word', () {
     final TextPainter painter = TextPainter()

--- a/packages/flutter/test/painting/text_painter_rtl_test.dart
+++ b/packages/flutter/test/painting/text_painter_rtl_test.dart
@@ -322,9 +322,7 @@ void main() {
         TextBox.fromLTRBD(0.0, 10.0, 10.0, 20.0, TextDirection.rtl), // Alef
       ],
     );
-  },
-  // Ahem-based tests don't yet quite work on Windows or some MacOS environments
-  skip: !isLinux);
+  });
 
   test('TextPainter - line wrap mid-word', () {
     final TextPainter painter = TextPainter()

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -32,7 +32,7 @@ void main() {
     painter.layout();
     caretOffset = painter.getOffsetForCaret(ui.TextPosition(offset: text.length), ui.Rect.zero);
     expect(caretOffset.dx, painter.width);
-  }, skip: isBrowser);
+  });
 
   test('TextPainter null text test', () {
     final TextPainter painter = TextPainter()
@@ -57,7 +57,7 @@ void main() {
     expect(caretOffset.dx, 0);
     caretOffset = painter.getOffsetForCaret(const ui.TextPosition(offset: 1), ui.Rect.zero);
     expect(caretOffset.dx, 0);
-  }, skip: isBrowser);
+  });
 
   test('TextPainter caret emoji test', () {
     final TextPainter painter = TextPainter()
@@ -121,7 +121,7 @@ void main() {
     expect(caretOffset.dx, 112); // 🇸
     caretOffset = painter.getOffsetForCaret(const ui.TextPosition(offset: 22), ui.Rect.zero);
     expect(caretOffset.dx, 112); // 🇸
-  }, skip: isBrowser);
+  });
 
   test('TextPainter caret center space test', () {
     final TextPainter painter = TextPainter()
@@ -143,7 +143,7 @@ void main() {
     expect(caretOffset.dx, 35);
     caretOffset = painter.getOffsetForCaret(const ui.TextPosition(offset: 2), ui.Rect.zero);
     expect(caretOffset.dx, 49);
-  }, skip: isBrowser);
+  });
 
   test('TextPainter error test', () {
     final TextPainter painter = TextPainter(textDirection: TextDirection.ltr);
@@ -171,7 +171,7 @@ void main() {
     );
     painter.layout();
     expect(painter.size, const Size(123.0, 123.0));
-  }, skip: isBrowser);
+  });
 
   test('TextPainter textScaleFactor test', () {
     final TextPainter painter = TextPainter(
@@ -188,7 +188,7 @@ void main() {
     );
     painter.layout();
     expect(painter.size, const Size(20.0, 20.0));
-  }, skip: isBrowser);
+  });
 
   test('TextPainter default text height is 14 pixels', () {
     final TextPainter painter = TextPainter(
@@ -198,7 +198,7 @@ void main() {
     painter.layout();
     expect(painter.preferredLineHeight, 14.0);
     expect(painter.size, const Size(14.0, 14.0));
-  }, skip: isBrowser);
+  });
 
   test('TextPainter sets paragraph size from root', () {
     final TextPainter painter = TextPainter(
@@ -208,7 +208,7 @@ void main() {
     painter.layout();
     expect(painter.preferredLineHeight, 100.0);
     expect(painter.size, const Size(100.0, 100.0));
-  }, skip: isBrowser);
+  });
 
   test('TextPainter intrinsic dimensions', () {
     const TextStyle style = TextStyle(
@@ -635,7 +635,7 @@ void main() {
     );
     expect(caretOffset.dx, closeTo(0.0, 0.0001));
     expect(caretOffset.dy, closeTo(0.0, 0.0001));
-  }, skip: isBrowser);
+  });
 
   test('TextPainter widget span', () {
     final TextPainter painter = TextPainter()
@@ -729,7 +729,7 @@ void main() {
     expect(painter.inlinePlaceholderBoxes[11], const TextBox.fromLTRBD(250, 30, 300, 60, TextDirection.ltr));
     expect(painter.inlinePlaceholderBoxes[12], const TextBox.fromLTRBD(300, 30, 351, 60, TextDirection.ltr));
     expect(painter.inlinePlaceholderBoxes[13], const TextBox.fromLTRBD(351, 30, 401, 60, TextDirection.ltr));
-  }, skip: isBrowser);
+  });
 
   // Null values are valid. See https://github.com/flutter/flutter/pull/48346#issuecomment-584839221
   test('TextPainter set TextHeightBehavior null test', () {
@@ -832,5 +832,5 @@ void main() {
       ui.Rect.zero,
     );
     expect(caretHeight, 50.0);
-  }, skip: kIsWeb);
+  });
 }

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -4,7 +4,6 @@
 
 import 'dart:ui' as ui;
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -121,7 +120,7 @@ void main() {
     expect(caretOffset.dx, 112); // 🇸
     caretOffset = painter.getOffsetForCaret(const ui.TextPosition(offset: 22), ui.Rect.zero);
     expect(caretOffset.dx, 112); // 🇸
-  });
+  }, skip: isBrowser); // Reference needed
 
   test('TextPainter caret center space test', () {
     final TextPainter painter = TextPainter()
@@ -143,7 +142,7 @@ void main() {
     expect(caretOffset.dx, 35);
     caretOffset = painter.getOffsetForCaret(const ui.TextPosition(offset: 2), ui.Rect.zero);
     expect(caretOffset.dx, 49);
-  });
+  }, skip: isBrowser); // Reference needed
 
   test('TextPainter error test', () {
     final TextPainter painter = TextPainter(textDirection: TextDirection.ltr);
@@ -729,7 +728,7 @@ void main() {
     expect(painter.inlinePlaceholderBoxes[11], const TextBox.fromLTRBD(250, 30, 300, 60, TextDirection.ltr));
     expect(painter.inlinePlaceholderBoxes[12], const TextBox.fromLTRBD(300, 30, 351, 60, TextDirection.ltr));
     expect(painter.inlinePlaceholderBoxes[13], const TextBox.fromLTRBD(351, 30, 401, 60, TextDirection.ltr));
-  });
+  }, skip: isBrowser); // Reference needed
 
   // Null values are valid. See https://github.com/flutter/flutter/pull/48346#issuecomment-584839221
   test('TextPainter set TextHeightBehavior null test', () {
@@ -832,5 +831,5 @@ void main() {
       ui.Rect.zero,
     );
     expect(caretHeight, 50.0);
-  });
+  }, skip: isBrowser); // Reference needed
 }

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -120,7 +120,7 @@ void main() {
     expect(caretOffset.dx, 112); // 🇸
     caretOffset = painter.getOffsetForCaret(const ui.TextPosition(offset: 22), ui.Rect.zero);
     expect(caretOffset.dx, 112); // 🇸
-  }, skip: isBrowser); // Reference needed
+  }, skip: isBrowser); // https://github.com/flutter/flutter/issues/56308
 
   test('TextPainter caret center space test', () {
     final TextPainter painter = TextPainter()
@@ -142,7 +142,7 @@ void main() {
     expect(caretOffset.dx, 35);
     caretOffset = painter.getOffsetForCaret(const ui.TextPosition(offset: 2), ui.Rect.zero);
     expect(caretOffset.dx, 49);
-  }, skip: isBrowser); // Reference needed
+  }, skip: isBrowser); // https://github.com/flutter/flutter/issues/56308
 
   test('TextPainter error test', () {
     final TextPainter painter = TextPainter(textDirection: TextDirection.ltr);
@@ -728,7 +728,7 @@ void main() {
     expect(painter.inlinePlaceholderBoxes[11], const TextBox.fromLTRBD(250, 30, 300, 60, TextDirection.ltr));
     expect(painter.inlinePlaceholderBoxes[12], const TextBox.fromLTRBD(300, 30, 351, 60, TextDirection.ltr));
     expect(painter.inlinePlaceholderBoxes[13], const TextBox.fromLTRBD(351, 30, 401, 60, TextDirection.ltr));
-  }, skip: isBrowser); // Reference needed
+  }, skip: isBrowser); // https://github.com/flutter/flutter/issues/42086
 
   // Null values are valid. See https://github.com/flutter/flutter/pull/48346#issuecomment-584839221
   test('TextPainter set TextHeightBehavior null test', () {
@@ -831,5 +831,5 @@ void main() {
       ui.Rect.zero,
     );
     expect(caretHeight, 50.0);
-  }, skip: isBrowser); // Reference needed
+  }, skip: isBrowser); // https://github.com/flutter/flutter/issues/56308
 }

--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -178,7 +178,7 @@ void main() {
     expect(ps2, equals(ui.ParagraphStyle(textAlign: TextAlign.center, fontWeight: FontWeight.w800, fontSize: 10.0, height: 100.0)));
     final ui.ParagraphStyle ps5 = s5.getParagraphStyle();
     expect(ps5, equals(ui.ParagraphStyle(fontWeight: FontWeight.w700, fontSize: 12.0, height: 123.0)));
-  });
+  }, skip: isBrowser); // Reference needed
 
 
   test('TextStyle with text direction', () {
@@ -208,7 +208,7 @@ void main() {
 
     const TextStyle s10 = TextStyle(fontFamilyFallback: <String>[], package: 'p');
     expect(s10.fontFamilyFallback, <String>[]);
-  });
+  }, skip: isBrowser); // Reference needed
 
   test('TextStyle font family fallback', () {
     const TextStyle s1 = TextStyle(fontFamilyFallback: <String>['Roboto', 'test']);
@@ -238,7 +238,7 @@ void main() {
     expect(s2.apply().fontFamilyFallback, const <String>['Roboto', 'test']);
     expect(s2.apply(fontFamily: 'bar').fontFamily, 'bar');
     expect(s2.apply(fontFamilyFallback: const <String>['Banana']).fontFamilyFallback, const <String>['Banana']);
-  });
+  }, skip: isBrowser); // Reference needed
 
   test('TextStyle.debugLabel', () {
     const TextStyle unknown = TextStyle();

--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -178,7 +178,7 @@ void main() {
     expect(ps2, equals(ui.ParagraphStyle(textAlign: TextAlign.center, fontWeight: FontWeight.w800, fontSize: 10.0, height: 100.0)));
     final ui.ParagraphStyle ps5 = s5.getParagraphStyle();
     expect(ps5, equals(ui.ParagraphStyle(fontWeight: FontWeight.w700, fontSize: 12.0, height: 123.0)));
-  }, skip: isBrowser);
+  });
 
 
   test('TextStyle with text direction', () {
@@ -208,7 +208,7 @@ void main() {
 
     const TextStyle s10 = TextStyle(fontFamilyFallback: <String>[], package: 'p');
     expect(s10.fontFamilyFallback, <String>[]);
-  }, skip: isBrowser);
+  });
 
   test('TextStyle font family fallback', () {
     const TextStyle s1 = TextStyle(fontFamilyFallback: <String>['Roboto', 'test']);
@@ -238,7 +238,7 @@ void main() {
     expect(s2.apply().fontFamilyFallback, const <String>['Roboto', 'test']);
     expect(s2.apply(fontFamily: 'bar').fontFamily, 'bar');
     expect(s2.apply(fontFamilyFallback: const <String>['Banana']).fontFamilyFallback, const <String>['Banana']);
-  }, skip: isBrowser);
+  });
 
   test('TextStyle.debugLabel', () {
     const TextStyle unknown = TextStyle();

--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -178,7 +178,7 @@ void main() {
     expect(ps2, equals(ui.ParagraphStyle(textAlign: TextAlign.center, fontWeight: FontWeight.w800, fontSize: 10.0, height: 100.0)));
     final ui.ParagraphStyle ps5 = s5.getParagraphStyle();
     expect(ps5, equals(ui.ParagraphStyle(fontWeight: FontWeight.w700, fontSize: 12.0, height: 123.0)));
-  }, skip: isBrowser); // Reference needed
+  }, skip: isBrowser); // https://github.com/flutter/flutter/issues/56307
 
 
   test('TextStyle with text direction', () {
@@ -208,7 +208,7 @@ void main() {
 
     const TextStyle s10 = TextStyle(fontFamilyFallback: <String>[], package: 'p');
     expect(s10.fontFamilyFallback, <String>[]);
-  }, skip: isBrowser); // Reference needed
+  }, skip: isBrowser); // https://github.com/flutter/flutter/issues/56307
 
   test('TextStyle font family fallback', () {
     const TextStyle s1 = TextStyle(fontFamilyFallback: <String>['Roboto', 'test']);
@@ -238,7 +238,7 @@ void main() {
     expect(s2.apply().fontFamilyFallback, const <String>['Roboto', 'test']);
     expect(s2.apply(fontFamily: 'bar').fontFamily, 'bar');
     expect(s2.apply(fontFamilyFallback: const <String>['Banana']).fontFamilyFallback, const <String>['Banana']);
-  }, skip: isBrowser); // Reference needed
+  }, skip: isBrowser); // https://github.com/flutter/flutter/issues/32233
 
   test('TextStyle.debugLabel', () {
     const TextStyle unknown = TextStyle();


### PR DESCRIPTION
## Description

Continuing audit of skipped tests in the codebase.

This PR removes 35 skips, and closes out 7 TODOs.
There are 16 outstanding skips that are now notated with an appropriate issue.

## Related Issues

#32233
#32238
#41389
#42086
#44572
#56307
#56308
#56312
#56314
#56317


## Tests

Enabled!

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
