### PR TITLE
Make initial daemon devices population fast

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
@@ -194,7 +194,7 @@ void main() {
         responses.add,
         notifyingLogger: notifyingLogger,
       );
-      final MockPollingDeviceDiscovery discoverer = MockPollingDeviceDiscovery();
+      final FakePollingDeviceDiscovery discoverer = FakePollingDeviceDiscovery();
       daemon.deviceDomain.addDeviceDiscoverer(discoverer);
       discoverer.addDevice(MockAndroidDevice());
       commands.add(<String, dynamic>{'id': 0, 'method': 'device.getDevices'});
@@ -216,7 +216,7 @@ void main() {
         notifyingLogger: notifyingLogger,
       );
 
-      final MockPollingDeviceDiscovery discoverer = MockPollingDeviceDiscovery();
+      final FakePollingDeviceDiscovery discoverer = FakePollingDeviceDiscovery();
       daemon.deviceDomain.addDeviceDiscoverer(discoverer);
       discoverer.addDevice(MockAndroidDevice());
 

--- a/packages/flutter_tools/test/general.shard/device_test.dart
+++ b/packages/flutter_tools/test/general.shard/device_test.dart
@@ -71,10 +71,13 @@ void main() {
         pollingDeviceDiscovery.startPolling();
         time.elapse(const Duration(milliseconds: 4001));
         time.flushMicrotasks();
+        // First check should use the default polling timeout
+        // to quickly populate the list.
         expect(pollingDeviceDiscovery.lastPollingTimeout, isNull);
 
         time.elapse(const Duration(milliseconds: 4001));
         time.flushMicrotasks();
+        // Subsequent polling should be much longer.
         expect(pollingDeviceDiscovery.lastPollingTimeout, const Duration(seconds: 30));
         pollingDeviceDiscovery.stopPolling();
       });

--- a/packages/flutter_tools/test/general.shard/device_test.dart
+++ b/packages/flutter_tools/test/general.shard/device_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:mockito/mockito.dart';
+import 'package:quiver/testing/async.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
@@ -60,6 +61,23 @@ void main() {
       final FakeDevice device2 = FakeDevice('Nexus 5X', '01abfc49119c410e');
       deviceManager.resetDevices(<Device>[device2]);
       expect(await deviceManager.refreshAllConnectedDevices(), <Device>[device2]);
+    });
+  });
+
+  group('PollingDeviceDiscovery', () {
+    testUsingContext('startPolling', () async {
+      FakeAsync().run((FakeAsync time) async {
+        final FakePollingDeviceDiscovery pollingDeviceDiscovery = FakePollingDeviceDiscovery();
+        pollingDeviceDiscovery.startPolling();
+        time.elapse(const Duration(milliseconds: 5000));
+        time.flushMicrotasks();
+        expect(pollingDeviceDiscovery.lastPollingTimeout, isNull);
+
+        time.elapse(const Duration(milliseconds: 5000));
+        time.flushMicrotasks();
+        expect(pollingDeviceDiscovery.lastPollingTimeout, const Duration(seconds: 30));
+        pollingDeviceDiscovery.stopPolling();
+      });
     });
   });
 
@@ -198,12 +216,12 @@ void main() {
 
 class TestDeviceManager extends DeviceManager {
   TestDeviceManager(List<Device> allDevices) {
-    _deviceDiscoverer = MockPollingDeviceDiscovery();
+    _deviceDiscoverer = FakePollingDeviceDiscovery();
     resetDevices(allDevices);
   }
   @override
   List<DeviceDiscovery> get deviceDiscoverers => <DeviceDiscovery>[_deviceDiscoverer];
-  MockPollingDeviceDiscovery _deviceDiscoverer;
+  FakePollingDeviceDiscovery _deviceDiscoverer;
 
   void resetDevices(List<Device> allDevices) {
     _deviceDiscoverer.setDevices(allDevices);

--- a/packages/flutter_tools/test/general.shard/device_test.dart
+++ b/packages/flutter_tools/test/general.shard/device_test.dart
@@ -66,7 +66,7 @@ void main() {
 
   group('PollingDeviceDiscovery', () {
     testUsingContext('startPolling', () async {
-      FakeAsync().run((FakeAsync time) async {
+      FakeAsync().run((FakeAsync time) {
         final FakePollingDeviceDiscovery pollingDeviceDiscovery = FakePollingDeviceDiscovery();
         pollingDeviceDiscovery.startPolling();
         time.elapse(const Duration(milliseconds: 4001));

--- a/packages/flutter_tools/test/general.shard/device_test.dart
+++ b/packages/flutter_tools/test/general.shard/device_test.dart
@@ -69,11 +69,11 @@ void main() {
       FakeAsync().run((FakeAsync time) async {
         final FakePollingDeviceDiscovery pollingDeviceDiscovery = FakePollingDeviceDiscovery();
         pollingDeviceDiscovery.startPolling();
-        time.elapse(const Duration(milliseconds: 5000));
+        time.elapse(const Duration(milliseconds: 4001));
         time.flushMicrotasks();
         expect(pollingDeviceDiscovery.lastPollingTimeout, isNull);
 
-        time.elapse(const Duration(milliseconds: 5000));
+        time.elapse(const Duration(milliseconds: 4001));
         time.flushMicrotasks();
         expect(pollingDeviceDiscovery.lastPollingTimeout, const Duration(seconds: 30));
         pollingDeviceDiscovery.stopPolling();

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -482,8 +482,8 @@ class MockStdio extends Stdio {
   List<String> get writtenToStderr => _stderr.writes.map<String>(_stderr.encoding.decode).toList();
 }
 
-class MockPollingDeviceDiscovery extends PollingDeviceDiscovery {
-  MockPollingDeviceDiscovery() : super('mock');
+class FakePollingDeviceDiscovery extends PollingDeviceDiscovery {
+  FakePollingDeviceDiscovery() : super('mock');
 
   final List<Device> _devices = <Device>[];
   final StreamController<Device> _onAddedController = StreamController<Device>.broadcast();


### PR DESCRIPTION
## Description

The first time daemon polling runs, use the default device discovery timeouts.  Use longer timeouts on subsequent calls to populate devices that may take longer than the timeout.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/56947
https://buganizer.corp.google.com/issues/156287108

## Tests

Added PollingDeviceDiscovery test.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*