### PR TITLE
Update Tab semantics in Cupertino to be the same as Material

### DIFF
--- a/packages/flutter/lib/src/cupertino/localizations.dart
+++ b/packages/flutter/lib/src/cupertino/localizations.dart
@@ -262,7 +262,7 @@ class _CupertinoLocalizationsDelegate extends LocalizationsDelegate<CupertinoLoc
   String toString() => 'DefaultCupertinoLocalizations.delegate(en_US)';
 }
 
-/// US English strings for the cupertino widgets.
+/// US English strings for the Cupertino widgets.
 class DefaultCupertinoLocalizations implements CupertinoLocalizations {
   /// Constructs an object that defines the cupertino widgets' localized strings
   /// for US English (only).
@@ -367,7 +367,7 @@ class DefaultCupertinoLocalizations implements CupertinoLocalizations {
   String tabSemanticsLabel({int tabIndex, int tabCount}) {
     assert(tabIndex >= 1);
     assert(tabCount >= 1);
-    return 'tab, $tabIndex of $tabCount';
+    return 'Tab $tabIndex of $tabCount';
   }
 
   @override

--- a/packages/flutter/test/cupertino/bottom_tab_bar_test.dart
+++ b/packages/flutter/test/cupertino/bottom_tab_bar_test.dart
@@ -385,14 +385,14 @@ void main() {
 
     expect(semantics, includesNodeWith(
       label: 'Tab 1',
-      hint: 'tab, 1 of 2',
+      hint: 'Tab 1 of 2',
       flags: <SemanticsFlag>[SemanticsFlag.isSelected],
       textDirection: TextDirection.ltr,
     ));
 
     expect(semantics, includesNodeWith(
       label: 'Tab 2',
-      hint: 'tab, 2 of 2',
+      hint: 'Tab 2 of 2',
       textDirection: TextDirection.ltr,
     ));
 

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_en.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_en.arb
@@ -43,7 +43,7 @@
     "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
   },
 
-  "tabSemanticsLabel": "tab, $tabIndex of $tabCount",
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
   "@tabSemanticsLabel": {
     "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
     "parameters": "tabIndex, tabCount"

--- a/packages/flutter_localizations/lib/src/l10n/generated_cupertino_localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/generated_cupertino_localizations.dart
@@ -2271,7 +2271,7 @@ class CupertinoLocalizationEn extends GlobalCupertinoLocalizations {
   String get selectAllButtonLabel => 'Select All';
 
   @override
-  String get tabSemanticsLabelRaw => 'tab, \$tabIndex of \$tabCount';
+  String get tabSemanticsLabelRaw => 'Tab \$tabIndex of \$tabCount';
 
   @override
   String get timerPickerHourLabelFew => null;


### PR DESCRIPTION
## Description

This PR updates the Cupertino tab semantics label to be the same as the Material tab semantics label.

## Tests

I added the following tests:
- n/a, updating the english message translation

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
