### PR TITLE
[flutter_tools] Make packages not required for local engine

### DIFF
--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -152,7 +152,7 @@ class _ManifestAssetBundle implements AssetBundle {
     }
 
     final String assetBasePath = globals.fs.path.dirname(globals.fs.path.absolute(manifestPath));
-    final PackageConfig packageConfig = await loadPackageConfigOrFail(
+    final PackageConfig packageConfig = await loadPackageConfigWithLogging(
       globals.fs.file(packagesPath),
       logger: globals.logger,
     );

--- a/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
@@ -154,7 +154,7 @@ class WebAssetServer implements AssetReader {
         address = (await InternetAddress.lookup(hostname)).first;
       }
       final HttpServer httpServer = await HttpServer.bind(address, port);
-      final PackageConfig packageConfig = await loadPackageConfigOrFail(
+      final PackageConfig packageConfig = await loadPackageConfigWithLogging(
         globals.fs.file(globalPackagesPath),
         logger: globals.logger,
       );

--- a/packages/flutter_tools/lib/src/build_system/targets/dart.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/dart.dart
@@ -231,7 +231,7 @@ class KernelSnapshot extends Target {
         forceLinkPlatform = false;
     }
 
-    final PackageConfig packageConfig = await loadPackageConfigOrFail(
+    final PackageConfig packageConfig = await loadPackageConfigWithLogging(
       environment.projectDir.childFile('.packages'),
       logger: environment.logger,
     );

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -62,7 +62,7 @@ class WebEntrypointTarget extends Target {
     final bool shouldInitializePlatform = environment.defines[kInitializePlatform] == 'true';
     final bool hasPlugins = environment.defines[kHasWebPlugins] == 'true';
     final Uri importUri = environment.fileSystem.file(targetFile).absolute.uri;
-    final PackageConfig packageConfig = await loadPackageConfigOrFail(
+    final PackageConfig packageConfig = await loadPackageConfigWithLogging(
       environment.projectDir.childFile('.packages'),
       logger: environment.logger,
     );

--- a/packages/flutter_tools/lib/src/dart/package_map.dart
+++ b/packages/flutter_tools/lib/src/dart/package_map.dart
@@ -25,8 +25,12 @@ String _globalPackagesPath;
 
 /// Load the package configuration from [file] or throws a [ToolExit]
 /// if the operation would fail.
-Future<PackageConfig> loadPackageConfigOrFail(File file, {
+///
+/// If [nonFatal] is true, in the event of an error an empty package
+/// config is returned.
+Future<PackageConfig> loadPackageConfigWithLogging(File file, {
   @required Logger logger,
+  bool nonFatal = false,
 }) {
   final FileSystem fileSystem = file.fileSystem;
   return loadPackageConfigUri(
@@ -39,6 +43,9 @@ Future<PackageConfig> loadPackageConfigOrFail(File file, {
       return Future<Uint8List>.value(configFile.readAsBytesSync());
     },
     onError: (dynamic error) {
+      if (nonFatal) {
+        return;
+      }
       logger.printTrace(error.toString());
       String message = '${file.path} does not exist.';
       final String pubspecPath = fileSystem.path.absolute(fileSystem.path.dirname(file.path), 'pubspec.yaml');

--- a/packages/flutter_tools/lib/src/dart/package_map.dart
+++ b/packages/flutter_tools/lib/src/dart/package_map.dart
@@ -30,7 +30,7 @@ String _globalPackagesPath;
 /// config is returned.
 Future<PackageConfig> loadPackageConfigWithLogging(File file, {
   @required Logger logger,
-  bool nonFatal = false,
+  bool throwOnError = true,
 }) {
   final FileSystem fileSystem = file.fileSystem;
   return loadPackageConfigUri(
@@ -43,7 +43,7 @@ Future<PackageConfig> loadPackageConfigWithLogging(File file, {
       return Future<Uint8List>.value(configFile.readAsBytesSync());
     },
     onError: (dynamic error) {
-      if (nonFatal) {
+      if (!throwOnError) {
         return;
       }
       logger.printTrace(error.toString());

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -305,7 +305,7 @@ Future<List<Plugin>> findPlugins(FlutterProject project) async {
     project.directory.path,
     globalPackagesPath,
   );
-  final PackageConfig packageConfig = await loadPackageConfigOrFail(
+  final PackageConfig packageConfig = await loadPackageConfigWithLogging(
     globals.fs.file(packagesFile),
     logger: globals.logger,
   );

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -157,7 +157,7 @@ class HotRunner extends ResidentRunner {
     final Stopwatch stopwatch = Stopwatch()..start();
     final UpdateFSReport results = UpdateFSReport(success: true);
     final List<Uri> invalidated =  <Uri>[Uri.parse(libraryId)];
-    final PackageConfig packageConfig = await loadPackageConfigOrFail(
+    final PackageConfig packageConfig = await loadPackageConfigWithLogging(
       globals.fs.file(globalPackagesPath),
       logger: globals.logger,
     );
@@ -355,7 +355,7 @@ class HotRunner extends ResidentRunner {
     firstBuildTime = DateTime.now();
 
     final List<Future<bool>> startupTasks = <Future<bool>>[];
-    final PackageConfig packageConfig = await loadPackageConfigOrFail(
+    final PackageConfig packageConfig = await loadPackageConfigWithLogging(
       globals.fs.file(globalPackagesPath),
       logger: globals.logger,
     );
@@ -1300,7 +1300,7 @@ class ProjectFileInvalidator {
   }
 
   Future<PackageConfig> _createPackageConfig(String packagesPath) {
-    return loadPackageConfigOrFail(
+    return loadPackageConfigWithLogging(
       _fileSystem.file(globalPackagesPath),
       logger: _logger,
     );

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -357,6 +357,7 @@ class FlutterCommandRunner extends CommandRunner<void> {
         final PackageConfig packageConfig = await loadPackageConfigWithLogging(
           globals.fs.file(globalPackagesPath),
           logger: globals.logger,
+          throwOnError: false,
         );
         Uri engineUri = packageConfig[kFlutterEnginePackageName]?.packageUriRoot;
         // Skip if sky_engine is the self-contained one.

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -354,7 +354,7 @@ class FlutterCommandRunner extends CommandRunner<void> {
 
     if (engineSourcePath == null && globalResults['local-engine'] != null) {
       try {
-        final PackageConfig packageConfig = await loadPackageConfigOrFail(
+        final PackageConfig packageConfig = await loadPackageConfigWithLogging(
           globals.fs.file(globalPackagesPath),
           logger: globals.logger,
         );

--- a/packages/flutter_tools/lib/src/template.dart
+++ b/packages/flutter_tools/lib/src/template.dart
@@ -249,7 +249,7 @@ Future<Directory> _templateImageDirectory(String name, FileSystem fileSystem) as
   if (!fileSystem.file(packageFilePath).existsSync()) {
     await _ensurePackageDependencies(toolPackagePath);
   }
-  final PackageConfig packageConfig = await loadPackageConfigOrFail(
+  final PackageConfig packageConfig = await loadPackageConfigWithLogging(
     fileSystem.file(packageFilePath),
     logger: globals.logger,
   );

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -97,12 +97,12 @@ class FlutterWebPlatform extends PlatformPlugin {
     );
   }
 
-  final Future<PackageConfig> _packagesFuture = loadPackageConfigOrFail(
+  final Future<PackageConfig> _packagesFuture = loadPackageConfigWithLogging(
     globals.fs.file(globalPackagesPath),
     logger: globals.logger,
   );
 
-  final Future<PackageConfig> _flutterToolsPackageMap = loadPackageConfigOrFail(
+  final Future<PackageConfig> _flutterToolsPackageMap = loadPackageConfigWithLogging(
     globals.fs.file(globals.fs.path.join(
       Cache.flutterRoot,
       'packages',

--- a/packages/flutter_tools/lib/src/test/test_compiler.dart
+++ b/packages/flutter_tools/lib/src/test/test_compiler.dart
@@ -129,7 +129,7 @@ class TestCompiler {
     if (!isEmpty) {
       return;
     }
-    _packageConfig ??= await loadPackageConfigOrFail(
+    _packageConfig ??= await loadPackageConfigWithLogging(
       globals.fs.file(globalPackagesPath),
       logger: globals.logger,
     );

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
@@ -131,7 +131,6 @@ void main() {
       }, initializeFlutterRoot: false);
 
       testUsingContext('works if --local-engine is specified and --local-engine-src-path is specified', () async {
-        fs.file(_kDotPackages).writeAsStringSync('\n');
         fs.directory('$_kArbitraryEngineRoot/src/out/ios_debug').createSync(recursive: true);
         fs.directory('$_kArbitraryEngineRoot/src/out/host_debug').createSync(recursive: true);
 

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
@@ -131,6 +131,7 @@ void main() {
       }, initializeFlutterRoot: false);
 
       testUsingContext('works if --local-engine is specified and --local-engine-src-path is specified', () async {
+        // Intentionally do not create a package_config to verify that it is not required.
         fs.directory('$_kArbitraryEngineRoot/src/out/ios_debug').createSync(recursive: true);
         fs.directory('$_kArbitraryEngineRoot/src/out/host_debug').createSync(recursive: true);
 


### PR DESCRIPTION
## Description

A package_config file is not required for all commands, but some commands were made to require one when the --local-engine flag was provided. Revert this change and add a comment to the test to ensure it doesn't get accidentally updated again.