### PR TITLE
Add VSCode to ide-config command

### DIFF
--- a/packages/flutter_tools/ide_templates/vscode/.vscode/launch.json.copy.tmpl
+++ b/packages/flutter_tools/ide_templates/vscode/.vscode/launch.json.copy.tmpl
@@ -1,0 +1,304 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "benchmarks - complex_layout",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/dev/benchmarks/complex_layout/lib/main.dart",
+            "cwd": "${workspaceRoot}/dev/benchmarks/complex_layout"
+        },
+        {
+            "name": "catalog - animated_list",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/examples/catalog/lib/animated_list.dart",
+            "cwd": "${workspaceRoot}/examples/catalog"
+        },
+        {
+            "name": "catalog - app_bar_bottom",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/examples/catalog/lib/app_bar_bottom.dart",
+            "cwd": "${workspaceRoot}/examples/catalog"
+        },
+        {
+            "name": "catalog - basic_app_bar",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/examples/catalog/lib/basic_app_bar.dart",
+            "cwd": "${workspaceRoot}/examples/catalog"
+        },
+        {
+            "name": "catalog - custom_a11y_traversal",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/examples/catalog/lib/custom_a11y_traversal.dart",
+            "cwd": "${workspaceRoot}/examples/catalog"
+        },
+        {
+            "name": "catalog - custom_semantics",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/examples/catalog/lib/custom_semantics.dart",
+            "cwd": "${workspaceRoot}/examples/catalog"
+        },
+        {
+            "name": "catalog - expansion_tile_sample",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/examples/catalog/lib/expansion_tile_sample.dart",
+            "cwd": "${workspaceRoot}/examples/catalog"
+        },
+        {
+            "name": "catalog - tabbed_app_bar",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/examples/catalog/lib/tabbed_app_bar.dart",
+            "cwd": "${workspaceRoot}/examples/catalog"
+        },
+        {
+            "name": "flutter_gallery",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/dev/integration_tests/flutter_gallery/lib/main.dart",
+            "cwd": "${workspaceRoot}/dev/integration_tests/flutter_gallery"
+        },
+        {
+            "name": "flutter_view",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/examples/flutter_view/lib/main.dart",
+            "cwd": "${workspaceRoot}/examples/flutter_view"
+        },
+        {
+            "name": "hello_world",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/examples/hello_world/lib/main.dart",
+            "cwd": "${workspaceRoot}/examples/hello_world"
+        },
+        {
+            "name": "layers - custom_render_box",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/examples/layers/widgets/custom_render_box.dart",
+            "cwd": "${workspaceRoot}/examples/layers"
+        },
+        {
+            "name": "layers - gestures",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/examples/layers/widgets/gestures.dart",
+            "cwd": "${workspaceRoot}/examples/layers"
+        },
+        {
+            "name": "layers - hello_world",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/examples/layers/widgets/hello_world.dart",
+            "cwd": "${workspaceRoot}/examples/layers"
+        },
+        {
+            "name": "layers - isolate",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/examples/layers/services/isolate.dart",
+            "cwd": "${workspaceRoot}/examples/layers"
+        },
+        {
+            "name": "layers - lifecycle",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/examples/layers/services/lifecycle.dart",
+            "cwd": "${workspaceRoot}/examples/layers"
+        },
+        {
+            "name": "layers - sectors",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/examples/layers/widgets/sectors.dart",
+            "cwd": "${workspaceRoot}/examples/layers"
+        },
+        {
+            "name": "layers - spinning_mixed",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/examples/layers/widgets/spinning_mixed.dart",
+            "cwd": "${workspaceRoot}/examples/layers"
+        },
+        {
+            "name": "layers - spinning_square",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/examples/layers/widgets/spinning_square.dart",
+            "cwd": "${workspaceRoot}/examples/layers"
+        },
+        {
+            "name": "layers - styled_text",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/examples/layers/widgets/styled_text.dart",
+            "cwd": "${workspaceRoot}/examples/layers"
+        },
+        {
+            "name": "manual_tests - actions",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/dev/manual_tests/lib/actions.dart",
+            "cwd": "${workspaceRoot}/dev/manual_tests"
+        },
+        {
+            "name": "manual_tests - animated_icons",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/dev/manual_tests/lib/animated_icons.dart",
+            "cwd": "${workspaceRoot}/dev/manual_tests"
+        },
+        {
+            "name": "manual_tests - card_collection",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/dev/manual_tests/lib/card_collection.dart",
+            "cwd": "${workspaceRoot}/dev/manual_tests"
+        },
+        {
+            "name": "manual_tests - color_testing_demo",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/dev/manual_tests/lib/color_testing_demo.dart",
+            "cwd": "${workspaceRoot}/dev/manual_tests"
+        },
+        {
+            "name": "manual_tests - density",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/dev/manual_tests/lib/density.dart",
+            "cwd": "${workspaceRoot}/dev/manual_tests"
+        },
+        {
+            "name": "manual_tests - drag_and_drop",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/dev/manual_tests/lib/drag_and_drop.dart",
+            "cwd": "${workspaceRoot}/dev/manual_tests"
+        },
+        {
+            "name": "manual_tests - focus",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/dev/manual_tests/lib/focus.dart",
+            "cwd": "${workspaceRoot}/dev/manual_tests"
+        },
+        {
+            "name": "manual_tests - hover",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/dev/manual_tests/lib/hover.dart",
+            "cwd": "${workspaceRoot}/dev/manual_tests"
+        },
+        {
+            "name": "manual_tests - material_arc",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/dev/manual_tests/lib/material_arc.dart",
+            "cwd": "${workspaceRoot}/dev/manual_tests"
+        },
+        {
+            "name": "manual_tests - overlay_geometry",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/dev/manual_tests/lib/overlay_geometry.dart",
+            "cwd": "${workspaceRoot}/dev/manual_tests"
+        },
+        {
+            "name": "manual_tests - page_view",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/dev/manual_tests/lib/page_view.dart",
+            "cwd": "${workspaceRoot}/dev/manual_tests"
+        },
+        {
+            "name": "manual_tests - raw_keyboard",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/dev/manual_tests/lib/raw_keyboard.dart",
+            "cwd": "${workspaceRoot}/dev/manual_tests"
+        },
+        {
+            "name": "manual_tests - text",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/dev/manual_tests/lib/text.dart",
+            "cwd": "${workspaceRoot}/dev/manual_tests"
+        },
+        {
+            "name": "platform_view",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/examples/platform_view/lib/main.dart",
+            "cwd": "${workspaceRoot}/examples/platform_view"
+        },
+        {
+            "name": "platform_channel",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/examples/platform_channel/lib/main.dart",
+            "cwd": "${workspaceRoot}/examples/platform_channel"
+        },
+        {
+            "name": "platform_channel_swift",
+            "type": "dart",
+            "request": "launch",
+            "args": [],
+            "program": "${workspaceRoot}/examples/platform_channel_swift/lib/main.dart",
+            "cwd": "${workspaceRoot}/examples/platform_channel_swift"
+        },
+        {
+            "name": "flutter_tools",
+            "type": "dart",
+            "request": "launch",
+            "args": ["ide-config", "--ide=vscode", "--update-templates"],
+            "program": "${workspaceRoot}/packages/flutter_tools/bin/flutter_tools.dart",
+            "cwd": "${workspaceRoot}"
+        }
+    ]
+}

