### PR TITLE
Remove button synthesis from event converter

### DIFF
--- a/packages/flutter/lib/src/gestures/converter.dart
+++ b/packages/flutter/lib/src/gestures/converter.dart
@@ -6,26 +6,6 @@ import 'dart:ui' as ui show PointerData, PointerChange, PointerSignalKind;
 
 import 'events.dart';
 
-// Add `kPrimaryButton` to [buttons] when a pointer of certain devices is down.
-//
-// TODO(tongmu): This patch is supposed to be done by embedders. Patching it
-// in framework is a workaround before [PointerEventConverter] is moved to embedders.
-// https://github.com/flutter/flutter/issues/30454
-int _synthesiseDownButtons(int buttons, PointerDeviceKind kind) {
-  switch (kind) {
-    case PointerDeviceKind.mouse:
-      return buttons;
-    case PointerDeviceKind.touch:
-    case PointerDeviceKind.stylus:
-    case PointerDeviceKind.invertedStylus:
-      return buttons | kPrimaryButton;
-    default:
-      // We have no information about the device but we know we never want
-      // buttons to be 0 when the pointer is down.
-      return buttons == 0 ? kPrimaryButton : buttons;
-  }
-}
-
 /// Converts from engine pointer data to framework pointer events.
 ///
 /// This takes [PointerDataPacket] objects, as received from the engine via
@@ -98,13 +78,14 @@ class PointerEventConverter {
             );
             break;
           case ui.PointerChange.down:
