### PR TITLE
Fix overly specific detection of non-UTF8 files in analyzer bot.

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -1086,13 +1086,9 @@ Future<void> verifyNoBinaries(String workingDirectory, { Set<Hash256> grandfathe
       try {
         utf8.decode(bytes);
       } on FormatException catch (error) {
-        if (error.message.startsWith('Bad UTF-8 encoding ')) {
-          final Digest digest = sha256.convert(bytes);
-          if (!grandfatheredBinaries.contains(Hash256.fromDigest(digest)))
-            problems.add('${file.path}:${error.offset}: file is not valid UTF-8');
-        } else {
-          rethrow;
-        }
+        final Digest digest = sha256.convert(bytes);
+        if (!grandfatheredBinaries.contains(Hash256.fromDigest(digest)))
+          problems.add('${file.path}:${error.offset}: file is not valid UTF-8');
       }
     }
     if (problems.isNotEmpty) {


### PR DESCRIPTION
## Description

An upcoming Dart SDK change
(https://github.com/dart-lang/sdk/commit/fa2fd41166db35afa4777e63f900e83d25709c5c)
changes the precise text of the exception generated by `utf8.decode`
if a non-UTF8 file is found.  This is causing a breakage in the Dart
team's `flutter-analyze` bot (and will presumably cause a breakage in
the corresponding Flutter bot as soon as this change is rolled into
Flutter).  To avoid this breakage, the bot shouldn't rely on the exact
exception text; it is sufficient to simply catch a FormatException.

## Related Issues

None

## Tests

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
