### PR TITLE
Handle uncaught error for warnIfSlow

### DIFF
--- a/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
@@ -633,7 +633,15 @@ Future<T> _warnIfSlow<T>({
   assert(future != null);
   assert(timeout != null);
   assert(message != null);
-  return future..timeout(timeout, onTimeout: () { _log(message); return null; });
+  future
+    .timeout(timeout, onTimeout: () {
+      _log(message);
+      return null;
+    })
+    // Don't duplicate errors if [future] completes with an error.
+    .catchError((dynamic e) => null);
+
+  return future;
 }
 
 /// Encapsulates connection information to an instance of a Flutter application.

--- a/packages/flutter_driver/test/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/flutter_driver_test.dart
@@ -665,6 +665,16 @@ void main() {
           expect(error.message, 'Error in Flutter application: {message: This is a failure}');
         }
       });
+
+      test('uncaught remote error', () async {
+        when(mockIsolate.invokeExtension(any, any)).thenAnswer((Invocation i) {
+          return Future<Map<String, dynamic>>.error(
+            rpc.RpcException(9999, 'test error'),
+          );
+        });
+
+        expect(driver.waitFor(find.byTooltip('foo')), throwsDriverError);
+      });
     });
   });
 


### PR DESCRIPTION
## Description

`_warnIfSlow` creates a new future that resolves after a timeout duration.

https://github.com/flutter/flutter/blob/8568eda15b2527afd48622257cee3811e0d9da04/packages/flutter_driver/lib/src/driver/vmservice_driver.dart#L636

This is a new future that is separate from the returned `future`. If the original `future` resolves with an error, `future.timeout` will also complete with an error that cannot be handled by callers of `_warnIfSlow`.

This fixes the breakage of the recovery flow for health checks at https://github.com/flutter/flutter/blob/8568eda15b2527afd48622257cee3811e0d9da04/packages/flutter_driver/lib/src/driver/vmservice_driver.dart#L220.

## Related Issues

None

## Tests

I added the following tests:

Add a test to simulate a rpc failure.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
