### PR TITLE
[flutter_tools] simplify hot reload integration tests

### DIFF
--- a/packages/flutter_tools/test/integration.shard/hot_reload_test.dart
+++ b/packages/flutter_tools/test/integration.shard/hot_reload_test.dart
@@ -7,163 +7,120 @@ import 'dart:async';
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:vm_service/vm_service.dart';
 
 import '../src/common.dart';
 import 'test_data/hot_reload_project.dart';
 import 'test_driver.dart';
 import 'test_utils.dart';
 
+final HotReloadProject project = HotReloadProject();
+
 void main() {
   Directory tempDir;
-  final HotReloadProject _project = HotReloadProject();
-  FlutterRunTestDriver _flutter;
+  FlutterRunTestDriver flutter;
 
   setUp(() async {
     tempDir = createResolvedTempDirectorySync('hot_reload_test.');
-    await _project.setUpIn(tempDir);
-    _flutter = FlutterRunTestDriver(tempDir);
+    await project.setUpIn(tempDir);
+    flutter = FlutterRunTestDriver(tempDir);
   });
 
   tearDown(() async {
-    await _flutter?.stop();
+    await flutter?.stop();
     tryToDelete(tempDir);
   });
 
   test('hot reload works without error', () async {
-    await _flutter.run();
-    await _flutter.hotReload();
-  });
-
-  test('newly added code executes during hot reload', () async {
-    final StringBuffer stdout = StringBuffer();
-    final StreamSubscription<String> subscription = _flutter.stdout.listen(stdout.writeln);
-    await _flutter.run();
-    _project.uncommentHotReloadPrint();
-    try {
-      await _flutter.hotReload();
-      expect(stdout.toString(), contains('(((((RELOAD WORKED)))))'));
-    } finally {
-      await subscription.cancel();
-    }
-  });
-
-  test('reloadMethod triggers hot reload behavior', () async {
-    final StringBuffer stdout = StringBuffer();
-    final StreamSubscription<String> subscription = _flutter.stdout.listen(stdout.writeln);
-    await _flutter.run();
-    _project.uncommentHotReloadPrint();
-    try {
-      final String libraryId = _project.buildBreakpointUri.toString();
-      await _flutter.reloadMethod(libraryId: libraryId, classId: 'MyApp');
-      // reloadMethod does not wait for the next frame, to allow scheduling a new
-      // update while the previous update was pending.
-      await Future<void>.delayed(const Duration(seconds: 1));
-      expect(stdout.toString(), contains('(((((RELOAD WORKED)))))'));
-    } finally {
-      await subscription.cancel();
-    }
+    await flutter.run();
+    await flutter.hotReload();
   });
 
   test('hot restart works without error', () async {
-    await _flutter.run();
-    await _flutter.hotRestart();
+    await flutter.run();
+    await flutter.hotRestart();
+  });
+
+  test('newly added code executes during hot reload', () async {
+    await flutter.run();
+
+    project.uncommentHotReloadPrint();
+    unawaited(flutter.hotReload());
+
+    await expectLater(flutter.stdout,
+      emitsThrough(contains('(((((RELOAD WORKED)))))')));
+  });
+
+  test('reloadMethod triggers hot reload behavior', () async {
+    await flutter.run();
+
+    project.uncommentHotReloadPrint();
+    final String libraryId = project.buildBreakpointUri.toString();
+    unawaited(flutter.reloadMethod(libraryId: libraryId, classId: 'MyApp'));
+
+    await expectLater(flutter.stdout,
+      emitsThrough(contains('(((((RELOAD WORKED)))))')));
   });
 
   test('breakpoints are hit after hot reload', () async {
-    Isolate isolate;
-    final Completer<void> sawTick1 = Completer<void>();
-    final Completer<void> sawDebuggerPausedMessage = Completer<void>();
-    final StreamSubscription<String> subscription = _flutter.stdout.listen(
-      (String line) {
-        if (line.contains('((((TICK 1))))')) {
-          expect(sawTick1.isCompleted, isFalse);
-          sawTick1.complete();
-        }
-        if (line.contains('The application is paused in the debugger on a breakpoint.')) {
-          expect(sawDebuggerPausedMessage.isCompleted, isFalse);
-          sawDebuggerPausedMessage.complete();
-        }
-      },
+    final Future<void> didStart = flutter.run(withDebugger: true);
+    await expectLater(flutter.stdout,
+      emitsThrough(contains('((((TICK 1))))')));
+
+    // Add first breakpoint and verify it is set.
+    await didStart;
+    await flutter.addBreakpoint(
+      project.scheduledBreakpointUri,
+      project.scheduledBreakpointLine,
     );
-    await _flutter.run(withDebugger: true, startPaused: true);
-    await _flutter.resume(); // we start paused so we can set up our TICK 1 listener before the app starts
-    unawaited(sawTick1.future.timeout(
-      const Duration(seconds: 5),
-      onTimeout: () { print('The test app is taking longer than expected to print its synchronization line...'); },
-    ));
-    await sawTick1.future; // after this, app is in steady state
-    await _flutter.addBreakpoint(
-      _project.scheduledBreakpointUri,
-      _project.scheduledBreakpointLine,
+
+    // reload triggers code which eventually hits the breakpoint
+    await flutter.hotReload();
+    await flutter.waitForPause();
+
+    // Resume and add a breakpoint to the build method.
+    await flutter.resume();
+    await flutter.addBreakpoint(
+      project.buildBreakpointUri,
+      project.buildBreakpointLine,
     );
-    await Future<void>.delayed(const Duration(seconds: 2));
-    await _flutter.hotReload(); // reload triggers code which eventually hits the breakpoint
-    isolate = await _flutter.waitForPause();
-    expect(isolate.pauseEvent.kind, equals(EventKind.kPauseBreakpoint));
-    await _flutter.resume();
-    await _flutter.addBreakpoint(
-      _project.buildBreakpointUri,
-      _project.buildBreakpointLine,
-    );
-    bool reloaded = false;
-    final Future<void> reloadFuture = _flutter.hotReload().then((void value) { reloaded = true; });
-    print('waiting for pause...');
-    isolate = await _flutter.waitForPause();
-    expect(isolate.pauseEvent.kind, equals(EventKind.kPauseBreakpoint));
-    print('waiting for debugger message...');
-    await sawDebuggerPausedMessage.future;
-    expect(reloaded, isFalse);
-    print('waiting for resume...');
-    await _flutter.resume();
-    print('waiting for reload future...');
-    await reloadFuture;
-    expect(reloaded, isTrue);
-    reloaded = false;
-    print('subscription cancel...');
-    await subscription.cancel();
+
+    // Start a hot reload and verify that we pause.
+    final Future<void> pendingHotReload = flutter.hotReload();
+
+    await expectLater(flutter.stdout, emitsThrough(contains(
+      'The application is paused in the debugger on a breakpoint.'
+    )));
+    await flutter.waitForPause();
+
+    // Verify that a resume leads to hot reload completion.
+    await flutter.resume();
+    await expectLater(pendingHotReload, completes);
   });
 
-  test("hot reload doesn't reassemble if paused", () async {
-    final Completer<void> sawTick1 = Completer<void>();
-    final Completer<void> sawDebuggerPausedMessage1 = Completer<void>();
-    final Completer<void> sawDebuggerPausedMessage2 = Completer<void>();
-    final StreamSubscription<String> subscription = _flutter.stdout.listen(
-      (String line) {
-        print('[LOG]:"$line"');
-        if (line.contains('(((TICK 1)))')) {
-          expect(sawTick1.isCompleted, isFalse);
-          sawTick1.complete();
-        }
-        if (line.contains('The application is paused in the debugger on a breakpoint.')) {
-          expect(sawDebuggerPausedMessage1.isCompleted, isFalse);
-          sawDebuggerPausedMessage1.complete();
-        }
-        if (line.contains('The application is paused in the debugger on a breakpoint; interface might not update.')) {
-          expect(sawDebuggerPausedMessage2.isCompleted, isFalse);
-          sawDebuggerPausedMessage2.complete();
-        }
-      },
+  test('hot reload does not reassemble if paused', () async {
+    final Future<void> didStart = flutter.run(withDebugger: true);
+
+    await expectLater(flutter.stdout,
+      emitsThrough(contains('((((TICK 1))))')));
+
+    await didStart;
+    await flutter.addBreakpoint(
+      project.buildBreakpointUri,
+      project.buildBreakpointLine,
     );
-    await _flutter.run(withDebugger: true);
-    await Future<void>.delayed(const Duration(seconds: 1));
-    await sawTick1.future;
-    await _flutter.addBreakpoint(
-      _project.buildBreakpointUri,
-      _project.buildBreakpointLine,
-    );
-    bool reloaded = false;
-    await Future<void>.delayed(const Duration(seconds: 1));
-    final Future<void> reloadFuture = _flutter.hotReload().then((void value) { reloaded = true; });
-    final Isolate isolate = await _flutter.waitForPause();
-    expect(isolate.pauseEvent.kind, equals(EventKind.kPauseBreakpoint));
-    expect(reloaded, isFalse);
-    await sawDebuggerPausedMessage1.future; // this is the one where it say "uh, you broke into the debugger while reloading"
-    await reloadFuture; // this is the one where it times out because you're in the debugger
-    expect(reloaded, isTrue);
-    await _flutter.hotReload(); // now we're already paused
-    await sawDebuggerPausedMessage2.future; // so we just get told that nothing is going to happen
-    await _flutter.resume();
-    await subscription.cancel();
+
+    final Future<void> pendingHotReload = flutter.hotReload();
+    await expectLater(flutter.stdout, emitsThrough(contains(
+      'The application is paused in the debugger on a breakpoint.'
+    )));
+    await expectLater(pendingHotReload, completes);
+
+    unawaited(flutter.hotReload());
+
+    await expectLater(flutter.stdout, emitsThrough(contains(
+      'The application is paused in the debugger on a breakpoint; '
+      'interface might not update.'
+    )));
+    await flutter.resume();
   });
 }

--- a/packages/flutter_tools/test/integration.shard/hot_reload_test.dart
+++ b/packages/flutter_tools/test/integration.shard/hot_reload_test.dart
@@ -30,17 +30,17 @@ void main() {
     tryToDelete(tempDir);
   });
 
-  test('hot reload works without error', () async {
+  testWithoutContext('hot reload works without error', () async {
     await flutter.run();
     await flutter.hotReload();
   });
 
-  test('hot restart works without error', () async {
+  testWithoutContext('hot restart works without error', () async {
     await flutter.run();
     await flutter.hotRestart();
   });
 
-  test('newly added code executes during hot reload', () async {
+  testWithoutContext('newly added code executes during hot reload', () async {
     await flutter.run();
 
     project.uncommentHotReloadPrint();
@@ -50,7 +50,7 @@ void main() {
       emitsThrough(contains('(((((RELOAD WORKED)))))')));
   });
 
-  test('reloadMethod triggers hot reload behavior', () async {
+  testWithoutContext('reloadMethod triggers hot reload behavior', () async {
     await flutter.run();
 
     project.uncommentHotReloadPrint();
@@ -61,7 +61,7 @@ void main() {
       emitsThrough(contains('(((((RELOAD WORKED)))))')));
   });
 
-  test('breakpoints are hit after hot reload', () async {
+  testWithoutContext('breakpoints are hit after hot reload', () async {
     final Future<void> didStart = flutter.run(withDebugger: true);
     await expectLater(flutter.stdout,
       emitsThrough(contains('((((TICK 1))))')));
@@ -97,7 +97,7 @@ void main() {
     await expectLater(pendingHotReload, completes);
   });
 
-  test('hot reload does not reassemble if paused', () async {
+  testWithoutContext('hot reload does not reassemble if paused', () async {
     final Future<void> didStart = flutter.run(withDebugger: true);
 
     await expectLater(flutter.stdout,

--- a/packages/flutter_tools/test/integration.shard/hot_reload_test.dart
+++ b/packages/flutter_tools/test/integration.shard/hot_reload_test.dart
@@ -30,17 +30,17 @@ void main() {
     tryToDelete(tempDir);
   });
 
-  testWithoutContext('hot reload works without error', () async {
+  test('hot reload works without error', () async {
     await flutter.run();
     await flutter.hotReload();
   });
 
-  testWithoutContext('hot restart works without error', () async {
+  test('hot restart works without error', () async {
     await flutter.run();
     await flutter.hotRestart();
   });
 
-  testWithoutContext('newly added code executes during hot reload', () async {
+  test('newly added code executes during hot reload', () async {
     await flutter.run();
 
     project.uncommentHotReloadPrint();
@@ -50,7 +50,7 @@ void main() {
       emitsThrough(contains('(((((RELOAD WORKED)))))')));
   });
 
-  testWithoutContext('reloadMethod triggers hot reload behavior', () async {
+  test('reloadMethod triggers hot reload behavior', () async {
     await flutter.run();
 
     project.uncommentHotReloadPrint();
@@ -61,7 +61,7 @@ void main() {
       emitsThrough(contains('(((((RELOAD WORKED)))))')));
   });
 
-  testWithoutContext('breakpoints are hit after hot reload', () async {
+  test('breakpoints are hit after hot reload', () async {
     final Future<void> didStart = flutter.run(withDebugger: true);
     await expectLater(flutter.stdout,
       emitsThrough(contains('((((TICK 1))))')));
@@ -97,7 +97,7 @@ void main() {
     await expectLater(pendingHotReload, completes);
   });
 
-  testWithoutContext('hot reload does not reassemble if paused', () async {
+  test('hot reload does not reassemble if paused', () async {
     final Future<void> didStart = flutter.run(withDebugger: true);
 
     await expectLater(flutter.stdout,

--- a/packages/flutter_tools/test/integration.shard/test_data/background_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/background_project.dart
@@ -103,6 +103,10 @@ class RepeatingBackgroundProject extends Project {
 
   void updateTestIsolatePhrase(String message) {
     final String newMainContents = main.replaceFirst('Isolate thread', message);
-    writeFile(globals.fs.path.join(dir.path, 'lib', 'main.dart'), newMainContents);
+    writeFile(
+      globals.fs.path.join(dir.path, 'lib', 'main.dart'),
+      newMainContents,
+      sendToFuture: true,
+    );
   }
 }

--- a/packages/flutter_tools/test/integration.shard/test_data/hot_reload_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/hot_reload_project.dart
@@ -86,6 +86,10 @@ class HotReloadProject extends Project {
       '// printHotReloadWorked();',
       'printHotReloadWorked();',
     );
-    writeFile(globals.fs.path.join(dir.path, 'lib', 'main.dart'), newMainContents);
+    writeFile(
+      globals.fs.path.join(dir.path, 'lib', 'main.dart'),
+      newMainContents,
+      sendToFuture: true,
+    );
   }
 }

--- a/packages/flutter_tools/test/integration.shard/test_data/project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/project.dart
@@ -40,7 +40,6 @@ abstract class Project {
       writeFile(globals.fs.path.join(dir.path, 'test', 'test.dart'), test);
     }
     writeFile(globals.fs.path.join(dir.path, 'web', 'index.html'), _kDefaultHtml);
-    writePackages(dir.path);
     await getPackages(dir.path);
   }
 

--- a/packages/flutter_tools/test/integration.shard/test_data/stateless_stateful_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/stateless_stateful_project.dart
@@ -74,6 +74,10 @@ class HotReloadProject extends Project {
 
   void toggleState() {
     stateful = !stateful;
-    writeFile(globals.fs.path.join(dir.path, 'lib', 'main.dart'), getCode(stateful));
+    writeFile(
+      globals.fs.path.join(dir.path, 'lib', 'main.dart'),
+      getCode(stateful),
+      sendToFuture: true,
+    );
   }
 }

--- a/packages/flutter_tools/test/integration.shard/test_utils.dart
+++ b/packages/flutter_tools/test/integration.shard/test_utils.dart
@@ -24,7 +24,7 @@ void writeFile(String path, String content, { bool sendToFuture = false }) {
     ..createSync(recursive: true)
     ..writeAsStringSync(content);
   // When making edits for hot reload changes, the synchronous file write combined
-  // with the immediate hot reload request may arrive too close together
+  // with the immediate hot reload request may arrive too close together.
   // Ensure the change is recognized by sending it into the future.
   if (sendToFuture) {
     file.setLastModifiedSync(DateTime.now().add(const Duration(seconds: 10)));

--- a/packages/flutter_tools/test/integration.shard/test_utils.dart
+++ b/packages/flutter_tools/test/integration.shard/test_utils.dart
@@ -25,7 +25,9 @@ void writeFile(String path, String content, { bool sendToFuture = false }) {
     ..writeAsStringSync(content);
   // When making edits for hot reload changes, the synchronous file write combined
   // with the immediate hot reload request may arrive too close together.
-  // Ensure the change is recognized by sending it into the future.
+  // The tool determines if a file is dirty by checking if the last modified
+  // timestamp occurred after the timestamp of the last compile, thus we can force
+  // it to be recognized by setting the last modified timestamp to a future time.
   if (sendToFuture) {
     file.setLastModifiedSync(DateTime.now().add(const Duration(seconds: 10)));
   }

--- a/packages/flutter_tools/test/integration.shard/test_utils.dart
+++ b/packages/flutter_tools/test/integration.shard/test_utils.dart
@@ -19,11 +19,16 @@ Directory createResolvedTempDirectorySync(String prefix) {
   return globals.fs.directory(tempDirectory.resolveSymbolicLinksSync());
 }
 
-void writeFile(String path, String content) {
-  globals.fs.file(path)
+void writeFile(String path, String content, { bool sendToFuture = false }) {
+  final File file = globals.fs.file(path)
     ..createSync(recursive: true)
-    ..writeAsStringSync(content)
-    ..setLastModifiedSync(DateTime.now().add(const Duration(seconds: 10)));
+    ..writeAsStringSync(content);
+  // When making edits for hot reload changes, the synchronous file write combined
+  // with the immediate hot reload request may arrive too close together
+  // Ensure the change is recognized by sending it into the future.
+  if (sendToFuture) {
+    file.setLastModifiedSync(DateTime.now().add(const Duration(seconds: 10)));
+  }
 }
 
 void writePackages(String folder) {


### PR DESCRIPTION
## Description

I noticed that the hot reload tests would never pass on my local workstation due to being "too fast" (thanks m2 ssd).

I pulled the thread for a bit and found that the workaround I added to ensure hot reload changes get picked up was causing the breakpoint tests to reload their main library, removing the breakpoints. While fixing this, I cleaned up the tests to avoid explicit stream/completer management.