### PR TITLE
[devicelab] Explicitly print stack trace from error in android attach test

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_attach_test_android.dart
+++ b/dev/devicelab/bin/tasks/flutter_attach_test_android.dart
@@ -174,6 +174,7 @@ void main() {
         await testReload(attachProcess);
       } catch (err, st) {
         print('Uncaught exception: $err\n$st');
+        rethrow;
       } finally {
         section('Uninstalling');
         await device.adb(<String>['uninstall', kAppId]);

--- a/dev/devicelab/bin/tasks/flutter_attach_test_android.dart
+++ b/dev/devicelab/bin/tasks/flutter_attach_test_android.dart
@@ -57,7 +57,9 @@ Future<void> testReload(Process process, { Future<void> Function() onListening }
       event,
       process.exitCode,
       // Keep the test from running for 15 minutes if it gets stuck.
-      Future<void>.delayed(const Duration(seconds: 10)),
+      Future<void>.delayed(const Duration(seconds: 10)).then<void>((void _) {
+        throw StateError('eventOrExit timed out');
+      }),
     ]);
   }
 
@@ -71,10 +73,12 @@ Future<void> testReload(Process process, { Future<void> Function() onListening }
   print('run:stdin: r');
   await process.stdin.flush();
   await eventOrExit(reloaded.future);
+
   process.stdin.write('R');
   print('run:stdin: R');
   await process.stdin.flush();
   await eventOrExit(restarted.future);
+
   process.stdin.write('q');
   print('run:stdin: q');
   await process.stdin.flush();
@@ -168,6 +172,8 @@ void main() {
         );
         // Verify that it can discover the observatory port from past logs.
         await testReload(attachProcess);
+      } catch (err, st) {
+        print('Uncaught exception: $err\n$st');
       } finally {
         section('Uninstalling');
         await device.adb(<String>['uninstall', kAppId]);


### PR DESCRIPTION
## Description

Ensure both the error and stack trace is printed. make sure the timeout throws an error instead of completing normally.