### PR TITLE
[web] Implement defaultTargetPlatform MacOS/iOS for web.

### DIFF
--- a/packages/flutter/lib/src/foundation/_platform_web.dart
+++ b/packages/flutter/lib/src/foundation/_platform_web.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:html' as html;
 import 'platform.dart' as platform;
 
 /// The dart:html implementation of [platform.defaultTargetPlatform].
@@ -9,8 +10,21 @@ platform.TargetPlatform get defaultTargetPlatform {
   // To getter a better guess at the targetPlatform we need to be able to
   // reference the window, but that won't be availible until we fix the
   // platforms configuration for Flutter.
-  platform.TargetPlatform result = platform.TargetPlatform.android;
+  platform.TargetPlatform result = _browserPlatform();
   if (platform.debugDefaultTargetPlatformOverride != null)
     result = platform.debugDefaultTargetPlatformOverride;
   return result;
+}
+
+platform.TargetPlatform _browserPlatform() {
+  final String navigatorPlatform = html.window.navigator.platform.toLowerCase();
+  if (navigatorPlatform.startsWith('mac')) {
+    return platform.TargetPlatform.macOS;
+  }
+  if (navigatorPlatform.contains('iphone') ||
+      navigatorPlatform.contains('ipad') ||
+      navigatorPlatform.contains('ipod')) {
+    return platform.TargetPlatform.iOS;
+  }
+  return platform.TargetPlatform.android;
 }


### PR DESCRIPTION
## Description

Returns correct platform when application is running on iOS and MacOS.

## Related Issues

https://github.com/flutter/flutter/issues/43633

## Tests

I added the following tests:
https://github.com/flutter/engine/pull/18065

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*
