### PR TITLE
Make DropdownMenuItem's value param required

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -675,7 +675,6 @@ class DropdownMenuItem<T> extends _DropdownMenuItemContainer {
     @required this.value,
     @required Widget child,
   }) : assert(child != null),
-       assert(value != null),
        super(key: key, child: child);
 
   /// Called when the dropdown menu item is tapped.

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -672,9 +672,10 @@ class DropdownMenuItem<T> extends _DropdownMenuItemContainer {
   const DropdownMenuItem({
     Key key,
     this.onTap,
-    this.value,
+    @required this.value,
     @required Widget child,
   }) : assert(child != null),
+       assert(value != null),
        super(key: key, child: child);
 
   /// Called when the dropdown menu item is tapped.

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -2616,6 +2616,7 @@ void main() {
               child: DropdownButton<String>(
                 onChanged: onChanged,
                 items: menuItems.map<DropdownMenuItem<String>>((String item) {
+                  // ignore: missing_required_param
                   return DropdownMenuItem<String>(
                     onTap: () {},
                     child: Text(item),

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -2605,28 +2605,4 @@ void main() {
     expect(value, equals('two'));
     expect(menuItemTapCounters, <int>[0, 2, 1, 0]);
   });
-
-  testWidgets('throws AssertionError if value param is not provide', (WidgetTester tester) async {
-    expect(() async {
-      await tester.pumpWidget(
-        TestApp(
-          textDirection: TextDirection.ltr,
-          child: Material(
-            child: RepaintBoundary(
-              child: DropdownButton<String>(
-                onChanged: onChanged,
-                items: menuItems.map<DropdownMenuItem<String>>((String item) {
-                  // ignore: missing_required_param
-                  return DropdownMenuItem<String>(
-                    onTap: () {},
-                    child: Text(item),
-                  );
-                }).toList(),
-              ),
-            ),
-          ),
-        ),
-      );
-    }, throwsAssertionError);
-  });
 }

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -2162,6 +2162,7 @@ void main() {
                       icon: Container(),
                       items: itemValues.map<DropdownMenuItem<String>>((String value) {
                         return DropdownMenuItem<String>(
+                          value: value,
                           child: Text(value),
                         );
                       }).toList(),

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -2604,4 +2604,27 @@ void main() {
     expect(value, equals('two'));
     expect(menuItemTapCounters, <int>[0, 2, 1, 0]);
   });
+  
+  testWidgets('throws AssertionError if value param is not provide', (WidgetTester tester) async {
+    expect(() async {
+      await tester.pumpWidget(
+        TestApp(
+          textDirection: TextDirection.ltr,
+          child: Material(
+            child: RepaintBoundary(
+              child: DropdownButton<String>(
+                onChanged: onChanged,
+                items: menuItems.map<DropdownMenuItem<String>>((String item) {
+                  return DropdownMenuItem<String>(
+                    onTap: () {},
+                    child: Text(item),
+                  );
+                }).toList(),
+              ),
+            ),
+          ),
+        ),
+      );
+    }, throwsAssertionError);
+  });
 }

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -2605,7 +2605,7 @@ void main() {
     expect(value, equals('two'));
     expect(menuItemTapCounters, <int>[0, 2, 1, 0]);
   });
-  
+
   testWidgets('throws AssertionError if value param is not provide', (WidgetTester tester) async {
     expect(() async {
       await tester.pumpWidget(


### PR DESCRIPTION
## Description

I proposed that `value` param of `DropdownMenuItem` should be required since it is easy to forget without being required and once it is a required value to this widget to function properly.

This fixes: https://github.com/flutter/flutter/issues/56725#issuecomment-626149509

## Related Issues

https://github.com/flutter/flutter/issues/56725#issuecomment-626149509

## Tests

I added the following tests:

I added a test that assert that `value` param is provided or throws AssertionError otherwise

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.