### PR TITLE
Added MaterialStateProperty.all() convenience method

### DIFF
--- a/packages/flutter/lib/src/material/material_state.dart
+++ b/packages/flutter/lib/src/material/material_state.dart
@@ -209,14 +209,27 @@ abstract class MaterialStateProperty<T> {
 
   /// Convenience method for creating a [MaterialStateProperty] from a
   /// [MaterialPropertyResolver] function alone.
-  static MaterialStateProperty<T> resolveWith<T>(MaterialPropertyResolver<T> callback) => _MaterialStateProperty<T>(callback);
+  static MaterialStateProperty<T> resolveWith<T>(MaterialPropertyResolver<T> callback) => _MaterialStatePropertyWith<T>(callback);
+
+  /// Convenience method for creating a [MaterialStateProperty] that resolves
+  /// to a single value for all states.
+  static MaterialStateProperty<T> all<T>(T value) => _MaterialStatePropertyAll<T>(value);
 }
 
-class _MaterialStateProperty<T> implements MaterialStateProperty<T> {
-  _MaterialStateProperty(this._resolve);
+class _MaterialStatePropertyWith<T> implements MaterialStateProperty<T> {
+  _MaterialStatePropertyWith(this._resolve);
 
   final MaterialPropertyResolver<T> _resolve;
 
   @override
   T resolve(Set<MaterialState> states) => _resolve(states);
+}
+
+class _MaterialStatePropertyAll<T> implements MaterialStateProperty<T> {
+  _MaterialStatePropertyAll(this.value);
+
+  final T value;
+
+  @override
+  T resolve(Set<MaterialState> states) => value;
 }

--- a/packages/flutter/test/material/material_state_property_test.dart
+++ b/packages/flutter/test/material/material_state_property_test.dart
@@ -1,0 +1,33 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+
+
+void main() {
+  test('MaterialStateProperty.resolveWith()', () {
+    final MaterialStateProperty<MaterialState> value = MaterialStateProperty.resolveWith<MaterialState>(
+      (Set<MaterialState> states) => states.first,
+    );
+    expect(value.resolve(<MaterialState>{MaterialState.hovered}), MaterialState.hovered);
+    expect(value.resolve(<MaterialState>{MaterialState.focused}), MaterialState.focused);
+    expect(value.resolve(<MaterialState>{MaterialState.pressed}), MaterialState.pressed);
+    expect(value.resolve(<MaterialState>{MaterialState.dragged}), MaterialState.dragged);
+    expect(value.resolve(<MaterialState>{MaterialState.selected}), MaterialState.selected);
+    expect(value.resolve(<MaterialState>{MaterialState.disabled}), MaterialState.disabled);
+    expect(value.resolve(<MaterialState>{MaterialState.error}), MaterialState.error);
+  });
+
+  test('MaterialStateProperty.all()', () {
+    final MaterialStateProperty<int> value = MaterialStateProperty.all<int>(123);
+    expect(value.resolve(<MaterialState>{MaterialState.hovered}), 123);
+    expect(value.resolve(<MaterialState>{MaterialState.focused}), 123);
+    expect(value.resolve(<MaterialState>{MaterialState.pressed}), 123);
+    expect(value.resolve(<MaterialState>{MaterialState.dragged}), 123);
+    expect(value.resolve(<MaterialState>{MaterialState.selected}), 123);
+    expect(value.resolve(<MaterialState>{MaterialState.disabled}), 123);
+    expect(value.resolve(<MaterialState>{MaterialState.error}), 123);
+  });
+}


### PR DESCRIPTION
Added a little bit of extra shorthand to MaterialStateProperty for the case where the MaterialStateProperty just represents one value for all states. 

Instead of writing this: 
```dart
MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) => Colors.blue)
```

You can write:
```dart
MaterialState.all<Color>(Colors.blue)
```

This case came up frequently in https://github.com/HansMuller/flutter_buttons