### PR TITLE
Save results of A/B test runs in a JSON file for future processing

### DIFF
--- a/dev/devicelab/README.md
+++ b/dev/devicelab/README.md
@@ -167,8 +167,10 @@ An example of a local engine architecture is `android_debug_unopt_x86`.
 You can run an A/B test that compares the performance of the default engine
 against a local engine build. The test runs the same benchmark a specified
 number of times against both engines, then outputs a tab-separated spreadsheet
-with the results. The results can be copied to a Google Spreadsheet for further
-inspection.
+with the results and stores them in a JSON file for future reference. The
+results can be copied to a Google Spreadsheet for further inspection and the
+JSON file can be reprocessed with the summarize.dart command for more detailed
+output.
 
 Example:
 
@@ -182,6 +184,11 @@ The `--ab=10` tells the runner to run an A/B test 10 times.
 
 `--local-engine=host_debug_unopt` tells the A/B test to use the `host_debug_unopt`
 engine build. `--local-engine` is required for A/B test.
+
+`--ab-result-file=filename` can be used to provide an alternate location to output
+the JSON results file (defaults to `ABresults#.json`). A single `#` character can be
+used to indicate where to insert a serial number if a file with that name already
+exists, otherwise the file will be overwritten.
 
 A/B can run exactly one task. Multiple tasks are not supported.
 
@@ -202,6 +209,21 @@ contains the speed-up value, i.e. how much _faster_ is the local engine than
 the default engine. Values less than 1.0 indicate a slow-down. For example,
 0.5x means the local engine is twice as slow as the default engine, and 2.0x
 means it's twice as fast. Higher is better.
+
+Summarize tool example:
+
+```sh
+../../bin/cache/dart-sdk/bin/dart bin/summarize.dart  --[no-]tsv-table --[no-]raw-summary \
+    ABresults.json ABresults1.json ABresults2.json ...
+```
+
+`--[no-]tsv-table` tells the tool to print the summary in a table with tabs for easy spreadsheet
+entry. (defaults to on)
+
+`--[no-]raw-summary` tells the tool to print all per-run data collected by the A/B test formatted
+with tabs for easy spreadsheet entry. (defaults to on)
+
+Multiple trailing filenames can be specified and each such results file will be processed in turn.
 
 # Reproducing broken builds locally
 

