### PR TITLE
Add --force to `roll_dev.dart`

### DIFF
--- a/dev/tools/lib/roll_dev.dart
+++ b/dev/tools/lib/roll_dev.dart
@@ -282,4 +282,3 @@ String incrementLevel(String version, String level) {
   }
   return getVersionFromParts(parts);
 }
-

--- a/dev/tools/lib/roll_dev.dart
+++ b/dev/tools/lib/roll_dev.dart
@@ -159,6 +159,7 @@ ArgResults parseArguments(ArgParser argParser, List<String> args) {
   );
   argParser.addFlag(
     kForce,
+    abbr: 'f',
     help: 'Force push. Necessary when the previous release had cherry-picks.',
     negatable: false,
   );

--- a/dev/tools/lib/roll_dev.dart
+++ b/dev/tools/lib/roll_dev.dart
@@ -27,47 +27,9 @@ const String kUpstreamRemote = 'git@github.com:flutter/flutter.git';
 void main(List<String> args) {
   final ArgParser argParser = ArgParser(allowTrailingOptions: false);
 
-  argParser.addOption(
-    kIncrement,
-    help: 'Specifies which part of the x.y.z version number to increment. Required.',
-    valueHelp: 'level',
-    allowed: <String>[kX, kY, kZ],
-    allowedHelp: <String, String>{
-      kX: 'Indicates a major development, e.g. typically changed after a big press event.',
-      kY: 'Indicates a minor development, e.g. typically changed after a beta release.',
-      kZ: 'Indicates the least notable level of change. You normally want this.',
-    },
-  );
-  argParser.addOption(
-    kCommit,
-    help: 'Specifies which git commit to roll to the dev branch. Required.',
-    valueHelp: 'hash',
-    defaultsTo: null, // This option is required
-  );
-  argParser.addOption(
-    kOrigin,
-    help: 'Specifies the name of the upstream repository',
-    valueHelp: 'repository',
-    defaultsTo: 'upstream',
-  );
-  argParser.addFlag(
-    kForce,
-    help: 'Force push. Necessary when the previous release had cherry-picks.',
-    negatable: false,
-  );
-  argParser.addFlag(
-    kJustPrint,
-    negatable: false,
-    help:
-        "Don't actually roll the dev channel; "
-        'just print the would-be version and quit.',
-  );
-  argParser.addFlag(kYes, negatable: false, abbr: 'y', help: 'Skip the confirmation prompt.');
-  argParser.addFlag(kHelp, negatable: false, help: 'Show this help message.', hide: true);
-
   ArgResults argResults;
   try {
-    argResults = argParser.parse(args);
+    argResults = parseArguments(argParser, args);
   } on ArgParserException catch (error) {
     print(error.message);
     print(argParser.usage);
@@ -135,6 +97,48 @@ void main(List<String> args) {
   print('Flutter version $version has been rolled to the "dev" channel!');
 }
 
+ArgResults parseArguments(ArgParser argParser, List<String> args) {
+  argParser.addOption(
+    kIncrement,
+    help: 'Specifies which part of the x.y.z version number to increment. Required.',
+    valueHelp: 'level',
+    allowed: <String>[kX, kY, kZ],
+    allowedHelp: <String, String>{
+      kX: 'Indicates a major development, e.g. typically changed after a big press event.',
+      kY: 'Indicates a minor development, e.g. typically changed after a beta release.',
+      kZ: 'Indicates the least notable level of change. You normally want this.',
+    },
+  );
+  argParser.addOption(
+    kCommit,
+    help: 'Specifies which git commit to roll to the dev branch. Required.',
+    valueHelp: 'hash',
+    defaultsTo: null, // This option is required
+  );
+  argParser.addOption(
+    kOrigin,
+    help: 'Specifies the name of the upstream repository',
+    valueHelp: 'repository',
+    defaultsTo: 'upstream',
+  );
+  argParser.addFlag(
+    kForce,
+    help: 'Force push. Necessary when the previous release had cherry-picks.',
+    negatable: false,
+  );
+  argParser.addFlag(
+    kJustPrint,
+    negatable: false,
+    help:
+        "Don't actually roll the dev channel; "
+        'just print the would-be version and quit.',
+  );
+  argParser.addFlag(kYes, negatable: false, abbr: 'y', help: 'Skip the confirmation prompt.');
+  argParser.addFlag(kHelp, negatable: false, help: 'Show this help message.', hide: true);
+
+  return argParser.parse(args);
+}
+
 /// Obtain the version tag of the previous dev release.
 String getFullTag() {
   const String glob = '*.*.*-*.*.pre';
@@ -196,13 +200,6 @@ String incrementLevel(String version, String level) {
   }
 
   final List<int> parts = match.groups(<int>[1, 2, 3, 4, 5]).map<int>(int.parse).toList();
-
-  if (match.group(6) == '0') {
-    throw Exception(
-      'This commit has already been released, as version '
-      '${getVersionFromParts(parts)}.'
-    );
-  }
 
   switch (level) {
     case kX:

--- a/dev/tools/lib/roll_dev.dart
+++ b/dev/tools/lib/roll_dev.dart
@@ -188,7 +188,7 @@ String getFullTag(Git git) {
 }
 
 Match parseFullTag(String version) {
-  // of the form: x.y.z-m.n.pre-c-g<revision>
+  // of the form: x.y.z-m.n.pre
   final RegExp versionPattern = RegExp(
     r'^(\d+)\.(\d+)\.(\d+)-(\d+)\.(\d+)\.pre$');
   return versionPattern.matchAsPrefix(version);
@@ -210,6 +210,7 @@ String getVersionFromParts(List<int> parts) {
 
 class Git {
   const Git();
+
   String getOutput(String command, String explanation) {
     final ProcessResult result = _run(command);
     if ((result.stderr as String).isEmpty && result.exitCode == 0)

--- a/dev/tools/lib/roll_dev.dart
+++ b/dev/tools/lib/roll_dev.dart
@@ -20,6 +20,7 @@ const String kOrigin = 'origin';
 const String kJustPrint = 'just-print';
 const String kYes = 'yes';
 const String kHelp = 'help';
+const String kForce = 'force';
 
 const String kUpstreamRemote = 'git@github.com:flutter/flutter.git';
 
@@ -48,6 +49,11 @@ void main(List<String> args) {
     help: 'Specifies the name of the upstream repository',
     valueHelp: 'repository',
     defaultsTo: 'upstream',
+  );
+  argParser.addFlag(
+    kForce,
+    help: 'Force push. Necessary when the previous release had cherry-picks.',
+    negatable: false,
   );
   argParser.addFlag(
     kJustPrint,

--- a/dev/tools/lib/roll_dev.dart
+++ b/dev/tools/lib/roll_dev.dart
@@ -63,6 +63,7 @@ bool run({
   final bool justPrint = argResults[kJustPrint] as bool;
   final bool autoApprove = argResults[kYes] as bool;
   final bool help = argResults[kHelp] as bool;
+  final bool force = argResults[kForce] as bool;
 
   if (help || level == null || commit == null) {
     print(
@@ -124,7 +125,10 @@ bool run({
   }
 
   git.run('push $origin $version', 'publish the version');
-  git.run('push $origin HEAD:dev', 'land the new version on the "dev" branch');
+  git.run(
+    'push ${force ? "--force " : ""}$origin HEAD:dev',
+    'land the new version on the "dev" branch',
+  );
   print('Flutter version $version has been rolled to the "dev" channel!');
   return true;
 }

--- a/dev/tools/lib/roll_dev.dart
+++ b/dev/tools/lib/roll_dev.dart
@@ -91,6 +91,7 @@ bool run({
     );
   }
 
+  // TODO(fujino): move this after `justPrint`
   git.run('fetch $origin', 'fetch $origin');
   git.run('reset $commit --hard', 'reset to the release commit');
 

--- a/dev/tools/lib/roll_dev.dart
+++ b/dev/tools/lib/roll_dev.dart
@@ -10,6 +10,7 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
+import 'package:meta/meta.dart';
 
 const String kIncrement = 'increment';
 const String kX = 'x';
@@ -43,9 +44,32 @@ void main(List<String> args) {
   final bool autoApprove = argResults[kYes] as bool;
   final bool help = argResults[kHelp] as bool;
 
+  run(
+    usage: argParser.usage,
+    argResults: argResults,
+    level: level,
+    commit: commit,
+    origin: origin,
+    justPrint: justPrint,
+    autoApprove: autoApprove,
+    help: help,
+  );
+}
+
+/// Main script execution.
+void run({
+  @required String usage,
+  @required ArgResults argResults,
+  @required String level,
+  @required String commit,
+  @required String origin,
+  @required bool justPrint,
+  @required bool autoApprove,
+  @required bool help,
+}) {
   if (help || level == null || commit == null) {
     print('roll_dev.dart --increment=level --commit=hash • update the version tags and roll a new dev build.\n');
-    print(argParser.usage);
+    print(usage);
     exit(0);
   }
 

--- a/dev/tools/lib/roll_dev.dart
+++ b/dev/tools/lib/roll_dev.dart
@@ -37,22 +37,10 @@ void main(List<String> args) {
     exit(1);
   }
 
-  final String level = argResults[kIncrement] as String;
-  final String commit = argResults[kCommit] as String;
-  final String origin = argResults[kOrigin] as String;
-  final bool justPrint = argResults[kJustPrint] as bool;
-  final bool autoApprove = argResults[kYes] as bool;
-  final bool help = argResults[kHelp] as bool;
-
   try {
     run(
       usage: argParser.usage,
-      level: level,
-      commit: commit,
-      origin: origin,
-      justPrint: justPrint,
-      autoApprove: autoApprove,
-      help: help,
+      argResults: argResults,
       getGitOutput: getGitOutput,
     );
   } on Exception catch (e) {
@@ -68,14 +56,16 @@ typedef GitWrapper = String Function(String command, String explanation);
 /// Returns true if publishing was successful, else false.
 bool run({
   @required String usage,
-  @required String level,
-  @required String commit,
-  @required String origin,
-  @required bool justPrint,
-  @required bool autoApprove,
-  @required bool help,
+  @required ArgResults argResults,
   @required GitWrapper getGitOutput,
 }) {
+  final String level = argResults[kIncrement] as String;
+  final String commit = argResults[kCommit] as String;
+  final String origin = argResults[kOrigin] as String;
+  final bool justPrint = argResults[kJustPrint] as bool;
+  final bool autoApprove = argResults[kYes] as bool;
+  final bool help = argResults[kHelp] as bool;
+
   if (help || level == null || commit == null) {
     print(
       'roll_dev.dart --increment=level --commit=hash • update the version tags '

--- a/dev/tools/lib/roll_dev.dart
+++ b/dev/tools/lib/roll_dev.dart
@@ -135,10 +135,13 @@ void main(List<String> args) {
   print('Flutter version $version has been rolled to the "dev" channel!');
 }
 
+/// Obtain the version tag of the previous dev release.
 String getFullTag() {
   const String glob = '*.*.*-*.*.pre';
+  // describe the latest dev release
+  const String ref = 'refs/heads/dev';
   return getGitOutput(
-    'describe --match $glob --first-parent --long --tags',
+    'describe --match $glob --exact-match --tags $ref',
     'obtain last released version number',
   );
 }
@@ -146,7 +149,7 @@ String getFullTag() {
 Match parseFullTag(String version) {
   // of the form: x.y.z-m.n.pre-c-g<revision>
   final RegExp versionPattern = RegExp(
-    r'^(\d+)\.(\d+)\.(\d+)-(\d+)\.(\d+)\.pre-(\d+)-g([a-f0-9]+)$');
+    r'^(\d+)\.(\d+)\.(\d+)-(\d+)\.(\d+)\.pre$');
   return versionPattern.matchAsPrefix(version);
 }
 

--- a/dev/tools/test/roll_dev_test.dart
+++ b/dev/tools/test/roll_dev_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:args/args.dart';
 import 'package:dev_tools/roll_dev.dart';
-import 'package:meta/meta.dart';
 import 'package:mockito/mockito.dart';
 
 import './common.dart';

--- a/dev/tools/test/roll_dev_test.dart
+++ b/dev/tools/test/roll_dev_test.dart
@@ -100,7 +100,7 @@ void main() {
       }
       const String pattern = r'The current directory is not a Flutter '
         'repository checkout with a correctly configured upstream remote.';
-      expect(exception.toString(), contains(pattern));
+      expect(exception?.toString(), contains(pattern));
     });
 
     test('throws exception if git checkout not clean', () {
@@ -129,7 +129,7 @@ void main() {
       const String pattern = r'Your git repository is not clean. Try running '
         '"git clean -fd". Warning, this will delete files! Run with -n to find '
         'out which ones.';
-      expect(exception.toString(), contains(pattern));
+      expect(exception?.toString(), contains(pattern));
     });
 
     test('does not tag if --just-print is specified', () {

--- a/dev/tools/test/roll_dev_test.dart
+++ b/dev/tools/test/roll_dev_test.dart
@@ -51,4 +51,73 @@ void main() {
       expect(getVersionFromParts(parts), '11.2.33-1.0.pre');
     });
   });
+
+  group('incrementLevel()', () {
+    const String hash = 'abc123';
+
+    test('throws exception if hash is not valid release candidate', () {
+      String level = 'z';
+
+      String version = '1.0.0-0.0.pre';
+      expect(
+        () => incrementLevel(version, level),
+        throwsException,
+        reason: 'should throw because $version is not valid output of `git describe`',
+      );
+
+      version = '1.1.1-1.1.pre.1-0-g$hash';
+      expect(
+        () => incrementLevel(version, level),
+        throwsException,
+        reason: 'should throw because $version is 0 commits past last tag'
+      );
+
+      version = '1.0.0-0.0.pre-1-g$hash';
+      level = 'q';
+      expect(
+        () => incrementLevel(version, level),
+        throwsException,
+        reason: 'should throw because $level is unsupported',
+      );
+    });
+
+    test('successfully increments x', () {
+      const String level = 'x';
+
+      String version = '1.0.0-0.0.pre-1-g$hash';
+      expect(incrementLevel(version, level), '2.0.0-0.0.pre');
+
+      version = '10.20.0-40.50.pre-1-g$hash';
+      expect(incrementLevel(version, level), '11.0.0-0.0.pre');
+
+      version = '1.18.0-3.0.pre-912-g$hash';
+      expect(incrementLevel(version, level), '2.0.0-0.0.pre');
+    });
+
+    test('successfully increments y', () {
+      const String level = 'y';
+
+      String version = '1.0.0-0.0.pre-1-g$hash';
+      expect(incrementLevel(version, level), '1.1.0-0.0.pre');
+
+      version = '10.20.0-40.50.pre-1-g$hash';
+      expect(incrementLevel(version, level), '10.21.0-0.0.pre');
+
+      version = '1.18.0-3.0.pre-912-g$hash';
+      expect(incrementLevel(version, level), '1.19.0-0.0.pre');
+    });
+
+    test('successfully increments z', () {
+      const String level = 'z';
+
+      String version = '1.0.0-0.0.pre-1-g$hash';
+      expect(incrementLevel(version, level), '1.0.0-1.0.pre');
+
+      version = '10.20.0-40.50.pre-1-g$hash';
+      expect(incrementLevel(version, level), '10.20.0-41.0.pre');
+
+      version = '1.18.0-3.0.pre-912-g$hash';
+      expect(incrementLevel(version, level), '1.18.0-4.0.pre');
+    });
+  });
 }

--- a/dev/tools/test/roll_dev_test.dart
+++ b/dev/tools/test/roll_dev_test.dart
@@ -9,13 +9,13 @@ void main() {
   group('parseFullTag', () {
     test('returns match on valid version input', () {
       final List<String> validTags = <String>[
-        '1.2.3-1.2.pre-3-gabc123',
-        '10.2.30-12.22.pre-45-gabc123',
-        '1.18.0-0.0.pre-0-gf0adb240a',
-        '2.0.0-1.99.pre-45-gf0adb240a',
-        '12.34.56-78.90.pre-12-g9db2703a2',
-        '0.0.1-0.0.pre-1-g07601eb95ff82f01e870566586340ed2e87b9cbb',
-        '958.80.144-6.224.pre-7803-g06e90',
+        '1.2.3-1.2.pre',
+        '10.2.30-12.22.pre',
+        '1.18.0-0.0.pre',
+        '2.0.0-1.99.pre',
+        '12.34.56-78.90.pre',
+        '0.0.1-0.0.pre',
+        '958.80.144-6.224.pre',
       ];
       for (final String validTag in validTags) {
         final Match match = parseFullTag(validTag);
@@ -25,15 +25,15 @@ void main() {
 
     test('returns null on invalid version input', () {
       final List<String> invalidTags = <String>[
-        '1.2.3-dev.1.2-3-gabc123',
-        '1.2.3-1.2-3-gabc123',
+        '1.2.3-1.2.pre-3-gabc123',
+        '1.2.3-1.2.3.pre',
+        '1.2.3.1.2.pre',
+        '1.2.3-dev.1.2',
+        '1.2.3-1.2-3',
         'v1.2.3',
         '2.0.0',
-        'v1.2.3-1.2.pre-3-gabc123',
-        '10.0.1-0.0.pre-gf0adb240a',
-        '10.0.1-0.0.pre-3-gggggggggg',
-        '1.2.3-1.2.pre-3-abc123',
-        '1.2.3-1.2.pre-3-gabc123_',
+        'v1.2.3-1.2.pre',
+        '1.2.3-1.2.pre_',
       ];
       for (final String invalidTag in invalidTags) {
         final Match match = parseFullTag(invalidTag);

--- a/dev/tools/test/roll_dev_test.dart
+++ b/dev/tools/test/roll_dev_test.dart
@@ -6,6 +6,58 @@ import 'package:dev_tools/roll_dev.dart';
 import './common.dart';
 
 void main() {
+  group('run()', () {
+    const String usage = 'usage info...';
+    const String level = 'z';
+    const String commit = 'abc123';
+    const String origin = 'upstream';
+
+    test('returns false if help requested', () {
+      expect(
+        run(
+          usage: usage,
+          level: level,
+          commit: commit,
+          origin: origin,
+          justPrint: false,
+          autoApprove: false,
+          help: true,
+        ),
+        false,
+      );
+    });
+
+    test('returns false if level not provided', () {
+      expect(
+        run(
+          usage: usage,
+          level: null,
+          commit: commit,
+          origin: origin,
+          justPrint: false,
+          autoApprove: false,
+          help: false,
+        ),
+        false,
+      );
+    });
+
+    test('returns false if commit not provided', () {
+      expect(
+        run(
+          usage: usage,
+          level: level,
+          commit: null,
+          origin: origin,
+          justPrint: false,
+          autoApprove: false,
+          help: false,
+        ),
+        false,
+      );
+    });
+  });
+
   group('parseFullTag', () {
     test('returns match on valid version input', () {
       final List<String> validTags = <String>[

--- a/dev/tools/test/roll_dev_test.dart
+++ b/dev/tools/test/roll_dev_test.dart
@@ -58,18 +58,18 @@ void main() {
     test('throws exception if hash is not valid release candidate', () {
       String level = 'z';
 
-      String version = '1.0.0-0.0.pre';
+      String version = '1.0.0-0.0.pre-1-g$hash';
       expect(
         () => incrementLevel(version, level),
         throwsException,
-        reason: 'should throw because $version is not valid output of `git describe`',
+        reason: 'should throw because $version should be an exact tag',
       );
 
-      version = '1.1.1-1.1.pre.1-0-g$hash';
+      version = '1.2.3';
       expect(
         () => incrementLevel(version, level),
         throwsException,
-        reason: 'should throw because $version is 0 commits past last tag'
+        reason: 'should throw because $version should be a dev tag, not stable.'
       );
 
       version = '1.0.0-0.0.pre-1-g$hash';
@@ -84,39 +84,39 @@ void main() {
     test('successfully increments x', () {
       const String level = 'x';
 
-      String version = '1.0.0-0.0.pre-1-g$hash';
+      String version = '1.0.0-0.0.pre';
       expect(incrementLevel(version, level), '2.0.0-0.0.pre');
 
-      version = '10.20.0-40.50.pre-1-g$hash';
+      version = '10.20.0-40.50.pre';
       expect(incrementLevel(version, level), '11.0.0-0.0.pre');
 
-      version = '1.18.0-3.0.pre-912-g$hash';
+      version = '1.18.0-3.0.pre';
       expect(incrementLevel(version, level), '2.0.0-0.0.pre');
     });
 
     test('successfully increments y', () {
       const String level = 'y';
 
-      String version = '1.0.0-0.0.pre-1-g$hash';
+      String version = '1.0.0-0.0.pre';
       expect(incrementLevel(version, level), '1.1.0-0.0.pre');
 
-      version = '10.20.0-40.50.pre-1-g$hash';
+      version = '10.20.0-40.50.pre';
       expect(incrementLevel(version, level), '10.21.0-0.0.pre');
 
-      version = '1.18.0-3.0.pre-912-g$hash';
+      version = '1.18.0-3.0.pre';
       expect(incrementLevel(version, level), '1.19.0-0.0.pre');
     });
 
     test('successfully increments z', () {
       const String level = 'z';
 
-      String version = '1.0.0-0.0.pre-1-g$hash';
+      String version = '1.0.0-0.0.pre';
       expect(incrementLevel(version, level), '1.0.0-1.0.pre');
 
-      version = '10.20.0-40.50.pre-1-g$hash';
+      version = '10.20.0-40.50.pre';
       expect(incrementLevel(version, level), '10.20.0-41.0.pre');
 
-      version = '1.18.0-3.0.pre-912-g$hash';
+      version = '1.18.0-3.0.pre';
       expect(incrementLevel(version, level), '1.18.0-4.0.pre');
     });
   });


### PR DESCRIPTION
## Description

This PR does the following:

1. Adds a `--force` flag, since dev releases can have cherry picks.
2. Changes the logic that detects the previous version to check the tip of the dev branch, rather than picking up the nearest ancestor, because a published cherry pick won't be an ancestor of the next dev release.
3. Refactors the code to allow more extensive unit testing.

## Related Issues

FIxes https://github.com/flutter/flutter/issues/56340

## Tests

Added extensive unit tests, exercising existing changed logic and the pre-existing logic.