### PR TITLE
restore quit timeout, adjust some integration test behaviors

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_attach_test_android.dart
+++ b/dev/devicelab/bin/tasks/flutter_attach_test_android.dart
@@ -56,6 +56,7 @@ Future<void> testReload(Process process, { Future<void> Function() onListening }
     return Future.any<dynamic>(<Future<dynamic>>[
       event,
       process.exitCode,
+      // Keep the test from running for 15 minutes if it gets stuck.
       Future<void>.delayed(const Duration(seconds: 10)),
     ]);
   }

--- a/dev/devicelab/bin/tasks/flutter_attach_test_android.dart
+++ b/dev/devicelab/bin/tasks/flutter_attach_test_android.dart
@@ -53,7 +53,11 @@ Future<void> testReload(Process process, { Future<void> Function() onListening }
   process.exitCode.then<void>((int processExitCode) { exitCode = processExitCode; });
 
   Future<dynamic> eventOrExit(Future<void> event) {
-    return Future.any<dynamic>(<Future<dynamic>>[ event, process.exitCode ]);
+    return Future.any<dynamic>(<Future<dynamic>>[
+      event,
+      process.exitCode,
+      Future<void>.delayed(const Duration(seconds: 10)),
+    ]);
   }
 
   await eventOrExit(listening.future);
@@ -63,13 +67,16 @@ Future<void> testReload(Process process, { Future<void> Function() onListening }
     throw TaskResult.failure('Failed to attach to test app; command unexpected exited, with exit code $exitCode.');
 
   process.stdin.write('r');
-  process.stdin.flush();
+  print('run:stdin: r');
+  await process.stdin.flush();
   await eventOrExit(reloaded.future);
   process.stdin.write('R');
-  process.stdin.flush();
+  print('run:stdin: R');
+  await process.stdin.flush();
   await eventOrExit(restarted.future);
   process.stdin.write('q');
-  process.stdin.flush();
+  print('run:stdin: q');
+  await process.stdin.flush();
   await eventOrExit(finished.future);
 
   await process.exitCode;

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -226,7 +226,7 @@ class FlutterDevice {
     return completer.future;
   }
 
-  // TODO(jonahwilliams): remove once all callsites are updated.
+  // f: remove once all callsites are updated.
   VMService get flutterDeprecatedVmService => vmService as VMService;
 
   Future<void> refreshViews() async {
@@ -286,10 +286,19 @@ class FlutterDevice {
         ));
       }
     }
-    // TODO(jonahwilliams): this only seems to fail on CI.
-    return vmService.onDone.timeout(const Duration(seconds: 2), onTimeout: () {
-      globals.logger.printTrace('error: vm service shutdown failed');
-    });
+    return vmService.onDone
+      .onError((dynamic error, StackTrace stackTrace) {
+        globals.logger.printError(
+          'unhanlded error waiting for vm service exit:\n $error',
+          stackTrace: stackTrace,
+         );
+      })
+      .timeout(const Duration(seconds: 2), onTimeout: () {
+        // TODO(jonahwilliams): this only seems to fail on CI in the
+        // flutter_attach_android_test. This log should help verify this
+        // is where the tool is getting stuck.
+        globals.logger.printTrace('error: vm service shutdown failed');
+      });
   }
 
   Future<Uri> setupDevFS(

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -286,7 +286,10 @@ class FlutterDevice {
         ));
       }
     }
-    return vmService.onDone;
+    // TODO(jonahwilliams): this only seems to fail on CI.
+    return vmService.onDone.timeout(const Duration(seconds: 2), onTimeout: () {
+      globals.logger.printTrace('error: vm service shutdown failed');
+    });
   }
 
   Future<Uri> setupDevFS(

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -287,7 +287,7 @@ class FlutterDevice {
       }
     }
     return vmService.onDone
-      .onError((dynamic error, StackTrace stackTrace) {
+      .catchError((dynamic error, StackTrace stackTrace) {
         globals.logger.printError(
           'unhanlded error waiting for vm service exit:\n $error',
           stackTrace: stackTrace,

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -226,7 +226,7 @@ class FlutterDevice {
     return completer.future;
   }
 
-  // f: remove once all callsites are updated.
+  // TODO(jonahwilliams): remove once all callsites are updated.
   VMService get flutterDeprecatedVmService => vmService as VMService;
 
   Future<void> refreshViews() async {


### PR DESCRIPTION
## Description

Trying to diagnose the cause of the flutter_attach_test_android failure on CI. this does not repro locally. Add back the timeout and verify if the vm service is not closing.