### PR TITLE
Expose includeSemantics option to RawKeyboardListener

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -367,15 +367,17 @@ class Focus extends StatefulWidget {
   /// still be focused explicitly.
   final bool skipTraversal;
 
-  /// Include semantics information in this [Focus] widget.
+  /// {@template flutter.widgets.Focus.includeSemantics}
+  /// Include semantics information in this widget.
   ///
-  /// If true, this [Focus] widget will include a [Semantics] node that
+  /// If true, this widget will include a [Semantics] node that
   /// indicates the [Semantics.focusable] and [Semantics.focused] properties.
   ///
   /// It is not typical to set this to false, as that can affect the semantics
   /// information available to accessibility systems.
   ///
   /// Must not be null, defaults to true.
+  /// {@endtemplate}
   final bool includeSemantics;
 
   /// {@template flutter.widgets.Focus.canRequestFocus}

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -367,17 +367,15 @@ class Focus extends StatefulWidget {
   /// still be focused explicitly.
   final bool skipTraversal;
 
-  /// {@template flutter.widgets.Focus.includeSemantics}
-  /// Include semantics information in this widget.
+  /// Include semantics information in this [Focus] widget.
   ///
-  /// If true, this widget will include a [Semantics] node that
+  /// If true, this [Focus] widget will include a [Semantics] node that
   /// indicates the [Semantics.focusable] and [Semantics.focused] properties.
   ///
   /// It is not typical to set this to false, as that can affect the semantics
   /// information available to accessibility systems.
   ///
   /// Must not be null, defaults to true.
-  /// {@endtemplate}
   final bool includeSemantics;
 
   /// {@template flutter.widgets.Focus.canRequestFocus}

--- a/packages/flutter/lib/src/widgets/raw_keyboard_listener.dart
+++ b/packages/flutter/lib/src/widgets/raw_keyboard_listener.dart
@@ -39,10 +39,12 @@ class RawKeyboardListener extends StatefulWidget {
     Key key,
     @required this.focusNode,
     this.autofocus = false,
+    this.includeSemantics = true,
     this.onKey,
     @required this.child,
   }) : assert(focusNode != null),
        assert(autofocus != null),
+       assert(includeSemantics != null),
        assert(child != null),
        super(key: key);
 
@@ -51,6 +53,9 @@ class RawKeyboardListener extends StatefulWidget {
 
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
+
+  /// {@macro flutter.widgets.Focus.includeSemantics}
+  final bool includeSemantics;
 
   /// Called whenever this widget receives a raw keyboard event.
   final ValueChanged<RawKeyEvent> onKey;
@@ -126,6 +131,7 @@ class _RawKeyboardListenerState extends State<RawKeyboardListener> {
     return Focus(
       focusNode: widget.focusNode,
       autofocus: widget.autofocus,
+      includeSemantics: widget.includeSemantics,
       child: widget.child,
     );
   }

--- a/packages/flutter/lib/src/widgets/raw_keyboard_listener.dart
+++ b/packages/flutter/lib/src/widgets/raw_keyboard_listener.dart
@@ -39,12 +39,10 @@ class RawKeyboardListener extends StatefulWidget {
     Key key,
     @required this.focusNode,
     this.autofocus = false,
-    this.includeSemantics = true,
     this.onKey,
     @required this.child,
   }) : assert(focusNode != null),
        assert(autofocus != null),
-       assert(includeSemantics != null),
        assert(child != null),
        super(key: key);
 
@@ -53,9 +51,6 @@ class RawKeyboardListener extends StatefulWidget {
 
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
-
-  /// {@macro flutter.widgets.Focus.includeSemantics}
-  final bool includeSemantics;
 
   /// Called whenever this widget receives a raw keyboard event.
   final ValueChanged<RawKeyEvent> onKey;
@@ -131,7 +126,6 @@ class _RawKeyboardListenerState extends State<RawKeyboardListener> {
     return Focus(
       focusNode: widget.focusNode,
       autofocus: widget.autofocus,
-      includeSemantics: widget.includeSemantics,
       child: widget.child,
     );
   }

--- a/packages/flutter/lib/src/widgets/raw_keyboard_listener.dart
+++ b/packages/flutter/lib/src/widgets/raw_keyboard_listener.dart
@@ -126,6 +126,7 @@ class _RawKeyboardListenerState extends State<RawKeyboardListener> {
     return Focus(
       focusNode: widget.focusNode,
       autofocus: widget.autofocus,
+      includeSemantics: false,
       child: widget.child,
     );
   }

--- a/packages/flutter/lib/src/widgets/raw_keyboard_listener.dart
+++ b/packages/flutter/lib/src/widgets/raw_keyboard_listener.dart
@@ -39,10 +39,12 @@ class RawKeyboardListener extends StatefulWidget {
     Key key,
     @required this.focusNode,
     this.autofocus = false,
+    this.includeSemantics = true,
     this.onKey,
     @required this.child,
   }) : assert(focusNode != null),
        assert(autofocus != null),
+       assert(includeSemantics != null),
        assert(child != null),
        super(key: key);
 
@@ -51,6 +53,9 @@ class RawKeyboardListener extends StatefulWidget {
 
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
+
+  /// {@macro flutter.widgets.Focus.includeSemantics}
+  final bool includeSemantics;
 
   /// Called whenever this widget receives a raw keyboard event.
   final ValueChanged<RawKeyEvent> onKey;
@@ -126,7 +131,7 @@ class _RawKeyboardListenerState extends State<RawKeyboardListener> {
     return Focus(
       focusNode: widget.focusNode,
       autofocus: widget.autofocus,
-      includeSemantics: false,
+      includeSemantics: widget.includeSemantics,
       child: widget.child,
     );
   }

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -2001,6 +2001,20 @@ void main() {
       expect(unfocusableNode.hasFocus, isFalse);
     });
   });
