### PR TITLE
[flutter_tools] Lazily inject logger into web devices

### DIFF
--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -93,7 +93,6 @@ class DeviceManager {
     WebDevices(
       featureFlags: featureFlags,
       fileSystem: globals.fs,
-      logger: globals.logger,
       platform: globals.platform,
       processManager: globals.processManager,
     ),

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -15,6 +15,7 @@ import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/os.dart';
 import '../convert.dart';
+import '../globals.dart' as globals;
 
 /// An environment variable used to override the location of Google Chrome.
 const String kChromeEnvironment = 'CHROME_EXECUTABLE';
@@ -121,7 +122,7 @@ class ChromiumLauncher {
   final Platform _platform;
   final ProcessManager _processManager;
   final OperatingSystemUtils _operatingSystemUtils;
-  final Logger _logger;
+  Logger _logger;
   final BrowserFinder _browserFinder;
   final FileSystemUtils _fileSystemUtils;
 
@@ -162,6 +163,7 @@ class ChromiumLauncher {
     bool skipCheck = false,
     Directory cacheDir,
   }) async {
+    _logger ??= globals.logger;
     if (_currentCompleter.isCompleted) {
       throwToolExit('Only one instance of chrome can be started.');
     }

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -14,6 +14,7 @@ import '../base/os.dart';
 import '../build_info.dart';
 import '../device.dart';
 import '../features.dart';
+import '../globals.dart' as globals;
 import '../project.dart';
 import 'chrome.dart';
 
@@ -35,7 +36,7 @@ abstract class ChromiumDevice extends Device {
     @required String name,
     @required this.chromeLauncher,
     @required FileSystem fileSystem,
-    @required Logger logger,
+    Logger logger,
   }) : _fileSystem = fileSystem,
        _logger = logger,
        super(
@@ -48,7 +49,7 @@ abstract class ChromiumDevice extends Device {
   final ChromiumLauncher chromeLauncher;
 
   final FileSystem _fileSystem;
-  final Logger _logger;
+  Logger _logger;
 
   /// The active chrome instance.
   Chromium _chrome;
@@ -114,6 +115,7 @@ abstract class ChromiumDevice extends Device {
     bool prebuiltApplication = false,
     bool ipv6 = false,
   }) async {
+    _logger ??= globals.logger;
     // See [ResidentWebRunner.run] in flutter_tools/lib/src/resident_web_runner.dart
     // for the web initialization and server logic.
     final String url = platformArgs['uri'] as String;
@@ -239,7 +241,10 @@ class MicrosoftEdgeDevice extends ChromiumDevice {
 class WebDevices extends PollingDeviceDiscovery {
   WebDevices({
     @required FileSystem fileSystem,
-    @required Logger logger,
+    // TODO(jonahwilliams): the logger is overriden by the daemon command
+    // to support IDE integration. Accessing the global logger too early
+    // will grab the old stdout logger.
+    Logger logger,
     @required Platform platform,
     @required ProcessManager processManager,
     @required FeatureFlags featureFlags,
@@ -302,7 +307,7 @@ String parseVersionForWindows(String input) {
 /// A special device type to allow serving for arbitrary browsers.
 class WebServerDevice extends Device {
   WebServerDevice({
-    @required Logger logger,
+    Logger logger,
   }) : _logger = logger,
        super(
          'web-server',
@@ -311,7 +316,7 @@ class WebServerDevice extends Device {
           ephemeral: false,
        );
 
-  final Logger _logger;
+  Logger _logger;
 
   @override
   void clearLogs() { }
@@ -367,6 +372,7 @@ class WebServerDevice extends Device {
     bool prebuiltApplication = false,
     bool ipv6 = false,
   }) async {
+    _logger ??= globals.logger;
     final String url = platformArgs['uri'] as String;
     if (debuggingOptions.startPaused) {
       _logger.printStatus('Waiting for connection from Dart debug extension at $url', emphasis: true);


### PR DESCRIPTION
## Description

Constructing the WebDevices with the global logger too early will lead to them grabbing the StdoutLogger when running in daemon mode. This prevents IDEs from seeing the correct debug message.

https://github.com/Dart-Code/Dart-Code/issues/2407#issuecomment-621114369