### PR TITLE
[devicelab] enable macOS, windows, linux, and web on devicelab bots

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_gallery_v2_chrome_run_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_v2_chrome_run_test.dart
@@ -47,17 +47,12 @@ class NewGalleryChromeRunTest {
         '-v',
         '--release',
         '--no-pub',
-      ], environment: <String, String>{
-        'FLUTTER_WEB': 'true',
-      });
+      ]);
 
       final List<String> options = <String>['-d', 'chrome', '--verbose', '--resident'];
       final Process process = await startProcess(
         path.join(flutterDirectory.path, 'bin', 'flutter'),
         flutterCommandArgs('run', options),
-        environment: <String, String>{
-          'FLUTTER_WEB': 'true',
-        },
       );
 
       final Completer<void> stdoutDone = Completer<void>();

--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_macos_target__benchmark.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_macos_target__benchmark.dart
@@ -8,7 +8,5 @@ import 'package:flutter_devicelab/tasks/hot_mode_tests.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 
 Future<void> main() async {
-  await task(createHotModeTest(deviceIdOverride: 'macos', environment: <String, String>{
-    'FLUTTER_MACOS': 'true',
-  }));
+  await task(createHotModeTest(deviceIdOverride: 'macos'));
 }

--- a/dev/devicelab/lib/framework/framework.dart
+++ b/dev/devicelab/lib/framework/framework.dart
@@ -86,10 +86,6 @@ class _TaskRunner {
       ).toSet();
       beforeRunningDartInstances.forEach(print);
 
