### PR TITLE
Remove deprecated child parameter for NestedScrollView's overlap managing slivers

### DIFF
--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -1502,17 +1502,9 @@ class SliverOverlapAbsorber extends SingleChildRenderObjectWidget {
   const SliverOverlapAbsorber({
     Key key,
     @required this.handle,
-    @Deprecated(
-      'Use sliver instead. '
-      'This feature was deprecated after v1.10.16.'
-    )
-    Widget child,
     Widget sliver,
   }) : assert(handle != null),
-      // ignore: deprecated_member_use_from_same_package
-      assert(child == null || sliver == null),
-      // ignore: deprecated_member_use_from_same_package
-      super(key: key, child: sliver ?? child);
+      super(key: key, child: sliver);
 
   /// The object in which the absorbed overlap is recorded.
   ///
@@ -1555,17 +1547,10 @@ class RenderSliverOverlapAbsorber extends RenderSliver with RenderObjectWithChil
   /// The [sliver] must be a [RenderSliver].
   RenderSliverOverlapAbsorber({
     @required SliverOverlapAbsorberHandle handle,
-    @Deprecated(
-      'Use sliver instead. '
-      'This feature was deprecated after v1.10.16.'
-    )
-    RenderSliver child,
     RenderSliver sliver,
   }) : assert(handle != null),
-       // ignore: deprecated_member_use_from_same_package
-       assert(child == null || sliver == null),
        _handle = handle {
-    this.child = sliver ?? child;
+    child = sliver;
   }
 
   /// The object in which the absorbed overlap is recorded.
@@ -1676,17 +1661,9 @@ class SliverOverlapInjector extends SingleChildRenderObjectWidget {
   const SliverOverlapInjector({
     Key key,
     @required this.handle,
-    @Deprecated(
-      'Use sliver instead. '
-      'This feature was deprecated after v1.10.16.'
-    )
-    Widget child,
     Widget sliver,
   }) : assert(handle != null),
-       // ignore: deprecated_member_use_from_same_package
-       assert(child == null || sliver == null),
-       // ignore: deprecated_member_use_from_same_package
-       super(key: key, child: sliver ?? child);
+       super(key: key, child: sliver);
 
   /// The handle to the [SliverOverlapAbsorber] that is feeding this injector.
   ///


### PR DESCRIPTION
## Description

These were deprecated in #44283, while the new breaking change policy was going into place. 
Checking that clients are migrated and that a migration guide will be available for when this is finally removed.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [x] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
