### PR TITLE
[devicelab] allow the tool to use the word waiting more than once

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_attach_test_android.dart
+++ b/dev/devicelab/bin/tasks/flutter_attach_test_android.dart
@@ -31,7 +31,7 @@ Future<void> testReload(Process process, { Future<void> Function() onListening }
       .listen((String line) {
     print('attach:stdout: $line');
     stdout.add(line);
-    if (line.contains('Waiting') && onListening != null)
+    if (line.contains('Waiting') && onListening != null && !listening.isCompleted)
       listening.complete(onListening());
     if (line.contains('Quit (terminate the application on the device)'))
       ready.complete();


### PR DESCRIPTION
## Description

The stdout state machine need not overly limit the vocabulary of the tool.