### PR TITLE
[flutter_tools] make gallery hot reload 5x faster with one neat trick

### DIFF
--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -74,7 +74,8 @@ class ManifestAssetBundle implements AssetBundle {
   final Map<String, DevFSContent> entries = <String, DevFSContent>{};
 
   // If an asset corresponds to a wildcard directory, then it may have been
-  // updated without changes to the manifest.
+  // updated without changes to the manifest. These are only tracked for
+  // the current project.
   final Map<Uri, Directory> _wildcardDirectories = <Uri, Directory>{};
 
   final LicenseCollector licenseCollector = LicenseCollector(fileSystem: globals.fs);
@@ -203,7 +204,8 @@ class ManifestAssetBundle implements AssetBundle {
         final Map<_Asset, List<_Asset>> packageAssets = _parseAssets(
           packageConfig,
           packageFlutterManifest,
-          wildcardDirectories,
+          // Do not track wildcard directories for dependencies.
+          <Uri>[],
           packageBasePath,
           packageName: package.name,
         );

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -14,6 +14,7 @@ import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:mockito/mockito.dart';
+import 'package:platform/platform.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
@@ -222,6 +223,48 @@ assets:
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
+  });
+
+  testUsingContext('does not track wildcard directories from dependencies', () async {
+    globals.fs.file('.packages').writeAsStringSync(r'''
+example:lib/
+foo:foo/lib/
+''');
+    globals.fs.file(globals.fs.path.join('assets', 'foo', 'bar.txt'))
+      .createSync(recursive: true);
+    globals.fs.file('pubspec.yaml')
+      ..createSync()
+      ..writeAsStringSync(r'''
+name: example
+dependencies:
+  foo: any
+''');
+    globals.fs.file('foo/pubspec.yaml')
+      ..createSync(recursive: true)
+      ..writeAsStringSync(r'''
+name: foo
+
+flutter:
+  assets:
+    - bar/
+''');
+    final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
+    globals.fs.file('foo/bar/fizz.txt').createSync(recursive: true);
+
+    await bundle.build(manifestPath: 'pubspec.yaml');
+
+    expect(bundle.entries, hasLength(4));
+    expect(bundle.needsBuild(manifestPath: 'pubspec.yaml'), false);
+
+    // Does not track dependency's wildcard directories.
+    globals.fs.file(globals.fs.path.join('assets', 'foo', 'bar.txt'))
+      .deleteSync();
+
+    expect(bundle.needsBuild(manifestPath: 'pubspec.yaml'), false);
+  }, overrides: <Type, Generator>{
+    FileSystem: () => MemoryFileSystem.test(),
+    ProcessManager: () => FakeProcessManager.any(),
+    Platform: () => FakePlatform(operatingSystem: 'linux'),
   });
 }
 


### PR DESCRIPTION
## Description

The AssetBundle tracks whether any changes to wildcard directories necessitate rebuilding the asset bundle. Rebuilding should be avoid since it can be quite expensive even if the assets haven't changed. 

However there was a bug! We (I) tracked the wrong directory for dependent packages, meaning everytime we checked if the asset bundle needed to be built, we saw a "newly missing" wildcard and said yes.

These don't even need to be tracked!