### PR TITLE
fix autovalidate in form widget to validate only when value changes

### DIFF
--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -373,6 +373,7 @@ class FormFieldState<T> extends State<FormField<T>> {
   /// Resets the field to its initial value.
   void reset() {
     setState(() {
+      _isStateDirty = false;
       _value = widget.initialValue;
       _errorText = null;
     });

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -338,6 +338,11 @@ class FormFieldState<T> extends State<FormField<T>> {
   T _value;
   String _errorText;
 
+  /// True when state becomes dirty for the first time, i.e. [ didChange(value) ] is called
+  ///
+  /// This ensures that [Form.autovalidate] only works once the state is modified at least once
+  bool _isStateDirty = false;
+
   /// The current value of the form field.
   T get value => _value;
 
@@ -388,7 +393,7 @@ class FormFieldState<T> extends State<FormField<T>> {
   }
 
   void _validate() {
-    if (widget.validator != null)
+    if (widget.validator != null && _isStateDirty)
       _errorText = widget.validator(_value);
   }
 
@@ -398,6 +403,7 @@ class FormFieldState<T> extends State<FormField<T>> {
   /// Triggers the [Form.onChanged] callback and, if the [Form.autovalidate]
   /// field is set, revalidates all the fields of the form.
   void didChange(T value) {
+    _isStateDirty = true;
     setState(() {
       _value = value;
     });

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -393,7 +393,7 @@ class FormFieldState<T> extends State<FormField<T>> {
   }
 
   void _validate() {
-    if (widget.validator != null && _isStateDirty)
+    if (widget.validator != null)
       _errorText = widget.validator(_value);
   }
 
@@ -436,8 +436,8 @@ class FormFieldState<T> extends State<FormField<T>> {
 
   @override
   Widget build(BuildContext context) {
-    // Only autovalidate if the widget is also enabled
-    if (widget.autovalidate && widget.enabled)
+    // Only autovalidate if the widget is also enabled and state value has changed at least once
+    if (widget.autovalidate && widget.enabled && _isStateDirty)
       _validate();
     Form.of(context)?._register(this);
     return widget.builder(this);

--- a/packages/flutter/test/widgets/form_test.dart
+++ b/packages/flutter/test/widgets/form_test.dart
@@ -620,8 +620,6 @@ void main() {
 
     await tester.pumpWidget(builder());
 
-
-
     Future<void> checkErrorText(String testValue) async {
       // state value was not changed yet
       expect(find.text(testValue + '/error'),findsNothing);


### PR DESCRIPTION
## Description

*The current `form` widget runs `_validate` function on every new build even when the form state is not changed, if `widget.autovalidate == true`, which as a result runs validations over all the fields in the form and you see errors corresponding each field due to empty field validation logic(if written by the developer), as soon as the user lands on to the screen. `The PR modifies the autovalidate feature such that it functions only when the state value for a field is changed at least once.`*

## Related Issues

[*36154*](https://github.com/flutter/flutter/issues/36154)
[*48876*](https://github.com/flutter/flutter/issues/48876)

## Tests

I added the following tests:

*in `flutter_test.dart` file added test case under description `autovalidate functions only when state value changes at least once`*

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change, except for one test case that checks for a field with error text, in form_test.dart  'Multiple TextFormFields communicate', which I feel is not a breaking change. Did the required modifications to make it work fine with a line change.
 