### PR TITLE
[web] Change display mode of PWA default to standalone

### DIFF
--- a/dev/integration_tests/flutter_gallery/web/manifest.json
+++ b/dev/integration_tests/flutter_gallery/web/manifest.json
@@ -2,7 +2,7 @@
     "name": "flutter_gallery",
     "short_name": "flutter_gallery",
     "start_url": ".",
-    "display": "minimal-ui",
+    "display": "standalone",
     "background_color": "#0175C2",
     "theme_color": "#0175C2",
     "description": "A new Flutter project.",

--- a/packages/flutter_tools/templates/app/web/manifest.json.tmpl
+++ b/packages/flutter_tools/templates/app/web/manifest.json.tmpl
@@ -2,7 +2,7 @@
     "name": "{{projectName}}",
     "short_name": "{{projectName}}",
     "start_url": ".",
-    "display": "minimal-ui",
+    "display": "standalone",
     "background_color": "#0175C2",
     "theme_color": "#0175C2",
     "description": "{{description}}",


### PR DESCRIPTION
## Description

PWA support 4 modes : Standalone,Fullscreen,Minimal-UI,Browser.
The current setting was minimal-ui. Since Flutter Apps typically provide elements for in app navigation, the better default is to use standalone that removes the browser bar for navigation.

## Related Issues

https://github.com/flutter/flutter/issues/55925

## Tests

Template update.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*
