### PR TITLE
Fix wrong link in description on the platform system channel

### DIFF
--- a/packages/flutter/lib/src/services/system_channels.dart
+++ b/packages/flutter/lib/src/services/system_channels.dart
@@ -85,7 +85,7 @@ class SystemChannels {
   ///    the green channel, the next eight bits being the red channel, and the
   ///    high eight bits being set, as from [Color.value] for an opaque color).
   ///    The `primaryColor` can also be zero to indicate that the system default
-  ///    should be used. See [SystemChrome.setPreferredOrientations].
+  ///    should be used. See [SystemChrome.setApplicationSwitcherDescription].
   ///
   ///  * `SystemChrome.setEnabledSystemUIOverlays`: Specifies the set of system
   ///    overlays to have visible when the application is running. The argument


### PR DESCRIPTION
Fixes what looks like a copy/paste error in the documentation.
