### PR TITLE
Fixes the navigator pages update crashes when there is still route wa…

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -830,20 +830,20 @@ abstract class TransitionDelegate<T> {
   ///
   /// For example, consider the following case.
   ///
-  ///    newPageRouteHistory = [A, B, C]
+  /// newPageRouteHistory = [A, B, C]
   ///
-  ///    locationToExitingPageRoute = {A -> D, C -> E}
+  /// locationToExitingPageRoute = {A -> D, C -> E}
   ///
   /// The following outputs are valid.
   ///
-  ///    result = [A, B ,C ,D ,E] is valid
-  ///    result = [D, A, B ,C ,E] is also valid because exiting route can be
-  ///    inserted in any place
+  /// result = [A, B ,C ,D ,E] is valid.
+  /// result = [D, A, B ,C ,E] is also valid because exiting route can be
+  /// inserted in any place.
   ///
   /// The following outputs are invalid.
   ///
-  ///    result = [B, A, C ,D ,E] is invalid because B must be after A.
-  ///    result = [A, B, C ,E] is invalid because results must include D.
+  /// result = [B, A, C ,D ,E] is invalid because B must be after A.
+  /// result = [A, B, C ,E] is invalid because results must include D.
   ///
   /// See also:
   ///
@@ -1379,10 +1379,15 @@ class Navigator extends StatefulWidget {
   /// This callback is responsible for calling [Route.didPop] and returning
   /// whether this pop is successful.
   ///
-  /// The [Navigator] widget should be rebuilt with a [pages] list that does not
-  /// contain the [Page] for the given [Route]. The next time the [pages] list
-  /// is updated, if the [Page] corresponding to this [Route] is still present,
-  /// it will be interpreted as a new route to display.
+  /// This callback is also responsible for updating the list of [Page]s that
+  /// was passed into the [pages]. If the [Page] corresponding to this [Route]
+  /// is still present the next time the [pages] list is updated, it will be
+  /// interpreted as a new route to display.
+  ///
+  /// When updating the list of [Page]s, this callback should avoid triggering
+  /// navigator rebuilds. The [Route.didPop] is sufficient for the navigator
+  /// to remove the route from the history. Additional rebuilds may potentially
+  /// impact the performance.
   final PopPageCallback onPopPage;
 
   /// The delegate used for deciding how routes transition in or off the screen
@@ -2514,7 +2519,8 @@ class _RouteEntry extends RouteTransitionRecord {
       'This route cannot be marked for pop. Either a decision has already been '
       'made or it does not require an explicit decision on how to transition out.'
     );
-    pop<dynamic>(result);
+    if (isPresent)
+      pop<dynamic>(result);
     _debugWaitingForExitDecision = false;
   }
 
@@ -2526,7 +2532,8 @@ class _RouteEntry extends RouteTransitionRecord {
       'been made or it does not require an explicit decision on how to transition '
       'out.'
     );
-    complete<dynamic>(result);
+    if (isPresent)
+      complete<dynamic>(result);
     _debugWaitingForExitDecision = false;
   }
 
@@ -2538,7 +2545,8 @@ class _RouteEntry extends RouteTransitionRecord {
       'been made or it does not require an explicit decision on how to transition '
       'out.'
     );
-    remove();
+    if (isPresent)
+      remove();
     _debugWaitingForExitDecision = false;
   }
 }

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -697,12 +697,14 @@ abstract class RouteTransitionRecord {
 ///
 ///     }
 ///     for (final RouteTransitionRecord exitingPageRoute in locationToExitingPageRoute.values) {
-///       exitingPageRoute.markForRemove();
-///       final List<RouteTransitionRecord> pagelessRoutes = pageRouteToPagelessRoutes[exitingPageRoute];
-///       if (pagelessRoutes != null) {
-///         for (final RouteTransitionRecord pagelessRoute in pagelessRoutes) {
-///           pagelessRoute.markForRemove();
-///         }
+///       if (exitingPageRoute.isWaitingForExitingDecision) {
+///        exitingPageRoute.markForRemove();
+///        final List<RouteTransitionRecord> pagelessRoutes = pageRouteToPagelessRoutes[exitingPageRoute];
+///        if (pagelessRoutes != null) {
+///          for (final RouteTransitionRecord pagelessRoute in pagelessRoutes) {
+///             pagelessRoute.markForRemove();
+///           }
+///        }
 ///       }
 ///       results.add(exitingPageRoute);
 ///

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -2367,6 +2367,37 @@ void main() {
       expect(find.text('forth'), findsOneWidget);
     });
 
