### PR TITLE
Remove semantics node generated by `ExcludeFocus`

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -997,6 +997,7 @@ class ExcludeFocus extends StatelessWidget {
     return Focus(
       canRequestFocus: false,
       skipTraversal: true,
+      includeSemantics: false,
       descendantsAreFocusable: !excluding,
       child: child,
     );

--- a/packages/flutter/test/widgets/focus_scope_test.dart
+++ b/packages/flutter/test/widgets/focus_scope_test.dart
@@ -8,6 +8,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/semantics.dart';
 
+import 'semantics_tester.dart';
+
 class TestFocus extends StatefulWidget {
   const TestFocus({
     Key key,
@@ -1585,6 +1587,12 @@ void main() {
       expect(containerNode.hasFocus, isFalse);
       expect(unfocusableNode.hasFocus, isFalse);
     });
+    testWidgets("Focus doesn't introduce a Semantics node when includeSemantics is false", (WidgetTester tester) async {
+      final SemanticsTester semantics = SemanticsTester(tester);
+      await tester.pumpWidget(Focus(includeSemantics: false, child: Container()));
+      final TestSemantics expectedSemantics = TestSemantics.root();
+      expect(semantics, hasSemantics(expectedSemantics));
+    });
   });
   group(ExcludeFocus, () {
     testWidgets("Descendants of ExcludeFocus aren't focusable.", (WidgetTester tester) async {
@@ -1624,6 +1632,12 @@ void main() {
       expect(gotFocus, isNull);
       expect(containerNode.hasFocus, isFalse);
       expect(unfocusableNode.hasFocus, isFalse);
+    });
+    testWidgets("ExcludeFocus doesn't introduce a Semantics node", (WidgetTester tester) async {
+      final SemanticsTester semantics = SemanticsTester(tester);
+      await tester.pumpWidget(ExcludeFocus(child: Container()));
+      final TestSemantics expectedSemantics = TestSemantics.root();
+      expect(semantics, hasSemantics(expectedSemantics));
     });
   });
 }


### PR DESCRIPTION
## Description

This sets `includeSemantics` to false on the internal `Focus` widget used by `ExcludeFocus` so that it won't affect the semantics tree.

## Tests

- Added a test for `includeSemantics` on the `Focus` widget, as well as a similar test on the `ExcludeFocus` widget.

## Breaking Change

- [X] No, this is *not* a breaking change.