### PR TITLE
[flutter_tools] android device stopApp handles null apk

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -647,6 +647,9 @@ class AndroidDevice extends Device {
 
   @override
   Future<bool> stopApp(AndroidApk app) {
+    if (app == null) {
+      return Future<bool>.value(false);
+    }
     final List<String> command = adbCommandForDevice(<String>['shell', 'am', 'force-stop', app.id]);
     return processUtils.stream(command).then<bool>(
         (int exitCode) => exitCode == 0 || allowHeapCorruptionOnWindows(exitCode));

--- a/packages/flutter_tools/test/general.shard/android/android_device_stop_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_stop_test.dart
@@ -1,0 +1,15 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tools/src/android/android_device.dart';
+
+import '../../src/common.dart';
+
+void main() {
+  testWithoutContext('AndroidDevice.stopApp handles a null ApplicationPackage', () async {
+    final AndroidDevice androidDevice = AndroidDevice('2');
+
+    expect(await androidDevice.stopApp(null), false);
+  });
+}


### PR DESCRIPTION
## Description

The resident runner does not check if the ApplicationPackage is null when trying to stop the app. Update AndroidDevice.stopApp to handle this case by returning false.

The package will be null on attach.