### PR TITLE
[flutter_tools] fix documentation on default built ios

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -22,7 +22,7 @@ class BuildIOSCommand extends BuildSubCommand {
   BuildIOSCommand({ @required bool verboseHelp }) {
     addTreeShakeIconsFlag();
     addSplitDebugInfoOption();
-    addBuildModeFlags(defaultToRelease: false);
+    addBuildModeFlags(defaultToRelease: true);
     usesTargetOption();
     usesFlavorOption();
     usesPubOption();
@@ -35,7 +35,8 @@ class BuildIOSCommand extends BuildSubCommand {
     addBuildPerformanceFile(hide: !verboseHelp);
     argParser
       ..addFlag('simulator',
-        help: 'Build for the iOS simulator instead of the device.',
+        help: 'Build for the iOS simulator instead of the device. This changes '
+          'the default build mode to debug if otherwise unspecified.',
       )
       ..addFlag('codesign',
         defaultsTo: true,


### PR DESCRIPTION
## Description

Fixes https://github.com/flutter/flutter/issues/56717

The default for build for `flutter build ios` should be release to match the other `build` commands. This is correctly handled in the command, but the documentation is incorrect. Update the documentation and the default to reflect the more common case of building for a physical device.