### PR TITLE
Add `barrierColor` option to `showCupertinoModalPopup`

### DIFF
--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -909,7 +909,7 @@ class _CupertinoModalPopupRoute<T> extends PopupRoute<T> {
 /// The `barrierColor` argument is used to determine use barrier [Color] to use.
 /// If [Color] passed is fully transparent (it's Alpha channel is equal 0) then
 /// barrier [Color] will be transparent. If `null` passed, then [Color] resolved
-/// from the given `context`.
+/// from the given `context`. Is is `_kModalBarrierColor` by default.
 ///
 /// The `semanticsDismissible` argument is used to determine whether the
 /// semantics of the modal barrier are included in the semantics tree.
@@ -933,22 +933,17 @@ Future<T> showCupertinoModalPopup<T>({
   @required BuildContext context,
   @required WidgetBuilder builder,
   ImageFilter filter,
-  Color barrierColor,
+  Color barrierColor = _kModalBarrierColor,
   bool useRootNavigator = true,
   bool semanticsDismissible,
 }) {
   assert(useRootNavigator != null);
 
-  barrierColor = barrierColor ?? CupertinoDynamicColor.resolve(_kModalBarrierColor, context);
-
-  if (barrierColor.alpha == 0) {
-    barrierColor = null;
-  }
-
   return Navigator.of(context, rootNavigator: useRootNavigator).push(
     _CupertinoModalPopupRoute<T>(
       barrierLabel: 'Dismiss',
-      barrierColor: barrierColor,
+      barrierColor:
+          barrierColor?.alpha == 0 ? null : CupertinoDynamicColor.resolve(barrierColor, context),
       builder: builder,
       filter: filter,
       semanticsDismissible: semanticsDismissible,

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -904,7 +904,12 @@ class _CupertinoModalPopupRoute<T> extends PopupRoute<T> {
 ///
 /// The `useRootNavigator` argument is used to determine whether to push the
 /// popup to the [Navigator] furthest from or nearest to the given `context`. It
-/// is `false` by default.
+/// is `true` by default.
+///
+/// The `barrierColor` argument is used to determine use barrier [Color] to use.
+/// If [Color] passed is fully transparent (it's Alpha channel is equal 0) then
+/// barrier [Color] will be transparent. If `null` passed, then [Color] resolved
+/// from the given `context`.
 ///
 /// The `semanticsDismissible` argument is used to determine whether the
 /// semantics of the modal barrier are included in the semantics tree.
@@ -928,14 +933,22 @@ Future<T> showCupertinoModalPopup<T>({
   @required BuildContext context,
   @required WidgetBuilder builder,
   ImageFilter filter,
+  Color barrierColor,
   bool useRootNavigator = true,
   bool semanticsDismissible,
 }) {
   assert(useRootNavigator != null);
+
+  barrierColor = barrierColor ?? CupertinoDynamicColor.resolve(_kModalBarrierColor, context);
+
+  if (barrierColor.alpha == 0) {
+    barrierColor = null;
+  }
+
   return Navigator.of(context, rootNavigator: useRootNavigator).push(
     _CupertinoModalPopupRoute<T>(
-      barrierColor: CupertinoDynamicColor.resolve(_kModalBarrierColor, context),
       barrierLabel: 'Dismiss',
+      barrierColor: barrierColor,
       builder: builder,
       filter: filter,
       semanticsDismissible: semanticsDismissible,

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -1304,15 +1304,45 @@ void main() {
   });
 
   testWidgets('showCupertinoModalPopup transparent barrier color', (WidgetTester tester) async {
+    const Color _kTransparentColor = Color(0x00000000);
+
     await tester.pumpWidget(CupertinoApp(
       home: CupertinoPageScaffold(
         child: Builder(builder: (BuildContext context) {
           return GestureDetector(
             onTap: () async {
               await showCupertinoModalPopup<void>(
-                  context: context,
-                  builder: (BuildContext context) => const SizedBox(),
-                  barrierColor: const Color(0x00000000));
+                context: context,
+                builder: (BuildContext context) => const SizedBox(),
+                barrierColor: _kTransparentColor,
+              );
+            },
+            child: const Text('tap'),
+          );
+        }),
+      ),
+    ));
+
+    await tester.tap(find.text('tap'));
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.widget<ModalBarrier>(find.byType(ModalBarrier).last).color,
+      null,
+    );
+  });
+
+  testWidgets('showCupertinoModalPopup null barrier color', (WidgetTester tester) async {
+    await tester.pumpWidget(CupertinoApp(
+      home: CupertinoPageScaffold(
+        child: Builder(builder: (BuildContext context) {
+          return GestureDetector(
+            onTap: () async {
+              await showCupertinoModalPopup<void>(
+                context: context,
+                builder: (BuildContext context) => const SizedBox(),
+                barrierColor: null,
+              );
             },
             child: const Text('tap'),
           );

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -1302,6 +1302,61 @@ void main() {
     ));
     debugDefaultTargetPlatformOverride = null;
   });
+
+  testWidgets('showCupertinoModalPopup transparent barrier color', (WidgetTester tester) async {
+    await tester.pumpWidget(CupertinoApp(
+      home: CupertinoPageScaffold(
+        child: Builder(builder: (BuildContext context) {
+          return GestureDetector(
+            onTap: () async {
+              await showCupertinoModalPopup<void>(
+                  context: context,
+                  builder: (BuildContext context) => const SizedBox(),
+                  barrierColor: const Color(0x00000000));
+            },
+            child: const Text('tap'),
+          );
+        }),
+      ),
+    ));
+
+    await tester.tap(find.text('tap'));
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.widget<ModalBarrier>(find.byType(ModalBarrier).last).color,
+      null,
+    );
+  });
+
+  testWidgets('showCupertinoModalPopup custom barrier color', (WidgetTester tester) async {
+    // Color shoule be the same both for Light and Dark theme
+    const Color customColor = Color(0x11223344);
+
+    await tester.pumpWidget(CupertinoApp(
+      home: CupertinoPageScaffold(
+        child: Builder(builder: (BuildContext context) {
+          return GestureDetector(
+            onTap: () async {
+              await showCupertinoModalPopup<void>(
+                  context: context,
+                  builder: (BuildContext context) => const SizedBox(),
+                  barrierColor: customColor);
+            },
+            child: const Text('tap'),
+          );
+        }),
+      ),
+    ));
+
+    await tester.tap(find.text('tap'));
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.widget<ModalBarrier>(find.byType(ModalBarrier).last).color,
+      customColor,
+    );
+  });
 }
 
 class MockNavigatorObserver extends Mock implements NavigatorObserver {}


### PR DESCRIPTION
## Description

This PR adds `barrierColor` option to `showCupertinoModalPopup` in Cupertino package.

## Related Issues

Fixes #53239

## Tests

I added the following tests:

* Added `'showCupertinoModalPopup transparent barrier color'` widget test to `cupertino/route_test.dart`
* Added `'showCupertinoModalPopup custom barrier color'` widget test to `cupertino/route_test.dart`

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
 