### PR TITLE
fix the reload and restart service extension methods

### DIFF
--- a/packages/flutter_tools/test/integration.shard/vmservice_integration_test.dart
+++ b/packages/flutter_tools/test/integration.shard/vmservice_integration_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:matcher/matcher.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:vm_service/vm_service_io.dart';
 
@@ -13,31 +14,70 @@ import 'test_driver.dart';
 import 'test_utils.dart';
 
 void main() {
-  Directory tempDir;
-  FlutterRunTestDriver flutter;
+  group('Flutter Tool VMService method', () {
+    Directory tempDir;
+    FlutterRunTestDriver flutter;
+    VmService vmService;
 
-  test('Flutter Tool VMService methods can be called', () async {
-    tempDir = createResolvedTempDirectorySync('vmservice_integration_test.');
+    setUpAll(() async {
+      tempDir = createResolvedTempDirectorySync('vmservice_integration_test.');
 
-    final BasicProject _project = BasicProject();
-    await _project.setUpIn(tempDir);
+      final BasicProject _project = BasicProject();
+      await _project.setUpIn(tempDir);
 
-    flutter = FlutterRunTestDriver(tempDir);
-    await flutter.run(withDebugger: true);
-    final int port = flutter.vmServicePort;
-    final VmService vmService = await vmServiceConnectUri('ws://localhost:$port/ws');
+      flutter = FlutterRunTestDriver(tempDir);
+      await flutter.run(withDebugger: true);
+      final int port = flutter.vmServicePort;
+      vmService = await vmServiceConnectUri('ws://localhost:$port/ws');
+    });
 
-    final Response versionResponse = await vmService.callMethod('s0.flutterVersion');
-    expect(versionResponse.type, 'Success');
-    expect(versionResponse.json, containsPair('frameworkRevisionShort', isNotNull));
-    expect(versionResponse.json, containsPair('engineRevisionShort', isNotNull));
+    tearDownAll(() async {
+      await flutter?.stop();
+      tryToDelete(tempDir);
+    });
 
-    final Response memoryInfoResponse = await vmService.callMethod('s0.flutterMemoryInfo');
-    expect(memoryInfoResponse.type, 'Success');
-  });
+    test('flutterVersion can be called', () async {
+      final Response response =
+          await vmService.callServiceExtension('s0.flutterVersion');
+      expect(response.type, 'Success');
+      expect(response.json, containsPair('frameworkRevisionShort', isNotNull));
+      expect(response.json, containsPair('engineRevisionShort', isNotNull));
+    });
 
-  tearDown(() {
-    tryToDelete(tempDir);
-    flutter?.stop();
+    test('flutterMemoryInfo can be called', () async {
+      final Response response =
+          await vmService.callServiceExtension('s0.flutterMemoryInfo');
+      expect(response.type, 'Success');
+    });
+
+    test('reloadSources can be called', () async {
+      final VM vm = await vmService.getVM();
+      final IsolateRef isolateRef = vm.isolates.first;
+
+      final Response response = await vmService.callMethod('s0.reloadSources',
+          isolateId: isolateRef.id);
+      expect(response.type, 'Success');
+    });
+
+    test('reloadSources fails on bad params', () async {
+      final Future<Response> response =
+          vmService.callMethod('s0.reloadSources', isolateId: '');
+      expect(response, throwsA(const TypeMatcher<RPCError>()));
+    });
+
+    test('hotRestart can be called', () async {
+      final VM vm = await vmService.getVM();
+      final IsolateRef isolateRef = vm.isolates.first;
+
+      final Response response =
+          await vmService.callMethod('s0.hotRestart', isolateId: isolateRef.id);
+      expect(response.type, 'Success');
+    });
+
+    test('hotRestart fails on bad params', () async {
+      final Future<Response> response = vmService.callMethod('s0.hotRestart',
+          args: <String, dynamic>{'pause': 'not_a_bool'});
+      expect(response, throwsA(const TypeMatcher<RPCError>()));
+    });
   });
 }

--- a/packages/flutter_tools/test/integration.shard/vmservice_integration_test.dart
+++ b/packages/flutter_tools/test/integration.shard/vmservice_integration_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io'; // ignore: dart_io_import
+
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:matcher/matcher.dart';
@@ -79,5 +81,7 @@ void main() {
           args: <String, dynamic>{'pause': 'not_a_bool'});
       expect(response, throwsA(const TypeMatcher<RPCError>()));
     });
-  });
+
+    // TODO(devoncarew): These tests fail on cirrus-ci windows.
+  }, skip: Platform.isWindows);
 }


### PR DESCRIPTION
## Description

This fixes the `reloadSources` and `hotRestart` service extension methods, which likely regressed as part of  flutter/flutter@4851888.

In addition, the PR:
- more uniformly validates parameters into the flutter tools service extensions methods
- fixes an issue in the existing integration tests where we were not awaiting `flutter?.stop()`, and were possibly leaking a flutter_tester process instance
- removes explicit exception handing and conversion to RPCErrors; this is handled by package:vm_service

## Related Issues

- fix https://github.com/flutter/devtools/issues/1896

## Tests

- added integration tests for the `reloadSources` and `hotRestart` service extension methods, as well as tests for bad params

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
