### PR TITLE
Add more documentation to addTimingsCallback

### DIFF
--- a/packages/flutter/test/scheduler/scheduler_test.dart
+++ b/packages/flutter/test/scheduler/scheduler_test.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:ui' show window, FrameTiming;
+import 'dart:ui' show window;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';


### PR DESCRIPTION
Since this is our recommended API, it seems worth documenting in more detail.

Also, I exported FrameTiming itself since it's part of the scheduler API. Any API that is exposed should be reexported.

cc @liyuqian 