### PR TITLE
Mark flutter_gallery_v2_chrome_run_test and flutter_gallery_v2_web_compile_test not flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -831,4 +831,3 @@ tasks:
       and the size of the compiled code.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
-    flaky: true

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -824,7 +824,6 @@ tasks:
       Checks that the New Flutter Gallery runs successfully on Chrome.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
-    flaky: true
 
   flutter_gallery_v2_web_compile_test:
     description: >


### PR DESCRIPTION
## Description

Looks stable.

## Related Issues

Introduced in https://github.com/flutter/flutter/pull/53096

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*