--- a/packages/flutter_tools/test/commands.shard/hermetic/ide_config_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/ide_config_test.dart
@@ -15,309 +15,501 @@ import '../../src/common.dart';
 import '../../src/context.dart';
 
 void main() {
-  group('ide_config', () {
-    Directory tempDir;
-    Directory templateDir;
-    Directory intellijDir;
-    Directory toolsDir;
+  Directory tempDir;
+  Directory templateDir;
+  Directory intellijDir;
+  Directory vscodeDir;
+  Directory toolsDir;
 
-    Map<String, String> _getFilesystemContents([ Directory root ]) {
-      final String tempPath = tempDir.absolute.path;
-      final List<String> paths =
+  Map<String, String> _getFilesystemContents([Directory root]) {
+    final String tempPath = tempDir.absolute.path;
+    final List<String> paths =
         (root ?? tempDir).listSync(recursive: true).map((FileSystemEntity entity) {
-          final String relativePath = globals.fs.path.relative(entity.path, from: tempPath);
-          return relativePath;
-        }).toList();
-      final Map<String, String> contents = <String, String>{};
-      for (final String path in paths) {
-        final String absPath = globals.fs.path.join(tempPath, path);
-        if (globals.fs.isDirectorySync(absPath)) {
-          contents[path] = 'dir';
-        } else if (globals.fs.isFileSync(absPath)) {
-          contents[path] = globals.fs.file(absPath).readAsStringSync();
-        }
-      }
-      return contents;
-    }
-
-    Map<String, String> _getManifest(Directory base, String marker, { bool isTemplate = false }) {
-      final String basePath = globals.fs.path.relative(base.path, from: tempDir.absolute.path);
-      final String suffix = isTemplate ? Template.copyTemplateExtension : '';
-      return <String, String>{
-        globals.fs.path.join(basePath, '.idea'): 'dir',
-        globals.fs.path.join(basePath, '.idea', 'modules.xml$suffix'): 'modules $marker',
-        globals.fs.path.join(basePath, '.idea', 'vcs.xml$suffix'): 'vcs $marker',
-        globals.fs.path.join(basePath, '.idea', '.name$suffix'): 'codeStyleSettings $marker',
-        globals.fs.path.join(basePath, '.idea', 'runConfigurations'): 'dir',
-        globals.fs.path.join(basePath, '.idea', 'runConfigurations', 'hello_world.xml$suffix'): 'hello_world $marker',
-        globals.fs.path.join(basePath, 'flutter.iml$suffix'): 'flutter $marker',
-        globals.fs.path.join(basePath, 'packages', 'new', 'deep.iml$suffix'): 'deep $marker',
-      };
-    }
-
-    void _populateDir(Map<String, String> manifest) {
-      for (final String key in manifest.keys) {
-        if (manifest[key] == 'dir') {
-          tempDir.childDirectory(key).createSync(recursive: true);
-        }
-      }
-      for (final String key in manifest.keys) {
-        if (manifest[key] != 'dir') {
-          tempDir.childFile(key)
-            ..createSync(recursive: true)
-            ..writeAsStringSync(manifest[key]);
-        }
+      final String relativePath = globals.fs.path.relative(entity.path, from: tempPath);
+      return relativePath;
+    }).toList();
+    final Map<String, String> contents = <String, String>{};
+    for (final String path in paths) {
+      final String absPath = globals.fs.path.join(tempPath, path);
+      if (globals.fs.isDirectorySync(absPath)) {
+        contents[path] = 'dir';
+      } else if (globals.fs.isFileSync(absPath)) {
+        contents[path] = globals.fs.file(absPath).readAsStringSync();
       }
     }
+    return contents;
+  }
 
-    bool _fileOrDirectoryExists(String path) {
+  Map<String, String> _getIntellijManifest(Directory base, String marker,
+      {bool isTemplate = false}) {
+    final String basePath = globals.fs.path.relative(base.path, from: tempDir.absolute.path);
+    final String suffix = isTemplate ? Template.copyTemplateExtension : '';
+    return <String, String>{
+      globals.fs.path.join(basePath, '.idea'): 'dir',
+      globals.fs.path.join(basePath, '.idea', 'modules.xml$suffix'): 'modules $marker',
+      globals.fs.path.join(basePath, '.idea', 'vcs.xml$suffix'): 'vcs $marker',
+      globals.fs.path.join(basePath, '.idea', '.name$suffix'): 'codeStyleSettings $marker',
+      globals.fs.path.join(basePath, '.idea', 'runConfigurations'): 'dir',
+      globals.fs.path.join(basePath, '.idea', 'runConfigurations', 'hello_world.xml$suffix'):
+          'hello_world $marker',
+      globals.fs.path.join(basePath, 'flutter.iml$suffix'): 'flutter $marker',
+      globals.fs.path.join(basePath, 'packages', 'new', 'deep.iml$suffix'): 'deep $marker',
+    };
+  }
+
+  Map<String, String> _getVsCodeManifest(Directory base, String marker, {bool isTemplate = false}) {
+    final String basePath = globals.fs.path.relative(base.path, from: tempDir.absolute.path);
+    final String suffix = isTemplate ? Template.copyTemplateExtension : '';
+    return <String, String>{
+      globals.fs.path.join(basePath, '.vscode'): 'dir',
+      globals.fs.path.join(basePath, '.vscode', 'launch.json$suffix'): 'flutter $marker',
+    };
+  }
+
+  void _populateDir(Map<String, String> manifest) {
+    for (final String key in manifest.keys) {
+      if (manifest[key] == 'dir') {
+        tempDir.childDirectory(key).createSync(recursive: true);
+      }
+    }
+    for (final String key in manifest.keys) {
+      if (manifest[key] != 'dir') {
+        tempDir.childFile(key)
+          ..createSync(recursive: true)
+          ..writeAsStringSync(manifest[key]);
+      }
+    }
+  }
+
+  bool _fileOrDirectoryExists(String path) {
+    final String absPath = globals.fs.path.join(tempDir.absolute.path, path);
+    return globals.fs.file(absPath).existsSync() || globals.fs.directory(absPath).existsSync();
+  }
+
+  Future<void> _updateIdeConfig({
+    Directory dir,
+    List<String> args = const <String>[],
+    Map<String, String> expectedContents = const <String, String>{},
+    List<String> unexpectedPaths = const <String>[],
+  }) async {
+    dir ??= tempDir;
+    final IdeConfigCommand command = IdeConfigCommand();
+    final CommandRunner<void> runner = createTestCommandRunner(command);
+    await runner.run(<String>[
+      '--flutter-root=${tempDir.absolute.path}',
+      'ide-config',
+      ...args,
+    ]);
+
+    for (final String path in expectedContents.keys) {
       final String absPath = globals.fs.path.join(tempDir.absolute.path, path);
-      return globals.fs.file(absPath).existsSync() || globals.fs.directory(absPath).existsSync();
-    }
-
-    Future<void> _updateIdeConfig({
-      Directory dir,
-      List<String> args = const <String>[],
-      Map<String, String> expectedContents = const <String, String>{},
-      List<String> unexpectedPaths = const <String>[],
-    }) async {
-      dir ??= tempDir;
-      final IdeConfigCommand command = IdeConfigCommand();
-      final CommandRunner<void> runner = createTestCommandRunner(command);
-      await runner.run(<String>[
-        '--flutter-root=${tempDir.absolute.path}',
-        'ide-config',
-        ...args,
-      ]);
-
-      for (final String path in expectedContents.keys) {
-        final String absPath = globals.fs.path.join(tempDir.absolute.path, path);
-        expect(_fileOrDirectoryExists(globals.fs.path.join(dir.path, path)), true,
-            reason: "$path doesn't exist");
-        if (globals.fs.file(absPath).existsSync()) {
-          expect(globals.fs.file(absPath).readAsStringSync(), equals(expectedContents[path]),
-              reason: "$path contents don't match");
-        }
-      }
-      for (final String path in unexpectedPaths) {
-        expect(_fileOrDirectoryExists(globals.fs.path.join(dir.path, path)), false, reason: '$path exists');
+      expect(_fileOrDirectoryExists(globals.fs.path.join(dir.path, path)), isTrue,
+          reason: "$path doesn't exist");
+      if (globals.fs.file(absPath).existsSync()) {
+        expect(globals.fs.file(absPath).readAsStringSync(), equals(expectedContents[path]),
+            reason: "$path contents don't match");
       }
     }
+    for (final String path in unexpectedPaths) {
+      expect(_fileOrDirectoryExists(globals.fs.path.join(dir.path, path)), isFalse);
+      expect(_fileOrDirectoryExists(globals.fs.path.join(dir.path, path)), isFalse,
+          reason: '$path exists');
+    }
+  }
 
-    setUpAll(() {
-      Cache.disableLocking();
-    });
+  setUpAll(() {
+    Cache.disableLocking();
+  });
 
-    setUp(() {
-      tempDir = globals.fs.systemTempDirectory.createTempSync('flutter_tools_ide_config_test.');
-      final Directory packagesDir = tempDir.childDirectory('packages')..createSync(recursive: true);
-      toolsDir = packagesDir.childDirectory('flutter_tools')..createSync();
-      templateDir = toolsDir.childDirectory('ide_templates')..createSync();
-      intellijDir = templateDir.childDirectory('intellij')..createSync();
-    });
+  setUp(() {
+    tempDir = globals.fs.systemTempDirectory.createTempSync('flutter_tools_ide_config_test.');
+    final Directory packagesDir = tempDir.childDirectory('packages')..createSync(recursive: true);
+    toolsDir = packagesDir.childDirectory('flutter_tools')..createSync();
+    templateDir = toolsDir.childDirectory('ide_templates')..createSync();
+    intellijDir = templateDir.childDirectory('intellij')..createSync();
+    vscodeDir = templateDir.childDirectory('vscode')..createSync();
+  });
 
-    tearDown(() {
-      tryToDelete(tempDir);
-    });
+  tearDown(() {
+    tryToDelete(tempDir);
+  });
 
-    testUsingContext("doesn't touch existing files without --overwrite", () async {
-      final Map<String, String> templateManifest = _getManifest(
-        intellijDir,
-        'template',
-        isTemplate: true,
-      );
-      final Map<String, String> flutterManifest = _getManifest(
-        tempDir,
-        'existing',
-      );
-      _populateDir(templateManifest);
-      _populateDir(flutterManifest);
-      final Map<String, String> expectedContents = _getFilesystemContents();
-      return _updateIdeConfig(
-        expectedContents: expectedContents,
-      );
-    });
+  testUsingContext("doesn't touch existing files without --overwrite", () async {
+    final Map<String, String> templateManifest = _getIntellijManifest(
+      intellijDir,
+      'template',
+      isTemplate: true,
+    );
+    final Map<String, String> flutterManifest = _getIntellijManifest(
+      tempDir,
+      'existing',
+    );
+    _populateDir(templateManifest);
+    _populateDir(flutterManifest);
+    final Map<String, String> expectedContents = _getFilesystemContents();
+    return _updateIdeConfig(
+      expectedContents: expectedContents,
+    );
+  });
 
-    testUsingContext('creates non-existent files', () async {
-      final Map<String, String> templateManifest = _getManifest(
-        intellijDir,
-        'template',
-        isTemplate: true,
-      );
-      final Map<String, String> flutterManifest = _getManifest(
-        tempDir,
-        'template',
-      );
-      _populateDir(templateManifest);
-      final Map<String, String> expectedContents = <String, String>{
-        ...templateManifest,
-        ...flutterManifest,
-      };
-      return _updateIdeConfig(
-        expectedContents: expectedContents,
-      );
-    });
+  testUsingContext("doesn't touch existing files without --overwrite for VSCode", () async {
+    final Map<String, String> templateManifest = _getVsCodeManifest(
+      vscodeDir,
+      'template',
+      isTemplate: true,
+    );
+    final Map<String, String> flutterManifest = _getVsCodeManifest(
+      tempDir,
+      'existing',
+    );
+    _populateDir(templateManifest);
+    _populateDir(flutterManifest);
+    final Map<String, String> expectedContents = _getFilesystemContents();
+    return _updateIdeConfig(
+      expectedContents: expectedContents,
+      args: <String>['--ide=vscode'],
+    );
+  });
 
-    testUsingContext('overwrites existing files with --overwrite', () async {
-      final Map<String, String> templateManifest = _getManifest(
-        intellijDir,
-        'template',
-        isTemplate: true,
-      );
-      final Map<String, String> flutterManifest = _getManifest(
-        tempDir,
-        'existing',
-      );
-      _populateDir(templateManifest);
-      _populateDir(flutterManifest);
-      final Map<String, String> overwrittenManifest = _getManifest(
-        tempDir,
-        'template',
-      );
-      final Map<String, String> expectedContents = <String, String>{
-        ...templateManifest,
-        ...overwrittenManifest,
-      };
-      return _updateIdeConfig(
-        args: <String>['--overwrite'],
-        expectedContents: expectedContents,
-      );
-    });
+  testUsingContext("doesn't populate files in IntelliJ when doing VSCode", () async {
+    final Map<String, String> templateManifest = _getVsCodeManifest(
+      vscodeDir,
+      'template',
+      isTemplate: true,
+    );
+    final Map<String, String> flutterManifest = _getVsCodeManifest(
+      tempDir,
+      'template',
+    );
+    _populateDir(templateManifest);
+    final Map<String, String> expectedContents = <String, String>{
+      ...templateManifest,
+      ...flutterManifest,
+    };
+    return _updateIdeConfig(
+      expectedContents: expectedContents,
+      args: <String>['--ide=vscode'],
+      unexpectedPaths: <String>['./.idea/vcs.xml'],
+    );
+  });
 
-    testUsingContext('only adds new templates without --overwrite', () async {
-      final Map<String, String> templateManifest = _getManifest(
-        intellijDir,
-        'template',
-        isTemplate: true,
-      );
-      final String flutterIml = globals.fs.path.join(
-        'packages',
-        'flutter_tools',
-        'ide_templates',
-        'intellij',
-        'flutter.iml${Template.copyTemplateExtension}',
-      );
-      templateManifest.remove(flutterIml);
-      _populateDir(templateManifest);
-      templateManifest[flutterIml] = 'flutter existing';
-      final Map<String, String> flutterManifest = _getManifest(
-        tempDir,
-        'existing',
-      );
-      _populateDir(flutterManifest);
-      final Map<String, String> expectedContents = <String, String>{
-        ...flutterManifest,
-        ...templateManifest,
-      };
-      return _updateIdeConfig(
-        args: <String>['--update-templates'],
-        expectedContents: expectedContents,
-      );
-    });
+  testUsingContext('creates non-existent files', () async {
+    final Map<String, String> templateManifest = _getIntellijManifest(
+      intellijDir,
+      'template',
+      isTemplate: true,
+    );
+    final Map<String, String> flutterManifest = _getIntellijManifest(
+      tempDir,
+      'template',
+    );
+    _populateDir(templateManifest);
+    final Map<String, String> expectedContents = <String, String>{
+      ...templateManifest,
+      ...flutterManifest,
+    };
+    return _updateIdeConfig(
+      expectedContents: expectedContents,
+    );
+  });
 
-    testUsingContext('update all templates with --overwrite', () async {
-      final Map<String, String> templateManifest = _getManifest(
-        intellijDir,
-        'template',
-        isTemplate: true,
-      );
-      _populateDir(templateManifest);
-      final Map<String, String> flutterManifest = _getManifest(
-        tempDir,
-        'existing',
-      );
-      _populateDir(flutterManifest);
-      final Map<String, String> updatedTemplates = _getManifest(
-        intellijDir,
-        'existing',
-        isTemplate: true,
-      );
-      final Map<String, String> expectedContents = <String, String>{
-        ...flutterManifest,
-        ...updatedTemplates,
-      };
-      return _updateIdeConfig(
-        args: <String>['--update-templates', '--overwrite'],
-        expectedContents: expectedContents,
-      );
-    });
+  testUsingContext('creates non-existent files for VSCode', () async {
+    final Map<String, String> templateManifest = _getVsCodeManifest(
+      vscodeDir,
+      'template',
+      isTemplate: true,
+    );
+    final Map<String, String> flutterManifest = _getVsCodeManifest(
+      tempDir,
+      'template',
+    );
+    _populateDir(templateManifest);
+    final Map<String, String> expectedContents = <String, String>{
+      ...templateManifest,
+      ...flutterManifest,
+    };
+    return _updateIdeConfig(
+      expectedContents: expectedContents,
+      args: <String>['--ide=vscode'],
+    );
+  });
 
-    testUsingContext('removes deleted imls with --overwrite', () async {
-      final Map<String, String> templateManifest = _getManifest(
-        intellijDir,
-        'template',
-        isTemplate: true,
-      );
-      _populateDir(templateManifest);
-      final Map<String, String> flutterManifest = _getManifest(
-        tempDir,
-        'existing',
-      );
-      flutterManifest.remove('flutter.iml');
-      _populateDir(flutterManifest);
-      final Map<String, String> updatedTemplates = _getManifest(
-        intellijDir,
-        'existing',
-        isTemplate: true,
-      );
-      final String flutterIml = globals.fs.path.join(
-        'packages',
-        'flutter_tools',
-        'ide_templates',
-        'intellij',
-        'flutter.iml${Template.copyTemplateExtension}',
-      );
-      updatedTemplates.remove(flutterIml);
-      final Map<String, String> expectedContents = <String, String>{
-        ...flutterManifest,
-        ...updatedTemplates,
-      };
-      return _updateIdeConfig(
-        args: <String>['--update-templates', '--overwrite'],
-        expectedContents: expectedContents,
-      );
-    });
+  testUsingContext('overwrites existing files with --overwrite', () async {
+    final Map<String, String> templateManifest = _getIntellijManifest(
+      intellijDir,
+      'template',
+      isTemplate: true,
+    );
+    final Map<String, String> flutterManifest = _getIntellijManifest(
+      tempDir,
+      'existing',
+    );
+    _populateDir(templateManifest);
+    _populateDir(flutterManifest);
+    final Map<String, String> overwrittenManifest = _getIntellijManifest(
+      tempDir,
+      'template',
+    );
+    final Map<String, String> expectedContents = <String, String>{
+      ...templateManifest,
+      ...overwrittenManifest,
+    };
+    return _updateIdeConfig(
+      args: <String>['--overwrite'],
+      expectedContents: expectedContents,
+    );
+  });
 
-    testUsingContext('removes deleted imls with --overwrite, including empty parent dirs', () async {
-      final Map<String, String> templateManifest = _getManifest(
-        intellijDir,
-        'template',
-        isTemplate: true,
-      );
-      _populateDir(templateManifest);
-      final Map<String, String> flutterManifest = _getManifest(
-        tempDir,
-        'existing',
-      );
-      flutterManifest.remove(globals.fs.path.join('packages', 'new', 'deep.iml'));
-      _populateDir(flutterManifest);
-      final Map<String, String> updatedTemplates = _getManifest(
-        intellijDir,
-        'existing',
-        isTemplate: true,
-      );
-      String deepIml = globals.fs.path.join(
-        'packages',
-        'flutter_tools',
-        'ide_templates',
-        'intellij');
-      // Remove the all the dir entries too.
-      updatedTemplates.remove(deepIml);
-      deepIml = globals.fs.path.join(deepIml, 'packages');
-      updatedTemplates.remove(deepIml);
-      deepIml = globals.fs.path.join(deepIml, 'new');
-      updatedTemplates.remove(deepIml);
-      deepIml = globals.fs.path.join(deepIml, 'deep.iml');
-      updatedTemplates.remove(deepIml);
-      final Map<String, String> expectedContents = <String, String>{
-        ...flutterManifest,
-        ...updatedTemplates,
-      };
-      return _updateIdeConfig(
-        args: <String>['--update-templates', '--overwrite'],
-        expectedContents: expectedContents,
-      );
-    });
+  testUsingContext('overwrites existing files with --overwrite for VSCode', () async {
+    final Map<String, String> templateManifest = _getVsCodeManifest(
+      vscodeDir,
+      'template',
+      isTemplate: true,
+    );
+    final Map<String, String> flutterManifest = _getVsCodeManifest(
+      tempDir,
+      'existing',
+    );
+    _populateDir(templateManifest);
+    _populateDir(flutterManifest);
+    final Map<String, String> overwrittenManifest = _getVsCodeManifest(
+      tempDir,
+      'template',
+    );
+    final Map<String, String> expectedContents = <String, String>{
+      ...templateManifest,
+      ...overwrittenManifest,
+    };
+    return _updateIdeConfig(
+      args: <String>['--overwrite', '--ide=vscode'],
+      expectedContents: expectedContents,
+    );
+  });
 
+  testUsingContext('only adds new templates without --overwrite', () async {
+    final Map<String, String> templateManifest = _getIntellijManifest(
+      intellijDir,
+      'template',
+      isTemplate: true,
+    );
+    final String flutterIml = globals.fs.path.join(
+      'packages',
+      'flutter_tools',
+      'ide_templates',
+      'intellij',
+      'flutter.iml${Template.copyTemplateExtension}',
+    );
+    templateManifest.remove(flutterIml);
+    _populateDir(templateManifest);
+    templateManifest[flutterIml] = 'flutter existing';
+    final Map<String, String> flutterManifest = _getIntellijManifest(
+      tempDir,
+      'existing',
+    );
+    _populateDir(flutterManifest);
+    final Map<String, String> expectedContents = <String, String>{
+      ...flutterManifest,
+      ...templateManifest,
+    };
+    return _updateIdeConfig(
+      args: <String>['--update-templates'],
+      expectedContents: expectedContents,
+    );
+  });
+
+  testUsingContext('only adds new templates without --overwrite for VSCode', () async {
+    final Map<String, String> templateManifest = _getVsCodeManifest(
+      vscodeDir,
+      'template',
+      isTemplate: true,
+    );
+    final String launchTemplate = globals.fs.path.join(
+      'packages',
+      'flutter_tools',
+      'ide_templates',
+      'vscode',
+      '.vscode',
+      'launch.json${Template.copyTemplateExtension}',
+    );
+    templateManifest.remove(launchTemplate);
+    _populateDir(templateManifest);
+    templateManifest[launchTemplate] = 'flutter existing';
+    final Map<String, String> flutterManifest = _getVsCodeManifest(
+      tempDir,
+      'existing',
+    );
+    _populateDir(flutterManifest);
+    final Map<String, String> expectedContents = <String, String>{
+      ...flutterManifest,
+      ...templateManifest,
+    };
+    return _updateIdeConfig(
+      args: <String>['--update-templates', '--ide=vscode'],
+      expectedContents: expectedContents,
+    );
+  });
+
+  testUsingContext('update all templates with --overwrite', () async {
+    final Map<String, String> templateManifest = _getIntellijManifest(
+      intellijDir,
+      'template',
+      isTemplate: true,
+    );
+    _populateDir(templateManifest);
+    final Map<String, String> flutterManifest = _getIntellijManifest(
+      tempDir,
+      'existing',
+    );
+    _populateDir(flutterManifest);
+    final Map<String, String> updatedTemplates = _getIntellijManifest(
+      intellijDir,
+      'existing',
+      isTemplate: true,
+    );
+    final Map<String, String> expectedContents = <String, String>{
+      ...flutterManifest,
+      ...updatedTemplates,
+    };
+    return _updateIdeConfig(
+      args: <String>['--update-templates', '--overwrite'],
+      expectedContents: expectedContents,
+    );
+  });
+
+  testUsingContext('update all templates with --overwrite for VSCode', () async {
+    final Map<String, String> templateManifest = _getVsCodeManifest(
+      vscodeDir,
+      'template',
+      isTemplate: true,
+    );
+    _populateDir(templateManifest);
+    final Map<String, String> flutterManifest = _getVsCodeManifest(
+      tempDir,
+      'existing',
+    );
+    _populateDir(flutterManifest);
+    final Map<String, String> updatedTemplates = _getVsCodeManifest(
+      vscodeDir,
+      'existing',
+      isTemplate: true,
+    );
+    final Map<String, String> expectedContents = <String, String>{
+      ...flutterManifest,
+      ...updatedTemplates,
+    };
+    return _updateIdeConfig(
+      args: <String>['--update-templates', '--overwrite', '--ide=vscode'],
+      expectedContents: expectedContents,
+    );
+  });
+
+  testUsingContext('removes deleted imls with --overwrite', () async {
+    final Map<String, String> templateManifest = _getIntellijManifest(
+      intellijDir,
+      'template',
+      isTemplate: true,
+    );
+    _populateDir(templateManifest);
+    final Map<String, String> flutterManifest = _getIntellijManifest(
+      tempDir,
+      'existing',
+    );
+    flutterManifest.remove('flutter.iml');
+    _populateDir(flutterManifest);
+    final Map<String, String> updatedTemplates = _getIntellijManifest(
+      intellijDir,
+      'existing',
+      isTemplate: true,
+    );
+    final String flutterIml = globals.fs.path.join(
+      'packages',
+      'flutter_tools',
+      'ide_templates',
+      'intellij',
+      'flutter.iml${Template.copyTemplateExtension}',
+    );
+    updatedTemplates.remove(flutterIml);
+    final Map<String, String> expectedContents = <String, String>{
+      ...flutterManifest,
+      ...updatedTemplates,
+    };
+    return _updateIdeConfig(
+      args: <String>['--update-templates', '--overwrite'],
+      expectedContents: expectedContents,
+    );
+  });
+
+  testUsingContext('removes deleted files with --overwrite on VSCode', () async {
+    final Map<String, String> templateManifest = _getVsCodeManifest(
+      vscodeDir,
+      'template',
+      isTemplate: true,
+    );
+    _populateDir(templateManifest);
+    final Map<String, String> flutterManifest = _getVsCodeManifest(
+      tempDir,
+      'existing',
+    );
+    flutterManifest.remove('.idea/launch.json');
+    _populateDir(flutterManifest);
+    final Map<String, String> updatedTemplates = _getVsCodeManifest(
+      vscodeDir,
+      'existing',
+      isTemplate: true,
+    );
+    final String flutterLaunchJson = globals.fs.path.join(
+      'packages',
+      'flutter_tools',
+      'ide_templates',
+      'vscode',
+      '.vscode',
+      'launch.json${Template.copyTemplateExtension}',
+    );
+    updatedTemplates.remove(flutterLaunchJson);
+    final Map<String, String> expectedContents = <String, String>{
+      ...flutterManifest,
+      ...updatedTemplates,
+    };
+    return _updateIdeConfig(
+      args: <String>['--update-templates', '--overwrite', '--ide=vscode'],
+      expectedContents: expectedContents,
+    );
+  });
+
+  testUsingContext('removes deleted imls with --overwrite, including empty parent dirs', () async {
+    final Map<String, String> templateManifest = _getIntellijManifest(
+      intellijDir,
+      'template',
+      isTemplate: true,
+    );
+    _populateDir(templateManifest);
+    final Map<String, String> flutterManifest = _getIntellijManifest(
+      tempDir,
+      'existing',
+    );
+    flutterManifest.remove(globals.fs.path.join('packages', 'new', 'deep.iml'));
+    _populateDir(flutterManifest);
+    final Map<String, String> updatedTemplates = _getIntellijManifest(
+      intellijDir,
+      'existing',
+      isTemplate: true,
+    );
+    String deepIml = globals.fs.path.join('packages', 'flutter_tools', 'ide_templates', 'intellij');
+    // Remove the all the dir entries too.
+    updatedTemplates.remove(deepIml);
+    deepIml = globals.fs.path.join(deepIml, 'packages');
+    updatedTemplates.remove(deepIml);
+    deepIml = globals.fs.path.join(deepIml, 'new');
+    updatedTemplates.remove(deepIml);
+    deepIml = globals.fs.path.join(deepIml, 'deep.iml');
+    updatedTemplates.remove(deepIml);
+    final Map<String, String> expectedContents = <String, String>{
+      ...flutterManifest,
+      ...updatedTemplates,
+    };
+    return _updateIdeConfig(
+      args: <String>['--update-templates', '--overwrite'],
+      expectedContents: expectedContents,
+    );
   });
 }


### PR DESCRIPTION
## Description

The `flutter ide-config` command has long been just for IntelliJ.  This PR makes it also support creating a default `launch.json` for VSCode.

This is just for Flutter developers working on the Flutter tree, and for people who want to run examples from the flutter tree.

It also adds it to the downloadable Flutter package so that the `.vscode` directory is setup by default when Flutter is unpacked.

## Tests

- Added a test to make sure the .vscode/launch.json gets created.

## Breaking Change

- [X] No, this is *not* a breaking change.