-      Future<TaskResult> futureResult = _performTask();
-      if (taskTimeout != null)
-        futureResult = futureResult.timeout(taskTimeout);
-
       print('enabling configs for macOS, Linux, Windows, and Web...');
       final int configResult = await exec(path.join(flutterDirectory.path, 'bin', 'flutter'), <String>[
         'config',
@@ -101,6 +97,10 @@ class _TaskRunner {
       if (configResult != 0) {
         print('Failed to enable configuration, tasks may not run.');
       }
+
+      Future<TaskResult> futureResult = _performTask();
+      if (taskTimeout != null)
+        futureResult = futureResult.timeout(taskTimeout);
 
       TaskResult result = await futureResult;
 

--- a/dev/devicelab/lib/framework/framework.dart
+++ b/dev/devicelab/lib/framework/framework.dart
@@ -90,7 +90,7 @@ class _TaskRunner {
       if (taskTimeout != null)
         futureResult = futureResult.timeout(taskTimeout);
 
-      print('enabling configs...');
+      print('enabling configs for macOS, Linux, Windows, and Web...');
       final int configResult = await exec(path.join(flutterDirectory.path, 'bin', 'flutter'), <String>[
         'config',
         '--enable-macos-desktop',

--- a/dev/devicelab/lib/framework/framework.dart
+++ b/dev/devicelab/lib/framework/framework.dart
@@ -8,6 +8,7 @@ import 'dart:developer';
 import 'dart:io';
 import 'dart:isolate';
 
+import 'package:path/path.dart' as path;
 import 'package:logging/logging.dart';
 import 'package:stack_trace/stack_trace.dart';
 
@@ -88,6 +89,19 @@ class _TaskRunner {
       Future<TaskResult> futureResult = _performTask();
       if (taskTimeout != null)
         futureResult = futureResult.timeout(taskTimeout);
+
+      print('enabling configs...');
+      final int configResult = await exec(path.join(flutterDirectory.path, 'bin', 'flutter'), <String>[
+        'config',
+        '--enable-macos-desktop',
+        '--enable-windows-desktop',
+        '--enable-linux-desktop',
+        '--enable-web'
+      ]);
+      if (configResult != 0) {
+        print('Failed to enable configuration, tasks may not run.');
+      }
+
       TaskResult result = await futureResult;
 
       section('Checking running Dart$exe processes after task...');

--- a/dev/devicelab/lib/tasks/integration_tests.dart
+++ b/dev/devicelab/lib/tasks/integration_tests.dart
@@ -71,9 +71,6 @@ TaskFunction createCodegenerationIntegrationTest() {
   return DriverTest(
     '${flutterDirectory.path}/dev/integration_tests/codegen',
     'lib/main.dart',
-    environment: <String, String>{
-      'FLUTTER_EXPERIMENTAL_BUILD': 'true',
-    },
   );
 }
 

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -377,9 +377,7 @@ class WebCompileTest {
         '-v',
         '--release',
         '--no-pub',
-      ], environment: <String, String>{
-        'FLUTTER_WEB': 'true',
-      });
+      ]);
       watch?.stop();
       final String outputFileName = path.join(directory, 'build/web/main.dart.js');
       metrics.addAll(await getSize(outputFileName, metric: metric));

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -350,9 +350,7 @@ class WebCompileTest {
     rmTree(sampleDir);
 
     await inDirectory<void>(Directory.systemTemp, () async {
-      await flutter('create', options: <String>['--template=app', sampleAppName], environment: <String, String>{
-        'FLUTTER_WEB': 'true',
-      });
+      await flutter('create', options: <String>['--template=app', sampleAppName]);
     });
 
     metrics.addAll(await runSingleBuildTest(

--- a/dev/devicelab/lib/tasks/track_widget_creation_enabled_task.dart
+++ b/dev/devicelab/lib/tasks/track_widget_creation_enabled_task.dart
@@ -23,25 +23,6 @@ class TrackWidgetCreationEnabledTask {
   String deviceIdOverride;
 
   Future<TaskResult> task() async {
-    try {
-      await exec(
-        path.join(flutterDirectory.path, 'bin', 'flutter'),
-        flutterCommandArgs('config', <String>[
-          '--enable-macos-desktop',
-        ])
-      );
-      return _task();
-    } finally {
-      await exec(
-        path.join(flutterDirectory.path, 'bin', 'flutter'),
-        flutterCommandArgs('config', <String>[
-          '--no-enable-macos-desktop',
-        ])
-      );
-    }
-  }
-
-  Future<TaskResult> _task() async {
     final File file = File(path.join(integrationTestDir.path, 'info'));
     if (file.existsSync()) {
       file.deleteSync();

--- a/dev/devicelab/lib/tasks/track_widget_creation_enabled_task.dart
+++ b/dev/devicelab/lib/tasks/track_widget_creation_enabled_task.dart
@@ -46,10 +46,6 @@ class TrackWidgetCreationEnabledTask {
           deviceIdOverride,
           path.join('lib/track_widget_creation.dart'),
         ]),
-        environment: <String, String>{
-          'FLUTTER_WEB': 'true',
-          'FLUTTER_MACOS': 'true',
-        }
       );
       runProcess.stdout
         .transform(utf8.decoder)
@@ -84,10 +80,6 @@ class TrackWidgetCreationEnabledTask {
           deviceIdOverride,
           path.join('lib/track_widget_creation.dart'),
         ]),
-        environment: <String, String>{
-          'FLUTTER_WEB': 'true',
-          'FLUTTER_MACOS': 'true',
-        }
       );
       runProcess.stdout
         .transform(utf8.decoder)

--- a/dev/devicelab/lib/tasks/track_widget_creation_enabled_task.dart
+++ b/dev/devicelab/lib/tasks/track_widget_creation_enabled_task.dart
@@ -23,6 +23,25 @@ class TrackWidgetCreationEnabledTask {
   String deviceIdOverride;
 
   Future<TaskResult> task() async {
+    try {
+      await exec(
+        path.join(flutterDirectory.path, 'bin', 'flutter'),
+        flutterCommandArgs('config', <String>[
+          '--enable-macos-desktop',
+        ])
+      );
+      return _task();
+    } finally {
+      await exec(
+        path.join(flutterDirectory.path, 'bin', 'flutter'),
+        flutterCommandArgs('config', <String>[
+          '--no-enable-macos-desktop',
+        ])
+      );
+    }
+  }
+
+  Future<TaskResult> _task() async {
     final File file = File(path.join(integrationTestDir.path, 'info'));
     if (file.existsSync()) {
       file.deleteSync();
@@ -48,7 +67,7 @@ class TrackWidgetCreationEnabledTask {
         ]),
         environment: <String, String>{
           'FLUTTER_WEB': 'true',
-          'FLUTTER_MACOS': 'true'
+          'FLUTTER_MACOS': 'true',
         }
       );
       runProcess.stdout
@@ -86,7 +105,7 @@ class TrackWidgetCreationEnabledTask {
         ]),
         environment: <String, String>{
           'FLUTTER_WEB': 'true',
-          'FLUTTER_MACOS': 'true'
+          'FLUTTER_MACOS': 'true',
         }
       );
       runProcess.stdout

--- a/dev/devicelab/lib/tasks/web_benchmarks.dart
+++ b/dev/devicelab/lib/tasks/web_benchmarks.dart
@@ -34,9 +34,7 @@ Future<TaskResult> runWebBenchmark({ @required bool useCanvasKit }) async {
       '--profile',
       '-t',
       'lib/web_benchmarks.dart',
-    ], environment: <String, String>{
-      'FLUTTER_WEB': 'true',
-    });
+    ]);
     final Completer<List<Map<String, dynamic>>> profileData = Completer<List<Map<String, dynamic>>>();
     final List<Map<String, dynamic>> collectedProfiles = <Map<String, dynamic>>[];
     List<String> benchmarks;

--- a/dev/devicelab/lib/tasks/web_dev_mode_tests.dart
+++ b/dev/devicelab/lib/tasks/web_dev_mode_tests.dart
@@ -45,21 +45,11 @@ TaskFunction createWebDevModeTest(String webDevice, bool enableIncrementalCompil
           final Process packagesGet = await startProcess(
               path.join(flutterDirectory.path, 'bin', 'flutter'),
               <String>['packages', 'get'],
-              environment: <String, String>{
-                'FLUTTER_WEB': 'true',
-                if (enableIncrementalCompiler)
-                  'WEB_INCREMENTAL_COMPILER': 'true',
-              },
           );
           await packagesGet.exitCode;
           final Process process = await startProcess(
               path.join(flutterDirectory.path, 'bin', 'flutter'),
               flutterCommandArgs('run', options),
-              environment: <String, String>{
-                'FLUTTER_WEB': 'true',
-                if (enableIncrementalCompiler)
-                  'WEB_INCREMENTAL_COMPILER': 'true',
-              },
           );
 
           final Completer<void> stdoutDone = Completer<void>();
@@ -140,11 +130,6 @@ TaskFunction createWebDevModeTest(String webDevice, bool enableIncrementalCompil
           final Process process = await startProcess(
               path.join(flutterDirectory.path, 'bin', 'flutter'),
               flutterCommandArgs('run', options),
-              environment: <String, String>{
-                'FLUTTER_WEB': 'true',
-                if (enableIncrementalCompiler)
-                  'WEB_INCREMENTAL_COMPILER': 'true',
-              },
           );
           final Completer<void> stdoutDone = Completer<void>();
           final Completer<void> stderrDone = Completer<void>();


### PR DESCRIPTION
## Description

Since the environment variable was set at the process level, the re-entrant assemble command does not pick it up. This leads to the tool building output in a partially valid state for the desktop builds.

Rather than setting these values in an ad-hoc fashion in each test, they can be turned on once globally so that the testing environment is consistent. This should not pose any issues to existing tests, since by convention device lab tests specify the appropriate device id.