### PR TITLE
Making DropdownButtonFormField to re-render if parent widget changes

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1561,4 +1561,12 @@ class _DropdownButtonFormFieldState<T> extends FormFieldState<T> {
     assert(widget.onChanged != null);
     widget.onChanged(value);
   }
+  
+  @override
+  void didUpdateWidget(DropdownButtonFormField<T> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.initialValue != widget.initialValue) {
+      setValue(widget.initialValue);
+    }
+  }
 }

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1561,7 +1561,7 @@ class _DropdownButtonFormFieldState<T> extends FormFieldState<T> {
     assert(widget.onChanged != null);
     widget.onChanged(value);
   }
-  
+
   @override
   void didUpdateWidget(DropdownButtonFormField<T> oldWidget) {
     super.didUpdateWidget(oldWidget);

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -739,9 +739,7 @@ void main() {
                     },
                   );
                 }).toList(),
-                onChanged: (String _) {
-                  // Ignored
-                },
+                onChanged: onChanged,
               ),
             ),
           );

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -725,9 +725,7 @@ void main() {
           return MaterialApp(
             home: Material(
               child: DropdownButtonFormField<String>(
-                key: key,
                 value: currentValue,
-                hint: const Text('Select Value'),
                 onChanged: onChanged,
                 items: menuItems.map((String value) {
                   return DropdownMenuItem<String>(
@@ -747,6 +745,7 @@ void main() {
       ),
     );
 
+    // Make sure the rendered text value matches the initial state value.
     expect(currentValue, equals('two'));
     expect(find.text(currentValue), findsOneWidget);
 
@@ -758,6 +757,7 @@ void main() {
     await tester.tap(find.text('one').last);
     await tester.pumpAndSettle();
 
+    // Make sure the rendered text value matches the updated state value.
     expect(currentValue, equals('one'));
     expect(find.text(currentValue), findsOneWidget);
   });

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -755,7 +755,7 @@ void main() {
 
     expect(currentValue, equals('two'));
 
-    await tester.tap(find.byType(dropdownButtonType).last);
+    await tester.tap(find.byType(dropdownButtonType));
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('one').last);

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -715,4 +715,52 @@ void main() {
     expect(value, equals('two'));
     expect(dropdownButtonTapCounter, 2); // Should not change.
   });
+
+  testWidgets('DropdownButtonFormField should re-render if value param changes', (WidgetTester tester) async {
+    String currentValue = 'two';
+    final GlobalKey<FormFieldState<String>> key = GlobalKey<FormFieldState<String>>();
+
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          return MaterialApp(
+            home: Material(
+              child: DropdownButtonFormField<String>(
+                key: key,
+                value: currentValue,
+                hint: const Text('Select Value'),
+                decoration: const InputDecoration(
+                    prefixIcon: Icon(Icons.fastfood)
+                ),
+                items: menuItems.map((String value) {
+                  return DropdownMenuItem<String>(
+                    value: value,
+                    child: Text(value),
+                    onTap: () {
+                      setState(() {
+                        currentValue = value;
+                      });
+                    },
+                  );
+                }).toList(),
+                onChanged: (String _) {
+                  // Ignored
+                },
+              ),
+            ),
+          );
+        },
+      ),
+    );
+
+    expect(currentValue, equals('two'));
+
+    await tester.tap(find.byType(dropdownButtonType).last);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('one').last);
+    await tester.pumpAndSettle();
+
+    expect(currentValue, equals('one'));
+  });
 }

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -718,7 +718,6 @@ void main() {
 
   testWidgets('DropdownButtonFormField should re-render if value param changes', (WidgetTester tester) async {
     String currentValue = 'two';
-    final GlobalKey<FormFieldState<String>> key = GlobalKey<FormFieldState<String>>();
 
     await tester.pumpWidget(
       StatefulBuilder(
@@ -729,9 +728,6 @@ void main() {
                 key: key,
                 value: currentValue,
                 hint: const Text('Select Value'),
-                decoration: const InputDecoration(
-                    prefixIcon: Icon(Icons.fastfood)
-                ),
                 items: menuItems.map((String value) {
                   return DropdownMenuItem<String>(
                     value: value,

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -758,6 +758,7 @@ void main() {
     await tester.tap(find.byType(dropdownButtonType));
     await tester.pumpAndSettle();
 
+    // Tap the first dropdown menu item.
     await tester.tap(find.text('one').last);
     await tester.pumpAndSettle();
 

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -728,6 +728,7 @@ void main() {
                 key: key,
                 value: currentValue,
                 hint: const Text('Select Value'),
+                onChanged: onChanged,
                 items: menuItems.map((String value) {
                   return DropdownMenuItem<String>(
                     value: value,
@@ -739,7 +740,6 @@ void main() {
                     },
                   );
                 }).toList(),
-                onChanged: onChanged,
               ),
             ),
           );

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -750,7 +750,9 @@ void main() {
     );
 
     expect(currentValue, equals('two'));
+    expect(find.text(currentValue), findsOneWidget);
 
+    // Tap the DropdownButtonFormField widget
     await tester.tap(find.byType(dropdownButtonType));
     await tester.pumpAndSettle();
 
@@ -759,5 +761,6 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(currentValue, equals('one'));
+    expect(find.text(currentValue), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Description

I'm just making DropdownButtonFormField to show new value by overriding the `didUpdateWidget()` function and replacing the current value with the new widget instance's value.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/56898
Fixes https://github.com/flutter/flutter/issues/56716

## Tests

I added the following tests:
- A test to ensure that the rendered DropdownButtonFormField contains updated text from the passed in `value`.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.