### PR TITLE
Add clipBehavior to widgets with clipRect

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/demo/pesto_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/pesto_demo.dart
@@ -224,6 +224,7 @@ class _PestoLogoState extends State<PestoLogo> {
         child: SizedBox(
           width: kLogoWidth,
           child: Stack(
+            clipBehavior: Clip.none,
             children: <Widget>[
               Positioned.fromRect(
                 rect: _imageRectTween.lerp(widget.t),

--- a/dev/integration_tests/flutter_gallery/lib/demo/pesto_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/pesto_demo.dart
@@ -224,7 +224,6 @@ class _PestoLogoState extends State<PestoLogo> {
         child: SizedBox(
           width: kLogoWidth,
           child: Stack(
-            overflow: Overflow.visible,
             children: <Widget>[
               Positioned.fromRect(
                 rect: _imageRectTween.lerp(widget.t),

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2425,6 +2425,9 @@ abstract class RenderBox extends RenderObject {
   }
 }
 
+/// A [RenderBox] subclass that can configure its clip behavior.
+abstract class ClippableRenderBox extends RenderBox with ClipBehaviorMixin {}
+
 /// A mixin that provides useful default behaviors for boxes with children
 /// managed by the [ContainerRenderObjectMixin] mixin.
 ///

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2425,9 +2425,6 @@ abstract class RenderBox extends RenderObject {
   }
 }
 
-/// A [RenderBox] subclass that can configure its clip behavior.
-abstract class ClippableRenderBox extends RenderBox with ClipBehaviorMixin {}
-
 /// A mixin that provides useful default behaviors for boxes with children
 /// managed by the [ContainerRenderObjectMixin] mixin.
 ///

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -174,7 +174,7 @@ bool _isTrailingSurrogate(int codeUnit) {
 /// Keyboard handling, IME handling, scrolling, toggling the [showCursor] value
 /// to actually blink the cursor, and other features not mentioned above are the
 /// responsibility of higher layers and not handled by this object.
-class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, ClipBehaviorMixin {
+class RenderEditable extends ClippableRenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// Creates a render object that implements the visual aspects of a text field.
   ///
   /// The [textAlign] argument must not be null. It defaults to [TextAlign.start].

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -174,7 +174,7 @@ bool _isTrailingSurrogate(int codeUnit) {
 /// Keyboard handling, IME handling, scrolling, toggling the [showCursor] value
 /// to actually blink the cursor, and other features not mentioned above are the
 /// responsibility of higher layers and not handled by this object.
-class RenderEditable extends ClippableRenderBox with RelayoutWhenSystemFontsChangeMixin {
+class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// Creates a render object that implements the visual aspects of a text field.
   ///
   /// The [textAlign] argument must not be null. It defaults to [TextAlign.start].
@@ -292,11 +292,11 @@ class RenderEditable extends ClippableRenderBox with RelayoutWhenSystemFontsChan
        _obscureText = obscureText,
        _readOnly = readOnly,
        _forceLine = forceLine,
-       _promptRectRange = promptRectRange {
+       _promptRectRange = promptRectRange,
+       _clipBehavior = clipBehavior {
     assert(_showCursor != null);
     assert(!_showCursor.value || cursorColor != null);
     this.hasFocus = hasFocus ?? false;
-    this.clipBehavior = clipBehavior;
     if (promptRectColor != null)
       _promptRectPaint.color = promptRectColor;
   }
@@ -1243,6 +1243,20 @@ class RenderEditable extends ClippableRenderBox with RelayoutWhenSystemFontsChan
   double _maxScrollExtent = 0;
 
   double get _caretMargin => _kCaretGap + cursorWidth;
+
+  /// {@macro flutter.widgets.Clip}
+  ///
+  /// Defaults to [Clip.hardEdge], and must not be null.
+  Clip get clipBehavior => _clipBehavior;
+  Clip _clipBehavior = Clip.hardEdge;
+  set clipBehavior(Clip value) {
+    assert(value != null);
+    if (value != _clipBehavior) {
+      _clipBehavior = value;
+      markNeedsPaint();
+      markNeedsSemanticsUpdate();
+    }
+  }
 
   @override
   void describeSemanticsConfiguration(SemanticsConfiguration config) {

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -174,7 +174,7 @@ bool _isTrailingSurrogate(int codeUnit) {
 /// Keyboard handling, IME handling, scrolling, toggling the [showCursor] value
 /// to actually blink the cursor, and other features not mentioned above are the
 /// responsibility of higher layers and not handled by this object.
-class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
+class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, ClipBehaviorMixin {
   /// Creates a render object that implements the visual aspects of a text field.
   ///
   /// The [textAlign] argument must not be null. It defaults to [TextAlign.start].
@@ -227,6 +227,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     EdgeInsets floatingCursorAddedMargin = const EdgeInsets.fromLTRB(4, 4, 4, 5),
     TextRange promptRectRange,
     Color promptRectColor,
+    Clip clipBehavior = Clip.hardEdge,
     @required this.textSelectionDelegate,
   }) : assert(textAlign != null),
        assert(textDirection != null, 'RenderEditable created without a textDirection.'),
@@ -257,6 +258,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
        assert(devicePixelRatio != null),
        assert(selectionHeightStyle != null),
        assert(selectionWidthStyle != null),
+       assert(clipBehavior != null),
        _textPainter = TextPainter(
          text: text,
          textAlign: textAlign,
@@ -294,6 +296,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     assert(_showCursor != null);
     assert(!_showCursor.value || cursorColor != null);
     this.hasFocus = hasFocus ?? false;
+    this.clipBehavior = clipBehavior;
     if (promptRectColor != null)
       _promptRectPaint.color = promptRectColor;
   }
@@ -2133,8 +2136,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   @override
   void paint(PaintingContext context, Offset offset) {
     _layoutText(minWidth: constraints.minWidth, maxWidth: constraints.maxWidth);
-    if (_hasVisualOverflow)
-      context.pushClipRect(needsCompositing, offset, Offset.zero & size, _paintContents);
+    if (_hasVisualOverflow && clipBehavior != Clip.none)
+      context.pushClipRect(needsCompositing, offset, Offset.zero & size, _paintContents, clipBehavior: clipBehavior);
     else
       _paintContents(context, offset);
     _paintHandleLayers(context, getEndpointsForSelection(selection));

--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -263,7 +263,8 @@ typedef _ChildSizingFunction = double Function(RenderBox child, double extent);
 ///  * [Row] and [Column], direction-specific variants of [Flex].
 class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, FlexParentData>,
                                         RenderBoxContainerDefaultsMixin<RenderBox, FlexParentData>,
-                                        DebugOverflowIndicatorMixin {
+                                        DebugOverflowIndicatorMixin,
+                                        ClipBehaviorMixin {
   /// Creates a flex render object.
   ///
   /// By default, the flex layout is horizontal and children are aligned to the
@@ -289,9 +290,9 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
        _crossAxisAlignment = crossAxisAlignment,
        _textDirection = textDirection,
        _verticalDirection = verticalDirection,
-       _textBaseline = textBaseline,
-       _clipBehavior = clipBehavior {
+       _textBaseline = textBaseline {
     addAll(children);
+    this.clipBehavior = clipBehavior;
   }
 
   /// The direction to use as the main axis.
@@ -429,19 +430,6 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
     if (_textBaseline != value) {
       _textBaseline = value;
       markNeedsLayout();
-    }
-  }
-
-  /// {@macro flutter.widgets.Clip}
-  ///
-  /// Defaults to [Clip.none], and must not be null.
-  Clip get clipBehavior => _clipBehavior;
-  Clip _clipBehavior;
-  set clipBehavior(Clip value) {
-    assert(value != null);
-    if (value != _clipBehavior) {
-      _clipBehavior = value;
-      markNeedsPaint();
     }
   }
 

--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -277,17 +277,20 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
     TextDirection textDirection,
     VerticalDirection verticalDirection = VerticalDirection.down,
     TextBaseline textBaseline,
+    Clip clipBehavior = Clip.none,
   }) : assert(direction != null),
        assert(mainAxisAlignment != null),
        assert(mainAxisSize != null),
        assert(crossAxisAlignment != null),
+       assert(clipBehavior != null),
        _direction = direction,
        _mainAxisAlignment = mainAxisAlignment,
        _mainAxisSize = mainAxisSize,
        _crossAxisAlignment = crossAxisAlignment,
        _textDirection = textDirection,
        _verticalDirection = verticalDirection,
-       _textBaseline = textBaseline {
+       _textBaseline = textBaseline,
+       _clipBehavior = clipBehavior {
     addAll(children);
   }
 
@@ -426,6 +429,19 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
     if (_textBaseline != value) {
       _textBaseline = value;
       markNeedsLayout();
+    }
+  }
+
+  /// {@macro flutter.widgets.Clip}
+  ///
+  /// Defaults to [Clip.none], and must not be null.
+  Clip get clipBehavior => _clipBehavior;
+  Clip _clipBehavior;
+  set clipBehavior(Clip value) {
+    assert(value != null);
+    if (value != _clipBehavior) {
+      _clipBehavior = value;
+      markNeedsPaint();
     }
   }
 
@@ -955,8 +971,12 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
     if (size.isEmpty)
       return;
 
-    // We have overflow. Clip it.
-    context.pushClipRect(needsCompositing, offset, Offset.zero & size, defaultPaint);
+    if (clipBehavior == Clip.none) {
+      defaultPaint(context, offset);
+    } else {
+      // We have overflow and the clipBehavior isn't none. Clip it.
+      context.pushClipRect(needsCompositing, offset, Offset.zero & size, defaultPaint, clipBehavior: clipBehavior);
+    }
 
     assert(() {
       // Only set this if it's null to save work. It gets reset to null if the

--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -261,10 +261,10 @@ typedef _ChildSizingFunction = double Function(RenderBox child, double extent);
 ///
 ///  * [Flex], the widget equivalent.
 ///  * [Row] and [Column], direction-specific variants of [Flex].
-class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, FlexParentData>,
-                                        RenderBoxContainerDefaultsMixin<RenderBox, FlexParentData>,
-                                        DebugOverflowIndicatorMixin,
-                                        ClipBehaviorMixin {
+class RenderFlex extends ClippableRenderBox
+    with ContainerRenderObjectMixin<RenderBox, FlexParentData>,
+         RenderBoxContainerDefaultsMixin<RenderBox, FlexParentData>,
+         DebugOverflowIndicatorMixin {
   /// Creates a flex render object.
   ///
   /// By default, the flex layout is horizontal and children are aligned to the

--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -261,10 +261,9 @@ typedef _ChildSizingFunction = double Function(RenderBox child, double extent);
 ///
 ///  * [Flex], the widget equivalent.
 ///  * [Row] and [Column], direction-specific variants of [Flex].
-class RenderFlex extends ClippableRenderBox
-    with ContainerRenderObjectMixin<RenderBox, FlexParentData>,
-         RenderBoxContainerDefaultsMixin<RenderBox, FlexParentData>,
-         DebugOverflowIndicatorMixin {
+class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, FlexParentData>,
+                                        RenderBoxContainerDefaultsMixin<RenderBox, FlexParentData>,
+                                        DebugOverflowIndicatorMixin {
   /// Creates a flex render object.
   ///
   /// By default, the flex layout is horizontal and children are aligned to the
@@ -290,9 +289,9 @@ class RenderFlex extends ClippableRenderBox
        _crossAxisAlignment = crossAxisAlignment,
        _textDirection = textDirection,
        _verticalDirection = verticalDirection,
-       _textBaseline = textBaseline {
+       _textBaseline = textBaseline,
+       _clipBehavior = clipBehavior {
     addAll(children);
-    this.clipBehavior = clipBehavior;
   }
 
   /// The direction to use as the main axis.
@@ -477,6 +476,20 @@ class RenderFlex extends ClippableRenderBox
   // Check whether any meaningful overflow is present. Values below an epsilon
   // are treated as not overflowing.
   bool get _hasOverflow => _overflow > precisionErrorTolerance;
+
+  /// {@macro flutter.widgets.Clip}
+  ///
+  /// Defaults to [Clip.none], and must not be null.
+  Clip get clipBehavior => _clipBehavior;
+  Clip _clipBehavior = Clip.none;
+  set clipBehavior(Clip value) {
+    assert(value != null);
+    if (value != _clipBehavior) {
+      _clipBehavior = value;
+      markNeedsPaint();
+      markNeedsSemanticsUpdate();
+    }
+  }
 
   @override
   void setupParentData(RenderBox child) {

--- a/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
+++ b/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
@@ -126,7 +126,7 @@ class ListWheelParentData extends ContainerBoxParentData<RenderBox> {
 ///    in the center of that plane will be mostly untransformed with children
 ///    above and below it being transformed more as the angle increases.
 class RenderListWheelViewport
-    extends ClippableRenderBox
+    extends RenderBox
     with ContainerRenderObjectMixin<RenderBox, ListWheelParentData>
     implements RenderAbstractViewport {
   /// Creates a [RenderListWheelViewport] which renders children on a wheel.
@@ -178,9 +178,9 @@ class RenderListWheelViewport
        _overAndUnderCenterOpacity = overAndUnderCenterOpacity,
        _itemExtent = itemExtent,
        _squeeze = squeeze,
-       _renderChildrenOutsideViewport = renderChildrenOutsideViewport {
+       _renderChildrenOutsideViewport = renderChildrenOutsideViewport,
+       _clipBehavior = clipBehavior {
     addAll(children);
-    this.clipBehavior = clipBehavior;
   }
 
   /// An arbitrary but aesthetically reasonable default value for [diameterRatio].
@@ -464,6 +464,20 @@ class RenderListWheelViewport
     _renderChildrenOutsideViewport = value;
     markNeedsLayout();
     markNeedsSemanticsUpdate();
+  }
+
+  /// {@macro flutter.widgets.Clip}
+  ///
+  /// Defaults to [Clip.hardEdge], and must not be null.
+  Clip get clipBehavior => _clipBehavior;
+  Clip _clipBehavior = Clip.hardEdge;
+  set clipBehavior(Clip value) {
+    assert(value != null);
+    if (value != _clipBehavior) {
+      _clipBehavior = value;
+      markNeedsPaint();
+      markNeedsSemanticsUpdate();
+    }
   }
 
   void _hasScrolled() {

--- a/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
+++ b/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
@@ -143,7 +143,6 @@ class RenderListWheelViewport
     double overAndUnderCenterOpacity = 1,
     @required double itemExtent,
     double squeeze = 1,
-    bool clipToSize = true,
     bool renderChildrenOutsideViewport = false,
     Clip clipBehavior = Clip.none,
     List<RenderBox> children,
@@ -164,12 +163,11 @@ class RenderListWheelViewport
        assert(squeeze != null),
        assert(squeeze > 0),
        assert(itemExtent > 0),
-       assert(clipToSize != null),
        assert(renderChildrenOutsideViewport != null),
        assert(clipBehavior != null),
        assert(
-         !renderChildrenOutsideViewport || !clipToSize,
-         clipToSizeAndRenderChildrenOutsideViewportConflict,
+         !renderChildrenOutsideViewport || clipBehavior == Clip.none,
+         clipBehaviorAndRenderChildrenOutsideViewportConflict,
        ),
        _offset = offset,
        _diameterRatio = diameterRatio,
@@ -180,7 +178,6 @@ class RenderListWheelViewport
        _overAndUnderCenterOpacity = overAndUnderCenterOpacity,
        _itemExtent = itemExtent,
        _squeeze = squeeze,
-       _clipToSize = clipToSize,
        _renderChildrenOutsideViewport = renderChildrenOutsideViewport {
     addAll(children);
     this.clipBehavior = clipBehavior;
@@ -202,10 +199,10 @@ class RenderListWheelViewport
       'be clipped in the z-axis and therefore not renderable. Value must be '
       'between 0 and 0.01.';
 
-  /// An error message to show when [clipToSize] and [renderChildrenOutsideViewport]
+  /// An error message to show when [clipBehavior] and [renderChildrenOutsideViewport]
   /// are set to conflicting values.
-  static const String clipToSizeAndRenderChildrenOutsideViewportConflict =
-      'Cannot renderChildrenOutsideViewport and clipToSize since children '
+  static const String clipBehaviorAndRenderChildrenOutsideViewportConflict =
+      'Cannot renderChildrenOutsideViewport and clip since children '
       'rendered outside will be clipped anyway.';
 
   /// The delegate that manages the children of this object.
@@ -444,37 +441,14 @@ class RenderListWheelViewport
     markNeedsSemanticsUpdate();
   }
 
-  /// {@template flutter.rendering.wheelList.clipToSize}
-  /// Whether to clip painted children to the inside of this viewport.
-  ///
-  /// Defaults to [true]. Must not be null.
-  ///
-  /// If this is false and [renderChildrenOutsideViewport] is false, the
-  /// first and last children may be painted partly outside of this scroll view.
-  /// {@endtemplate}
-  bool get clipToSize => _clipToSize;
-  bool _clipToSize;
-  set clipToSize(bool value) {
-    assert(value != null);
-    assert(
-      !renderChildrenOutsideViewport || !clipToSize,
-      clipToSizeAndRenderChildrenOutsideViewportConflict,
-    );
-    if (value == _clipToSize)
-      return;
-    _clipToSize = value;
-    markNeedsPaint();
-    markNeedsSemanticsUpdate();
-  }
-
   /// {@template flutter.rendering.wheelList.renderChildrenOutsideViewport}
   /// Whether to paint children inside the viewport only.
   ///
   /// If false, every child will be painted. However the [Scrollable] is still
   /// the size of the viewport and detects gestures inside only.
   ///
-  /// Defaults to [false]. Must not be null. Cannot be true if [clipToSize]
-  /// is also true since children outside the viewport will be clipped, and
+  /// Defaults to [false]. Must not be null. Cannot be true if [clipBehavior]
+  /// is not [Clip.none] since children outside the viewport will be clipped, and
   /// therefore cannot render children outside the viewport.
   /// {@endtemplate}
   bool get renderChildrenOutsideViewport => _renderChildrenOutsideViewport;
@@ -482,8 +456,8 @@ class RenderListWheelViewport
   set renderChildrenOutsideViewport(bool value) {
     assert(value != null);
     assert(
-      !renderChildrenOutsideViewport || !clipToSize,
-      clipToSizeAndRenderChildrenOutsideViewportConflict,
+      !renderChildrenOutsideViewport || clipBehavior == Clip.none,
+      clipBehaviorAndRenderChildrenOutsideViewportConflict,
     );
     if (value == _renderChildrenOutsideViewport)
       return;
@@ -789,9 +763,8 @@ class RenderListWheelViewport
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    assert(_clipToSize == (clipBehavior != Clip.none));
     if (childCount > 0) {
-      if (_clipToSize && _shouldClipAtCurrentOffset() && clipBehavior != Clip.none) {
+      if (_shouldClipAtCurrentOffset() && clipBehavior != Clip.none) {
         context.pushClipRect(
           needsCompositing,
           offset,

--- a/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
+++ b/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
@@ -127,7 +127,7 @@ class ListWheelParentData extends ContainerBoxParentData<RenderBox> {
 ///    above and below it being transformed more as the angle increases.
 class RenderListWheelViewport
     extends RenderBox
-    with ContainerRenderObjectMixin<RenderBox, ListWheelParentData>
+    with ContainerRenderObjectMixin<RenderBox, ListWheelParentData>, ClipBehaviorMixin
     implements RenderAbstractViewport {
   /// Creates a [RenderListWheelViewport] which renders children on a wheel.
   ///
@@ -145,6 +145,7 @@ class RenderListWheelViewport
     double squeeze = 1,
     bool clipToSize = true,
     bool renderChildrenOutsideViewport = false,
+    Clip clipBehavior = Clip.none,
     List<RenderBox> children,
   }) : assert(childManager != null),
        assert(offset != null),
@@ -165,6 +166,7 @@ class RenderListWheelViewport
        assert(itemExtent > 0),
        assert(clipToSize != null),
        assert(renderChildrenOutsideViewport != null),
+       assert(clipBehavior != null),
        assert(
          !renderChildrenOutsideViewport || !clipToSize,
          clipToSizeAndRenderChildrenOutsideViewportConflict,
@@ -181,6 +183,7 @@ class RenderListWheelViewport
        _clipToSize = clipToSize,
        _renderChildrenOutsideViewport = renderChildrenOutsideViewport {
     addAll(children);
+    this.clipBehavior = clipBehavior;
   }
 
   /// An arbitrary but aesthetically reasonable default value for [diameterRatio].
@@ -786,13 +789,15 @@ class RenderListWheelViewport
 
   @override
   void paint(PaintingContext context, Offset offset) {
+    assert(_clipToSize == (clipBehavior != Clip.none));
     if (childCount > 0) {
-      if (_clipToSize && _shouldClipAtCurrentOffset()) {
+      if (_clipToSize && _shouldClipAtCurrentOffset() && clipBehavior != Clip.none) {
         context.pushClipRect(
           needsCompositing,
           offset,
           Offset.zero & size,
           _paintVisibleChildren,
+          clipBehavior: clipBehavior,
         );
       } else {
         _paintVisibleChildren(context, offset);

--- a/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
+++ b/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
@@ -126,8 +126,8 @@ class ListWheelParentData extends ContainerBoxParentData<RenderBox> {
 ///    in the center of that plane will be mostly untransformed with children
 ///    above and below it being transformed more as the angle increases.
 class RenderListWheelViewport
-    extends RenderBox
-    with ContainerRenderObjectMixin<RenderBox, ListWheelParentData>, ClipBehaviorMixin
+    extends ClippableRenderBox
+    with ContainerRenderObjectMixin<RenderBox, ListWheelParentData>
     implements RenderAbstractViewport {
   /// Creates a [RenderListWheelViewport] which renders children on a wheel.
   ///

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -3916,20 +3916,3 @@ class DiagnosticsDebugCreator extends DiagnosticsProperty<Object> {
         level: DiagnosticLevel.hidden,
       );
 }
-
-/// A mixin for [RenderObject] subclasses that can configure its clip behavior.
-mixin ClipBehaviorMixin on RenderObject {
-  /// {@macro flutter.widgets.Clip}
-  ///
-  /// Defaults to [Clip.none], and must not be null.
-  Clip get clipBehavior => _clipBehavior;
-  Clip _clipBehavior = Clip.none;
-  set clipBehavior(Clip value) {
-    assert(value != null);
-    if (value != _clipBehavior) {
-      _clipBehavior = value;
-      markNeedsPaint();
-      markNeedsSemanticsUpdate();
-    }
-  }
-}

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -3916,3 +3916,19 @@ class DiagnosticsDebugCreator extends DiagnosticsProperty<Object> {
         level: DiagnosticLevel.hidden,
       );
 }
+
+/// A mixin for [RenderObject] subclasses that can configure its clip behavior.
+mixin ClipBehaviorMixin on RenderObject {
+  /// {@macro flutter.widgets.Clip}
+  ///
+  /// Defaults to [Clip.none], and must not be null.
+  Clip get clipBehavior => _clipBehavior;
+  Clip _clipBehavior = Clip.none;
+  set clipBehavior(Clip value) {
+    assert(value != null);
+    if (value != _clipBehavior) {
+      _clipBehavior = value;
+      markNeedsPaint();
+    }
+  }
+}

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -3929,6 +3929,7 @@ mixin ClipBehaviorMixin on RenderObject {
     if (value != _clipBehavior) {
       _clipBehavior = value;
       markNeedsPaint();
+      markNeedsSemanticsUpdate();
     }
   }
 }

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2283,7 +2283,7 @@ class RenderTransform extends RenderProxyBox {
 }
 
 /// Scales and positions its child within itself according to [fit].
-class RenderFittedBox extends RenderProxyBox {
+class RenderFittedBox extends RenderProxyBox with ClipBehaviorMixin {
   /// Scales and positions its child within itself.
   ///
   /// The [fit] and [alignment] arguments must not be null.
@@ -2292,12 +2292,16 @@ class RenderFittedBox extends RenderProxyBox {
     AlignmentGeometry alignment = Alignment.center,
     TextDirection textDirection,
     RenderBox child,
+    Clip clipBehavior = Clip.none,
   }) : assert(fit != null),
        assert(alignment != null),
+       assert(clipBehavior != null),
        _fit = fit,
        _alignment = alignment,
        _textDirection = textDirection,
-       super(child);
+       super(child) {
+    this.clipBehavior = clipBehavior;
+  }
 
   Alignment _resolvedAlignment;
 
@@ -2418,9 +2422,9 @@ class RenderFittedBox extends RenderProxyBox {
       return;
     _updatePaintData();
     if (child != null) {
-      if (_hasVisualOverflow)
+      if (_hasVisualOverflow && clipBehavior != Clip.none)
         layer = context.pushClipRect(needsCompositing, offset, Offset.zero & size, _paintChildWithTransform,
-            oldLayer: layer is ClipRectLayer ? layer as ClipRectLayer : null);
+            oldLayer: layer is ClipRectLayer ? layer as ClipRectLayer : null, clipBehavior: clipBehavior);
       else
         layer = _paintChildWithTransform(context, offset);
     }

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2283,7 +2283,7 @@ class RenderTransform extends RenderProxyBox {
 }
 
 /// Scales and positions its child within itself according to [fit].
-class RenderFittedBox extends RenderProxyBox with ClipBehaviorMixin {
+class RenderFittedBox extends RenderProxyBox {
   /// Scales and positions its child within itself.
   ///
   /// The [fit] and [alignment] arguments must not be null.
@@ -2299,9 +2299,8 @@ class RenderFittedBox extends RenderProxyBox with ClipBehaviorMixin {
        _fit = fit,
        _alignment = alignment,
        _textDirection = textDirection,
-       super(child) {
-    this.clipBehavior = clipBehavior;
-  }
+       _clipBehavior = clipBehavior,
+       super(child);
 
   Alignment _resolvedAlignment;
 
@@ -2376,6 +2375,20 @@ class RenderFittedBox extends RenderProxyBox with ClipBehaviorMixin {
 
   bool _hasVisualOverflow;
   Matrix4 _transform;
+
+  /// {@macro flutter.widgets.Clip}
+  ///
+  /// Defaults to [Clip.none], and must not be null.
+  Clip get clipBehavior => _clipBehavior;
+  Clip _clipBehavior = Clip.none;
+  set clipBehavior(Clip value) {
+    assert(value != null);
+    if (value != _clipBehavior) {
+      _clipBehavior = value;
+      markNeedsPaint();
+      markNeedsSemanticsUpdate();
+    }
+  }
 
   void _clearPaintData() {
     _hasVisualOverflow = null;

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -616,7 +616,7 @@ class RenderConstrainedOverflowBox extends RenderAligningShiftedBox {
 ///  * [RenderSizedOverflowBox], a render object that is a specific size but
 ///    passes its original constraints through to its child, which it allows to
 ///    overflow.
-class RenderUnconstrainedBox extends RenderAligningShiftedBox with DebugOverflowIndicatorMixin, ClipBehaviorMixin {
+class RenderUnconstrainedBox extends RenderAligningShiftedBox with DebugOverflowIndicatorMixin {
   /// Create a render object that sizes itself to the child but does not
   /// pass the [constraints] down to that child.
   ///
@@ -630,9 +630,8 @@ class RenderUnconstrainedBox extends RenderAligningShiftedBox with DebugOverflow
   }) : assert(alignment != null),
        assert(clipBehavior != null),
        _constrainedAxis = constrainedAxis,
-       super.mixin(alignment, textDirection, child) {
-    this.clipBehavior = clipBehavior;
-  }
+       _clipBehavior = clipBehavior,
+       super.mixin(alignment, textDirection, child);
 
   /// The axis to retain constraints on, if any.
   ///
@@ -652,6 +651,20 @@ class RenderUnconstrainedBox extends RenderAligningShiftedBox with DebugOverflow
   Rect _overflowContainerRect = Rect.zero;
   Rect _overflowChildRect = Rect.zero;
   bool _isOverflowing = false;
+
+  /// {@macro flutter.widgets.Clip}
+  ///
+  /// Defaults to [Clip.none], and must not be null.
+  Clip get clipBehavior => _clipBehavior;
+  Clip _clipBehavior = Clip.none;
+  set clipBehavior(Clip value) {
+    assert(value != null);
+    if (value != _clipBehavior) {
+      _clipBehavior = value;
+      markNeedsPaint();
+      markNeedsSemanticsUpdate();
+    }
+  }
 
   @override
   void performLayout() {

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -616,7 +616,7 @@ class RenderConstrainedOverflowBox extends RenderAligningShiftedBox {
 ///  * [RenderSizedOverflowBox], a render object that is a specific size but
 ///    passes its original constraints through to its child, which it allows to
 ///    overflow.
-class RenderUnconstrainedBox extends RenderAligningShiftedBox with DebugOverflowIndicatorMixin {
+class RenderUnconstrainedBox extends RenderAligningShiftedBox with DebugOverflowIndicatorMixin, ClipBehaviorMixin {
   /// Create a render object that sizes itself to the child but does not
   /// pass the [constraints] down to that child.
   ///
@@ -626,9 +626,13 @@ class RenderUnconstrainedBox extends RenderAligningShiftedBox with DebugOverflow
     @required TextDirection textDirection,
     Axis constrainedAxis,
     RenderBox child,
+    Clip clipBehavior = Clip.none,
   }) : assert(alignment != null),
+       assert(clipBehavior != null),
        _constrainedAxis = constrainedAxis,
-       super.mixin(alignment, textDirection, child);
+       super.mixin(alignment, textDirection, child) {
+    this.clipBehavior = clipBehavior;
+  }
 
   /// The axis to retain constraints on, if any.
   ///
@@ -694,8 +698,12 @@ class RenderUnconstrainedBox extends RenderAligningShiftedBox with DebugOverflow
       return;
     }
 
-    // We have overflow. Clip it.
-    context.pushClipRect(needsCompositing, offset, Offset.zero & size, super.paint);
+    if (clipBehavior == Clip.none) {
+      super.paint(context, offset);
+    } else {
+      // We have overflow and the clipBehavior isn't none. Clip it.
+      context.pushClipRect(needsCompositing, offset, Offset.zero & size, super.paint, clipBehavior: clipBehavior);
+    }
 
     // Display the overflow indicator.
     assert(() {

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -316,7 +316,8 @@ enum Overflow {
 ///  * [RenderFlow]
 class RenderStack extends RenderBox
     with ContainerRenderObjectMixin<RenderBox, StackParentData>,
-         RenderBoxContainerDefaultsMixin<RenderBox, StackParentData> {
+         RenderBoxContainerDefaultsMixin<RenderBox, StackParentData>,
+         ClipBehaviorMixin {
   /// Creates a stack render object.
   ///
   /// By default, the non-positioned children of the stack are aligned by their
@@ -326,15 +327,18 @@ class RenderStack extends RenderBox
     AlignmentGeometry alignment = AlignmentDirectional.topStart,
     TextDirection textDirection,
     StackFit fit = StackFit.loose,
-    Overflow overflow = Overflow.clip,
+    Overflow overflow = Overflow.visible,
+    Clip clipBehavior = Clip.none,
   }) : assert(alignment != null),
        assert(fit != null),
        assert(overflow != null),
+       assert(clipBehavior != null),
        _alignment = alignment,
        _textDirection = textDirection,
        _fit = fit,
        _overflow = overflow {
     addAll(children);
+    this.clipBehavior = clipBehavior;
   }
 
   bool _hasVisualOverflow = false;
@@ -604,8 +608,11 @@ class RenderStack extends RenderBox
 
   @override
   void paint(PaintingContext context, Offset offset) {
+    // Make sure that _overflow and clipBehavior are compatible.
+    assert((_overflow == Overflow.visible) == (clipBehavior == Clip.none));
+
     if (_overflow == Overflow.clip && _hasVisualOverflow) {
-      context.pushClipRect(needsCompositing, offset, Offset.zero & size, paintStack);
+      context.pushClipRect(needsCompositing, offset, Offset.zero & size, paintStack, clipBehavior: clipBehavior);
     } else {
       paintStack(context, offset);
     }

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -268,7 +268,8 @@ enum StackFit {
   passthrough,
 }
 
-// TODO(liyuqian): remove `Overflow` once its usages are removed from Google.
+// TODO(liyuqian): Deprecate and remove `Overflow` once its usages are removed from Google.
+
 /// Whether overflowing children should be clipped, or their overflow be
 /// visible.
 enum Overflow {

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -268,16 +268,6 @@ enum StackFit {
   passthrough,
 }
 
-/// Whether overflowing children should be clipped, or their overflow be
-/// visible.
-enum Overflow {
-  /// Overflowing children will be visible.
-  visible,
-
-  /// Overflowing children will be clipped to the bounds of their parent.
-  clip,
-}
-
 /// Implements the stack layout algorithm
 ///
 /// In a stack layout, the children are positioned on top of each other in the
@@ -326,16 +316,13 @@ class RenderStack extends ClippableRenderBox
     AlignmentGeometry alignment = AlignmentDirectional.topStart,
     TextDirection textDirection,
     StackFit fit = StackFit.loose,
-    Overflow overflow = Overflow.visible,
     Clip clipBehavior = Clip.none,
   }) : assert(alignment != null),
        assert(fit != null),
-       assert(overflow != null),
        assert(clipBehavior != null),
        _alignment = alignment,
        _textDirection = textDirection,
-       _fit = fit,
-       _overflow = overflow {
+       _fit = fit {
     addAll(children);
     this.clipBehavior = clipBehavior;
   }
@@ -411,20 +398,6 @@ class RenderStack extends ClippableRenderBox
     if (_fit != value) {
       _fit = value;
       markNeedsLayout();
-    }
-  }
-
-  /// Whether overflowing children should be clipped. See [Overflow].
-  ///
-  /// Some children in a stack might overflow its box. When this flag is set to
-  /// [Overflow.clip], children cannot paint outside of the stack's box.
-  Overflow get overflow => _overflow;
-  Overflow _overflow;
-  set overflow(Overflow value) {
-    assert(value != null);
-    if (_overflow != value) {
-      _overflow = value;
-      markNeedsPaint();
     }
   }
 
@@ -607,10 +580,7 @@ class RenderStack extends ClippableRenderBox
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    // Make sure that _overflow and clipBehavior are compatible.
-    assert((_overflow == Overflow.visible) == (clipBehavior == Clip.none));
-
-    if (_overflow == Overflow.clip && _hasVisualOverflow) {
+    if (clipBehavior != Clip.none && _hasVisualOverflow) {
       context.pushClipRect(needsCompositing, offset, Offset.zero & size, paintStack, clipBehavior: clipBehavior);
     } else {
       paintStack(context, offset);
@@ -626,7 +596,7 @@ class RenderStack extends ClippableRenderBox
     properties.add(DiagnosticsProperty<AlignmentGeometry>('alignment', alignment));
     properties.add(EnumProperty<TextDirection>('textDirection', textDirection));
     properties.add(EnumProperty<StackFit>('fit', fit));
-    properties.add(EnumProperty<Overflow>('overflow', overflow));
+    properties.add(EnumProperty<Clip>('clipBehavior', clipBehavior));
   }
 }
 

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -268,6 +268,17 @@ enum StackFit {
   passthrough,
 }
 
+// TODO(liyuqian): remove `Overflow` once its usages are removed from Google.
+/// Whether overflowing children should be clipped, or their overflow be
+/// visible.
+enum Overflow {
+  /// Overflowing children will be visible.
+  visible,
+
+  /// Overflowing children will be clipped to the bounds of their parent.
+  clip,
+}
+
 /// Implements the stack layout algorithm
 ///
 /// In a stack layout, the children are positioned on top of each other in the

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -304,7 +304,7 @@ enum StackFit {
 /// See also:
 ///
 ///  * [RenderFlow]
-class RenderStack extends ClippableRenderBox
+class RenderStack extends RenderBox
     with ContainerRenderObjectMixin<RenderBox, StackParentData>,
          RenderBoxContainerDefaultsMixin<RenderBox, StackParentData> {
   /// Creates a stack render object.
@@ -316,15 +316,15 @@ class RenderStack extends ClippableRenderBox
     AlignmentGeometry alignment = AlignmentDirectional.topStart,
     TextDirection textDirection,
     StackFit fit = StackFit.loose,
-    Clip clipBehavior = Clip.none,
+    Clip clipBehavior = Clip.hardEdge,
   }) : assert(alignment != null),
        assert(fit != null),
        assert(clipBehavior != null),
        _alignment = alignment,
        _textDirection = textDirection,
-       _fit = fit {
+       _fit = fit,
+       _clipBehavior = clipBehavior {
     addAll(children);
-    this.clipBehavior = clipBehavior;
   }
 
   bool _hasVisualOverflow = false;
@@ -398,6 +398,20 @@ class RenderStack extends ClippableRenderBox
     if (_fit != value) {
       _fit = value;
       markNeedsLayout();
+    }
+  }
+
+  /// {@macro flutter.widgets.Clip}
+  ///
+  /// Defaults to [Clip.hardEdge], and must not be null.
+  Clip get clipBehavior => _clipBehavior;
+  Clip _clipBehavior = Clip.hardEdge;
+  set clipBehavior(Clip value) {
+    assert(value != null);
+    if (value != _clipBehavior) {
+      _clipBehavior = value;
+      markNeedsPaint();
+      markNeedsSemanticsUpdate();
     }
   }
 
@@ -596,7 +610,7 @@ class RenderStack extends ClippableRenderBox
     properties.add(DiagnosticsProperty<AlignmentGeometry>('alignment', alignment));
     properties.add(EnumProperty<TextDirection>('textDirection', textDirection));
     properties.add(EnumProperty<StackFit>('fit', fit));
-    properties.add(EnumProperty<Clip>('clipBehavior', clipBehavior));
+    properties.add(EnumProperty<Clip>('clipBehavior', clipBehavior, defaultValue: Clip.hardEdge));
   }
 }
 

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -314,10 +314,9 @@ enum Overflow {
 /// See also:
 ///
 ///  * [RenderFlow]
-class RenderStack extends RenderBox
+class RenderStack extends ClippableRenderBox
     with ContainerRenderObjectMixin<RenderBox, StackParentData>,
-         RenderBoxContainerDefaultsMixin<RenderBox, StackParentData>,
-         ClipBehaviorMixin {
+         RenderBoxContainerDefaultsMixin<RenderBox, StackParentData> {
   /// Creates a stack render object.
   ///
   /// By default, the non-positioned children of the stack are aligned by their

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -162,7 +162,7 @@ class RevealedOffset {
 ///  * [RenderSliverToBoxAdapter], which allows a [RenderBox] object to be
 ///    placed inside a [RenderSliver] (the opposite of this class).
 abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMixin<RenderSliver>>
-    extends ClippableRenderBox with ContainerRenderObjectMixin<RenderSliver, ParentDataClass>
+    extends RenderBox with ContainerRenderObjectMixin<RenderSliver, ParentDataClass>
     implements RenderAbstractViewport {
   /// Initializes fields for subclasses.
   RenderViewportBase({
@@ -183,9 +183,8 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
        _crossAxisDirection = crossAxisDirection,
        _offset = offset,
        _cacheExtent = cacheExtent ?? RenderAbstractViewport.defaultCacheExtent,
-       _cacheExtentStyle = cacheExtentStyle {
-    this.clipBehavior = clipBehavior;
-  }
+       _cacheExtentStyle = cacheExtentStyle,
+       _clipBehavior = clipBehavior;
 
   @override
   void describeSemanticsConfiguration(SemanticsConfiguration config) {
@@ -316,6 +315,20 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     }
     _cacheExtentStyle = value;
     markNeedsLayout();
+  }
+
+  /// {@macro flutter.widgets.Clip}
+  ///
+  /// Defaults to [Clip.hardEdge], and must not be null.
+  Clip get clipBehavior => _clipBehavior;
+  Clip _clipBehavior = Clip.hardEdge;
+  set clipBehavior(Clip value) {
+    assert(value != null);
+    if (value != _clipBehavior) {
+      _clipBehavior = value;
+      markNeedsPaint();
+      markNeedsSemanticsUpdate();
+    }
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -162,7 +162,7 @@ class RevealedOffset {
 ///  * [RenderSliverToBoxAdapter], which allows a [RenderBox] object to be
 ///    placed inside a [RenderSliver] (the opposite of this class).
 abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMixin<RenderSliver>>
-    extends RenderBox with ContainerRenderObjectMixin<RenderSliver, ParentDataClass>
+    extends ClippableRenderBox with ContainerRenderObjectMixin<RenderSliver, ParentDataClass>
     implements RenderAbstractViewport {
   /// Initializes fields for subclasses.
   RenderViewportBase({
@@ -171,17 +171,21 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     @required ViewportOffset offset,
     double cacheExtent,
     CacheExtentStyle cacheExtentStyle = CacheExtentStyle.pixel,
+    Clip clipBehavior = Clip.hardEdge,
   }) : assert(axisDirection != null),
        assert(crossAxisDirection != null),
        assert(offset != null),
        assert(axisDirectionToAxis(axisDirection) != axisDirectionToAxis(crossAxisDirection)),
        assert(cacheExtentStyle != null),
        assert(cacheExtent != null || cacheExtentStyle == CacheExtentStyle.pixel),
+       assert(clipBehavior != null),
        _axisDirection = axisDirection,
        _crossAxisDirection = crossAxisDirection,
        _offset = offset,
        _cacheExtent = cacheExtent ?? RenderAbstractViewport.defaultCacheExtent,
-       _cacheExtentStyle = cacheExtentStyle;
+       _cacheExtentStyle = cacheExtentStyle {
+    this.clipBehavior = clipBehavior;
+  }
 
   @override
   void describeSemanticsConfiguration(SemanticsConfiguration config) {
@@ -574,8 +578,8 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   void paint(PaintingContext context, Offset offset) {
     if (firstChild == null)
       return;
-    if (hasVisualOverflow) {
-      context.pushClipRect(needsCompositing, offset, Offset.zero & size, _paintContents);
+    if (hasVisualOverflow && clipBehavior != Clip.none) {
+      context.pushClipRect(needsCompositing, offset, Offset.zero & size, _paintContents, clipBehavior: clipBehavior);
     } else {
       _paintContents(context, offset);
     }
@@ -1136,9 +1140,11 @@ class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentDat
     RenderSliver center,
     double cacheExtent,
     CacheExtentStyle cacheExtentStyle = CacheExtentStyle.pixel,
+    Clip clipBehavior = Clip.hardEdge,
   }) : assert(anchor != null),
        assert(anchor >= 0.0 && anchor <= 1.0),
        assert(cacheExtentStyle != CacheExtentStyle.viewport || cacheExtent != null),
+       assert(clipBehavior != null),
        _anchor = anchor,
        _center = center,
        super(
@@ -1147,6 +1153,7 @@ class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentDat
          offset: offset,
          cacheExtent: cacheExtent,
          cacheExtentStyle: cacheExtentStyle,
+         clipBehavior: clipBehavior,
        ) {
     addAll(children);
     if (center == null && firstChild != null)
@@ -1658,8 +1665,14 @@ class RenderShrinkWrappingViewport extends RenderViewportBase<SliverLogicalConta
     AxisDirection axisDirection = AxisDirection.down,
     @required AxisDirection crossAxisDirection,
     @required ViewportOffset offset,
+    Clip clipBehavior = Clip.hardEdge,
     List<RenderSliver> children,
-  }) : super(axisDirection: axisDirection, crossAxisDirection: crossAxisDirection, offset: offset) {
+  }) : super(
+        axisDirection: axisDirection,
+        crossAxisDirection: crossAxisDirection,
+        offset: offset,
+        clipBehavior: clipBehavior,
+       ) {
     addAll(children);
   }
 

--- a/packages/flutter/lib/src/rendering/wrap.dart
+++ b/packages/flutter/lib/src/rendering/wrap.dart
@@ -101,7 +101,7 @@ class WrapParentData extends ContainerBoxParentData<RenderBox> {
 ///
 /// The runs themselves are then positioned in the cross axis according to the
 /// [runSpacing] and [runAlignment].
-class RenderWrap extends ClippableRenderBox
+class RenderWrap extends RenderBox
     with ContainerRenderObjectMixin<RenderBox, WrapParentData>,
          RenderBoxContainerDefaultsMixin<RenderBox, WrapParentData> {
   /// Creates a wrap render object.
@@ -133,9 +133,9 @@ class RenderWrap extends ClippableRenderBox
        _runSpacing = runSpacing,
        _crossAxisAlignment = crossAxisAlignment,
        _textDirection = textDirection,
-       _verticalDirection = verticalDirection {
+       _verticalDirection = verticalDirection,
+       _clipBehavior = clipBehavior {
     addAll(children);
-    this.clipBehavior = clipBehavior;
   }
 
   /// The direction to use as the main axis.
@@ -327,6 +327,20 @@ class RenderWrap extends ClippableRenderBox
     if (_verticalDirection != value) {
       _verticalDirection = value;
       markNeedsLayout();
+    }
+  }
+
+  /// {@macro flutter.widgets.Clip}
+  ///
+  /// Defaults to [Clip.none], and must not be null.
+  Clip get clipBehavior => _clipBehavior;
+  Clip _clipBehavior = Clip.none;
+  set clipBehavior(Clip value) {
+    assert(value != null);
+    if (value != _clipBehavior) {
+      _clipBehavior = value;
+      markNeedsPaint();
+      markNeedsSemanticsUpdate();
     }
   }
 

--- a/packages/flutter/lib/src/rendering/wrap.dart
+++ b/packages/flutter/lib/src/rendering/wrap.dart
@@ -101,9 +101,9 @@ class WrapParentData extends ContainerBoxParentData<RenderBox> {
 ///
 /// The runs themselves are then positioned in the cross axis according to the
 /// [runSpacing] and [runAlignment].
-class RenderWrap extends RenderBox with ContainerRenderObjectMixin<RenderBox, WrapParentData>,
-                                        RenderBoxContainerDefaultsMixin<RenderBox, WrapParentData>,
-                                        ClipBehaviorMixin {
+class RenderWrap extends ClippableRenderBox
+    with ContainerRenderObjectMixin<RenderBox, WrapParentData>,
+         RenderBoxContainerDefaultsMixin<RenderBox, WrapParentData> {
   /// Creates a wrap render object.
   ///
   /// By default, the wrap layout is horizontal and both the children and the

--- a/packages/flutter/lib/src/rendering/wrap.dart
+++ b/packages/flutter/lib/src/rendering/wrap.dart
@@ -102,7 +102,8 @@ class WrapParentData extends ContainerBoxParentData<RenderBox> {
 /// The runs themselves are then positioned in the cross axis according to the
 /// [runSpacing] and [runAlignment].
 class RenderWrap extends RenderBox with ContainerRenderObjectMixin<RenderBox, WrapParentData>,
-                                        RenderBoxContainerDefaultsMixin<RenderBox, WrapParentData> {
+                                        RenderBoxContainerDefaultsMixin<RenderBox, WrapParentData>,
+                                        ClipBehaviorMixin {
   /// Creates a wrap render object.
   ///
   /// By default, the wrap layout is horizontal and both the children and the
@@ -117,12 +118,14 @@ class RenderWrap extends RenderBox with ContainerRenderObjectMixin<RenderBox, Wr
     WrapCrossAlignment crossAxisAlignment = WrapCrossAlignment.start,
     TextDirection textDirection,
     VerticalDirection verticalDirection = VerticalDirection.down,
+    Clip clipBehavior = Clip.none,
   }) : assert(direction != null),
        assert(alignment != null),
        assert(spacing != null),
        assert(runAlignment != null),
        assert(runSpacing != null),
        assert(crossAxisAlignment != null),
+       assert(clipBehavior != null),
        _direction = direction,
        _alignment = alignment,
        _spacing = spacing,
@@ -132,6 +135,7 @@ class RenderWrap extends RenderBox with ContainerRenderObjectMixin<RenderBox, Wr
        _textDirection = textDirection,
        _verticalDirection = verticalDirection {
     addAll(children);
+    this.clipBehavior = clipBehavior;
   }
 
   /// The direction to use as the main axis.
@@ -749,8 +753,8 @@ class RenderWrap extends RenderBox with ContainerRenderObjectMixin<RenderBox, Wr
   void paint(PaintingContext context, Offset offset) {
     // TODO(ianh): move the debug flex overflow paint logic somewhere common so
     // it can be reused here
-    if (_hasVisualOverflow)
-      context.pushClipRect(needsCompositing, offset, Offset.zero & size, defaultPaint);
+    if (_hasVisualOverflow && clipBehavior != Clip.none)
+      context.pushClipRect(needsCompositing, offset, Offset.zero & size, defaultPaint, clipBehavior: clipBehavior);
     else
       defaultPaint(context, offset);
   }

--- a/packages/flutter/lib/src/widgets/animated_cross_fade.dart
+++ b/packages/flutter/lib/src/widgets/animated_cross_fade.dart
@@ -216,6 +216,7 @@ class AnimatedCrossFade extends StatefulWidget {
   /// [AnimatedCrossFadeBuilder].
   static Widget defaultLayoutBuilder(Widget topChild, Key topChildKey, Widget bottomChild, Key bottomChildKey) {
     return Stack(
+      clipBehavior: Clip.none,
       children: <Widget>[
         Positioned(
           key: bottomChildKey,

--- a/packages/flutter/lib/src/widgets/animated_cross_fade.dart
+++ b/packages/flutter/lib/src/widgets/animated_cross_fade.dart
@@ -216,7 +216,6 @@ class AnimatedCrossFade extends StatefulWidget {
   /// [AnimatedCrossFadeBuilder].
   static Widget defaultLayoutBuilder(Widget topChild, Key topChildKey, Widget bottomChild, Key bottomChildKey) {
     return Stack(
-      overflow: Overflow.visible,
       children: <Widget>[
         Positioned(
           key: bottomChildKey,

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3231,9 +3231,10 @@ class Stack extends MultiChildRenderObjectWidget {
     this.alignment = AlignmentDirectional.topStart,
     this.textDirection,
     this.fit = StackFit.loose,
-    this.overflow = Overflow.clip,
+    this.overflow = Overflow.visible,
+    this.clipBehavior = Clip.none,
     List<Widget> children = const <Widget>[],
-  }) : super(key: key, children: children);
+  }) : assert(clipBehavior != null), super(key: key, children: children);
 
   /// How to align the non-positioned and partially-positioned children in the
   /// stack.
@@ -3276,6 +3277,11 @@ class Stack extends MultiChildRenderObjectWidget {
   /// [Overflow.clip], children cannot paint outside of the stack's box.
   final Overflow overflow;
 
+  /// {@macro flutter.widgets.Clip}
+  ///
+  /// Defaults to [Clip.none].
+  final Clip clipBehavior;
+
   @override
   RenderStack createRenderObject(BuildContext context) {
     return RenderStack(
@@ -3283,6 +3289,7 @@ class Stack extends MultiChildRenderObjectWidget {
       textDirection: textDirection ?? Directionality.of(context),
       fit: fit,
       overflow: overflow,
+      clipBehavior: clipBehavior,
     );
   }
 
@@ -3292,7 +3299,8 @@ class Stack extends MultiChildRenderObjectWidget {
       ..alignment = alignment
       ..textDirection = textDirection ?? Directionality.of(context)
       ..fit = fit
-      ..overflow = overflow;
+      ..overflow = overflow
+      ..clipBehavior = clipBehavior;
   }
 
   @override
@@ -4653,8 +4661,9 @@ class Wrap extends MultiChildRenderObjectWidget {
     this.crossAxisAlignment = WrapCrossAlignment.start,
     this.textDirection,
     this.verticalDirection = VerticalDirection.down,
+    this.clipBehavior = Clip.none,
     List<Widget> children = const <Widget>[],
-  }) : super(key: key, children: children);
+  }) : assert(clipBehavior != null), super(key: key, children: children);
 
   /// The direction to use as the main axis.
   ///
@@ -4788,6 +4797,11 @@ class Wrap extends MultiChildRenderObjectWidget {
   /// [verticalDirection] must not be null.
   final VerticalDirection verticalDirection;
 
+  /// {@macro flutter.widgets.Clip}
+  ///
+  /// Defaults to [Clip.none].
+  final Clip clipBehavior;
+
   @override
   RenderWrap createRenderObject(BuildContext context) {
     return RenderWrap(
@@ -4799,6 +4813,7 @@ class Wrap extends MultiChildRenderObjectWidget {
       crossAxisAlignment: crossAxisAlignment,
       textDirection: textDirection ?? Directionality.of(context),
       verticalDirection: verticalDirection,
+      clipBehavior: clipBehavior,
     );
   }
 
@@ -4812,7 +4827,8 @@ class Wrap extends MultiChildRenderObjectWidget {
       ..runSpacing = runSpacing
       ..crossAxisAlignment = crossAxisAlignment
       ..textDirection = textDirection ?? Directionality.of(context)
-      ..verticalDirection = verticalDirection;
+      ..verticalDirection = verticalDirection
+      ..clipBehavior = clipBehavior;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3230,6 +3230,7 @@ class Stack extends MultiChildRenderObjectWidget {
     this.alignment = AlignmentDirectional.topStart,
     this.textDirection,
     this.fit = StackFit.loose,
+    this.overflow = Overflow.clip,
     this.clipBehavior = Clip.hardEdge,
     List<Widget> children = const <Widget>[],
   }) : assert(clipBehavior != null),
@@ -3270,6 +3271,16 @@ class Stack extends MultiChildRenderObjectWidget {
   /// ([StackFit.expand]).
   final StackFit fit;
 
+  // TODO(liyuqian): remove this once its usages are removed from Google.
+  /// Whether overflowing children should be clipped. See [Overflow].
+  ///
+  /// Some children in a stack might overflow its box. When this flag is set to
+  /// [Overflow.clip], children cannot paint outside of the stack's box.
+  ///
+  /// This overrides [clipBehavior] for now due to a staged roll out without
+  /// breaking Google. We will remove it and only use [clipBehavior] soon.
+  final Overflow overflow;
+
   /// {@macro flutter.widgets.Clip}
   ///
   /// Defaults to [Clip.hardEdge].
@@ -3281,7 +3292,7 @@ class Stack extends MultiChildRenderObjectWidget {
       alignment: alignment,
       textDirection: textDirection ?? Directionality.of(context),
       fit: fit,
-      clipBehavior: clipBehavior,
+      clipBehavior: overflow == Overflow.clip ? Clip.hardEdge : clipBehavior,
     );
   }
 
@@ -3291,7 +3302,7 @@ class Stack extends MultiChildRenderObjectWidget {
       ..alignment = alignment
       ..textDirection = textDirection ?? Directionality.of(context)
       ..fit = fit
-      ..clipBehavior = clipBehavior;
+      ..clipBehavior = overflow == Overflow.clip ? Clip.hardEdge : clipBehavior;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3234,7 +3234,9 @@ class Stack extends MultiChildRenderObjectWidget {
     this.overflow = Overflow.visible,
     this.clipBehavior = Clip.none,
     List<Widget> children = const <Widget>[],
-  }) : assert(clipBehavior != null), super(key: key, children: children);
+  }) : assert(clipBehavior != null),
+       assert((overflow == Overflow.visible) == (clipBehavior == Clip.none)),
+       super(key: key, children: children);
 
   /// How to align the non-positioned and partially-positioned children in the
   /// stack.

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3230,7 +3230,7 @@ class Stack extends MultiChildRenderObjectWidget {
     this.alignment = AlignmentDirectional.topStart,
     this.textDirection,
     this.fit = StackFit.loose,
-    this.clipBehavior = Clip.none,
+    this.clipBehavior = Clip.hardEdge,
     List<Widget> children = const <Widget>[],
   }) : assert(clipBehavior != null),
        super(key: key, children: children);
@@ -3272,7 +3272,7 @@ class Stack extends MultiChildRenderObjectWidget {
 
   /// {@macro flutter.widgets.Clip}
   ///
-  /// Defaults to [Clip.none].
+  /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
 
   @override
@@ -3300,7 +3300,7 @@ class Stack extends MultiChildRenderObjectWidget {
     properties.add(DiagnosticsProperty<AlignmentGeometry>('alignment', alignment));
     properties.add(EnumProperty<TextDirection>('textDirection', textDirection, defaultValue: null));
     properties.add(EnumProperty<StackFit>('fit', fit));
-    properties.add(EnumProperty<Clip>('clipBehavior', clipBehavior));
+    properties.add(EnumProperty<Clip>('clipBehavior', clipBehavior, defaultValue: Clip.hardEdge));
   }
 }
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1411,9 +1411,11 @@ class FittedBox extends SingleChildRenderObjectWidget {
     Key key,
     this.fit = BoxFit.contain,
     this.alignment = Alignment.center,
+    this.clipBehavior = Clip.none,
     Widget child,
   }) : assert(fit != null),
        assert(alignment != null),
+       assert(clipBehavior != null),
        super(key: key, child: child);
 
   /// How to inscribe the child into the space allocated during layout.
@@ -1435,12 +1437,18 @@ class FittedBox extends SingleChildRenderObjectWidget {
   ///    relative to text direction.
   final AlignmentGeometry alignment;
 
+  /// {@macro flutter.widgets.Clip}
+  ///
+  /// Defaults to [Clip.none].
+  final Clip clipBehavior;
+
   @override
   RenderFittedBox createRenderObject(BuildContext context) {
     return RenderFittedBox(
       fit: fit,
       alignment: alignment,
       textDirection: Directionality.of(context),
+      clipBehavior: clipBehavior,
     );
   }
 
@@ -1449,7 +1457,8 @@ class FittedBox extends SingleChildRenderObjectWidget {
     renderObject
       ..fit = fit
       ..alignment = alignment
-      ..textDirection = Directionality.of(context);
+      ..textDirection = Directionality.of(context)
+      ..clipBehavior = clipBehavior;
   }
 
   @override
@@ -3809,6 +3818,7 @@ class Flex extends MultiChildRenderObjectWidget {
     this.textDirection,
     this.verticalDirection = VerticalDirection.down,
     this.textBaseline,
+    this.clipBehavior = Clip.none,
     List<Widget> children = const <Widget>[],
   }) : assert(direction != null),
        assert(mainAxisAlignment != null),
@@ -3816,6 +3826,7 @@ class Flex extends MultiChildRenderObjectWidget {
        assert(crossAxisAlignment != null),
        assert(verticalDirection != null),
        assert(crossAxisAlignment != CrossAxisAlignment.baseline || textBaseline != null),
+       assert(clipBehavior != null),
        super(key: key, children: children);
 
   /// The direction to use as the main axis.
@@ -3900,6 +3911,11 @@ class Flex extends MultiChildRenderObjectWidget {
   /// If aligning items according to their baseline, which baseline to use.
   final TextBaseline textBaseline;
 
+  /// {@macro flutter.widgets.Clip}
+  ///
+  /// Defaults to [Clip.none].
+  final Clip clipBehavior;
+
   bool get _needTextDirection {
     assert(direction != null);
     switch (direction) {
@@ -3943,6 +3959,7 @@ class Flex extends MultiChildRenderObjectWidget {
       textDirection: getEffectiveTextDirection(context),
       verticalDirection: verticalDirection,
       textBaseline: textBaseline,
+      clipBehavior: clipBehavior,
     );
   }
 
@@ -3955,7 +3972,8 @@ class Flex extends MultiChildRenderObjectWidget {
       ..crossAxisAlignment = crossAxisAlignment
       ..textDirection = getEffectiveTextDirection(context)
       ..verticalDirection = verticalDirection
-      ..textBaseline = textBaseline;
+      ..textBaseline = textBaseline
+      ..clipBehavior = clipBehavior;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2240,7 +2240,9 @@ class UnconstrainedBox extends SingleChildRenderObjectWidget {
     this.textDirection,
     this.alignment = Alignment.center,
     this.constrainedAxis,
+    this.clipBehavior = Clip.none,
   }) : assert(alignment != null),
+       assert(clipBehavior != null),
        super(key: key, child: child);
 
   /// The text direction to use when interpreting the [alignment] if it is an
@@ -2266,12 +2268,18 @@ class UnconstrainedBox extends SingleChildRenderObjectWidget {
   /// will be retained.
   final Axis constrainedAxis;
 
+  /// {@macro flutter.widgets.Clip}
+  ///
+  /// Defaults to [Clip.none].
+  final Clip clipBehavior;
+
   @override
   void updateRenderObject(BuildContext context, covariant RenderUnconstrainedBox renderObject) {
     renderObject
       ..textDirection = textDirection ?? Directionality.of(context)
       ..alignment = alignment
-      ..constrainedAxis = constrainedAxis;
+      ..constrainedAxis = constrainedAxis
+      ..clipBehavior = clipBehavior;
   }
 
   @override
@@ -2279,6 +2287,7 @@ class UnconstrainedBox extends SingleChildRenderObjectWidget {
     textDirection: textDirection ?? Directionality.of(context),
     alignment: alignment,
     constrainedAxis: constrainedAxis,
+    clipBehavior: clipBehavior,
   );
 
   @override

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -42,7 +42,6 @@ export 'package:flutter/rendering.dart' show
   MainAxisAlignment,
   MainAxisSize,
   MultiChildLayoutDelegate,
-  Overflow,
   PaintingContext,
   PointerCancelEvent,
   PointerCancelEventListener,

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3231,11 +3231,9 @@ class Stack extends MultiChildRenderObjectWidget {
     this.alignment = AlignmentDirectional.topStart,
     this.textDirection,
     this.fit = StackFit.loose,
-    this.overflow = Overflow.visible,
     this.clipBehavior = Clip.none,
     List<Widget> children = const <Widget>[],
   }) : assert(clipBehavior != null),
-       assert((overflow == Overflow.visible) == (clipBehavior == Clip.none)),
        super(key: key, children: children);
 
   /// How to align the non-positioned and partially-positioned children in the
@@ -3273,12 +3271,6 @@ class Stack extends MultiChildRenderObjectWidget {
   /// ([StackFit.expand]).
   final StackFit fit;
 
-  /// Whether overflowing children should be clipped. See [Overflow].
-  ///
-  /// Some children in a stack might overflow its box. When this flag is set to
-  /// [Overflow.clip], children cannot paint outside of the stack's box.
-  final Overflow overflow;
-
   /// {@macro flutter.widgets.Clip}
   ///
   /// Defaults to [Clip.none].
@@ -3290,7 +3282,6 @@ class Stack extends MultiChildRenderObjectWidget {
       alignment: alignment,
       textDirection: textDirection ?? Directionality.of(context),
       fit: fit,
-      overflow: overflow,
       clipBehavior: clipBehavior,
     );
   }
@@ -3301,7 +3292,6 @@ class Stack extends MultiChildRenderObjectWidget {
       ..alignment = alignment
       ..textDirection = textDirection ?? Directionality.of(context)
       ..fit = fit
-      ..overflow = overflow
       ..clipBehavior = clipBehavior;
   }
 
@@ -3311,7 +3301,7 @@ class Stack extends MultiChildRenderObjectWidget {
     properties.add(DiagnosticsProperty<AlignmentGeometry>('alignment', alignment));
     properties.add(EnumProperty<TextDirection>('textDirection', textDirection, defaultValue: null));
     properties.add(EnumProperty<StackFit>('fit', fit));
-    properties.add(EnumProperty<Overflow>('overflow', overflow));
+    properties.add(EnumProperty<Clip>('clipBehavior', clipBehavior));
   }
 }
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1410,7 +1410,7 @@ class FittedBox extends SingleChildRenderObjectWidget {
     Key key,
     this.fit = BoxFit.contain,
     this.alignment = Alignment.center,
-    this.clipBehavior = Clip.none,
+    this.clipBehavior = Clip.hardEdge,
     Widget child,
   }) : assert(fit != null),
        assert(alignment != null),
@@ -1436,9 +1436,10 @@ class FittedBox extends SingleChildRenderObjectWidget {
   ///    relative to text direction.
   final AlignmentGeometry alignment;
 
+  // TODO(liyuqian): defaults to [Clip.none] once Google references are updated.
   /// {@macro flutter.widgets.Clip}
   ///
-  /// Defaults to [Clip.none].
+  /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
 
   @override
@@ -2239,7 +2240,7 @@ class UnconstrainedBox extends SingleChildRenderObjectWidget {
     this.textDirection,
     this.alignment = Alignment.center,
     this.constrainedAxis,
-    this.clipBehavior = Clip.none,
+    this.clipBehavior = Clip.hardEdge,
   }) : assert(alignment != null),
        assert(clipBehavior != null),
        super(key: key, child: child);
@@ -2267,9 +2268,10 @@ class UnconstrainedBox extends SingleChildRenderObjectWidget {
   /// will be retained.
   final Axis constrainedAxis;
 
+  // TODO(liyuqian): defaults to [Clip.none] once Google references are updated.
   /// {@macro flutter.widgets.Clip}
   ///
-  /// Defaults to [Clip.none].
+  /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
 
   @override
@@ -3837,7 +3839,7 @@ class Flex extends MultiChildRenderObjectWidget {
     this.textDirection,
     this.verticalDirection = VerticalDirection.down,
     this.textBaseline,
-    this.clipBehavior = Clip.none,
+    this.clipBehavior = Clip.hardEdge,
     List<Widget> children = const <Widget>[],
   }) : assert(direction != null),
        assert(mainAxisAlignment != null),
@@ -3930,9 +3932,10 @@ class Flex extends MultiChildRenderObjectWidget {
   /// If aligning items according to their baseline, which baseline to use.
   final TextBaseline textBaseline;
 
+  // TODO(liyuqian): defaults to [Clip.none] once Google references are updated.
   /// {@macro flutter.widgets.Clip}
   ///
-  /// Defaults to [Clip.none].
+  /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
 
   bool get _needTextDirection {
@@ -4663,7 +4666,7 @@ class Wrap extends MultiChildRenderObjectWidget {
     this.crossAxisAlignment = WrapCrossAlignment.start,
     this.textDirection,
     this.verticalDirection = VerticalDirection.down,
-    this.clipBehavior = Clip.none,
+    this.clipBehavior = Clip.hardEdge,
     List<Widget> children = const <Widget>[],
   }) : assert(clipBehavior != null), super(key: key, children: children);
 
@@ -4799,9 +4802,10 @@ class Wrap extends MultiChildRenderObjectWidget {
   /// [verticalDirection] must not be null.
   final VerticalDirection verticalDirection;
 
+  // TODO(liyuqian): defaults to [Clip.none] once Google references are updated.
   /// {@macro flutter.widgets.Clip}
   ///
-  /// Defaults to [Clip.none].
+  /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
 
   @override

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3273,7 +3273,8 @@ class Stack extends MultiChildRenderObjectWidget {
   /// ([StackFit.expand]).
   final StackFit fit;
 
-  // TODO(liyuqian): remove this once its usages are removed from Google.
+  // TODO(liyuqian): Deprecate and remove [overflow] once its usages are removed from Google.
+
   /// Whether overflowing children should be clipped. See [Overflow].
   ///
   /// Some children in a stack might overflow its box. When this flag is set to

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1124,7 +1124,7 @@ class EditableText extends StatefulWidget {
 
   /// {@macro flutter.widgets.Clip}
   ///
-  /// Defaults to [Clip.none].
+  /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
 
   @override

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2036,7 +2036,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     super.build(context); // See AutomaticKeepAliveClientMixin.
 
     final TextSelectionControls controls = widget.selectionControls;
-<<<<<<< HEAD
     return MouseRegion(
       cursor: widget.mouseCursor ?? SystemMouseCursors.text,
       child: Scrollable(

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -413,6 +413,7 @@ class EditableText extends StatefulWidget {
       selectAll: true,
     ),
     this.autofillHints,
+    this.clipBehavior = Clip.hardEdge,
   }) : assert(controller != null),
        assert(focusNode != null),
        assert(obscuringCharacter != null && obscuringCharacter.length == 1),
@@ -450,6 +451,7 @@ class EditableText extends StatefulWidget {
        assert(scrollPadding != null),
        assert(dragStartBehavior != null),
        assert(toolbarOptions != null),
+       assert(clipBehavior != null),
        _strutStyle = strutStyle,
        keyboardType = keyboardType ?? (maxLines == 1 ? TextInputType.text : TextInputType.multiline),
        inputFormatters = maxLines == 1
@@ -1119,6 +1121,11 @@ class EditableText extends StatefulWidget {
   /// {@macro flutter.services.autofill.autofillHints}
   /// {@endtemplate}
   final Iterable<String> autofillHints;
+
+  /// {@macro flutter.widgets.Clip}
+  ///
+  /// Defaults to [Clip.none].
+  final Clip clipBehavior;
 
   @override
   EditableTextState createState() => EditableTextState();
@@ -2029,6 +2036,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     super.build(context); // See AutomaticKeepAliveClientMixin.
 
     final TextSelectionControls controls = widget.selectionControls;
+<<<<<<< HEAD
     return MouseRegion(
       cursor: widget.mouseCursor ?? SystemMouseCursors.text,
       child: Scrollable(
@@ -2089,6 +2097,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
                 devicePixelRatio: _devicePixelRatio,
                 promptRectRange: _currentPromptRectRange,
                 promptRectColor: widget.autocorrectionTextRectColor,
+                clipBehavior: widget.clipBehavior,
               ),
             ),
           );
@@ -2163,6 +2172,7 @@ class _Editable extends LeafRenderObjectWidget {
     this.devicePixelRatio,
     this.promptRectRange,
     this.promptRectColor,
+    this.clipBehavior,
   }) : assert(textDirection != null),
        assert(rendererIgnoresPointer != null),
        super(key: key);
@@ -2208,6 +2218,7 @@ class _Editable extends LeafRenderObjectWidget {
   final double devicePixelRatio;
   final TextRange promptRectRange;
   final Color promptRectColor;
+  final Clip clipBehavior;
 
   @override
   RenderEditable createRenderObject(BuildContext context) {
@@ -2249,6 +2260,7 @@ class _Editable extends LeafRenderObjectWidget {
       devicePixelRatio: devicePixelRatio,
       promptRectRange: promptRectRange,
       promptRectColor: promptRectColor,
+      clipBehavior: clipBehavior,
     );
   }
 
@@ -2289,6 +2301,7 @@ class _Editable extends LeafRenderObjectWidget {
       ..devicePixelRatio = devicePixelRatio
       ..paintCursorAboveText = paintCursorAboveText
       ..promptRectColor = promptRectColor
+      ..clipBehavior = clipBehavior
       ..setPromptRectRange(promptRectRange);
   }
 }

--- a/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
@@ -581,6 +581,7 @@ class ListWheelScrollView extends StatefulWidget {
     this.onSelectedItemChanged,
     this.clipToSize = true,
     this.renderChildrenOutsideViewport = false,
+    this.clipBehavior = Clip.hardEdge,
     @required List<Widget> children,
   }) : assert(children != null),
        assert(diameterRatio != null),
@@ -597,6 +598,7 @@ class ListWheelScrollView extends StatefulWidget {
        assert(squeeze > 0),
        assert(clipToSize != null),
        assert(renderChildrenOutsideViewport != null),
+       assert(clipBehavior != null),
        assert(
          !renderChildrenOutsideViewport || !clipToSize,
          RenderListWheelViewport.clipToSizeAndRenderChildrenOutsideViewportConflict,
@@ -621,6 +623,7 @@ class ListWheelScrollView extends StatefulWidget {
     this.onSelectedItemChanged,
     this.clipToSize = true,
     this.renderChildrenOutsideViewport = false,
+    this.clipBehavior = Clip.hardEdge,
     @required this.childDelegate,
   }) : assert(childDelegate != null),
        assert(diameterRatio != null),
@@ -637,6 +640,7 @@ class ListWheelScrollView extends StatefulWidget {
        assert(squeeze > 0),
        assert(clipToSize != null),
        assert(renderChildrenOutsideViewport != null),
+       assert(clipBehavior != null),
        assert(
          !renderChildrenOutsideViewport || !clipToSize,
          RenderListWheelViewport.clipToSizeAndRenderChildrenOutsideViewportConflict,
@@ -707,6 +711,11 @@ class ListWheelScrollView extends StatefulWidget {
   /// A delegate that helps lazily instantiating child.
   final ListWheelChildDelegate childDelegate;
 
+  /// {@macro flutter.widgets.Clip}
+  ///
+  /// Defaults to [Clip.none].
+  final Clip clipBehavior;
+
   @override
   _ListWheelScrollViewState createState() => _ListWheelScrollViewState();
 }
@@ -773,6 +782,7 @@ class _ListWheelScrollViewState extends State<ListWheelScrollView> {
             renderChildrenOutsideViewport: widget.renderChildrenOutsideViewport,
             offset: offset,
             childDelegate: widget.childDelegate,
+            clipBehavior: widget.clipBehavior,
           );
         },
       ),
@@ -970,6 +980,7 @@ class ListWheelViewport extends RenderObjectWidget {
     this.renderChildrenOutsideViewport = false,
     @required this.offset,
     @required this.childDelegate,
+    this.clipBehavior = Clip.hardEdge,
   }) : assert(childDelegate != null),
        assert(offset != null),
        assert(diameterRatio != null),
@@ -985,6 +996,8 @@ class ListWheelViewport extends RenderObjectWidget {
        assert(squeeze > 0),
        assert(clipToSize != null),
        assert(renderChildrenOutsideViewport != null),
+       assert(clipBehavior != null),
+       assert(clipToSize == (clipBehavior != Clip.none)),
        assert(
          !renderChildrenOutsideViewport || !clipToSize,
          RenderListWheelViewport.clipToSizeAndRenderChildrenOutsideViewportConflict,
@@ -1030,6 +1043,11 @@ class ListWheelViewport extends RenderObjectWidget {
   /// A delegate that lazily instantiates children.
   final ListWheelChildDelegate childDelegate;
 
+  /// {@macro flutter.widgets.Clip}
+  ///
+  /// Defaults to [Clip.none].
+  final Clip clipBehavior;
+
   @override
   ListWheelElement createElement() => ListWheelElement(this);
 
@@ -1049,6 +1067,7 @@ class ListWheelViewport extends RenderObjectWidget {
       squeeze: squeeze,
       clipToSize: clipToSize,
       renderChildrenOutsideViewport: renderChildrenOutsideViewport,
+      clipBehavior: clipBehavior,
     );
   }
 
@@ -1065,6 +1084,7 @@ class ListWheelViewport extends RenderObjectWidget {
       ..itemExtent = itemExtent
       ..squeeze = squeeze
       ..clipToSize = clipToSize
-      ..renderChildrenOutsideViewport = renderChildrenOutsideViewport;
+      ..renderChildrenOutsideViewport = renderChildrenOutsideViewport
+      ..clipBehavior = clipBehavior;
   }
 }

--- a/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
@@ -579,7 +579,6 @@ class ListWheelScrollView extends StatefulWidget {
     @required this.itemExtent,
     this.squeeze = 1.0,
     this.onSelectedItemChanged,
-    this.clipToSize = true,
     this.renderChildrenOutsideViewport = false,
     this.clipBehavior = Clip.hardEdge,
     @required List<Widget> children,
@@ -596,12 +595,11 @@ class ListWheelScrollView extends StatefulWidget {
        assert(itemExtent > 0),
        assert(squeeze != null),
        assert(squeeze > 0),
-       assert(clipToSize != null),
        assert(renderChildrenOutsideViewport != null),
        assert(clipBehavior != null),
        assert(
-         !renderChildrenOutsideViewport || !clipToSize,
-         RenderListWheelViewport.clipToSizeAndRenderChildrenOutsideViewportConflict,
+         !renderChildrenOutsideViewport || clipBehavior == Clip.none,
+         RenderListWheelViewport.clipBehaviorAndRenderChildrenOutsideViewportConflict,
        ),
        childDelegate = ListWheelChildListDelegate(children: children),
        super(key: key);
@@ -621,7 +619,6 @@ class ListWheelScrollView extends StatefulWidget {
     @required this.itemExtent,
     this.squeeze = 1.0,
     this.onSelectedItemChanged,
-    this.clipToSize = true,
     this.renderChildrenOutsideViewport = false,
     this.clipBehavior = Clip.hardEdge,
     @required this.childDelegate,
@@ -638,12 +635,11 @@ class ListWheelScrollView extends StatefulWidget {
        assert(itemExtent > 0),
        assert(squeeze != null),
        assert(squeeze > 0),
-       assert(clipToSize != null),
        assert(renderChildrenOutsideViewport != null),
        assert(clipBehavior != null),
        assert(
-         !renderChildrenOutsideViewport || !clipToSize,
-         RenderListWheelViewport.clipToSizeAndRenderChildrenOutsideViewportConflict,
+         !renderChildrenOutsideViewport || clipBehavior == Clip.none,
+         RenderListWheelViewport.clipBehaviorAndRenderChildrenOutsideViewportConflict,
        ),
        super(key: key);
 
@@ -701,9 +697,6 @@ class ListWheelScrollView extends StatefulWidget {
 
   /// On optional listener that's called when the centered item changes.
   final ValueChanged<int> onSelectedItemChanged;
-
-  /// {@macro flutter.rendering.wheelList.clipToSize}
-  final bool clipToSize;
 
   /// {@macro flutter.rendering.wheelList.renderChildrenOutsideViewport}
   final bool renderChildrenOutsideViewport;
@@ -778,7 +771,6 @@ class _ListWheelScrollViewState extends State<ListWheelScrollView> {
             overAndUnderCenterOpacity: widget.overAndUnderCenterOpacity,
             itemExtent: widget.itemExtent,
             squeeze: widget.squeeze,
-            clipToSize: widget.clipToSize,
             renderChildrenOutsideViewport: widget.renderChildrenOutsideViewport,
             offset: offset,
             childDelegate: widget.childDelegate,
@@ -960,7 +952,7 @@ class ListWheelViewport extends RenderObjectWidget {
   ///
   /// The [itemExtent] argument in pixels must be provided and must be positive.
   ///
-  /// The [clipToSize] argument defaults to true and must not be null.
+  /// The [clipBehavior] argument defaults to [Clip.hardEdge] and must not be null.
   ///
   /// The [renderChildrenOutsideViewport] argument defaults to false and must
   /// not be null.
@@ -976,7 +968,6 @@ class ListWheelViewport extends RenderObjectWidget {
     this.overAndUnderCenterOpacity = 1.0,
     @required this.itemExtent,
     this.squeeze = 1.0,
-    this.clipToSize = true,
     this.renderChildrenOutsideViewport = false,
     @required this.offset,
     @required this.childDelegate,
@@ -994,13 +985,11 @@ class ListWheelViewport extends RenderObjectWidget {
        assert(itemExtent > 0),
        assert(squeeze != null),
        assert(squeeze > 0),
-       assert(clipToSize != null),
        assert(renderChildrenOutsideViewport != null),
        assert(clipBehavior != null),
-       assert(clipToSize == (clipBehavior != Clip.none)),
        assert(
-         !renderChildrenOutsideViewport || !clipToSize,
-         RenderListWheelViewport.clipToSizeAndRenderChildrenOutsideViewportConflict,
+         !renderChildrenOutsideViewport || clipBehavior == Clip.none,
+         RenderListWheelViewport.clipBehaviorAndRenderChildrenOutsideViewportConflict,
        ),
        super(key: key);
 
@@ -1029,9 +1018,6 @@ class ListWheelViewport extends RenderObjectWidget {
   ///
   /// Defaults to 1.
   final double squeeze;
-
-  /// {@macro flutter.rendering.wheelList.clipToSize}
-  final bool clipToSize;
 
   /// {@macro flutter.rendering.wheelList.renderChildrenOutsideViewport}
   final bool renderChildrenOutsideViewport;
@@ -1065,7 +1051,6 @@ class ListWheelViewport extends RenderObjectWidget {
       overAndUnderCenterOpacity: overAndUnderCenterOpacity,
       itemExtent: itemExtent,
       squeeze: squeeze,
-      clipToSize: clipToSize,
       renderChildrenOutsideViewport: renderChildrenOutsideViewport,
       clipBehavior: clipBehavior,
     );
@@ -1083,7 +1068,6 @@ class ListWheelViewport extends RenderObjectWidget {
       ..overAndUnderCenterOpacity = overAndUnderCenterOpacity
       ..itemExtent = itemExtent
       ..squeeze = squeeze
-      ..clipToSize = clipToSize
       ..renderChildrenOutsideViewport = renderChildrenOutsideViewport
       ..clipBehavior = clipBehavior;
   }

--- a/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
@@ -713,7 +713,7 @@ class ListWheelScrollView extends StatefulWidget {
 
   /// {@macro flutter.widgets.Clip}
   ///
-  /// Defaults to [Clip.none].
+  /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
 
   @override

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -193,10 +193,12 @@ class NestedScrollView extends StatefulWidget {
     @required this.headerSliverBuilder,
     @required this.body,
     this.dragStartBehavior = DragStartBehavior.start,
+    this.clipBehavior = Clip.hardEdge,
   }) : assert(scrollDirection != null),
        assert(reverse != null),
        assert(headerSliverBuilder != null),
        assert(body != null),
+       assert(clipBehavior != null),
        super(key: key);
 
   /// An object that can be used to control the position to which the outer
@@ -259,6 +261,11 @@ class NestedScrollView extends StatefulWidget {
 
   /// {@macro flutter.widgets.scrollable.dragStartBehavior}
   final DragStartBehavior dragStartBehavior;
+
+  /// {@macro flutter.widgets.Clip}
+  ///
+  /// Defaults to [Clip.none].
+  final Clip clipBehavior;
 
   /// Returns the [SliverOverlapAbsorberHandle] of the nearest ancestor
   /// [NestedScrollView].
@@ -437,6 +444,7 @@ class NestedScrollViewState extends State<NestedScrollView> {
               _lastHasScrolledBody,
             ),
             handle: _absorberHandle,
+            clipBehavior: widget.clipBehavior,
           );
         },
       ),
@@ -452,6 +460,7 @@ class _NestedScrollViewCustomScrollView extends CustomScrollView {
     @required ScrollController controller,
     @required List<Widget> slivers,
     @required this.handle,
+    @required this.clipBehavior,
     DragStartBehavior dragStartBehavior = DragStartBehavior.start,
   }) : super(
          scrollDirection: scrollDirection,
@@ -463,6 +472,7 @@ class _NestedScrollViewCustomScrollView extends CustomScrollView {
        );
 
   final SliverOverlapAbsorberHandle handle;
+  final Clip clipBehavior;
 
   @override
   Widget buildViewport(
@@ -477,6 +487,7 @@ class _NestedScrollViewCustomScrollView extends CustomScrollView {
       offset: offset,
       slivers: slivers,
       handle: handle,
+      clipBehavior: clipBehavior,
     );
   }
 }
@@ -1824,6 +1835,7 @@ class NestedScrollViewViewport extends Viewport {
     Key center,
     List<Widget> slivers = const <Widget>[],
     @required this.handle,
+    Clip clipBehavior = Clip.hardEdge,
   }) : assert(handle != null),
        super(
          key: key,
@@ -1833,6 +1845,7 @@ class NestedScrollViewViewport extends Viewport {
          offset: offset,
          center: center,
          slivers: slivers,
+         clipBehavior: clipBehavior,
        );
 
   /// The handle to the [SliverOverlapAbsorber] that is feeding this injector.
@@ -1849,6 +1862,7 @@ class NestedScrollViewViewport extends Viewport {
       anchor: anchor,
       offset: offset,
       handle: handle,
+      clipBehavior: clipBehavior,
     );
   }
 
@@ -1862,7 +1876,8 @@ class NestedScrollViewViewport extends Viewport {
       )
       ..anchor = anchor
       ..offset = offset
-      ..handle = handle;
+      ..handle = handle
+      ..clipBehavior = clipBehavior;
   }
 
   @override
@@ -1889,6 +1904,7 @@ class RenderNestedScrollViewViewport extends RenderViewport {
     List<RenderSliver> children,
     RenderSliver center,
     @required SliverOverlapAbsorberHandle handle,
+    Clip clipBehavior = Clip.hardEdge,
   }) : assert(handle != null),
        _handle = handle,
        super(
@@ -1898,6 +1914,7 @@ class RenderNestedScrollViewViewport extends RenderViewport {
          anchor: anchor,
          children: children,
          center: center,
+         clipBehavior: clipBehavior,
        );
 
   /// The object to notify when [markNeedsLayout] is called.

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -264,7 +264,7 @@ class NestedScrollView extends StatefulWidget {
 
   /// {@macro flutter.widgets.Clip}
   ///
-  /// Defaults to [Clip.none].
+  /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
 
   /// Returns the [SliverOverlapAbsorberHandle] of the nearest ancestor

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -294,7 +294,7 @@ class SingleChildScrollView extends StatelessWidget {
 
   /// {@macro flutter.widgets.Clip}
   ///
-  /// Defaults to [Clip.none].
+  /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
 
   AxisDirection _getDirection(BuildContext context) {

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -364,9 +364,7 @@ class _SingleChildViewport extends SingleChildRenderObjectWidget {
   }
 }
 
-class _RenderSingleChildViewport extends ClippableRenderBox
-    with RenderObjectWithChildMixin<RenderBox>
-    implements RenderAbstractViewport {
+class _RenderSingleChildViewport extends RenderBox with RenderObjectWithChildMixin<RenderBox> implements RenderAbstractViewport {
   _RenderSingleChildViewport({
     AxisDirection axisDirection = AxisDirection.down,
     @required ViewportOffset offset,
@@ -379,9 +377,9 @@ class _RenderSingleChildViewport extends ClippableRenderBox
        assert(clipBehavior != null),
        _axisDirection = axisDirection,
        _offset = offset,
-       _cacheExtent = cacheExtent {
+       _cacheExtent = cacheExtent,
+       _clipBehavior = clipBehavior {
     this.child = child;
-    this.clipBehavior = clipBehavior;
   }
 
   AxisDirection get axisDirection => _axisDirection;
@@ -419,6 +417,20 @@ class _RenderSingleChildViewport extends ClippableRenderBox
       return;
     _cacheExtent = value;
     markNeedsLayout();
+  }
+
+  /// {@macro flutter.widgets.Clip}
+  ///
+  /// Defaults to [Clip.none], and must not be null.
+  Clip get clipBehavior => _clipBehavior;
+  Clip _clipBehavior = Clip.none;
+  set clipBehavior(Clip value) {
+    assert(value != null);
+    if (value != _clipBehavior) {
+      _clipBehavior = value;
+      markNeedsPaint();
+      markNeedsSemanticsUpdate();
+    }
   }
 
   void _hasScrolled() {

--- a/packages/flutter/lib/src/widgets/viewport.dart
+++ b/packages/flutter/lib/src/widgets/viewport.dart
@@ -58,12 +58,14 @@ class Viewport extends MultiChildRenderObjectWidget {
     this.center,
     this.cacheExtent,
     this.cacheExtentStyle = CacheExtentStyle.pixel,
+    this.clipBehavior = Clip.hardEdge,
     List<Widget> slivers = const <Widget>[],
   }) : assert(offset != null),
        assert(slivers != null),
        assert(center == null || slivers.where((Widget child) => child.key == center).length == 1),
        assert(cacheExtentStyle != null),
        assert(cacheExtentStyle != CacheExtentStyle.viewport || cacheExtent != null),
+       assert(clipBehavior != null),
        super(key: key, children: slivers);
 
   /// The direction in which the [offset]'s [ViewportOffset.pixels] increases.
@@ -118,6 +120,11 @@ class Viewport extends MultiChildRenderObjectWidget {
   /// {@macro flutter.rendering.viewport.cacheExtentStyle}
   final CacheExtentStyle cacheExtentStyle;
 
+  /// {@macro flutter.widgets.Clip}
+  ///
+  /// Defaults to [Clip.none].
+  final Clip clipBehavior;
+
   /// Given a [BuildContext] and an [AxisDirection], determine the correct cross
   /// axis direction.
   ///
@@ -147,6 +154,7 @@ class Viewport extends MultiChildRenderObjectWidget {
       offset: offset,
       cacheExtent: cacheExtent,
       cacheExtentStyle: cacheExtentStyle,
+      clipBehavior: clipBehavior,
     );
   }
 
@@ -158,7 +166,8 @@ class Viewport extends MultiChildRenderObjectWidget {
       ..anchor = anchor
       ..offset = offset
       ..cacheExtent = cacheExtent
-      ..cacheExtentStyle = cacheExtentStyle;
+      ..cacheExtentStyle = cacheExtentStyle
+      ..clipBehavior = clipBehavior;
   }
 
   @override
@@ -263,6 +272,7 @@ class ShrinkWrappingViewport extends MultiChildRenderObjectWidget {
     this.axisDirection = AxisDirection.down,
     this.crossAxisDirection,
     @required this.offset,
+    this.clipBehavior = Clip.hardEdge,
     List<Widget> slivers = const <Widget>[],
   }) : assert(offset != null),
        super(key: key, children: slivers);
@@ -295,12 +305,18 @@ class ShrinkWrappingViewport extends MultiChildRenderObjectWidget {
   /// Typically a [ScrollPosition].
   final ViewportOffset offset;
 
+  /// {@macro flutter.widgets.Clip}
+  ///
+  /// Defaults to [Clip.none].
+  final Clip clipBehavior;
+
   @override
   RenderShrinkWrappingViewport createRenderObject(BuildContext context) {
     return RenderShrinkWrappingViewport(
       axisDirection: axisDirection,
       crossAxisDirection: crossAxisDirection ?? Viewport.getDefaultCrossAxisDirection(context, axisDirection),
       offset: offset,
+      clipBehavior: clipBehavior,
     );
   }
 
@@ -309,7 +325,8 @@ class ShrinkWrappingViewport extends MultiChildRenderObjectWidget {
     renderObject
       ..axisDirection = axisDirection
       ..crossAxisDirection = crossAxisDirection ?? Viewport.getDefaultCrossAxisDirection(context, axisDirection)
-      ..offset = offset;
+      ..offset = offset
+      ..clipBehavior = clipBehavior;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/viewport.dart
+++ b/packages/flutter/lib/src/widgets/viewport.dart
@@ -307,7 +307,7 @@ class ShrinkWrappingViewport extends MultiChildRenderObjectWidget {
 
   /// {@macro flutter.widgets.Clip}
   ///
-  /// Defaults to [Clip.none].
+  /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
 
   @override

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -2144,7 +2144,6 @@ void main() {
                           // this hint aligns "properly" with the menu.
                           return Stack(
                             alignment: Alignment.topCenter,
-                            overflow: Overflow.visible,
                             children: <Widget>[
                               PositionedDirectional(
                                 width: constraints.maxWidth + hintPaddingOffset,

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -2143,6 +2143,7 @@ void main() {
                           // hard coded 16px margin in the dropdown code, so that
                           // this hint aligns "properly" with the menu.
                           return Stack(
+                            clipBehavior: Clip.none,
                             alignment: Alignment.topCenter,
                             children: <Widget>[
                               PositionedDirectional(

--- a/packages/flutter/test/rendering/box_test.dart
+++ b/packages/flutter/test/rendering/box_test.dart
@@ -670,6 +670,33 @@ void main() {
     expect(unconstrained.size.height, equals(100.0), reason: 'constrained height');
   });
 
+  test('clipBehavior is respected', () {
+    const BoxConstraints viewport = BoxConstraints(maxHeight: 100.0, maxWidth: 100.0);
+    final TestClipPaintingContext context = TestClipPaintingContext();
+
+    // By default, clipBehavior should be Clip.none
+    final RenderUnconstrainedBox defaultBox = RenderUnconstrainedBox(
+      alignment: Alignment.center,
+      textDirection: TextDirection.ltr,
+      child: box200x200,
+    );
+    layout(defaultBox, constraints: viewport, phase: EnginePhase.composite, onErrors: expectOverflowedErrors);
+    defaultBox.paint(context, Offset.zero);
+    expect(context.clipBehavior, equals(Clip.none));
+
+    for (final Clip clip in Clip.values) {
+      final RenderUnconstrainedBox box = RenderUnconstrainedBox(
+          alignment: Alignment.center,
+          textDirection: TextDirection.ltr,
+          child: box200x200,
+          clipBehavior: clip,
+      );
+      layout(box, constraints: viewport, phase: EnginePhase.composite, onErrors: expectOverflowedErrors);
+      box.paint(context, Offset.zero);
+      expect(context.clipBehavior, equals(clip));
+    }
+  });
+
   group('hit testing', () {
     test('BoxHitTestResult wrapping HitTestResult', () {
       final HitTestEntry entry1 = HitTestEntry(_DummyHitTestTarget());

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -24,6 +24,44 @@ class FakeEditableTextState with TextSelectionDelegate {
 }
 
 void main() {
+  test('RenderEditable respects clipBehavior', () {
+    const BoxConstraints viewport = BoxConstraints(maxHeight: 100.0, maxWidth: 100.0);
+    final TestClipPaintingContext context = TestClipPaintingContext();
+
+    final String longString = 'a' * 10000;
+
+    // By default, clipBehavior should be Clip.none
+    final RenderEditable defaultEditable = RenderEditable(
+      text: TextSpan(text: longString),
+      textDirection: TextDirection.ltr,
+      startHandleLayerLink: LayerLink(),
+      endHandleLayerLink: LayerLink(),
+      offset: ViewportOffset.zero(),
+      textSelectionDelegate: FakeEditableTextState(),
+      selection: const TextSelection(baseOffset: 0, extentOffset: 0),
+    );
+    layout(defaultEditable, constraints: viewport, phase: EnginePhase.composite, onErrors: expectOverflowedErrors);
+    defaultEditable.paint(context, Offset.zero);
+    expect(context.clipBehavior, equals(Clip.hardEdge));
+
+    context.clipBehavior = Clip.none; // Reset as Clip.none won't write into clipBehavior.
+    for (final Clip clip in Clip.values) {
+      final RenderEditable editable = RenderEditable(
+        text: TextSpan(text: longString),
+        textDirection: TextDirection.ltr,
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        offset: ViewportOffset.zero(),
+        textSelectionDelegate: FakeEditableTextState(),
+        selection: const TextSelection(baseOffset: 0, extentOffset: 0),
+        clipBehavior: clip,
+      );
+      layout(editable, constraints: viewport, phase: EnginePhase.composite, onErrors: expectOverflowedErrors);
+      editable.paint(context, Offset.zero);
+      expect(context.clipBehavior, equals(clip));
+    }
+  });
+
   test('editable intrinsics', () {
     final TextSelectionDelegate delegate = FakeEditableTextState();
     final RenderEditable editable = RenderEditable(

--- a/packages/flutter/test/rendering/flex_test.dart
+++ b/packages/flutter/test/rendering/flex_test.dart
@@ -52,6 +52,33 @@ void main() {
     FlutterError.onError = oldHandler;
   });
 
+  List<RenderBox> _overflowFlexChildren() => <RenderBox>[
+    RenderConstrainedBox(additionalConstraints: const BoxConstraints.tightFor(height: 200.0, width: 200.0)),
+  ];
+
+  void _expectOverflowedErrors() {
+    final FlutterErrorDetails errorDetails = renderer.takeFlutterErrorDetails();
+    expect(errorDetails.toString().contains('overflowed'), isTrue);
+  }
+
+  test('Clip behavior is respected', () {
+    const BoxConstraints viewport = BoxConstraints(maxHeight: 100.0, maxWidth: 100.0);
+    final TestClipPaintingContext context = TestClipPaintingContext();
+
+    // By default, clipBehavior should be Clip.none
+    final RenderFlex defaultFlex = RenderFlex(direction: Axis.vertical, children: _overflowFlexChildren());
+    layout(defaultFlex, constraints: viewport, phase: EnginePhase.composite, onErrors: _expectOverflowedErrors);
+    defaultFlex.paint(context, Offset.zero);
+    expect(context.clipBehavior, equals(Clip.none));
+
+    for (final Clip clip in Clip.values) {
+      final RenderFlex flex = RenderFlex(direction: Axis.vertical, children: _overflowFlexChildren(), clipBehavior: clip);
+      layout(flex, constraints: viewport, phase: EnginePhase.composite, onErrors: _expectOverflowedErrors);
+      flex.paint(context, Offset.zero);
+      expect(context.clipBehavior, equals(clip));
+    }
+  });
+
   test('Vertical Overflow', () {
     final RenderConstrainedBox flexible = RenderConstrainedBox(
       additionalConstraints: const BoxConstraints.expand()

--- a/packages/flutter/test/rendering/flex_test.dart
+++ b/packages/flutter/test/rendering/flex_test.dart
@@ -52,28 +52,19 @@ void main() {
     FlutterError.onError = oldHandler;
   });
 
-  List<RenderBox> _overflowFlexChildren() => <RenderBox>[
-    RenderConstrainedBox(additionalConstraints: const BoxConstraints.tightFor(height: 200.0, width: 200.0)),
-  ];
-
-  void _expectOverflowedErrors() {
-    final FlutterErrorDetails errorDetails = renderer.takeFlutterErrorDetails();
-    expect(errorDetails.toString().contains('overflowed'), isTrue);
-  }
-
   test('Clip behavior is respected', () {
     const BoxConstraints viewport = BoxConstraints(maxHeight: 100.0, maxWidth: 100.0);
     final TestClipPaintingContext context = TestClipPaintingContext();
 
     // By default, clipBehavior should be Clip.none
-    final RenderFlex defaultFlex = RenderFlex(direction: Axis.vertical, children: _overflowFlexChildren());
-    layout(defaultFlex, constraints: viewport, phase: EnginePhase.composite, onErrors: _expectOverflowedErrors);
+    final RenderFlex defaultFlex = RenderFlex(direction: Axis.vertical, children: <RenderBox>[box200x200]);
+    layout(defaultFlex, constraints: viewport, phase: EnginePhase.composite, onErrors: expectOverflowedErrors);
     defaultFlex.paint(context, Offset.zero);
     expect(context.clipBehavior, equals(Clip.none));
 
     for (final Clip clip in Clip.values) {
-      final RenderFlex flex = RenderFlex(direction: Axis.vertical, children: _overflowFlexChildren(), clipBehavior: clip);
-      layout(flex, constraints: viewport, phase: EnginePhase.composite, onErrors: _expectOverflowedErrors);
+      final RenderFlex flex = RenderFlex(direction: Axis.vertical, children: <RenderBox>[box200x200], clipBehavior: clip);
+      layout(flex, constraints: viewport, phase: EnginePhase.composite, onErrors: expectOverflowedErrors);
       flex.paint(context, Offset.zero);
       expect(context.clipBehavior, equals(clip));
     }

--- a/packages/flutter/test/rendering/proxy_box_test.dart
+++ b/packages/flutter/test/rendering/proxy_box_test.dart
@@ -431,6 +431,7 @@ void main() {
     _testLayerReuse<ClipRectLayer>(RenderFittedBox(
       alignment: Alignment.center,
       fit: BoxFit.cover,
+      clipBehavior: Clip.hardEdge,
       // Inject opacity under the clip to force compositing.
       child: RenderOpacity(
         opacity: 0.5,

--- a/packages/flutter/test/rendering/proxy_box_test.dart
+++ b/packages/flutter/test/rendering/proxy_box_test.dart
@@ -468,6 +468,24 @@ void main() {
     _testFittedBoxWithClipRectLayer();
   });
 
+  test('RenderFittedBox respects clipBehavior', () {
+    const BoxConstraints viewport = BoxConstraints(maxHeight: 100.0, maxWidth: 100.0);
+    final TestClipPaintingContext context = TestClipPaintingContext();
+
+    // By default, clipBehavior should be Clip.none
+    final RenderFittedBox defaultBox = RenderFittedBox(child: box200x200, fit: BoxFit.none);
+    layout(defaultBox, constraints: viewport, phase: EnginePhase.composite, onErrors: expectOverflowedErrors);
+    defaultBox.paint(context, Offset.zero);
+    expect(context.clipBehavior, equals(Clip.none));
+
+    for (final Clip clip in Clip.values) {
+      final RenderFittedBox box = RenderFittedBox(child: box200x200, fit: BoxFit.none, clipBehavior: clip);
+      layout(box, constraints: viewport, phase: EnginePhase.composite, onErrors: expectOverflowedErrors);
+      box.paint(context, Offset.zero);
+      expect(context.clipBehavior, equals(clip));
+    }
+  });
+
   test('RenderMouseRegion can change properties when detached', () {
     renderer.initMouseTracker(MouseTracker(
       renderer.pointerRouter,

--- a/packages/flutter/test/rendering/rendering_tester.dart
+++ b/packages/flutter/test/rendering/rendering_tester.dart
@@ -305,3 +305,14 @@ class TestClipPaintingContext extends PaintingContext {
 
   Clip clipBehavior = Clip.none;
 }
+
+void expectOverflowedErrors() {
+  final FlutterErrorDetails errorDetails = renderer.takeFlutterErrorDetails();
+  final bool overflowed = errorDetails.toString().contains('overflowed');
+  if (!overflowed) {
+    FlutterError.reportError(errorDetails);
+  }
+}
+
+RenderConstrainedBox get box200x200 =>
+    RenderConstrainedBox(additionalConstraints: const BoxConstraints.tightFor(height: 200.0, width: 200.0));

--- a/packages/flutter/test/rendering/rendering_tester.dart
+++ b/packages/flutter/test/rendering/rendering_tester.dart
@@ -299,8 +299,9 @@ class TestClipPaintingContext extends PaintingContext {
   TestClipPaintingContext() : super(ContainerLayer(), Rect.zero);
 
   @override
-  ClipRectLayer pushClipRect(bool needsCompositing, Offset offset, Rect clipRect, painter, {Clip clipBehavior = Clip.hardEdge, ClipRectLayer oldLayer}) {
+  ClipRectLayer pushClipRect(bool needsCompositing, Offset offset, Rect clipRect, PaintingContextCallback painter, {Clip clipBehavior = Clip.hardEdge, ClipRectLayer oldLayer}) {
     this.clipBehavior = clipBehavior;
+    return null;
   }
 
   Clip clipBehavior = Clip.none;

--- a/packages/flutter/test/rendering/rendering_tester.dart
+++ b/packages/flutter/test/rendering/rendering_tester.dart
@@ -294,3 +294,14 @@ class FakeTicker implements Ticker {
     return DiagnosticsProperty<Ticker>(name, this, style: DiagnosticsTreeStyle.errorProperty);
   }
 }
+
+class TestClipPaintingContext extends PaintingContext {
+  TestClipPaintingContext() : super(ContainerLayer(), Rect.zero);
+
+  @override
+  ClipRectLayer pushClipRect(bool needsCompositing, Offset offset, Rect clipRect, painter, {Clip clipBehavior = Clip.hardEdge, ClipRectLayer oldLayer}) {
+    this.clipBehavior = clipBehavior;
+  }
+
+  Clip clipBehavior = Clip.none;
+}

--- a/packages/flutter/test/rendering/stack_test.dart
+++ b/packages/flutter/test/rendering/stack_test.dart
@@ -76,7 +76,7 @@ void main() {
       final RenderStack stack = RenderStack(
           textDirection: TextDirection.ltr,
           children: <RenderBox>[child],
-          clipBehavior: clip, overflow: clip == Clip.none ? Overflow.visible : Overflow.clip,
+          clipBehavior: clip,
       );
       { // Make sure that the child is positioned so the stack will consider it as overflowed.
         final StackParentData parentData = child.parentData as StackParentData;

--- a/packages/flutter/test/rendering/stack_test.dart
+++ b/packages/flutter/test/rendering/stack_test.dart
@@ -61,6 +61,33 @@ void main() {
     expect(stack.size.height, equals(100.0));
   });
 
+  test('Stack respects clipBehavior', () {
+    const BoxConstraints viewport = BoxConstraints(maxHeight: 100.0, maxWidth: 100.0);
+    final TestClipPaintingContext context = TestClipPaintingContext();
+
+    // By default, clipBehavior should be Clip.none
+    final RenderStack defaultStack = RenderStack(textDirection: TextDirection.ltr, children: <RenderBox>[box200x200]);
+    layout(defaultStack, constraints: viewport, phase: EnginePhase.composite, onErrors: expectOverflowedErrors);
+    defaultStack.paint(context, Offset.zero);
+    expect(context.clipBehavior, equals(Clip.none));
+
+    for (final Clip clip in Clip.values) {
+      final RenderBox child = box200x200;
+      final RenderStack stack = RenderStack(
+          textDirection: TextDirection.ltr,
+          children: <RenderBox>[child],
+          clipBehavior: clip, overflow: clip == Clip.none ? Overflow.visible : Overflow.clip,
+      );
+      { // Make sure that the child is positioned so the stack will consider it as overflowed.
+        final StackParentData parentData = child.parentData as StackParentData;
+        parentData.left = parentData.right = 0;
+      }
+      layout(stack, constraints: viewport, phase: EnginePhase.composite, onErrors: expectOverflowedErrors);
+      stack.paint(context, Offset.zero);
+      expect(context.clipBehavior, equals(clip));
+    }
+  });
+
   group('RenderIndexedStack', () {
     test('visitChildrenForSemantics only visits displayed child', () {
       final RenderBox child1 = RenderConstrainedBox(

--- a/packages/flutter/test/rendering/wrap_test.dart
+++ b/packages/flutter/test/rendering/wrap_test.dart
@@ -5,6 +5,8 @@
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'rendering_tester.dart';
+
 void main() {
   test('Wrap test; toStringDeep', () {
     final RenderWrap renderWrap = RenderWrap();
@@ -150,5 +152,23 @@ void main() {
     expect(renderWrap.computeMinIntrinsicWidth(100), 80);
     expect(renderWrap.computeMinIntrinsicWidth(79), 80);
     expect(renderWrap.computeMinIntrinsicWidth(80), 80);
+  });
+
+  test('Wrap respects clipBehavior', () {
+    const BoxConstraints viewport = BoxConstraints(maxHeight: 100.0, maxWidth: 100.0);
+    final TestClipPaintingContext context = TestClipPaintingContext();
+
+    // By default, clipBehavior should be Clip.none
+    final RenderWrap defaultWrap = RenderWrap(textDirection: TextDirection.ltr, children: <RenderBox>[box200x200]);
+    layout(defaultWrap, constraints: viewport, phase: EnginePhase.composite, onErrors: expectOverflowedErrors);
+    defaultWrap.paint(context, Offset.zero);
+    expect(context.clipBehavior, equals(Clip.none));
+
+    for (final Clip clip in Clip.values) {
+      final RenderWrap wrap = RenderWrap(textDirection: TextDirection.ltr, children: <RenderBox>[box200x200], clipBehavior: clip);
+      layout(wrap, constraints: viewport, phase: EnginePhase.composite, onErrors: expectOverflowedErrors);
+      wrap.paint(context, Offset.zero);
+      expect(context.clipBehavior, equals(clip));
+    }
   });
 }

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -280,6 +280,15 @@ void main() {
     );
   });
 
+  testWidgets('UnconstrainedBox can set and update clipBehavior', (WidgetTester tester) async {
+    await tester.pumpWidget(const UnconstrainedBox());
+    final RenderUnconstrainedBox renderObject = tester.allRenderObjects.whereType<RenderUnconstrainedBox>().first;
+    expect(renderObject.clipBehavior, equals(Clip.none));
+
+    await tester.pumpWidget(const UnconstrainedBox(clipBehavior: Clip.hardEdge));
+    expect(renderObject.clipBehavior, equals(Clip.hardEdge));
+  });
+
   group('ColoredBox', () {
     _MockCanvas mockCanvas;
     _MockPaintingContext mockContext;

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -283,10 +283,10 @@ void main() {
   testWidgets('UnconstrainedBox can set and update clipBehavior', (WidgetTester tester) async {
     await tester.pumpWidget(const UnconstrainedBox());
     final RenderUnconstrainedBox renderObject = tester.allRenderObjects.whereType<RenderUnconstrainedBox>().first;
-    expect(renderObject.clipBehavior, equals(Clip.none));
-
-    await tester.pumpWidget(const UnconstrainedBox(clipBehavior: Clip.hardEdge));
     expect(renderObject.clipBehavior, equals(Clip.hardEdge));
+
+    await tester.pumpWidget(const UnconstrainedBox(clipBehavior: Clip.antiAlias));
+    expect(renderObject.clipBehavior, equals(Clip.antiAlias));
   });
 
   group('ColoredBox', () {

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4761,6 +4761,48 @@ void main() {
 
     expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.text);
   });
+
+  testWidgets('EditableText can set and update clipBehavior', (WidgetTester tester) async {
+    await tester.pumpWidget(MediaQuery(
+      data: const MediaQueryData(devicePixelRatio: 1.0),
+      child: Directionality(
+        textDirection: TextDirection.ltr,
+        child: FocusScope(
+          node: focusScopeNode,
+          autofocus: true,
+          child: EditableText(
+            backgroundCursorColor: Colors.grey,
+            controller: controller,
+            focusNode: focusNode,
+            style: textStyle,
+            cursorColor: cursorColor,
+          ),
+        ),
+      ),
+    ));
+    final RenderEditable renderObject = tester.allRenderObjects.whereType<RenderEditable>().first;
+    expect(renderObject.clipBehavior, equals(Clip.hardEdge));
+
+    await tester.pumpWidget(MediaQuery(
+      data: const MediaQueryData(devicePixelRatio: 1.0),
+      child: Directionality(
+        textDirection: TextDirection.ltr,
+        child: FocusScope(
+          node: focusScopeNode,
+          autofocus: true,
+          child: EditableText(
+            backgroundCursorColor: Colors.grey,
+            controller: controller,
+            focusNode: focusNode,
+            style: textStyle,
+            cursorColor: cursorColor,
+            clipBehavior: Clip.antiAlias,
+          ),
+        ),
+      ),
+    ));
+    expect(renderObject.clipBehavior, equals(Clip.antiAlias));
+  });
 }
 
 class MockTextFormatter extends TextInputFormatter {

--- a/packages/flutter/test/widgets/fitted_box_test.dart
+++ b/packages/flutter/test/widgets/fitted_box_test.dart
@@ -479,10 +479,10 @@ void main() {
   testWidgets('Can set and update clipBehavior', (WidgetTester tester) async {
     await tester.pumpWidget(FittedBox(fit: BoxFit.none, child: Container()));
     final RenderFittedBox renderObject = tester.allRenderObjects.whereType<RenderFittedBox>().first;
-    expect(renderObject.clipBehavior, equals(Clip.none));
-
-    await tester.pumpWidget(FittedBox(fit: BoxFit.none, child: Container(), clipBehavior: Clip.hardEdge));
     expect(renderObject.clipBehavior, equals(Clip.hardEdge));
+
+    await tester.pumpWidget(FittedBox(fit: BoxFit.none, child: Container(), clipBehavior: Clip.antiAlias));
+    expect(renderObject.clipBehavior, equals(Clip.antiAlias));
   });
 }
 

--- a/packages/flutter/test/widgets/fitted_box_test.dart
+++ b/packages/flutter/test/widgets/fitted_box_test.dart
@@ -472,6 +472,15 @@ void main() {
     await tester.tap(find.byKey(key1));
     expect(_pointerDown, isTrue);
   });
+
+  testWidgets('Can set and update clipBehavior', (WidgetTester tester) async {
+    await tester.pumpWidget(FittedBox(fit: BoxFit.none, child: Container()));
+    final RenderFittedBox renderObject = tester.allRenderObjects.whereType<RenderFittedBox>().first;
+    expect(renderObject.clipBehavior, equals(Clip.none));
+
+    await tester.pumpWidget(FittedBox(fit: BoxFit.none, child: Container(), clipBehavior: Clip.hardEdge));
+    expect(renderObject.clipBehavior, equals(Clip.hardEdge));
+  });
 }
 
 List<Type> getLayers() {

--- a/packages/flutter/test/widgets/fitted_box_test.dart
+++ b/packages/flutter/test/widgets/fitted_box_test.dart
@@ -369,6 +369,7 @@ void main() {
           height: 10.0,
           child: FittedBox(
             fit: BoxFit.cover,
+            clipBehavior: Clip.hardEdge,
             child: SizedBox(
               width: 10.0,
               height: 50.0,
@@ -391,6 +392,7 @@ void main() {
           height: 100.0,
           child: FittedBox(
             fit: BoxFit.cover,
+            clipBehavior: Clip.hardEdge,
             child: SizedBox(
               width: 50.0,
               height: 10.0,
@@ -418,6 +420,7 @@ void main() {
                   height: b,
                   child: FittedBox(
                     fit: BoxFit.none,
+                    clipBehavior: Clip.hardEdge,
                     child: SizedBox(
                       width: c,
                       height: d,

--- a/packages/flutter/test/widgets/flex_test.dart
+++ b/packages/flutter/test/widgets/flex_test.dart
@@ -140,4 +140,13 @@ void main() {
     final String message = tester.takeException().toString();
     expect(message, contains('\nSee also:'));
   });
+
+  testWidgets('Can set and update clipBehavior', (WidgetTester tester) async {
+    await tester.pumpWidget(Flex(direction: Axis.vertical));
+    final RenderFlex renderObject = tester.allRenderObjects.whereType<RenderFlex>().first;
+    expect(renderObject.clipBehavior, equals(Clip.none));
+
+    await tester.pumpWidget(Flex(direction: Axis.vertical, clipBehavior: Clip.hardEdge));
+    expect(renderObject.clipBehavior, equals(Clip.hardEdge));
+  });
 }

--- a/packages/flutter/test/widgets/flex_test.dart
+++ b/packages/flutter/test/widgets/flex_test.dart
@@ -144,9 +144,9 @@ void main() {
   testWidgets('Can set and update clipBehavior', (WidgetTester tester) async {
     await tester.pumpWidget(Flex(direction: Axis.vertical));
     final RenderFlex renderObject = tester.allRenderObjects.whereType<RenderFlex>().first;
-    expect(renderObject.clipBehavior, equals(Clip.none));
-
-    await tester.pumpWidget(Flex(direction: Axis.vertical, clipBehavior: Clip.hardEdge));
     expect(renderObject.clipBehavior, equals(Clip.hardEdge));
+
+    await tester.pumpWidget(Flex(direction: Axis.vertical, clipBehavior: Clip.antiAlias));
+    expect(renderObject.clipBehavior, equals(Clip.antiAlias));
   });
 }

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -719,7 +719,7 @@ void main() {
       equalsIgnoringHashCodes(
         'Duplicate keys found.\n'
         'If multiple keyed nodes exist as children of another node, they must have unique keys.\n'
-        'Stack(alignment: AlignmentDirectional.topStart, textDirection: ltr, fit: loose, overflow: clip) has multiple children with key [GlobalKey#00000 problematic].'
+        'Stack(alignment: AlignmentDirectional.topStart, textDirection: ltr, fit: loose, overflow: visible) has multiple children with key [GlobalKey#00000 problematic].'
       ),
     );
   });
@@ -889,7 +889,7 @@ void main() {
         'The specific parent that did not update after having one or more children forcibly '
         'removed due to GlobalKey reparenting is:\n'
         '- Stack(alignment: AlignmentDirectional.topStart, textDirection: ltr, fit: loose, '
-        'overflow: clip, renderObject: RenderStack#00000)\n'
+        'overflow: visible, renderObject: RenderStack#00000)\n'
         'A GlobalKey can only be specified on one widget at a time in the widget tree.'
       ),
     );

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -719,7 +719,7 @@ void main() {
       equalsIgnoringHashCodes(
         'Duplicate keys found.\n'
         'If multiple keyed nodes exist as children of another node, they must have unique keys.\n'
-        'Stack(alignment: AlignmentDirectional.topStart, textDirection: ltr, fit: loose, clipBehavior: none) has multiple children with key [GlobalKey#00000 problematic].'
+        'Stack(alignment: AlignmentDirectional.topStart, textDirection: ltr, fit: loose) has multiple children with key [GlobalKey#00000 problematic].'
       ),
     );
   });
@@ -889,7 +889,7 @@ void main() {
         'The specific parent that did not update after having one or more children forcibly '
         'removed due to GlobalKey reparenting is:\n'
         '- Stack(alignment: AlignmentDirectional.topStart, textDirection: ltr, fit: loose, '
-        'clipBehavior: none, renderObject: RenderStack#00000)\n'
+        'renderObject: RenderStack#00000)\n'
         'A GlobalKey can only be specified on one widget at a time in the widget tree.'
       ),
     );

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -719,7 +719,7 @@ void main() {
       equalsIgnoringHashCodes(
         'Duplicate keys found.\n'
         'If multiple keyed nodes exist as children of another node, they must have unique keys.\n'
-        'Stack(alignment: AlignmentDirectional.topStart, textDirection: ltr, fit: loose, overflow: visible) has multiple children with key [GlobalKey#00000 problematic].'
+        'Stack(alignment: AlignmentDirectional.topStart, textDirection: ltr, fit: loose, clipBehavior: none) has multiple children with key [GlobalKey#00000 problematic].'
       ),
     );
   });
@@ -889,7 +889,7 @@ void main() {
         'The specific parent that did not update after having one or more children forcibly '
         'removed due to GlobalKey reparenting is:\n'
         '- Stack(alignment: AlignmentDirectional.topStart, textDirection: ltr, fit: loose, '
-        'overflow: visible, renderObject: RenderStack#00000)\n'
+        'clipBehavior: none, renderObject: RenderStack#00000)\n'
         'A GlobalKey can only be specified on one widget at a time in the widget tree.'
       ),
     );

--- a/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
@@ -11,6 +11,44 @@ import '../rendering/mock_canvas.dart';
 import '../rendering/rendering_tester.dart';
 
 void main() {
+  testWidgets('ListWheelScrollView respects clipBehavior', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: ListWheelScrollView(
+          itemExtent: 2000.0, // huge extent to trigger clip
+          children: <Widget>[Container()],
+        ),
+      ),
+    );
+
+    // 1st, check that the render object has received the clip behavior.
+    final RenderListWheelViewport renderObject = tester.allRenderObjects.whereType<RenderListWheelViewport>().first;
+    expect(renderObject.clipBehavior, equals(Clip.hardEdge));
+
+    // 2nd, check that the painting context has received the clip behavior.
+    final TestClipPaintingContext context = TestClipPaintingContext();
+    renderObject.paint(context, Offset.zero);
+    expect(context.clipBehavior, equals(Clip.hardEdge));
+
+    // 3rd, pump a new widget to check that the render object can update its clip behavior.
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: ListWheelScrollView(
+          itemExtent: 2000.0, // huge extent to trigger clip
+          children: <Widget>[Container()],
+          clipBehavior: Clip.antiAlias,
+        ),
+      ),
+    );
+    expect(renderObject.clipBehavior, equals(Clip.antiAlias));
+
+    // 4th, check that a non-default clip behavior can be sent to the painting context.
+    renderObject.paint(context, Offset.zero);
+    expect(context.clipBehavior, equals(Clip.antiAlias));
+  });
+
   group('construction check', () {
     testWidgets('ListWheelScrollView needs positive diameter ratio', (WidgetTester tester) async {
       try {

--- a/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
@@ -22,11 +22,11 @@ void main() {
       ),
     );
 
-    // 1st, check that the render object has received the clip behavior.
+    // 1st, check that the render object has received the default clip behavior.
     final RenderListWheelViewport renderObject = tester.allRenderObjects.whereType<RenderListWheelViewport>().first;
     expect(renderObject.clipBehavior, equals(Clip.hardEdge));
 
-    // 2nd, check that the painting context has received the clip behavior.
+    // 2nd, check that the painting context has received the default clip behavior.
     final TestClipPaintingContext context = TestClipPaintingContext();
     renderObject.paint(context, Offset.zero);
     expect(context.clipBehavior, equals(Clip.hardEdge));

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -8,6 +8,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/gestures.dart' show DragStartBehavior;
 import 'package:flutter/rendering.dart';
 
+import '../rendering/rendering_tester.dart';
+
 class _CustomPhysics extends ClampingScrollPhysics {
   const _CustomPhysics({ ScrollPhysics parent }) : super(parent: parent);
 
@@ -118,6 +120,55 @@ Widget buildTest({
 }
 
 void main() {
+  testWidgets('NestedScrollView respects clipBehavior', (WidgetTester tester) async {
+    Widget build(NestedScrollView nestedScrollView) {
+      return Localizations(
+        locale: const Locale('en', 'US'),
+        delegates: const <LocalizationsDelegate<dynamic>>[
+          DefaultMaterialLocalizations.delegate,
+          DefaultWidgetsLocalizations.delegate,
+        ],
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: nestedScrollView,
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(build(
+      NestedScrollView(
+        headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) => <Widget>[const SliverAppBar()],
+        body: Container(height: 2000.0),
+      )
+    ));
+
+    // 1st, check that the render object has received the default clip behavior.
+    final RenderNestedScrollViewViewport renderObject = tester.allRenderObjects.whereType<RenderNestedScrollViewViewport>().first;
+    expect(renderObject.clipBehavior, equals(Clip.hardEdge));
+
+    // 2nd, check that the painting context has received the default clip behavior.
+    final TestClipPaintingContext context = TestClipPaintingContext();
+    renderObject.paint(context, Offset.zero);
+    expect(context.clipBehavior, equals(Clip.hardEdge));
+
+    // 3rd, pump a new widget to check that the render object can update its clip behavior.
+    await tester.pumpWidget(build(
+        NestedScrollView(
+          headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) => <Widget>[const SliverAppBar()],
+          body: Container(height: 2000.0),
+          clipBehavior: Clip.antiAlias,
+        )
+    ));
+    expect(renderObject.clipBehavior, equals(Clip.antiAlias));
+
+    // 4th, check that a non-default clip behavior can be sent to the painting context.
+    renderObject.paint(context, Offset.zero);
+    expect(context.clipBehavior, equals(Clip.antiAlias));
+  });
+
   testWidgets('NestedScrollView overscroll and release and hold', (WidgetTester tester) async {
     await tester.pumpWidget(buildTest());
     expect(find.text('aaa2'), findsOneWidget);

--- a/packages/flutter/test/widgets/shrink_wrapping_viewport_test.dart
+++ b/packages/flutter/test/widgets/shrink_wrapping_viewport_test.dart
@@ -1,0 +1,50 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+
+import '../rendering/rendering_tester.dart';
+
+void main() {
+  testWidgets('ShrinkWrappingViewport respects clipBehavior', (WidgetTester tester) async {
+    Widget build(ShrinkWrappingViewport child) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: child,
+      );
+    }
+
+    await tester.pumpWidget(build(
+        ShrinkWrappingViewport(
+          offset: ViewportOffset.zero(),
+          slivers: <Widget>[SliverToBoxAdapter(child: Container(height: 2000.0))],
+        )
+    ));
+
+    // 1st, check that the render object has received the default clip behavior.
+    final RenderShrinkWrappingViewport renderObject = tester.allRenderObjects.whereType<RenderShrinkWrappingViewport>().first;
+    expect(renderObject.clipBehavior, equals(Clip.hardEdge));
+
+    // 2nd, check that the painting context has received the default clip behavior.
+    final TestClipPaintingContext context = TestClipPaintingContext();
+    renderObject.paint(context, Offset.zero);
+    expect(context.clipBehavior, equals(Clip.hardEdge));
+
+    // 3rd, pump a new widget to check that the render object can update its clip behavior.
+    await tester.pumpWidget(build(
+        ShrinkWrappingViewport(
+          offset: ViewportOffset.zero(),
+          slivers: <Widget>[SliverToBoxAdapter(child: Container(height: 2000.0))],
+          clipBehavior: Clip.antiAlias,
+        )
+    ));
+    expect(renderObject.clipBehavior, equals(Clip.antiAlias));
+
+    // 4th, check that a non-default clip behavior can be sent to the painting context.
+    renderObject.paint(context, Offset.zero);
+    expect(context.clipBehavior, equals(Clip.antiAlias));
+  });
+}

--- a/packages/flutter/test/widgets/single_child_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/single_child_scroll_view_test.dart
@@ -41,12 +41,12 @@ void main() {
   testWidgets('SingleChildScrollView respects clipBehavior', (WidgetTester tester) async {
     await tester.pumpWidget(SingleChildScrollView(child: Container(height: 2000.0)));
 
-    // 1st, check that the render object has received the clip behavior.
+    // 1st, check that the render object has received the default clip behavior.
     final ClippableRenderBox renderObject = tester.allRenderObjects.whereType<ClippableRenderBox>().first;
     expect(renderObject.runtimeType.toString(), equals('_RenderSingleChildViewport'));
     expect(renderObject.clipBehavior, equals(Clip.hardEdge));
 
-    // 2nd, check that the painting context has received the clip behavior.
+    // 2nd, check that the painting context has received the default clip behavior.
     final TestClipPaintingContext context = TestClipPaintingContext();
     renderObject.paint(context, Offset.zero);
     expect(context.clipBehavior, equals(Clip.hardEdge));

--- a/packages/flutter/test/widgets/single_child_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/single_child_scroll_view_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+import '../rendering/rendering_tester.dart';
 import 'semantics_tester.dart';
 
 class TestScrollPosition extends ScrollPositionWithSingleContext {
@@ -37,6 +38,28 @@ class TestScrollController extends ScrollController {
 }
 
 void main() {
+  testWidgets('SingleChildScrollView respects clipBehavior', (WidgetTester tester) async {
+    await tester.pumpWidget(SingleChildScrollView(child: Container(height: 2000.0)));
+
+    // 1st, check that the render object has received the clip behavior.
+    final ClippableRenderBox renderObject = tester.allRenderObjects.whereType<ClippableRenderBox>().first;
+    expect(renderObject.runtimeType.toString(), equals('_RenderSingleChildViewport'));
+    expect(renderObject.clipBehavior, equals(Clip.hardEdge));
+
+    // 2nd, check that the painting context has received the clip behavior.
+    final TestClipPaintingContext context = TestClipPaintingContext();
+    renderObject.paint(context, Offset.zero);
+    expect(context.clipBehavior, equals(Clip.hardEdge));
+
+    // 3rd, pump a new widget to check that the render object can update its clip behavior.
+    await tester.pumpWidget(SingleChildScrollView(clipBehavior: Clip.antiAlias, child: Container(height: 2000.0)));
+    expect(renderObject.clipBehavior, equals(Clip.antiAlias));
+
+    // 4th, check that a non-default clip behavior can be sent to the painting context.
+    renderObject.paint(context, Offset.zero);
+    expect(context.clipBehavior, equals(Clip.antiAlias));
+  });
+
   testWidgets('SingleChildScrollView control test', (WidgetTester tester) async {
     await tester.pumpWidget(SingleChildScrollView(
       child: Container(

--- a/packages/flutter/test/widgets/single_child_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/single_child_scroll_view_test.dart
@@ -42,8 +42,7 @@ void main() {
     await tester.pumpWidget(SingleChildScrollView(child: Container(height: 2000.0)));
 
     // 1st, check that the render object has received the default clip behavior.
-    final ClippableRenderBox renderObject = tester.allRenderObjects.whereType<ClippableRenderBox>().first;
-    expect(renderObject.runtimeType.toString(), equals('_RenderSingleChildViewport'));
+    final dynamic renderObject = tester.allRenderObjects.where((RenderObject o) => o.runtimeType.toString() == '_RenderSingleChildViewport').first;
     expect(renderObject.clipBehavior, equals(Clip.hardEdge));
 
     // 2nd, check that the painting context has received the default clip behavior.

--- a/packages/flutter/test/widgets/stack_test.dart
+++ b/packages/flutter/test/widgets/stack_test.dart
@@ -451,6 +451,7 @@ void main() {
         textDirection: TextDirection.ltr,
         child: Center(
           child: Stack(
+            overflow: Overflow.visible,
             clipBehavior: Clip.none,
             children: const <Widget>[
               SizedBox(

--- a/packages/flutter/test/widgets/stack_test.dart
+++ b/packages/flutter/test/widgets/stack_test.dart
@@ -421,6 +421,8 @@ void main() {
         textDirection: TextDirection.ltr,
         child: Center(
           child: Stack(
+            clipBehavior: Clip.hardEdge,
+            overflow: Overflow.clip,
             children: const <Widget>[
               SizedBox(
                 width: 100.0,

--- a/packages/flutter/test/widgets/stack_test.dart
+++ b/packages/flutter/test/widgets/stack_test.dart
@@ -381,7 +381,7 @@ void main() {
     final RenderStack renderObject = tester.allRenderObjects.whereType<RenderStack>().first;
     expect(renderObject.clipBehavior, equals(Clip.none));
 
-    await tester.pumpWidget(Stack(textDirection: TextDirection.ltr, clipBehavior: Clip.hardEdge, overflow: Overflow.clip));
+    await tester.pumpWidget(Stack(textDirection: TextDirection.ltr, clipBehavior: Clip.hardEdge));
     expect(renderObject.clipBehavior, equals(Clip.hardEdge));
   });
 
@@ -422,7 +422,6 @@ void main() {
         child: Center(
           child: Stack(
             clipBehavior: Clip.hardEdge,
-            overflow: Overflow.clip,
             children: const <Widget>[
               SizedBox(
                 width: 100.0,
@@ -452,7 +451,6 @@ void main() {
         textDirection: TextDirection.ltr,
         child: Center(
           child: Stack(
-            overflow: Overflow.visible,
             children: const <Widget>[
               SizedBox(
                 width: 100.0,

--- a/packages/flutter/test/widgets/stack_test.dart
+++ b/packages/flutter/test/widgets/stack_test.dart
@@ -376,6 +376,15 @@ void main() {
     expect(renderBox.size.height, equals(12.0));
   });
 
+  testWidgets('Can set and update clipBehavior', (WidgetTester tester) async {
+    await tester.pumpWidget(Stack(textDirection: TextDirection.ltr));
+    final RenderStack renderObject = tester.allRenderObjects.whereType<RenderStack>().first;
+    expect(renderObject.clipBehavior, equals(Clip.none));
+
+    await tester.pumpWidget(Stack(textDirection: TextDirection.ltr, clipBehavior: Clip.hardEdge, overflow: Overflow.clip));
+    expect(renderObject.clipBehavior, equals(Clip.hardEdge));
+  });
+
   testWidgets('IndexedStack with null index', (WidgetTester tester) async {
     bool tapped;
 

--- a/packages/flutter/test/widgets/stack_test.dart
+++ b/packages/flutter/test/widgets/stack_test.dart
@@ -379,7 +379,7 @@ void main() {
   testWidgets('Can set and update clipBehavior', (WidgetTester tester) async {
     await tester.pumpWidget(Stack(textDirection: TextDirection.ltr));
     final RenderStack renderObject = tester.allRenderObjects.whereType<RenderStack>().first;
-    expect(renderObject.clipBehavior, equals(Clip.none));
+    expect(renderObject.clipBehavior, equals(Clip.hardEdge));
 
     await tester.pumpWidget(Stack(textDirection: TextDirection.ltr, clipBehavior: Clip.hardEdge));
     expect(renderObject.clipBehavior, equals(Clip.hardEdge));
@@ -451,6 +451,7 @@ void main() {
         textDirection: TextDirection.ltr,
         child: Center(
           child: Stack(
+            clipBehavior: Clip.none,
             children: const <Widget>[
               SizedBox(
                 width: 100.0,

--- a/packages/flutter/test/widgets/wrap_test.dart
+++ b/packages/flutter/test/widgets/wrap_test.dart
@@ -733,6 +733,7 @@ void main() {
 
     await tester.pumpWidget(Wrap(
       textDirection: TextDirection.ltr,
+      clipBehavior: Clip.hardEdge,
       children: const <Widget>[
         SizedBox(width: 500.0, height: 500.0),
         SizedBox(width: 500.0, height: 500.0),

--- a/packages/flutter/test/widgets/wrap_test.dart
+++ b/packages/flutter/test/widgets/wrap_test.dart
@@ -900,9 +900,9 @@ void main() {
   testWidgets('Wrap can set and update clipBehavior', (WidgetTester tester) async {
     await tester.pumpWidget(Wrap(textDirection: TextDirection.ltr));
     final RenderWrap renderObject = tester.allRenderObjects.whereType<RenderWrap>().first;
-    expect(renderObject.clipBehavior, equals(Clip.none));
-
-    await tester.pumpWidget(Wrap(textDirection: TextDirection.ltr, clipBehavior: Clip.hardEdge));
     expect(renderObject.clipBehavior, equals(Clip.hardEdge));
+
+    await tester.pumpWidget(Wrap(textDirection: TextDirection.ltr, clipBehavior: Clip.antiAlias));
+    expect(renderObject.clipBehavior, equals(Clip.antiAlias));
   });
 }

--- a/packages/flutter/test/widgets/wrap_test.dart
+++ b/packages/flutter/test/widgets/wrap_test.dart
@@ -895,4 +895,13 @@ void main() {
       const Offset(0.0, 20.0),
     ]);
   });
+
+  testWidgets('Wrap can set and update clipBehavior', (WidgetTester tester) async {
+    await tester.pumpWidget(Wrap(textDirection: TextDirection.ltr));
+    final RenderWrap renderObject = tester.allRenderObjects.whereType<RenderWrap>().first;
+    expect(renderObject.clipBehavior, equals(Clip.none));
+
+    await tester.pumpWidget(Wrap(textDirection: TextDirection.ltr, clipBehavior: Clip.hardEdge));
+    expect(renderObject.clipBehavior, equals(Clip.hardEdge));
+  });
 }


### PR DESCRIPTION
## Description
We add `clipBehavior` to
1. Flex
2. FittedBox
3. UnconstrainedBox
4. Wrap
5. Stack
6. EditableText
7. ListWheelScrollView
8. SingleChildScrollView
9. NestedScrollView
10. ShrinkWrappingViewport

Eventually, the first 4 of them will be default to `Clip.none` while the remaining 6 of them are default to `Clip.hardEdge`.

In the current PR, all of them are still default to `Clip.hardEdge` to not break some Google usages. Once we've updated the code inside Google, we'll update the clipBehavior.

## Related Issues
This is a continuation of https://github.com/flutter/flutter/issues/18057, and this fixes https://github.com/flutter/flutter/issues/21830

## Tests
Unit tests added to each modified widget and render object.

## Breaking Change
- [x] Yes, this is a breaking change as all those widgets previously default to clip with anti-alias.
   - [x] I wrote a design doc: https://flutter.dev/go/clip-behavior
   - [x] I got input from the developer relations team, specifically from filiph
   - [x] I wrote a [migration guide](https://docs.google.com/document/d/1gC5Di4ykTCqupD77PWpy9D8xXo0Ide5CnrH0zzVIhKo/edit?usp=sharing)
