### PR TITLE
Always remove the workspace settings when set to legacy build settings

### DIFF
--- a/packages/flutter_tools/lib/src/ios/migrations/xcode_build_system_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/xcode_build_system_migration.dart
@@ -28,14 +28,10 @@ class XcodeBuildSystemMigration extends IOSMigrator {
 
     final String contents = _xcodeWorkspaceSharedSettings.readAsStringSync();
 
-    // Only delete this file when it matches the original Flutter template.
+    // Only delete this file when it is pointing to the legacy build system.
     const String legacyBuildSettingsWorkspace = '''
-<plist version="1.0">
-<dict>
 	<key>BuildSystemType</key>
-	<string>Original</string>
-</dict>
-</plist>''';
+	<string>Original</string>''';
 
     // contains instead of equals to ignore newline file ending variance.
     if (contents.contains(legacyBuildSettingsWorkspace)) {

--- a/packages/flutter_tools/test/general.shard/ios/ios_project_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_project_migration_test.dart
@@ -322,6 +322,8 @@ keep this 2
 <dict>
 	<key>BuildSystemType</key>
 	<string>Original</string>
+	<key>PreviewsEnabled</key>
+	<false/>
 </dict>
 </plist>''';
         xcodeWorkspaceSharedSettings.writeAsStringSync(contents);


### PR DESCRIPTION
## Description

Make https://github.com/flutter/flutter/pull/52288 migration more aggressive by always deleting the workspace settings when it's set to the legacy build system.  Xcode likes to add keys to this file like `PreviewsEnabled`.
Reset to defaults by removing this file.  There's not usually anything interesting in this file, and Xcode will add whatever it wants next time it opens, but it won't reset the `BuildSystemType` to Original so this migration will only run once.

## Related Issues

https://github.com/flutter/flutter/issues/56567 and duplicates.

## Tests

Updated ios_project_migration_test.dart

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*