### PR TITLE
Revert "[flutter_tools] remove flutter view cache"

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -191,11 +191,6 @@ abstract class ResidentWebRunner extends ResidentRunner {
   }
 
   @override
-  Future<List<FlutterView>> listFlutterViews() async {
-    return <FlutterView>[];
-  }
-
-  @override
   Future<void> debugDumpApp() async {
     try {
       await _vmService

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -95,6 +95,7 @@ class ColdRunner extends ResidentRunner {
         continue;
       }
       await device.initLogReader();
+      await device.refreshViews();
       globals.printTrace('Connected to ${device.device.name}');
     }
 
@@ -144,9 +145,9 @@ class ColdRunner extends ResidentRunner {
     for (final FlutterDevice device in flutterDevices) {
       await device.initLogReader();
     }
+    await refreshViews();
     for (final FlutterDevice device in flutterDevices) {
-      final List<FlutterView> views = await device.vmService.getFlutterViews();
-      for (final FlutterView view in views) {
+      for (final FlutterView view in device.views) {
         globals.printTrace('Connected to $view.');
       }
     }

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -198,8 +198,7 @@ class HotRunner extends ResidentRunner {
     }
 
     for (final FlutterDevice device in flutterDevices) {
-      final List<FlutterView> views = await device.vmService.getFlutterViews();
-      for (final FlutterView view in views) {
+      for (final FlutterView view in device.views) {
         await device.vmService.flutterFastReassemble(
           classId,
           isolateId: view.uiIsolate.id,
@@ -278,14 +277,14 @@ class HotRunner extends ResidentRunner {
       return 3;
     }
 
+    await refreshViews();
     for (final FlutterDevice device in flutterDevices) {
       // VM must have accepted the kernel binary, there will be no reload
       // report, so we let incremental compiler know that source code was accepted.
       if (device.generator != null) {
         device.generator.accept();
       }
-      final List<FlutterView> views = await device.vmService.getFlutterViews();
-      for (final FlutterView view in views) {
+      for (final FlutterView view in device.views) {
         globals.printTrace('Connected to $view.');
       }
     }
@@ -475,15 +474,15 @@ class HotRunner extends ResidentRunner {
     Uri main,
     Uri assetsDirectory,
   ) async {
-    final List<FlutterView> views = await device.vmService.getFlutterViews();
     await Future.wait(<Future<void>>[
-      for (final FlutterView view in views)
+      for (final FlutterView view in device.views)
         device.vmService.runInView(
           viewId: view.id,
           main: main,
           assetsDirectory: assetsDirectory,
         ),
     ]);
+    await device.refreshViews();
   }
 
   Future<void> _launchFromDevFS(String mainScript) async {
@@ -502,8 +501,7 @@ class HotRunner extends ResidentRunner {
     if (benchmarkMode) {
       futures.clear();
       for (final FlutterDevice device in flutterDevices) {
-        final List<FlutterView> views = await device.vmService.getFlutterViews();
-        for (final FlutterView view in views) {
+        for (final FlutterView view in device.views) {
           futures.add(device.vmService
             .flushUIThreadTasks(uiIsolateId: view.uiIsolate.id));
         }
@@ -516,6 +514,9 @@ class HotRunner extends ResidentRunner {
     String reason,
     bool benchmarkMode = false,
   }) async {
+    globals.printTrace('Refreshing active FlutterViews before restarting.');
+    await refreshViews();
+
     final Stopwatch restartTimer = Stopwatch()..start();
     // TODO(aam): Add generator reset logic once we switch to using incremental
     // compiler for full application recompilation on restart.
@@ -540,8 +541,7 @@ class HotRunner extends ResidentRunner {
     final List<Future<void>> operations = <Future<void>>[];
     for (final FlutterDevice device in flutterDevices) {
       final Set<String> uiIsolatesIds = <String>{};
-      final List<FlutterView> views = await device.vmService.getFlutterViews();
-      for (final FlutterView view in views) {
+      for (final FlutterView view in device.views) {
         if (view.uiIsolate == null) {
           continue;
         }
@@ -810,8 +810,7 @@ class HotRunner extends ResidentRunner {
     void Function(String message) onSlow,
   }) async {
     for (final FlutterDevice device in flutterDevices) {
-      final List<FlutterView> views = await device.vmService.getFlutterViews();
-      for (final FlutterView view in views) {
+      for (final FlutterView view in device.views) {
         if (view.uiIsolate == null) {
           return OperationResult(2, 'Application isolate not found', fatal: true);
         }
@@ -819,6 +818,10 @@ class HotRunner extends ResidentRunner {
     }
 
     final Stopwatch reloadTimer = Stopwatch()..start();
+
+    globals.printTrace('Refreshing active FlutterViews before reloading.');
+    await refreshViews();
+
     final Stopwatch devFSTimer = Stopwatch()..start();
     final UpdateFSReport updatedDevFS = await _updateDevFS();
     // Record time it took to synchronize to DevFS.
@@ -909,6 +912,14 @@ class HotRunner extends ResidentRunner {
     // Record time it took for the VM to reload the sources.
     _addBenchmarkData('hotReloadVMReloadMilliseconds', vmReloadTimer.elapsed.inMilliseconds);
     final Stopwatch reassembleTimer = Stopwatch()..start();
+
+    // Reload the isolate data.
+    await Future.wait(<Future<void>>[
+      for (final FlutterDevice device in flutterDevices)
+        device.refreshViews()
+    ]);
+
+    globals.printTrace('Evicting dirty assets');
     await _evictDirtyAssets();
 
     // Check if any isolates are paused and reassemble those
@@ -919,8 +930,7 @@ class HotRunner extends ResidentRunner {
     int pausedIsolatesFound = 0;
     bool failedReassemble = false;
     for (final FlutterDevice device in flutterDevices) {
-      final List<FlutterView> views = await device.vmService.getFlutterViews();
-      for (final FlutterView view in views) {
+      for (final FlutterView view in device.views) {
         // Check if the isolate is paused, and if so, don't reassemble. Ignore the
         // PostPauseEvent event - the client requesting the pause will resume the app.
         final vm_service.Isolate isolate = await device.vmService
@@ -1045,7 +1055,11 @@ class HotRunner extends ResidentRunner {
     final StringBuffer message = StringBuffer();
     bool plural;
     if (pausedIsolatesFound == 1) {
-      message.write('The application is ');
+      if (flutterDevices.length == 1 && flutterDevices.single.views.length == 1) {
+        message.write('The application is ');
+      } else {
+        message.write('An isolate is ');
+      }
       plural = false;
     } else {
       message.write('$pausedIsolatesFound isolates are ');
@@ -1107,14 +1121,13 @@ class HotRunner extends ResidentRunner {
     }
   }
 
-  Future<void> _evictDirtyAssets() async {
+  Future<void> _evictDirtyAssets() {
     final List<Future<Map<String, dynamic>>> futures = <Future<Map<String, dynamic>>>[];
     for (final FlutterDevice device in flutterDevices) {
       if (device.devFS.assetPathsToEvict.isEmpty) {
         continue;
       }
-      final List<FlutterView> views = await device.vmService.getFlutterViews();
-      if (views.first.uiIsolate == null) {
+      if (device.views.first.uiIsolate == null) {
         globals.printError('Application isolate not found for $device');
         continue;
       }
@@ -1123,7 +1136,7 @@ class HotRunner extends ResidentRunner {
           device.vmService
             .flutterEvictAsset(
               assetPath,
-              isolateId: views.first.uiIsolate.id,
+              isolateId: device.views.first.uiIsolate.id,
             )
         );
       }

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -684,29 +684,15 @@ extension FlutterVmService on vm_service.VmService {
   }
 
   /// List all [FlutterView]s attached to the current VM.
-  ///
-  /// If this returns an empty list, it will poll forever unless [returnEarly]
-  /// is set to true.
-  ///
-  /// By default, the poll duration is 50 milliseconds.
-  Future<List<FlutterView>> getFlutterViews({
-    bool returnEarly = false,
-    Duration delay = const Duration(milliseconds: 50),
-  }) async {
-    while (true) {
-      final vm_service.Response response = await callMethod(
-        kListViewsMethod,
-      );
-      final List<Object> rawViews = response.json['views'] as List<Object>;
-      final List<FlutterView> views = <FlutterView>[
-        for (final Object rawView in rawViews)
-          FlutterView.parse(rawView as Map<String, Object>)
-      ];
-      if (views.isNotEmpty || returnEarly) {
-        return views;
-      }
-      await Future<void>.delayed(delay);
-    }
+  Future<List<FlutterView>> getFlutterViews() async {
+    final vm_service.Response response = await callMethod(
+      kListViewsMethod,
+    );
+    final List<Object> rawViews = response.json['views'] as List<Object>;
+    return <FlutterView>[
+      for (final Object rawView in rawViews)
+        FlutterView.parse(rawView as Map<String, Object>)
+    ];
   }
 
   /// Attempt to retrieve the isolate with id [isolateId], or `null` if it has

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -66,7 +66,7 @@ abstract class ChromiumDevice extends Device {
   bool get supportsStartPaused => true;
 
   @override
-  bool get supportsFlutterExit => false;
+  bool get supportsFlutterExit => true;
 
   @override
   bool get supportsScreenshot => false;
@@ -342,9 +342,6 @@ class WebServerDevice extends Device {
 
   @override
   Future<bool> isLatestBuildInstalled(ApplicationPackage app) async => true;
-
-  @override
-  bool get supportsFlutterExit => false;
 
   @override
   Future<bool> get isLocalEmulator async => false;

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -685,6 +685,7 @@ VMServiceConnector getFakeVmServiceFactory({
     final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
       requests: <VmServiceExpectation>[
         FakeVmServiceRequest(
+          id: '1',
           method: kListViewsMethod,
           args: null,
           jsonResponse: <String, Object>{
@@ -697,12 +698,14 @@ VMServiceConnector getFakeVmServiceFactory({
           },
         ),
         FakeVmServiceRequest(
+          id: '2',
           method: 'getVM',
           args: null,
           jsonResponse: vm_service.VM.parse(<String, Object>{})
             .toJson(),
         ),
         FakeVmServiceRequest(
+          id: '3',
           method: '_createDevFS',
           args: <String, Object>{
             'fsName': globals.fs.currentDirectory.absolute.path,
@@ -712,6 +715,7 @@ VMServiceConnector getFakeVmServiceFactory({
           },
         ),
         FakeVmServiceRequest(
+          id: '4',
           method: kListViewsMethod,
           args: null,
           jsonResponse: <String, Object>{

--- a/packages/flutter_tools/test/commands.shard/permeable/devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/devices_test.dart
@@ -65,7 +65,7 @@ void main() {
             'hotRestart': true,
             'screenshot': false,
             'fastStart': false,
-            'flutterExit': false,
+            'flutterExit': true,
             'hardwareRendering': false,
             'startPaused': true
           }

--- a/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
+++ b/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
@@ -12,6 +12,7 @@ void main() {
     final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
       requests: <VmServiceExpectation>[
         FakeVmServiceRequest(
+          id: '1',
           method: 'getVM',
           jsonResponse: (vm_service.VM.parse(<String, Object>{})
             ..isolates = <vm_service.IsolateRef>[
@@ -22,6 +23,7 @@ void main() {
           ).toJson(),
         ),
         const FakeVmServiceRequest(
+          id: '2',
           method: 'getScripts',
           args: <String, Object>{
             'isolateId': '1',

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -129,6 +129,7 @@ void main() {
         final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
           requests: <VmServiceExpectation>[
             FakeVmServiceRequest(
+              id: '1',
               method: '_createDevFS',
               args: <String, Object>{
                 'fsName': 'test',
@@ -201,6 +202,7 @@ void main() {
       final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
         requests: <VmServiceExpectation>[
           FakeVmServiceRequest(
+            id: '1',
             method: '_createDevFS',
             args: <String, Object>{
               'fsName': 'test',

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
@@ -637,6 +637,7 @@ void main() {
       final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
         requests: <VmServiceExpectation>[
           FakeVmServiceRequest(
+            id: '1',
             method: kListViewsMethod,
             jsonResponse: <String, Object>{
               'views': <Object>[

--- a/packages/flutter_tools/test/general.shard/hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/hot_test.dart
@@ -21,36 +21,6 @@ import '../src/common.dart';
 import '../src/context.dart';
 import '../src/mocks.dart';
 
-final vm_service.Isolate fakeUnpausedIsolate = vm_service.Isolate(
-  id: '1',
-  pauseEvent: vm_service.Event(
-    kind: vm_service.EventKind.kResume,
-    timestamp: 0
-  ),
-  breakpoints: <vm_service.Breakpoint>[],
-  exceptionPauseMode: null,
-  libraries: <vm_service.LibraryRef>[],
-  livePorts: 0,
-  name: 'test',
-  number: '1',
-  pauseOnExit: false,
-  runnable: true,
-  startTime: 0,
-);
-
-final FlutterView fakeFlutterView = FlutterView(
-  id: 'a',
-  uiIsolate: fakeUnpausedIsolate,
-);
-
-final FakeVmServiceRequest listViews = FakeVmServiceRequest(
-  method: kListViewsMethod,
-  jsonResponse: <String, Object>{
-    'views': <Object>[
-      fakeFlutterView.toJson(),
-    ],
-  },
-);
 void main() {
   group('validateReloadReport', () {
     testUsingContext('invalid', () async {
@@ -202,72 +172,42 @@ void main() {
 
     testUsingContext('Does hot restarts when all devices support it', () async {
       final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-        listViews,
-        FakeVmServiceRequest(
-          method: 'getIsolate',
-          args: <String, Object>{
-            'isolateId': fakeUnpausedIsolate.id,
-          },
-          jsonResponse: fakeUnpausedIsolate.toJson(),
+        const FakeVmServiceRequest(
+          id: '1',
+          method: kListViewsMethod,
+          jsonResponse: <String, Object>{
+            'views': <Object>[],
+          }
+        ),
+         const FakeVmServiceRequest(
+          id: '2',
+          method: kListViewsMethod,
+          jsonResponse: <String, Object>{
+            'views': <Object>[],
+          }
         ),
         FakeVmServiceRequest(
+          id: '3',
           method: 'getVM',
           jsonResponse: vm_service.VM.parse(<String, Object>{}).toJson()
         ),
-        listViews,
         FakeVmServiceRequest(
-          method: 'getIsolate',
-          args: <String, Object>{
-            'isolateId': fakeUnpausedIsolate.id,
-          },
-          jsonResponse: fakeUnpausedIsolate.toJson(),
-        ),
-        FakeVmServiceRequest(
+          id: '4',
           method: 'getVM',
           jsonResponse: vm_service.VM.parse(<String, Object>{}).toJson()
         ),
-        listViews,
-        listViews,
         const FakeVmServiceRequest(
-          method: 'streamListen',
-          args: <String, Object>{
-            'streamId': 'Isolate',
+          id: '5',
+          method: kListViewsMethod,
+          jsonResponse: <String, Object>{
+            'views': <Object>[],
           }
         ),
         const FakeVmServiceRequest(
-          method: 'streamListen',
-          args: <String, Object>{
-            'streamId': 'Isolate',
-          }
-        ),
-        FakeVmServiceStreamResponse(
-          streamId: 'Isolate',
-          event: vm_service.Event(
-            timestamp: 0,
-            kind: vm_service.EventKind.kIsolateRunnable,
-          )
-        ),
-        FakeVmServiceStreamResponse(
-          streamId: 'Isolate',
-          event: vm_service.Event(
-            timestamp: 0,
-            kind: vm_service.EventKind.kIsolateRunnable,
-          )
-        ),
-        FakeVmServiceRequest(
-          method: kRunInViewMethod,
-          args: <String, Object>{
-            'viewId': fakeFlutterView.id,
-            'mainScript': 'lib/main.dart.dill',
-            'assetDirectory': 'build/flutter_assets',
-          }
-        ),
-        FakeVmServiceRequest(
-          method: kRunInViewMethod,
-          args: <String, Object>{
-            'viewId': fakeFlutterView.id,
-            'mainScript': 'lib/main.dart.dill',
-            'assetDirectory': 'build/flutter_assets',
+          id: '6',
+          method: kListViewsMethod,
+          jsonResponse: <String, Object>{
+            'views': <Object>[],
           }
         ),
       ]);
@@ -317,39 +257,24 @@ void main() {
     testUsingContext('hot restart supported', () async {
       // Setup mocks
       final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-        listViews,
-        FakeVmServiceRequest(
-          method: 'getIsolate',
-          args: <String, Object>{
-            'isolateId': fakeUnpausedIsolate.id,
-          },
-          jsonResponse: fakeUnpausedIsolate.toJson(),
-        ),
-        FakeVmServiceRequest(
-          method: 'getVM',
-          jsonResponse: vm_service.VM.parse(<String, Object>{}).toJson(),
-        ),
-        listViews,
         const FakeVmServiceRequest(
-          method: 'streamListen',
-          args: <String, Object>{
-            'streamId': 'Isolate',
+          id: '1',
+          method: kListViewsMethod,
+          jsonResponse: <String, Object>{
+            'views': <Object>[],
           }
         ),
         FakeVmServiceRequest(
-          method: kRunInViewMethod,
-          args: <String, Object>{
-            'viewId': fakeFlutterView.id,
-            'mainScript': 'lib/main.dart.dill',
-            'assetDirectory': 'build/flutter_assets',
-          }
+          id: '2',
+          method: 'getVM',
+          jsonResponse: vm_service.VM.parse(<String, Object>{}).toJson()
         ),
-        FakeVmServiceStreamResponse(
-          streamId: 'Isolate',
-          event: vm_service.Event(
-            timestamp: 0,
-            kind: vm_service.EventKind.kIsolateRunnable,
-          )
+        const FakeVmServiceRequest(
+          id: '3',
+          method: kListViewsMethod,
+          jsonResponse: <String, Object>{
+            'views': <Object>[],
+          }
         ),
       ]);
       final MockDevice mockDevice = MockDevice();

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -70,15 +70,6 @@ final FlutterView fakeFlutterView = FlutterView(
   uiIsolate: fakeUnpausedIsolate,
 );
 
-final FakeVmServiceRequest listViews = FakeVmServiceRequest(
-  method: kListViewsMethod,
-  jsonResponse: <String, Object>{
-    'views': <Object>[
-      fakeFlutterView.toJson(),
-    ],
-  },
-);
-
 void main() {
   final Uri testUri = Uri.parse('foo://bar');
   Testbed testbed;
@@ -136,6 +127,10 @@ void main() {
       );
     });
     when(mockFlutterDevice.devFS).thenReturn(mockDevFS);
+    when(mockFlutterDevice.views).thenReturn(<FlutterView>[
+      // NB: still using mock FlutterDevice.
+      fakeFlutterView,
+    ]);
     when(mockFlutterDevice.device).thenReturn(mockDevice);
     when(mockFlutterDevice.stopEchoingDeviceLog()).thenAnswer((Invocation invocation) async { });
     when(mockFlutterDevice.observatoryUris).thenAnswer((_) => Stream<Uri>.value(testUri));
@@ -151,6 +146,7 @@ void main() {
     when(mockFlutterDevice.vmService).thenAnswer((Invocation invocation) {
       return fakeVmServiceHost.vmService;
     });
+    when(mockFlutterDevice.refreshViews()).thenAnswer((Invocation invocation) async { });
     when(mockFlutterDevice.reloadSources(any, pause: anyNamed('pause'))).thenAnswer((Invocation invocation) async {
       return <Future<vm_service.ReloadReport>>[
         Future<vm_service.ReloadReport>.value(vm_service.ReloadReport.parse(<String, dynamic>{
@@ -170,7 +166,15 @@ void main() {
 
   test('FlutterDevice can list views with a filter', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
+      FakeVmServiceRequest(
+        id: '1',
+        method: kListViewsMethod,
+        jsonResponse: <String, Object>{
+          'views': <Object>[
+            fakeFlutterView.toJson(),
+          ],
+        },
+      ),
     ]);
     final MockDevice mockDevice = MockDevice();
     final FlutterDevice flutterDevice = FlutterDevice(
@@ -180,13 +184,14 @@ void main() {
     );
 
     flutterDevice.vmService = fakeVmServiceHost.vmService;
+
+    await flutterDevice.refreshViews();
+
+    expect(flutterDevice.views, isEmpty);
   }));
 
   test('ResidentRunner can attach to device successfully', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ]);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     final Completer<DebugConnectionInfo> onConnectionInfo = Completer<DebugConnectionInfo>.sync();
     final Completer<void> onAppStart = Completer<void>.sync();
     final Future<int> result = residentRunner.attach(
@@ -202,15 +207,12 @@ void main() {
     expect(onConnectionInfo.isCompleted, true);
     expect((await connectionInfo).baseUri, 'foo://bar');
     expect(onAppStart.isCompleted, true);
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }));
 
   test('ResidentRunner can attach to device successfully with --fast-start', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-      listViews,
       FakeVmServiceRequest(
+        id: '1',
         method: 'getIsolate',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -218,17 +220,19 @@ void main() {
         jsonResponse: fakeUnpausedIsolate.toJson(),
       ),
       FakeVmServiceRequest(
+        id: '2',
         method: 'getVM',
         jsonResponse: vm_service.VM.parse(<String, Object>{}).toJson(),
       ),
-      listViews,
       const FakeVmServiceRequest(
+        id: '3',
         method: 'streamListen',
         args: <String, Object>{
           'streamId': 'Isolate',
         }
       ),
       FakeVmServiceRequest(
+        id: '4',
         method: kRunInViewMethod,
         args: <String, Object>{
           'viewId': fakeFlutterView.id,
@@ -280,15 +284,10 @@ void main() {
     expect(onConnectionInfo.isCompleted, true);
     expect((await connectionInfo).baseUri, 'foo://bar');
     expect(onAppStart.isCompleted, true);
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }));
 
   test('ResidentRunner can handle an RPC exception from hot reload', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-      listViews,
-    ]);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     when(mockDevice.sdkNameAndVersion).thenAnswer((Invocation invocation) async {
       return 'Example';
     });
@@ -330,18 +329,15 @@ void main() {
       cdKey(CustomDimensions.hotEventEmulator): 'false',
       cdKey(CustomDimensions.hotEventFullRestart): 'false',
     })).called(1);
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     Usage: () => MockUsage(),
   }));
 
   test('ResidentRunner can send target platform to analytics from hot reload', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-      listViews,
-      listViews,
+      // Not all requests are present due to existing mocks
       FakeVmServiceRequest(
+        id: '1',
         method: 'getIsolate',
         args: <String, Object>{
           'isolateId': '1',
@@ -349,6 +345,7 @@ void main() {
         jsonResponse: fakeUnpausedIsolate.toJson(),
       ),
       FakeVmServiceRequest(
+        id: '2',
         method: 'ext.flutter.reassemble',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -384,11 +381,10 @@ void main() {
   }));
 
   test('ResidentRunner can send target platform to analytics from full restart', () => testbed.run(() async {
+     // Not all requests are present due to existing mocks
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-      listViews,
       FakeVmServiceRequest(
+        id: '1',
         method: 'getIsolate',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -396,17 +392,19 @@ void main() {
         jsonResponse: fakeUnpausedIsolate.toJson(),
       ),
       FakeVmServiceRequest(
+        id: '2',
         method: 'getVM',
         jsonResponse: vm_service.VM.parse(<String, Object>{}).toJson(),
       ),
-      listViews,
       const FakeVmServiceRequest(
+        id: '3',
         method: 'streamListen',
         args: <String, Object>{
           'streamId': 'Isolate',
         },
       ),
       FakeVmServiceRequest(
+        id: '4',
         method: kRunInViewMethod,
         args: <String, Object>{
           'viewId': fakeFlutterView.id,
@@ -447,16 +445,12 @@ void main() {
       containsPair(cdKey(CustomDimensions.hotEventTargetPlatform),
                    getNameForTargetPlatform(TargetPlatform.android_arm)),
     );
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     Usage: () => MockUsage(),
   }));
 
   test('ResidentRunner Can handle an RPC exception from hot restart', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ]);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     when(mockDevice.sdkNameAndVersion).thenAnswer((Invocation invocation) async {
       return 'Example';
     });
@@ -499,7 +493,6 @@ void main() {
       cdKey(CustomDimensions.hotEventEmulator): 'false',
       cdKey(CustomDimensions.hotEventFullRestart): 'true',
     })).called(1);
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     Usage: () => MockUsage(),
   }));
@@ -585,15 +578,14 @@ void main() {
 
   test('ResidentRunner does support CanvasKit', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-
     expect(() => residentRunner.toggleCanvaskit(),
       throwsA(isA<Exception>()));
   }));
 
   test('ResidentRunner handles writeSkSL returning no data', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      FakeVmServiceRequest(
+       FakeVmServiceRequest(
+        id: '1',
         method: kGetSkSLsMethod,
         args: <String, Object>{
           'viewId': fakeFlutterView.id,
@@ -601,18 +593,17 @@ void main() {
         jsonResponse: <String, Object>{
           'SkSLs': <String, Object>{}
         }
-      ),
+      )
     ]);
     await residentRunner.writeSkSL();
 
     expect(testLogger.statusText, contains('No data was receieved'));
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }));
 
   test('ResidentRunner can write SkSL data to a unique file with engine revision, platform, and device name', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
       FakeVmServiceRequest(
+        id: '1',
         method: kGetSkSLsMethod,
         args: <String, Object>{
           'viewId': fakeFlutterView.id,
@@ -643,8 +634,8 @@ void main() {
 
   test('ResidentRunner can take screenshot on debug device', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
       FakeVmServiceRequest(
+        id: '1',
         method: 'ext.flutter.debugAllowBanner',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -652,6 +643,7 @@ void main() {
         },
       ),
       FakeVmServiceRequest(
+        id: '2',
         method: 'ext.flutter.debugAllowBanner',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -684,8 +676,8 @@ void main() {
 
   test('ResidentRunner bails taking screenshot on debug device if debugAllowBanner throws RpcError', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
       FakeVmServiceRequest(
+        id: '1',
         method: 'ext.flutter.debugAllowBanner',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -704,8 +696,8 @@ void main() {
 
   test('ResidentRunner bails taking screenshot on debug device if debugAllowBanner during second request', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
       FakeVmServiceRequest(
+        id: '1',
         method: 'ext.flutter.debugAllowBanner',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -713,6 +705,7 @@ void main() {
         },
       ),
       FakeVmServiceRequest(
+        id: '2',
         method: 'ext.flutter.debugAllowBanner',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -726,13 +719,12 @@ void main() {
     await residentRunner.screenshot(mockFlutterDevice);
 
     expect(testLogger.errorText, contains('Error'));
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }));
 
   test('ResidentRunner bails taking screenshot on debug device if takeScreenshot throws', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
       FakeVmServiceRequest(
+        id: '1',
         method: 'ext.flutter.debugAllowBanner',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -740,6 +732,7 @@ void main() {
         },
       ),
       FakeVmServiceRequest(
+        id: '2',
         method: 'ext.flutter.debugAllowBanner',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -761,13 +754,10 @@ void main() {
 
     expect(() => residentRunner.screenshot(mockFlutterDevice),
         throwsAssertionError);
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }));
 
   test('ResidentRunner does not toggle banner in non-debug mode', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-    ]);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     residentRunner = HotRunner(
       <FlutterDevice>[
         mockFlutterDevice,
@@ -791,6 +781,7 @@ void main() {
   test('FlutterDevice will not exit a paused isolate', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       FakeVmServiceRequest(
+        id: '1',
         method: '_flutter.listViews',
         jsonResponse: <String, Object>{
           'views': <Object>[
@@ -799,6 +790,7 @@ void main() {
         },
       ),
       FakeVmServiceRequest(
+        id: '2',
         method: 'getIsolate',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -808,6 +800,7 @@ void main() {
     ]);
     final TestFlutterDevice flutterDevice = TestFlutterDevice(
       mockDevice,
+      <FlutterView>[ fakeFlutterView ],
     );
     flutterDevice.vmService = fakeVmServiceHost.vmService;
     when(mockDevice.supportsFlutterExit).thenReturn(true);
@@ -821,6 +814,7 @@ void main() {
   test('FlutterDevice will call stopApp if the exit request times out', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       FakeVmServiceRequest(
+        id: '1',
         method: '_flutter.listViews',
         jsonResponse: <String, Object>{
           'views': <Object>[
@@ -829,6 +823,7 @@ void main() {
         },
       ),
       FakeVmServiceRequest(
+        id: '2',
         method: 'getIsolate',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -836,6 +831,7 @@ void main() {
         jsonResponse: fakeUnpausedIsolate.toJson(),
       ),
       FakeVmServiceRequest(
+        id: '3',
         method: 'ext.flutter.exit',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -846,6 +842,7 @@ void main() {
     ]);
     final TestFlutterDevice flutterDevice = TestFlutterDevice(
       mockDevice,
+      <FlutterView>[ fakeFlutterView ],
     );
     flutterDevice.vmService = fakeVmServiceHost.vmService;
     when(mockDevice.supportsFlutterExit).thenReturn(true);
@@ -861,6 +858,7 @@ void main() {
   test('FlutterDevice will exit an un-paused isolate', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       FakeVmServiceRequest(
+        id: '1',
         method: kListViewsMethod,
         jsonResponse: <String, Object>{
           'views': <Object>[
@@ -869,6 +867,7 @@ void main() {
         },
       ),
       FakeVmServiceRequest(
+        id: '2',
         method: 'getIsolate',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id
@@ -876,6 +875,7 @@ void main() {
         jsonResponse: fakeUnpausedIsolate.toJson(),
       ),
       FakeVmServiceRequest(
+        id: '3',
         method: 'ext.flutter.exit',
         args: <String, Object>{
           'isolateId': fakeUnpausedIsolate.id,
@@ -885,6 +885,7 @@ void main() {
     ]);
     final TestFlutterDevice flutterDevice = TestFlutterDevice(
       mockDevice,
+      <FlutterView> [fakeFlutterView ],
     );
     flutterDevice.vmService = fakeVmServiceHost.vmService;
 
@@ -896,10 +897,18 @@ void main() {
     expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }));
 
+  test('ResidentRunner refreshViews calls flutter device', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    await residentRunner.refreshViews();
+
+    verify(mockFlutterDevice.refreshViews()).called(1);
+  }));
+
   test('ResidentRunner debugDumpApp calls flutter device', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     await residentRunner.debugDumpApp();
 
+    verify(mockFlutterDevice.refreshViews()).called(1);
     verify(mockFlutterDevice.debugDumpApp()).called(1);
   }));
 
@@ -907,6 +916,7 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     await residentRunner.debugDumpRenderTree();
 
+    verify(mockFlutterDevice.refreshViews()).called(1);
     verify(mockFlutterDevice.debugDumpRenderTree()).called(1);
   }));
 
@@ -914,6 +924,7 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     await residentRunner.debugDumpLayerTree();
 
+    verify(mockFlutterDevice.refreshViews()).called(1);
     verify(mockFlutterDevice.debugDumpLayerTree()).called(1);
   }));
 
@@ -921,6 +932,7 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     await residentRunner.debugDumpSemanticsTreeInTraversalOrder();
 
+    verify(mockFlutterDevice.refreshViews()).called(1);
     verify(mockFlutterDevice.debugDumpSemanticsTreeInTraversalOrder()).called(1);
   }));
 
@@ -928,6 +940,7 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     await residentRunner.debugDumpSemanticsTreeInInverseHitTestOrder();
 
+    verify(mockFlutterDevice.refreshViews()).called(1);
     verify(mockFlutterDevice.debugDumpSemanticsTreeInInverseHitTestOrder()).called(1);
   }));
 
@@ -935,6 +948,7 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     await residentRunner.debugToggleDebugPaintSizeEnabled();
 
+    verify(mockFlutterDevice.refreshViews()).called(1);
     verify(mockFlutterDevice.toggleDebugPaintSizeEnabled()).called(1);
   }));
 
@@ -942,6 +956,7 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     await residentRunner.debugToggleDebugCheckElevationsEnabled();
 
+    verify(mockFlutterDevice.refreshViews()).called(1);
     verify(mockFlutterDevice.toggleDebugCheckElevationsEnabled()).called(1);
   }));
 
@@ -949,6 +964,7 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     await residentRunner.debugTogglePerformanceOverlayOverride();
 
+    verify(mockFlutterDevice.refreshViews()).called(1);
     verify(mockFlutterDevice.debugTogglePerformanceOverlayOverride()).called(1);
   }));
 
@@ -956,6 +972,7 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     await residentRunner.debugToggleWidgetInspector();
 
+    verify(mockFlutterDevice.refreshViews()).called(1);
     verify(mockFlutterDevice.toggleWidgetInspector()).called(1);
   }));
 
@@ -963,14 +980,12 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     await residentRunner.debugToggleProfileWidgetBuilds();
 
+    verify(mockFlutterDevice.refreshViews()).called(1);
     verify(mockFlutterDevice.toggleProfileWidgetBuilds()).called(1);
   }));
 
   test('HotRunner writes vm service file when providing debugging option', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ]);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     setWsAddress(testUri, fakeVmServiceHost.vmService);
     globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
     residentRunner = HotRunner(
@@ -992,10 +1007,7 @@ void main() {
   }));
 
   test('HotRunner unforwards device ports', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ]);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     final MockDevicePortForwarder mockPortForwarder = MockDevicePortForwarder();
     when(mockDevice.portForwarder).thenReturn(mockPortForwarder);
     globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
@@ -1023,10 +1035,7 @@ void main() {
   }));
 
   test('HotRunner handles failure to write vmservice file', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-      listViews,
-    ]);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
     residentRunner = HotRunner(
       <FlutterDevice>[
@@ -1044,16 +1053,13 @@ void main() {
     await residentRunner.run();
 
     expect(testLogger.errorText, contains('Failed to write vmservice-out-file at foo'));
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => ThrowingForwardingFileSystem(MemoryFileSystem()),
   }));
 
 
   test('ColdRunner writes vm service file when providing debugging option', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      listViews,
-    ]);
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
     setWsAddress(testUri, fakeVmServiceHost.vmService);
     residentRunner = ColdRunner(
@@ -1072,7 +1078,6 @@ void main() {
     await residentRunner.run();
 
     expect(await globals.fs.file('foo').readAsString(), testUri.toString());
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }));
 
   test('FlutterDevice uses dartdevc configuration when targeting web', () => testbed.run(() async {
@@ -1112,6 +1117,7 @@ void main() {
 
     final TestFlutterDevice flutterDevice = TestFlutterDevice(
       mockDevice,
+      <FlutterView>[],
       observatoryUris: Stream<Uri>.value(testUri),
     );
 
@@ -1147,10 +1153,13 @@ class MockUsage extends Mock implements Usage {}
 class MockProcessManager extends Mock implements ProcessManager {}
 
 class TestFlutterDevice extends FlutterDevice {
-  TestFlutterDevice(Device device, { Stream<Uri> observatoryUris })
+  TestFlutterDevice(Device device, this.views, { Stream<Uri> observatoryUris })
     : super(device, buildInfo: BuildInfo.debug) {
     _observatoryUris = observatoryUris;
   }
+
+  @override
+  final List<FlutterView> views;
 
   @override
   Stream<Uri> get observatoryUris => _observatoryUris;

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -36,12 +36,14 @@ import '../src/testbed.dart';
 
 const List<VmServiceExpectation> kAttachLogExpectations = <VmServiceExpectation>[
   FakeVmServiceRequest(
+    id: '1',
     method: 'streamListen',
     args: <String, Object>{
       'streamId': 'Stdout',
     },
   ),
   FakeVmServiceRequest(
+    id: '2',
     method: 'streamListen',
     args: <String, Object>{
       'streamId': 'Stderr',
@@ -51,12 +53,14 @@ const List<VmServiceExpectation> kAttachLogExpectations = <VmServiceExpectation>
 
 const List<VmServiceExpectation> kAttachIsolateExpectations = <VmServiceExpectation>[
   FakeVmServiceRequest(
+    id: '3',
     method: 'streamListen',
     args: <String, Object>{
       'streamId': 'Isolate'
     }
   ),
   FakeVmServiceRequest(
+    id: '4',
     method: 'registerService',
     args: <String, Object>{
       'service': 'reloadSources',
@@ -358,6 +362,7 @@ void main() {
       ...kAttachExpectations,
       const FakeVmServiceRequest(
         method: 'hotRestart',
+        id: '5',
         jsonResponse: <String, Object>{
           'type': 'Success',
         }
@@ -434,6 +439,7 @@ void main() {
       ...kAttachExpectations,
       const FakeVmServiceRequest(
         method: 'hotRestart',
+        id: '5',
         jsonResponse: <String, Object>{
           'type': 'Success',
         }
@@ -664,6 +670,7 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
+        id: '5',
         method: 'hotRestart',
         jsonResponse: <String, Object>{
           'type': 'Failed',
@@ -686,6 +693,7 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
+        id: '5',
         method: 'hotRestart',
         // Failed response,
         errorCode: RPCErrorCodes.kInternalError,
@@ -717,6 +725,7 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
+        id: '5',
         method: 'ext.flutter.debugDumpApp',
         args: <String, Object>{
           'isolateId': null,
@@ -738,6 +747,7 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
+        id: '5',
         method: 'ext.flutter.debugDumpLayerTree',
         args: <String, Object>{
           'isolateId': null,
@@ -759,6 +769,7 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
+        id: '5',
         method: 'ext.flutter.debugDumpRenderTree',
         args: <String, Object>{
           'isolateId': null,
@@ -780,6 +791,7 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
+        id: '5',
         method: 'ext.flutter.debugDumpSemanticsTreeInTraversalOrder',
         args: <String, Object>{
           'isolateId': null,
@@ -801,6 +813,7 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
+        id: '5',
         method: 'ext.flutter.debugDumpSemanticsTreeInInverseHitTestOrder',
         args: <String, Object>{
           'isolateId': null,
@@ -823,6 +836,7 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
+        id: '5',
         method: 'ext.flutter.debugPaint',
         args: <String, Object>{
           'isolateId': null,
@@ -832,6 +846,7 @@ void main() {
         },
       ),
       const FakeVmServiceRequest(
+        id: '6',
         method: 'ext.flutter.debugPaint',
         args: <String, Object>{
           'isolateId': null,
@@ -859,6 +874,7 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
+        id: '5',
         method: 'ext.flutter.showPerformanceOverlay',
         args: <String, Object>{
           'isolateId': null,
@@ -868,6 +884,7 @@ void main() {
         },
       ),
       const FakeVmServiceRequest(
+        id: '6',
         method: 'ext.flutter.showPerformanceOverlay',
         args: <String, Object>{
           'isolateId': null,
@@ -894,6 +911,7 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
+        id: '5',
         method: 'ext.flutter.inspector.show',
         args: <String, Object>{
           'isolateId': null,
@@ -903,6 +921,7 @@ void main() {
         },
       ),
       const FakeVmServiceRequest(
+        id: '6',
         method: 'ext.flutter.inspector.show',
         args: <String, Object>{
           'isolateId': null,
@@ -929,6 +948,7 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
+        id: '5',
         method: 'ext.flutter.profileWidgetBuilds',
         args: <String, Object>{
           'isolateId': null,
@@ -938,6 +958,7 @@ void main() {
         },
       ),
       const FakeVmServiceRequest(
+        id: '6',
         method: 'ext.flutter.profileWidgetBuilds',
         args: <String, Object>{
           'isolateId': null,
@@ -964,6 +985,7 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachExpectations,
       const FakeVmServiceRequest(
+        id: '5',
         method: 'ext.flutter.platformOverride',
         args: <String, Object>{
           'isolateId': null,
@@ -973,6 +995,7 @@ void main() {
         },
       ),
       const FakeVmServiceRequest(
+        id: '6',
         method: 'ext.flutter.platformOverride',
         args: <String, Object>{
           'isolateId': null,
@@ -1066,12 +1089,14 @@ void main() {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachLogExpectations,
       const FakeVmServiceRequest(
+        id: '3',
         method: 'streamListen',
         args: <String, Object>{
           'streamId': 'Isolate'
         }
       ),
       const FakeVmServiceRequest(
+        id: '4',
         method: 'registerService',
         args: <String, Object>{
           'service': 'reloadSources',

--- a/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
@@ -139,9 +139,7 @@ void main() {
       final MockFlutterDevice mockFlutterDevice = MockFlutterDevice();
       when(mockResidentRunner.isRunningDebug).thenReturn(true);
       when(mockResidentRunner.flutterDevices).thenReturn(<FlutterDevice>[mockFlutterDevice]);
-      when(mockResidentRunner.listFlutterViews()).thenAnswer((Invocation invocation) async {
-        return <FlutterView>[];
-      });
+      when(mockFlutterDevice.views).thenReturn(<FlutterView>[]);
 
       await terminalHandler.processTerminalInput('l');
 

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -231,10 +231,10 @@ void main() {
   testWithoutContext('runInView forwards arguments correctly', () async {
     final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
       requests: <VmServiceExpectation>[
-        const FakeVmServiceRequest(method: 'streamListen', args: <String, Object>{
+        const FakeVmServiceRequest(method: 'streamListen', id: '1', args: <String, Object>{
           'streamId': 'Isolate'
         }),
-        const FakeVmServiceRequest(method: kRunInViewMethod, args: <String, Object>{
+        const FakeVmServiceRequest(method: kRunInViewMethod, id: '2', args: <String, Object>{
           'viewId': '1234',
           'mainScript': 'main.dart',
           'assetDirectory': 'flutter_assets/',
@@ -253,65 +253,6 @@ void main() {
       viewId: '1234',
       main: Uri.file('main.dart'),
       assetsDirectory: Uri.file('flutter_assets/'),
-    );
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
-  });
-
-  testWithoutContext('getFlutterViews polls until a view is returned', () async {
-    final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
-      requests: <VmServiceExpectation>[
-        const FakeVmServiceRequest(
-          method: kListViewsMethod,
-          jsonResponse: <String, Object>{
-            'views': <Object>[],
-          },
-        ),
-        const FakeVmServiceRequest(
-          method: kListViewsMethod,
-          jsonResponse: <String, Object>{
-            'views': <Object>[],
-          },
-        ),
-        const FakeVmServiceRequest(
-          method: kListViewsMethod,
-          jsonResponse: <String, Object>{
-            'views': <Object>[
-              <String, Object>{
-                'id': 'a',
-                'isolate': <String, Object>{},
-              },
-            ],
-          },
-        ),
-      ]
-    );
-
-    expect(
-      await fakeVmServiceHost.vmService.getFlutterViews(
-        delay: Duration.zero,
-      ),
-      isNotEmpty,
-    );
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
-  });
-
-  testWithoutContext('getFlutterViews does not poll if returnEarly is true', () async {
-    final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
-      requests: <VmServiceExpectation>[
-        const FakeVmServiceRequest(
-          method: kListViewsMethod,
-          jsonResponse: <String, Object>{
-            'views': <Object>[],
-          },
-        ),
-      ]
-    );
-
-    expect(
-      await fakeVmServiceHost.vmService.getFlutterViews(
-        returnEarly: true,
-      ),
-      isEmpty,
     );
     expect(fakeVmServiceHost.hasRemainingExpectations, false);
   });

--- a/packages/flutter_tools/test/general.shard/web/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devices_test.dart
@@ -76,7 +76,7 @@ void main() {
     expect(chromeDevice.supportsHotReload, true);
     expect(chromeDevice.supportsHotRestart, true);
     expect(chromeDevice.supportsStartPaused, true);
-    expect(chromeDevice.supportsFlutterExit, false);
+    expect(chromeDevice.supportsFlutterExit, true);
     expect(chromeDevice.supportsScreenshot, false);
     expect(await chromeDevice.isLocalEmulator, false);
     expect(chromeDevice.getLogReader(), isA<NoOpDeviceLogReader>());
@@ -96,7 +96,7 @@ void main() {
     expect(chromeDevice.supportsHotReload, true);
     expect(chromeDevice.supportsHotRestart, true);
     expect(chromeDevice.supportsStartPaused, true);
-    expect(chromeDevice.supportsFlutterExit, false);
+    expect(chromeDevice.supportsFlutterExit, true);
     expect(chromeDevice.supportsScreenshot, false);
     expect(await chromeDevice.isLocalEmulator, false);
     expect(chromeDevice.getLogReader(), isA<NoOpDeviceLogReader>());
@@ -114,7 +114,7 @@ void main() {
     expect(device.supportsHotReload, true);
     expect(device.supportsHotRestart, true);
     expect(device.supportsStartPaused, true);
-    expect(device.supportsFlutterExit, false);
+    expect(device.supportsFlutterExit, true);
     expect(device.supportsScreenshot, false);
     expect(await device.isLocalEmulator, false);
     expect(device.getLogReader(), isA<NoOpDeviceLogReader>());

--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -239,6 +239,7 @@ class FakeVmServiceHost {
       final FakeVmServiceRequest fakeRequest = _requests.removeAt(0) as FakeVmServiceRequest;
       expect(request, isA<Map<String, Object>>()
         .having((Map<String, Object> request) => request['method'], 'method', fakeRequest.method)
+        .having((Map<String, Object> request) => request['id'], 'id', fakeRequest.id)
         .having((Map<String, Object> request) => request['params'], 'args', fakeRequest.args)
       );
       if (fakeRequest.close) {
@@ -249,13 +250,13 @@ class FakeVmServiceHost {
       if (fakeRequest.errorCode == null) {
         _input.add(json.encode(<String, Object>{
           'jsonrpc': '2.0',
-          'id': request['id'],
+          'id': fakeRequest.id,
           'result': fakeRequest.jsonResponse ?? <String, Object>{'type': 'Success'},
         }));
       } else {
         _input.add(json.encode(<String, Object>{
           'jsonrpc': '2.0',
-          'id': request['id'],
+          'id': fakeRequest.id,
           'error': <String, Object>{
             'code': fakeRequest.errorCode,
           }
@@ -298,6 +299,7 @@ abstract class VmServiceExpectation {
 class FakeVmServiceRequest implements VmServiceExpectation {
   const FakeVmServiceRequest({
     @required this.method,
+    @required this.id,
     this.args = const <String, Object>{},
     this.jsonResponse,
     this.errorCode,
@@ -305,6 +307,7 @@ class FakeVmServiceRequest implements VmServiceExpectation {
   });
 
   final String method;
+  final String id;
 
   /// When true, the vm service is automatically closed.
   final bool close;


### PR DESCRIPTION
Reverts flutter/flutter#56223

This broke the run_release_test:

```
2020-05-05T11:13:12.214517: run:stderr: NoSuchMethodError: The method 'callMethod' was called on null.
run:stderr: Receiver: null
run:stderr: Tried calling: callMethod("_flutter.listViews")
run:stderr: #0      Object.noSuchMethod (dart:core-patch/object_patch.dart:53:5)
2020-05-05T11:13:12.214689: run:stderr: #1      FlutterVmService.getFlutterViews (package:flutter_tools/src/vmservice.dart:697:50)
run:stderr: #2      FlutterDevice.exitApps (package:flutter_tools/src/resident_runner.dart:235:53)
run:stderr: #3      ResidentRunner.exitApp (package:flutter_tools/src/resident_runner.dart:1170:66)
run:stderr: #4      ResidentRunner.exit (package:flutter_tools/src/resident_runner.dart:894:11)
run:stderr: <asynchronous suspension>
run:stderr: #5      TerminalHandler._commonTerminalInputHandler (package:flutter_tools/src/resident_runner.dart:1392:30)
run:stderr: #6      TerminalHandler.processTerminalInput (package:flutter_tools/src/resident_runner.dart:1476:13)
run:stderr: #7      _rootRunUnary (dart:async/zone.dart:1192:38)
run:stderr: #8      _CustomZone.runUnary (dart:async/zone.dart:1085:19)
run:stderr: #9      _CustomZone.runUnaryGuarded (dart:async/zone.dart:987:7)
run:stderr: #10     _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:339:11)
2020-05-05T11:13:12.214811: run:stderr: #11     _BufferingStreamSubscription._add (dart:async/stream_impl.dart:266:7)
run:stderr: #12     _SyncBroadcastStreamController._sendData (dart:async/broadcast_stream_controller.dart:378:20)
run:stderr: #13     _BroadcastStreamController.add (dart:async/broadcast_stream_controller.dart:252:5)
run:stderr: #14     _AsBroadcastStreamController.add (dart:async/broadcast_stream_controller.dart:477:11)
run:stderr: #15     _rootRunUnary (dart:async/zone.dart:1192:38)
run:stderr: #16     _CustomZone.runUnary (dart:async/zone.dart:1085:19)
run:stderr: #17     _CustomZone.runUnaryGuarded (dart:async/zone.dart:987:7)
run:stderr: #18     _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:339:11)
2020-05-05T11:13:12.214927: run:stderr: #19     _BufferingStreamSubscription._add (dart:async/stream_impl.dart:266:7)
run:stderr: #20     _SinkTransformerStreamSubscription._add (dart:async/stream_transformers.dart:70:11)
run:stderr: #21     _EventSinkWrapper.add (dart:async/stream_transformers.dart:17:11)
run:stderr: #22     _StringAdapterSink.add (dart:convert/string_conversion.dart:238:11)
run:stderr: #23     _StringAdapterSink.addSlice (dart:convert/string_conversion.dart:243:7)
run:stderr: #24     _Utf8ConversionSink.addSlice (dart:convert/string_conversion.dart:315:20)
2020-05-05T11:13:12.215052: run:stderr: #25     _ErrorHandlingAsciiDecoderSink.addSlice (dart:convert/ascii.dart:254:17)
run:stderr: #26     _ErrorHandlingAsciiDecoderSink.add (dart:convert/ascii.dart:240:5)
run:stderr: #27     _ConverterStreamEventSink.add (dart:convert/chunked_conversion.dart:74:18)
run:stderr: #28     _SinkTransformerStreamSubscription._handleData (dart:async/stream_transformers.dart:122:24)
run:stderr: #29     _rootRunUnary (dart:async/zone.dart:1192:38)
run:stderr: #30     _CustomZone.runUnary (dart:async/zone.dart:1085:19)
run:stderr: #31     _CustomZone.runUnaryGuarded (dart:async/zone.dart:987:7)
2020-05-05T11:13:12.215166: run:stderr: #32     _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:339:11)
run:stderr: #33     _BufferingStreamSubscription._add (dart:async/stream_impl.dart:266:7)
run:stderr: #34     _SyncStreamControllerDispatch._sendData (dart:async/stream_controller.dart:779:19)
run:stderr: #35     _StreamController._add (dart:async/stream_controller.dart:655:7)
run:stderr: #36     _StreamController.add (dart:async/stream_controller.dart:597:5)
run:stderr: #37     _Socket._onData (dart:io-patch/socket_patch.dart:1999:41)
run:stderr: #38     _rootRunUnary (dart:async/zone.dart:1196:13)
2020-05-05T11:13:12.215313: run:stderr: #39     _CustomZone.runUnary (dart:async/zone.dart:1085:19)
run:stderr: #40     _CustomZone.runUnaryGuarded (dart:async/zone.dart:987:7)
run:stderr: #41     _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:339:11)
run:stderr: #42     _BufferingStreamSubscription._add (dart:async/stream_impl.dart:266:7)
run:stderr: #43     _SyncStreamControllerDispatch._sendData (dart:async/stream_controller.dart:779:19)
run:stderr: #44     _StreamController._add (dart:async/stream_controller.dart:655:7)
run:stderr: #45     _StreamController.add (dart:async/stream_controller.dart:597:5)
run:stderr: #46     new _RawSocket.<anonymous closure> (dart:io-patch/socket_patch.dart:1544:33)
2020-05-05T11:13:12.215429: run:stderr: #47     _NativeSocket.issueReadEvent.issue (dart:io-patch/socket_patch.dart:1036:14)
run:stderr: #48     _microtaskLoop (dart:async/schedule_microtask.dart:43:21)
run:stderr: #49     _startMicrotaskLoop (dart:async/schedule_microtask.dart:52:5)
run:stderr: #50     _runPendingImmediateCallback (dart:isolate-patch/isolate_patch.dart:118:13)
run:stderr: #51     _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:169:5)
run:stderr: 
2020-05-05T11:13:12.222191: run:stderr: 
2020-05-05T11:13:12.229922: run:stderr: Oops; flutter has exited unexpectedly: "NoSuchMethodError: The method 'callMethod' was called on null.
run:stderr: Receiver: null
run:stderr: Tried calling: callMethod("_flutter.listViews")".
2020-05-05T11:13:17.148286: run:stderr: A crash report has been written to /Users/flutter/.cocoon/flutter/dev/integration_tests/ui/flutter_01.log.
2020-05-05T11:13:17.148450: run:stdout: This crash may already be reported. Check GitHub for similar crashes.
2020-05-05T11:13:17.148895: run:stdout: https://github.com/flutter/flutter/issues?q=is%3Aissue+NoSuchMethodError%3A+The+method+%27callMethod%27+was+called+on+null.%0AReceiver%3A+null%0ATried+calling%3A+callMethod%28%22_flutter.listViews%22%29
2020-05-05T11:13:17.149115: run:stdout: 
2020-05-05T11:13:17.149250: run:stdout: To report your crash to the Flutter team, first read the guide to filing a bug.
run:stdout: https://flutter.dev/docs/resources/bug-reports
2020-05-05T11:13:17.149383: run:stdout: 
2020-05-05T11:13:17.149511: run:stdout: Create a new GitHub issue by pasting this link into your browser and completing the issue template. Thank you!
2020-05-05T11:13:17.765088: run:stdout: https://git.io/JfZUx
run:stdout: 
2020-05-05T11:13:17.781709: "/Users/flutter/.cocoon/flutter/bin/flutter" exit code: 1
2020-05-05T11:13:17.792642: Task failed: flutter run --release had output on standard error.2020-05-05T11:13:17.793089: 

```

TBR @jmagman 