+    testWidgets('can repush a page that was previously popped before it has finished popping', (WidgetTester tester) async {
+      final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+      List<Page<dynamic>> myPages = <TestPage>[
+        const TestPage(key: ValueKey<String>('1'), name: 'initial'),
+        const TestPage(key: ValueKey<String>('2'), name: 'second'),
+      ];
+      bool onPopPage(Route<dynamic> route, dynamic result) {
+        myPages.removeWhere((Page<dynamic> page) => route.settings == page);
+        return route.didPop(result);
+      }
+      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator));
+
+      // Pops the second page route.
+      myPages = <TestPage>[
+        const TestPage(key: ValueKey<String>('1'), name: 'initial'),
+      ];
+      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator));
+
+      // Re-push the second page again before it finishes popping.
+      myPages = <TestPage>[
+        const TestPage(key: ValueKey<String>('1'), name: 'initial'),
+        const TestPage(key: ValueKey<String>('2'), name: 'second'),
+      ];
+      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator));
+
+      // It should not crash the app.
+      expect(tester.takeException(), isNull);
+      await tester.pumpAndSettle();
+      expect(find.text('second'), findsOneWidget);
+    });
+
     testWidgets('can update pages before a route has finished popping', (WidgetTester tester) async {
       final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
       List<Page<dynamic>> myPages = <TestPage>[
@@ -2444,23 +2475,24 @@ class AlwaysRemoveTransitionDelegate extends TransitionDelegate<void> {
         return;
 
       final RouteTransitionRecord exitingPageRoute = locationToExitingPageRoute[location];
-      final bool hasPagelessRoute = pageRouteToPagelessRoutes.containsKey(exitingPageRoute);
-
-      exitingPageRoute.markForRemove();
-      results.add(exitingPageRoute);
-
-      if (hasPagelessRoute) {
-        final List<RouteTransitionRecord> pagelessRoutes = pageRouteToPagelessRoutes[exitingPageRoute];
-        for (final RouteTransitionRecord pagelessRoute in pagelessRoutes) {
-          pagelessRoute.markForRemove();
+      if (exitingPageRoute.isWaitingForExitingDecision) {
+        final bool hasPagelessRoute = pageRouteToPagelessRoutes.containsKey(exitingPageRoute);
+        exitingPageRoute.markForRemove();
+        if (hasPagelessRoute) {
+          final List<RouteTransitionRecord> pagelessRoutes = pageRouteToPagelessRoutes[exitingPageRoute];
+          for (final RouteTransitionRecord pagelessRoute in pagelessRoutes) {
+            pagelessRoute.markForRemove();
+          }
         }
       }
+      results.add(exitingPageRoute);
+
       handleExitingRoute(exitingPageRoute);
     }
     handleExitingRoute(null);
 
     for (final RouteTransitionRecord pageRoute in newPageRouteHistory) {
-      if (pageRoute.isEntering) {
+      if (pageRoute.isWaitingForEnteringDecision) {
         pageRoute.markForAdd();
       }
       results.add(pageRoute);


### PR DESCRIPTION
…iting for popping animation to finish

## Description

Consider this case:

`page= [A, B], the history stack in navigator is [A, B]`

after one frame the pages gets updated:

`page = [A] , the history stack in navigator is [A, B(popping)]`

the next frame the pages gets updated again:

`page = [C], the navigator will try to mark A for complete and try to mark B for pop again and crashes.`

This pr fixes this issue by checking if the route has already been removed in markForPop, markForComplete, and markForRemove.


## Related Issues

https://github.com/flutter/flutter/issues/45938

## Tests

I added the following tests:

see files

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
