### PR TITLE
Fix WidgetsBinding.firstFrameRasterized not completing

### DIFF
--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -877,6 +877,9 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
     }
     _needToReportFirstFrame = false;
     if (firstFrameCallback != null && !sendFramesToEngine) {
+      // This frame is deferred and not the first frame sent to the engine that
+      // should be reported.
+      _needToReportFirstFrame = true;
       SchedulerBinding.instance.removeTimingsCallback(firstFrameCallback);
     }
   }

--- a/packages/flutter/test/widgets/binding_first_frame_rasterized_test.dart
+++ b/packages/flutter/test/widgets/binding_first_frame_rasterized_test.dart
@@ -15,7 +15,7 @@ void main() {
 
   test('Deferred frames will trigger the first frame callback', () {
     FakeAsync().run((FakeAsync fakeAsync) {
-      final WidgetsBinding binding = WidgetsBinding.instance;
+      final WidgetsBinding binding = WidgetsFlutterBinding.ensureInitialized();
       binding.deferFirstFrame();
 
       runApp(const Placeholder());

--- a/packages/flutter/test/widgets/binding_first_frame_rasterized_test.dart
+++ b/packages/flutter/test/widgets/binding_first_frame_rasterized_test.dart
@@ -1,0 +1,39 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:quiver/testing/async.dart';
+
+void main() {
+  setUp(() {
+    WidgetsFlutterBinding.ensureInitialized();
+  });
+
+  test('Deferred frames will trigger the first frame callback', () {
+    FakeAsync().run((FakeAsync fakeAsync) {
+      final WidgetsBinding binding = WidgetsBinding.instance;
+      binding.deferFirstFrame();
+
+      runApp(const Placeholder());
+      fakeAsync.flushTimers();
+
+      // Simulates the engine completing a frame render to trigger the
+      // appropriate callback setting [WidgetBinding.firstFrameRasterized].
+      binding.window.onReportTimings(
+        // The actual timings are not important.
+        <FrameTiming>[]);
+      expect(binding.firstFrameRasterized, isFalse);
+
+      binding.allowFirstFrame();
+      fakeAsync.flushTimers();
+
+      // Simulates the engine again.
+      binding.window.onReportTimings(<FrameTiming>[]);
+      expect(binding.firstFrameRasterized, isTrue);
+    });
+  });
+}

--- a/packages/flutter/test/widgets/binding_first_frame_rasterized_test.dart
+++ b/packages/flutter/test/widgets/binding_first_frame_rasterized_test.dart
@@ -9,10 +9,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:quiver/testing/async.dart';
 
 void main() {
-  setUp(() {
-    WidgetsFlutterBinding.ensureInitialized();
-  });
-
   test('Deferred frames will trigger the first frame callback', () {
     FakeAsync().run((FakeAsync fakeAsync) {
       final WidgetsBinding binding = WidgetsFlutterBinding.ensureInitialized();
@@ -23,9 +19,7 @@ void main() {
 
       // Simulates the engine completing a frame render to trigger the
       // appropriate callback setting [WidgetBinding.firstFrameRasterized].
-      binding.window.onReportTimings(
-        // The actual timings are not important.
-        <FrameTiming>[]);
+      binding.window.onReportTimings(<FrameTiming>[]);
       expect(binding.firstFrameRasterized, isFalse);
 
       binding.allowFirstFrame();


### PR DESCRIPTION
## Description

The completer backing `WidgetsBinding.firstFrameRasterized` never completes when `deferFirstFrame` is used. 

Please see https://github.com/jiahaog/repro_flutter_first_frame/commit/ed49ba44f655f8ec8d725f929bced153774d7a3d for a small reproduction.

This is because `firstFrameCallback` is removed here when the current frame is a deferred frame
https://github.com/flutter/flutter/blob/bd6ccb606a11dacf7c72970a9d623e6b89668d70/packages/flutter/lib/src/widgets/binding.dart#L880

but `_needToReportFirstFrame` is reset back to `true`. As a result, the next iteration of `drawFrame` for the frame that should be sent to the engine will never trigger the conditional block that reports the frames.

https://github.com/flutter/flutter/blob/bd6ccb606a11dacf7c72970a9d623e6b89668d70/packages/flutter/lib/src/widgets/binding.dart#L843-L860

This affects driver tests as well when the [`FlutterDriver.waitUntilFirstFrameRasterized`](https://api.flutter.dev/flutter/flutter_driver/FlutterDriver/waitUntilFirstFrameRasterized.html) is used. (Internal bug b/155033896)

## Related Issues

#45135

## Tests

I added the following tests:

- Add a test where deferred frames will trigger the first frame rasterized flag.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
