### PR TITLE
Use androidSdk globals variable everywhere

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_builder.dart
+++ b/packages/flutter_tools/lib/src/android/android_builder.dart
@@ -12,7 +12,6 @@ import '../base/file_system.dart';
 import '../build_info.dart';
 import '../globals.dart' as globals;
 import '../project.dart';
-import 'android_sdk.dart';
 import 'gradle.dart';
 
 /// The builder in the current context.
@@ -87,7 +86,7 @@ class _AndroidBuilderImpl extends AndroidBuilder {
         buildNumber: buildNumber,
       );
     } finally {
-      androidSdk?.reinitialize();
+      globals.androidSdk?.reinitialize();
     }
   }
 
@@ -107,7 +106,7 @@ class _AndroidBuilderImpl extends AndroidBuilder {
         localGradleErrors: gradleErrors,
       );
     } finally {
-      androidSdk?.reinitialize();
+      globals.androidSdk?.reinitialize();
     }
   }
 
@@ -127,7 +126,7 @@ class _AndroidBuilderImpl extends AndroidBuilder {
         localGradleErrors: gradleErrors,
       );
     } finally {
-      androidSdk?.reinitialize();
+      globals.androidSdk?.reinitialize();
     }
   }
 }

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -217,7 +217,7 @@ class AndroidDevice extends Device {
   _AndroidDevicePortForwarder _portForwarder;
 
   List<String> adbCommandForDevice(List<String> args) {
-    return <String>[getAdbPath(androidSdk), '-s', id, ...args];
+    return <String>[getAdbPath(globals.androidSdk), '-s', id, ...args];
   }
 
   String runAdbCheckedSync(
@@ -274,19 +274,19 @@ class AndroidDevice extends Device {
   }
 
   Future<bool> _checkForSupportedAdbVersion() async {
-    if (androidSdk == null) {
+    if (globals.androidSdk == null) {
       return false;
     }
 
     try {
       final RunResult adbVersion = await processUtils.run(
-        <String>[getAdbPath(androidSdk), 'version'],
+        <String>[getAdbPath(globals.androidSdk), 'version'],
         throwOnError: true,
       );
       if (_isValidAdbVersion(adbVersion.stdout)) {
         return true;
       }
-      globals.printError('The ADB at "${getAdbPath(androidSdk)}" is too old; please install version 1.0.39 or later.');
+      globals.printError('The ADB at "${getAdbPath(globals.androidSdk)}" is too old; please install version 1.0.39 or later.');
     } on Exception catch (error, trace) {
       globals.printError('Error running ADB: $error', stackTrace: trace);
     }
@@ -301,7 +301,7 @@ class AndroidDevice extends Device {
       //   adb server is out of date.  killing..
       //   * daemon started successfully *
       await processUtils.run(
-        <String>[getAdbPath(androidSdk), 'start-server'],
+        <String>[getAdbPath(globals.androidSdk), 'start-server'],
         throwOnError: true,
       );
 
@@ -507,7 +507,7 @@ class AndroidDevice extends Device {
         return LaunchResult.failed();
     }
 
-    if (!prebuiltApplication || androidSdk.licensesAvailable && androidSdk.latestVersion == null) {
+    if (!prebuiltApplication || globals.androidSdk.licensesAvailable && globals.androidSdk.latestVersion == null) {
       globals.printTrace('Building APK');
       final FlutterProject project = FlutterProject.current();
       await androidBuilder.buildApk(

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -55,7 +55,7 @@ class AndroidEmulator extends Emulator {
   @override
   Future<void> launch() async {
     final Process process = await processUtils.start(
-      <String>[getEmulatorPath(androidSdk), '-avd', id],
+      <String>[getEmulatorPath(globals.androidSdk), '-avd', id],
     );
 
     // Record output from the emulator process.
@@ -112,7 +112,7 @@ class AndroidEmulator extends Emulator {
 
 /// Return the list of available emulator AVDs.
 List<AndroidEmulator> getEmulatorAvds() {
-  final String emulatorPath = getEmulatorPath(androidSdk);
+  final String emulatorPath = getEmulatorPath(globals.androidSdk);
   if (emulatorPath == null) {
     return <AndroidEmulator>[];
   }

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -6,7 +6,6 @@ import 'package:meta/meta.dart';
 import 'package:platform/platform.dart';
 
 import '../base/common.dart';
-import '../base/context.dart';
 import '../base/file_system.dart';
 import '../base/os.dart';
 import '../base/process.dart';
@@ -14,8 +13,6 @@ import '../base/version.dart';
 import '../convert.dart';
 import '../globals.dart' as globals;
 import 'android_studio.dart';
-
-AndroidSdk get androidSdk => context.get<AndroidSdk>();
 
 const String kAndroidHome = 'ANDROID_HOME';
 const String kAndroidSdkRoot = 'ANDROID_SDK_ROOT';

--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -48,13 +48,13 @@ class AndroidWorkflow implements Workflow {
   bool get appliesToHostPlatform => true;
 
   @override
-  bool get canListDevices => getAdbPath(androidSdk) != null;
+  bool get canListDevices => getAdbPath(globals.androidSdk) != null;
 
   @override
-  bool get canLaunchDevices => androidSdk != null && androidSdk.validateSdkWellFormed().isEmpty;
+  bool get canLaunchDevices => globals.androidSdk != null && globals.androidSdk.validateSdkWellFormed().isEmpty;
 
   @override
-  bool get canListEmulators => getEmulatorPath(androidSdk) != null;
+  bool get canListEmulators => getEmulatorPath(globals.androidSdk) != null;
 }
 
 class AndroidValidator extends DoctorValidator {
@@ -242,13 +242,13 @@ class AndroidLicenseValidator extends DoctorValidator {
     final List<ValidationMessage> messages = <ValidationMessage>[];
 
     // Match pre-existing early termination behavior
-    if (androidSdk == null || androidSdk.latestVersion == null ||
-        androidSdk.validateSdkWellFormed().isNotEmpty ||
+    if (globals.androidSdk == null || globals.androidSdk.latestVersion == null ||
+        globals.androidSdk.validateSdkWellFormed().isNotEmpty ||
         ! await _checkJavaVersionNoOutput()) {
       return ValidationResult(ValidationType.missing, messages);
     }
 
-    final String sdkVersionText = userMessages.androidStatusInfo(androidSdk.latestVersion.buildToolsVersionName);
+    final String sdkVersionText = userMessages.androidStatusInfo(globals.androidSdk.latestVersion.buildToolsVersionName);
 
     // Check for licenses.
     switch (await licensesAccepted) {
@@ -325,8 +325,8 @@ class AndroidLicenseValidator extends DoctorValidator {
 
     try {
       final Process process = await processUtils.start(
-        <String>[androidSdk.sdkManagerPath, '--licenses'],
-        environment: androidSdk.sdkManagerEnv,
+        <String>[globals.androidSdk.sdkManagerPath, '--licenses'],
+        environment: globals.androidSdk.sdkManagerEnv,
       );
       process.stdin.write('n\n');
       // We expect logcat streams to occasionally contain invalid utf-8,
@@ -351,19 +351,19 @@ class AndroidLicenseValidator extends DoctorValidator {
 
   /// Run the Android SDK manager tool in order to accept SDK licenses.
   static Future<bool> runLicenseManager() async {
-    if (androidSdk == null) {
+    if (globals.androidSdk == null) {
       globals.printStatus(userMessages.androidSdkShort);
       return false;
     }
 
     if (!_canRunSdkManager()) {
-      throwToolExit(userMessages.androidMissingSdkManager(androidSdk.sdkManagerPath, globals.platform));
+      throwToolExit(userMessages.androidMissingSdkManager(globals.androidSdk.sdkManagerPath, globals.platform));
     }
 
     try {
       final Process process = await processUtils.start(
-        <String>[androidSdk.sdkManagerPath, '--licenses'],
-        environment: androidSdk.sdkManagerEnv,
+        <String>[globals.androidSdk.sdkManagerPath, '--licenses'],
+        environment: globals.androidSdk.sdkManagerEnv,
       );
 
       // The real stdin will never finish streaming. Pipe until the child process
@@ -393,7 +393,7 @@ class AndroidLicenseValidator extends DoctorValidator {
       return exitCode == 0;
     } on ProcessException catch (e) {
       throwToolExit(userMessages.androidCannotRunSdkManager(
-        androidSdk.sdkManagerPath,
+        globals.androidSdk.sdkManagerPath,
         e.toString(),
         globals.platform,
       ));
@@ -402,8 +402,8 @@ class AndroidLicenseValidator extends DoctorValidator {
   }
 
   static bool _canRunSdkManager() {
-    assert(androidSdk != null);
-    final String sdkManagerPath = androidSdk.sdkManagerPath;
+    assert(globals.androidSdk != null);
+    final String sdkManagerPath = globals.androidSdk.sdkManagerPath;
     return globals.processManager.canRun(sdkManagerPath);
   }
 }

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -8,7 +8,6 @@ import 'package:crypto/crypto.dart';
 import 'package:meta/meta.dart';
 import 'package:xml/xml.dart' as xml;
 
-import '../android/android_sdk.dart';
 import '../artifacts.dart';
 import '../base/common.dart';
 import '../base/file_system.dart';
@@ -23,7 +22,6 @@ import '../flutter_manifest.dart';
 import '../globals.dart' as globals;
 import '../project.dart';
 import '../reporting/reporting.dart';
-import 'android_sdk.dart';
 import 'gradle_errors.dart';
 import 'gradle_utils.dart';
 
@@ -149,7 +147,7 @@ Future<void> checkGradleDependencies() async {
     workingDirectory: flutterProject.android.hostAppGradleRoot.path,
     environment: gradleEnvironment,
   );
-  androidSdk?.reinitialize();
+  globals.androidSdk?.reinitialize();
   progress.stop();
 }
 
@@ -229,7 +227,7 @@ Future<void> buildGradleApp({
   assert(target != null);
   assert(isBuildingBundle != null);
   assert(localGradleErrors != null);
-  assert(androidSdk != null);
+  assert(globals.androidSdk != null);
 
   if (!project.android.isUsingGradle) {
     _exitWithProjectNotUsingGradleMessage();
@@ -520,7 +518,7 @@ Future<void> buildGradleAar({
   assert(target != null);
   assert(androidBuildInfo != null);
   assert(outputDirectory != null);
-  assert(androidSdk != null);
+  assert(globals.androidSdk != null);
 
   final FlutterManifest manifest = project.manifest;
   if (!manifest.isModule && !manifest.isPlugin) {

--- a/packages/flutter_tools/lib/src/android/gradle_utils.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_utils.dart
@@ -4,7 +4,6 @@
 
 import 'package:meta/meta.dart';
 
-import '../android/android_sdk.dart';
 import '../base/common.dart';
 import '../base/context.dart';
 import '../base/file_system.dart';
@@ -16,7 +15,6 @@ import '../cache.dart';
 import '../globals.dart' as globals;
 import '../project.dart';
 import '../reporting/reporting.dart';
-import 'android_sdk.dart';
 import 'android_studio.dart';
 
 /// The environment variables needed to run Gradle.
@@ -239,7 +237,7 @@ void updateLocalProperties({
   BuildInfo buildInfo,
   bool requireAndroidSdk = true,
 }) {
-  if (requireAndroidSdk && androidSdk == null) {
+  if (requireAndroidSdk && globals.androidSdk == null) {
     exitWithNoSdkMessage();
   }
   final File localProperties = project.android.localPropertiesFile;
@@ -265,8 +263,8 @@ void updateLocalProperties({
     changed = true;
   }
 
-  if (androidSdk != null) {
-    changeIfNecessary('sdk.dir', globals.fsUtils.escapePath(androidSdk.directory));
+  if (globals.androidSdk != null) {
+    changeIfNecessary('sdk.dir', globals.fsUtils.escapePath(globals.androidSdk.directory));
   }
 
   changeIfNecessary('flutter.sdk', globals.fsUtils.escapePath(Cache.flutterRoot));
@@ -294,8 +292,8 @@ void updateLocalProperties({
 /// Writes the path to the Android SDK, if known.
 void writeLocalProperties(File properties) {
   final SettingsFile settings = SettingsFile();
-  if (androidSdk != null) {
-    settings.values['sdk.dir'] = globals.fsUtils.escapePath(androidSdk.directory);
+  if (globals.androidSdk != null) {
+    settings.values['sdk.dir'] = globals.fsUtils.escapePath(globals.androidSdk.directory);
   }
   settings.writeContents(properties);
 }

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -8,7 +8,6 @@ import 'dart:collection';
 import 'package:meta/meta.dart';
 import 'package:xml/xml.dart' as xml;
 
-import 'android/android_sdk.dart';
 import 'android/gradle.dart';
 import 'base/common.dart';
 import 'base/context.dart';
@@ -40,7 +39,7 @@ class ApplicationPackageFactory {
       case TargetPlatform.android_arm64:
       case TargetPlatform.android_x64:
       case TargetPlatform.android_x86:
-        if (androidSdk?.licensesAvailable == true  && androidSdk?.latestVersion == null) {
+        if (globals.androidSdk?.licensesAvailable == true  && globals.androidSdk?.latestVersion == null) {
           await checkGradleDependencies();
         }
         return applicationBinary == null
@@ -109,7 +108,7 @@ class AndroidApk extends ApplicationPackage {
 
   /// Creates a new AndroidApk from an existing APK.
   factory AndroidApk.fromApk(File apk) {
-    final String aaptPath = androidSdk?.latestVersion?.aaptPath;
+    final String aaptPath = globals.androidSdk?.latestVersion?.aaptPath;
     if (aaptPath == null) {
       globals.printError(userMessages.aaptNotFound);
       return null;

--- a/packages/flutter_tools/lib/src/commands/build_aar.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aar.dart
@@ -5,12 +5,12 @@
 import 'dart:async';
 
 import '../android/android_builder.dart';
-import '../android/android_sdk.dart';
 import '../android/gradle_utils.dart';
 import '../base/common.dart';
 import '../base/os.dart';
 import '../build_info.dart';
 import '../cache.dart';
+import '../globals.dart' as globals;
 import '../project.dart';
 import '../reporting/reporting.dart';
 import '../runner/flutter_command.dart' show FlutterCommandResult;
@@ -88,7 +88,7 @@ class BuildAarCommand extends BuildSubCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
-    if (androidSdk == null) {
+    if (globals.androidSdk == null) {
       exitWithNoSdkMessage();
     }
     final Set<AndroidBuildInfo> androidBuildInfo = <AndroidBuildInfo>{};

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import '../android/android_builder.dart';
-import '../android/android_sdk.dart';
 import '../android/gradle_utils.dart';
 import '../base/terminal.dart';
 import '../build_info.dart';
@@ -86,7 +85,7 @@ class BuildApkCommand extends BuildSubCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
-    if (androidSdk == null) {
+    if (globals.androidSdk == null) {
       exitWithNoSdkMessage();
     }
     final BuildInfo buildInfo = getBuildInfo();

--- a/packages/flutter_tools/lib/src/commands/build_appbundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_appbundle.dart
@@ -5,10 +5,10 @@
 import 'dart:async';
 
 import '../android/android_builder.dart';
-import '../android/android_sdk.dart';
 import '../android/gradle_utils.dart';
 import '../build_info.dart';
 import '../cache.dart';
+import '../globals.dart' as globals;
 import '../project.dart';
 import '../reporting/reporting.dart';
 import '../runner/flutter_command.dart' show FlutterCommandResult;
@@ -76,7 +76,7 @@ class BuildAppBundleCommand extends BuildSubCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
-    if (androidSdk == null) {
+    if (globals.androidSdk == null) {
       exitWithNoSdkMessage();
     }
     final AndroidBuildInfo androidBuildInfo = AndroidBuildInfo(getBuildInfo(),

--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import '../android/android_sdk.dart';
 import '../android/android_studio.dart';
 import '../base/common.dart';
 import '../convert.dart';
@@ -172,8 +171,8 @@ class ConfigCommand extends FlutterCommand {
     if (results['android-studio-dir'] == null && androidStudio != null) {
       results['android-studio-dir'] = androidStudio.directory;
     }
-    if (results['android-sdk'] == null && androidSdk != null) {
-      results['android-sdk'] = androidSdk.directory;
+    if (results['android-sdk'] == null && globals.androidSdk != null) {
+      results['android-sdk'] = globals.androidSdk.directory;
     }
 
     globals.printStatus(const JsonEncoder.withIndent('  ').convert(results));

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -115,7 +115,7 @@ class EmulatorManager {
     }
 
     final List<String> args = <String>[
-      getAvdManagerPath(androidSdk),
+      getAvdManagerPath(globals.androidSdk),
       'create',
       'avd',
       '-n', name,
@@ -123,7 +123,7 @@ class EmulatorManager {
       '-d', device,
     ];
     final RunResult runResult = processUtils.runSync(args,
-        environment: androidSdk?.sdkManagerEnv);
+        environment: globals.androidSdk?.sdkManagerEnv);
     return CreateEmulatorResult(
       name,
       success: runResult.exitCode == 0,
@@ -138,13 +138,13 @@ class EmulatorManager {
   ];
   Future<String> _getPreferredAvailableDevice() async {
     final List<String> args = <String>[
-      getAvdManagerPath(androidSdk),
+      getAvdManagerPath(globals.androidSdk),
       'list',
       'device',
       '-c',
     ];
     final RunResult runResult = processUtils.runSync(args,
-        environment: androidSdk?.sdkManagerEnv);
+        environment: globals.androidSdk?.sdkManagerEnv);
     if (runResult.exitCode != 0) {
       return null;
     }
@@ -165,13 +165,13 @@ class EmulatorManager {
     // It seems that to get the available list of images, we need to send a
     // request to create without the image and it'll provide us a list :-(
     final List<String> args = <String>[
-      getAvdManagerPath(androidSdk),
+      getAvdManagerPath(globals.androidSdk),
       'create',
       'avd',
       '-n', 'temp',
     ];
     final RunResult runResult = processUtils.runSync(args,
-        environment: androidSdk?.sdkManagerEnv);
+        environment: globals.androidSdk?.sdkManagerEnv);
 
     // Get the list of IDs that match our criteria
     final List<String> availableIDs = runResult.stderr

--- a/packages/flutter_tools/test/general.shard/android/android_emulator_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_emulator_test.dart
@@ -7,10 +7,11 @@ import 'dart:async';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/android/android_sdk.dart'
-  show getEmulatorPath, AndroidSdk, androidSdk;
+  show getEmulatorPath, AndroidSdk;
 import 'package:flutter_tools/src/android/android_emulator.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:mockito/mockito.dart';
 import 'package:quiver/testing/async.dart';
 
@@ -130,7 +131,7 @@ void main() {
 
     testUsingContext('succeeds', () async {
       final AndroidEmulator emulator = AndroidEmulator(emulatorID);
-      expect(getEmulatorPath(androidSdk), mockSdk.emulatorPath);
+      expect(getEmulatorPath(globals.androidSdk), mockSdk.emulatorPath);
       final Completer<void> completer = Completer<void>();
       FakeAsync().run((FakeAsync time) {
         unawaited(emulator.launch().whenComplete(completer.complete));


### PR DESCRIPTION
## Description

Remove `androidSdk` from android_sdk.dart, use existing `globals.androidSdk` everywhere.

## Related Issues

Part of https://github.com/flutter/flutter/issues/47161

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*