### PR TITLE
Remove direct uses of LocalPlatform

### DIFF
--- a/dev/devicelab/lib/framework/manifest.dart
+++ b/dev/devicelab/lib/framework/manifest.dart
@@ -2,14 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:meta/meta.dart';
-import 'package:platform/platform.dart';
 import 'package:yaml/yaml.dart';
 
 import 'utils.dart';
-
-Platform get platform => _platform ??= const LocalPlatform();
-Platform _platform;
 
 /// Loads manifest data from `manifest.yaml` file or from [yaml], if present.
 Manifest loadTaskManifest([ String yaml ]) {
@@ -73,7 +71,7 @@ class ManifestTask {
         (String str) => str.split('/')[0]
       )
     );
-    String hostPlatform = platform.operatingSystem;
+    String hostPlatform = Platform.operatingSystem;
     if (hostPlatform == 'macos') {
       hostPlatform = 'mac'; // package:platform uses 'macos' while manifest.yaml uses 'mac'
     }

--- a/dev/snippets/lib/main.dart
+++ b/dev/snippets/lib/main.dart
@@ -2,11 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io' hide Platform;
+import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:path/path.dart' as path;
-import 'package:platform/platform.dart';
 
 import 'configuration.dart';
 import 'snippets.dart';
@@ -35,8 +34,7 @@ String getChannelName() {
 /// Generates snippet dartdoc output for a given input, and creates any sample
 /// applications needed by the snippet.
 void main(List<String> argList) {
-  const Platform platform = LocalPlatform();
-  final Map<String, String> environment = platform.environment;
+  final Map<String, String> environment = Platform.environment;
   final ArgParser parser = ArgParser();
   final List<String> snippetTypes =
       SnippetType.values.map<String>((SnippetType type) => getEnumName(type)).toList();

--- a/dev/tools/gen_keycodes/lib/utils.dart
+++ b/dev/tools/gen_keycodes/lib/utils.dart
@@ -2,14 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io' hide Platform;
+import 'dart:io';
 
 import 'package:path/path.dart' as path;
-import 'package:platform/platform.dart' show LocalPlatform;
 
 /// The location of the Flutter root directory, based on the known location of
 /// this script.
-final Directory flutterRoot = Directory(path.dirname(const LocalPlatform().script.toFilePath())).parent.parent.parent.parent;
+final Directory flutterRoot = Directory(path.dirname(Platform.script.toFilePath())).parent.parent.parent.parent;
 
 /// Converts `FOO_BAR` to `fooBar`.
 String shoutingToLowerCamel(String shouting) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -3,14 +3,13 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' as io;
+import 'dart:io';
 
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
-import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/attach.dart';
@@ -393,7 +392,7 @@ void main() {
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
-    }, skip: io.Platform.isWindows); // mDNS does not work on Windows.
+    }, skip: Platform.isWindows); // mDNS does not work on Windows.
 
     group('forwarding to given port', () {
       const int devicePort = 499;

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io' as io;
 
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/common.dart';
@@ -392,7 +393,7 @@ void main() {
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
-    }, skip: const LocalPlatform().isWindows); // mDNS does not work on Windows.
+    }, skip: io.Platform.isWindows); // mDNS does not work on Windows.
 
     group('forwarding to given port', () {
       const int devicePort = 499;


### PR DESCRIPTION
When `const LocalPlatform` is used immediately and not passed as a
dependency it does not have utility over the static properties from
`dart:io`. Remove these uses to reduce the noise around how the
instantiable `Platform` class is used.

## Description

Internal cleanup.

## Tests

There are no visible behavior changes, existing tests should pass.
