### PR TITLE
feature: add usermessage when miss platform project

### DIFF
--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:args/command_runner.dart';
 import 'package:intl/intl.dart' as intl;

--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:typed_data';
 
 import 'package:args/command_runner.dart';
 import 'package:intl/intl.dart' as intl;

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -220,7 +220,9 @@ class UserMessages {
       "matching '$deviceId'";
   String get flutterNoDevicesFound => 'No devices found';
   String get flutterNoSupportedDevices => 'No supported devices connected.';
-  String flutterMissPlatformProject(String flutterProject) => '`android`, `iOS` or other platform projects may missing in your project $flutterProject, please check it.';
+  String flutterMissPlatformProject(String flutterProject) =>
+      'Is your project missing a platform project in your project $flutterProject'
+      '\nConsider running "flutter create ." to create one.';
   String get flutterFoundButUnSupportedDevices=> 'Follow devices are founded but not support in this project: ';
   String flutterFoundSpecifiedDevices(int count, String deviceId) =>
       'Found $count devices with name or id matching $deviceId:';

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -221,8 +221,8 @@ class UserMessages {
   String get flutterNoDevicesFound => 'No devices found';
   String get flutterNoSupportedDevices => 'No supported devices connected.';
   String flutterMissPlatformProject(String flutterProject) =>
-      'Is your project missing a platform project in your project $flutterProject'
-      '\nConsider running "flutter create ." to create one.';
+      'Your project $flutterProject is missing some platform projects.'
+          '\n Consider running "flutter create ." in the root project to create them.';
   String get flutterFoundButUnSupportedDevices=> 'Follow devices are founded but not support in this project: ';
   String flutterFoundSpecifiedDevices(int count, String deviceId) =>
       'Found $count devices with name or id matching $deviceId:';

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -222,7 +222,7 @@ class UserMessages {
   String get flutterNoSupportedDevices => 'No supported devices connected.';
   String flutterMissPlatformProject(String flutterProject) =>
       'Your project $flutterProject is missing some platform projects.'
-          '\n Consider running "flutter create ." in the root project to create them.';
+          '\nConsider running "flutter create ." in the root project to create them.';
   String get flutterFoundButUnSupportedDevices=> 'Follow devices are founded but not support in this project: ';
   String flutterFoundSpecifiedDevices(int count, String deviceId) =>
       'Found $count devices with name or id matching $deviceId:';

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -220,6 +220,8 @@ class UserMessages {
       "matching '$deviceId'";
   String get flutterNoDevicesFound => 'No devices found';
   String get flutterNoSupportedDevices => 'No supported devices connected.';
+  String flutterMissPlatformProject(String flutterProject) => '`android`, `iOS` or other platform projects may missing in your project $flutterProject, please check it.';
+  String get flutterFoundButUnSupportedDevices=> 'Follow devices are founded but not support in this project: ';
   String flutterFoundSpecifiedDevices(int count, String deviceId) =>
       'Found $count devices with name or id matching $deviceId:';
   String get flutterSpecifyDeviceWithAllOption =>

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -220,10 +220,10 @@ class UserMessages {
       "matching '$deviceId'";
   String get flutterNoDevicesFound => 'No devices found';
   String get flutterNoSupportedDevices => 'No supported devices connected.';
-  String flutterMissPlatformProject(String flutterProject) =>
+  String flutterMissPlatformProject(String flutterProject, List<String> unsupportedDevicesType) =>
       'Your project $flutterProject is missing some platform projects.'
-          '\nConsider running "flutter create ." in the root project to create them.';
-  String get flutterFoundButUnSupportedDevices=> 'Follow devices are founded but not support in this project: ';
+          '\nIf you would like your app to run on ${unsupportedDevicesType.join(' or ')}, consider running `flutter create .` to generate projects for these platforms.';
+  String get flutterFoundButUnsupportedDevices=> 'The following devices were found, but are not supported by this project:';
   String flutterFoundSpecifiedDevices(int count, String deviceId) =>
       'Found $count devices with name or id matching $deviceId:';
   String get flutterSpecifyDeviceWithAllOption =>

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -220,8 +220,8 @@ class UserMessages {
       "matching '$deviceId'";
   String get flutterNoDevicesFound => 'No devices found';
   String get flutterNoSupportedDevices => 'No supported devices connected.';
-  String flutterMissPlatformProject(List<String> unsupportedDevicesType) =>
-          'If you would like your app to run on ${unsupportedDevicesType.join(' or ')}, consider running `flutter create .` to generate projects for these platforms.';
+  String flutterMissPlatformProjects(List<String> unsupportedDevicesType) =>
+      'If you would like your app to run on ${unsupportedDevicesType.join(' or ')}, consider running `flutter create .` to generate projects for these platforms.';
   String get flutterFoundButUnsupportedDevices => 'The following devices were found, but are not supported by this project:';
   String flutterFoundSpecifiedDevices(int count, String deviceId) =>
       'Found $count devices with name or id matching $deviceId:';

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -220,10 +220,9 @@ class UserMessages {
       "matching '$deviceId'";
   String get flutterNoDevicesFound => 'No devices found';
   String get flutterNoSupportedDevices => 'No supported devices connected.';
-  String flutterMissPlatformProject(String flutterProject, List<String> unsupportedDevicesType) =>
-      'Your project $flutterProject is missing some platform projects.'
-          '\nIf you would like your app to run on ${unsupportedDevicesType.join(' or ')}, consider running `flutter create .` to generate projects for these platforms.';
-  String get flutterFoundButUnsupportedDevices=> 'The following devices were found, but are not supported by this project:';
+  String flutterMissPlatformProject(List<String> unsupportedDevicesType) =>
+          'If you would like your app to run on ${unsupportedDevicesType.join(' or ')}, consider running `flutter create .` to generate projects for these platforms.';
+  String get flutterFoundButUnsupportedDevices => 'The following devices were found, but are not supported by this project:';
   String flutterFoundSpecifiedDevices(int count, String deviceId) =>
       'Found $count devices with name or id matching $deviceId:';
   String get flutterSpecifyDeviceWithAllOption =>

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -550,6 +550,12 @@ abstract class Device {
     await descriptions(devices).forEach(globals.printStatus);
   }
 
+  static List<String> devicesPlatformTypes(List<Device> devices) {
+    return devices.map(
+        (Device d) => d.platformType.toString(),
+      ).toSet().toList();
+  }
+
   /// Convert the Device object to a JSON representation suitable for serialization.
   Future<Map<String, Object>> toJson() async {
     final bool isLocalEmu = await isLocalEmulator;

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -551,11 +551,10 @@ abstract class Device {
   }
 
   static List<String> devicesPlatformTypes(List<Device> devices) {
-    final List<String> platformTypes = devices.map(
-        (Device d) => d.platformType.toString(),
-      ).toSet().toList();
-    platformTypes.sort();
-    return platformTypes;
+    return devices
+        .map(
+          (Device d) => d.platformType.toString(),
+        ).toSet().toList()..sort();
   }
 
   /// Convert the Device object to a JSON representation suitable for serialization.

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -551,9 +551,11 @@ abstract class Device {
   }
 
   static List<String> devicesPlatformTypes(List<Device> devices) {
-    return devices.map(
+    final List<String> platformTypes = devices.map(
         (Device d) => d.platformType.toString(),
       ).toSet().toList();
+    platformTypes.sort();
+    return platformTypes;
   }
 
   /// Convert the Device object to a JSON representation suitable for serialization.

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -834,7 +834,7 @@ abstract class FlutterCommand extends Command<void> {
         globals.printStatus('');
         await Device.printDevices(unSupportedDevices);
         globals.printStatus('');
-        globals.printStatus(userMessages.flutterMissPlatformProject(FlutterProject.current().directory.path));
+        globals.printError(userMessages.flutterMissPlatformProject(FlutterProject.current().directory.path));
       }
       return null;
     } else if (devices.length > 1 && !deviceManager.hasSpecifiedAllDevices) {

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -822,11 +822,20 @@ abstract class FlutterCommand extends Command<void> {
     if (devices.isEmpty && deviceManager.hasSpecifiedDeviceId) {
       globals.printStatus(userMessages.flutterNoMatchingDevice(deviceManager.specifiedDeviceId));
       return null;
-    } else if (devices.isEmpty && deviceManager.hasSpecifiedAllDevices) {
-      globals.printStatus(userMessages.flutterNoDevicesFound);
-      return null;
     } else if (devices.isEmpty) {
-      globals.printStatus(userMessages.flutterNoSupportedDevices);
+      if (deviceManager.hasSpecifiedAllDevices) {
+        globals.printStatus(userMessages.flutterNoDevicesFound);
+      } else {
+        globals.printStatus(userMessages.flutterNoSupportedDevices);
+      }
+      final List<Device> unSupportedDevices = await deviceManager.getDevices();
+      if (unSupportedDevices.isNotEmpty) {
+        globals.printStatus('Follow devices are founded but not support in this project:');
+        globals.printStatus('');
+        await Device.printDevices(unSupportedDevices);
+        globals.printStatus('');
+        globals.printStatus(userMessages.flutterMissPlatformProject(FlutterProject.current().directory.path));
+      }
       return null;
     } else if (devices.length > 1 && !deviceManager.hasSpecifiedAllDevices) {
       if (deviceManager.hasSpecifiedDeviceId) {

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -830,7 +830,7 @@ abstract class FlutterCommand extends Command<void> {
       }
       final List<Device> unSupportedDevices = await deviceManager.getDevices();
       if (unSupportedDevices.isNotEmpty) {
-        globals.printStatus('Follow devices are founded but not support in this project:');
+        globals.printStatus('The following devices were found, but they aren\'t supported in this project');
         globals.printStatus('');
         await Device.printDevices(unSupportedDevices);
         globals.printStatus('');

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -830,11 +830,11 @@ abstract class FlutterCommand extends Command<void> {
       }
       final List<Device> unSupportedDevices = await deviceManager.getDevices();
       if (unSupportedDevices.isNotEmpty) {
-        globals.printStatus('The following devices were found, but they aren\'t supported in this project');
+        globals.printStatus(userMessages.flutterFoundButUnSupportedDevices);
         globals.printStatus('');
         await Device.printDevices(unSupportedDevices);
         globals.printStatus('');
-        globals.printError(userMessages.flutterMissPlatformProject(FlutterProject.current().directory.path));
+        globals.printStatus(userMessages.flutterMissPlatformProject(FlutterProject.current().directory.path));
       }
       return null;
     } else if (devices.length > 1 && !deviceManager.hasSpecifiedAllDevices) {

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -828,13 +828,16 @@ abstract class FlutterCommand extends Command<void> {
       } else {
         globals.printStatus(userMessages.flutterNoSupportedDevices);
       }
-      final List<Device> unSupportedDevices = await deviceManager.getDevices();
-      if (unSupportedDevices.isNotEmpty) {
-        globals.printStatus(userMessages.flutterFoundButUnSupportedDevices);
+      final List<Device> unsupportedDevices = await deviceManager.getDevices();
+      if (unsupportedDevices.isNotEmpty) {
+        globals.printStatus(userMessages.flutterFoundButUnsupportedDevices);
         globals.printStatus('');
-        await Device.printDevices(unSupportedDevices);
+        await Device.printDevices(unsupportedDevices);
         globals.printStatus('');
-        globals.printStatus(userMessages.flutterMissPlatformProject(FlutterProject.current().directory.path));
+        globals.printStatus(userMessages.flutterMissPlatformProject(
+          FlutterProject.current().directory.path,
+          Device.devicesPlatformTypes(unsupportedDevices),
+        ));
       }
       return null;
     } else if (devices.length > 1 && !deviceManager.hasSpecifiedAllDevices) {

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -835,7 +835,6 @@ abstract class FlutterCommand extends Command<void> {
         await Device.printDevices(unsupportedDevices);
         globals.printStatus('');
         globals.printStatus(userMessages.flutterMissPlatformProject(
-          FlutterProject.current().directory.path,
           Device.devicesPlatformTypes(unsupportedDevices),
         ));
       }

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -830,13 +830,19 @@ abstract class FlutterCommand extends Command<void> {
       }
       final List<Device> unsupportedDevices = await deviceManager.getDevices();
       if (unsupportedDevices.isNotEmpty) {
-        globals.printStatus(userMessages.flutterFoundButUnsupportedDevices);
-        globals.printStatus('');
-        await Device.printDevices(unsupportedDevices);
-        globals.printStatus('');
-        globals.printStatus(userMessages.flutterMissPlatformProject(
+        final StringBuffer result = StringBuffer();
+        result.writeln(userMessages.flutterFoundButUnsupportedDevices);
+        result.writeAll(
+          await Device.descriptions(unsupportedDevices)
+              .map((String desc) => desc)
+              .toList(),
+          '\n',
+        );
+        result.writeln('');
+        result.writeln(userMessages.flutterMissPlatformProjects(
           Device.devicesPlatformTypes(unsupportedDevices),
         ));
+        globals.printStatus(result.toString());
       }
       return null;
     } else if (devices.length > 1 && !deviceManager.hasSpecifiedAllDevices) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/devices_test.dart
@@ -10,7 +10,6 @@ import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/devices.dart';
 import 'package:flutter_tools/src/device.dart';
-import 'package:flutter_tools/src/globals.dart';
 import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/devices_test.dart
@@ -39,14 +39,13 @@ void main() {
     });
 
     testUsingContext('get devices\' platform types', () async {
-      final List<String> platformTypes = Device.devicesPlatformTypes(await deviceManager.getAllConnectedDevices());
-      expect(
-        platformTypes,
-        <String>['android', 'web']
+      final List<String> platformTypes = Device.devicesPlatformTypes(
+        await deviceManager.getAllConnectedDevices(),
       );
+      expect(platformTypes, <String>['android', 'web']);
     }, overrides: <Type, Generator>{
-          DeviceManager: () => _FakeDeviceManager(),
-          ProcessManager: () => MockProcessManager(),
+      DeviceManager: () => _FakeDeviceManager(),
+      ProcessManager: () => MockProcessManager(),
     });
 
     testUsingContext('Outputs parsable JSON with --machine flag', () async {

--- a/packages/flutter_tools/test/commands.shard/hermetic/devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/devices_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/devices.dart';
 import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/globals.dart';
 import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
 
@@ -36,6 +37,17 @@ void main() {
       AndroidSdk: () => null,
       DeviceManager: () => DeviceManager(),
       ProcessManager: () => MockProcessManager(),
+    });
+
+    testUsingContext('get devices\' platform types', () async {
+      final List<String> platformTypes = Device.devicesPlatformTypes(await deviceManager.getAllConnectedDevices());
+      expect(
+        platformTypes,
+        <String>['android', 'web']
+      );
+    }, overrides: <Type, Generator>{
+          DeviceManager: () => _FakeDeviceManager(),
+          ProcessManager: () => MockProcessManager(),
     });
 
     testUsingContext('Outputs parsable JSON with --machine flag', () async {

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -287,7 +287,7 @@ void main() {
           containsIgnoringWhitespace(
             userMessages.flutterMissPlatformProject(
               fs.path.current,
-              Device.devicesPlatformTypes([mockDevice]),
+              Device.devicesPlatformTypes(<Device>[mockDevice]),
             ),
           ),
         );

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -241,7 +241,7 @@ void main() {
         ProcessManager: () => mockProcessManager,
       });
 
-      testUsingContext('exist with unsupported device message when missing platform project',  () async {
+      testUsingContext('shows unsupported devices when no supported devices are found',  () async {
         final RunCommand command = RunCommand();
         applyMocksToCommand(command);
 
@@ -280,11 +280,16 @@ void main() {
         );
         expect(
           testLogger.statusText,
-          containsIgnoringWhitespace(userMessages.flutterFoundButUnSupportedDevices),
+          containsIgnoringWhitespace(userMessages.flutterFoundButUnsupportedDevices),
         );
         expect(
           testLogger.statusText,
-          containsIgnoringWhitespace(userMessages.flutterMissPlatformProject(fs.path.current)),
+          containsIgnoringWhitespace(
+            userMessages.flutterMissPlatformProject(
+              fs.path.current,
+              Device.devicesPlatformTypes([mockDevice]),
+            ),
+          ),
         );
       }, overrides: <Type, Generator>{
         DeviceManager: () => mockDeviceManager,

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -286,7 +286,6 @@ void main() {
           testLogger.statusText,
           containsIgnoringWhitespace(
             userMessages.flutterMissPlatformProject(
-              fs.path.current,
               Device.devicesPlatformTypes(<Device>[mockDevice]),
             ),
           ),

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -251,6 +251,7 @@ void main() {
         when(mockDevice.supportsFastStart).thenReturn(true);
         when(mockDevice.id).thenReturn('mock-id');
         when(mockDevice.name).thenReturn('mock-name');
+        when(mockDevice.platformType).thenReturn(PlatformType.android);
         when(mockDevice.sdkNameAndVersion).thenAnswer((Invocation invocation) => Future<String>.value('api-14'));
 
         when(mockDeviceManager.getDevices()).thenAnswer((Invocation invocation) {
@@ -285,7 +286,7 @@ void main() {
         expect(
           testLogger.statusText,
           containsIgnoringWhitespace(
-            userMessages.flutterMissPlatformProject(
+            userMessages.flutterMissPlatformProjects(
               Device.devicesPlatformTypes(<Device>[mockDevice]),
             ),
           ),

--- a/packages/flutter_tools/test/src/fake_devices.dart
+++ b/packages/flutter_tools/test/src/fake_devices.dart
@@ -11,7 +11,7 @@ import 'package:flutter_tools/src/project.dart';
 /// (`Device.toJson()` and `--machine` flag for `devices` command)
 List<FakeDeviceJsonData> fakeDevices = <FakeDeviceJsonData>[
   FakeDeviceJsonData(
-    FakeDevice('ephemeral', 'ephemeral', true),
+    FakeDevice('ephemeral', 'ephemeral', true, true, PlatformType.android),
     <String, Object>{
       'name': 'ephemeral',
       'id': 'ephemeral',
@@ -56,9 +56,9 @@ List<FakeDeviceJsonData> fakeDevices = <FakeDeviceJsonData>[
 
 /// Fake device to test `devices` command
 class FakeDevice extends Device {
-  FakeDevice(this.name, String id, [bool ephemeral = true, this._isSupported = true]) : super(
+  FakeDevice(this.name, String id, [bool ephemeral = true, this._isSupported = true, PlatformType type = PlatformType.web]) : super(
       id,
-      platformType: PlatformType.web,
+      platformType: type,
       category: Category.mobile,
       ephemeral: ephemeral,
   );


### PR DESCRIPTION
## Description
When Flutter project miss platform sub-project (like `android` or `iOS` dir), run `flutter run` will get result like:

``` shell
No supported devices connected.
```

this is a confusing message，because devices is supported but miss this sub-project.
So I added log printing in this case, such as：

``` shell
No supported devices connected.
Follow devices are founded but not support in this project:

Web Server • web-server • web-javascript • Flutter Tools
Chrome     • chrome     • web-javascript • Google Chrome 81.0.4044.138

Is your project missing a platform project in your project /Users/liufengkai/Documents/Code/FlutterSupport/app
Consider running "flutter create ." to create one.

```

## Related Issues

https://github.com/flutter/flutter/issues/56315

## Tests

I added the following tests:

https://github.com/flutter/flutter/compare/master...lfkdsk:feature-support-miss-platform-project-user-message?expand=1#diff-09cce1e3642fa7c47801e06ff46fcd60

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes

