### PR TITLE
Add OutlinedBorder class

### DIFF
--- a/packages/flutter/lib/src/painting/beveled_rectangle_border.dart
+++ b/packages/flutter/lib/src/painting/beveled_rectangle_border.dart
@@ -80,6 +80,14 @@ class BeveledRectangleBorder extends ShapeBorder {
     return super.lerpTo(b, t);
   }
 
+  @override
+  ShapeBorder withSide(BorderSide side) {
+    return BeveledRectangleBorder(
+      side: side,
+      borderRadius: borderRadius,
+    );
+  }
+
   Path _getPath(RRect rrect) {
     final Offset centerLeft = Offset(rrect.left, rrect.center.dy);
     final Offset centerRight = Offset(rrect.right, rrect.center.dy);

--- a/packages/flutter/lib/src/painting/beveled_rectangle_border.dart
+++ b/packages/flutter/lib/src/painting/beveled_rectangle_border.dart
@@ -18,19 +18,17 @@ import 'edge_insets.dart';
 /// but not farther than the side's center. If all the border radii
 /// exceed the sides' half widths/heights the resulting shape is
 /// diamond made by connecting the centers of the sides.
-class BeveledRectangleBorder extends ShapeBorder {
+class BeveledRectangleBorder extends OutlinedBorder {
   /// Creates a border like a [RoundedRectangleBorder] except that the corners
   /// are joined by straight lines instead of arcs.
   ///
   /// The arguments must not be null.
   const BeveledRectangleBorder({
-    this.side = BorderSide.none,
+    BorderSide side = BorderSide.none,
     this.borderRadius = BorderRadius.zero,
   }) : assert(side != null),
-       assert(borderRadius != null);
-
-  /// The style of this border.
-  final BorderSide side;
+       assert(borderRadius != null),
+       super(side: side);
 
   /// The radii for each corner.
   ///
@@ -80,11 +78,13 @@ class BeveledRectangleBorder extends ShapeBorder {
     return super.lerpTo(b, t);
   }
 
+  /// Returns a copy of this RoundedRectangleBorder with the given fields
+  /// replaced with the new values.
   @override
-  ShapeBorder withSide(BorderSide side) {
+  BeveledRectangleBorder copyWith({ BorderSide side, BorderRadius borderRadius }) {
     return BeveledRectangleBorder(
-      side: side,
-      borderRadius: borderRadius,
+      side: side ?? this.side,
+      borderRadius: borderRadius ?? this.borderRadius,
     );
   }
 

--- a/packages/flutter/lib/src/painting/borders.dart
+++ b/packages/flutter/lib/src/painting/borders.dart
@@ -436,13 +436,6 @@ abstract class ShapeBorder {
     return result ?? (t < 0.5 ? a : b);
   }
 
-  /// Returns a copy of this ShapeBorder that paints its outline with the
-  /// specified [side].
-  ///
-  /// Returns this ShapeBorder if the subclass does not support painting
-  /// an outline.
-  ShapeBorder withSide(BorderSide side) => this;
-
   /// Create a [Path] that describes the outer edge of the border.
   ///
   /// This path must not cross the path given by [getInnerPath] for the same
@@ -497,6 +490,27 @@ abstract class ShapeBorder {
   String toString() {
     return '${objectRuntimeType(this, 'ShapeBorder')}()';
   }
+}
+
+/// A ShapeBorder that draws an outline with the width and color specified
+/// by [side].
+@immutable
+abstract class OutlinedBorder extends ShapeBorder {
+  /// Abstract const constructor. This constructor enables subclasses to provide
+  /// const constructors so that they can be used in const expressions.
+  ///
+  /// The value of [side] must not be null.
+  const OutlinedBorder({ this.side = BorderSide.none }) : assert(side != null);
+
+  /// The border outline's color and weight.
+  ///
+  /// If [side] is [BorderSide.none], which is the default, an outline is not drawn.
+  /// Otherwise the outline is centered over the shape's boundary.
+  final BorderSide side;
+
+  /// Returns a copy of this OutlinedBorder that draws its outline with the
+  /// specified [side], if [side] is non-null.
+  OutlinedBorder copyWith({ BorderSide side });
 }
 
 /// Represents the addition of two otherwise-incompatible borders.
@@ -565,13 +579,6 @@ class _CompoundBorder extends ShapeBorder {
   @override
   ShapeBorder lerpTo(ShapeBorder b, double t) {
     return _CompoundBorder.lerp(this, b, t);
-  }
-
-  @override
-  ShapeBorder withSide(BorderSide side) {
-    return _CompoundBorder(
-      borders.map<ShapeBorder>((ShapeBorder border) => border.withSide(side)).toList()
-    );
   }
 
   static _CompoundBorder lerp(ShapeBorder a, ShapeBorder b, double t) {

--- a/packages/flutter/lib/src/painting/borders.dart
+++ b/packages/flutter/lib/src/painting/borders.dart
@@ -436,6 +436,13 @@ abstract class ShapeBorder {
     return result ?? (t < 0.5 ? a : b);
   }
 
+  /// Returns a copy of this ShapeBorder that paints its outline with the
+  /// specified [side].
+  ///
+  /// Returns this ShapeBorder if the subclass does not support painting
+  /// an outline.
+  ShapeBorder withSide(BorderSide side) => this;
+
   /// Create a [Path] that describes the outer edge of the border.
   ///
   /// This path must not cross the path given by [getInnerPath] for the same
@@ -558,6 +565,13 @@ class _CompoundBorder extends ShapeBorder {
   @override
   ShapeBorder lerpTo(ShapeBorder b, double t) {
     return _CompoundBorder.lerp(this, b, t);
+  }
+
+  @override
+  ShapeBorder withSide(BorderSide side) {
+    return _CompoundBorder(
+      borders.map<ShapeBorder>((ShapeBorder border) => border.withSide(side)).toList()
+    );
   }
 
   static _CompoundBorder lerp(ShapeBorder a, ShapeBorder b, double t) {

--- a/packages/flutter/lib/src/painting/circle_border.dart
+++ b/packages/flutter/lib/src/painting/circle_border.dart
@@ -73,6 +73,11 @@ class CircleBorder extends ShapeBorder {
   }
 
   @override
+  ShapeBorder withSide(BorderSide side) {
+    return CircleBorder(side: side);
+  }
+
+  @override
   void paint(Canvas canvas, Rect rect, { TextDirection textDirection }) {
     switch (side.style) {
       case BorderStyle.none:

--- a/packages/flutter/lib/src/painting/circle_border.dart
+++ b/packages/flutter/lib/src/painting/circle_border.dart
@@ -23,14 +23,11 @@ import 'edge_insets.dart';
 ///  * [BorderSide], which is used to describe each side of the box.
 ///  * [Border], which, when used with [BoxDecoration], can also
 ///    describe a circle.
-class CircleBorder extends ShapeBorder {
+class CircleBorder extends OutlinedBorder {
   /// Create a circle border.
   ///
   /// The [side] argument must not be null.
-  const CircleBorder({ this.side = BorderSide.none }) : assert(side != null);
-
-  /// The style of this border.
-  final BorderSide side;
+  const CircleBorder({ BorderSide side = BorderSide.none }) : assert(side != null), super(side: side);
 
   @override
   EdgeInsetsGeometry get dimensions {
@@ -73,7 +70,7 @@ class CircleBorder extends ShapeBorder {
   }
 
   @override
-  ShapeBorder withSide(BorderSide side) {
+  CircleBorder copyWith({ BorderSide side }) {
     return CircleBorder(side: side);
   }
 

--- a/packages/flutter/lib/src/painting/circle_border.dart
+++ b/packages/flutter/lib/src/painting/circle_border.dart
@@ -71,7 +71,7 @@ class CircleBorder extends OutlinedBorder {
 
   @override
   CircleBorder copyWith({ BorderSide side }) {
-    return CircleBorder(side: side);
+    return CircleBorder(side: side ?? this.side);
   }
 
   @override

--- a/packages/flutter/lib/src/painting/continuous_rectangle_border.dart
+++ b/packages/flutter/lib/src/painting/continuous_rectangle_border.dart
@@ -32,13 +32,14 @@ import 'edge_insets.dart';
 ///    however its straight sides change into a rounded corner with a circular
 ///    radius in a step function instead of gradually like the
 ///    [ContinuousRectangleBorder].
-class ContinuousRectangleBorder extends ShapeBorder {
+class ContinuousRectangleBorder extends OutlinedBorder {
   /// The arguments must not be null.
   const ContinuousRectangleBorder({
-    this.side = BorderSide.none,
+    BorderSide side = BorderSide.none,
     this.borderRadius = BorderRadius.zero,
   }) : assert(side != null),
-       assert(borderRadius != null);
+       assert(borderRadius != null),
+       super(side: side);
 
   /// The radius for each corner.
   ///
@@ -46,10 +47,7 @@ class ContinuousRectangleBorder extends ShapeBorder {
   /// [getOuterPath].
   final BorderRadiusGeometry borderRadius;
 
-  /// The style of this border.
-  final BorderSide side;
-
-  @override
+   @override
   EdgeInsetsGeometry get dimensions => EdgeInsets.all(side.width);
 
   @override
@@ -135,10 +133,10 @@ class ContinuousRectangleBorder extends ShapeBorder {
   }
 
   @override
-  ShapeBorder withSide(BorderSide side) {
+  ContinuousRectangleBorder copyWith({ BorderSide side, BorderRadius borderRadius }) {
     return ContinuousRectangleBorder(
-      side: side,
-      borderRadius: borderRadius,
+      side: side ?? this.side,
+      borderRadius: borderRadius ?? this.borderRadius,
     );
   }
 

--- a/packages/flutter/lib/src/painting/continuous_rectangle_border.dart
+++ b/packages/flutter/lib/src/painting/continuous_rectangle_border.dart
@@ -135,6 +135,14 @@ class ContinuousRectangleBorder extends ShapeBorder {
   }
 
   @override
+  ShapeBorder withSide(BorderSide side) {
+    return ContinuousRectangleBorder(
+      side: side,
+      borderRadius: borderRadius,
+    );
+  }
+
+  @override
   void paint(Canvas canvas, Rect rect, { TextDirection textDirection }) {
     if (rect.isEmpty)
       return;

--- a/packages/flutter/lib/src/painting/rounded_rectangle_border.dart
+++ b/packages/flutter/lib/src/painting/rounded_rectangle_border.dart
@@ -24,18 +24,16 @@ import 'edge_insets.dart';
 ///  * [BorderSide], which is used to describe each side of the box.
 ///  * [Border], which, when used with [BoxDecoration], can also
 ///    describe a rounded rectangle.
-class RoundedRectangleBorder extends ShapeBorder {
+class RoundedRectangleBorder extends OutlinedBorder {
   /// Creates a rounded rectangle border.
   ///
   /// The arguments must not be null.
   const RoundedRectangleBorder({
-    this.side = BorderSide.none,
+    BorderSide side = BorderSide.none,
     this.borderRadius = BorderRadius.zero,
   }) : assert(side != null),
-       assert(borderRadius != null);
-
-  /// The style of this border.
-  final BorderSide side;
+       assert(borderRadius != null),
+       super(side: side);
 
   /// The radii for each corner.
   final BorderRadiusGeometry borderRadius;
@@ -91,11 +89,13 @@ class RoundedRectangleBorder extends ShapeBorder {
     return super.lerpTo(b, t);
   }
 
+  /// Returns a copy of this RoundedRectangleBorder with the given fields
+  /// replaced with the new values.
   @override
-  ShapeBorder withSide(BorderSide side) {
+  RoundedRectangleBorder copyWith({ BorderSide side, BorderRadius borderRadius }) {
     return RoundedRectangleBorder(
-      side: side,
-      borderRadius: borderRadius,
+      side: side ?? this.side,
+      borderRadius: borderRadius ?? this.borderRadius,
     );
   }
 
@@ -148,16 +148,15 @@ class RoundedRectangleBorder extends ShapeBorder {
   }
 }
 
-class _RoundedRectangleToCircleBorder extends ShapeBorder {
+class _RoundedRectangleToCircleBorder extends OutlinedBorder {
   const _RoundedRectangleToCircleBorder({
-    this.side = BorderSide.none,
+    BorderSide side = BorderSide.none,
     this.borderRadius = BorderRadius.zero,
     @required this.circleness,
   }) : assert(side != null),
        assert(borderRadius != null),
-       assert(circleness != null);
-
-  final BorderSide side;
+       assert(circleness != null),
+       super(side: side);
 
   final BorderRadiusGeometry borderRadius;
 
@@ -272,11 +271,11 @@ class _RoundedRectangleToCircleBorder extends ShapeBorder {
   }
 
   @override
-  ShapeBorder withSide(BorderSide side) {
+  _RoundedRectangleToCircleBorder copyWith({ BorderSide side, BorderRadius borderRadius, double circleness }) {
     return _RoundedRectangleToCircleBorder(
-      side: side,
-      borderRadius: borderRadius,
-      circleness: circleness,
+      side: side ?? this.side,
+      borderRadius: borderRadius ?? this.borderRadius,
+      circleness: circleness ?? this.circleness,
     );
   }
 

--- a/packages/flutter/lib/src/painting/rounded_rectangle_border.dart
+++ b/packages/flutter/lib/src/painting/rounded_rectangle_border.dart
@@ -92,6 +92,14 @@ class RoundedRectangleBorder extends ShapeBorder {
   }
 
   @override
+  ShapeBorder withSide(BorderSide side) {
+    return RoundedRectangleBorder(
+      side: side,
+      borderRadius: borderRadius,
+    );
+  }
+
+  @override
   Path getInnerPath(Rect rect, { TextDirection textDirection }) {
     return Path()
       ..addRRect(borderRadius.resolve(textDirection).toRRect(rect).deflate(side.width));
@@ -261,6 +269,15 @@ class _RoundedRectangleToCircleBorder extends ShapeBorder {
   Path getOuterPath(Rect rect, { TextDirection textDirection }) {
     return Path()
       ..addRRect(_adjustBorderRadius(rect, textDirection).toRRect(_adjustRect(rect)));
+  }
+
+  @override
+  ShapeBorder withSide(BorderSide side) {
+    return _RoundedRectangleToCircleBorder(
+      side: side,
+      borderRadius: borderRadius,
+      circleness: circleness,
+    );
   }
 
   @override

--- a/packages/flutter/lib/src/painting/stadium_border.dart
+++ b/packages/flutter/lib/src/painting/stadium_border.dart
@@ -84,6 +84,11 @@ class StadiumBorder extends ShapeBorder {
   }
 
   @override
+  ShapeBorder withSide(BorderSide side) {
+    return StadiumBorder(side: side);
+  }
+
+  @override
   Path getInnerPath(Rect rect, { TextDirection textDirection }) {
     final Radius radius = Radius.circular(rect.shortestSide / 2.0);
     return Path()
@@ -240,6 +245,14 @@ class _StadiumToCircleBorder extends ShapeBorder {
   }
 
   @override
+  ShapeBorder withSide(BorderSide side) {
+    return _StadiumToCircleBorder(
+      side: side,
+      circleness: circleness,
+    );
+  }
+
+  @override
   void paint(Canvas canvas, Rect rect, { TextDirection textDirection }) {
     switch (side.style) {
       case BorderStyle.none:
@@ -379,6 +392,15 @@ class _StadiumToRoundedRectangleBorder extends ShapeBorder {
   Path getOuterPath(Rect rect, { TextDirection textDirection }) {
     return Path()
       ..addRRect(_adjustBorderRadius(rect).toRRect(rect));
+  }
+
+  @override
+  ShapeBorder withSide(BorderSide side) {
+    return _StadiumToRoundedRectangleBorder(
+      side: side,
+      borderRadius: borderRadius,
+      rectness: rectness,
+    );
   }
 
   @override

--- a/packages/flutter/lib/src/painting/stadium_border.dart
+++ b/packages/flutter/lib/src/painting/stadium_border.dart
@@ -24,14 +24,11 @@ import 'rounded_rectangle_border.dart';
 /// See also:
 ///
 ///  * [BorderSide], which is used to describe the border of the stadium.
-class StadiumBorder extends ShapeBorder {
+class StadiumBorder extends OutlinedBorder {
   /// Create a stadium border.
   ///
   /// The [side] argument must not be null.
-  const StadiumBorder({this.side = BorderSide.none}) : assert(side != null);
-
-  /// The style of this border.
-  final BorderSide side;
+  const StadiumBorder({ BorderSide side = BorderSide.none }) : assert(side != null), super(side: side);
 
   @override
   EdgeInsetsGeometry get dimensions {
@@ -84,8 +81,8 @@ class StadiumBorder extends ShapeBorder {
   }
 
   @override
-  ShapeBorder withSide(BorderSide side) {
-    return StadiumBorder(side: side);
+  StadiumBorder copyWith({ BorderSide side }) {
+    return StadiumBorder(side: side ?? this.side);
   }
 
   @override
@@ -134,14 +131,13 @@ class StadiumBorder extends ShapeBorder {
 }
 
 // Class to help with transitioning to/from a CircleBorder.
-class _StadiumToCircleBorder extends ShapeBorder {
+class _StadiumToCircleBorder extends OutlinedBorder {
   const _StadiumToCircleBorder({
-    this.side = BorderSide.none,
+    BorderSide side = BorderSide.none,
     this.circleness = 0.0,
   }) : assert(side != null),
-       assert(circleness != null);
-
-  final BorderSide side;
+       assert(circleness != null),
+       super(side: side);
 
   final double circleness;
 
@@ -245,10 +241,10 @@ class _StadiumToCircleBorder extends ShapeBorder {
   }
 
   @override
-  ShapeBorder withSide(BorderSide side) {
+  _StadiumToCircleBorder copyWith({ BorderSide side, double circleness }) {
     return _StadiumToCircleBorder(
-      side: side,
-      circleness: circleness,
+      side: side ?? this.side,
+      circleness: circleness ?? this.circleness,
     );
   }
 
@@ -291,16 +287,15 @@ class _StadiumToCircleBorder extends ShapeBorder {
 }
 
 // Class to help with transitioning to/from a RoundedRectBorder.
-class _StadiumToRoundedRectangleBorder extends ShapeBorder {
+class _StadiumToRoundedRectangleBorder extends OutlinedBorder {
   const _StadiumToRoundedRectangleBorder({
-    this.side = BorderSide.none,
+    BorderSide side = BorderSide.none,
     this.borderRadius = BorderRadius.zero,
     this.rectness = 0.0,
   }) : assert(side != null),
        assert(borderRadius != null),
-       assert(rectness != null);
-
-  final BorderSide side;
+       assert(rectness != null),
+       super(side: side);
 
   final BorderRadius borderRadius;
 
@@ -395,11 +390,11 @@ class _StadiumToRoundedRectangleBorder extends ShapeBorder {
   }
 
   @override
-  ShapeBorder withSide(BorderSide side) {
+  _StadiumToRoundedRectangleBorder copyWith({ BorderSide side, BorderRadius borderRadius, double rectness }) {
     return _StadiumToRoundedRectangleBorder(
-      side: side,
-      borderRadius: borderRadius,
-      rectness: rectness,
+      side: side ?? this.side,
+      borderRadius: borderRadius ?? this.borderRadius,
+      rectness: rectness ?? this.rectness
     );
   }
 

--- a/packages/flutter/test/painting/beveled_rectangle_border_test.dart
+++ b/packages/flutter/test/painting/beveled_rectangle_border_test.dart
@@ -8,6 +8,23 @@ import 'package:flutter_test/flutter_test.dart';
 import '../rendering/mock_canvas.dart';
 
 void main() {
+  test('BeveledRectangleBorder defaults', () {
+    const BeveledRectangleBorder border = BeveledRectangleBorder();
+    expect(border.side, BorderSide.none);
+    expect(border.borderRadius, BorderRadius.zero);
+  });
+
+  test('BeveledRectangleBorder copyWith, ==, hashCode', () {
+    expect(const BeveledRectangleBorder(), const BeveledRectangleBorder().copyWith());
+    expect(const BeveledRectangleBorder().hashCode, const BeveledRectangleBorder().copyWith().hashCode);
+    const BorderSide side = BorderSide(width: 10.0, color: Color(0xff123456));
+    const BorderRadius radius = BorderRadius.all(Radius.circular(16.0));
+    expect(
+      const BeveledRectangleBorder().copyWith(side: side, borderRadius: radius),
+      const BeveledRectangleBorder(side: side, borderRadius: radius),
+    );
+  });
+
   test('BeveledRectangleBorder scale and lerp', () {
     final BeveledRectangleBorder c10 = BeveledRectangleBorder(side: const BorderSide(width: 10.0), borderRadius: BorderRadius.circular(100.0));
     final BeveledRectangleBorder c15 = BeveledRectangleBorder(side: const BorderSide(width: 15.0), borderRadius: BorderRadius.circular(150.0));

--- a/packages/flutter/test/painting/circle_border_test.dart
+++ b/packages/flutter/test/painting/circle_border_test.dart
@@ -9,6 +9,18 @@ import '../rendering/mock_canvas.dart';
 import 'common_matchers.dart';
 
 void main() {
+  test('CircleBorder defaults', () {
+    const CircleBorder border = CircleBorder();
+    expect(border.side, BorderSide.none);
+  });
+
+  test('CircleBorder copyWith, ==, hashCode', () {
+    expect(const CircleBorder(), const CircleBorder().copyWith());
+    expect(const CircleBorder().hashCode, const CircleBorder().copyWith().hashCode);
+    const BorderSide side = BorderSide(width: 10.0, color: Color(0xff123456));
+    expect(const CircleBorder().copyWith(side: side), const CircleBorder(side: side));
+  });
+
   test('CircleBorder', () {
     const CircleBorder c10 = CircleBorder(side: BorderSide(width: 10.0));
     const CircleBorder c15 = CircleBorder(side: BorderSide(width: 15.0));

--- a/packages/flutter/test/painting/continous_rectangle_border_test.dart
+++ b/packages/flutter/test/painting/continous_rectangle_border_test.dart
@@ -9,6 +9,23 @@ import 'package:flutter_test/flutter_test.dart';
 import '../rendering/mock_canvas.dart';
 
 void main() {
+  test('ContinuousRectangleBorder defaults', () {
+    const ContinuousRectangleBorder border = ContinuousRectangleBorder();
+    expect(border.side, BorderSide.none);
+    expect(border.borderRadius, BorderRadius.zero);
+  });
+
+  test('ContinuousRectangleBorder copyWith, ==, hashCode', () {
+    expect(const ContinuousRectangleBorder(), const ContinuousRectangleBorder().copyWith());
+    expect(const ContinuousRectangleBorder().hashCode, const ContinuousRectangleBorder().copyWith().hashCode);
+    const BorderSide side = BorderSide(width: 10.0, color: Color(0xff123456));
+    const BorderRadius radius = BorderRadius.all(Radius.circular(16.0));
+    expect(
+      const ContinuousRectangleBorder().copyWith(side: side, borderRadius: radius),
+      const ContinuousRectangleBorder(side: side, borderRadius: radius),
+    );
+  });
+
   test('ContinuousRectangleBorder scale and lerp', () {
     final ContinuousRectangleBorder c10 = ContinuousRectangleBorder(side: const BorderSide(width: 10.0), borderRadius: BorderRadius.circular(100.0));
     final ContinuousRectangleBorder c15 = ContinuousRectangleBorder(side: const BorderSide(width: 15.0), borderRadius: BorderRadius.circular(150.0));

--- a/packages/flutter/test/painting/rounded_rectangle_border_test.dart
+++ b/packages/flutter/test/painting/rounded_rectangle_border_test.dart
@@ -9,6 +9,23 @@ import '../rendering/mock_canvas.dart';
 import 'common_matchers.dart';
 
 void main() {
+  test('RoundedRectangleBorder defaults', () {
+    const RoundedRectangleBorder border = RoundedRectangleBorder();
+    expect(border.side, BorderSide.none);
+    expect(border.borderRadius, BorderRadius.zero);
+  });
+
+  test('RoundedRectangleBorder copyWith, ==, hashCode', () {
+    expect(const RoundedRectangleBorder(), const RoundedRectangleBorder().copyWith());
+    expect(const RoundedRectangleBorder().hashCode, const RoundedRectangleBorder().copyWith().hashCode);
+    const BorderSide side = BorderSide(width: 10.0, color: Color(0xff123456));
+    const BorderRadius radius = BorderRadius.all(Radius.circular(16.0));
+    expect(
+      const RoundedRectangleBorder().copyWith(side: side, borderRadius: radius),
+      const RoundedRectangleBorder(side: side, borderRadius: radius),
+    );
+  });
+
   test('RoundedRectangleBorder', () {
     final RoundedRectangleBorder c10 = RoundedRectangleBorder(side: const BorderSide(width: 10.0), borderRadius: BorderRadius.circular(100.0));
     final RoundedRectangleBorder c15 = RoundedRectangleBorder(side: const BorderSide(width: 15.0), borderRadius: BorderRadius.circular(150.0));

--- a/packages/flutter/test/painting/stadium_border_test.dart
+++ b/packages/flutter/test/painting/stadium_border_test.dart
@@ -9,6 +9,18 @@ import '../rendering/mock_canvas.dart';
 import 'common_matchers.dart';
 
 void main() {
+  test('StadiumBorder defaults', () {
+    const StadiumBorder border = StadiumBorder();
+    expect(border.side, BorderSide.none);
+  });
+
+  test('StadiumBorder copyWith, ==, hashCode', () {
+    expect(const StadiumBorder(), const StadiumBorder().copyWith());
+    expect(const StadiumBorder().hashCode, const StadiumBorder().copyWith().hashCode);
+    const BorderSide side = BorderSide(width: 10.0, color: Color(0xff123456));
+    expect(const StadiumBorder().copyWith(side: side), const StadiumBorder(side: side));
+  });
+
   test('StadiumBorder', () {
     const StadiumBorder c10 = StadiumBorder(side: BorderSide(width: 10.0));
     const StadiumBorder c15 = StadiumBorder(side: BorderSide(width: 15.0));


### PR DESCRIPTION
Defined a new `OutlinedBorder` abstract class in between ShapeBorder and the existing concrete subclasses like RoundedRectangleBorder. OutlinedBorder adds a BorderSide property and a `copyWith` method with the usual semantics. That makes it possible to combine an OutlinedBorder that defines a component's shape, with a BorderSide that defines how the border outline is to appear.

For example: 
```dart
RoundedRectangleBorder().copyWith(
  side: BorderSide(color: Colors.green, width: 3),
)
```

BeveledRectangleBorder, CircleBorder, ContinuousRectangleBorder, RoundedRectangleBorder, and StadiumBorder are now OutlinedBorders.

This PR does not update the existing InputBorder class to be an OutlinedBorder. InputBorder's BorderSide property and constructor parameter is called "borderSide"; other than that, the two classes are compatible. A future PR could make InputBorder an OutlinedBorder however, that would be a breaking change.

