### PR TITLE
fix `roll_dev.dart` to query remote ref, rather than local

### DIFF
--- a/dev/tools/lib/roll_dev.dart
+++ b/dev/tools/lib/roll_dev.dart
@@ -96,7 +96,7 @@ bool run({
   git.run('fetch $origin', 'fetch $origin');
   git.run('reset $commit --hard', 'reset to the release commit');
 
-  String version = getFullTag(git);
+  String version = getFullTag(git, origin);
 
   version = incrementLevel(version, level);
 
@@ -177,10 +177,10 @@ ArgResults parseArguments(ArgParser argParser, List<String> args) {
 }
 
 /// Obtain the version tag of the previous dev release.
-String getFullTag(Git git) {
+String getFullTag(Git git, String remote) {
   const String glob = '*.*.*-*.*.pre';
   // describe the latest dev release
-  const String ref = 'refs/heads/dev';
+  final String ref = 'refs/remotes/$remote/dev';
   return git.getOutput(
     'describe --match $glob --exact-match --tags $ref',
     'obtain last released version number',

--- a/dev/tools/test/roll_dev_test.dart
+++ b/dev/tools/test/roll_dev_test.dart
@@ -136,7 +136,7 @@ void main() {
       when(mockGit.getOutput('remote get-url $origin', any)).thenReturn(kUpstreamRemote);
       when(mockGit.getOutput('status --porcelain', any)).thenReturn('');
       when(mockGit.getOutput(
-        'describe --match *.*.*-*.*.pre --exact-match --tags refs/heads/dev',
+        'describe --match *.*.*-*.*.pre --exact-match --tags refs/remotes/$origin/dev',
         any,
       )).thenReturn('1.2.3-0.0.pre');
       fakeArgResults = FakeArgResults(
@@ -161,7 +161,7 @@ void main() {
       when(mockGit.getOutput('remote get-url $origin', any)).thenReturn(kUpstreamRemote);
       when(mockGit.getOutput('status --porcelain', any)).thenReturn('');
       when(mockGit.getOutput(
-        'describe --match *.*.*-*.*.pre --exact-match --tags refs/heads/dev',
+        'describe --match *.*.*-*.*.pre --exact-match --tags refs/remotes/$origin/dev',
         any,
       )).thenReturn('1.2.3-0.0.pre');
       when(mockGit.getOutput('rev-parse HEAD', any)).thenReturn(commit);
@@ -188,7 +188,7 @@ void main() {
       when(mockGit.getOutput('remote get-url $origin', any)).thenReturn(kUpstreamRemote);
       when(mockGit.getOutput('status --porcelain', any)).thenReturn('');
       when(mockGit.getOutput(
-        'describe --match *.*.*-*.*.pre --exact-match --tags refs/heads/dev',
+        'describe --match *.*.*-*.*.pre --exact-match --tags refs/remotes/$origin/dev',
         any,
       )).thenReturn('1.2.3-0.0.pre');
       when(mockGit.getOutput('rev-parse HEAD', any)).thenReturn(commit);


### PR DESCRIPTION
## Description

I introduced a bug with https://github.com/flutter/flutter/pull/56501 where the script would query the local ref `refs/heads/dev`, when it should have been the remote ref `refs/remotes/<remote_name>/dev`.

## Issues

Fixes https://github.com/flutter/flutter/issues/56705

## Tests

Updated existing tests.