### PR TITLE
[gen_l10n] Fix unintended breaking change introduced by output-dir option

### DIFF
--- a/dev/tools/localization/bin/gen_l10n.dart
+++ b/dev/tools/localization/bin/gen_l10n.dart
@@ -132,7 +132,7 @@ void main(List<String> arguments) {
     localizationsGenerator
       ..initialize(
         inputPathString: inputPathString,
-        outputPathString: outputPathString ?? inputPathString,
+        outputPathString: outputPathString,
         templateArbFileName: templateArbFileName,
         outputFileString: outputFileString,
         classNameString: classNameString,

--- a/dev/tools/localization/bin/gen_l10n.dart
+++ b/dev/tools/localization/bin/gen_l10n.dart
@@ -27,10 +27,10 @@ void main(List<String> arguments) {
   );
   parser.addOption(
     'output-dir',
-    defaultsTo: path.join('lib', 'l10n'),
     help: 'The directory where the generated localization classes will be written. '
       'The app must import the file specified in the \'output-localization-file\' '
-      'option from this directory.'
+      'option from this directory. If unspecified, this defaults to the same '
+      'directory as the input directory specified in \'arb-dir\'.'
   );
   parser.addOption(
     'template-arb-file',
@@ -132,7 +132,7 @@ void main(List<String> arguments) {
     localizationsGenerator
       ..initialize(
         inputPathString: inputPathString,
-        outputPathString: outputPathString,
+        outputPathString: outputPathString ?? inputPathString,
         templateArbFileName: templateArbFileName,
         outputFileString: outputFileString,
         classNameString: classNameString,

--- a/dev/tools/localization/gen_l10n.dart
+++ b/dev/tools/localization/gen_l10n.dart
@@ -511,7 +511,7 @@ class LocalizationsGenerator {
     bool useDeferredLoading = false,
   }) {
     setInputDirectory(inputPathString);
-    setOutputDirectory(outputPathString);
+    setOutputDirectory(outputPathString ?? inputPathString);
     setTemplateArbFile(templateArbFileName);
     setOutputFile(outputFileString);
     setPreferredSupportedLocales(preferredSupportedLocaleString);

--- a/dev/tools/test/localization/gen_l10n_test.dart
+++ b/dev/tools/test/localization/gen_l10n_test.dart
@@ -346,6 +346,30 @@ void main() {
     expect(unimplementedOutputString, contains('subtitle'));
   });
 
+  test('uses inputPathString as outputPathString when the outputPathString is null', () {
+    _standardFlutterDirectoryL10nSetup(fs);
+    LocalizationsGenerator generator;
+    try {
+      generator = LocalizationsGenerator(fs);
+      generator
+        ..initialize(
+          inputPathString: defaultL10nPathString,
+          templateArbFileName: defaultTemplateArbFileName,
+          outputFileString: defaultOutputFileString,
+          classNameString: defaultClassNameString,
+        )
+        ..loadResources()
+        ..writeOutputFile();
+    } on L10nException catch (e) {
+      fail('Generating output should not fail: \n${e.message}');
+    }
+
+    final Directory outputDirectory = fs.directory('lib').childDirectory('l10n');
+    expect(outputDirectory.childFile('output-localization-file.dart').existsSync(), isTrue);
+    expect(outputDirectory.childFile('output-localization-file_en.dart').existsSync(), isTrue);
+    expect(outputDirectory.childFile('output-localization-file_es.dart').existsSync(), isTrue);
+  });
+
   test('correctly generates output files in non-default output directory if it already exists', () {
   final Directory l10nDirectory = fs.currentDirectory
     .childDirectory('lib')


### PR DESCRIPTION
## Description

Fixes an unintended breaking change introduced by https://github.com/flutter/flutter/pull/55792, which introduced an output-dir option. If `arb-dir` is a custom value, existing users of the `gen_l10n` tool would realize that their output-dir defaults to `lib/l10n` instead of the input directory. This behavior is a breaking change and likely undesired by most users. This PR introduced a fix to make sure that the output-dir is always the input-dir by default.

## Tests

I added the following tests:
- A test to ensure that the gen_l10n tool defaults to using the input directory as the output directory if unspecified.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
