### PR TITLE
[flutter_tools] increase stopApp timeout for FlutterDevice.exitApps

### DIFF
--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -676,6 +676,7 @@ extension FlutterVmService on vm_service.VmService {
       'ext.flutter.exit',
       isolateId: isolateId,
     ).catchError((dynamic error, StackTrace stackTrace) {
+      globals.logger.printTrace('Failure in ext.flutter.exit: $error\n$stackTrace');
       // Do nothing on sentinel or exception, the isolate already exited.
     }, test: (dynamic error) => error is vm_service.SentinelException || error is vm_service.RPCError);
   }


### PR DESCRIPTION
## Description

killing the app might take more than 2 seconds. If this fails, use device.stopApp instead of leaving it running.