### PR TITLE
[flutter_tools] remove flutter view cache

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -191,6 +191,11 @@ abstract class ResidentWebRunner extends ResidentRunner {
   }
 
   @override
+  Future<List<FlutterView>> listFlutterViews() async {
+    return <FlutterView>[];
+  }
+
+  @override
   Future<void> debugDumpApp() async {
     try {
       await _vmService

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1072,7 +1072,15 @@ abstract class ResidentRunner {
         reloadMethod: reloadMethod,
       );
       // This will wait for at least one flutter view before returning.
-      await device.vmService.getFlutterViews();
+      final Status status = globals.logger.startProgress(
+        'Waiting for ${device.device.name} to report its views...',
+        timeout: const Duration(milliseconds: 200),
+      );
+      try {
+        await device.vmService.getFlutterViews();
+      } finally {
+        status.stop();
+      }
       // This hooks up callbacks for when the connection stops in the future.
       // We don't want to wait for them. We don't handle errors in those callbacks'
       // futures either because they just print to logger and is not critical.

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1065,6 +1065,12 @@ abstract class ResidentRunner {
     _finished = Completer<int>();
     // Listen for service protocol connection to close.
     for (final FlutterDevice device in flutterDevices) {
+      await device.connect(
+        reloadSources: reloadSources,
+        restart: restart,
+        compileExpression: compileExpression,
+        reloadMethod: reloadMethod,
+      );
       // This hooks up callbacks for when the connection stops in the future.
       // We don't want to wait for them. We don't handle errors in those callbacks'
       // futures either because they just print to logger and is not critical.

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1071,6 +1071,8 @@ abstract class ResidentRunner {
         compileExpression: compileExpression,
         reloadMethod: reloadMethod,
       );
+      // This will wait for at least one flutter view before returning.
+      await device.vmService.getFlutterViews();
       // This hooks up callbacks for when the connection stops in the future.
       // We don't want to wait for them. We don't handle errors in those callbacks'
       // futures either because they just print to logger and is not critical.

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -164,68 +164,6 @@ class FlutterDevice {
   /// Whether the stream [observatoryUris] is still open.
   bool get isWaitingForObservatory => _isListeningForObservatoryUri ?? false;
 
-  /// If the [reloadSources] parameter is not null the 'reloadSources' service
-  /// will be registered.
-  /// The 'reloadSources' service can be used by other Service Protocol clients
-  /// connected to the VM (e.g. Observatory) to request a reload of the source
-  /// code of the running application (a.k.a. HotReload).
-  /// The 'compileExpression' service can be used to compile user-provided
-  /// expressions requested during debugging of the application.
-  /// This ensures that the reload process follows the normal orchestration of
-  /// the Flutter Tools and not just the VM internal service.
-  Future<void> connect({
-    ReloadSources reloadSources,
-    Restart restart,
-    CompileExpression compileExpression,
-    ReloadMethod reloadMethod,
-  }) {
-    final Completer<void> completer = Completer<void>();
-    StreamSubscription<void> subscription;
-    bool isWaitingForVm = false;
-
-    subscription = observatoryUris.listen((Uri observatoryUri) async {
-      // FYI, this message is used as a sentinel in tests.
-      globals.printTrace('Connecting to service protocol: $observatoryUri');
-      isWaitingForVm = true;
-      vm_service.VmService service;
-
-      try {
-        service = await connectToVmService(
-          observatoryUri,
-          reloadSources: reloadSources,
-          restart: restart,
-          compileExpression: compileExpression,
-          reloadMethod: reloadMethod,
-          device: device,
-        );
-      } on Exception catch (exception) {
-        globals.printTrace('Fail to connect to service protocol: $observatoryUri: $exception');
-        if (!completer.isCompleted && !_isListeningForObservatoryUri) {
-          completer.completeError('failed to connect to $observatoryUri');
-        }
-        return;
-      }
-      if (completer.isCompleted) {
-        return;
-      }
-      globals.printTrace('Successfully connected to service protocol: $observatoryUri');
-
-      vmService = service;
-      (await device.getLogReader(app: package)).connectedVMService = vmService;
-      completer.complete();
-      await subscription.cancel();
-    }, onError: (dynamic error) {
-      globals.printTrace('Fail to handle observatory URI: $error');
-    }, onDone: () {
-      _isListeningForObservatoryUri = false;
-      if (!completer.isCompleted && !isWaitingForVm) {
-        completer.completeError('connection to device ended too early');
-      }
-    });
-    _isListeningForObservatoryUri = true;
-    return completer.future;
-  }
-
   Future<void> exitApps({
     @visibleForTesting Duration timeoutDelay = const Duration(seconds: 10),
   }) async {
@@ -446,8 +384,9 @@ class FlutterDevice {
 
   Future<void> initLogReader() async {
     final vm_service.VM vm = await vmService.getVM();
+    print(vm);
     final DeviceLogReader logReader = await device.getLogReader(app: package);
-    logReader.appPid = vm.pid;
+    logReader?.appPid = vm.pid;
   }
 
   Future<int> runHot({

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -226,38 +226,13 @@ class FlutterDevice {
     return completer.future;
   }
 
-  Future<void> refreshViews() async {
-    if (vmService == null) {
-      return;
-    }
-    final List<FlutterView> updatedViews = await vmService.getFlutterViews();
-    _views
-      ..clear()
-      ..addAll(updatedViews);
-  }
-  final List<FlutterView> _views = <FlutterView>[];
-
-  List<FlutterView> get views {
-    if (vmService == null) {
-      return <FlutterView>[];
-    }
-    if (viewFilter != null) {
-      return <FlutterView>[
-        for (final FlutterView flutterView in _views)
-          if (flutterView.uiIsolate.name.contains(viewFilter))
-            flutterView
-      ];
-    }
-    return _views;
-  }
-
   Future<void> exitApps({
     @visibleForTesting Duration timeoutDelay = const Duration(seconds: 10),
   }) async {
     if (!device.supportsFlutterExit) {
       return device.stopApp(package);
     }
-    await refreshViews();
+    final List<FlutterView> views = await vmService.getFlutterViews();
     if (views == null || views.isEmpty) {
       return device.stopApp(package);
     }
@@ -333,6 +308,7 @@ class FlutterDevice {
     final Uri deviceAssetsDirectoryUri = devFS.baseUri.resolveUri(
         globals.fs.path.toUri(getAssetBuildDirectory()));
     assert(deviceAssetsDirectoryUri != null);
+    final List<FlutterView> views = await vmService.getFlutterViews();
     await Future.wait<void>(views.map<Future<void>>(
       (FlutterView view) => vmService.setAssetDirectory(
         assetsDirectory: deviceAssetsDirectoryUri,
@@ -343,6 +319,7 @@ class FlutterDevice {
   }
 
   Future<void> debugDumpApp() async {
+    final List<FlutterView> views = await vmService.getFlutterViews();
     for (final FlutterView view in views) {
       await vmService.flutterDebugDumpApp(
         isolateId: view.uiIsolate.id,
@@ -351,6 +328,7 @@ class FlutterDevice {
   }
 
   Future<void> debugDumpRenderTree() async {
+    final List<FlutterView> views = await vmService.getFlutterViews();
     for (final FlutterView view in views) {
       await vmService.flutterDebugDumpRenderTree(
         isolateId: view.uiIsolate.id,
@@ -359,6 +337,7 @@ class FlutterDevice {
   }
 
   Future<void> debugDumpLayerTree() async {
+    final List<FlutterView> views = await vmService.getFlutterViews();
     for (final FlutterView view in views) {
       await vmService.flutterDebugDumpLayerTree(
         isolateId: view.uiIsolate.id,
@@ -367,6 +346,7 @@ class FlutterDevice {
   }
 
   Future<void> debugDumpSemanticsTreeInTraversalOrder() async {
+    final List<FlutterView> views = await vmService.getFlutterViews();
     for (final FlutterView view in views) {
       await vmService.flutterDebugDumpSemanticsTreeInTraversalOrder(
         isolateId: view.uiIsolate.id,
@@ -375,6 +355,7 @@ class FlutterDevice {
   }
 
   Future<void> debugDumpSemanticsTreeInInverseHitTestOrder() async {
+    final List<FlutterView> views = await vmService.getFlutterViews();
     for (final FlutterView view in views) {
       await vmService.flutterDebugDumpSemanticsTreeInInverseHitTestOrder(
         isolateId: view.uiIsolate.id,
@@ -383,6 +364,7 @@ class FlutterDevice {
   }
 
   Future<void> toggleDebugPaintSizeEnabled() async {
+    final List<FlutterView> views = await vmService.getFlutterViews();
     for (final FlutterView view in views) {
       await vmService.flutterToggleDebugPaintSizeEnabled(
         isolateId: view.uiIsolate.id,
@@ -391,6 +373,7 @@ class FlutterDevice {
   }
 
   Future<void> toggleDebugCheckElevationsEnabled() async {
+    final List<FlutterView> views = await vmService.getFlutterViews();
     for (final FlutterView view in views) {
       await vmService.flutterToggleDebugCheckElevationsEnabled(
         isolateId: view.uiIsolate.id,
@@ -399,6 +382,7 @@ class FlutterDevice {
   }
 
   Future<void> debugTogglePerformanceOverlayOverride() async {
+    final List<FlutterView> views = await vmService.getFlutterViews();
     for (final FlutterView view in views) {
       await vmService.flutterTogglePerformanceOverlayOverride(
         isolateId: view.uiIsolate.id,
@@ -407,6 +391,7 @@ class FlutterDevice {
   }
 
   Future<void> toggleWidgetInspector() async {
+    final List<FlutterView> views = await vmService.getFlutterViews();
     for (final FlutterView view in views) {
       await vmService.flutterToggleWidgetInspector(
         isolateId: view.uiIsolate.id,
@@ -415,6 +400,7 @@ class FlutterDevice {
   }
 
   Future<void> toggleProfileWidgetBuilds() async {
+    final List<FlutterView> views = await vmService.getFlutterViews();
     for (final FlutterView view in views) {
       await vmService.flutterToggleProfileWidgetBuilds(
         isolateId: view.uiIsolate.id,
@@ -423,6 +409,7 @@ class FlutterDevice {
   }
 
   Future<String> togglePlatform({ String from }) async {
+    final List<FlutterView> views = await vmService.getFlutterViews();
     final String to = nextPlatform(from, featureFlags);
     for (final FlutterView view in views) {
       await vmService.flutterPlatformOverride(
@@ -764,15 +751,17 @@ abstract class ResidentRunner {
   Future<Map<String, dynamic>> invokeFlutterExtensionRpcRawOnFirstIsolate(
     String method, {
     Map<String, dynamic> params,
-  }) {
+  }) async {
+    final List<FlutterView> views = await flutterDevices
+      .first
+      .vmService.getFlutterViews();
     return flutterDevices
       .first
       .vmService
       .invokeFlutterExtensionRpcRaw(
         method,
         args: params,
-        isolateId: flutterDevices
-          .first.views
+        isolateId: views
           .first.uiIsolate.id
       );
   }
@@ -811,13 +800,23 @@ abstract class ResidentRunner {
     throw Exception('Canvaskit not supported by this runner.');
   }
 
+  /// List the attached flutter views.
+  Future<List<FlutterView>> listFlutterViews() async {
+    return (await Future.wait(
+      flutterDevices.map((FlutterDevice d) => d.vmService.getFlutterViews()))
+    ).expand((List<FlutterView> views) => views).toList();
+  }
+
   /// Write the SkSL shaders to a zip file in build directory.
   Future<void> writeSkSL() async {
     if (!supportsWriteSkSL) {
       throw Exception('writeSkSL is not supported by this runner.');
     }
+    final List<FlutterView> views = await flutterDevices
+      .first
+      .vmService.getFlutterViews();
     final Map<String, Object> data = await flutterDevices.first.vmService.getSkSLs(
-      viewId: flutterDevices.first.views.first.id,
+      viewId: views.first.id,
     );
     if (data.isEmpty) {
       globals.logger.printStatus(
@@ -902,78 +901,61 @@ abstract class ResidentRunner {
     appFinished();
   }
 
-  Future<void> refreshViews() async {
-    final List<Future<void>> futures = <Future<void>>[
-      for (final FlutterDevice device in flutterDevices) device.refreshViews(),
-    ];
-    await Future.wait(futures);
-  }
-
   Future<void> debugDumpApp() async {
-    await refreshViews();
     for (final FlutterDevice device in flutterDevices) {
       await device.debugDumpApp();
     }
   }
 
   Future<void> debugDumpRenderTree() async {
-    await refreshViews();
     for (final FlutterDevice device in flutterDevices) {
       await device.debugDumpRenderTree();
     }
   }
 
   Future<void> debugDumpLayerTree() async {
-    await refreshViews();
     for (final FlutterDevice device in flutterDevices) {
       await device.debugDumpLayerTree();
     }
   }
 
   Future<void> debugDumpSemanticsTreeInTraversalOrder() async {
-    await refreshViews();
     for (final FlutterDevice device in flutterDevices) {
       await device.debugDumpSemanticsTreeInTraversalOrder();
     }
   }
 
   Future<void> debugDumpSemanticsTreeInInverseHitTestOrder() async {
-    await refreshViews();
     for (final FlutterDevice device in flutterDevices) {
       await device.debugDumpSemanticsTreeInInverseHitTestOrder();
     }
   }
 
   Future<void> debugToggleDebugPaintSizeEnabled() async {
-    await refreshViews();
     for (final FlutterDevice device in flutterDevices) {
       await device.toggleDebugPaintSizeEnabled();
     }
   }
 
   Future<void> debugToggleDebugCheckElevationsEnabled() async {
-    await refreshViews();
     for (final FlutterDevice device in flutterDevices) {
       await device.toggleDebugCheckElevationsEnabled();
     }
   }
 
   Future<void> debugTogglePerformanceOverlayOverride() async {
-    await refreshViews();
     for (final FlutterDevice device in flutterDevices) {
       await device.debugTogglePerformanceOverlayOverride();
     }
   }
 
   Future<void> debugToggleWidgetInspector() async {
-    await refreshViews();
     for (final FlutterDevice device in flutterDevices) {
       await device.toggleWidgetInspector();
     }
   }
 
   Future<void> debugToggleProfileWidgetBuilds() async {
-    await refreshViews();
     for (final FlutterDevice device in flutterDevices) {
       await device.toggleProfileWidgetBuilds();
     }
@@ -997,11 +979,12 @@ abstract class ResidentRunner {
       'flutter',
       'png',
     );
+    final List<FlutterView> views = await device
+      .vmService.getFlutterViews();
     try {
       if (supportsServiceProtocol && isRunningDebug) {
-        await device.refreshViews();
         try {
-          for (final FlutterView view in device.views) {
+          for (final FlutterView view in views) {
             await device.vmService.flutterDebugAllowBanner(
               false,
               isolateId: view.uiIsolate.id,
@@ -1018,7 +1001,7 @@ abstract class ResidentRunner {
       } finally {
         if (supportsServiceProtocol && isRunningDebug) {
           try {
-            for (final FlutterView view in device.views) {
+            for (final FlutterView view in views) {
               await device.vmService.flutterDebugAllowBanner(
                 true,
                 isolateId: view.uiIsolate.id,
@@ -1043,9 +1026,10 @@ abstract class ResidentRunner {
   }
 
   Future<void> debugTogglePlatform() async {
-    await refreshViews();
-    final String isolateId = flutterDevices
-      .first.views.first.uiIsolate.id;
+    final List<FlutterView> views = await flutterDevices
+      .first
+      .vmService.getFlutterViews();
+    final String isolateId = views.first.uiIsolate.id;
     final String from = await flutterDevices
       .first.vmService.flutterPlatformOverride(
         isolateId: isolateId,
@@ -1078,30 +1062,7 @@ abstract class ResidentRunner {
     if (!debuggingOptions.debuggingEnabled) {
       throw 'The service protocol is not enabled.';
     }
-
     _finished = Completer<int>();
-
-    bool viewFound = false;
-    for (final FlutterDevice device in flutterDevices) {
-      await device.connect(
-        reloadSources: reloadSources,
-        restart: restart,
-        compileExpression: compileExpression,
-        reloadMethod: reloadMethod,
-      );
-      await device.refreshViews();
-      if (device.views.isNotEmpty) {
-        viewFound = true;
-      }
-    }
-    if (!viewFound) {
-      if (flutterDevices.length == 1) {
-        throw 'No Flutter view is available on ${flutterDevices.first.device.name}.';
-      }
-      throw 'No Flutter view is available on any device '
-            '(${flutterDevices.map<String>((FlutterDevice device) => device.device.name).join(', ')}).';
-    }
-
     // Listen for service protocol connection to close.
     for (final FlutterDevice device in flutterDevices) {
       // This hooks up callbacks for when the connection stops in the future.
@@ -1372,8 +1333,7 @@ class TerminalHandler {
         }
         return false;
       case 'l':
-        final List<FlutterView> views = residentRunner.flutterDevices
-            .expand((FlutterDevice d) => d.views).toList();
+        final List<FlutterView> views = await residentRunner.listFlutterViews();
         globals.printStatus('Connected ${pluralize('view', views.length)}:');
         for (final FlutterView v in views) {
           globals.printStatus('${v.uiIsolate.name} (${v.uiIsolate.id})', indent: 2);

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -95,7 +95,6 @@ class ColdRunner extends ResidentRunner {
         continue;
       }
       await device.initLogReader();
-      await device.refreshViews();
       globals.printTrace('Connected to ${device.device.name}');
     }
 
@@ -145,9 +144,9 @@ class ColdRunner extends ResidentRunner {
     for (final FlutterDevice device in flutterDevices) {
       await device.initLogReader();
     }
-    await refreshViews();
     for (final FlutterDevice device in flutterDevices) {
-      for (final FlutterView view in device.views) {
+      final List<FlutterView> views = await device.vmService.getFlutterViews();
+      for (final FlutterView view in views) {
         globals.printTrace('Connected to $view.');
       }
     }

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -730,15 +730,29 @@ extension FlutterVmService on vm_service.VmService {
   }
 
   /// List all [FlutterView]s attached to the current VM.
-  Future<List<FlutterView>> getFlutterViews() async {
-    final vm_service.Response response = await callMethod(
-      kListViewsMethod,
-    );
-    final List<Object> rawViews = response.json['views'] as List<Object>;
-    return <FlutterView>[
-      for (final Object rawView in rawViews)
-        FlutterView.parse(rawView as Map<String, Object>)
-    ];
+  ///
+  /// If this returns an empty list, it will poll forever unless [returnEarly]
+  /// is set to true.
+  ///
+  /// By default, the poll duration is 50 milliseconds.
+  Future<List<FlutterView>> getFlutterViews({
+    bool returnEarly = false,
+    Duration delay = const Duration(milliseconds: 50),
+  }) async {
+    while (true) {
+      final vm_service.Response response = await callMethod(
+        kListViewsMethod,
+      );
+      final List<Object> rawViews = response.json['views'] as List<Object>;
+      final List<FlutterView> views = <FlutterView>[
+        for (final Object rawView in rawViews)
+          FlutterView.parse(rawView as Map<String, Object>)
+      ];
+      if (views.isNotEmpty || returnEarly) {
+        return views;
+      }
+      await Future<void>.delayed(delay);
+    }
   }
 
   /// Attempt to retrieve the isolate with id [isolateId], or `null` if it has

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -66,7 +66,7 @@ abstract class ChromiumDevice extends Device {
   bool get supportsStartPaused => true;
 
   @override
-  bool get supportsFlutterExit => true;
+  bool get supportsFlutterExit => false;
 
   @override
   bool get supportsScreenshot => false;
@@ -342,6 +342,9 @@ class WebServerDevice extends Device {
 
   @override
   Future<bool> isLatestBuildInstalled(ApplicationPackage app) async => true;
+
+  @override
+  bool get supportsFlutterExit => false;
 
   @override
   Future<bool> get isLocalEmulator async => false;

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -685,7 +685,6 @@ VMServiceConnector getFakeVmServiceFactory({
     final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
       requests: <VmServiceExpectation>[
         FakeVmServiceRequest(
-          id: '1',
           method: kListViewsMethod,
           args: null,
           jsonResponse: <String, Object>{
@@ -698,14 +697,12 @@ VMServiceConnector getFakeVmServiceFactory({
           },
         ),
         FakeVmServiceRequest(
-          id: '2',
           method: 'getVM',
           args: null,
           jsonResponse: vm_service.VM.parse(<String, Object>{})
             .toJson(),
         ),
         FakeVmServiceRequest(
-          id: '3',
           method: '_createDevFS',
           args: <String, Object>{
             'fsName': globals.fs.currentDirectory.absolute.path,
@@ -715,7 +712,6 @@ VMServiceConnector getFakeVmServiceFactory({
           },
         ),
         FakeVmServiceRequest(
-          id: '4',
           method: kListViewsMethod,
           args: null,
           jsonResponse: <String, Object>{

--- a/packages/flutter_tools/test/commands.shard/permeable/devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/devices_test.dart
@@ -65,7 +65,7 @@ void main() {
             'hotRestart': true,
             'screenshot': false,
             'fastStart': false,
-            'flutterExit': true,
+            'flutterExit': false,
             'hardwareRendering': false,
             'startPaused': true
           }

--- a/packages/flutter_tools/test/general.shard/cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/cold_test.dart
@@ -5,95 +5,16 @@
 import 'dart:async';
 
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/base/io.dart';
-import 'package:flutter_tools/src/base/logger.dart';
-import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/build_info.dart';
-import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:flutter_tools/src/run_cold.dart';
-import 'package:flutter_tools/src/vmservice.dart';
-import 'package:meta/meta.dart';
 import 'package:mockito/mockito.dart';
-import 'package:platform/platform.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
-import '../src/mocks.dart';
 
 void main() {
-  group('cold attach', () {
-    MockResidentCompiler residentCompiler;
-    BufferLogger mockLogger;
-
-    setUp(() {
-      mockLogger = BufferLogger(
-        terminal: AnsiTerminal(
-          stdio: null,
-          platform: const LocalPlatform(),
-        ),
-        outputPreferences: OutputPreferences.test(),
-    );
-      residentCompiler = MockResidentCompiler();
-    });
-
-    testUsingContext('Prints message when HttpException is thrown - 1', () async {
-      final MockDevice mockDevice = MockDevice();
-      when(mockDevice.supportsHotReload).thenReturn(true);
-      when(mockDevice.supportsHotRestart).thenReturn(false);
-      when(mockDevice.targetPlatform).thenAnswer((Invocation _) async => TargetPlatform.tester);
-      when(mockDevice.sdkNameAndVersion).thenAnswer((Invocation _) async => 'Android 10');
-
-      final List<FlutterDevice> devices = <FlutterDevice>[
-        TestFlutterDevice(
-          device: mockDevice,
-          generator: residentCompiler,
-          exception: const HttpException('Connection closed before full header was received, '
-              'uri = http://127.0.0.1:63394/5ZmLv8A59xY=/ws'),
-        ),
-      ];
-
-      final int exitCode = await ColdRunner(devices,
-        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      ).attach();
-      expect(exitCode, 2);
-      expect(mockLogger.statusText, contains('If you are using an emulator running Android Q Beta, '
-          'consider using an emulator running API level 29 or lower.'));
-      expect(mockLogger.statusText, contains('Learn more about the status of this issue on '
-          'https://issuetracker.google.com/issues/132325318'));
-    }, overrides: <Type, Generator>{
-      Logger: () => mockLogger,
-    });
-
-    testUsingContext('Prints message when HttpException is thrown - 2', () async {
-      final MockDevice mockDevice = MockDevice();
-      when(mockDevice.supportsHotReload).thenReturn(true);
-      when(mockDevice.supportsHotRestart).thenReturn(false);
-      when(mockDevice.targetPlatform).thenAnswer((Invocation _) async => TargetPlatform.tester);
-      when(mockDevice.sdkNameAndVersion).thenAnswer((Invocation _) async => 'Android 10');
-
-      final List<FlutterDevice> devices = <FlutterDevice>[
-        TestFlutterDevice(
-          device: mockDevice,
-          generator: residentCompiler,
-          exception: const HttpException(', uri = http://127.0.0.1:63394/5ZmLv8A59xY=/ws'),
-        ),
-      ];
-
-      final int exitCode = await ColdRunner(devices,
-        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      ).attach();
-      expect(exitCode, 2);
-      expect(mockLogger.statusText, contains('If you are using an emulator running Android Q Beta, '
-          'consider using an emulator running API level 29 or lower.'));
-      expect(mockLogger.statusText, contains('Learn more about the status of this issue on '
-          'https://issuetracker.google.com/issues/132325318'));
-    }, overrides: <Type, Generator>{
-      Logger: () => mockLogger,
-    });
-  });
-
   group('cleanupAtFinish()', () {
     MockFlutterDevice mockFlutterDeviceFactory(Device device) {
       final MockFlutterDevice mockFlutterDevice = MockFlutterDevice();
@@ -164,27 +85,5 @@ class MockFlutterDevice extends Mock implements FlutterDevice {}
 class MockDevice extends Mock implements Device {
   MockDevice() {
     when(isSupported()).thenReturn(true);
-  }
-}
-
-class TestFlutterDevice extends FlutterDevice {
-  TestFlutterDevice({
-    @required Device device,
-    @required this.exception,
-    @required ResidentCompiler generator,
-  })  : assert(exception != null),
-        super(device, buildInfo: BuildInfo.debug, generator: generator);
-
-  /// The exception to throw when the connect method is called.
-  final Exception exception;
-
-  @override
-  Future<void> connect({
-    ReloadSources reloadSources,
-    Restart restart,
-    CompileExpression compileExpression,
-    ReloadMethod reloadMethod,
-  }) async {
-    throw exception;
   }
 }

--- a/packages/flutter_tools/test/general.shard/cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/cold_test.dart
@@ -5,16 +5,95 @@
 import 'dart:async';
 
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:flutter_tools/src/run_cold.dart';
+import 'package:flutter_tools/src/vmservice.dart';
+import 'package:meta/meta.dart';
 import 'package:mockito/mockito.dart';
+import 'package:platform/platform.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
+import '../src/mocks.dart';
 
 void main() {
+  group('cold attach', () {
+    MockResidentCompiler residentCompiler;
+    BufferLogger mockLogger;
+
+    setUp(() {
+      mockLogger = BufferLogger(
+        terminal: AnsiTerminal(
+          stdio: null,
+          platform: const LocalPlatform(),
+        ),
+        outputPreferences: OutputPreferences.test(),
+    );
+      residentCompiler = MockResidentCompiler();
+    });
+
+    testUsingContext('Prints message when HttpException is thrown - 1', () async {
+      final MockDevice mockDevice = MockDevice();
+      when(mockDevice.supportsHotReload).thenReturn(true);
+      when(mockDevice.supportsHotRestart).thenReturn(false);
+      when(mockDevice.targetPlatform).thenAnswer((Invocation _) async => TargetPlatform.tester);
+      when(mockDevice.sdkNameAndVersion).thenAnswer((Invocation _) async => 'Android 10');
+
+      final List<FlutterDevice> devices = <FlutterDevice>[
+        TestFlutterDevice(
+          device: mockDevice,
+          generator: residentCompiler,
+          exception: const HttpException('Connection closed before full header was received, '
+              'uri = http://127.0.0.1:63394/5ZmLv8A59xY=/ws'),
+        ),
+      ];
+
+      final int exitCode = await ColdRunner(devices,
+        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      ).attach();
+      expect(exitCode, 2);
+      expect(mockLogger.statusText, contains('If you are using an emulator running Android Q Beta, '
+          'consider using an emulator running API level 29 or lower.'));
+      expect(mockLogger.statusText, contains('Learn more about the status of this issue on '
+          'https://issuetracker.google.com/issues/132325318'));
+    }, overrides: <Type, Generator>{
+      Logger: () => mockLogger,
+    });
+
+    testUsingContext('Prints message when HttpException is thrown - 2', () async {
+      final MockDevice mockDevice = MockDevice();
+      when(mockDevice.supportsHotReload).thenReturn(true);
+      when(mockDevice.supportsHotRestart).thenReturn(false);
+      when(mockDevice.targetPlatform).thenAnswer((Invocation _) async => TargetPlatform.tester);
+      when(mockDevice.sdkNameAndVersion).thenAnswer((Invocation _) async => 'Android 10');
+
+      final List<FlutterDevice> devices = <FlutterDevice>[
+        TestFlutterDevice(
+          device: mockDevice,
+          generator: residentCompiler,
+          exception: const HttpException(', uri = http://127.0.0.1:63394/5ZmLv8A59xY=/ws'),
+        ),
+      ];
+
+      final int exitCode = await ColdRunner(devices,
+        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      ).attach();
+      expect(exitCode, 2);
+      expect(mockLogger.statusText, contains('If you are using an emulator running Android Q Beta, '
+          'consider using an emulator running API level 29 or lower.'));
+      expect(mockLogger.statusText, contains('Learn more about the status of this issue on '
+          'https://issuetracker.google.com/issues/132325318'));
+    }, overrides: <Type, Generator>{
+      Logger: () => mockLogger,
+    });
+  });
+
   group('cleanupAtFinish()', () {
     MockFlutterDevice mockFlutterDeviceFactory(Device device) {
       final MockFlutterDevice mockFlutterDevice = MockFlutterDevice();
@@ -85,5 +164,27 @@ class MockFlutterDevice extends Mock implements FlutterDevice {}
 class MockDevice extends Mock implements Device {
   MockDevice() {
     when(isSupported()).thenReturn(true);
+  }
+}
+
+class TestFlutterDevice extends FlutterDevice {
+  TestFlutterDevice({
+    @required Device device,
+    @required this.exception,
+    @required ResidentCompiler generator,
+  })  : assert(exception != null),
+        super(device, buildInfo: BuildInfo.debug, generator: generator);
+
+  /// The exception to throw when the connect method is called.
+  final Exception exception;
+
+  @override
+  Future<void> connect({
+    ReloadSources reloadSources,
+    Restart restart,
+    CompileExpression compileExpression,
+    ReloadMethod reloadMethod,
+  }) async {
+    throw exception;
   }
 }

--- a/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
+++ b/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
@@ -12,7 +12,6 @@ void main() {
     final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
       requests: <VmServiceExpectation>[
         FakeVmServiceRequest(
-          id: '1',
           method: 'getVM',
           jsonResponse: (vm_service.VM.parse(<String, Object>{})
             ..isolates = <vm_service.IsolateRef>[
@@ -23,7 +22,6 @@ void main() {
           ).toJson(),
         ),
         const FakeVmServiceRequest(
-          id: '2',
           method: 'getScripts',
           args: <String, Object>{
             'isolateId': '1',

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -129,7 +129,6 @@ void main() {
         final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
           requests: <VmServiceExpectation>[
             FakeVmServiceRequest(
-              id: '1',
               method: '_createDevFS',
               args: <String, Object>{
                 'fsName': 'test',
@@ -202,7 +201,6 @@ void main() {
       final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
         requests: <VmServiceExpectation>[
           FakeVmServiceRequest(
-            id: '1',
             method: '_createDevFS',
             args: <String, Object>{
               'fsName': 'test',

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
@@ -637,7 +637,6 @@ void main() {
       final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
         requests: <VmServiceExpectation>[
           FakeVmServiceRequest(
-            id: '1',
             method: kListViewsMethod,
             jsonResponse: <String, Object>{
               'views': <Object>[

--- a/packages/flutter_tools/test/general.shard/hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/hot_test.dart
@@ -6,7 +6,9 @@ import 'dart:async';
 
 import 'package:vm_service/vm_service.dart' as vm_service;
 import 'package:flutter_tools/src/artifacts.dart';
+import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
@@ -315,6 +317,73 @@ void main() {
     });
   });
 
+  group('hot attach', () {
+    MockResidentCompiler residentCompiler = MockResidentCompiler();
+    MockLocalEngineArtifacts mockArtifacts;
+
+    setUp(() {
+      residentCompiler = MockResidentCompiler();
+      mockArtifacts = MockLocalEngineArtifacts();
+    });
+
+    testUsingContext('Prints message when HttpException is thrown - 1', () async {
+      final MockDevice mockDevice = MockDevice();
+      when(mockDevice.supportsHotReload).thenReturn(true);
+      when(mockDevice.supportsHotRestart).thenReturn(false);
+      when(mockDevice.targetPlatform).thenAnswer((Invocation _) async => TargetPlatform.tester);
+      when(mockDevice.sdkNameAndVersion).thenAnswer((Invocation _) async => 'Android 10');
+
+      final List<FlutterDevice> devices = <FlutterDevice>[
+        TestFlutterDevice(
+          device: mockDevice,
+          generator: residentCompiler,
+          exception: const HttpException('Connection closed before full header was received, '
+              'uri = http://127.0.0.1:63394/5ZmLv8A59xY=/ws'),
+        ),
+      ];
+
+      final int exitCode = await HotRunner(devices,
+        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      ).attach();
+      expect(exitCode, 2);
+      expect(testLogger.statusText, contains('If you are using an emulator running Android Q Beta, '
+          'consider using an emulator running API level 29 or lower.'));
+      expect(testLogger.statusText, contains('Learn more about the status of this issue on '
+          'https://issuetracker.google.com/issues/132325318'));
+    }, overrides: <Type, Generator>{
+      Artifacts: () => mockArtifacts,
+      HotRunnerConfig: () => TestHotRunnerConfig(successfulSetup: true),
+    });
+
+    testUsingContext('Prints message when HttpException is thrown - 2', () async {
+      final MockDevice mockDevice = MockDevice();
+      when(mockDevice.supportsHotReload).thenReturn(true);
+      when(mockDevice.supportsHotRestart).thenReturn(false);
+      when(mockDevice.targetPlatform).thenAnswer((Invocation _) async => TargetPlatform.tester);
+      when(mockDevice.sdkNameAndVersion).thenAnswer((Invocation _) async => 'Android 10');
+
+      final List<FlutterDevice> devices = <FlutterDevice>[
+        TestFlutterDevice(
+          device: mockDevice,
+          generator: residentCompiler,
+          exception: const HttpException(', uri = http://127.0.0.1:63394/5ZmLv8A59xY=/ws'),
+        ),
+      ];
+
+      final int exitCode = await HotRunner(devices,
+        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      ).attach();
+      expect(exitCode, 2);
+      expect(testLogger.statusText, contains('If you are using an emulator running Android Q Beta, '
+          'consider using an emulator running API level 29 or lower.'));
+      expect(testLogger.statusText, contains('Learn more about the status of this issue on '
+          'https://issuetracker.google.com/issues/132325318'));
+    }, overrides: <Type, Generator>{
+      Artifacts: () => mockArtifacts,
+      HotRunnerConfig: () => TestHotRunnerConfig(successfulSetup: true),
+    });
+  });
+
   group('hot cleanupAtFinish()', () {
     MockFlutterDevice mockFlutterDeviceFactory(Device device) {
       final MockFlutterDevice mockFlutterDevice = MockFlutterDevice();
@@ -357,6 +426,28 @@ class MockDevice extends Mock implements Device {
 }
 
 class MockFlutterDevice extends Mock implements FlutterDevice {}
+
+class TestFlutterDevice extends FlutterDevice {
+  TestFlutterDevice({
+    @required Device device,
+    @required this.exception,
+    @required ResidentCompiler generator,
+  })  : assert(exception != null),
+        super(device, buildInfo: BuildInfo.debug, generator: generator);
+
+  /// The exception to throw when the connect method is called.
+  final Exception exception;
+
+  @override
+  Future<void> connect({
+    ReloadSources reloadSources,
+    Restart restart,
+    CompileExpression compileExpression,
+    ReloadMethod reloadMethod,
+  }) async {
+    throw exception;
+  }
+}
 
 class TestHotRunnerConfig extends HotRunnerConfig {
   TestHotRunnerConfig({@required this.successfulSetup});

--- a/packages/flutter_tools/test/general.shard/hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/hot_test.dart
@@ -21,13 +21,36 @@ import '../src/common.dart';
 import '../src/context.dart';
 import '../src/mocks.dart';
 
-const FakeVmServiceRequest listViews = FakeVmServiceRequest(
-  method: kListViewsMethod,
-  jsonResponse: <String, Object>{
-    'views': <Object>[],
-  }
+final vm_service.Isolate fakeUnpausedIsolate = vm_service.Isolate(
+  id: '1',
+  pauseEvent: vm_service.Event(
+    kind: vm_service.EventKind.kResume,
+    timestamp: 0
+  ),
+  breakpoints: <vm_service.Breakpoint>[],
+  exceptionPauseMode: null,
+  libraries: <vm_service.LibraryRef>[],
+  livePorts: 0,
+  name: 'test',
+  number: '1',
+  pauseOnExit: false,
+  runnable: true,
+  startTime: 0,
 );
 
+final FlutterView fakeFlutterView = FlutterView(
+  id: 'a',
+  uiIsolate: fakeUnpausedIsolate,
+);
+
+final FakeVmServiceRequest listViews = FakeVmServiceRequest(
+  method: kListViewsMethod,
+  jsonResponse: <String, Object>{
+    'views': <Object>[
+      fakeFlutterView.toJson(),
+    ],
+  },
+);
 void main() {
   group('validateReloadReport', () {
     testUsingContext('invalid', () async {
@@ -181,16 +204,72 @@ void main() {
       final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
         listViews,
         FakeVmServiceRequest(
+          method: 'getIsolate',
+          args: <String, Object>{
+            'isolateId': fakeUnpausedIsolate.id,
+          },
+          jsonResponse: fakeUnpausedIsolate.toJson(),
+        ),
+        FakeVmServiceRequest(
           method: 'getVM',
           jsonResponse: vm_service.VM.parse(<String, Object>{}).toJson()
         ),
         listViews,
+        FakeVmServiceRequest(
+          method: 'getIsolate',
+          args: <String, Object>{
+            'isolateId': fakeUnpausedIsolate.id,
+          },
+          jsonResponse: fakeUnpausedIsolate.toJson(),
+        ),
         FakeVmServiceRequest(
           method: 'getVM',
           jsonResponse: vm_service.VM.parse(<String, Object>{}).toJson()
         ),
         listViews,
         listViews,
+        const FakeVmServiceRequest(
+          method: 'streamListen',
+          args: <String, Object>{
+            'streamId': 'Isolate',
+          }
+        ),
+        const FakeVmServiceRequest(
+          method: 'streamListen',
+          args: <String, Object>{
+            'streamId': 'Isolate',
+          }
+        ),
+        FakeVmServiceStreamResponse(
+          streamId: 'Isolate',
+          event: vm_service.Event(
+            timestamp: 0,
+            kind: vm_service.EventKind.kIsolateRunnable,
+          )
+        ),
+        FakeVmServiceStreamResponse(
+          streamId: 'Isolate',
+          event: vm_service.Event(
+            timestamp: 0,
+            kind: vm_service.EventKind.kIsolateRunnable,
+          )
+        ),
+        FakeVmServiceRequest(
+          method: kRunInViewMethod,
+          args: <String, Object>{
+            'viewId': fakeFlutterView.id,
+            'mainScript': 'lib/main.dart.dill',
+            'assetDirectory': 'build/flutter_assets',
+          }
+        ),
+        FakeVmServiceRequest(
+          method: kRunInViewMethod,
+          args: <String, Object>{
+            'viewId': fakeFlutterView.id,
+            'mainScript': 'lib/main.dart.dill',
+            'assetDirectory': 'build/flutter_assets',
+          }
+        ),
       ]);
       // Setup mocks
       final MockDevice mockDevice = MockDevice();
@@ -238,21 +317,39 @@ void main() {
     testUsingContext('hot restart supported', () async {
       // Setup mocks
       final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-        const FakeVmServiceRequest(
-          method: kListViewsMethod,
-          jsonResponse: <String, Object>{
-            'views': <Object>[],
-          }
+        listViews,
+        FakeVmServiceRequest(
+          method: 'getIsolate',
+          args: <String, Object>{
+            'isolateId': fakeUnpausedIsolate.id,
+          },
+          jsonResponse: fakeUnpausedIsolate.toJson(),
         ),
         FakeVmServiceRequest(
           method: 'getVM',
-          jsonResponse: vm_service.VM.parse(<String, Object>{}).toJson()
+          jsonResponse: vm_service.VM.parse(<String, Object>{}).toJson(),
         ),
+        listViews,
         const FakeVmServiceRequest(
-          method: kListViewsMethod,
-          jsonResponse: <String, Object>{
-            'views': <Object>[],
+          method: 'streamListen',
+          args: <String, Object>{
+            'streamId': 'Isolate',
           }
+        ),
+        FakeVmServiceRequest(
+          method: kRunInViewMethod,
+          args: <String, Object>{
+            'viewId': fakeFlutterView.id,
+            'mainScript': 'lib/main.dart.dill',
+            'assetDirectory': 'build/flutter_assets',
+          }
+        ),
+        FakeVmServiceStreamResponse(
+          streamId: 'Isolate',
+          event: vm_service.Event(
+            timestamp: 0,
+            kind: vm_service.EventKind.kIsolateRunnable,
+          )
         ),
       ]);
       final MockDevice mockDevice = MockDevice();

--- a/packages/flutter_tools/test/general.shard/hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/hot_test.dart
@@ -6,9 +6,7 @@ import 'dart:async';
 
 import 'package:vm_service/vm_service.dart' as vm_service;
 import 'package:flutter_tools/src/artifacts.dart';
-import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/build_info.dart';
-import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
@@ -317,73 +315,6 @@ void main() {
     });
   });
 
-  group('hot attach', () {
-    MockResidentCompiler residentCompiler = MockResidentCompiler();
-    MockLocalEngineArtifacts mockArtifacts;
-
-    setUp(() {
-      residentCompiler = MockResidentCompiler();
-      mockArtifacts = MockLocalEngineArtifacts();
-    });
-
-    testUsingContext('Prints message when HttpException is thrown - 1', () async {
-      final MockDevice mockDevice = MockDevice();
-      when(mockDevice.supportsHotReload).thenReturn(true);
-      when(mockDevice.supportsHotRestart).thenReturn(false);
-      when(mockDevice.targetPlatform).thenAnswer((Invocation _) async => TargetPlatform.tester);
-      when(mockDevice.sdkNameAndVersion).thenAnswer((Invocation _) async => 'Android 10');
-
-      final List<FlutterDevice> devices = <FlutterDevice>[
-        TestFlutterDevice(
-          device: mockDevice,
-          generator: residentCompiler,
-          exception: const HttpException('Connection closed before full header was received, '
-              'uri = http://127.0.0.1:63394/5ZmLv8A59xY=/ws'),
-        ),
-      ];
-
-      final int exitCode = await HotRunner(devices,
-        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      ).attach();
-      expect(exitCode, 2);
-      expect(testLogger.statusText, contains('If you are using an emulator running Android Q Beta, '
-          'consider using an emulator running API level 29 or lower.'));
-      expect(testLogger.statusText, contains('Learn more about the status of this issue on '
-          'https://issuetracker.google.com/issues/132325318'));
-    }, overrides: <Type, Generator>{
-      Artifacts: () => mockArtifacts,
-      HotRunnerConfig: () => TestHotRunnerConfig(successfulSetup: true),
-    });
-
-    testUsingContext('Prints message when HttpException is thrown - 2', () async {
-      final MockDevice mockDevice = MockDevice();
-      when(mockDevice.supportsHotReload).thenReturn(true);
-      when(mockDevice.supportsHotRestart).thenReturn(false);
-      when(mockDevice.targetPlatform).thenAnswer((Invocation _) async => TargetPlatform.tester);
-      when(mockDevice.sdkNameAndVersion).thenAnswer((Invocation _) async => 'Android 10');
-
-      final List<FlutterDevice> devices = <FlutterDevice>[
-        TestFlutterDevice(
-          device: mockDevice,
-          generator: residentCompiler,
-          exception: const HttpException(', uri = http://127.0.0.1:63394/5ZmLv8A59xY=/ws'),
-        ),
-      ];
-
-      final int exitCode = await HotRunner(devices,
-        debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-      ).attach();
-      expect(exitCode, 2);
-      expect(testLogger.statusText, contains('If you are using an emulator running Android Q Beta, '
-          'consider using an emulator running API level 29 or lower.'));
-      expect(testLogger.statusText, contains('Learn more about the status of this issue on '
-          'https://issuetracker.google.com/issues/132325318'));
-    }, overrides: <Type, Generator>{
-      Artifacts: () => mockArtifacts,
-      HotRunnerConfig: () => TestHotRunnerConfig(successfulSetup: true),
-    });
-  });
-
   group('hot cleanupAtFinish()', () {
     MockFlutterDevice mockFlutterDeviceFactory(Device device) {
       final MockFlutterDevice mockFlutterDevice = MockFlutterDevice();
@@ -426,28 +357,6 @@ class MockDevice extends Mock implements Device {
 }
 
 class MockFlutterDevice extends Mock implements FlutterDevice {}
-
-class TestFlutterDevice extends FlutterDevice {
-  TestFlutterDevice({
-    @required Device device,
-    @required this.exception,
-    @required ResidentCompiler generator,
-  })  : assert(exception != null),
-        super(device, buildInfo: BuildInfo.debug, generator: generator);
-
-  /// The exception to throw when the connect method is called.
-  final Exception exception;
-
-  @override
-  Future<void> connect({
-    ReloadSources reloadSources,
-    Restart restart,
-    CompileExpression compileExpression,
-    ReloadMethod reloadMethod,
-  }) async {
-    throw exception;
-  }
-}
 
 class TestHotRunnerConfig extends HotRunnerConfig {
   TestHotRunnerConfig({@required this.successfulSetup});

--- a/packages/flutter_tools/test/general.shard/hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/hot_test.dart
@@ -21,6 +21,13 @@ import '../src/common.dart';
 import '../src/context.dart';
 import '../src/mocks.dart';
 
+const FakeVmServiceRequest listViews = FakeVmServiceRequest(
+  method: kListViewsMethod,
+  jsonResponse: <String, Object>{
+    'views': <Object>[],
+  }
+);
+
 void main() {
   group('validateReloadReport', () {
     testUsingContext('invalid', () async {
@@ -172,44 +179,18 @@ void main() {
 
     testUsingContext('Does hot restarts when all devices support it', () async {
       final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-        const FakeVmServiceRequest(
-          id: '1',
-          method: kListViewsMethod,
-          jsonResponse: <String, Object>{
-            'views': <Object>[],
-          }
-        ),
-         const FakeVmServiceRequest(
-          id: '2',
-          method: kListViewsMethod,
-          jsonResponse: <String, Object>{
-            'views': <Object>[],
-          }
-        ),
+        listViews,
         FakeVmServiceRequest(
-          id: '3',
           method: 'getVM',
           jsonResponse: vm_service.VM.parse(<String, Object>{}).toJson()
         ),
+        listViews,
         FakeVmServiceRequest(
-          id: '4',
           method: 'getVM',
           jsonResponse: vm_service.VM.parse(<String, Object>{}).toJson()
         ),
-        const FakeVmServiceRequest(
-          id: '5',
-          method: kListViewsMethod,
-          jsonResponse: <String, Object>{
-            'views': <Object>[],
-          }
-        ),
-        const FakeVmServiceRequest(
-          id: '6',
-          method: kListViewsMethod,
-          jsonResponse: <String, Object>{
-            'views': <Object>[],
-          }
-        ),
+        listViews,
+        listViews,
       ]);
       // Setup mocks
       final MockDevice mockDevice = MockDevice();
@@ -258,19 +239,16 @@ void main() {
       // Setup mocks
       final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
         const FakeVmServiceRequest(
-          id: '1',
           method: kListViewsMethod,
           jsonResponse: <String, Object>{
             'views': <Object>[],
           }
         ),
         FakeVmServiceRequest(
-          id: '2',
           method: 'getVM',
           jsonResponse: vm_service.VM.parse(<String, Object>{}).toJson()
         ),
         const FakeVmServiceRequest(
-          id: '3',
           method: kListViewsMethod,
           jsonResponse: <String, Object>{
             'views': <Object>[],

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -185,7 +185,6 @@ void main() {
   test('ResidentRunner can attach to device successfully', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       listViews,
-      listViews,
     ]);
     final Completer<DebugConnectionInfo> onConnectionInfo = Completer<DebugConnectionInfo>.sync();
     final Completer<void> onAppStart = Completer<void>.sync();
@@ -207,7 +206,6 @@ void main() {
 
   test('ResidentRunner can attach to device successfully with --fast-start', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
       listViews,
       listViews,
       FakeVmServiceRequest(
@@ -287,7 +285,6 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       listViews,
       listViews,
-      listViews,
     ]);
     when(mockDevice.sdkNameAndVersion).thenAnswer((Invocation invocation) async {
       return 'Example';
@@ -340,7 +337,6 @@ void main() {
       listViews,
       listViews,
       listViews,
-      listViews,
       FakeVmServiceRequest(
         method: 'getIsolate',
         args: <String, Object>{
@@ -385,7 +381,6 @@ void main() {
 
   test('ResidentRunner can send target platform to analytics from full restart', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
       listViews,
       listViews,
       FakeVmServiceRequest(
@@ -454,7 +449,6 @@ void main() {
 
   test('ResidentRunner Can handle an RPC exception from hot restart', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
       listViews,
     ]);
     when(mockDevice.sdkNameAndVersion).thenAnswer((Invocation invocation) async {
@@ -969,7 +963,6 @@ void main() {
   test('HotRunner writes vm service file when providing debugging option', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       listViews,
-      listViews,
     ]);
     setWsAddress(testUri, fakeVmServiceHost.vmService);
     globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
@@ -993,7 +986,6 @@ void main() {
 
   test('HotRunner unforwards device ports', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
       listViews,
     ]);
     final MockDevicePortForwarder mockPortForwarder = MockDevicePortForwarder();
@@ -1025,7 +1017,6 @@ void main() {
   test('HotRunner handles failure to write vmservice file', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       listViews,
-      listViews,
     ]);
     globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
     residentRunner = HotRunner(
@@ -1051,9 +1042,7 @@ void main() {
 
 
   test('ColdRunner writes vm service file when providing debugging option', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-    ]);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
     setWsAddress(testUri, fakeVmServiceHost.vmService);
     residentRunner = ColdRunner(

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -30,7 +30,6 @@ import 'package:mockito/mockito.dart';
 import '../src/common.dart';
 import '../src/context.dart';
 import '../src/testbed.dart';
-import 'vmservice_test.dart';
 
 final vm_service.Isolate fakeUnpausedIsolate = vm_service.Isolate(
   id: '1',

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -30,6 +30,7 @@ import 'package:mockito/mockito.dart';
 import '../src/common.dart';
 import '../src/context.dart';
 import '../src/testbed.dart';
+import 'vmservice_test.dart';
 
 final vm_service.Isolate fakeUnpausedIsolate = vm_service.Isolate(
   id: '1',
@@ -68,6 +69,15 @@ final vm_service.Isolate fakePausedIsolate = vm_service.Isolate(
 final FlutterView fakeFlutterView = FlutterView(
   id: 'a',
   uiIsolate: fakeUnpausedIsolate,
+);
+
+final FakeVmServiceRequest listViews = FakeVmServiceRequest(
+  method: kListViewsMethod,
+  jsonResponse: <String, Object>{
+    'views': <Object>[
+      fakeFlutterView.toJson(),
+    ],
+  },
 );
 
 void main() {
@@ -127,10 +137,6 @@ void main() {
       );
     });
     when(mockFlutterDevice.devFS).thenReturn(mockDevFS);
-    when(mockFlutterDevice.views).thenReturn(<FlutterView>[
-      // NB: still using mock FlutterDevice.
-      fakeFlutterView,
-    ]);
     when(mockFlutterDevice.device).thenReturn(mockDevice);
     when(mockFlutterDevice.stopEchoingDeviceLog()).thenAnswer((Invocation invocation) async { });
     when(mockFlutterDevice.observatoryUris).thenAnswer((_) => Stream<Uri>.value(testUri));
@@ -146,7 +152,6 @@ void main() {
     when(mockFlutterDevice.vmService).thenAnswer((Invocation invocation) {
       return fakeVmServiceHost.vmService;
     });
-    when(mockFlutterDevice.refreshViews()).thenAnswer((Invocation invocation) async { });
     when(mockFlutterDevice.reloadSources(any, pause: anyNamed('pause'))).thenAnswer((Invocation invocation) async {
       return <Future<vm_service.ReloadReport>>[
         Future<vm_service.ReloadReport>.value(vm_service.ReloadReport.parse(<String, dynamic>{
@@ -166,15 +171,7 @@ void main() {
 
   test('FlutterDevice can list views with a filter', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      FakeVmServiceRequest(
-        id: '1',
-        method: kListViewsMethod,
-        jsonResponse: <String, Object>{
-          'views': <Object>[
-            fakeFlutterView.toJson(),
-          ],
-        },
-      ),
+      listViews,
     ]);
     final MockDevice mockDevice = MockDevice();
     final FlutterDevice flutterDevice = FlutterDevice(
@@ -184,14 +181,13 @@ void main() {
     );
 
     flutterDevice.vmService = fakeVmServiceHost.vmService;
-
-    await flutterDevice.refreshViews();
-
-    expect(flutterDevice.views, isEmpty);
   }));
 
   test('ResidentRunner can attach to device successfully', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ]);
     final Completer<DebugConnectionInfo> onConnectionInfo = Completer<DebugConnectionInfo>.sync();
     final Completer<void> onAppStart = Completer<void>.sync();
     final Future<int> result = residentRunner.attach(
@@ -207,12 +203,15 @@ void main() {
     expect(onConnectionInfo.isCompleted, true);
     expect((await connectionInfo).baseUri, 'foo://bar');
     expect(onAppStart.isCompleted, true);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }));
 
   test('ResidentRunner can attach to device successfully with --fast-start', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+      listViews,
       FakeVmServiceRequest(
-        id: '1',
         method: 'getIsolate',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -220,19 +219,17 @@ void main() {
         jsonResponse: fakeUnpausedIsolate.toJson(),
       ),
       FakeVmServiceRequest(
-        id: '2',
         method: 'getVM',
         jsonResponse: vm_service.VM.parse(<String, Object>{}).toJson(),
       ),
+      listViews,
       const FakeVmServiceRequest(
-        id: '3',
         method: 'streamListen',
         args: <String, Object>{
           'streamId': 'Isolate',
         }
       ),
       FakeVmServiceRequest(
-        id: '4',
         method: kRunInViewMethod,
         args: <String, Object>{
           'viewId': fakeFlutterView.id,
@@ -284,10 +281,15 @@ void main() {
     expect(onConnectionInfo.isCompleted, true);
     expect((await connectionInfo).baseUri, 'foo://bar');
     expect(onAppStart.isCompleted, true);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }));
 
   test('ResidentRunner can handle an RPC exception from hot reload', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+      listViews,
+    ]);
     when(mockDevice.sdkNameAndVersion).thenAnswer((Invocation invocation) async {
       return 'Example';
     });
@@ -329,15 +331,18 @@ void main() {
       cdKey(CustomDimensions.hotEventEmulator): 'false',
       cdKey(CustomDimensions.hotEventFullRestart): 'false',
     })).called(1);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     Usage: () => MockUsage(),
   }));
 
   test('ResidentRunner can send target platform to analytics from hot reload', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      // Not all requests are present due to existing mocks
+      listViews,
+      listViews,
+      listViews,
+      listViews,
       FakeVmServiceRequest(
-        id: '1',
         method: 'getIsolate',
         args: <String, Object>{
           'isolateId': '1',
@@ -345,7 +350,6 @@ void main() {
         jsonResponse: fakeUnpausedIsolate.toJson(),
       ),
       FakeVmServiceRequest(
-        id: '2',
         method: 'ext.flutter.reassemble',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -381,10 +385,11 @@ void main() {
   }));
 
   test('ResidentRunner can send target platform to analytics from full restart', () => testbed.run(() async {
-     // Not all requests are present due to existing mocks
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+      listViews,
       FakeVmServiceRequest(
-        id: '1',
         method: 'getIsolate',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -392,19 +397,17 @@ void main() {
         jsonResponse: fakeUnpausedIsolate.toJson(),
       ),
       FakeVmServiceRequest(
-        id: '2',
         method: 'getVM',
         jsonResponse: vm_service.VM.parse(<String, Object>{}).toJson(),
       ),
+      listViews,
       const FakeVmServiceRequest(
-        id: '3',
         method: 'streamListen',
         args: <String, Object>{
           'streamId': 'Isolate',
         },
       ),
       FakeVmServiceRequest(
-        id: '4',
         method: kRunInViewMethod,
         args: <String, Object>{
           'viewId': fakeFlutterView.id,
@@ -445,12 +448,16 @@ void main() {
       containsPair(cdKey(CustomDimensions.hotEventTargetPlatform),
                    getNameForTargetPlatform(TargetPlatform.android_arm)),
     );
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     Usage: () => MockUsage(),
   }));
 
   test('ResidentRunner Can handle an RPC exception from hot restart', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ]);
     when(mockDevice.sdkNameAndVersion).thenAnswer((Invocation invocation) async {
       return 'Example';
     });
@@ -493,6 +500,7 @@ void main() {
       cdKey(CustomDimensions.hotEventEmulator): 'false',
       cdKey(CustomDimensions.hotEventFullRestart): 'true',
     })).called(1);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     Usage: () => MockUsage(),
   }));
@@ -578,14 +586,15 @@ void main() {
 
   test('ResidentRunner does support CanvasKit', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+
     expect(() => residentRunner.toggleCanvaskit(),
       throwsA(isA<Exception>()));
   }));
 
   test('ResidentRunner handles writeSkSL returning no data', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-       FakeVmServiceRequest(
-        id: '1',
+      listViews,
+      FakeVmServiceRequest(
         method: kGetSkSLsMethod,
         args: <String, Object>{
           'viewId': fakeFlutterView.id,
@@ -593,17 +602,18 @@ void main() {
         jsonResponse: <String, Object>{
           'SkSLs': <String, Object>{}
         }
-      )
+      ),
     ]);
     await residentRunner.writeSkSL();
 
     expect(testLogger.statusText, contains('No data was receieved'));
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }));
 
   test('ResidentRunner can write SkSL data to a unique file with engine revision, platform, and device name', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
       FakeVmServiceRequest(
-        id: '1',
         method: kGetSkSLsMethod,
         args: <String, Object>{
           'viewId': fakeFlutterView.id,
@@ -634,8 +644,8 @@ void main() {
 
   test('ResidentRunner can take screenshot on debug device', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
       FakeVmServiceRequest(
-        id: '1',
         method: 'ext.flutter.debugAllowBanner',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -643,7 +653,6 @@ void main() {
         },
       ),
       FakeVmServiceRequest(
-        id: '2',
         method: 'ext.flutter.debugAllowBanner',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -676,8 +685,8 @@ void main() {
 
   test('ResidentRunner bails taking screenshot on debug device if debugAllowBanner throws RpcError', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
       FakeVmServiceRequest(
-        id: '1',
         method: 'ext.flutter.debugAllowBanner',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -696,8 +705,8 @@ void main() {
 
   test('ResidentRunner bails taking screenshot on debug device if debugAllowBanner during second request', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
       FakeVmServiceRequest(
-        id: '1',
         method: 'ext.flutter.debugAllowBanner',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -705,7 +714,6 @@ void main() {
         },
       ),
       FakeVmServiceRequest(
-        id: '2',
         method: 'ext.flutter.debugAllowBanner',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -719,12 +727,13 @@ void main() {
     await residentRunner.screenshot(mockFlutterDevice);
 
     expect(testLogger.errorText, contains('Error'));
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }));
 
   test('ResidentRunner bails taking screenshot on debug device if takeScreenshot throws', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
       FakeVmServiceRequest(
-        id: '1',
         method: 'ext.flutter.debugAllowBanner',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -732,7 +741,6 @@ void main() {
         },
       ),
       FakeVmServiceRequest(
-        id: '2',
         method: 'ext.flutter.debugAllowBanner',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -754,10 +762,13 @@ void main() {
 
     expect(() => residentRunner.screenshot(mockFlutterDevice),
         throwsAssertionError);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }));
 
   test('ResidentRunner does not toggle banner in non-debug mode', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+    ]);
     residentRunner = HotRunner(
       <FlutterDevice>[
         mockFlutterDevice,
@@ -781,7 +792,6 @@ void main() {
   test('FlutterDevice will not exit a paused isolate', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       FakeVmServiceRequest(
-        id: '1',
         method: '_flutter.listViews',
         jsonResponse: <String, Object>{
           'views': <Object>[
@@ -790,7 +800,6 @@ void main() {
         },
       ),
       FakeVmServiceRequest(
-        id: '2',
         method: 'getIsolate',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -800,7 +809,6 @@ void main() {
     ]);
     final TestFlutterDevice flutterDevice = TestFlutterDevice(
       mockDevice,
-      <FlutterView>[ fakeFlutterView ],
     );
     flutterDevice.vmService = fakeVmServiceHost.vmService;
     when(mockDevice.supportsFlutterExit).thenReturn(true);
@@ -814,7 +822,6 @@ void main() {
   test('FlutterDevice will call stopApp if the exit request times out', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       FakeVmServiceRequest(
-        id: '1',
         method: '_flutter.listViews',
         jsonResponse: <String, Object>{
           'views': <Object>[
@@ -823,7 +830,6 @@ void main() {
         },
       ),
       FakeVmServiceRequest(
-        id: '2',
         method: 'getIsolate',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -831,7 +837,6 @@ void main() {
         jsonResponse: fakeUnpausedIsolate.toJson(),
       ),
       FakeVmServiceRequest(
-        id: '3',
         method: 'ext.flutter.exit',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -842,7 +847,6 @@ void main() {
     ]);
     final TestFlutterDevice flutterDevice = TestFlutterDevice(
       mockDevice,
-      <FlutterView>[ fakeFlutterView ],
     );
     flutterDevice.vmService = fakeVmServiceHost.vmService;
     when(mockDevice.supportsFlutterExit).thenReturn(true);
@@ -858,7 +862,6 @@ void main() {
   test('FlutterDevice will exit an un-paused isolate', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       FakeVmServiceRequest(
-        id: '1',
         method: kListViewsMethod,
         jsonResponse: <String, Object>{
           'views': <Object>[
@@ -867,7 +870,6 @@ void main() {
         },
       ),
       FakeVmServiceRequest(
-        id: '2',
         method: 'getIsolate',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id
@@ -875,7 +877,6 @@ void main() {
         jsonResponse: fakeUnpausedIsolate.toJson(),
       ),
       FakeVmServiceRequest(
-        id: '3',
         method: 'ext.flutter.exit',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -885,7 +886,6 @@ void main() {
     ]);
     final TestFlutterDevice flutterDevice = TestFlutterDevice(
       mockDevice,
-      <FlutterView> [fakeFlutterView ],
     );
     flutterDevice.vmService = fakeVmServiceHost.vmService;
 
@@ -897,18 +897,10 @@ void main() {
     expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }));
 
-  test('ResidentRunner refreshViews calls flutter device', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    await residentRunner.refreshViews();
-
-    verify(mockFlutterDevice.refreshViews()).called(1);
-  }));
-
   test('ResidentRunner debugDumpApp calls flutter device', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     await residentRunner.debugDumpApp();
 
-    verify(mockFlutterDevice.refreshViews()).called(1);
     verify(mockFlutterDevice.debugDumpApp()).called(1);
   }));
 
@@ -916,7 +908,6 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     await residentRunner.debugDumpRenderTree();
 
-    verify(mockFlutterDevice.refreshViews()).called(1);
     verify(mockFlutterDevice.debugDumpRenderTree()).called(1);
   }));
 
@@ -924,7 +915,6 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     await residentRunner.debugDumpLayerTree();
 
-    verify(mockFlutterDevice.refreshViews()).called(1);
     verify(mockFlutterDevice.debugDumpLayerTree()).called(1);
   }));
 
@@ -932,7 +922,6 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     await residentRunner.debugDumpSemanticsTreeInTraversalOrder();
 
-    verify(mockFlutterDevice.refreshViews()).called(1);
     verify(mockFlutterDevice.debugDumpSemanticsTreeInTraversalOrder()).called(1);
   }));
 
@@ -940,7 +929,6 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     await residentRunner.debugDumpSemanticsTreeInInverseHitTestOrder();
 
-    verify(mockFlutterDevice.refreshViews()).called(1);
     verify(mockFlutterDevice.debugDumpSemanticsTreeInInverseHitTestOrder()).called(1);
   }));
 
@@ -948,7 +936,6 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     await residentRunner.debugToggleDebugPaintSizeEnabled();
 
-    verify(mockFlutterDevice.refreshViews()).called(1);
     verify(mockFlutterDevice.toggleDebugPaintSizeEnabled()).called(1);
   }));
 
@@ -956,7 +943,6 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     await residentRunner.debugToggleDebugCheckElevationsEnabled();
 
-    verify(mockFlutterDevice.refreshViews()).called(1);
     verify(mockFlutterDevice.toggleDebugCheckElevationsEnabled()).called(1);
   }));
 
@@ -964,7 +950,6 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     await residentRunner.debugTogglePerformanceOverlayOverride();
 
-    verify(mockFlutterDevice.refreshViews()).called(1);
     verify(mockFlutterDevice.debugTogglePerformanceOverlayOverride()).called(1);
   }));
 
@@ -972,7 +957,6 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     await residentRunner.debugToggleWidgetInspector();
 
-    verify(mockFlutterDevice.refreshViews()).called(1);
     verify(mockFlutterDevice.toggleWidgetInspector()).called(1);
   }));
 
@@ -980,12 +964,14 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     await residentRunner.debugToggleProfileWidgetBuilds();
 
-    verify(mockFlutterDevice.refreshViews()).called(1);
     verify(mockFlutterDevice.toggleProfileWidgetBuilds()).called(1);
   }));
 
   test('HotRunner writes vm service file when providing debugging option', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ]);
     setWsAddress(testUri, fakeVmServiceHost.vmService);
     globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
     residentRunner = HotRunner(
@@ -1007,7 +993,10 @@ void main() {
   }));
 
   test('HotRunner unforwards device ports', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ]);
     final MockDevicePortForwarder mockPortForwarder = MockDevicePortForwarder();
     when(mockDevice.portForwarder).thenReturn(mockPortForwarder);
     globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
@@ -1035,7 +1024,10 @@ void main() {
   }));
 
   test('HotRunner handles failure to write vmservice file', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ]);
     globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
     residentRunner = HotRunner(
       <FlutterDevice>[
@@ -1053,13 +1045,16 @@ void main() {
     await residentRunner.run();
 
     expect(testLogger.errorText, contains('Failed to write vmservice-out-file at foo'));
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => ThrowingForwardingFileSystem(MemoryFileSystem()),
   }));
 
 
   test('ColdRunner writes vm service file when providing debugging option', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+    ]);
     globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
     setWsAddress(testUri, fakeVmServiceHost.vmService);
     residentRunner = ColdRunner(
@@ -1078,6 +1073,7 @@ void main() {
     await residentRunner.run();
 
     expect(await globals.fs.file('foo').readAsString(), testUri.toString());
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }));
 
   test('FlutterDevice uses dartdevc configuration when targeting web', () => testbed.run(() async {
@@ -1117,7 +1113,6 @@ void main() {
 
     final TestFlutterDevice flutterDevice = TestFlutterDevice(
       mockDevice,
-      <FlutterView>[],
       observatoryUris: Stream<Uri>.value(testUri),
     );
 
@@ -1153,13 +1148,10 @@ class MockUsage extends Mock implements Usage {}
 class MockProcessManager extends Mock implements ProcessManager {}
 
 class TestFlutterDevice extends FlutterDevice {
-  TestFlutterDevice(Device device, this.views, { Stream<Uri> observatoryUris })
+  TestFlutterDevice(Device device, { Stream<Uri> observatoryUris })
     : super(device, buildInfo: BuildInfo.debug) {
     _observatoryUris = observatoryUris;
   }
-
-  @override
-  final List<FlutterView> views;
 
   @override
   Stream<Uri> get observatoryUris => _observatoryUris;

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -185,6 +185,7 @@ void main() {
   test('ResidentRunner can attach to device successfully', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       listViews,
+      listViews,
     ]);
     final Completer<DebugConnectionInfo> onConnectionInfo = Completer<DebugConnectionInfo>.sync();
     final Completer<void> onAppStart = Completer<void>.sync();
@@ -206,6 +207,7 @@ void main() {
 
   test('ResidentRunner can attach to device successfully with --fast-start', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
       listViews,
       listViews,
       FakeVmServiceRequest(
@@ -285,6 +287,7 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       listViews,
       listViews,
+      listViews,
     ]);
     when(mockDevice.sdkNameAndVersion).thenAnswer((Invocation invocation) async {
       return 'Example';
@@ -337,6 +340,7 @@ void main() {
       listViews,
       listViews,
       listViews,
+      listViews,
       FakeVmServiceRequest(
         method: 'getIsolate',
         args: <String, Object>{
@@ -381,6 +385,7 @@ void main() {
 
   test('ResidentRunner can send target platform to analytics from full restart', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
       listViews,
       listViews,
       FakeVmServiceRequest(
@@ -449,6 +454,7 @@ void main() {
 
   test('ResidentRunner Can handle an RPC exception from hot restart', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
       listViews,
     ]);
     when(mockDevice.sdkNameAndVersion).thenAnswer((Invocation invocation) async {
@@ -963,6 +969,7 @@ void main() {
   test('HotRunner writes vm service file when providing debugging option', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       listViews,
+      listViews,
     ]);
     setWsAddress(testUri, fakeVmServiceHost.vmService);
     globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
@@ -986,6 +993,7 @@ void main() {
 
   test('HotRunner unforwards device ports', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
       listViews,
     ]);
     final MockDevicePortForwarder mockPortForwarder = MockDevicePortForwarder();
@@ -1017,6 +1025,7 @@ void main() {
   test('HotRunner handles failure to write vmservice file', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       listViews,
+      listViews,
     ]);
     globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
     residentRunner = HotRunner(
@@ -1042,7 +1051,9 @@ void main() {
 
 
   test('ColdRunner writes vm service file when providing debugging option', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+    ]);
     globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
     setWsAddress(testUri, fakeVmServiceHost.vmService);
     residentRunner = ColdRunner(

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -36,14 +36,12 @@ import '../src/testbed.dart';
 
 const List<VmServiceExpectation> kAttachLogExpectations = <VmServiceExpectation>[
   FakeVmServiceRequest(
-    id: '1',
     method: 'streamListen',
     args: <String, Object>{
       'streamId': 'Stdout',
     },
   ),
   FakeVmServiceRequest(
-    id: '2',
     method: 'streamListen',
     args: <String, Object>{
       'streamId': 'Stderr',
@@ -53,14 +51,12 @@ const List<VmServiceExpectation> kAttachLogExpectations = <VmServiceExpectation>
 
 const List<VmServiceExpectation> kAttachIsolateExpectations = <VmServiceExpectation>[
   FakeVmServiceRequest(
-    id: '3',
     method: 'streamListen',
     args: <String, Object>{
       'streamId': 'Isolate'
     }
   ),
   FakeVmServiceRequest(
-    id: '4',
     method: 'registerService',
     args: <String, Object>{
       'service': 'reloadSources',
@@ -362,7 +358,6 @@ void main() {
       ...kAttachExpectations,
       const FakeVmServiceRequest(
         method: 'hotRestart',
-        id: '5',
         jsonResponse: <String, Object>{
           'type': 'Success',
         }
@@ -439,7 +434,6 @@ void main() {
       ...kAttachExpectations,
       const FakeVmServiceRequest(
         method: 'hotRestart',
-        id: '5',
         jsonResponse: <String, Object>{
           'type': 'Success',
         }
@@ -670,7 +664,6 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
-        id: '5',
         method: 'hotRestart',
         jsonResponse: <String, Object>{
           'type': 'Failed',
@@ -693,7 +686,6 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
-        id: '5',
         method: 'hotRestart',
         // Failed response,
         errorCode: RPCErrorCodes.kInternalError,
@@ -725,7 +717,6 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
-        id: '5',
         method: 'ext.flutter.debugDumpApp',
         args: <String, Object>{
           'isolateId': null,
@@ -747,7 +738,6 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
-        id: '5',
         method: 'ext.flutter.debugDumpLayerTree',
         args: <String, Object>{
           'isolateId': null,
@@ -769,7 +759,6 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
-        id: '5',
         method: 'ext.flutter.debugDumpRenderTree',
         args: <String, Object>{
           'isolateId': null,
@@ -791,7 +780,6 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
-        id: '5',
         method: 'ext.flutter.debugDumpSemanticsTreeInTraversalOrder',
         args: <String, Object>{
           'isolateId': null,
@@ -813,7 +801,6 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
-        id: '5',
         method: 'ext.flutter.debugDumpSemanticsTreeInInverseHitTestOrder',
         args: <String, Object>{
           'isolateId': null,
@@ -836,7 +823,6 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
-        id: '5',
         method: 'ext.flutter.debugPaint',
         args: <String, Object>{
           'isolateId': null,
@@ -846,7 +832,6 @@ void main() {
         },
       ),
       const FakeVmServiceRequest(
-        id: '6',
         method: 'ext.flutter.debugPaint',
         args: <String, Object>{
           'isolateId': null,
@@ -874,7 +859,6 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
-        id: '5',
         method: 'ext.flutter.showPerformanceOverlay',
         args: <String, Object>{
           'isolateId': null,
@@ -884,7 +868,6 @@ void main() {
         },
       ),
       const FakeVmServiceRequest(
-        id: '6',
         method: 'ext.flutter.showPerformanceOverlay',
         args: <String, Object>{
           'isolateId': null,
@@ -911,7 +894,6 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
-        id: '5',
         method: 'ext.flutter.inspector.show',
         args: <String, Object>{
           'isolateId': null,
@@ -921,7 +903,6 @@ void main() {
         },
       ),
       const FakeVmServiceRequest(
-        id: '6',
         method: 'ext.flutter.inspector.show',
         args: <String, Object>{
           'isolateId': null,
@@ -948,7 +929,6 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
-        id: '5',
         method: 'ext.flutter.profileWidgetBuilds',
         args: <String, Object>{
           'isolateId': null,
@@ -958,7 +938,6 @@ void main() {
         },
       ),
       const FakeVmServiceRequest(
-        id: '6',
         method: 'ext.flutter.profileWidgetBuilds',
         args: <String, Object>{
           'isolateId': null,
@@ -985,7 +964,6 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
-        id: '5',
         method: 'ext.flutter.platformOverride',
         args: <String, Object>{
           'isolateId': null,
@@ -995,7 +973,6 @@ void main() {
         },
       ),
       const FakeVmServiceRequest(
-        id: '6',
         method: 'ext.flutter.platformOverride',
         args: <String, Object>{
           'isolateId': null,
@@ -1089,14 +1066,12 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachLogExpectations,
       const FakeVmServiceRequest(
-        id: '3',
         method: 'streamListen',
         args: <String, Object>{
           'streamId': 'Isolate'
         }
       ),
       const FakeVmServiceRequest(
-        id: '4',
         method: 'registerService',
         args: <String, Object>{
           'service': 'reloadSources',

--- a/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
@@ -139,7 +139,9 @@ void main() {
       final MockFlutterDevice mockFlutterDevice = MockFlutterDevice();
       when(mockResidentRunner.isRunningDebug).thenReturn(true);
       when(mockResidentRunner.flutterDevices).thenReturn(<FlutterDevice>[mockFlutterDevice]);
-      when(mockFlutterDevice.views).thenReturn(<FlutterView>[]);
+      when(mockResidentRunner.listFlutterViews()).thenAnswer((Invocation invocation) async {
+        return <FlutterView>[];
+      });
 
       await terminalHandler.processTerminalInput('l');
 

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -231,10 +231,10 @@ void main() {
   testWithoutContext('runInView forwards arguments correctly', () async {
     final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
       requests: <VmServiceExpectation>[
-        const FakeVmServiceRequest(method: 'streamListen', id: '1', args: <String, Object>{
+        const FakeVmServiceRequest(method: 'streamListen', args: <String, Object>{
           'streamId': 'Isolate'
         }),
-        const FakeVmServiceRequest(method: kRunInViewMethod, id: '2', args: <String, Object>{
+        const FakeVmServiceRequest(method: kRunInViewMethod, args: <String, Object>{
           'viewId': '1234',
           'mainScript': 'main.dart',
           'assetDirectory': 'flutter_assets/',

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -256,6 +256,65 @@ void main() {
     );
     expect(fakeVmServiceHost.hasRemainingExpectations, false);
   });
+
+  testWithoutContext('getFlutterViews polls until a view is returned', () async {
+    final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
+      requests: <VmServiceExpectation>[
+        const FakeVmServiceRequest(
+          method: kListViewsMethod,
+          jsonResponse: <String, Object>{
+            'views': <Object>[],
+          },
+        ),
+        const FakeVmServiceRequest(
+          method: kListViewsMethod,
+          jsonResponse: <String, Object>{
+            'views': <Object>[],
+          },
+        ),
+        const FakeVmServiceRequest(
+          method: kListViewsMethod,
+          jsonResponse: <String, Object>{
+            'views': <Object>[
+              <String, Object>{
+                'id': 'a',
+                'isolate': <String, Object>{},
+              },
+            ],
+          },
+        ),
+      ]
+    );
+
+    expect(
+      await fakeVmServiceHost.vmService.getFlutterViews(
+        delay: Duration.zero,
+      ),
+      isNotEmpty,
+    );
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+  });
+
+  testWithoutContext('getFlutterViews does not poll if returnEarly is true', () async {
+    final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
+      requests: <VmServiceExpectation>[
+        const FakeVmServiceRequest(
+          method: kListViewsMethod,
+          jsonResponse: <String, Object>{
+            'views': <Object>[],
+          },
+        ),
+      ]
+    );
+
+    expect(
+      await fakeVmServiceHost.vmService.getFlutterViews(
+        returnEarly: true,
+      ),
+      isEmpty,
+    );
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+  });
 }
 
 class MockDevice extends Mock implements Device {}

--- a/packages/flutter_tools/test/general.shard/web/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devices_test.dart
@@ -76,7 +76,7 @@ void main() {
     expect(chromeDevice.supportsHotReload, true);
     expect(chromeDevice.supportsHotRestart, true);
     expect(chromeDevice.supportsStartPaused, true);
-    expect(chromeDevice.supportsFlutterExit, true);
+    expect(chromeDevice.supportsFlutterExit, false);
     expect(chromeDevice.supportsScreenshot, false);
     expect(await chromeDevice.isLocalEmulator, false);
     expect(chromeDevice.getLogReader(), isA<NoOpDeviceLogReader>());
@@ -96,7 +96,7 @@ void main() {
     expect(chromeDevice.supportsHotReload, true);
     expect(chromeDevice.supportsHotRestart, true);
     expect(chromeDevice.supportsStartPaused, true);
-    expect(chromeDevice.supportsFlutterExit, true);
+    expect(chromeDevice.supportsFlutterExit, false);
     expect(chromeDevice.supportsScreenshot, false);
     expect(await chromeDevice.isLocalEmulator, false);
     expect(chromeDevice.getLogReader(), isA<NoOpDeviceLogReader>());

--- a/packages/flutter_tools/test/general.shard/web/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devices_test.dart
@@ -114,7 +114,7 @@ void main() {
     expect(device.supportsHotReload, true);
     expect(device.supportsHotRestart, true);
     expect(device.supportsStartPaused, true);
-    expect(device.supportsFlutterExit, true);
+    expect(device.supportsFlutterExit, false);
     expect(device.supportsScreenshot, false);
     expect(await device.isLocalEmulator, false);
     expect(device.getLogReader(), isA<NoOpDeviceLogReader>());

--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -239,7 +239,6 @@ class FakeVmServiceHost {
       final FakeVmServiceRequest fakeRequest = _requests.removeAt(0) as FakeVmServiceRequest;
       expect(request, isA<Map<String, Object>>()
         .having((Map<String, Object> request) => request['method'], 'method', fakeRequest.method)
-        .having((Map<String, Object> request) => request['id'], 'id', fakeRequest.id)
         .having((Map<String, Object> request) => request['params'], 'args', fakeRequest.args)
       );
       if (fakeRequest.close) {
@@ -250,13 +249,13 @@ class FakeVmServiceHost {
       if (fakeRequest.errorCode == null) {
         _input.add(json.encode(<String, Object>{
           'jsonrpc': '2.0',
-          'id': fakeRequest.id,
+          'id': request['id'],
           'result': fakeRequest.jsonResponse ?? <String, Object>{'type': 'Success'},
         }));
       } else {
         _input.add(json.encode(<String, Object>{
           'jsonrpc': '2.0',
-          'id': fakeRequest.id,
+          'id': request['id'],
           'error': <String, Object>{
             'code': fakeRequest.errorCode,
           }
@@ -299,7 +298,6 @@ abstract class VmServiceExpectation {
 class FakeVmServiceRequest implements VmServiceExpectation {
   const FakeVmServiceRequest({
     @required this.method,
-    @required this.id,
     this.args = const <String, Object>{},
     this.jsonResponse,
     this.errorCode,
@@ -307,7 +305,6 @@ class FakeVmServiceRequest implements VmServiceExpectation {
   });
 
   final String method;
-  final String id;
 
   /// When true, the vm service is automatically closed.
   final bool close;


### PR DESCRIPTION
## Description

Fixes https://github.com/flutter/flutter/issues/56194

Remove caching of FlutterView. Perhaps the FlutterView RPC might return an empty list if the VM is not quite up yet? We had some old logic to poll the flutter views RPC for up to 200ms. That doesn't seem like a great approach, so instead we could forgo it entirely and trust that either the views come up before the developer tries to interact, or we crash.

https://github.com/flutter/flutter/blob/stable/packages/flutter_tools/lib/src/vmservice.dart#L1070