### PR TITLE
[flutter_tools] re-enable non-nullable test

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -604,7 +604,7 @@ Future<void> _runFrameworkTests() async {
     await _runFlutterTest(path.join(flutterRoot, 'packages', 'fuchsia_remote_debug_protocol'), tableData: bigqueryApi?.tabledata);
     await _runFlutterTest(path.join(flutterRoot, 'dev', 'integration_tests', 'non_nullable'),
       options: <String>['--enable-experiment=non-nullable'],
-      skip: true, // TODO(jonahwilliams): re-enable after https://github.com/flutter/flutter/issues/55872
+      skip: true,
     );
     await _runFlutterTest(
       path.join(flutterRoot, 'dev', 'tracing_tests'),

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -604,7 +604,6 @@ Future<void> _runFrameworkTests() async {
     await _runFlutterTest(path.join(flutterRoot, 'packages', 'fuchsia_remote_debug_protocol'), tableData: bigqueryApi?.tabledata);
     await _runFlutterTest(path.join(flutterRoot, 'dev', 'integration_tests', 'non_nullable'),
       options: <String>['--enable-experiment=non-nullable'],
-      skip: true,
     );
     await _runFlutterTest(
       path.join(flutterRoot, 'dev', 'tracing_tests'),

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -213,7 +213,7 @@ void catchIsolateErrors() {
 
 void main() {
   print('$_kStartTimeoutTimerMessage');
-  String serverPort = Platform.environment['SERVER_PORT'];
+  String serverPort = Platform.environment['SERVER_PORT'] ?? '';
   String server = Uri.decodeComponent('$encodedWebsocketUrl:\$serverPort');
   StreamChannel<dynamic> channel = serializeSuite(() {
     catchIsolateErrors();


### PR DESCRIPTION
## Description

Re-enable the skipped null safety test by applying a fix to an unsound usage of Platform.environment. The compilation error was:

```
jonahwilliams-macbookpro2:hello_world jonahwilliams$ flutter test --enable-experiment=non-nullable
00:02 +0: loading /Users/jonahwilliams/Documents/flutter/examples/hello_world/test/hello_test.dart                                         
Compiler message:
/var/folders/sq/vd7vtp0j60ld19wt58vg7n5c00c4f_/T/flutter_test_listener.bKm0dn/listener.dart:41:43: Error: A value of type 'String?' can't be
assigned to a variable of type 'String'.
  String serverPort = Platform.environment['SERVER_PORT'];
                                          ^
```

Fixes https://github.com/flutter/flutter/issues/55872