### PR TITLE
[flutter_tools] expose track-widget-creation to build aar

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_aar.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aar.dart
@@ -40,6 +40,7 @@ class BuildAarCommand extends BuildSubCommand {
     usesPubOption();
     addSplitDebugInfoOption();
     addDartObfuscationOption();
+    usesTrackWidgetCreation(verboseHelp: false);
     argParser
       ..addMultiOption(
         'target-platform',

--- a/packages/flutter_tools/test/general.shard/commands/build_aar_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_aar_test.dart
@@ -142,8 +142,10 @@ void main() {
         buildModes.add(buildInfo.mode);
         if (buildInfo.mode.isPrecompiled) {
           expect(buildInfo.treeShakeIcons, isTrue);
+          expect(buildInfo.trackWidgetCreation, isTrue);
         } else {
           expect(buildInfo.treeShakeIcons, isFalse);
+          expect(buildInfo.trackWidgetCreation, isTrue);
         }
         expect(buildInfo.flavor, isNull);
         expect(buildInfo.splitDebugInfoPath, isNull);


### PR DESCRIPTION
## Description

Add a track-widget-creation flag to build aar so that it defaults to "on".
