### PR TITLE
DoubleTap recognizer support and improved error message

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -918,7 +918,7 @@ class RenderParagraph extends RenderBox
             configuration.isLink = true;
           } else if (recognizer is LongPressGestureRecognizer) {
             configuration.onLongPress = recognizer.onLongPress;
-          } else if {
+          } else {
             assert(false, '${recognizer.runtimeType} not supported.');
           }
         }

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -916,6 +916,12 @@ class RenderParagraph extends RenderBox
           if (recognizer is TapGestureRecognizer) {
             configuration.onTap = recognizer.onTap;
             configuration.isLink = true;
+          } else if (recognizer is DoubleTapGestureRecognizer) {
+            configuration.onTap = recognizer.onTap;
+            configuration.isLink = true;
+          } else if (recognizer is MultiTapGestureRecognizer) {
+            configuration.onTap = recognizer.onTap;
+            configuration.isLink = true;
           } else if (recognizer is LongPressGestureRecognizer) {
             configuration.onLongPress = recognizer.onLongPress;
           } else {

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -919,7 +919,7 @@ class RenderParagraph extends RenderBox
           } else if (recognizer is LongPressGestureRecognizer) {
             configuration.onLongPress = recognizer.onLongPress;
           } else {
-            assert(false, '${recognizer.runtimeType} not supported.');
+            assert(false, '${recognizer.runtimeType} is not supported.');
           }
         }
         final SemanticsNode newChild = (_cachedChildNodes?.isNotEmpty == true)

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -918,8 +918,8 @@ class RenderParagraph extends RenderBox
             configuration.isLink = true;
           } else if (recognizer is LongPressGestureRecognizer) {
             configuration.onLongPress = recognizer.onLongPress;
-          } else {
-            assert(false);
+          } else if {
+            assert(false, '${recognizer.runtimeType} not supported.');
           }
         }
         final SemanticsNode newChild = (_cachedChildNodes?.isNotEmpty == true)

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -917,10 +917,7 @@ class RenderParagraph extends RenderBox
             configuration.onTap = recognizer.onTap;
             configuration.isLink = true;
           } else if (recognizer is DoubleTapGestureRecognizer) {
-            configuration.onTap = recognizer.onTap;
-            configuration.isLink = true;
-          } else if (recognizer is MultiTapGestureRecognizer) {
-            configuration.onTap = recognizer.onTap;
+            configuration.onTap = recognizer.onDoubleTap;
             configuration.isLink = true;
           } else if (recognizer is LongPressGestureRecognizer) {
             configuration.onLongPress = recognizer.onLongPress;

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -417,4 +417,37 @@ void main() {
     expect(boxes[8], const TextBox.fromLTRBD(14.0, 28.0, 28.0, 42.0 , TextDirection.ltr));
   // Ahem-based tests don't yet quite work on Windows or some MacOS environments
   }, skip: isWindows || isMacOS || isBrowser);
+
+  test('Supports gesture recognizer semantics', () {
+    final RenderParagraph paragraph = RenderParagraph(
+      TextSpan(text: _kText, children: <InlineSpan>[
+        TextSpan(text: 'one', recognizer: TapGestureRecognizer()..onTap = () {}),
+        TextSpan(text: 'two', recognizer: LongPressGestureRecognizer()..onLongPress = () {}),
+        TextSpan(text: 'three', recognizer: DoubleTapGestureRecognizer()..onDoubleTap = () {}),
+      ]),
+      textDirection: TextDirection.rtl,
+    );
+    layout(paragraph);
+
+    paragraph.assembleSemanticsNode(SemanticsNode(), SemanticsConfiguration(), <SemanticsNode>[]);
+  });
+
+  test('Asserts on unsupported gesture recognizer', () {
+    final RenderParagraph paragraph = RenderParagraph(
+      TextSpan(text: _kText, children: <InlineSpan>[
+        TextSpan(text: 'three', recognizer: MultiTapGestureRecognizer()..onTap = (int id) {}),
+      ]),
+      textDirection: TextDirection.rtl,
+    );
+    layout(paragraph);
+
+    bool failed = false;
+    try {
+      paragraph.assembleSemanticsNode(SemanticsNode(), SemanticsConfiguration(), <SemanticsNode>[]);
+    } catch(e) {
+      failed = true;
+      expect(e.message, 'MultiTapGestureRecognizer is not supported.');
+    }
+    expect(failed, true);
+  });
 }


### PR DESCRIPTION
## Description

We currently only support `TapGestureRecognizer` and `LongPressGestureRecognizer` and `assert(false)` otherwise. This results in a very unclear error.

Add an error message to make this more clear.

We could support additional detectors, in particular, DoubleTap and MultiTap, if deemed appropriate.

## Related Issues

See https://github.com/flutter/flutter/issues/56304

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
