### PR TITLE
Update Linux template for headless mode

### DIFF
--- a/packages/flutter_tools/templates/app/linux.tmpl/Makefile
+++ b/packages/flutter_tools/templates/app/linux.tmpl/Makefile
@@ -49,6 +49,7 @@ ALL_LIBS_OUT=$(FLUTTER_LIB_OUT) \
 # issues if they start with one or more '../'s.
 WRAPPER_ROOT=$(abspath $(FLUTTER_EPHEMERAL_DIR)/cpp_client_wrapper_glfw)
 WRAPPER_SOURCES= \
+	$(WRAPPER_ROOT)/flutter_engine.cc \
 	$(WRAPPER_ROOT)/flutter_window_controller.cc \
 	$(WRAPPER_ROOT)/plugin_registrar.cc \
 	$(WRAPPER_ROOT)/engine_method_result.cc


### PR DESCRIPTION
## Description

GLFW fails to initialize on machines without DISPLAY set, which can be
true for CI. This updates the template to fall back to headless mode to
make it easy to test (e.g., via Flutter Driver) when in that
environment.

Also updates the template to use relative asset support, which was added
some time ago to the engine but hadn't yet been changed in the template.

## Related Issues

None

## Tests

I added the following tests: None; require e2e testing that isn't yet running.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
