### PR TITLE
Fixed color of list_tile icon

### DIFF
--- a/dev/benchmarks/test_apps/stocks/test/icon_color_test.dart
+++ b/dev/benchmarks/test_apps/stocks/test/icon_color_test.dart
@@ -75,7 +75,7 @@ void main() {
     // check the color of the icon - light mode
     checkIconColor(tester, 'Stock List', Colors.purple); // theme primary color
     checkIconColor(tester, 'Account Balance', Colors.black38); // disabled
-    checkIconColor(tester, 'About', Colors.black45); // enabled
+    checkIconColor(tester, 'About', ThemeData().iconTheme.color); // enabled
 
     // switch to dark mode
     await tester.tap(find.text('Pessimistic'));

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -8,7 +8,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 
-import 'colors.dart';
 import 'constants.dart';
 import 'debug.dart';
 import 'divider.dart';

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -797,7 +797,7 @@ class ListTile extends StatelessWidget {
 
     switch (theme.brightness) {
       case Brightness.light:
-        return selected ? theme.primaryColor : Colors.black45;
+        return selected ? theme.primaryColor : null; // null - use current icon theme color
       case Brightness.dark:
         return selected ? theme.accentColor : null; // null - use current icon theme color
     }


### PR DESCRIPTION
## Description

Actually ListTile replaces the icon theme color of the app to place a fixed color, with this change, I can set the color of the trailing icon of the ListTile by the Theme.

## Related Issues

I made this PR by a problem that I had, but I found this other issue that can be related to this: #11593

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

 - [x] No, no existing tests failed, so this is *not* a breaking change.
 