### PR TITLE
Updated gen_missing_localizations to copy the english strings instead of using 'TBD'.

### DIFF
--- a/dev/tools/localization/bin/gen_missing_localizations.dart
+++ b/dev/tools/localization/bin/gen_missing_localizations.dart
@@ -77,7 +77,8 @@ void updateMissingResources(String localizationPath, String groupPrefix) {
   final Directory localizationDir = Directory(localizationPath);
   final RegExp filenamePattern = RegExp('${groupPrefix}_(\\w+)\\.arb');
 
-  final Set<String> requiredKeys = resourceKeys(loadBundle(File(path.join(localizationPath, '${groupPrefix}_en.arb'))));
+  final Map<String, dynamic> englishBundle = loadBundle(File(path.join(localizationPath, '${groupPrefix}_en.arb')));
+  final Set<String> requiredKeys = resourceKeys(englishBundle);
 
   for (final FileSystemEntity entity in localizationDir.listSync().toList()..sort(sortFilesByPath)) {
     final String entityPath = entity.path;
@@ -94,7 +95,8 @@ void updateMissingResources(String localizationPath, String groupPrefix) {
           (String key) => !isPluralVariation(key, localeBundle) && !intentionallyOmitted(key, localeBundle)
         ).toSet();
         if (missingResources.isNotEmpty) {
-          localeBundle.addEntries(missingResources.map((String k) => MapEntry<String, String>(k, 'TBD')));
+          localeBundle.addEntries(missingResources.map((String k) =>
+            MapEntry<String, String>(k, englishBundle[k].toString())));
           writeBundle(arbFile, localeBundle);
           print('Updated $entityPath with missing entries for $missingResources');
         }

--- a/packages/flutter/lib/src/material/material_localizations.dart
+++ b/packages/flutter/lib/src/material/material_localizations.dart
@@ -29,11 +29,13 @@ import 'typography.dart';
 //    flutter_localizations package, you must first add it to the English
 //    translations (lib/src/l10n/material_en.arb), including a description.
 //
-//    Then you need to add  new `TBD` entries for the string to all of the other
+//    Then you need to add new entries for the string to all of the other
 //    language locale files by running:
 //    ```
 //    dart dev/tools/localization/bin/gen_missing_localizations.dart
 //    ```
+//    Which will copy the english strings into the other locales as placeholders
+//    until they can be translated.
 //
 //    Finally you need to re-generate lib/src/l10n/localizations.dart by running:
 //    ```
@@ -45,10 +47,6 @@ import 'typography.dart';
 //
 // 5. If you are a Google employee, you should then also follow the instructions
 //    at go/flutter-l10n. If you're not, don't worry about it.
-//
-// 6. If you're adding a String for the sake of Flutter, not for an app-specific
-//    version of this interface, you are making a breaking API change. See
-//    https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes.
 
 /// Defines the localized resource values used by the Material widgets.
 ///


### PR DESCRIPTION
## Description

The current process for adding a new localized string to the Material Library requires adding 'TBD' entries for the string to all non-english locales. These 'TBD' entries are temporary placeholder entries for use until the string can be localized. However, this can lead to some broken interfaces when using non-translated interfaces. It would be better to default to the english text for these until they are translated. That way it is not a breaking change, as the results are the same as before the string was added to the localization system (i.e. the english text is used). 

This PR adjusts the script that created the 'TBD' entries to just copy the english text for each missing entry.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them?

- [x] No, no existing tests failed, so this is *not* a breaking change.
