### PR TITLE
[flutter_tools] fix aar defaults test

### DIFF
--- a/packages/flutter_tools/test/general.shard/commands/build_aar_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_aar_test.dart
@@ -140,7 +140,11 @@ void main() {
       for (final AndroidBuildInfo androidBuildInfo in androidBuildInfos) {
         final BuildInfo buildInfo = androidBuildInfo.buildInfo;
         buildModes.add(buildInfo.mode);
-        expect(buildInfo.treeShakeIcons, isFalse);
+        if (buildInfo.mode.isPrecompiled) {
+          expect(buildInfo.treeShakeIcons, isTrue);
+        } else {
+          expect(buildInfo.treeShakeIcons, isFalse);
+        }
         expect(buildInfo.flavor, isNull);
         expect(buildInfo.splitDebugInfoPath, isNull);
         expect(buildInfo.dartObfuscation, isFalse);


### PR DESCRIPTION
## Description

PR landed that was branched before this test was updated, change the default to the correct value.