### PR TITLE
 Fix: When the input box supports expressions, there will be one more character and cursor migration problem when the length is limited.

### DIFF
--- a/packages/flutter/lib/src/services/text_formatter.dart
+++ b/packages/flutter/lib/src/services/text_formatter.dart
@@ -214,6 +214,71 @@ class LengthLimitingTextInputFormatter extends TextInputFormatter {
   }
 }
 
+///Used to support the problem of limiting the maximum length when there is an emoji in the input box
+///author: linsixudream@163.com
+///data: April 28, 2020
+///defect：When the maximum length is reached, the cursor will move after the last character. Temporarily unable to resolve
+class EmojiLengthLimitingTextInputFormatter extends TextInputFormatter {
+  EmojiTextLengthLimitingTextInputFormatter(this.maxLength) : assert(maxLength == null || maxLength == -1 || maxLength > 0);
+
+  final int maxLength;
+
+  bool hasAlreadyMaxLength = false;
+
+  @override
+  TextEditingValue formatEditUpdate(
+      TextEditingValue oldValue, // unused.
+      TextEditingValue newValue,
+      ) {
+    hasAlreadyMaxLength = oldValue.text.length >= maxLength && newValue.text.length >= maxLength;
+    if (!hasAlreadyMaxLength && maxLength != null && maxLength > 0 && newValue.text.runes.length >= maxLength) {
+      return _resetSelection(newValue);
+    } else if (hasAlreadyMaxLength && maxLength != null && maxLength > 0 && newValue.text.runes.length >= maxLength) {
+      return _initOldDataSelection(oldValue, newValue);
+    } else {
+      return newValue;
+    }
+  }
+
+  TextEditingValue _resetSelection(TextEditingValue newValue) {
+    hasAlreadyMaxLength = true;
+    var sRunes = newValue.text.runes;
+    String result;
+    int i = 0;
+    for (i = 0; i < sRunes.length; i++) {
+      if (String.fromCharCodes(sRunes, 0, sRunes.length - i).length <= maxLength) {
+        result = String.fromCharCodes(sRunes, 0, sRunes.length - i);
+        if (result.runes.last == 105) {
+          //If there is a space left after deletion, continue to delete
+          result = String.fromCharCodes(result.runes, 0, result.runes.length - 1);
+        }
+        break;
+      }
+    }
+    TextSelection temp = newValue.selection.copyWith(
+      baseOffset: result.length,
+      extentOffset: result.length,
+    );
+    TextRange fixRange = newValue.composing;
+    if (newValue.composing.end > result.length) {
+      fixRange = TextRange(start: fixRange.start - i, end: result.length);
+    }
+    return TextEditingValue(text: result, selection: temp, composing: fixRange);
+  }
+
+  TextEditingValue _initOldDataSelection(TextEditingValue oldValue, TextEditingValue newValue) {
+    TextSelection actualSelection = newValue.selection;
+    actualSelection = newValue.selection.copyWith(
+      baseOffset: oldValue.text.length,
+      extentOffset: oldValue.text.length,
+    );
+    //ios:When TextRange is not -1, next time update will discard all the variable values ​​directly from start and end.
+    // When you are sure that the content is unchanged, please change them to -1
+    TextRange fixRange = TextRange(start: -1, end: -1);
+    return TextEditingValue(text: oldValue.text, selection: actualSelection, composing: fixRange);
+  }
+}
+
 /// A [TextInputFormatter] that allows only the insertion of whitelisted
 /// characters patterns.
 ///

--- a/packages/flutter/lib/src/services/text_formatter.dart
+++ b/packages/flutter/lib/src/services/text_formatter.dart
@@ -219,7 +219,7 @@ class LengthLimitingTextInputFormatter extends TextInputFormatter {
 ///data: April 28, 2020
 ///defect：When the maximum length is reached, the cursor will move after the last character. Temporarily unable to resolve
 class EmojiLengthLimitingTextInputFormatter extends TextInputFormatter {
-  EmojiTextLengthLimitingTextInputFormatter(this.maxLength) : assert(maxLength == null || maxLength == -1 || maxLength > 0);
+  EmojiLengthLimitingTextInputFormatter(this.maxLength) : assert(maxLength == null || maxLength == -1 || maxLength > 0);
 
   final int maxLength;
 


### PR DESCRIPTION
## Description

When the input box supports emoticons, when we have text and emoticons in the input box at the same time, there will be abnormal text length and cursor. For example, maxLength = 15, when there is an emoticon in the input box, the length of the text in the input box can reach 16, and then the cursor will automatically move one bit.

中文描述：
输入框支持表情时候，当我们输入框中同时存在文字与表情符号时候，会出现文字长度与光标异常。例如，maxLength= 15，当输入框中有表情符号时候，输入框的文案长度可以达到16，然后光标会自动迁移一位。

## Related Issues
https://github.com/flutter/flutter/issues/55670

## Tests
1. Normal characters do not contain expressions, normal
2. Normal characters contain expressions, normal
3. The maximum length can be just right

#### flutter version
Flutter 1.12.13+hotfix.7 • channel