### PR TITLE
[flutter_tools] fix windows vs code lookup with missing platform environment variables

### DIFF
--- a/packages/flutter_tools/lib/src/vscode/vscode_validator.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode_validator.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import '../base/user_messages.dart';
 import '../base/version.dart';
 import '../doctor.dart';
+import '../globals.dart' as globals;
 import 'vscode.dart';
 
 class VsCodeValidator extends DoctorValidator {
@@ -16,7 +17,7 @@ class VsCodeValidator extends DoctorValidator {
 
   static Iterable<DoctorValidator> get installedValidators {
     return VsCode
-        .allInstalled()
+        .allInstalled(globals.fs, globals.platform)
         .map<DoctorValidator>((VsCode vsCode) => VsCodeValidator(vsCode));
   }
 

--- a/packages/flutter_tools/test/general.shard/vscode/vscode_test.dart
+++ b/packages/flutter_tools/test/general.shard/vscode/vscode_test.dart
@@ -10,8 +10,8 @@ import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/vscode/vscode.dart';
 
-import '../src/common.dart';
-import '../src/context.dart';
+import '../../src/common.dart';
+import '../../src/context.dart';
 
 void main() {
   testUsingContext('VsCode.fromDirectory does not crash when packages.json is malformed', () {

--- a/packages/flutter_tools/test/general.shard/vscode/vscode_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/vscode/vscode_validator_test.dart
@@ -1,0 +1,22 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/vscode/vscode.dart';
+
+import '../../src/common.dart';
+
+void main() {
+  testWithoutContext('VsCode search locations on windows supports an empty environment', () {
+    final FileSystem fileSystem = MemoryFileSystem.test(style: FileSystemStyle.windows);
+    final Platform platform = FakePlatform(
+      operatingSystem: 'windows',
+      environment: <String, String>{},
+    );
+
+    expect(VsCode.allInstalled(fileSystem, platform), isEmpty);
+  });
+}


### PR DESCRIPTION
## Description

If any of the Platform.environment variables for program files were null, the tool could crash looking up vscode. Restructure to avoid several globals and validate we can handle no results.

```
ArgumentError: Invalid argument(s): join(null, "Microsoft VS Code"): part 0 was null, but part 1 was not

at _validateArgList | (context.dart:1087 )
-- | --
  | at Context.join | (context.dart:231 )
  | at VsCode._installedWindows | (vscode.dart:171 )
  | at VsCode.allInstalled | (vscode.dart:94 )
  | at VsCodeValidator.installedValidators | (vscode_validator.dart:19 )
  | at _DefaultDoctorValidatorsProvider.validators | (doctor.dart:78 )
  | at Doctor.validators | (doctor.dart:159 )
  | at Doctor.startValidatorTasks | (doctor.dart:165 )
  | at Doctor.diagnose | (doctor.dart:271 )
  | at DoctorCommand.runCommand | (doctor.dart:60 )
  | at FlutterCommand.verifyThenRunCommand | (flutter_command.dart:722 )
  | at _rootRunUnary | (zone.dart:1192 )
  | at _CustomZone.runUnary | (zone.dart:1085 )
  | at _FutureListener.handleValue | (future_impl.dart:141 )
  | at Future._propagateToListeners.handleValueCallback | (future_impl.dart:682 )
  | at Future._propagateToListeners | (future_impl.dart:711 )
  | at Future._completeWithValue | (future_impl.dart:526 )
  | at Future._asyncComplete.<anonymous closure> | (future_impl.dart:556 )
  | at _rootRun | (zone.dart:1184 )
  | at _CustomZone.run | (zone.dart:1077 )
  | at _CustomZone.runGuarded | (zone.dart:979 )
  | at _CustomZone.bindCallbackGuarded.<anonymous closure> | (zone.dart:1019 )
  | at _microtaskLoop | (schedule_microtask.dart:43 )
  | at _startMicrotaskLoop | (schedule_microtask.dart:52 )
  | at _runPendingImmediateCallback | (isolate_patch.dart:118 )
  | at _RawReceivePortImpl._handleMessage | (isolate_patch.dart:169 )


```