### PR TITLE
Add package_root for fuchsia_tools

### DIFF
--- a/packages/flutter_tools/BUILD.gn
+++ b/packages/flutter_tools/BUILD.gn
@@ -57,6 +57,7 @@ dart_library("flutter_tools") {
 
 dart_tool("fuchsia_builder") {
   main_dart = "bin/fuchsia_builder.dart"
+  package_root = "fuchsia_entrypoint_shim/fuchsia_builder"
 
   disable_analysis = true
 
@@ -67,6 +68,7 @@ dart_tool("fuchsia_builder") {
 
 dart_tool("fuchsia_asset_builder") {
   main_dart = "bin/fuchsia_asset_builder.dart"
+  package_root = "fuchsia_entrypoint_shim/fuchsia_asset_builder"
 
   disable_analysis = true
 
@@ -153,6 +155,7 @@ dart_tool("fuchsia_asset_builder") {
 
 dart_tool("fuchsia_tester") {
   main_dart = "bin/fuchsia_tester.dart"
+  package_root = "fuchsia_entrypoint_shim/tester"
 
   disable_analysis = true
 
@@ -248,6 +251,7 @@ dart_tool("fuchsia_tester") {
 dart_tool("fuchsia_attach") {
   package_name = "fuchsia_attach"
   main_dart = "bin/fuchsia_attach.dart"
+  package_root = "fuchsia_entrypoint_shim/attach"
 
   # Can be left empty as analysis is disabled.
   sources = []

--- a/packages/flutter_tools/fuchsia_entrypoint_shim/README.md
+++ b/packages/flutter_tools/fuchsia_entrypoint_shim/README.md
@@ -1,0 +1,21 @@
+This directory serves as a placeholder directory for the package roots of
+various fuchsia tools which use the flutter_tools library.
+
+This is required to provide a workaround for the fuchsia build system.
+When this directory is not present the various tools specified in the
+`dart_tool` directives in the flutter_tools/BUILD.gn file will end up
+having the same package root entry written in the .packages file. This
+causes the build to fail because the dart compiler has a requirement that
+libraries must have a unique package uri. By specifying a package root which
+is a subdirectory of this directory for these tools we avoid having the build
+system create duplicate package roots for the generated libraries for these
+tools.
+
+Note that we cannot move the location of the main files for these tools because
+the paths are hard coded in the fuchsia tree.
+
+
+Tracking Bugs:
+- fxbug.dev/51373 (move flutter_tools/BUILD.gn to fuchsia repo)
+- fxbug.dev/51375 (do not refence fuchsia_tester.dart directly)
+- fxbug.dev/51375 (remove the fuchsia_entrypoint_shim directory)

--- a/packages/flutter_tools/fuchsia_entrypoint_shim/fuchsia_asset_builder/pubspec.yaml
+++ b/packages/flutter_tools/fuchsia_entrypoint_shim/fuchsia_asset_builder/pubspec.yaml
@@ -1,0 +1,14 @@
+name: flutter_asset_builder
+description: Tools for building Flutter applications
+homepage: https://flutter.dev
+author: Flutter Authors <flutter-dev@googlegroups.com>
+
+environment:
+  # The pub client defaults to an <2.0.0 sdk constraint which we need to explicitly overwrite.
+  sdk: ">=2.7.0 <3.0.0"
+
+dartdoc:
+  # Exclude this package from the hosted API docs.
+  nodoc: true
+
+# PUBSPEC CHECKSUM: 0000

--- a/packages/flutter_tools/fuchsia_entrypoint_shim/fuchsia_attach/pubspec.yaml
+++ b/packages/flutter_tools/fuchsia_entrypoint_shim/fuchsia_attach/pubspec.yaml
@@ -1,0 +1,14 @@
+name: flutter_attach
+description: Tools for building Flutter applications
+homepage: https://flutter.dev
+author: Flutter Authors <flutter-dev@googlegroups.com>
+
+environment:
+  # The pub client defaults to an <2.0.0 sdk constraint which we need to explicitly overwrite.
+  sdk: ">=2.7.0 <3.0.0"
+
+dartdoc:
+  # Exclude this package from the hosted API docs.
+  nodoc: true
+
+# PUBSPEC CHECKSUM: 0000

--- a/packages/flutter_tools/fuchsia_entrypoint_shim/fuchsia_builder/pubspec.yaml
+++ b/packages/flutter_tools/fuchsia_entrypoint_shim/fuchsia_builder/pubspec.yaml
@@ -1,0 +1,14 @@
+name: flutter_builder
+description: Tools for building Flutter applications
+homepage: https://flutter.dev
+author: Flutter Authors <flutter-dev@googlegroups.com>
+
+environment:
+  # The pub client defaults to an <2.0.0 sdk constraint which we need to explicitly overwrite.
+  sdk: ">=2.7.0 <3.0.0"
+
+dartdoc:
+  # Exclude this package from the hosted API docs.
+  nodoc: true
+
+# PUBSPEC CHECKSUM: 0000

--- a/packages/flutter_tools/fuchsia_entrypoint_shim/fuchsia_tester/pubspec.yaml
+++ b/packages/flutter_tools/fuchsia_entrypoint_shim/fuchsia_tester/pubspec.yaml
@@ -1,0 +1,14 @@
+name: flutter_tester
+description: Tools for building Flutter applications
+homepage: https://flutter.dev
+author: Flutter Authors <flutter-dev@googlegroups.com>
+
+environment:
+  # The pub client defaults to an <2.0.0 sdk constraint which we need to explicitly overwrite.
+  sdk: ">=2.7.0 <3.0.0"
+
+dartdoc:
+  # Exclude this package from the hosted API docs.
+  nodoc: true
+
+# PUBSPEC CHECKSUM: 0000


### PR DESCRIPTION
## Description

Fixes an issue which was blocking rolls from flutter to fuchsia. The problem was that when fuchsia was building the fuchsia_asset_builder it was causing overlapping package roots to be entered into the .packages file. Dart no longer allows multiple packages to have the same package root so this was causing compilation errors.

## Related Issues

http://fxbug.dev/47170

## Tests

I went through the instructions in go/flutter-fuchsia-manual-roll and was able to successfully build locally.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
