### PR TITLE
Swap xcode_tests from MockProcessManager to FakeProcessManager

### DIFF
--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/artifacts.dart';
-import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart' show ProcessException, ProcessResult;
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -20,267 +19,356 @@ import '../../src/common.dart';
 import '../../src/context.dart';
 
 void main() {
-  ProcessManager processManager;
   Logger logger;
 
   setUp(() {
     logger = BufferLogger.test();
-    processManager = MockProcessManager();
   });
 
-  group('Xcode', () {
-    Xcode xcode;
-    MockXcodeProjectInterpreter mockXcodeProjectInterpreter;
-    MockPlatform platform;
-    FileSystem fileSystem;
+  // Work around https://github.com/flutter/flutter/issues/56415.
+  group('MockProcessManager', () {
+    ProcessManager processManager;
 
     setUp(() {
-      fileSystem = MemoryFileSystem();
-      mockXcodeProjectInterpreter = MockXcodeProjectInterpreter();
-      platform = MockPlatform();
-      xcode = Xcode(
-        logger: logger,
-        platform: platform,
-        fileSystem: fileSystem,
-        processManager: processManager,
-        xcodeProjectInterpreter: mockXcodeProjectInterpreter,
-      );
+      processManager = MockProcessManager();
     });
 
-    testWithoutContext('xcodeSelectPath returns null when xcode-select is not installed', () {
-      when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
+    group('Xcode', () {
+      Xcode xcode;
+
+      setUp(() {
+        xcode = Xcode(
+          logger: logger,
+          platform: MockPlatform(),
+          fileSystem: MemoryFileSystem.test(),
+          processManager: processManager,
+          xcodeProjectInterpreter: MockXcodeProjectInterpreter(),
+        );
+      });
+
+      testWithoutContext('xcodeSelectPath returns null when xcode-select is not installed', () {
+        when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
           .thenThrow(const ProcessException('/usr/bin/xcode-select', <String>['--print-path']));
-      expect(xcode.xcodeSelectPath, isNull);
-      when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
+        expect(xcode.xcodeSelectPath, isNull);
+        when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
           .thenThrow(ArgumentError('Invalid argument(s): Cannot find executable for /usr/bin/xcode-select'));
 
-      expect(xcode.xcodeSelectPath, isNull);
-    });
+        expect(xcode.xcodeSelectPath, isNull);
+      });
 
-    testWithoutContext('xcodeSelectPath returns path when xcode-select is installed', () {
-      const String xcodePath = '/Applications/Xcode8.0.app/Contents/Developer';
-      when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
-          .thenReturn(ProcessResult(1, 0, xcodePath, ''));
-
-      expect(xcode.xcodeSelectPath, xcodePath);
-    });
-
-    testWithoutContext('xcodeVersionSatisfactory is false when version is less than minimum', () {
-      when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-      when(mockXcodeProjectInterpreter.majorVersion).thenReturn(9);
-      when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
-
-      expect(xcode.isVersionSatisfactory, isFalse);
-    });
-
-    testWithoutContext('xcodeVersionSatisfactory is false when xcodebuild tools are not installed', () {
-      when(mockXcodeProjectInterpreter.isInstalled).thenReturn(false);
-
-      expect(xcode.isVersionSatisfactory, isFalse);
-    });
-
-    testWithoutContext('xcodeVersionSatisfactory is true when version meets minimum', () {
-      when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-      when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
-      when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
-
-      expect(xcode.isVersionSatisfactory, isTrue);
-    });
-
-    testWithoutContext('xcodeVersionSatisfactory is true when major version exceeds minimum', () {
-      when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-      when(mockXcodeProjectInterpreter.majorVersion).thenReturn(12);
-      when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
-
-      expect(xcode.isVersionSatisfactory, isTrue);
-    });
-
-    testWithoutContext('xcodeVersionSatisfactory is true when minor version exceeds minimum', () {
-      when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-      when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
-      when(mockXcodeProjectInterpreter.minorVersion).thenReturn(3);
-
-      expect(xcode.isVersionSatisfactory, isTrue);
-    });
-
-    testWithoutContext('isInstalledAndMeetsVersionCheck is false when not macOS', () {
-      when(platform.isMacOS).thenReturn(false);
-
-      expect(xcode.isInstalledAndMeetsVersionCheck, isFalse);
-    });
-
-    testWithoutContext('isInstalledAndMeetsVersionCheck is false when not installed', () {
-      when(platform.isMacOS).thenReturn(true);
-      const String xcodePath = '/Applications/Xcode8.0.app/Contents/Developer';
-      when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
-        .thenReturn(ProcessResult(1, 0, xcodePath, ''));
-      when(mockXcodeProjectInterpreter.isInstalled).thenReturn(false);
-
-      expect(xcode.isInstalledAndMeetsVersionCheck, isFalse);
-    });
-
-    testWithoutContext('isInstalledAndMeetsVersionCheck is false when no xcode-select', () {
-      when(platform.isMacOS).thenReturn(true);
-      when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
-        .thenReturn(ProcessResult(1, 127, '', 'ERROR'));
-      when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-      when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
-      when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
-
-      expect(xcode.isInstalledAndMeetsVersionCheck, isFalse);
-    });
-
-    testWithoutContext('isInstalledAndMeetsVersionCheck is false when version not satisfied', () {
-      when(platform.isMacOS).thenReturn(true);
-      const String xcodePath = '/Applications/Xcode8.0.app/Contents/Developer';
-      when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
-        .thenReturn(ProcessResult(1, 0, xcodePath, ''));
-      when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-      when(mockXcodeProjectInterpreter.majorVersion).thenReturn(10);
-      when(mockXcodeProjectInterpreter.minorVersion).thenReturn(2);
-
-      expect(xcode.isInstalledAndMeetsVersionCheck, isFalse);
-    });
-
-    testWithoutContext('isInstalledAndMeetsVersionCheck is true when macOS and installed and version is satisfied', () {
-      when(platform.isMacOS).thenReturn(true);
-      const String xcodePath = '/Applications/Xcode8.0.app/Contents/Developer';
-      when(processManager.runSync(<String>['/usr/bin/xcode-select', '--print-path']))
-        .thenReturn(ProcessResult(1, 0, xcodePath, ''));
-      when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-      when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
-      when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
-
-      expect(xcode.isInstalledAndMeetsVersionCheck, isTrue);
-    });
-
-    testWithoutContext('eulaSigned is false when clang is not installed', () {
-      when(processManager.runSync(<String>['/usr/bin/xcrun', 'clang']))
+      testWithoutContext('eulaSigned is false when clang is not installed', () {
+        when(processManager.runSync(<String>['/usr/bin/xcrun', 'clang']))
           .thenThrow(const ProcessException('/usr/bin/xcrun', <String>['clang']));
 
-      expect(xcode.eulaSigned, isFalse);
-    });
-
-    testWithoutContext('eulaSigned is false when clang output indicates EULA not yet accepted', () {
-      when(processManager.runSync(<String>['/usr/bin/xcrun', 'clang']))
-          .thenReturn(ProcessResult(1, 1, '', 'Xcode EULA has not been accepted.\nLaunch Xcode and accept the license.'));
-
-      expect(xcode.eulaSigned, isFalse);
-    });
-
-    testWithoutContext('eulaSigned is true when clang output indicates EULA has been accepted', () {
-      when(processManager.runSync(<String>['/usr/bin/xcrun', 'clang']))
-          .thenReturn(ProcessResult(1, 1, '', 'clang: error: no input files'));
-
-      expect(xcode.eulaSigned, isTrue);
-    });
-
-    testWithoutContext('SDK name', () {
-      expect(getNameForSdk(SdkType.iPhone), 'iphoneos');
-      expect(getNameForSdk(SdkType.iPhoneSimulator), 'iphonesimulator');
-      expect(getNameForSdk(SdkType.macOS), 'macosx');
-    });
-
-    group('SDK location', () {
-      const String sdkroot = 'Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS13.2.sdk';
-
-      testWithoutContext('--show-sdk-path iphoneos', () async {
-        when(processManager.run(<String>['xcrun', '--sdk', 'iphoneos', '--show-sdk-path'])).thenAnswer((_) =>
-        Future<ProcessResult>.value(ProcessResult(1, 0, sdkroot, '')));
-
-        expect(await xcode.sdkLocation(SdkType.iPhone), sdkroot);
-      });
-
-      testWithoutContext('--show-sdk-path macosx', () async {
-        when(processManager.run(<String>['xcrun', '--sdk', 'macosx', '--show-sdk-path'])).thenAnswer((_) =>
-        Future<ProcessResult>.value(ProcessResult(1, 0, sdkroot, '')));
-
-        expect(await xcode.sdkLocation(SdkType.macOS), sdkroot);
-      });
-
-      testWithoutContext('--show-sdk-path fails', () async {
-        when(processManager.run(<String>['xcrun', '--sdk', 'iphoneos', '--show-sdk-path'])).thenAnswer((_) =>
-        Future<ProcessResult>.value(ProcessResult(1, 1, '', 'xcrun: error:')));
-
-        expect(() async => await xcode.sdkLocation(SdkType.iPhone),
-          throwsToolExit(message: 'Could not find SDK location'));
+        expect(xcode.eulaSigned, isFalse);
       });
     });
-  });
 
-  group('xcdevice', () {
-    XCDevice xcdevice;
-    MockXcode mockXcode;
-    MockArtifacts mockArtifacts;
-    MockCache mockCache;
+    group('xcdevice', () {
+      XCDevice xcdevice;
+      MockXcode mockXcode;
 
-    setUp(() {
-      mockXcode = MockXcode();
-      mockArtifacts = MockArtifacts();
-      mockCache = MockCache();
-      xcdevice = XCDevice(
-        processManager: processManager,
-        logger: logger,
-        xcode: mockXcode,
-        platform: null,
-        artifacts: mockArtifacts,
-        cache: mockCache,
-      );
-    });
-
-    group('installed', () {
-      testWithoutContext('Xcode not installed', () {
-        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(false);
-        expect(xcdevice.isInstalled, false);
+      setUp(() {
+        mockXcode = MockXcode();
+        xcdevice = XCDevice(
+          processManager: processManager,
+          logger: logger,
+          xcode: mockXcode,
+          platform: null,
+          artifacts: MockArtifacts(),
+          cache: MockCache(),
+        );
       });
 
       testWithoutContext("xcrun can't find xcdevice", () {
         when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
 
         when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
-            .thenThrow(const ProcessException('xcrun', <String>['--find', 'xcdevice']));
+          .thenThrow(const ProcessException('xcrun', <String>['--find', 'xcdevice']));
         expect(xcdevice.isInstalled, false);
         verify(processManager.runSync(any)).called(1);
       });
 
-      testWithoutContext('is installed', () {
+      testWithoutContext('available devices xcdevice fails', () async {
         when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
 
         when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
-            .thenReturn(ProcessResult(1, 0, '/path/to/xcdevice', ''));
-        expect(xcdevice.isInstalled, true);
+          .thenReturn(ProcessResult(1, 0, '/path/to/xcdevice', ''));
+
+        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '2']))
+          .thenThrow(const ProcessException('xcrun', <String>['xcdevice', 'list', '--timeout', '2']));
+
+        expect(await xcdevice.getAvailableTetheredIOSDevices(), isEmpty);
+      });
+
+      testWithoutContext('diagnostics xcdevice fails', () async {
+        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
+
+        when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
+          .thenReturn(ProcessResult(1, 0, '/path/to/xcdevice', ''));
+
+        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '2']))
+          .thenThrow(const ProcessException('xcrun', <String>['xcdevice', 'list', '--timeout', '2']));
+
+        expect(await xcdevice.getDiagnostics(), isEmpty);
+      });
+    });
+  });
+
+  group('FakeProcessManager', () {
+    FakeProcessManager fakeProcessManager;
+
+    setUp(() {
+      fakeProcessManager = FakeProcessManager.list(<FakeCommand>[]);
+    });
+
+    group('Xcode', () {
+      Xcode xcode;
+      MockXcodeProjectInterpreter mockXcodeProjectInterpreter;
+      MockPlatform platform;
+
+      setUp(() {
+        mockXcodeProjectInterpreter = MockXcodeProjectInterpreter();
+        platform = MockPlatform();
+        xcode = Xcode(
+          logger: logger,
+          platform: platform,
+          fileSystem: MemoryFileSystem.test(),
+          processManager: fakeProcessManager,
+          xcodeProjectInterpreter: mockXcodeProjectInterpreter,
+        );
+      });
+
+      testWithoutContext('xcodeSelectPath returns path when xcode-select is installed', () {
+        const String xcodePath = '/Applications/Xcode8.0.app/Contents/Developer';
+        fakeProcessManager.addCommand(const FakeCommand(
+          command: <String>['/usr/bin/xcode-select', '--print-path'],
+          stdout: xcodePath,
+        ));
+
+        expect(xcode.xcodeSelectPath, xcodePath);
+        expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      });
+
+      testWithoutContext('xcodeVersionSatisfactory is false when version is less than minimum', () {
+        when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
+        when(mockXcodeProjectInterpreter.majorVersion).thenReturn(9);
+        when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
+
+        expect(xcode.isVersionSatisfactory, isFalse);
+      });
+
+      testWithoutContext('xcodeVersionSatisfactory is false when xcodebuild tools are not installed', () {
+        when(mockXcodeProjectInterpreter.isInstalled).thenReturn(false);
+
+        expect(xcode.isVersionSatisfactory, isFalse);
+      });
+
+      testWithoutContext('xcodeVersionSatisfactory is true when version meets minimum', () {
+        when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
+        when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
+        when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
+
+        expect(xcode.isVersionSatisfactory, isTrue);
+      });
+
+      testWithoutContext('xcodeVersionSatisfactory is true when major version exceeds minimum', () {
+        when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
+        when(mockXcodeProjectInterpreter.majorVersion).thenReturn(12);
+        when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
+
+        expect(xcode.isVersionSatisfactory, isTrue);
+      });
+
+      testWithoutContext('xcodeVersionSatisfactory is true when minor version exceeds minimum', () {
+        when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
+        when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
+        when(mockXcodeProjectInterpreter.minorVersion).thenReturn(3);
+
+        expect(xcode.isVersionSatisfactory, isTrue);
+      });
+
+      testWithoutContext('isInstalledAndMeetsVersionCheck is false when not macOS', () {
+        when(platform.isMacOS).thenReturn(false);
+
+        expect(xcode.isInstalledAndMeetsVersionCheck, isFalse);
+      });
+
+      testWithoutContext('isInstalledAndMeetsVersionCheck is false when not installed', () {
+        when(platform.isMacOS).thenReturn(true);
+        fakeProcessManager.addCommand(const FakeCommand(
+          command: <String>['/usr/bin/xcode-select', '--print-path'],
+          stdout: '/Applications/Xcode8.0.app/Contents/Developer',
+        ));
+        when(mockXcodeProjectInterpreter.isInstalled).thenReturn(false);
+
+        expect(xcode.isInstalledAndMeetsVersionCheck, isFalse);
+        expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      });
+
+      testWithoutContext('isInstalledAndMeetsVersionCheck is false when no xcode-select', () {
+        when(platform.isMacOS).thenReturn(true);
+        fakeProcessManager.addCommand(const FakeCommand(
+          command: <String>['/usr/bin/xcode-select', '--print-path'],
+          exitCode: 127,
+          stderr: 'ERROR',
+        ));
+        when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
+        when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
+        when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
+
+        expect(xcode.isInstalledAndMeetsVersionCheck, isFalse);
+        expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      });
+
+      testWithoutContext('isInstalledAndMeetsVersionCheck is false when version not satisfied', () {
+        when(platform.isMacOS).thenReturn(true);
+        fakeProcessManager.addCommand(const FakeCommand(
+          command: <String>['/usr/bin/xcode-select', '--print-path'],
+          stdout: '/Applications/Xcode8.0.app/Contents/Developer',
+        ));
+        when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
+        when(mockXcodeProjectInterpreter.majorVersion).thenReturn(10);
+        when(mockXcodeProjectInterpreter.minorVersion).thenReturn(2);
+
+        expect(xcode.isInstalledAndMeetsVersionCheck, isFalse);
+        expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      });
+
+      testWithoutContext('isInstalledAndMeetsVersionCheck is true when macOS and installed and version is satisfied', () {
+        when(platform.isMacOS).thenReturn(true);
+        fakeProcessManager.addCommand(const FakeCommand(
+          command: <String>['/usr/bin/xcode-select', '--print-path'],
+          stdout: '/Applications/Xcode8.0.app/Contents/Developer',
+        ));
+        when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
+        when(mockXcodeProjectInterpreter.majorVersion).thenReturn(11);
+        when(mockXcodeProjectInterpreter.minorVersion).thenReturn(0);
+
+        expect(xcode.isInstalledAndMeetsVersionCheck, isTrue);
+        expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      });
+
+      testWithoutContext('eulaSigned is false when clang output indicates EULA not yet accepted', () {
+        fakeProcessManager.addCommand(const FakeCommand(
+          command: <String>['/usr/bin/xcrun', 'clang'],
+          exitCode: 1,
+          stderr: 'Xcode EULA has not been accepted.\nLaunch Xcode and accept the license.',
+        ));
+
+        expect(xcode.eulaSigned, isFalse);
+        expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      });
+
+      testWithoutContext('eulaSigned is true when clang output indicates EULA has been accepted', () {
+        fakeProcessManager.addCommand(const FakeCommand(
+          command: <String>['/usr/bin/xcrun', 'clang'],
+          exitCode: 1,
+          stderr: 'clang: error: no input files',
+        ));
+
+        expect(xcode.eulaSigned, isTrue);
+        expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      });
+
+      testWithoutContext('SDK name', () {
+        expect(getNameForSdk(SdkType.iPhone), 'iphoneos');
+        expect(getNameForSdk(SdkType.iPhoneSimulator), 'iphonesimulator');
+        expect(getNameForSdk(SdkType.macOS), 'macosx');
+      });
+
+      group('SDK location', () {
+        const String sdkroot = 'Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS13.2.sdk';
+
+        testWithoutContext('--show-sdk-path iphoneos', () async {
+          fakeProcessManager.addCommand(const FakeCommand(
+            command: <String>['xcrun', '--sdk', 'iphoneos', '--show-sdk-path'],
+            stdout: sdkroot,
+          ));
+
+          expect(await xcode.sdkLocation(SdkType.iPhone), sdkroot);
+          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        });
+
+        testWithoutContext('--show-sdk-path macosx', () async {
+          fakeProcessManager.addCommand(const FakeCommand(
+            command: <String>['xcrun', '--sdk', 'macosx', '--show-sdk-path'],
+            stdout: sdkroot,
+          ));
+
+          expect(await xcode.sdkLocation(SdkType.macOS), sdkroot);
+          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        });
+
+        testWithoutContext('--show-sdk-path fails', () async {
+          fakeProcessManager.addCommand(const FakeCommand(
+            command: <String>['xcrun', '--sdk', 'iphoneos', '--show-sdk-path'],
+            exitCode: 1,
+            stderr: 'xcrun: error:',
+          ));
+
+          expect(() async => await xcode.sdkLocation(SdkType.iPhone),
+            throwsToolExit(message: 'Could not find SDK location'));
+          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        });
       });
     });
 
-    group('available devices', () {
-      final FakePlatform macPlatform = FakePlatform(operatingSystem: 'macos');
+    group('xcdevice', () {
+      XCDevice xcdevice;
+      MockXcode mockXcode;
+      MockArtifacts mockArtifacts;
+      MockCache mockCache;
 
-      testWithoutContext('Xcode not installed', () async {
-        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(false);
-
-        expect(await xcdevice.getAvailableTetheredIOSDevices(), isEmpty);
-        verifyNever(processManager.run(any));
+      setUp(() {
+        mockXcode = MockXcode();
+        mockArtifacts = MockArtifacts();
+        mockCache = MockCache();
+        xcdevice = XCDevice(
+          processManager: fakeProcessManager,
+          logger: logger,
+          xcode: mockXcode,
+          platform: null,
+          artifacts: mockArtifacts,
+          cache: mockCache,
+        );
       });
 
-      testWithoutContext('xcdevice fails', () async {
-        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
+      group('installed', () {
+        testWithoutContext('Xcode not installed', () {
+          when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(false);
+          expect(xcdevice.isInstalled, false);
+        });
 
-        when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
-            .thenReturn(ProcessResult(1, 0, '/path/to/xcdevice', ''));
+        testWithoutContext('is installed', () {
+          when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
+          fakeProcessManager.addCommand(const FakeCommand(
+            command: <String>['xcrun', '--find', 'xcdevice'],
+            stdout: '/path/to/xcdevice',
+          ));
 
-        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '2']))
-            .thenThrow(const ProcessException('xcrun', <String>['xcdevice', 'list', '--timeout', '2']));
-
-        expect(await xcdevice.getAvailableTetheredIOSDevices(), isEmpty);
+          expect(xcdevice.isInstalled, true);
+          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        });
       });
 
-      testUsingContext('returns devices', () async {
-        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
+      group('available devices', () {
+        final FakePlatform macPlatform = FakePlatform(operatingSystem: 'macos');
 
-        when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
-            .thenReturn(ProcessResult(1, 0, '/path/to/xcdevice', ''));
+        testWithoutContext('Xcode not installed', () async {
+          when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(false);
 
-        const String devicesOutput = '''
+          expect(await xcdevice.getAvailableTetheredIOSDevices(), isEmpty);
+        });
+
+        testUsingContext('returns devices', () async {
+          when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
+          fakeProcessManager.addCommand(const FakeCommand(
+            command: <String>['xcrun', '--find', 'xcdevice'],
+            stdout: '/path/to/xcdevice',
+          ));
+
+          const String devicesOutput = '''
 [
   {
     "simulator" : true,
@@ -373,45 +461,52 @@ void main() {
 ]
 ''';
 
-        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '2']))
-            .thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 0, devicesOutput, '')));
-        final List<IOSDevice> devices = await xcdevice.getAvailableTetheredIOSDevices();
-        expect(devices, hasLength(3));
-        expect(devices[0].id, 'd83d5bc53967baa0ee18626ba87b6254b2ab5418');
-        expect(devices[0].name, 'An iPhone (Space Gray)');
-        expect(await devices[0].sdkNameAndVersion, 'iOS 13.3');
-        expect(devices[0].cpuArchitecture, DarwinArch.arm64);
-        expect(devices[1].id, '98206e7a4afd4aedaff06e687594e089dede3c44');
-        expect(devices[1].name, 'iPad 1');
-        expect(await devices[1].sdkNameAndVersion, 'iOS 10.1');
-        expect(devices[1].cpuArchitecture, DarwinArch.armv7);
-        expect(devices[2].id, 'f577a7903cc54959be2e34bc4f7f80b7009efcf4');
-        expect(devices[2].name, 'iPad 2');
-        expect(await devices[2].sdkNameAndVersion, 'iOS 10.1');
-        expect(devices[2].cpuArchitecture, DarwinArch.arm64); // Defaults to arm64 for unknown architecture.
-      }, overrides: <Type, Generator>{
-        Platform: () => macPlatform,
-      });
+          fakeProcessManager.addCommand(const FakeCommand(
+            command: <String>['xcrun', 'xcdevice', 'list', '--timeout', '2'],
+            stdout: devicesOutput,
+          ));
+          final List<IOSDevice> devices = await xcdevice.getAvailableTetheredIOSDevices();
+          expect(devices, hasLength(3));
+          expect(devices[0].id, 'd83d5bc53967baa0ee18626ba87b6254b2ab5418');
+          expect(devices[0].name, 'An iPhone (Space Gray)');
+          expect(await devices[0].sdkNameAndVersion, 'iOS 13.3');
+          expect(devices[0].cpuArchitecture, DarwinArch.arm64);
+          expect(devices[1].id, '98206e7a4afd4aedaff06e687594e089dede3c44');
+          expect(devices[1].name, 'iPad 1');
+          expect(await devices[1].sdkNameAndVersion, 'iOS 10.1');
+          expect(devices[1].cpuArchitecture, DarwinArch.armv7);
+          expect(devices[2].id, 'f577a7903cc54959be2e34bc4f7f80b7009efcf4');
+          expect(devices[2].name, 'iPad 2');
+          expect(await devices[2].sdkNameAndVersion, 'iOS 10.1');
+          expect(devices[2].cpuArchitecture, DarwinArch.arm64); // Defaults to arm64 for unknown architecture.
+          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        }, overrides: <Type, Generator>{
+          Platform: () => macPlatform,
+        });
 
-      testWithoutContext('uses timeout', () async {
-        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
+        testWithoutContext('uses timeout', () async {
+          when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
+          fakeProcessManager.addCommand(const FakeCommand(
+            command: <String>['xcrun', '--find', 'xcdevice'],
+            stdout: '/path/to/xcdevice',
+          ));
 
-        when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
-          .thenReturn(ProcessResult(1, 0, '/path/to/xcdevice', ''));
+          fakeProcessManager.addCommand(const FakeCommand(
+            command: <String>['xcrun', 'xcdevice', 'list', '--timeout', '20'],
+            stdout: '[]',
+          ));
+          await xcdevice.getAvailableTetheredIOSDevices(timeout: const Duration(seconds: 20));
+          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        });
 
-        when(processManager.run(any))
-          .thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 0, '[]', '')));
-        await xcdevice.getAvailableTetheredIOSDevices(timeout: const Duration(seconds: 20));
-        verify(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '20'])).called(1);
-      });
+        testUsingContext('ignores "Preparing debugger support for iPhone" error', () async {
+          when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
+          fakeProcessManager.addCommand(const FakeCommand(
+            command: <String>['xcrun', '--find', 'xcdevice'],
+            stdout: '/path/to/xcdevice',
+          ));
 
-      testUsingContext('ignores "Preparing debugger support for iPhone" error', () async {
-        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
-
-        when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
-            .thenReturn(ProcessResult(1, 0, '/path/to/xcdevice', ''));
-
-        const String devicesOutput = '''
+          const String devicesOutput = '''
 [
   {
     "simulator" : false,
@@ -435,22 +530,26 @@ void main() {
 ]
 ''';
 
-        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '2']))
-            .thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 0, devicesOutput, '')));
-        final List<IOSDevice> devices = await xcdevice.getAvailableTetheredIOSDevices();
-        expect(devices, hasLength(1));
-        expect(devices[0].id, '43ad2fda7991b34fe1acbda82f9e2fd3d6ddc9f7');
-      }, overrides: <Type, Generator>{
-        Platform: () => macPlatform,
-      });
+          fakeProcessManager.addCommand(const FakeCommand(
+            command: <String>['xcrun', 'xcdevice', 'list', '--timeout', '2'],
+            stdout: devicesOutput,
+          ));
+          final List<IOSDevice> devices = await xcdevice.getAvailableTetheredIOSDevices();
+          expect(devices, hasLength(1));
+          expect(devices[0].id, '43ad2fda7991b34fe1acbda82f9e2fd3d6ddc9f7');
+          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        }, overrides: <Type, Generator>{
+          Platform: () => macPlatform,
+        });
 
-      testUsingContext('handles unknown architectures', () async {
-        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
+        testUsingContext('handles unknown architectures', () async {
+          when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
+          fakeProcessManager.addCommand(const FakeCommand(
+            command: <String>['xcrun', '--find', 'xcdevice'],
+            stdout: '/path/to/xcdevice',
+          ));
 
-        when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
-          .thenReturn(ProcessResult(1, 0, '/path/to/xcdevice', ''));
-
-        const String devicesOutput = '''
+          const String devicesOutput = '''
 [
   {
     "simulator" : false,
@@ -479,45 +578,36 @@ void main() {
 ]
 ''';
 
-        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '2']))
-          .thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 0, devicesOutput, '')));
-        final List<IOSDevice> devices = await xcdevice.getAvailableTetheredIOSDevices();
-        expect(devices[0].cpuArchitecture, DarwinArch.armv7);
-        expect(devices[1].cpuArchitecture, DarwinArch.arm64);
-      }, overrides: <Type, Generator>{
-        Platform: () => macPlatform,
-      });
-    });
-
-    group('diagnostics', () {
-      final FakePlatform macPlatform = FakePlatform(operatingSystem: 'macos');
-
-      testWithoutContext('Xcode not installed', () async {
-        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(false);
-
-        expect(await xcdevice.getDiagnostics(), isEmpty);
-        verifyNever(processManager.run(any));
+          fakeProcessManager.addCommand(const FakeCommand(
+            command: <String>['xcrun', 'xcdevice', 'list', '--timeout', '2'],
+            stdout: devicesOutput,
+          ));
+          final List<IOSDevice> devices = await xcdevice.getAvailableTetheredIOSDevices();
+          expect(devices[0].cpuArchitecture, DarwinArch.armv7);
+          expect(devices[1].cpuArchitecture, DarwinArch.arm64);
+          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        }, overrides: <Type, Generator>{
+          Platform: () => macPlatform,
+        });
       });
 
-      testWithoutContext('xcdevice fails', () async {
-        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
+      group('diagnostics', () {
+        final FakePlatform macPlatform = FakePlatform(operatingSystem: 'macos');
 
-        when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
-            .thenReturn(ProcessResult(1, 0, '/path/to/xcdevice', ''));
+        testWithoutContext('Xcode not installed', () async {
+          when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(false);
 
-        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '2']))
-            .thenThrow(const ProcessException('xcrun', <String>['xcdevice', 'list', '--timeout', '2']));
+          expect(await xcdevice.getDiagnostics(), isEmpty);
+        });
 
-        expect(await xcdevice.getDiagnostics(), isEmpty);
-      });
+        testUsingContext('uses cache', () async {
+          when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
+          fakeProcessManager.addCommand(const FakeCommand(
+            command: <String>['xcrun', '--find', 'xcdevice'],
+            stdout: '/path/to/xcdevice',
+          ));
 
-      testUsingContext('uses cache', () async {
-        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
-
-        when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
-            .thenReturn(ProcessResult(1, 0, '/path/to/xcdevice', ''));
-
-        const String devicesOutput = '''
+          const String devicesOutput = '''
 [
   {
     "simulator" : false,
@@ -538,24 +628,27 @@ void main() {
 ]
 ''';
 
-        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '2']))
-            .thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 0, devicesOutput, '')));
-        await xcdevice.getAvailableTetheredIOSDevices();
-        final List<String> errors = await xcdevice.getDiagnostics();
-        expect(errors, hasLength(1));
+          fakeProcessManager.addCommand(const FakeCommand(
+            command: <String>['xcrun', 'xcdevice', 'list', '--timeout', '2'],
+            stdout: devicesOutput,
+          ));
 
-        verify(processManager.run(any)).called(1);
-      }, overrides: <Type, Generator>{
-        Platform: () => macPlatform,
-      });
+          await xcdevice.getAvailableTetheredIOSDevices();
+          final List<String> errors = await xcdevice.getDiagnostics();
+          expect(errors, hasLength(1));
+          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        }, overrides: <Type, Generator>{
+          Platform: () => macPlatform,
+        });
 
-      testUsingContext('returns error message', () async {
-        when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
+        testUsingContext('returns error message', () async {
+          when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
+          fakeProcessManager.addCommand(const FakeCommand(
+            command: <String>['xcrun', '--find', 'xcdevice'],
+            stdout: '/path/to/xcdevice',
+          ));
 
-        when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
-            .thenReturn(ProcessResult(1, 0, '/path/to/xcdevice', ''));
-
-        const String devicesOutput = '''
+          const String devicesOutput = '''
 [
    {
     "simulator" : false,
@@ -640,16 +733,21 @@ void main() {
 ]
 ''';
 
-        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '2']))
-            .thenAnswer((_) => Future<ProcessResult>.value(ProcessResult(1, 0, devicesOutput, '')));
-        final List<String> errors = await xcdevice.getDiagnostics();
-        expect(errors, hasLength(4));
-        expect(errors[0], 'Error: iPhone is not paired with your computer. To use iPhone with Xcode, unlock it and choose to trust this computer when prompted. (code -9)');
-        expect(errors[1], 'Error: iPhone is not paired with your computer.');
-        expect(errors[2], 'Error: Xcode pairing error. (code -13)');
-        expect(errors[3], 'Error: iPhone is busy: Preparing debugger support for iPhone. Xcode will continue when iPhone is finished. (code -10)');
-      }, overrides: <Type, Generator>{
-        Platform: () => macPlatform,
+          fakeProcessManager.addCommand(const FakeCommand(
+            command: <String>['xcrun', 'xcdevice', 'list', '--timeout', '2'],
+            stdout: devicesOutput,
+          ));
+
+          final List<String> errors = await xcdevice.getDiagnostics();
+          expect(errors, hasLength(4));
+          expect(errors[0], 'Error: iPhone is not paired with your computer. To use iPhone with Xcode, unlock it and choose to trust this computer when prompted. (code -9)');
+          expect(errors[1], 'Error: iPhone is not paired with your computer.');
+          expect(errors[2], 'Error: Xcode pairing error. (code -13)');
+          expect(errors[3], 'Error: iPhone is busy: Preparing debugger support for iPhone. Xcode will continue when iPhone is finished. (code -10)');
+          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        }, overrides: <Type, Generator>{
+          Platform: () => macPlatform,
+        });
       });
     });
   });

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -25,7 +25,8 @@ void main() {
     logger = BufferLogger.test();
   });
 
-  // Work around https://github.com/flutter/flutter/issues/56415.
+  // Group exists to work around https://github.com/flutter/flutter/issues/56415.
+  // Do not add more `MockProcessManager` tests.
   group('MockProcessManager', () {
     ProcessManager processManager;
 


### PR DESCRIPTION
## Description

Change most of the xcode_tests from MockProcessManager to FakeProcessManager.  I had to keep MockProcessManager for the tests that needed to throw on run to work around https://github.com/flutter/flutter/issues/56415.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*