### PR TITLE
Eagerly wait for the driver extension on FlutterDriver.connect()

### DIFF
--- a/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
@@ -189,19 +189,6 @@ class VMServiceFlutterDriver extends FlutterDriver {
       });
     }
 
-    await enableIsolateStreams();
-
-    // We will never receive the extension event if the user does not register
-    // it. If that happens, show a message but continue waiting.
-    await _warnIfSlow<void>(
-      future: waitForServiceExtension(),
-      timeout: kUnusuallyLongTimeout,
-      message: 'Flutter Driver extension is taking a long time to become available. '
-          'Ensure your test app (often "lib/main.dart") imports '
-          '"package:flutter_driver/driver_extension.dart" and '
-          'calls enableFlutterDriverExtension() as the first call in main().',
-    );
-
     // Attempt to resume isolate if it was paused
     if (isolate.pauseEvent is VMPauseStartEvent) {
       _log('Isolate is paused at start.');
@@ -223,6 +210,19 @@ class VMServiceFlutterDriver extends FlutterDriver {
               'Assuming application is ready.'
       );
     }
+
+    await enableIsolateStreams();
+
+    // We will never receive the extension event if the user does not register
+    // it. If that happens, show a message but continue waiting.
+    await _warnIfSlow<void>(
+      future: waitForServiceExtension(),
+      timeout: kUnusuallyLongTimeout,
+      message: 'Flutter Driver extension is taking a long time to become available. '
+          'Ensure your test app (often "lib/main.dart") imports '
+          '"package:flutter_driver/driver_extension.dart" and '
+          'calls enableFlutterDriverExtension() as the first call in main().',
+    );
 
     final Health health = await driver.checkHealth();
     if (health.status != HealthStatus.ok) {

--- a/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
@@ -8,7 +8,6 @@ import 'dart:io';
 
 import 'package:file/file.dart' as f;
 import 'package:fuchsia_remote_debug_protocol/fuchsia_remote_debug_protocol.dart' as fuchsia;
-import 'package:json_rpc_2/error_code.dart' as error_code;
 import 'package:json_rpc_2/json_rpc_2.dart' as rpc;
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
@@ -150,11 +149,31 @@ class VMServiceFlutterDriver extends FlutterDriver {
     }
 
     /// Waits for a signal from the VM service that the extension is registered.
-    /// Returns [_flutterExtensionMethodName]
-    Future<String> waitForServiceExtension() {
-      return isolate.onExtensionAdded.firstWhere((String extension) {
-        return extension == _flutterExtensionMethodName;
-      });
+    ///
+    /// Looks at the list of loaded extensions for the current [isolateRef], as
+    /// well as the stream of added extensions.
+    Future<void> waitForServiceExtension() async {
+      _log('Waiting for service extension');
+
+      final Future<bool> extensionAlreadyAdded = isolateRef
+        .loadRunnable()
+        .then((VMIsolate isolate) {
+          if (isolate.extensionRpcs.contains(_flutterExtensionMethodName)) {
+            return true;
+          }
+          // Never complete. Rely on the stream listener to find the service
+          // extension instead.
+          return Completer<bool>().future;
+        });
+      final Future<bool> extensionAddedEvent = isolate.onExtensionAdded
+        .contains(_flutterExtensionMethodName);
+
+      final bool isDriverExtensionFound = await Future.any(<Future<bool>>[
+        extensionAlreadyAdded,
+        extensionAddedEvent,
+      ]);
+      assert(isDriverExtensionFound);
+      _log('Found service extension');
     }
 
     /// Tells the Dart VM Service to notify us about "Isolate" events.
@@ -170,29 +189,24 @@ class VMServiceFlutterDriver extends FlutterDriver {
       });
     }
 
+    await enableIsolateStreams();
+
+    // We will never receive the extension event if the user does not register
+    // it. If that happens, show a message but continue waiting.
+    await _warnIfSlow<void>(
+      future: waitForServiceExtension(),
+      timeout: kUnusuallyLongTimeout,
+      message: 'Flutter Driver extension is taking a long time to become available. '
+          'Ensure your test app (often "lib/main.dart") imports '
+          '"package:flutter_driver/driver_extension.dart" and '
+          'calls enableFlutterDriverExtension() as the first call in main().',
+    );
+
     // Attempt to resume isolate if it was paused
     if (isolate.pauseEvent is VMPauseStartEvent) {
       _log('Isolate is paused at start.');
 
-      // If the isolate is paused at the start, e.g. via the --start-paused
-      // option, then the VM service extension is not registered yet. Wait for
-      // it to be registered.
-      await enableIsolateStreams();
-      final Future<String> whenServiceExtensionReady = waitForServiceExtension();
-      final Future<dynamic> whenResumed = resumeLeniently();
-      await whenResumed;
-
-      _log('Waiting for service extension');
-      // We will never receive the extension event if the user does not
-      // register it. If that happens, show a message but continue waiting.
-      await _warnIfSlow<String>(
-        future: whenServiceExtensionReady,
-        timeout: kUnusuallyLongTimeout,
-        message: 'Flutter Driver extension is taking a long time to become available. '
-            'Ensure your test app (often "lib/main.dart") imports '
-            '"package:flutter_driver/driver_extension.dart" and '
-            'calls enableFlutterDriverExtension() as the first call in main().',
-      );
+      await resumeLeniently();
     } else if (isolate.pauseEvent is VMPauseExitEvent ||
         isolate.pauseEvent is VMPauseBreakpointEvent ||
         isolate.pauseEvent is VMPauseExceptionEvent ||
@@ -210,27 +224,7 @@ class VMServiceFlutterDriver extends FlutterDriver {
       );
     }
 
