### PR TITLE
[gen_l10n] Optionally generate list of inputs/outputs

### DIFF
--- a/dev/tools/localization/bin/gen_l10n.dart
+++ b/dev/tools/localization/bin/gen_l10n.dart
@@ -159,7 +159,7 @@ void main(List<String> arguments) {
         inputsAndOutputsListPath: inputsAndOutputsListPath,
       )
       ..loadResources()
-      ..writeOutputFile()
+      ..writeOutputFiles()
       ..outputUnimplementedMessages(untranslatedMessagesFile);
   } on FileSystemException catch (e) {
     exitWithError(e.message);

--- a/dev/tools/localization/bin/gen_l10n.dart
+++ b/dev/tools/localization/bin/gen_l10n.dart
@@ -109,13 +109,13 @@ void main(List<String> arguments) {
     'gen-inputs-and-outputs-list',
     valueHelp: 'path-to-output-directory',
     help: 'When specified, the tool generates a JSON file containing the '
-      'tool\'s inputs and outputs titled gen_l10n_inputs_and_outputs.json.'
+      'tool\'s inputs and outputs named gen_l10n_inputs_and_outputs.json.'
       '\n\n'
       'This can be useful for keeping track of which files of the Flutter '
       'project were used when generating the latest set of localizations. '
       'For example, the Flutter tool\'s build system uses this file to '
       'keep track of when to call gen_l10n during hot reload.\n\n'
-      'This option takes in the directory where the JSON file will be '
+      'The value of this option is the directory where the JSON file will be '
       'generated.'
       '\n\n'
       'When null, the JSON file will not be generated.'

--- a/dev/tools/localization/bin/gen_l10n.dart
+++ b/dev/tools/localization/bin/gen_l10n.dart
@@ -105,6 +105,21 @@ void main(List<String> arguments) {
       'Note that this flag does not affect other platforms such as mobile or '
       'desktop.',
   );
+  parser.addOption(
+    'gen-inputs-and-outputs-list',
+    valueHelp: 'path-to-output-directory',
+    help: 'When specified, the tool generates a JSON file containing the '
+      'tool\'s inputs and outputs titled gen_l10n_inputs_and_outputs.json.'
+      '\n\n'
+      'This can be useful for keeping track of which files of the Flutter '
+      'project were used when generating the latest set of localizations. '
+      'For example, the Flutter tool\'s build system uses this file to '
+      'keep track of when to call gen_l10n during hot reload.\n\n'
+      'This option takes in the directory where the JSON file will be '
+      'generated.'
+      '\n\n'
+      'When null, the JSON file will not be generated.'
+  );
 
   final argslib.ArgResults results = parser.parse(arguments);
   if (results['help'] == true) {
@@ -124,6 +139,7 @@ void main(List<String> arguments) {
   final String headerString = results['header'] as String;
   final String headerFile = results['header-file'] as String;
   final bool useDeferredLoading = results['use-deferred-loading'] as bool;
+  final String inputsAndOutputsListPath = results['gen-inputs-and-outputs-list'] as String;
 
   const local.LocalFileSystem fs = local.LocalFileSystem();
   final LocalizationsGenerator localizationsGenerator = LocalizationsGenerator(fs);
@@ -140,6 +156,7 @@ void main(List<String> arguments) {
         headerString: headerString,
         headerFile: headerFile,
         useDeferredLoading: useDeferredLoading,
+        inputsAndOutputsListPath: inputsAndOutputsListPath,
       )
       ..loadResources()
       ..writeOutputFile()

--- a/dev/tools/localization/gen_l10n.dart
+++ b/dev/tools/localization/gen_l10n.dart
@@ -919,7 +919,7 @@ class LocalizationsGenerator {
       .replaceAll('@(delegateClass)', delegateClass);
   }
 
-  void writeOutputFile() {
+  void writeOutputFiles() {
     // First, generate the string contents of all necessary files.
     _generateCode();
 

--- a/dev/tools/localization/gen_l10n.dart
+++ b/dev/tools/localization/gen_l10n.dart
@@ -418,11 +418,13 @@ class LocalizationsGenerator {
   /// This file is specified with the [initialize] method.
   File templateArbFile;
 
-  /// The file to write the generated localizations and localizations delegate
-  /// classes to.
+  /// The file to write the generated abstract localizations and
+  /// localizations delegate classes to. Separate localizations
+  /// files will also be generated for each language using this
+  /// filename as a prefix and the locale as the suffix.
   ///
   /// This file is specified with the [initialize] method.
-  File outputFile;
+  File baseOutputFile;
 
   /// The class name to be used for the localizations class in [outputFile].
   ///
@@ -491,6 +493,12 @@ class LocalizationsGenerator {
   /// classes.
   String _generatedLocalizationsFile;
 
+  /// The file that contains the list of inputs and outputs for generating
+  /// localizations.
+  File _inputsAndOutputsListFile;
+  List<String> _inputFileList;
+  List<String> _outputFileList;
+
   /// Initializes [inputDirectory], [outputDirectory], [templateArbFile],
   /// [outputFile] and [className].
   ///
@@ -509,15 +517,17 @@ class LocalizationsGenerator {
     String headerString,
     String headerFile,
     bool useDeferredLoading = false,
+    String inputsAndOutputsListPath,
   }) {
     setInputDirectory(inputPathString);
     setOutputDirectory(outputPathString ?? inputPathString);
     setTemplateArbFile(templateArbFileName);
-    setOutputFile(outputFileString);
+    setBaseOutputFile(outputFileString);
     setPreferredSupportedLocales(preferredSupportedLocaleString);
     _setHeader(headerString, headerFile);
     _setUseDeferredLoading(useDeferredLoading);
     className = classNameString;
+    _setInputsAndOutputsListFile(inputsAndOutputsListPath);
   }
 
   static bool _isNotReadable(FileStat fileStat) {
@@ -581,10 +591,10 @@ class LocalizationsGenerator {
 
   /// Sets the reference [File] for the localizations delegate [outputFile].
   @visibleForTesting
-  void setOutputFile(String outputFileString) {
+  void setBaseOutputFile(String outputFileString) {
     if (outputFileString == null)
       throw L10nException('outputFileString argument cannot be null');
-    outputFile = _fs.file(path.join(outputDirectory.path, outputFileString));
+    baseOutputFile = _fs.file(path.join(outputDirectory.path, outputFileString));
   }
 
   static bool _isValidClassName(String className) {
@@ -664,6 +674,17 @@ class LocalizationsGenerator {
     _useDeferredLoading = useDeferredLoading;
   }
 
+  void _setInputsAndOutputsListFile(String inputsAndOutputsListPath) {
+    if (inputsAndOutputsListPath == null)
+      return;
+
+    _inputsAndOutputsListFile = File(
+      path.join(inputsAndOutputsListPath, 'gen_l10n_inputs_and_outputs.json'),
+    );
+    _inputFileList = <String>[];
+    _outputFileList = <String>[];
+  }
+
   static bool _isValidGetterAndMethodName(String name) {
     // Public Dart method name must not start with an underscore
     if (name[0] == '_')
@@ -697,6 +718,11 @@ class LocalizationsGenerator {
       }
 
     _allBundles = AppResourceBundleCollection(inputDirectory);
+    if (_inputsAndOutputsListFile != null) {
+      _inputFileList.addAll(_allBundles.bundles.map((AppResourceBundle bundle) {
+        return bundle.file.absolute.path;
+      }));
+    }
 
     final List<LocaleInfo> allLocales = List<LocaleInfo>.from(_allBundles.locales);
     for (final LocaleInfo preferredLocale in preferredSupportedLocales) {
@@ -800,7 +826,7 @@ class LocalizationsGenerator {
     }
 
     final String directory = path.basename(outputDirectory.path);
-    final String outputFileName = path.basename(outputFile.path);
+    final String outputFileName = path.basename(baseOutputFile.path);
 
     final Iterable<String> supportedLocalesCode = supportedLocales.map((LocaleInfo locale) {
       final String languageCode = locale.languageCode;
@@ -913,8 +939,20 @@ class LocalizationsGenerator {
     // Generate the required files for localizations.
     _languageFileMap.forEach((File file, String contents) {
       file.writeAsStringSync(contents);
+      if (_inputsAndOutputsListFile != null) {
+        _outputFileList.add(file.absolute.path);
+      }
     });
-    outputFile.writeAsStringSync(_generatedLocalizationsFile);
+
+    baseOutputFile.writeAsStringSync(_generatedLocalizationsFile);
+    if (_inputsAndOutputsListFile != null) {
+      _outputFileList.add(baseOutputFile.absolute.path);
+    }
+
+    // Generate a JSON file containing the inputs and outputs of the gen_l10n script.
+    // TODO: implement JSON generating function.
+    print(_inputFileList);
+    print(_outputFileList);
   }
 
   void outputUnimplementedMessages(String untranslatedMessagesFile) {

--- a/dev/tools/localization/gen_l10n.dart
+++ b/dev/tools/localization/gen_l10n.dart
@@ -950,9 +950,11 @@ class LocalizationsGenerator {
     }
 
     // Generate a JSON file containing the inputs and outputs of the gen_l10n script.
-    // TODO: implement JSON generating function.
-    print(_inputFileList);
-    print(_outputFileList);
+    _inputsAndOutputsListFile.writeAsStringSync(
+      inputAndOutputsJsonFileTemplate
+        .replaceAll('@(inputs)', _inputFileList.map((String file) => '"$file"').join(',\n    '))
+        .replaceAll('@(outputs)', _outputFileList.map((String file) => '"$file"').join(',\n    '))
+    );
   }
 
   void outputUnimplementedMessages(String untranslatedMessagesFile) {

--- a/dev/tools/localization/gen_l10n.dart
+++ b/dev/tools/localization/gen_l10n.dart
@@ -953,10 +953,12 @@ class LocalizationsGenerator {
       if (!_inputsAndOutputsListFile.existsSync()) {
         _inputsAndOutputsListFile.createSync(recursive: true);
       }
+
       _inputsAndOutputsListFile.writeAsStringSync(
-        inputAndOutputsJsonFileTemplate
-          .replaceAll('@(inputs)', _inputFileList.map((String file) => '"$file"').join(',\n    '))
-          .replaceAll('@(outputs)', _outputFileList.map((String file) => '"$file"').join(',\n    '))
+        json.encode(<String, Object> {
+          'inputs': _inputFileList,
+          'outputs': _outputFileList,
+        }),
       );
     }
   }

--- a/dev/tools/localization/gen_l10n_templates.dart
+++ b/dev/tools/localization/gen_l10n_templates.dart
@@ -263,3 +263,15 @@ const String allCodesLookupTemplate = '''// Lookup logic when language+script+co
     @(allCodesSwitchClauses)
   }
 ''';
+
+/// Generates inputs and outputs JSON file containing input and output files
+/// for an iteration of the gen_l10n tool.
+const String inputAndOutputsJsonFileTemplate = '''{
+  "inputs": [
+    @(inputs)
+  ],
+  "outputs": [
+    @(outputs)
+  ]
+}
+''';

--- a/dev/tools/localization/gen_l10n_templates.dart
+++ b/dev/tools/localization/gen_l10n_templates.dart
@@ -263,15 +263,3 @@ const String allCodesLookupTemplate = '''// Lookup logic when language+script+co
     @(allCodesSwitchClauses)
   }
 ''';
-
-/// Generates inputs and outputs JSON file containing input and output files
-/// for an iteration of the gen_l10n tool.
-const String inputAndOutputsJsonFileTemplate = '''{
-  "inputs": [
-    @(inputs)
-  ],
-  "outputs": [
-    @(outputs)
-  ]
-}
-''';

--- a/dev/tools/test/localization/gen_l10n_test.dart
+++ b/dev/tools/test/localization/gen_l10n_test.dart
@@ -161,18 +161,18 @@ void main() {
       );
     });
 
-    test('setOutputFile fails if input string is null', () {
+    test('setBaseOutputFile fails if input string is null', () {
       _standardFlutterDirectoryL10nSetup(fs);
       final LocalizationsGenerator generator = LocalizationsGenerator(fs);
       try {
-        generator.setOutputFile(null);
+        generator.setBaseOutputFile(null);
       } on L10nException catch (e) {
         expect(e.message, contains('cannot be null'));
         return;
       }
 
       fail(
-        'Attempting to set LocalizationsGenerator.setOutputFile should fail if the '
+        'Attempting to set LocalizationsGenerator.setBaseOutputFile should fail if the '
         'the input string is null.'
       );
     });
@@ -202,7 +202,7 @@ void main() {
           generator.setInputDirectory(defaultL10nPathString);
           generator.setOutputDirectory(defaultL10nPathString);
           generator.setTemplateArbFile(defaultTemplateArbFileName);
-          generator.setOutputFile(defaultOutputFileString);
+          generator.setBaseOutputFile(defaultOutputFileString);
         } on L10nException catch (e) {
           throw TestFailure('Unexpected failure during test setup: ${e.message}');
         }

--- a/dev/tools/test/localization/gen_l10n_test.dart
+++ b/dev/tools/test/localization/gen_l10n_test.dart
@@ -456,10 +456,10 @@ void main() {
       fail('Generating output should not fail: \n${e.message}');
     }
 
-    final Directory outputDirectory = fs.directory('lib').childDirectory('l10n');
-    expect(outputDirectory.existsSync(), isTrue);
-
-    final File inputsAndOutputsList = outputDirectory.childFile('gen_l10n_inputs_and_outputs.json');
+    final File inputsAndOutputsList = fs
+      .directory('lib')
+      .childDirectory('l10n')
+      .childFile('gen_l10n_inputs_and_outputs.json');
     expect(inputsAndOutputsList.existsSync(), isTrue);
 
     final Map<String, dynamic> jsonResult = json.decode(inputsAndOutputsList.readAsStringSync()) as Map<String, dynamic>;

--- a/dev/tools/test/localization/gen_l10n_test.dart
+++ b/dev/tools/test/localization/gen_l10n_test.dart
@@ -326,7 +326,7 @@ void main() {
           classNameString: defaultClassNameString,
         )
         ..loadResources()
-        ..generateCode()
+        ..writeOutputFile()
         ..outputUnimplementedMessages(path.join('lib', 'l10n', 'unimplemented_message_translations.json'));
     } on L10nException catch (e) {
       fail('Generating output should not fail: \n${e.message}');
@@ -434,6 +434,45 @@ void main() {
     expect(outputDirectory.childFile('output-localization-file.dart').existsSync(), isTrue);
     expect(outputDirectory.childFile('output-localization-file_en.dart').existsSync(), isTrue);
     expect(outputDirectory.childFile('output-localization-file_es.dart').existsSync(), isTrue);
+  });
+
+  test('creates list of inputs and outputs when file path is specified', () {
+    _standardFlutterDirectoryL10nSetup(fs);
+
+    LocalizationsGenerator generator;
+    try {
+      generator = LocalizationsGenerator(fs);
+      generator
+        ..initialize(
+          inputPathString: defaultL10nPathString,
+          templateArbFileName: defaultTemplateArbFileName,
+          outputFileString: defaultOutputFileString,
+          classNameString: defaultClassNameString,
+          inputsAndOutputsListPath: defaultL10nPathString,
+        )
+        ..loadResources()
+        ..writeOutputFile();
+    } on L10nException catch (e) {
+      fail('Generating output should not fail: \n${e.message}');
+    }
+
+    final Directory outputDirectory = fs.directory('lib').childDirectory('l10n');
+    expect(outputDirectory.existsSync(), isTrue);
+
+    final File inputsAndOutputsList = outputDirectory.childFile('gen_l10n_inputs_and_outputs.json');
+    expect(inputsAndOutputsList.existsSync(), isTrue);
+
+    final Map<String, dynamic> jsonResult = json.decode(inputsAndOutputsList.readAsStringSync()) as Map<String, dynamic>;
+    expect(jsonResult.containsKey('inputs'), isTrue);
+    final List<dynamic> inputList = jsonResult['inputs'] as List<dynamic>;
+    expect(inputList, contains('/lib/l10n/app_en.arb'));
+    expect(inputList, contains('/lib/l10n/app_es.arb'));
+
+    expect(jsonResult.containsKey('outputs'), isTrue);
+    final List<dynamic> outputList = jsonResult['outputs'] as List<dynamic>;
+    expect(outputList, contains('/lib/l10n/output-localization-file.dart'));
+    expect(outputList, contains('/lib/l10n/output-localization-file_en.dart'));
+    expect(outputList, contains('/lib/l10n/output-localization-file_es.dart'));
   });
 
   test('setting both a headerString and a headerFile should fail', () {
@@ -904,7 +943,7 @@ void main() {
     });
   });
 
-  group('generateCode', () {
+  group('writeOutputFile', () {
     test('should generate a file per language', () {
       const String singleEnCaMessageArbFileString = '''
 {
@@ -1033,7 +1072,7 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
             classNameString: defaultClassNameString,
           );
           generator.loadResources();
-          generator.generateCode();
+          generator.writeOutputFile();
         } on L10nException catch (e) {
           expect(e.message, contains('asdf'));
           expect(e.message, contains('springStartDate'));
@@ -1072,7 +1111,7 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
             classNameString: defaultClassNameString,
           );
           generator.loadResources();
-          generator.generateCode();
+          generator.writeOutputFile();
         } on L10nException catch (e) {
           expect(e.message, contains('the "format" attribute needs to be set'));
           return;
@@ -1110,7 +1149,7 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
             classNameString: defaultClassNameString,
           );
           generator.loadResources();
-          generator.generateCode();
+          generator.writeOutputFile();
         } on L10nException catch (e) {
           expect(e.message, contains('asdf'));
           expect(e.message, contains('progress'));
@@ -1147,7 +1186,7 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
             classNameString: defaultClassNameString,
           );
           generator.loadResources();
-          generator.generateCode();
+          generator.writeOutputFile();
         } on L10nException catch (e) {
           expect(e.message, contains('Check to see if the plural message is in the proper ICU syntax format'));
           return;
@@ -1180,7 +1219,7 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
             classNameString: defaultClassNameString,
           );
           generator.loadResources();
-          generator.generateCode();
+          generator.writeOutputFile();
         } on L10nException catch (e) {
           expect(e.message, contains('Check to see if the plural message is in the proper ICU syntax format'));
           return;
@@ -1209,7 +1248,7 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
             classNameString: defaultClassNameString,
           );
           generator.loadResources();
-          generator.generateCode();
+          generator.writeOutputFile();
         } on L10nException catch (e) {
           expect(e.message, contains('Resource attribute "@helloWorlds" was not found'));
           return;
@@ -1241,7 +1280,7 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
             classNameString: defaultClassNameString,
           );
           generator.loadResources();
-          generator.generateCode();
+          generator.writeOutputFile();
         } on L10nException catch (e) {
           expect(e.message, contains('is not properly formatted'));
           expect(e.message, contains('Ensure that it is a map with string valued keys'));
@@ -1274,7 +1313,7 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
           classNameString: defaultClassNameString,
         );
         generator.loadResources();
-        generator.generateCode();
+        generator.writeOutputFile();
       } on FormatException catch (e) {
         expect(e.message, contains('Unexpected character'));
         return;
@@ -1306,7 +1345,7 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
           classNameString: defaultClassNameString,
         );
         generator.loadResources();
-        generator.generateCode();
+        generator.writeOutputFile();
       } on L10nException catch (e) {
         expect(e.message, contains('Resource attribute "@title" was not found'));
         return;
@@ -1342,7 +1381,7 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
             classNameString: defaultClassNameString,
           );
           generator.loadResources();
-          generator.generateCode();
+          generator.writeOutputFile();
         } on L10nException catch (e) {
           expect(e.message, contains('Invalid ARB resource name'));
           return;
@@ -1374,7 +1413,7 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
             classNameString: defaultClassNameString,
           );
           generator.loadResources();
-          generator.generateCode();
+          generator.writeOutputFile();
         } on L10nException catch (e) {
           expect(e.message, contains('Invalid ARB resource name'));
           return;
@@ -1406,7 +1445,7 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
             classNameString: defaultClassNameString,
           );
           generator.loadResources();
-          generator.generateCode();
+          generator.writeOutputFile();
         } on L10nException catch (e) {
           expect(e.message, contains('Invalid ARB resource name'));
           return;

--- a/dev/tools/test/localization/gen_l10n_test.dart
+++ b/dev/tools/test/localization/gen_l10n_test.dart
@@ -465,14 +465,14 @@ void main() {
     final Map<String, dynamic> jsonResult = json.decode(inputsAndOutputsList.readAsStringSync()) as Map<String, dynamic>;
     expect(jsonResult.containsKey('inputs'), isTrue);
     final List<dynamic> inputList = jsonResult['inputs'] as List<dynamic>;
-    expect(inputList, contains('/lib/l10n/app_en.arb'));
-    expect(inputList, contains('/lib/l10n/app_es.arb'));
+    expect(inputList, contains(path.join('/lib', 'l10n', 'app_en.arb')));
+    expect(inputList, contains(path.join('/lib', 'l10n', 'app_es.arb')));
 
     expect(jsonResult.containsKey('outputs'), isTrue);
     final List<dynamic> outputList = jsonResult['outputs'] as List<dynamic>;
-    expect(outputList, contains('/lib/l10n/output-localization-file.dart'));
-    expect(outputList, contains('/lib/l10n/output-localization-file_en.dart'));
-    expect(outputList, contains('/lib/l10n/output-localization-file_es.dart'));
+    expect(outputList, contains(path.join('/lib', 'l10n', 'output-localization-file.dart')));
+    expect(outputList, contains(path.join('/lib', 'l10n', 'output-localization-file_en.dart')));
+    expect(outputList, contains(path.join('/lib', 'l10n', 'output-localization-file_es.dart')));
   });
 
   test('setting both a headerString and a headerFile should fail', () {
@@ -749,15 +749,9 @@ void main() {
         fail('Setting language and locales should not fail: \n${e.message}');
       }
 
-      if (Platform.isWindows) {
-        expect(generator.arbPathStrings.first, r'lib\l10n\app_en.arb');
-        expect(generator.arbPathStrings.elementAt(1), r'lib\l10n\app_es.arb');
-        expect(generator.arbPathStrings.elementAt(2), r'lib\l10n\app_zh.arb');
-      } else {
-        expect(generator.arbPathStrings.first, 'lib/l10n/app_en.arb');
-        expect(generator.arbPathStrings.elementAt(1), 'lib/l10n/app_es.arb');
-        expect(generator.arbPathStrings.elementAt(2), 'lib/l10n/app_zh.arb');
-      }
+      expect(generator.arbPathStrings.first, path.join('lib', 'l10n', 'app_en.arb'));
+      expect(generator.arbPathStrings.elementAt(1), path.join('lib', 'l10n', 'app_es.arb'));
+      expect(generator.arbPathStrings.elementAt(2), path.join('lib', 'l10n', 'app_zh.arb'));
     });
 
     test('correctly parses @@locale property in arb file', () {

--- a/dev/tools/test/localization/gen_l10n_test.dart
+++ b/dev/tools/test/localization/gen_l10n_test.dart
@@ -94,7 +94,7 @@ void main() {
 
       fail(
         'LocalizationsGenerator.setInputDirectory should fail if the '
-        'the input string is null.'
+        'input string is null.'
       );
     });
 
@@ -110,7 +110,7 @@ void main() {
 
       fail(
         'LocalizationsGenerator.setOutputDirectory should fail if the '
-        'the input string is null.'
+        'input string is null.'
       );
     });
 
@@ -125,7 +125,7 @@ void main() {
 
       fail(
         'LocalizationsGenerator.setTemplateArbFile should fail if the '
-        'the inputDirectory is not specified.'
+        'inputDirectory is not specified.'
       );
     });
 
@@ -141,7 +141,7 @@ void main() {
 
       fail(
         'LocalizationsGenerator.setTemplateArbFile should fail if the '
-        'the templateArbFileName passed in is null.'
+        'templateArbFileName passed in is null.'
       );
     });
 
@@ -157,7 +157,7 @@ void main() {
 
       fail(
         'LocalizationsGenerator.setTemplateArbFile should fail if the '
-        'the input string is null.'
+        'input string is null.'
       );
     });
 
@@ -173,7 +173,7 @@ void main() {
 
       fail(
         'LocalizationsGenerator.setBaseOutputFile should fail if the '
-        'the input string is null.'
+        'input string is null.'
       );
     });
 
@@ -189,7 +189,7 @@ void main() {
 
       fail(
         'LocalizationsGenerator.className should fail if the '
-        'the input string is null.'
+        'input string is null.'
       );
     });
 
@@ -217,7 +217,7 @@ void main() {
         }
         fail(
           'LocalizationsGenerator.className should fail if the '
-          'the input string is not a valid Dart class name.'
+          'input string is not a valid Dart class name.'
         );
       });
 
@@ -230,7 +230,7 @@ void main() {
         }
         fail(
           'LocalizationsGenerator.className should fail if the '
-          'the input string is not a valid public Dart class name.'
+          'input string is not a valid public Dart class name.'
         );
       });
 
@@ -243,7 +243,7 @@ void main() {
         }
         fail(
           'LocalizationsGenerator.className should fail if the '
-          'the input string is not a valid public Dart class name.'
+          'input string is not a valid public Dart class name.'
         );
       });
 
@@ -256,7 +256,7 @@ void main() {
         }
         fail(
           'LocalizationsGenerator.className should fail if the '
-          'the input string is not a valid public Dart class name.'
+          'input string is not a valid public Dart class name.'
         );
       });
     });

--- a/dev/tools/test/localization/gen_l10n_test.dart
+++ b/dev/tools/test/localization/gen_l10n_test.dart
@@ -77,7 +77,7 @@ void main() {
       }
 
       fail(
-        'Attempting to set LocalizationsGenerator.setInputDirectory should fail if the '
+        'LocalizationsGenerator.setInputDirectory should fail if the '
         'directory does not exist.'
       );
     });
@@ -93,7 +93,7 @@ void main() {
       }
 
       fail(
-        'Attempting to set LocalizationsGenerator.setInputDirectory should fail if the '
+        'LocalizationsGenerator.setInputDirectory should fail if the '
         'the input string is null.'
       );
     });
@@ -109,7 +109,7 @@ void main() {
       }
 
       fail(
-        'Attempting to set LocalizationsGenerator.setOutputDirectory should fail if the '
+        'LocalizationsGenerator.setOutputDirectory should fail if the '
         'the input string is null.'
       );
     });
@@ -124,7 +124,7 @@ void main() {
       }
 
       fail(
-        'Attempting to set LocalizationsGenerator.setTemplateArbFile should fail if the '
+        'LocalizationsGenerator.setTemplateArbFile should fail if the '
         'the inputDirectory is not specified.'
       );
     });
@@ -140,7 +140,7 @@ void main() {
       }
 
       fail(
-        'Attempting to set LocalizationsGenerator.setTemplateArbFile should fail if the '
+        'LocalizationsGenerator.setTemplateArbFile should fail if the '
         'the templateArbFileName passed in is null.'
       );
     });
@@ -156,7 +156,7 @@ void main() {
       }
 
       fail(
-        'Attempting to set LocalizationsGenerator.setTemplateArbFile should fail if the '
+        'LocalizationsGenerator.setTemplateArbFile should fail if the '
         'the input string is null.'
       );
     });
@@ -172,7 +172,7 @@ void main() {
       }
 
       fail(
-        'Attempting to set LocalizationsGenerator.setBaseOutputFile should fail if the '
+        'LocalizationsGenerator.setBaseOutputFile should fail if the '
         'the input string is null.'
       );
     });
@@ -188,7 +188,7 @@ void main() {
       }
 
       fail(
-        'Attempting to set LocalizationsGenerator.className should fail if the '
+        'LocalizationsGenerator.className should fail if the '
         'the input string is null.'
       );
     });
@@ -216,7 +216,7 @@ void main() {
           return;
         }
         fail(
-          'Attempting to set LocalizationsGenerator.className should fail if the '
+          'LocalizationsGenerator.className should fail if the '
           'the input string is not a valid Dart class name.'
         );
       });
@@ -229,7 +229,7 @@ void main() {
           return;
         }
         fail(
-          'Attempting to set LocalizationsGenerator.className should fail if the '
+          'LocalizationsGenerator.className should fail if the '
           'the input string is not a valid public Dart class name.'
         );
       });
@@ -242,7 +242,7 @@ void main() {
           return;
         }
         fail(
-          'Attempting to set LocalizationsGenerator.className should fail if the '
+          'LocalizationsGenerator.className should fail if the '
           'the input string is not a valid public Dart class name.'
         );
       });
@@ -255,7 +255,7 @@ void main() {
           return;
         }
         fail(
-          'Attempting to set LocalizationsGenerator.className should fail if the '
+          'LocalizationsGenerator.className should fail if the '
           'the input string is not a valid public Dart class name.'
         );
       });

--- a/dev/tools/test/localization/gen_l10n_test.dart
+++ b/dev/tools/test/localization/gen_l10n_test.dart
@@ -326,7 +326,7 @@ void main() {
           classNameString: defaultClassNameString,
         )
         ..loadResources()
-        ..writeOutputFile()
+        ..writeOutputFiles()
         ..outputUnimplementedMessages(path.join('lib', 'l10n', 'unimplemented_message_translations.json'));
     } on L10nException catch (e) {
       fail('Generating output should not fail: \n${e.message}');
@@ -359,7 +359,7 @@ void main() {
           classNameString: defaultClassNameString,
         )
         ..loadResources()
-        ..writeOutputFile();
+        ..writeOutputFiles();
     } on L10nException catch (e) {
       fail('Generating output should not fail: \n${e.message}');
     }
@@ -397,7 +397,7 @@ void main() {
           classNameString: defaultClassNameString,
         )
         ..loadResources()
-        ..writeOutputFile();
+        ..writeOutputFiles();
     } on L10nException catch (e) {
       fail('Generating output should not fail: \n${e.message}');
     }
@@ -424,7 +424,7 @@ void main() {
           classNameString: defaultClassNameString,
         )
         ..loadResources()
-        ..writeOutputFile();
+        ..writeOutputFiles();
     } on L10nException catch (e) {
       fail('Generating output should not fail: \n${e.message}');
     }
@@ -451,7 +451,7 @@ void main() {
           inputsAndOutputsListPath: defaultL10nPathString,
         )
         ..loadResources()
-        ..writeOutputFile();
+        ..writeOutputFiles();
     } on L10nException catch (e) {
       fail('Generating output should not fail: \n${e.message}');
     }
@@ -943,7 +943,7 @@ void main() {
     });
   });
 
-  group('writeOutputFile', () {
+  group('writeOutputFiles', () {
     test('should generate a file per language', () {
       const String singleEnCaMessageArbFileString = '''
 {
@@ -963,7 +963,7 @@ void main() {
           classNameString: defaultClassNameString,
         );
         generator.loadResources();
-        generator.writeOutputFile();
+        generator.writeOutputFiles();
       } on Exception catch (e) {
         fail('Generating output files should not fail: $e');
       }
@@ -996,7 +996,7 @@ void main() {
           preferredSupportedLocaleString: preferredSupportedLocaleString,
         );
         generator.loadResources();
-        generator.writeOutputFile();
+        generator.writeOutputFiles();
       } on Exception catch (e) {
         fail('Generating output files should not fail: $e');
       }
@@ -1027,7 +1027,7 @@ import 'output-localization-file_zh.dart';
           useDeferredLoading: true,
         );
         generator.loadResources();
-        generator.writeOutputFile();
+        generator.writeOutputFiles();
       } on Exception catch (e) {
         fail('Generating output files should not fail: $e');
       }
@@ -1072,7 +1072,7 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
             classNameString: defaultClassNameString,
           );
           generator.loadResources();
-          generator.writeOutputFile();
+          generator.writeOutputFiles();
         } on L10nException catch (e) {
           expect(e.message, contains('asdf'));
           expect(e.message, contains('springStartDate'));
@@ -1111,7 +1111,7 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
             classNameString: defaultClassNameString,
           );
           generator.loadResources();
-          generator.writeOutputFile();
+          generator.writeOutputFiles();
         } on L10nException catch (e) {
           expect(e.message, contains('the "format" attribute needs to be set'));
           return;
@@ -1149,7 +1149,7 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
             classNameString: defaultClassNameString,
           );
           generator.loadResources();
-          generator.writeOutputFile();
+          generator.writeOutputFiles();
         } on L10nException catch (e) {
           expect(e.message, contains('asdf'));
           expect(e.message, contains('progress'));
@@ -1186,7 +1186,7 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
             classNameString: defaultClassNameString,
           );
           generator.loadResources();
-          generator.writeOutputFile();
+          generator.writeOutputFiles();
         } on L10nException catch (e) {
           expect(e.message, contains('Check to see if the plural message is in the proper ICU syntax format'));
           return;
@@ -1219,7 +1219,7 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
             classNameString: defaultClassNameString,
           );
           generator.loadResources();
-          generator.writeOutputFile();
+          generator.writeOutputFiles();
         } on L10nException catch (e) {
           expect(e.message, contains('Check to see if the plural message is in the proper ICU syntax format'));
           return;
@@ -1248,7 +1248,7 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
             classNameString: defaultClassNameString,
           );
           generator.loadResources();
-          generator.writeOutputFile();
+          generator.writeOutputFiles();
         } on L10nException catch (e) {
           expect(e.message, contains('Resource attribute "@helloWorlds" was not found'));
           return;
@@ -1280,7 +1280,7 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
             classNameString: defaultClassNameString,
           );
           generator.loadResources();
-          generator.writeOutputFile();
+          generator.writeOutputFiles();
         } on L10nException catch (e) {
           expect(e.message, contains('is not properly formatted'));
           expect(e.message, contains('Ensure that it is a map with string valued keys'));
@@ -1313,7 +1313,7 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
           classNameString: defaultClassNameString,
         );
         generator.loadResources();
-        generator.writeOutputFile();
+        generator.writeOutputFiles();
       } on FormatException catch (e) {
         expect(e.message, contains('Unexpected character'));
         return;
@@ -1345,7 +1345,7 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
           classNameString: defaultClassNameString,
         );
         generator.loadResources();
-        generator.writeOutputFile();
+        generator.writeOutputFiles();
       } on L10nException catch (e) {
         expect(e.message, contains('Resource attribute "@title" was not found'));
         return;
@@ -1381,7 +1381,7 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
             classNameString: defaultClassNameString,
           );
           generator.loadResources();
-          generator.writeOutputFile();
+          generator.writeOutputFiles();
         } on L10nException catch (e) {
           expect(e.message, contains('Invalid ARB resource name'));
           return;
@@ -1413,7 +1413,7 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
             classNameString: defaultClassNameString,
           );
           generator.loadResources();
-          generator.writeOutputFile();
+          generator.writeOutputFiles();
         } on L10nException catch (e) {
           expect(e.message, contains('Invalid ARB resource name'));
           return;
@@ -1445,7 +1445,7 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
             classNameString: defaultClassNameString,
           );
           generator.loadResources();
-          generator.writeOutputFile();
+          generator.writeOutputFiles();
         } on L10nException catch (e) {
           expect(e.message, contains('Invalid ARB resource name'));
           return;

--- a/dev/tools/test/localization/gen_l10n_test.dart
+++ b/dev/tools/test/localization/gen_l10n_test.dart
@@ -465,14 +465,14 @@ void main() {
     final Map<String, dynamic> jsonResult = json.decode(inputsAndOutputsList.readAsStringSync()) as Map<String, dynamic>;
     expect(jsonResult.containsKey('inputs'), isTrue);
     final List<dynamic> inputList = jsonResult['inputs'] as List<dynamic>;
-    expect(inputList, contains(fs.directory(path.join('lib', 'l10n', 'app_en.arb')).absolute.path));
-    expect(inputList, contains(fs.directory(path.join('lib', 'l10n', 'app_es.arb')).absolute.path));
+    expect(inputList, contains(fs.path.absolute('lib', 'l10n', 'app_en.arb')));
+    expect(inputList, contains(fs.path.absolute('lib', 'l10n', 'app_es.arb')));
 
     expect(jsonResult.containsKey('outputs'), isTrue);
     final List<dynamic> outputList = jsonResult['outputs'] as List<dynamic>;
-    expect(outputList, contains(fs.directory(path.join('lib', 'l10n', 'output-localization-file.dart')).absolute.path));
-    expect(outputList, contains(fs.directory(path.join('lib', 'l10n', 'output-localization-file_en.dart')).absolute.path));
-    expect(outputList, contains(fs.directory(path.join('lib', 'l10n', 'output-localization-file_es.dart')).absolute.path));
+    expect(outputList, contains(fs.path.absolute('lib', 'l10n', 'output-localization-file.dart')));
+    expect(outputList, contains(fs.path.absolute('lib', 'l10n', 'output-localization-file_en.dart')));
+    expect(outputList, contains(fs.path.absolute('lib', 'l10n', 'output-localization-file_es.dart')));
   });
 
   test('setting both a headerString and a headerFile should fail', () {

--- a/dev/tools/test/localization/gen_l10n_test.dart
+++ b/dev/tools/test/localization/gen_l10n_test.dart
@@ -465,14 +465,14 @@ void main() {
     final Map<String, dynamic> jsonResult = json.decode(inputsAndOutputsList.readAsStringSync()) as Map<String, dynamic>;
     expect(jsonResult.containsKey('inputs'), isTrue);
     final List<dynamic> inputList = jsonResult['inputs'] as List<dynamic>;
-    expect(inputList, contains(path.join('/lib', 'l10n', 'app_en.arb')));
-    expect(inputList, contains(path.join('/lib', 'l10n', 'app_es.arb')));
+    expect(inputList, contains(fs.directory(path.join('lib', 'l10n', 'app_en.arb')).absolute.path));
+    expect(inputList, contains(fs.directory(path.join('lib', 'l10n', 'app_es.arb')).absolute.path));
 
     expect(jsonResult.containsKey('outputs'), isTrue);
     final List<dynamic> outputList = jsonResult['outputs'] as List<dynamic>;
-    expect(outputList, contains(path.join('/lib', 'l10n', 'output-localization-file.dart')));
-    expect(outputList, contains(path.join('/lib', 'l10n', 'output-localization-file_en.dart')));
-    expect(outputList, contains(path.join('/lib', 'l10n', 'output-localization-file_es.dart')));
+    expect(outputList, contains(fs.directory(path.join('lib', 'l10n', 'output-localization-file.dart')).absolute.path));
+    expect(outputList, contains(fs.directory(path.join('lib', 'l10n', 'output-localization-file_en.dart')).absolute.path));
+    expect(outputList, contains(fs.directory(path.join('lib', 'l10n', 'output-localization-file_es.dart')).absolute.path));
   });
 
   test('setting both a headerString and a headerFile should fail', () {


### PR DESCRIPTION
## Description

This PR creates a new option to output a list of inputs and outputs for the gen_l10n tool. It takes in the path (either relative or absolute) and creates an `gen_l10n_inputs_and_outputs.json` file. Using this option for the stocks app example, here is a sample output:

```
{
  "inputs": [
    "absolute/path/to/app/stocks/lib/i18n/stocks_en.arb",
    "absolute/path/to/app/stocks/lib/i18n/stocks_en_US.arb",
    "absolute/path/to/app/stocks/lib/i18n/stocks_es.arb"
  ],
  "outputs": [
    "absolute/path/to/app/stocks/lib/i18n/stock_strings_en.dart",
    "absolute/path/to/app/stocks/lib/i18n/stock_strings_es.dart",
    "absolute/path/to/app/stocks/lib/i18n/stock_strings.dart"
  ]
}
```

The PR also gratuitously fixes up terminology and tests that could be improved surrounding `writeOutputFile` and `generateCode`. These updates should not be breaking, since the developer API has not been modified.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/55503

## Tests

I added the following tests:

- Adds a test to ensure that the json file is produced at the path specified
- Modifies existing tests to call writeOutputFile() instead of generateCode(), since `generateCode` has become an implementation of `writeOutputFile`
- Modified `writeOutputFile` to plural `writeOutputFiles` since the tool now generates more than one localization file (it has been generating more than one file prior to this PR, but the code hasn't been updated so it was confusing).

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
