### PR TITLE
Allow waitUntilFirstFrameRasterized without a root widget

### DIFF
--- a/packages/flutter_driver/lib/src/common/wait.dart
+++ b/packages/flutter_driver/lib/src/common/wait.dart
@@ -31,6 +31,9 @@ class WaitForCondition extends Command {
 
   @override
   String get kind => 'waitForCondition';
+
+  @override
+  bool get requiresRootWidgetAttached => condition.requiresRootWidgetAttached;
 }
 
 /// A Flutter Driver command that waits until there are no more transient callbacks in the queue.
@@ -148,6 +151,20 @@ abstract class SerializableWaitCondition {
       'conditionName': conditionName
     };
   }
+
+  /// Whether this command requires the widget tree to be initialized before
+  /// the command may be run.
+  ///
+  /// This defaults to true to force the application under test to call [runApp]
+  /// before attempting to remotely drive the application. Subclasses may
+  /// override this to return false if they allow invocation before the
+  /// application has started.
+  ///
+  /// See also:
+  ///
+  ///  * [WidgetsBinding.isRootWidgetAttached], which indicates whether the
+  ///    widget tree has been initialized.
+  bool get requiresRootWidgetAttached => true;
 }
 
 /// A condition that waits until no transient callbacks are scheduled.
@@ -208,6 +225,9 @@ class FirstFrameRasterized extends SerializableWaitCondition {
 
   @override
   String get conditionName => 'FirstFrameRasterizedCondition';
+
+  @override
+  bool get requiresRootWidgetAttached => false;
 }
 
 /// A condition that waits until there are no pending platform messages.

--- a/packages/flutter_driver/test/src/real_tests/wait_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/wait_test.dart
@@ -41,6 +41,17 @@ void main() {
       expect(waitForCondition.condition, equals(const NoTransientCallbacks()));
       expect(waitForCondition.timeout, equals(const Duration(milliseconds: 10)));
     });
+
+    test('WaitForCondition requiresRootWidget', () {
+        expect(
+            const WaitForCondition(NoTransientCallbacks())
+                .requiresRootWidgetAttached,
+            isTrue);
+        expect(
+            const WaitForCondition(FirstFrameRasterized())
+                .requiresRootWidgetAttached,
+            isFalse);
+      });
   });
 
   group('NoTransientCallbacksCondition', () {
@@ -112,6 +123,10 @@ void main() {
           () => FirstFrameRasterized.deserialize(<String, String>{'conditionName': 'Unknown'}),
           throwsA(predicate<SerializationException>((SerializationException e) =>
               e.message == 'Error occurred during deserializing the FirstFrameRasterizedCondition JSON string: {conditionName: Unknown}')));
+    });
+
+    test('FirstFrameRasterizedCondition requiresRootWidget', () {
+      expect(const FirstFrameRasterized().requiresRootWidgetAttached, isFalse);
     });
   });
 


### PR DESCRIPTION
## Description

If the flutter driver extension is setup on the device, but the root widget is not yet attached, calling flutter driver commands except `checkHealth` will result in the following assertion error from

https://github.com/flutter/flutter/blob/8568eda15b2527afd48622257cee3811e0d9da04/packages/flutter_driver/lib/src/extension/extension.dart#L214-L215

This allows [`driver.waitUntilFirstFrameRasterized`](https://api.flutter.dev/flutter/flutter_driver/FlutterDriver/waitUntilFirstFrameRasterized.html) to be used as a signal for when the root widget is attached, and also when the application is ready for driver commands.

## Related Issues

#41029

## Tests

I added the following tests: 

- Checks for `requiresRootWidgetAttached`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
