### PR TITLE
flutter tool: PowerShell executable detection added, fixing usage of PS version >=6

### DIFF
--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -43,6 +43,19 @@ IF NOT EXIST "%flutter_root%\.git" (
   EXIT /B 1
 )
 
+REM Detect which PowerShell executable is available on the Host
+REM PowerShell version <= 5: PowerShell.exe
+REM PowerShell version >= 6: pwsh.exe
+WHERE /Q pwsh.exe && (
+    SET powershell_executable=pwsh.exe
+) || WHERE /Q PowerShell.exe && (
+    SET powershell_executable=PowerShell.exe
+) || (
+    ECHO Error: PowerShell executable not found.
+    ECHO        Either pwsh.exe or PowerShell.exe must be in your PATH.
+    EXIT /B 1
+)
+
 REM Ensure that bin/cache exists.
 IF NOT EXIST "%cache_dir%" MKDIR "%cache_dir%"
 
@@ -101,7 +114,7 @@ GOTO :after_subroutine
     SET update_dart_bin=%FLUTTER_ROOT%/bin/internal/update_dart_sdk.ps1
     REM Escape apostrophes from the executable path
     SET "update_dart_bin=!update_dart_bin:'=''!"
-    PowerShell.exe -ExecutionPolicy Bypass -Command "Unblock-File -Path '%update_dart_bin%'; & '%update_dart_bin%'"
+    %powershell_executable% -ExecutionPolicy Bypass -Command "Unblock-File -Path '%update_dart_bin%'; & '%update_dart_bin%'"
     IF "%ERRORLEVEL%" NEQ "0" (
       ECHO Error: Unable to update Dart SDK. Retrying...
       timeout /t 5 /nobreak


### PR DESCRIPTION
# PowerShell executable detection added, fixing usage of PS version >=6

## Description

The name of the PowerShell executable has changed from version 6 (PS core).

PowerShell version <= 5: `PowerShell.exe`
PowerShell version >= 6: `pwsh.exe`

The `flutter.bat` command line script currently requires the PowerShell executable to be `PowerShell.exe`. This PR introduces a lookup for an available executable.

Old behavior:
The script fails if `PowerShell.exe` is not in the PATH, even if `pwsh.exe` is available:
```
The system cannot find the path specified
```

New behavior:
- with `pwsh.exe` and `PowerShell.exe` on the path, `pwsh.exe` is used
- with only `pwsh.exe` on the path. `pwsh.exe` is used
- with only `PowerShell.exe` on the path, `PowerShell.exe` is used
- without `pwsh.exe` or `PowerShell.exe` on the path, the script fails with the following error message:
```
Error: PowerShell executable not found.
       Either pwsh.exe or PowerShell.exe must be in your PATH.
```

## Related Issues

https://github.com/flutter/flutter/issues/53135
https://github.com/flutter/flutter/issues/55491

## Tests

I tested manually:
- with both `pwsh.exe` and `PowerShell.exe` on the path
- with only `pwsh.exe` on the path
- with only `PowerShell.exe` on the path
- without either `pwsh.exe` or `PowerShell.exe` on the path

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
