### PR TITLE
expose ExpansionTileState with isExpanded setter

### DIFF
--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -94,6 +94,8 @@ class ExpansionTile extends StatefulWidget {
   ExpansionTileState createState() => ExpansionTileState();
 }
 
+/// Contains the state for a [ExpansionTile]. This class can be used to
+/// programmatically control expanded state, see the [isExpanded] getter and setter.
 class ExpansionTileState extends State<ExpansionTile> with SingleTickerProviderStateMixin {
   static final Animatable<double> _easeOutTween = CurveTween(curve: Curves.easeOut);
   static final Animatable<double> _easeInTween = CurveTween(curve: Curves.easeIn);

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -91,10 +91,10 @@ class ExpansionTile extends StatefulWidget {
   final EdgeInsetsGeometry tilePadding;
 
   @override
-  _ExpansionTileState createState() => _ExpansionTileState();
+  ExpansionTileState createState() => ExpansionTileState();
 }
 
-class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProviderStateMixin {
+class ExpansionTileState extends State<ExpansionTile> with SingleTickerProviderStateMixin {
   static final Animatable<double> _easeOutTween = CurveTween(curve: Curves.easeOut);
   static final Animatable<double> _easeInTween = CurveTween(curve: Curves.easeIn);
   static final Animatable<double> _halfTween = Tween<double>(begin: 0.0, end: 0.5);
@@ -136,9 +136,19 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
     super.dispose();
   }
 
-  void _handleTap() {
+  /// current expansion state
+  bool get isExpanded => _isExpanded;
+
+  /// Change expansion state.
+  /// If this method is called with state equal to current,
+  /// it quietly does nothing.
+  ///
+  /// [ExpansionTile.onExpansionChanged] is called
+  set isExpanded(bool state) {
+    if (_isExpanded == state)
+      return;
     setState(() {
-      _isExpanded = !_isExpanded;
+      _isExpanded = state;
       if (_isExpanded) {
         _controller.forward();
       } else {
@@ -154,6 +164,10 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
     });
     if (widget.onExpansionChanged != null)
       widget.onExpansionChanged(_isExpanded);
+  }
+
+  void _handleTap() {
+    isExpanded = !isExpanded;
   }
 
   Widget _buildChildren(BuildContext context, Widget child) {

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -155,6 +155,114 @@ void main() {
     expect(collapsedContainerDecoration.border.bottom.color, _dividerColor);
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
+
+  testWidgets('ExpansionTileState isExpanded setter', (WidgetTester tester) async {
+    final Key topKey = UniqueKey();
+    final GlobalKey<ExpansionTileState> expandedKey = GlobalKey<ExpansionTileState>();
+    final GlobalKey<ExpansionTileState> collapsedKey = GlobalKey<ExpansionTileState>();
+    final GlobalKey<ExpansionTileState> defaultKey = GlobalKey<ExpansionTileState>();
+
+    final Key tileKey = UniqueKey();
+
+    await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(
+        dividerColor: _dividerColor,
+      ),
+      home: Material(
+        child: SingleChildScrollView(
+          child: Column(
+            children: <Widget>[
+              ListTile(title: const Text('Top'), key: topKey),
+              ExpansionTile(
+                key: expandedKey,
+                initiallyExpanded: true,
+                title: const Text('Expanded'),
+                backgroundColor: Colors.red,
+                children: <Widget>[
+                  ListTile(
+                    key: tileKey,
+                    title: const Text('0'),
+                  ),
+                ],
+              ),
+              ExpansionTile(
+                key: collapsedKey,
+                initiallyExpanded: false,
+                title: const Text('Collapsed'),
+                children: <Widget>[
+                  ListTile(
+                    key: tileKey,
+                    title: const Text('0'),
+                  ),
+                ],
+              ),
+              ExpansionTile(
+                key: defaultKey,
+                title: const Text('Default'),
+                children: const <Widget>[
+                  ListTile(title: Text('0')),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    ));
+
+    double getHeight(Key key) => tester.getSize(find.byKey(key)).height;
+    Container getContainer(Key key) => tester.firstWidget(find.descendant(
+      of: find.byKey(key),
+      matching: find.byType(Container),
+    ));
+
+    expect(getHeight(topKey), getHeight(expandedKey) - getHeight(tileKey) - 2.0);
+    expect(getHeight(topKey), getHeight(collapsedKey) - 2.0);
+    expect(getHeight(topKey), getHeight(defaultKey) - 2.0);
+
+    BoxDecoration expandedContainerDecoration = getContainer(expandedKey).decoration as BoxDecoration;
+    expect(expandedContainerDecoration.color, Colors.red);
+    expect(expandedContainerDecoration.border.top.color, _dividerColor);
+    expect(expandedContainerDecoration.border.bottom.color, _dividerColor);
+
+    BoxDecoration collapsedContainerDecoration = getContainer(collapsedKey).decoration as BoxDecoration;
+    expect(collapsedContainerDecoration.color, Colors.transparent);
+    expect(collapsedContainerDecoration.border.top.color, Colors.transparent);
+    expect(collapsedContainerDecoration.border.bottom.color, Colors.transparent);
+
+    expandedKey.currentState.isExpanded = !expandedKey.currentState.isExpanded;
+    collapsedKey.currentState.isExpanded = !collapsedKey.currentState.isExpanded;
+    defaultKey.currentState.isExpanded = !defaultKey.currentState.isExpanded;
+
+    await tester.pump();
+
+    // Pump to the middle of the animation for expansion.
+    await tester.pump(const Duration(milliseconds: 100));
+    final BoxDecoration collapsingContainerDecoration = getContainer(collapsedKey).decoration as BoxDecoration;
+    expect(collapsingContainerDecoration.color, Colors.transparent);
+    // Opacity should change but color component should remain the same.
+    expect(collapsingContainerDecoration.border.top.color, const Color(0x15333333));
+    expect(collapsingContainerDecoration.border.bottom.color, const Color(0x15333333));
+
+    // Pump all the way to the end now.
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(getHeight(topKey), getHeight(expandedKey) - 2.0);
+    expect(getHeight(topKey), getHeight(collapsedKey) - getHeight(tileKey) - 2.0);
+    expect(getHeight(topKey), getHeight(defaultKey) - getHeight(tileKey) - 2.0);
+
+    // Expanded should be collapsed now.
+    expandedContainerDecoration = getContainer(expandedKey).decoration as BoxDecoration;
+    expect(expandedContainerDecoration.color, Colors.transparent);
+    expect(expandedContainerDecoration.border.top.color, Colors.transparent);
+    expect(expandedContainerDecoration.border.bottom.color, Colors.transparent);
+
+    // Collapsed should be expanded now.
+    collapsedContainerDecoration = getContainer(collapsedKey).decoration as BoxDecoration;
+    expect(collapsedContainerDecoration.color, Colors.transparent);
+    expect(collapsedContainerDecoration.border.top.color, _dividerColor);
+    expect(collapsedContainerDecoration.border.bottom.color, _dividerColor);
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
+
   testWidgets('ListTileTheme', (WidgetTester tester) async {
     final Key expandedTitleKey = UniqueKey();
     final Key collapsedTitleKey = UniqueKey();


### PR DESCRIPTION
## Description

Expose `ExpasionTileState` with `isExpanded` setter to be able to change it's state programmatically without "change key hack" and with appropriate animation.

I used `RefreshIndicatorState.show` as an example of similar implementation 

## Related Issues

closes #7024

## Tests

I added the following tests:
copy of "ExpansionTile initial state", but taps replaced by `isExpanded` setters calls

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
 