+  group(RawKeyboardListener, () {
+    testWidgets("Raw keyboard listener doesn't introduce a Semantics node", (WidgetTester tester) async {
+      final SemanticsTester semantics = SemanticsTester(tester);
+      final FocusNode focusNode = FocusNode();
+      await tester.pumpWidget(
+          RawKeyboardListener(
+              focusNode: focusNode,
+              child: Container(),
+          ),
+      );
+      final TestSemantics expectedSemantics = TestSemantics.root();
+      expect(semantics, hasSemantics(expectedSemantics));
+    });
+  });
 }
 
 class TestRoute extends PageRouteBuilder<void> {

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -2002,12 +2002,38 @@ void main() {
     });
   });
   group(RawKeyboardListener, () {
-    testWidgets("Raw keyboard listener doesn't introduce a Semantics node", (WidgetTester tester) async {
+    testWidgets('Raw keyboard listener introduces a Semantics node by default', (WidgetTester tester) async {
+      final SemanticsTester semantics = SemanticsTester(tester);
+      final FocusNode focusNode = FocusNode();
+      await tester.pumpWidget(
+        RawKeyboardListener(
+          focusNode: focusNode,
+          child: Container(),
+        ),
+      );
+      final TestSemantics expectedSemantics = TestSemantics.root(
+        children: <TestSemantics>[
+          TestSemantics.rootChild(
+            flags: <SemanticsFlag>[
+              SemanticsFlag.isFocusable,
+            ],
+          ),
+        ],
+      );
+      expect(semantics, hasSemantics(
+        expectedSemantics,
+        ignoreId: true,
+        ignoreRect: true,
+        ignoreTransform: true,
+      ));
+    });
+    testWidgets("Raw keyboard listener doesn't introduce a Semantics node when specified", (WidgetTester tester) async {
       final SemanticsTester semantics = SemanticsTester(tester);
       final FocusNode focusNode = FocusNode();
       await tester.pumpWidget(
           RawKeyboardListener(
               focusNode: focusNode,
+              includeSemantics: false,
               child: Container(),
           ),
       );


### PR DESCRIPTION
## Description

RawKeyboardListener is implemented with a Focus, which introduces a Semantics node. This results in empty Semantics node + announcement on iOS. 

This PR exposes the `includeSemantics` flag, which, when set to false, doesn't introduce a Semantics node.

## Tests

I added the following tests:

- A test to verify that RawKeyboardListener doesn't introduce a Semantics node

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
