### PR TITLE
Roll new gallery version in the perf test

### DIFF
--- a/dev/devicelab/lib/tasks/new_gallery.dart
+++ b/dev/devicelab/lib/tasks/new_gallery.dart
@@ -19,7 +19,7 @@ class NewGalleryPerfTest extends PerfTest {
     // Manually roll the new gallery version for now. If the new gallery repo
     // turns out to be updated frequently in the future, we can set up an auto
     // roller to update this version.
-    await getNewGallery('59489e5571ddf554fc62ef52e9b16f1fed291026', galleryDir);
+    await getNewGallery('c1682ac4b35dc239f023eaf0238a98910b3a2d6c', galleryDir);
     return await super.run();
   }
 

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -784,6 +784,7 @@ tasks:
       Measures the performance of screen transitions in the new Flutter Gallery on Android.
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
+    flaky: true
 
   fast_scroll_large_images__memory:
     description: >

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -779,12 +779,11 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
 
-# TODO(https://github.com/flutter/flutter/issues/56135)
-#  new_gallery__transition_perf:
-#    description: >
-#      Measures the performance of screen transitions in the new Flutter Gallery on Android.
-#    stage: devicelab
-#    required_agent_capabilities: ["mac/android"]
+  new_gallery__transition_perf:
+    description: >
+      Measures the performance of screen transitions in the new Flutter Gallery on Android.
+    stage: devicelab
+    required_agent_capabilities: ["mac/android"]
 
   fast_scroll_large_images__memory:
     description: >


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/issues/56135
