### PR TITLE
typo fix on the FLUTTER_STORAGE_BASE_URL usage

### DIFF
--- a/dev/devicelab/bin/tasks/android_engine_dependency_proxy_test.dart
+++ b/dev/devicelab/bin/tasks/android_engine_dependency_proxy_test.dart
@@ -58,7 +58,7 @@ task printEngineMavenUrl() {
           gradlewExecutable,
           <String>['printEngineMavenUrl', '-q'],
           environment: <String, String>{
-            'FLUTTER_STORAGE_BASE_URL': 'my.special.proxy',
+            'FLUTTER_STORAGE_BASE_URL': 'https://my.special.proxy',
           }
         );
 

--- a/packages/flutter_tools/gradle/aar_init_script.gradle
+++ b/packages/flutter_tools/gradle/aar_init_script.gradle
@@ -53,12 +53,12 @@ void configureProject(Project project, String outputDir) {
             "See: https://github.com/flutter/flutter/issues/40866")
     }
 
-    String storageUrl = System.getenv('FLUTTER_STORAGE_BASE_URL') ?: "storage.googleapis.com"
+    String storageUrl = System.getenv('FLUTTER_STORAGE_BASE_URL') ?: "https://storage.googleapis.com"
     // This is a Flutter plugin project. Plugin projects don't apply the Flutter Gradle plugin,
     // as a result, add the dependency on the embedding.
     project.repositories {
         maven {
-            url "https://$storageUrl/download.flutter.io"
+            url "$storageUrl/download.flutter.io"
         }
     }
     String engineVersion = Paths.get(getFlutterRoot(project), "bin", "internal", "engine.version")

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -41,7 +41,7 @@ android {
 apply plugin: FlutterPlugin
 
 class FlutterPlugin implements Plugin<Project> {
-    private static final String DEFAULT_MAVEN_HOST = "storage.googleapis.com";
+    private static final String DEFAULT_MAVEN_HOST = "https://storage.googleapis.com";
 
     // The platforms that can be passed to the `--Ptarget-platform` flag.
     private static final String PLATFORM_ARM32  = "android-arm";
@@ -203,7 +203,7 @@ class FlutterPlugin implements Plugin<Project> {
         String hostedRepository = System.env.FLUTTER_STORAGE_BASE_URL ?: DEFAULT_MAVEN_HOST
         String repository = useLocalEngine()
             ? project.property('local-engine-repo')
-            : "https://$hostedRepository/download.flutter.io"
+            : "$hostedRepository/download.flutter.io"
         project.rootProject.allprojects {
             repositories {
                 maven {

--- a/packages/flutter_tools/gradle/resolve_dependencies.gradle
+++ b/packages/flutter_tools/gradle/resolve_dependencies.gradle
@@ -14,13 +14,13 @@
 
 import java.nio.file.Paths
 
-String storageUrl = System.getenv('FLUTTER_STORAGE_BASE_URL') ?: "storage.googleapis.com"
+String storageUrl = System.getenv('FLUTTER_STORAGE_BASE_URL') ?: "https://storage.googleapis.com"
 
 repositories {
     google()
     jcenter()
     maven {
-        url "https://$storageUrl/download.flutter.io"
+        url "$storageUrl/download.flutter.io"
     }
 }
 

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -664,13 +664,13 @@ void printHowToConsumeAar({
   1. Open ${fileSystem.path.join('<host>', 'app', 'build.gradle')}
   2. Ensure you have the repositories configured, otherwise add them:
 
-      String storageUrl = System.env.FLUTTER_STORAGE_BASE_URL ?: "storage.googleapis.com"
+      String storageUrl = System.env.FLUTTER_STORAGE_BASE_URL ?: "https://storage.googleapis.com"
       repositories {
         maven {
             url '${repoDirectory.path}'
         }
         maven {
-            url 'https://\$storageUrl/download.flutter.io'
+            url '\$storageUrl/download.flutter.io'
         }
       }
 

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -2324,13 +2324,13 @@ plugin1=${plugin1.path}
           '  1. Open <host>/app/build.gradle\n'
           '  2. Ensure you have the repositories configured, otherwise add them:\n'
           '\n'
-          '      String storageUrl = System.env.FLUTTER_STORAGE_BASE_URL ?: "storage.googleapis.com"\n'
+          '      String storageUrl = System.env.FLUTTER_STORAGE_BASE_URL ?: "https://storage.googleapis.com"\n'
           '      repositories {\n'
           '        maven {\n'
           "            url 'build/'\n"
           '        }\n'
           '        maven {\n'
-          "            url 'https://\$storageUrl/download.flutter.io'\n"
+          "            url '\$storageUrl/download.flutter.io'\n"
           '        }\n'
           '      }\n'
           '\n'
@@ -2375,13 +2375,13 @@ plugin1=${plugin1.path}
           '  1. Open <host>/app/build.gradle\n'
           '  2. Ensure you have the repositories configured, otherwise add them:\n'
           '\n'
-          '      String storageUrl = System.env.FLUTTER_STORAGE_BASE_URL ?: "storage.googleapis.com"\n'
+          '      String storageUrl = System.env.FLUTTER_STORAGE_BASE_URL ?: "https://storage.googleapis.com"\n'
           '      repositories {\n'
           '        maven {\n'
           "            url 'build/'\n"
           '        }\n'
           '        maven {\n'
-          "            url 'https://\$storageUrl/download.flutter.io'\n"
+          "            url '\$storageUrl/download.flutter.io'\n"
           '        }\n'
           '      }\n'
           '\n'
@@ -2413,13 +2413,13 @@ plugin1=${plugin1.path}
           '  1. Open <host>/app/build.gradle\n'
           '  2. Ensure you have the repositories configured, otherwise add them:\n'
           '\n'
-          '      String storageUrl = System.env.FLUTTER_STORAGE_BASE_URL ?: "storage.googleapis.com"\n'
+          '      String storageUrl = System.env.FLUTTER_STORAGE_BASE_URL ?: "https://storage.googleapis.com"\n'
           '      repositories {\n'
           '        maven {\n'
           "            url 'build/'\n"
           '        }\n'
           '        maven {\n'
-          "            url 'https://\$storageUrl/download.flutter.io'\n"
+          "            url '\$storageUrl/download.flutter.io'\n"
           '        }\n'
           '      }\n'
           '\n'
@@ -2452,13 +2452,13 @@ plugin1=${plugin1.path}
           '  1. Open <host>/app/build.gradle\n'
           '  2. Ensure you have the repositories configured, otherwise add them:\n'
           '\n'
-          '      String storageUrl = System.env.FLUTTER_STORAGE_BASE_URL ?: "storage.googleapis.com"\n'
+          '      String storageUrl = System.env.FLUTTER_STORAGE_BASE_URL ?: "https://storage.googleapis.com"\n'
           '      repositories {\n'
           '        maven {\n'
           "            url 'build/'\n"
           '        }\n'
           '        maven {\n'
-          "            url 'https://\$storageUrl/download.flutter.io'\n"
+          "            url '\$storageUrl/download.flutter.io'\n"
           '        }\n'
           '      }\n'
           '\n'


### PR DESCRIPTION
## Description

A small fix to #56164, also @xster .

Since the `FLUTTER_STORAGE_BASE_URL` has been set up to a complete URL like:
```export FLUTTER_STORAGE_BASE_URL=https://storage.flutter-io.cn```

hence the scheme `https://` which in the maven URL setting should be removed as well as added it to the default setting: `storage.googleapis.com`,
or the final URL will be like: `https://https/storage.flutter-io.cn/download.flutter.io` as Issue #56678 mentioned, which will be connection failed.

## Related Issues

#55134
Fixes #56678

## Tests

Could we use the existing tests that @xster created?

dev/devicelab/bin/tasks/android_engine_dependency_proxy_test.dart

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
