### PR TITLE
Shard Cirrus build_tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -236,7 +236,17 @@ task:
     - name: web_tests-7_last-linux # last Web shard must end with _last
       << : *WEB_SHARD_TEMPLATE
 
-    - name: build_tests-linux
+    - name: build_tests-0-linux
+      environment:
+        # With 1 CPU and 4G of RAM, as of October 2019, build_tests-linux would get OOM-killed.
+        # Increasing the RAM to 12G allowed it to finish in about 30 minutes, any extra CPU (tried 2
+        # and 4) reduced that to just over 20 minutes. 6G was enough not to get OOM-killed.
+        CPU: 2
+        MEMORY: 6G
+      script:
+        - dart --enable-asserts ./dev/bots/test.dart
+
+    - name: build_tests-1_last-linux
       environment:
         # With 1 CPU and 4G of RAM, as of October 2019, build_tests-linux would get OOM-killed.
         # Increasing the RAM to 12G allowed it to finish in about 30 minutes, any extra CPU (tried 2
@@ -289,7 +299,7 @@ task:
     - name: firebase_test_lab_tests-1-linux
       <<: *FIREBASE_SHARD_TEMPLATE
 
-    - name: firebase_test_lab_tests-2-linux
+    - name: firebase_test_lab_tests-2_last-linux
       <<: *FIREBASE_SHARD_TEMPLATE
 
     - name: web_smoke_test
@@ -436,7 +446,18 @@ task:
 
     # TODO(ianh): Enable Web tests on Windows
 
-    - name: build_tests-windows
+    - name: build_tests-0-windows
+      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || $CIRRUS_PR == ''" # https://github.com/flutter/flutter/issues/41941
+      environment:
+        # As of December 2019, the build_tests-windows shard requires 6 GB RAM to pass.
+        # Emperically, using 6 CPUs and 10 GB RAM yielded optimal results (~33 minutes);
+        # bumping beyond these limits yielded no extra gain.
+        CPU: 6
+        MEMORY: 10G
+      script:
+        - dart --enable-asserts dev\bots\test.dart
+
+    - name: build_tests-1_last-windows
       only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || $CIRRUS_PR == ''" # https://github.com/flutter/flutter/issues/41941
       environment:
         # As of December 2019, the build_tests-windows shard requires 6 GB RAM to pass.
@@ -577,7 +598,12 @@ task:
 
     # TODO(ianh): Enable Web tests on macOS.
 
-    - name: build_tests-macos
+    - name: build_tests-0-macos
+      only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || $CIRRUS_PR == ''" # https://github.com/flutter/flutter/issues/41940
+      script:
+        - dart --enable-asserts ./dev/bots/test.dart
+
+    - name: build_tests-1_last-macos
       only_if: "changesInclude('.cirrus.yml', 'dev/**', 'bin/internal/**') || $CIRRUS_PR == ''" # https://github.com/flutter/flutter/issues/41940
       script:
         - dart --enable-asserts ./dev/bots/test.dart


### PR DESCRIPTION
## Description

Shard build_tests Cirrus tests into two tests.

DRY out subshard selection logic for indexed subshards (like `build_tests-0-linux`).  Add the `_last` trick to firebase_test_lab_tests to catch mismatches between Cirrus and `test.dart`

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*