### PR TITLE
fix pushAndRemoveUntil incorrectly removes the routes below the first…

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -3435,9 +3435,8 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
     assert(predicate != null);
     int index = _history.length - 1;
     _history.add(_RouteEntry(newRoute, initialState: _RouteLifecycle.push));
-    while (index >= 0) {
-      final _RouteEntry entry = _history[index];
-      if (entry.isPresent && !predicate(entry.route))
+    while (index >= 0 && !predicate(_history[index].route)) {
+      if (_history[index].isPresent)
         _history[index].remove();
       index -= 1;
     }

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -686,7 +686,7 @@ void main() {
     // Regression https://github.com/flutter/flutter/issues/56688
     final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
-      '/' : (BuildContext context) => const Text('home'),
+      '/': (BuildContext context) => const Text('home'),
       '/A': (BuildContext context) => const Text('page A'),
       '/A/B': (BuildContext context) => OnTapPage(
         id: 'B',

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -682,6 +682,42 @@ void main() {
     expect(find.text('B'), isOnstage);
   });
 
+  testWidgets('pushAndRemoveUntil does not remove routes below the first route that pass the predicate', (WidgetTester tester) async {
+    // Regression https://github.com/flutter/flutter/issues/56688
+    final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+    final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
+      '/' : (BuildContext context) => const Text('home'),
+      '/A': (BuildContext context) => const Text('page A'),
+      '/A/B': (BuildContext context) => OnTapPage(
+        id: 'B',
+        onTap: () {
+          Navigator.of(context).pushNamedAndRemoveUntil('/D', ModalRoute.withName('/A'));
+        },
+      ),
+      '/D': (BuildContext context) => const Text('page D'),
+    };
+
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: navigator,
+        routes: routes,
+        initialRoute: '/A/B',
+      )
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('B'));
+    await tester.pumpAndSettle();
+    expect(find.text('page D'), isOnstage);
+
+    navigator.currentState.pop();
+    await tester.pumpAndSettle();
+    expect(find.text('page A'), isOnstage);
+
+    navigator.currentState.pop();
+    await tester.pumpAndSettle();
+    expect(find.text('home'), isOnstage);
+  });
+
   testWidgets('replaceNamed returned value', (WidgetTester tester) async {
     Future<String> value;
 


### PR DESCRIPTION
… matching route

## Description

The navigator refactor accidentally change the behavior of pushAndRemoveUntil method. Instead of stopping at the first route that match the predicate, it continue scanning through the entire route history and removing all the routes that does not match the predicate.

This pr fixes it.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/56688

## Tests

I added the following tests:

See files

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
