### PR TITLE
Fix minor typo in 'flutter create --list-samples' help text

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -76,7 +76,7 @@ class CreateCommand extends FlutterCommand {
     argParser.addOption(
       'list-samples',
       help: 'Specifies a JSON output file for a listing of Flutter code samples '
-        'that can created with --sample.',
+        'that can be created with --sample.',
       valueHelp: 'path',
     );
     argParser.addFlag(


### PR DESCRIPTION
Came across this minor typo when running `flutter create -h`.