### PR TITLE
[flutter_tools] do not set timestamp of package_config file

### DIFF
--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -223,7 +223,7 @@ class _DefaultPub implements Pub {
     }
 
     if (!packageConfigFile.existsSync()) {
-      throwToolExit('$directory: pub did not create .packages file.');
+      throwToolExit('$directory: pub did not create .dart_tools/package_config.json file.');
     }
     if (pubSpecYaml.lastModifiedSync() != originalPubspecYamlModificationTime) {
       throwToolExit(
@@ -243,18 +243,6 @@ class _DefaultPub implements Pub {
         'The timestamp was: $originalPubspecYamlModificationTime\n'
         'The time now is: $now'
       );
-    } else {
-      packageConfigFile.setLastModifiedSync(now);
-      final DateTime newDotPackagesTimestamp = packageConfigFile.lastModifiedSync();
-      if (newDotPackagesTimestamp.isBefore(originalPubspecYamlModificationTime)) {
-        _logger.printError(
-          'Warning: Failed to set timestamp of "${_fileSystem.path.absolute(packageConfigFile.path)}". '
-          'Tried to set timestamp to $now, but new timestamp is $newDotPackagesTimestamp.'
-        );
-        if (newDotPackagesTimestamp.isAfter(now)) {
-          _logger.printError('Maybe the file was concurrently modified?');
-        }
-      }
     }
   }
 

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -232,8 +232,6 @@ class _DefaultPub implements Pub {
     }
     // We don't check if dotPackages was actually modified, because as far as we can tell sometimes
     // pub will decide it does not need to actually modify it.
-    // Since we rely on the file having a more recent timestamp, though, we do manually force the
-    // file to be more recently modified.
     final DateTime now = DateTime.now();
     if (now.isBefore(originalPubspecYamlModificationTime)) {
       _logger.printError(

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -338,8 +338,6 @@ void main() {
     expect(logger.statusText, 'Running "flutter pub get" in /...\n');
     expect(logger.errorText, isEmpty);
     expect(fileSystem.file('pubspec.yaml').lastModifiedSync(), DateTime(2001)); // because nothing should touch it
-    expect(fileSystem.file('.dart_tool/package_config.json').lastModifiedSync(), isNot(DateTime(2000))); // because pub changes it to 2002
-    expect(fileSystem.file('.dart_tool/package_config.json').lastModifiedSync(), isNot(DateTime(2002))); // because we set the timestamp again after pub
     logger.clear();
 
     // bad scenario 1: pub doesn't update file; doesn't matter, because we do instead
@@ -352,8 +350,6 @@ void main() {
     expect(logger.statusText, 'Running "flutter pub get" in /...\n');
     expect(logger.errorText, isEmpty);
     expect(fileSystem.file('pubspec.yaml').lastModifiedSync(), DateTime(2001)); // because nothing should touch it
-    expect(fileSystem.file('.dart_tool/package_config.json').lastModifiedSync(), isNot(DateTime(2000))); // because we set the timestamp
-    expect(fileSystem.file('.dart_tool/package_config.json').lastModifiedSync(), isNot(DateTime(2002))); // just in case FakeProcessManager is buggy
     logger.clear();
 
     // bad scenario 2: pub changes pubspec.yaml instead
@@ -370,7 +366,6 @@ void main() {
     expect(logger.statusText, 'Running "flutter pub get" in /...\n');
     expect(logger.errorText, isEmpty);
     expect(fileSystem.file('pubspec.yaml').lastModifiedSync(), DateTime(2002)); // because fake pub above touched it
-    expect(fileSystem.file('.dart_tool/package_config.json').lastModifiedSync(), DateTime(2000)); // because nothing touched it
 
     // bad scenario 3: pubspec.yaml was created in the future
     fileSystem.file('.dart_tool/package_config.json')


### PR DESCRIPTION
## Description

One of our top stable crashes is a failure to set this modification time. The exact trigger is unknown, but because this operation is not strictly necessary it seems safer to remove.

The timestamp of the .package_config is not used during building, the md5 checksum is. Similarly, during hot reload we only look for timestamps that have changed since the reload process has begun, but the exact values don't exactly matter.

https://github.com/flutter/flutter/issues/55979
https://github.com/flutter/flutter/issues/56747
https://github.com/flutter/flutter/issues/56438