--- a/dev/devicelab/bin/run.dart
+++ b/dev/devicelab/bin/run.dart
@@ -125,7 +125,7 @@ Future<void> _runABTest() async {
 
   print('$taskName A/B test. Will run $runsPerTest times.');
 
-  final ABTest abTest = ABTest();
+  final ABTest abTest = ABTest(localEngine, taskName);
   for (int i = 1; i <= runsPerTest; i++) {
     section('Run #$i');
 
@@ -168,6 +168,10 @@ Future<void> _runABTest() async {
       print(abTest.printSummary());
     }
   }
+  abTest.finalize();
+
+  final File jsonFile = _uniqueFile(args['abresultfile'] as String ?? 'ABresults#.json');
+  jsonFile.writeAsString(const JsonEncoder.withIndent('  ').convert(abTest.jsonMap));
 
   if (!silent) {
     section('Raw results');
@@ -176,6 +180,23 @@ Future<void> _runABTest() async {
 
   section('Final A/B results');
   print(abTest.printSummary());
+
+  print('');
+  print('Results saved to ${jsonFile.path}');
+}
+
+File _uniqueFile(String filenameTemplate) {
+  final List<String> parts = filenameTemplate.split('#');
+  if (parts.length != 2) {
+    return File(filenameTemplate);
+  }
+  File file = File(parts[0] + parts[1]);
+  int i = 1;
+  while (file.existsSync()) {
+    file = File(parts[0]+i.toString()+parts[1]);
+    i++;
+  }
+  return file;
 }
 
 void addTasks({
@@ -244,6 +265,10 @@ final ArgParser _argParser = ArgParser()
         throw ArgParserException('Option --ab must be a number, but was "$value".');
       }
     },
+  )
+  ..addOption(
+    'abresultfile',
+    help: 'The filename in which to place the json encoded results of an A/B test.',
   )
   ..addFlag(
     'all',

--- a/dev/devicelab/bin/run.dart
+++ b/dev/devicelab/bin/run.dart
@@ -170,7 +170,7 @@ Future<void> _runABTest() async {
   }
   abTest.finalize();
 
-  final File jsonFile = _uniqueFile(args['abresultfile'] as String ?? 'ABresults#.json');
+  final File jsonFile = _uniqueFile(args['ab-result-file'] as String ?? 'ABresults#.json');
   jsonFile.writeAsString(const JsonEncoder.withIndent('  ').convert(abTest.jsonMap));
 
   if (!silent) {
@@ -267,8 +267,10 @@ final ArgParser _argParser = ArgParser()
     },
   )
   ..addOption(
-    'abresultfile',
-    help: 'The filename in which to place the json encoded results of an A/B test.',
+    'ab-result-file',
+    help: 'The filename in which to place the json encoded results of an A/B test.\n'
+          'The filename may contain a single # character to be replaced by a sequence\n'
+          'number if the name already exists.',
   )
   ..addFlag(
     'all',

--- a/dev/devicelab/bin/summarize.dart
+++ b/dev/devicelab/bin/summarize.dart
@@ -12,6 +12,7 @@ import 'package:flutter_devicelab/framework/utils.dart';
 
 String kRawSummaryOpt = 'raw-summary';
 String kTabTableOpt = 'tsv-table';
+String kAsciiTableOpt = 'ascii-table';
 
 void _usage(String error) {
   stderr.writeln(error);
@@ -56,11 +57,20 @@ Future<void> main(List<String> rawArgs) async {
       section('A/B comparison for "$filename"');
       print(test.printSummary());
     }
+    if (args[kAsciiTableOpt] as bool) {
+      section('Formatted summary for "$filename"');
+      print(test.asciiSummary());
+    }
   }
 }
 
 /// Command-line options for the `summarize.dart` command.
 final ArgParser _argParser = ArgParser()
+  ..addFlag(
+    kAsciiTableOpt,
+    defaultsTo: true,
+    help: 'Prints the summary in a table formatted nicely for terminal output.',
+  )
   ..addFlag(
     kTabTableOpt,
     defaultsTo: true,

--- a/dev/devicelab/bin/summarize.dart
+++ b/dev/devicelab/bin/summarize.dart
@@ -1,0 +1,74 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:args/args.dart';
+
+import 'package:flutter_devicelab/framework/ab.dart';
+import 'package:flutter_devicelab/framework/utils.dart';
+
+String kRawSummaryOpt = 'raw-summary';
+String kTabTableOpt = 'tsv-table';
+
+void _usage(String error) {
+  stderr.writeln(error);
+  stderr.writeln('Usage:\n');
+  stderr.writeln(_argParser.usage);
+  exitCode = 1;
+}
+
+Future<void> main(List<String> rawArgs) async {
+  ArgResults args;
+  try {
+    args = _argParser.parse(rawArgs);
+  } on FormatException catch (error) {
+    _usage('${error.message}\n');
+    return;
+  }
+
+  final List<String> jsonFiles = args.rest.isNotEmpty ? args.rest : <String>[ 'ABresults.json' ];
+
+  for (final String filename in jsonFiles) {
+    final File file = File(filename);
+    if (!file.existsSync()) {
+      _usage('File "$filename" does not exist');
+      return;
+    }
+
+    ABTest test;
+    try {
+      test = ABTest.fromJsonMap(
+          const JsonDecoder().convert(await file.readAsString()) as Map<String, dynamic>
+      );
+    } catch(error) {
+      _usage('Could not parse json file "$filename"');
+      return;
+    }
+
+    if (args[kRawSummaryOpt] as bool) {
+      section('Raw results for "$filename"');
+      print(test.rawResults());
+    }
+    if (args[kTabTableOpt] as bool) {
+      section('A/B comparison for "$filename"');
+      print(test.printSummary());
+    }
+  }
+}
+
+/// Command-line options for the `summarize.dart` command.
+final ArgParser _argParser = ArgParser()
+  ..addFlag(
+    kTabTableOpt,
+    defaultsTo: true,
+    help: 'Prints the summary in a table with tabs for easy spreadsheet entry.',
+  )
+  ..addFlag(
+    kRawSummaryOpt,
+    defaultsTo: true,
+    help: 'Prints all per-run data collected by the A/B test formatted with\n'
+        'tabs for easy spreadsheet entry.',
+  );

--- a/dev/devicelab/lib/framework/ab.dart
+++ b/dev/devicelab/lib/framework/ab.dart
@@ -2,15 +2,90 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+import 'dart:io';
 import 'dart:math' as math;
+
 import 'package:meta/meta.dart';
+import 'package:args/args.dart';
+
+const String kBenchmarkTypeKeyName = 'benchmark results type';
+const String kBenchmarkVersionKeyName = 'version';
+const String kLocalEngineKeyName = 'local engine name';
+const String kTaskNameKeyName = 'task name';
+const String kRunStartKeyName = 'run start date';
+const String kRunEndKeyName = 'run end date';
+const String kAResultsKeyName = 'default engine results';
+const String kBResultsKeyName = 'local engine results';
+
+const String kBenchmarkResultsType = 'A/B summaries';
+const String kBenchmarkABVersion = '1.0';
+
+void _usage(String error) {
+  stderr.writeln(error);
+  stderr.writeln('Usage:\n');
+  stderr.writeln(_argParser.usage);
+  exitCode = 1;
+}
+
+Future<void> main(List<String> rawArgs) async {
+  ArgResults args;
+  try {
+    args = _argParser.parse(rawArgs);
+  } on FormatException catch (error) {
+    _usage('${error.message}\n');
+    return;
+  }
+
+  if (args.rest.length > 1) {
+    _usage('Too many file name arguments');
+    return;
+  }
+  final String filename = args.rest.isEmpty ? 'ABresults.json' : args.rest[0];
+  final ABTest test = ABTest.fromJsonMap(
+      const JsonDecoder().convert(await File(filename).readAsString()) as Map<String, dynamic>
+  );
+  if (args['raw'] as bool) {
+    print(test.rawResults());
+  }
+  if (args['tsv'] as bool) {
+    print(test.printSummary());
+  }
+}
 
 /// Collects data from an A/B test and produces a summary for human evaluation.
 ///
 /// See [printSummary] for more.
 class ABTest {
-  final Map<String, List<double>> _aResults = <String, List<double>>{};
-  final Map<String, List<double>> _bResults = <String, List<double>>{};
+  ABTest(this.localEngine, this.taskName)
+      : runStart = DateTime.now(),
+        _aResults = <String, List<double>>{},
+        _bResults = <String, List<double>>{};
+
+  ABTest.fromJsonMap(Map<String, dynamic> jsonResults)
+      : localEngine = jsonResults[kLocalEngineKeyName] as String,
+        taskName = jsonResults[kTaskNameKeyName] as String,
+        runStart = DateTime.parse(jsonResults[kRunStartKeyName] as String),
+        _runEnd = DateTime.parse(jsonResults[kRunEndKeyName] as String),
+        _aResults = _convertFrom(jsonResults[kAResultsKeyName] as Map<String, dynamic>),
+        _bResults = _convertFrom(jsonResults[kBResultsKeyName] as Map<String, dynamic>);
+
+  final String localEngine;
+  final String taskName;
+  final DateTime runStart;
+  DateTime _runEnd;
+  DateTime get runEnd => _runEnd;
+
+  final Map<String, List<double>> _aResults;
+  final Map<String, List<double>> _bResults;
+
+  static Map<String, List<double>> _convertFrom(dynamic results) {
+    final Map<String, dynamic> resultMap = results as Map<String, dynamic>;
+    return <String, List<double>> {
+      for (String key in resultMap.keys)
+        key: (resultMap[key] as List<dynamic>).cast<double>()
+    };
+  }
 
   /// Adds the result of a single A run of the benchmark.
   ///
@@ -18,7 +93,11 @@ class ABTest {
   ///
   /// [result] is expected to be a serialization of [TaskResult].
   void addAResult(Map<String, dynamic> result) {
-    _addResult(result, _aResults);
+    if (_runEnd == null) {
+      _addResult(result, _aResults);
+    } else {
+      throw StateError('Cannot add results to ABTest after it is finalized');
+    }
   }
 
   /// Adds the result of a single B run of the benchmark.
@@ -27,8 +106,27 @@ class ABTest {
   ///
   /// [result] is expected to be a serialization of [TaskResult].
   void addBResult(Map<String, dynamic> result) {
-    _addResult(result, _bResults);
+    if (_runEnd == null) {
+      _addResult(result, _bResults);
+    } else {
+      throw StateError('Cannot add results to ABTest after it is finalized');
+    }
   }
+
+  void finalize() {
+    _runEnd = DateTime.now();
+  }
+
+  Map<String, dynamic> get jsonMap => <String, dynamic>{
+    kBenchmarkTypeKeyName:     kBenchmarkResultsType,
+    kBenchmarkVersionKeyName:  kBenchmarkABVersion,
+    kLocalEngineKeyName:       localEngine,
+    kTaskNameKeyName:          taskName,
+    kRunStartKeyName:          runStart.toIso8601String(),
+    kRunEndKeyName:            runEnd.toIso8601String(),
+    kAResultsKeyName:          _aResults,
+    kBResultsKeyName:          _bResults,
+  };
 
   /// Returns unprocessed data collected by the A/B test formatted as
   /// a tab-separated spreadsheet.
@@ -166,3 +264,17 @@ double _computeStandardDeviationForPopulation(Iterable<double> population) {
 String _ratioToPercent(double value) {
   return '${(value * 100).toStringAsFixed(2)}%';
 }
+
+/// Command-line options for the `ab.dart` command.
+final ArgParser _argParser = ArgParser(allowTrailingOptions: true)
+  ..addFlag(
+    'tsv',
+    defaultsTo: true,
+    help: 'Prints the summary as a tab-separated spreadsheet.',
+  )
+  ..addFlag(
+    'raw',
+    defaultsTo: true,
+    help: 'Returns unprocessed data collected by the A/B test formatted as\n'
+        'a tab-separated spreadsheet.',
+  );

--- a/dev/devicelab/lib/framework/ab.dart
+++ b/dev/devicelab/lib/framework/ab.dart
@@ -17,6 +17,8 @@ const String kBResultsKeyName = 'local_engine_results';
 const String kBenchmarkResultsType = 'A/B summaries';
 const String kBenchmarkABVersion = '1.0';
 
+enum FieldJustification { LEFT, RIGHT, CENTER }
+
 /// Collects data from an A/B test and produces a summary for human evaluation.
 ///
 /// See [printSummary] for more.
@@ -90,6 +92,94 @@ class ABTest {
     kBResultsKeyName:          _bResults,
   };
 
+  static void updateColumnLengths(List<int> lengths, List<String> results) {
+    for (int column = 0; column < lengths.length; column++) {
+      if (results[column] != null) {
+        lengths[column] = math.max(lengths[column], results[column].length);
+      }
+    }
+  }
+
+  static void formatResult(StringBuffer buffer,
+                           List<int> lengths,
+                           List<FieldJustification> aligns,
+                           List<String> values) {
+    for (int column = 0; column < lengths.length; column++) {
+      final int len = lengths[column];
+      String value = values[column];
+      if (value == null) {
+        value = ''.padRight(len);
+      } else {
+        switch (aligns[column]) {
+          case FieldJustification.LEFT:
+            value = value.padRight(len);
+            break;
+          case FieldJustification.RIGHT:
+            value = value.padLeft(len);
+            break;
+          case FieldJustification.CENTER:
+            value = value.padLeft((len + value.length) ~/2);
+            value = value.padRight(len);
+            break;
+        }
+      }
+      if (column > 0) {
+        value = value.padLeft(len+1);
+      }
+      buffer.write(value);
+    }
+    buffer.writeln();
+  }
+
+  /// Returns the summary as a tab-separated spreadsheet.
+  ///
+  /// This value can be copied straight to a Google Spreadsheet for further analysis.
+  String asciiSummary() {
+    final Map<String, _ScoreSummary> summariesA = _summarize(_aResults);
+    final Map<String, _ScoreSummary> summariesB = _summarize(_bResults);
+
+    final List<List<String>> tableRows = <List<String>>[
+      for (final String scoreKey in <String>{...summariesA.keys, ...summariesB.keys})
+        <String>[
+          scoreKey,
+          summariesA[scoreKey]?.averageString, summariesA[scoreKey]?.noiseString,
+          summariesB[scoreKey]?.averageString, summariesB[scoreKey]?.noiseString,
+          summariesA[scoreKey]?.improvementOver(summariesB[scoreKey]),
+        ],
+    ];
+
+    final List<String> titles = <String>[
+      'Score',
+      'Average A', '(noise)',
+      'Average B', '(noise)',
+      'Speed-up'
+    ];
+    final List<FieldJustification> alignments = <FieldJustification>[
+      FieldJustification.LEFT,
+      FieldJustification.RIGHT, FieldJustification.LEFT,
+      FieldJustification.RIGHT, FieldJustification.LEFT,
+      FieldJustification.CENTER
+    ];
+
+    final List<int> lengths = List<int>.filled(6, 0);
+    updateColumnLengths(lengths, titles);
+    for (final List<String> row in tableRows) {
+      updateColumnLengths(lengths, row);
+    }
+
+    final StringBuffer buffer = StringBuffer();
+    formatResult(buffer, lengths,
+        <FieldJustification>[
+          FieldJustification.CENTER,
+          ...alignments.skip(1),
+        ], titles);
+    for (final List<String> row in tableRows) {
+      formatResult(buffer, lengths, alignments, row);
+    }
+
+    return buffer.toString();
+  }
+
   /// Returns unprocessed data collected by the A/B test formatted as
   /// a tab-separated spreadsheet.
   String rawResults() {
@@ -143,19 +233,19 @@ class ABTest {
       buffer.write('$scoreKey\t');
 
       if (summaryA != null) {
-        buffer.write('${summaryA.average.toStringAsFixed(2)} (${_ratioToPercent(summaryA.noise)})\t');
+        buffer.write('${summaryA.averageString} ${summaryA.noiseString}\t');
       } else {
         buffer.write('\t');
       }
 
       if (summaryB != null) {
-        buffer.write('${summaryB.average.toStringAsFixed(2)} (${_ratioToPercent(summaryB.noise)})\t');
+        buffer.write('${summaryB.averageString} ${summaryB.noiseString}\t');
       } else {
         buffer.write('\t');
       }
 
       if (summaryA != null && summaryB != null) {
-        buffer.write('${(summaryA.average / summaryB.average).toStringAsFixed(2)}x\t');
+        buffer.write('${summaryA.improvementOver(summaryB)}\t');
       }
 
       buffer.writeln();
@@ -177,6 +267,13 @@ class _ScoreSummary {
   /// The noise (standard deviation divided by [average]) in the collected
   /// values.
   final double noise;
+
+  String get averageString => average.toStringAsFixed(2);
+  String get noiseString => '(${_ratioToPercent(noise)})';
+
+  String improvementOver(_ScoreSummary other) {
+    return other == null ? '' : '${(average / other.average).toStringAsFixed(2)}x';
+  }
 }
 
 void _addResult(Map<String, dynamic> result, Map<String, List<double>> results) {

--- a/dev/devicelab/test/ab_test.dart
+++ b/dev/devicelab/test/ab_test.dart
@@ -8,7 +8,7 @@ import 'common.dart';
 
 void main() {
   test('ABTest', () {
-    final ABTest ab = ABTest();
+    final ABTest ab = ABTest('engine', 'test');
 
     for (int i = 0; i < 5; i++) {
       ab.addAResult(<String, dynamic>{

--- a/dev/devicelab/test/ab_test.dart
+++ b/dev/devicelab/test/ab_test.dart
@@ -28,6 +28,7 @@ void main() {
         'benchmarkScoreKeys': <String>['i', 'k'],
       });
     }
+    ab.finalize();
 
     expect(
       ab.rawResults(),


### PR DESCRIPTION
This is a proof of concept for writing the results of an A/B run to a JSON file.

I also modified the `ab.dart` source file to be a `main()` program that can read the files back in and print out reports or do other processing. Thus far, the only things it can do is to write out the same reports that were originally printed during the test, but more processing could be added in the future, such as combining runs, generating some code for graphs, etc.

My naming conventions probably violate a number of dart/json style and naming guidelines, but suggestions are welcome!

The PR is marked WIP, because I know it will have to be revised quite a bit before it goes back, but I do specifically want some input at this point so ignore the "do not review" part of the label...