### PR TITLE
Add mirror overrides to doctor output

### DIFF
--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -22,6 +22,8 @@ class UserMessages {
       'Framework revision $revision ($age), $date';
   String engineRevision(String revision) => 'Engine revision $revision';
   String dartRevision(String revision) => 'Dart version $revision';
+  String pubMirrorURL(String url) => 'Pub download mirror $url';
+  String flutterMirrorURL(String url) => 'Flutter download mirror $url';
   String get flutterBinariesDoNotRun =>
       'Downloaded executables cannot execute on host.\n'
       'See https://github.com/flutter/flutter/issues/6207 for more information';

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -642,6 +642,12 @@ class FlutterValidator extends DoctorValidator {
       )));
       messages.add(ValidationMessage(userMessages.engineRevision(version.engineRevisionShort)));
       messages.add(ValidationMessage(userMessages.dartRevision(version.dartSdkVersion)));
+      if (globals.platform.environment.containsKey('PUB_HOSTED_URL')) {
+        messages.add(ValidationMessage(userMessages.pubMirrorURL(globals.platform.environment['PUB_HOSTED_URL'])));
+      }
+      if (globals.platform.environment.containsKey('FLUTTER_STORAGE_BASE_URL')) {
+        messages.add(ValidationMessage(userMessages.flutterMirrorURL(globals.platform.environment['FLUTTER_STORAGE_BASE_URL'])));
+      }
     } on VersionCheckError catch (e) {
       messages.add(ValidationMessage.error(e.message));
       valid = ValidationType.partial;

--- a/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
@@ -35,6 +35,7 @@ import '../../src/testbed.dart';
 
 final Generator _kNoColorOutputPlatform = () => FakePlatform(
   localeName: 'en_US.UTF-8',
+  environment: <String, String>{},
   stdoutSupportsAnsi: false,
 );
 
@@ -580,6 +581,24 @@ void main() {
           '    ✗ version error\n\n'
           '! Doctor found issues in 1 category.\n'
       ));
+    }, overrides: <Type, Generator>{
+      Artifacts: () => mockArtifacts,
+      FileSystem: () => memoryFileSystem,
+      OutputPreferences: () => OutputPreferences(wrapText: false),
+      ProcessManager: () => mockProcessManager,
+      Platform: _kNoColorOutputPlatform,
+      FlutterVersion: () => mockFlutterVersion,
+    });
+
+    testUsingContext('shows mirrors', () async {
+      (globals.platform as FakePlatform).environment = <String, String>{
+        'PUB_HOSTED_URL': 'https://example.com/pub',
+        'FLUTTER_STORAGE_BASE_URL': 'https://example.com/flutter',
+      };
+
+      expect(await FlutterValidatorDoctor(logger).diagnose(verbose: true), isTrue);
+      expect(logger.statusText, contains('Pub download mirror https://example.com/pub'));
+      expect(logger.statusText, contains('Flutter download mirror https://example.com/flutter'));
     }, overrides: <Type, Generator>{
       Artifacts: () => mockArtifacts,
       FileSystem: () => memoryFileSystem,


### PR DESCRIPTION
## Description

Show `PUB_HOSTED_URL` and `FLUTTER_STORAGE_BASE_URL` in verbose doctor output.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/56738

## Tests

doctor_test

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*