+            assert(datum.buttons != 0);
             yield PointerDownEvent(
               timeStamp: timeStamp,
               pointer: datum.pointerIdentifier,
               kind: kind,
               device: datum.device,
               position: position,
-              buttons: _synthesiseDownButtons(datum.buttons, kind),
+              buttons: datum.buttons,
               obscured: datum.obscured,
               pressure: datum.pressure,
               pressureMin: datum.pressureMin,
@@ -120,6 +101,7 @@ class PointerEventConverter {
             );
             break;
           case ui.PointerChange.move:
+            assert(datum.buttons != 0);
             yield PointerMoveEvent(
               timeStamp: timeStamp,
               pointer: datum.pointerIdentifier,
@@ -127,7 +109,7 @@ class PointerEventConverter {
               device: datum.device,
               position: position,
               delta: delta,
-              buttons: _synthesiseDownButtons(datum.buttons, kind),
+              buttons: datum.buttons,
               obscured: datum.obscured,
               pressure: datum.pressure,
               pressureMin: datum.pressureMin,

--- a/packages/flutter/test/gestures/gesture_binding_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_test.dart
@@ -35,7 +35,7 @@ void main() {
   test('Pointer tap events', () {
     const ui.PointerDataPacket packet = ui.PointerDataPacket(
       data: <ui.PointerData>[
-        ui.PointerData(change: ui.PointerChange.down),
+        ui.PointerData(change: ui.PointerChange.down, buttons: 1),
         ui.PointerData(change: ui.PointerChange.up),
       ],
     );
@@ -52,8 +52,8 @@ void main() {
   test('Pointer move events', () {
     const ui.PointerDataPacket packet = ui.PointerDataPacket(
       data: <ui.PointerData>[
-        ui.PointerData(change: ui.PointerChange.down),
-        ui.PointerData(change: ui.PointerChange.move),
+        ui.PointerData(change: ui.PointerChange.down, buttons: 1),
+        ui.PointerData(change: ui.PointerChange.move, buttons: 1),
         ui.PointerData(change: ui.PointerChange.up),
       ],
     );
@@ -101,7 +101,7 @@ void main() {
   test('Pointer cancel events', () {
     const ui.PointerDataPacket packet = ui.PointerDataPacket(
       data: <ui.PointerData>[
-        ui.PointerData(change: ui.PointerChange.down),
+        ui.PointerData(change: ui.PointerChange.down, buttons: 1),
         ui.PointerData(change: ui.PointerChange.cancel),
       ],
     );
@@ -118,7 +118,7 @@ void main() {
   test('Can cancel pointers', () {
     const ui.PointerDataPacket packet = ui.PointerDataPacket(
       data: <ui.PointerData>[
-        ui.PointerData(change: ui.PointerChange.down),
+        ui.PointerData(change: ui.PointerChange.down, buttons: 1),
         ui.PointerData(change: ui.PointerChange.up),
       ],
     );
@@ -172,129 +172,5 @@ void main() {
     expect(events.length, 2);
     expect(events[0].runtimeType, equals(PointerAddedEvent));
     expect(events[1].runtimeType, equals(PointerScrollEvent));
-  });
-
-  test('Should synthesize kPrimaryButton for touch', () {
-    final Offset location = const Offset(10.0, 10.0) * ui.window.devicePixelRatio;
-    const PointerDeviceKind kind = PointerDeviceKind.touch;
-    final ui.PointerDataPacket packet = ui.PointerDataPacket(
-      data: <ui.PointerData>[
-        ui.PointerData(change: ui.PointerChange.add, kind: kind, physicalX: location.dx, physicalY: location.dy),
-        ui.PointerData(change: ui.PointerChange.hover, kind: kind, physicalX: location.dx, physicalY: location.dy),
-        ui.PointerData(change: ui.PointerChange.down, kind: kind, physicalX: location.dx, physicalY: location.dy),
-        ui.PointerData(change: ui.PointerChange.move, kind: kind, physicalX: location.dx, physicalY: location.dy),
-        ui.PointerData(change: ui.PointerChange.up, kind: kind, physicalX: location.dx, physicalY: location.dy),
-      ],
-    );
-
-    final List<PointerEvent> events = PointerEventConverter.expand(
-      packet.data, ui.window.devicePixelRatio).toList();
-
-    expect(events.length, 5);
-    expect(events[0].runtimeType, equals(PointerAddedEvent));
-    expect(events[0].buttons, equals(0));
-    expect(events[1].runtimeType, equals(PointerHoverEvent));
-    expect(events[1].buttons, equals(0));
-    expect(events[2].runtimeType, equals(PointerDownEvent));
-    expect(events[2].buttons, equals(kPrimaryButton));
-    expect(events[3].runtimeType, equals(PointerMoveEvent));
-    expect(events[3].buttons, equals(kPrimaryButton));
-    expect(events[4].runtimeType, equals(PointerUpEvent));
-    expect(events[4].buttons, equals(0));
-  });
-
-  test('Should synthesize kPrimaryButton for stylus', () {
-    final Offset location = const Offset(10.0, 10.0) * ui.window.devicePixelRatio;
-    for (final PointerDeviceKind kind in <PointerDeviceKind>[
-      PointerDeviceKind.stylus,
-      PointerDeviceKind.invertedStylus,
-    ]) {
-
-      final ui.PointerDataPacket packet = ui.PointerDataPacket(
-        data: <ui.PointerData>[
-          ui.PointerData(change: ui.PointerChange.add, kind: kind, physicalX: location.dx, physicalY: location.dy),
-          ui.PointerData(change: ui.PointerChange.hover, kind: kind, physicalX: location.dx, physicalY: location.dy),
-          ui.PointerData(change: ui.PointerChange.down, kind: kind, physicalX: location.dx, physicalY: location.dy),
-          ui.PointerData(change: ui.PointerChange.move, buttons: kSecondaryStylusButton, kind: kind, physicalX: location.dx, physicalY: location.dy),
-          ui.PointerData(change: ui.PointerChange.up, kind: kind, physicalX: location.dx, physicalY: location.dy),
-        ],
-      );
-
-      final List<PointerEvent> events = PointerEventConverter.expand(
-        packet.data, ui.window.devicePixelRatio).toList();
-
-      expect(events.length, 5);
-      expect(events[0].runtimeType, equals(PointerAddedEvent));
-      expect(events[0].buttons, equals(0));
-      expect(events[1].runtimeType, equals(PointerHoverEvent));
-      expect(events[1].buttons, equals(0));
-      expect(events[2].runtimeType, equals(PointerDownEvent));
-      expect(events[2].buttons, equals(kPrimaryButton));
-      expect(events[3].runtimeType, equals(PointerMoveEvent));
-      expect(events[3].buttons, equals(kPrimaryButton | kSecondaryStylusButton));
-      expect(events[4].runtimeType, equals(PointerUpEvent));
-      expect(events[4].buttons, equals(0));
-    }
-  });
-
-  test('Should synthesize kPrimaryButton for unknown devices', () {
-    final Offset location = const Offset(10.0, 10.0) * ui.window.devicePixelRatio;
-    const PointerDeviceKind kind = PointerDeviceKind.unknown;
-    final ui.PointerDataPacket packet = ui.PointerDataPacket(
-      data: <ui.PointerData>[
-        ui.PointerData(change: ui.PointerChange.add, kind: kind, physicalX: location.dx, physicalY: location.dy),
-        ui.PointerData(change: ui.PointerChange.hover, kind: kind, physicalX: location.dx, physicalY: location.dy),
-        ui.PointerData(change: ui.PointerChange.down, kind: kind, physicalX: location.dx, physicalY: location.dy),
-        ui.PointerData(change: ui.PointerChange.move, kind: kind, physicalX: location.dx, physicalY: location.dy),
-        ui.PointerData(change: ui.PointerChange.up, kind: kind, physicalX: location.dx, physicalY: location.dy),
-      ],
-    );
-
-    final List<PointerEvent> events = PointerEventConverter.expand(
-      packet.data, ui.window.devicePixelRatio).toList();
-
-    expect(events.length, 5);
-    expect(events[0].runtimeType, equals(PointerAddedEvent));
-    expect(events[0].buttons, equals(0));
-    expect(events[1].runtimeType, equals(PointerHoverEvent));
-    expect(events[1].buttons, equals(0));
-    expect(events[2].runtimeType, equals(PointerDownEvent));
-    expect(events[2].buttons, equals(kPrimaryButton));
-    expect(events[3].runtimeType, equals(PointerMoveEvent));
-    expect(events[3].buttons, equals(kPrimaryButton));
-    expect(events[4].runtimeType, equals(PointerUpEvent));
-    expect(events[4].buttons, equals(0));
-  });
-
-  test('Should not synthesize kPrimaryButton for mouse', () {
-    final Offset location = const Offset(10.0, 10.0) * ui.window.devicePixelRatio;
-    for (final PointerDeviceKind kind in <PointerDeviceKind>[
-      PointerDeviceKind.mouse,
-    ]) {
-      final ui.PointerDataPacket packet = ui.PointerDataPacket(
-        data: <ui.PointerData>[
-          ui.PointerData(change: ui.PointerChange.add, kind: kind, physicalX: location.dx, physicalY: location.dy),
-          ui.PointerData(change: ui.PointerChange.hover, kind: kind, physicalX: location.dx, physicalY: location.dy),
-          ui.PointerData(change: ui.PointerChange.down, kind: kind, buttons: kMiddleMouseButton, physicalX: location.dx, physicalY: location.dy),
-          ui.PointerData(change: ui.PointerChange.move, kind: kind, buttons: kMiddleMouseButton | kSecondaryMouseButton, physicalX: location.dx, physicalY: location.dy),
-          ui.PointerData(change: ui.PointerChange.up, kind: kind, physicalX: location.dx, physicalY: location.dy),
-        ],
-      );
-
-      final List<PointerEvent> events = PointerEventConverter.expand(
-        packet.data, ui.window.devicePixelRatio).toList();
-
-      expect(events.length, 5);
-      expect(events[0].runtimeType, equals(PointerAddedEvent));
-      expect(events[0].buttons, equals(0));
-      expect(events[1].runtimeType, equals(PointerHoverEvent));
-      expect(events[1].buttons, equals(0));
-      expect(events[2].runtimeType, equals(PointerDownEvent));
-      expect(events[2].buttons, equals(kMiddleMouseButton));
-      expect(events[3].runtimeType, equals(PointerMoveEvent));
-      expect(events[3].buttons, equals(kMiddleMouseButton | kSecondaryMouseButton));
-      expect(events[4].runtimeType, equals(PointerUpEvent));
-      expect(events[4].buttons, equals(0));
-    }
   });
 }

--- a/packages/flutter/test/gestures/locking_test.dart
+++ b/packages/flutter/test/gestures/locking_test.dart
@@ -24,7 +24,7 @@ class TestGestureFlutterBinding extends BindingBase with GestureBinding {
 
   static const ui.PointerDataPacket packet = ui.PointerDataPacket(
     data: <ui.PointerData>[
-      ui.PointerData(change: ui.PointerChange.down),
+      ui.PointerData(change: ui.PointerChange.down, buttons: 0x1),
       ui.PointerData(change: ui.PointerChange.up),
     ],
   );

--- a/packages/flutter/test/rendering/mouse_tracking_test.dart
+++ b/packages/flutter/test/rendering/mouse_tracking_test.dart
@@ -254,7 +254,7 @@ void main() {
 
     ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 101.0)),
-      _pointerData(PointerChange.down, const Offset(0.0, 101.0)),
+      _pointerData(PointerChange.down, const Offset(0.0, 101.0), buttons: 1),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<PointerEvent>[
       // This Enter event is triggered by the [PointerAddedEvent] The
@@ -264,7 +264,7 @@ void main() {
     events.clear();
 
     ui.window.onPointerDataPacket(ui.PointerDataPacket(data: <ui.PointerData>[
-      _pointerData(PointerChange.move, const Offset(0.0, 201.0)),
+      _pointerData(PointerChange.move, const Offset(0.0, 201.0), buttons: 1),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<PointerEvent>[
     ]));
@@ -614,6 +614,7 @@ ui.PointerData _pointerData(
   Offset logicalPosition, {
   int device = 0,
   PointerDeviceKind kind = PointerDeviceKind.mouse,
+  int buttons = 0,
 }) {
   return ui.PointerData(
     change: change,
@@ -621,6 +622,7 @@ ui.PointerData _pointerData(
     physicalY: logicalPosition.dy * ui.window.devicePixelRatio,
     kind: kind,
     device: device,
+    buttons: buttons,
   );
 }
 


### PR DESCRIPTION
## Description

This PR removes a workaround, which was added because some events used to have `buttons: 0` incorrectly (https://github.com/flutter/flutter/issues/30454). Related tests are fixed or removed.

## Related Issues

- https://github.com/flutter/flutter/pull/55789
- #30454

## Tests

No tests are added. Some tests are removed because framework no longer provides button synthesis.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
