### PR TITLE
[a11y] Fix semantics for nested Navigators

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -3811,9 +3811,17 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
         child: FocusScope(
           node: focusScopeNode,
           autofocus: true,
-          child: Overlay(
-            key: _overlayKey,
-            initialEntries: overlay == null ?  _allRouteOverlayEntries.toList(growable: false) : const <OverlayEntry>[],
+          child: Semantics(
+            // The [Overlay] may contain a [BlockSemantics] widget, e.g. as
+            // part of a modal barrier. To ensure that [BlockSemantics] only
+            // drops the semantics of other overlay entries (and not siblings
+            // of the Navigator itself) the overlay is wrapped in its own
+            // semantics container.
+            container: true,
+            child: Overlay(
+              key: _overlayKey,
+              initialEntries: overlay == null ?  _allRouteOverlayEntries.toList(growable: false) : const <OverlayEntry>[],
+            ),
           ),
         ),
       ),

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -2366,7 +2366,40 @@ void main() {
       expect(thirdPageless1Completed, false);
       expect(find.text('forth'), findsOneWidget);
     });
+  });
 
+  testWidgets('ModalBarrier does not block sibling semantics of Navigator', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/55758.
+
+    final SemanticsTester semantics = SemanticsTester(tester);
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Semantics(
+          explicitChildNodes: true,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              const Expanded(child: Text('1')),
+              Expanded(
+                child: Navigator(
+                  initialRoute: '/',
+                  onGenerateRoute: (_) => PageRouteBuilder<void>(pageBuilder: (_, __, ___) => const Text('2')),
+                ),
+              ),
+              const Expanded(child:  Text('3')),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(BlockSemantics), findsOneWidget);
+    expect(find.byType(ModalBarrier), findsOneWidget);
+    expect(semantics, includesNodeWith(label: '1'));
+    expect(semantics, includesNodeWith(label: '2'));
+    expect(semantics, includesNodeWith(label: '3'));
+    semantics.dispose();
   });
 }
 


### PR DESCRIPTION
## Description

ModalBarriers include a BlockSemantics widget, which drops the semantics of all sibling semantics nodes within the same container. It's meant to only drop the semantics of sibling routes, but in some nested navigator situations it may also incorrectly drop the semantics nodes of siblings to the Navigator (if those end up sharing the same semantics container with the ModalBarrier/BlockSemantics widget). This PR fixes the issue by wrapping the Navigator in its own Semantics container to ensure that the siblings semantics nodes of the navigator don't become siblings to the BlockSemantics semantics node.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/55758.

## Tests

I added the following tests:

* test derived from repro case in https://github.com/flutter/flutter/issues/55758

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
