### PR TITLE
Allow updating textAlignVertical

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -781,20 +781,22 @@ class _RenderDecoration extends RenderBox {
     markNeedsLayout();
   }
 
+  TextAlignVertical get _defaultTextAlignVertical => _isOutlineAligned
+      ? TextAlignVertical.center
+      : TextAlignVertical.top;
   TextAlignVertical get textAlignVertical {
     if (_textAlignVertical == null) {
-      return _isOutlineAligned ? TextAlignVertical.center : TextAlignVertical.top;
+      return _defaultTextAlignVertical;
     }
     return _textAlignVertical;
   }
   TextAlignVertical _textAlignVertical;
   set textAlignVertical(TextAlignVertical value) {
-    assert(value != null);
     if (_textAlignVertical == value) {
       return;
     }
     // No need to relayout if the effective value is still the same.
-    if (textAlignVertical.y == value.y) {
+    if (textAlignVertical.y == (value?.y ?? _defaultTextAlignVertical.y)) {
       _textAlignVertical = value;
       return;
     }
@@ -1709,12 +1711,9 @@ class _Decorator extends RenderObjectWidget {
      ..decoration = decoration
      ..expands = expands
      ..isFocused = isFocused
+     ..textAlignVertical = textAlignVertical
      ..textBaseline = textBaseline
      ..textDirection = textDirection;
-
-    if (textAlignVertical != null) {
-      renderObject.textAlignVertical = textAlignVertical;
-    }
   }
 }
 

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1707,10 +1707,14 @@ class _Decorator extends RenderObjectWidget {
   void updateRenderObject(BuildContext context, _RenderDecoration renderObject) {
     renderObject
      ..decoration = decoration
-     ..textDirection = textDirection
-     ..textBaseline = textBaseline
      ..expands = expands
-     ..isFocused = isFocused;
+     ..isFocused = isFocused
+     ..textBaseline = textBaseline
+     ..textDirection = textDirection;
+
+    if (textAlignVertical != null) {
+      renderObject.textAlignVertical = textAlignVertical;
+    }
   }
 }
 

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -4000,7 +4000,7 @@ void main() {
 
   testWidgets('textAlignVertical can be updated', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/56933
-    final String hintText = 'hint';
+    const String hintText = 'hint';
     TextAlignVertical alignment = TextAlignVertical.top;
     StateSetter setState;
     await tester.pumpWidget(
@@ -4010,7 +4010,7 @@ void main() {
             setState = setter;
             return InputDecorator(
               textAlignVertical: alignment,
-              decoration: InputDecoration(
+              decoration: const InputDecoration(
                 hintText: hintText,
               ),
             );

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -3997,4 +3997,35 @@ void main() {
     // because the label is not initially floating.
     expect(tester.getTopLeft(find.text('label')).dy, 20.0);
   });
+
+  testWidgets('textAlignVertical can be updated', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/56933
+    final String hintText = 'hint';
+    TextAlignVertical alignment = TextAlignVertical.top;
+    StateSetter setState;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setter) {
+            setState = setter;
+            return InputDecorator(
+              textAlignVertical: alignment,
+              decoration: InputDecoration(
+                hintText: hintText,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    final double topPosition = tester.getTopLeft(find.text(hintText)).dy;
+
+    setState(() {
+      alignment = TextAlignVertical.bottom;
+    });
+    await tester.pump();
+
+    expect(tester.getTopLeft(find.text(hintText)).dy, greaterThan(topPosition));
+  });
 }

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -4027,5 +4027,13 @@ void main() {
     await tester.pump();
 
     expect(tester.getTopLeft(find.text(hintText)).dy, greaterThan(topPosition));
+
+    // Setting textAlignVertical back to null works and reverts to the default.
+    setState(() {
+      alignment = null;
+    });
+    await tester.pump();
+
+    expect(tester.getTopLeft(find.text(hintText)).dy, topPosition);
   });
 }


### PR DESCRIPTION
## Description

`textAlignVertical` was not being updated in _Decorator.  This passes it through. 

## Related Issues

Closes https://github.com/flutter/flutter/issues/56933

## Tests

I added a regression test that updates the alignment from `top` to `bottom` and checks that the hint text has moved down.

## Breaking Change

No.