### PR TITLE
[devicelab] increase eventOrExit timeout to 1 minute

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_attach_test_android.dart
+++ b/dev/devicelab/bin/tasks/flutter_attach_test_android.dart
@@ -57,7 +57,7 @@ Future<void> testReload(Process process, { Future<void> Function() onListening }
       event,
       process.exitCode,
       // Keep the test from running for 15 minutes if it gets stuck.
-      Future<void>.delayed(const Duration(seconds: 10)).then<void>((void _) {
+      Future<void>.delayed(const Duration(minutes: 1)).then<void>((void _) {
         throw StateError('eventOrExit timed out');
       }),
     ]);


### PR DESCRIPTION
## Description

Increase eventOrExit timeout to see if this is just _really_ slow