-    // Invoked checkHealth and try to fix delays in the registration of Service
-    // extensions
-    Future<Health> checkHealth() async {
-      try {
-        // At this point the service extension must be installed. Verify it.
-        return await driver.checkHealth();
-      } on rpc.RpcException catch (e) {
-        if (e.code != error_code.METHOD_NOT_FOUND) {
-          rethrow;
-        }
-        _log(
-            'Check Health failed, try to wait for the service extensions to be '
-                'registered.'
-        );
-        await enableIsolateStreams();
-        await waitForServiceExtension();
-        return driver.checkHealth();
-      }
-    }
-
-    final Health health = await checkHealth();
+    final Health health = await driver.checkHealth();
     if (health.status != HealthStatus.ok) {
       await client.close();
       throw DriverError('Flutter application health check failed.');

--- a/packages/flutter_driver/test/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/flutter_driver_test.dart
@@ -49,6 +49,10 @@ void main() {
       when(mockClient.getVM()).thenAnswer((_) => Future<MockVM>.value(mockVM));
       when(mockVM.isolates).thenReturn(<VMRunnableIsolate>[mockIsolate]);
       when(mockIsolate.loadRunnable()).thenAnswer((_) => Future<MockIsolate>.value(mockIsolate));
+      when(mockIsolate.extensionRpcs).thenReturn(<String>[]);
+      when(mockIsolate.onExtensionAdded).thenAnswer((Invocation invocation) {
+        return Stream<String>.fromIterable(<String>['ext.flutter.driver']);
+      });
       when(mockIsolate.invokeExtension(any, any)).thenAnswer(
           (Invocation invocation) => makeMockResponse(<String, dynamic>{'status': 'ok'}));
       vmServiceConnectFunction = (String url, {Map<String, dynamic> headers}) {
@@ -112,6 +116,18 @@ void main() {
 
     test('connects to unpaused isolate', () async {
       when(mockIsolate.pauseEvent).thenReturn(MockVMResumeEvent());
+      final FlutterDriver driver = await FlutterDriver.connect(dartVmServiceUrl: '');
+      expect(driver, isNotNull);
+      expectLogContains('Isolate is not paused. Assuming application is ready.');
+    });
+
+    test('connects to unpaused when onExtensionAdded does not contain the '
+      'driver extension', () async {
+      when(mockIsolate.pauseEvent).thenReturn(MockVMResumeEvent());
+      when(mockIsolate.extensionRpcs).thenReturn(<String>['ext.flutter.driver']);
+      when(mockIsolate.onExtensionAdded).thenAnswer((Invocation invocation) {
+        return const Stream<String>.empty();
+      });
       final FlutterDriver driver = await FlutterDriver.connect(dartVmServiceUrl: '');
       expect(driver, isNotNull);
       expectLogContains('Isolate is not paused. Assuming application is ready.');

--- a/packages/flutter_driver/test/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/flutter_driver_test.dart
@@ -85,7 +85,7 @@ void main() {
       final FlutterDriver driver = await FlutterDriver.connect(dartVmServiceUrl: '');
       expect(driver, isNotNull);
       expectLogContains('Isolate is paused at start');
-      expect(connectionLog, <String>['streamListen', 'onExtensionAdded', 'resume']);
+      expect(connectionLog, <String>['resume', 'streamListen', 'onExtensionAdded']);
     });
 
     test('connects to isolate paused mid-flight', () async {


### PR DESCRIPTION
## Description

It is possible for the `FlutterDriver` to attempt to connect to the application before the driver extension has been installed. This results in a `JSON-RPC error -32601 (method not found)` error.

The current mechanism to recover from this error

https://github.com/flutter/flutter/blob/8568eda15b2527afd48622257cee3811e0d9da04/packages/flutter_driver/lib/src/driver/vmservice_driver.dart#L219-L229

is not working in two ways:

1. A `DriverError` is thrown instead of a `RpcException`
2. It is possible for `waitForServiceExtension` to be called *after* the driver extension has been installed, resulting in a timeout

This PR changes the connect flow to eagerly wait for the driver extension so `driver.checkHealth()` will always succeed.

To address (2), we check both the list of extensions in the isolate and listen to added isolates.

## Related Issues

#41029

## Tests

Change existing tests to support this flow, add a test for (2).

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
