### PR TITLE
throw more specific toolexit when git fails during upgrade

### DIFF
--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -219,16 +219,18 @@ class UpgradeCommandRunner {
           workingDirectory: workingDirectory,
       );
       revision = result.stdout.trim();
-    } on Exception catch (e){
+    } on Exception catch (e) {
       final String errorString = e.toString();
-      if (RegExp(r'fatal: HEAD does not point to a branch').hasMatch(errorString)) {
+      if (errorString.contains('fatal: HEAD does not point to a branch')) {
         throwToolExit(
           'You are not currently on a release branch. Use git to '
-          'check out an official branch\n(\'stable\', \'beta\', \'dev\', or \'master\') '
-          'and retry, for example \'git checkout stable\'.'
+          'check out an official branch (\'stable\', \'beta\', \'dev\', or \'master\') '
+          'and retry, for example:\n'
+          '  git checkout stable'
         );
-      } else if (RegExp(r'fatal: no upstream configured for branch').hasMatch(errorString)) {
-        throwToolExit('Unable to upgrade Flutter: no origin repository configured. '
+      } else if (errorString.contains('fatal: no upstream configured for branch')) {
+        throwToolExit(
+          'Unable to upgrade Flutter: no origin repository configured. '
           'Run \'git remote add origin '
           'https://github.com/flutter/flutter\' in $workingDirectory');
       } else {

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -219,12 +219,21 @@ class UpgradeCommandRunner {
           workingDirectory: workingDirectory,
       );
       revision = result.stdout.trim();
-    } on Exception {
-      throwToolExit(
-        'Unable to upgrade Flutter: no origin repository configured. '
-        "Run 'git remote add origin "
-        "https://github.com/flutter/flutter' in $workingDirectory",
-      );
+    } on Exception catch (e){
+      final String errorString = e.toString();
+      if (RegExp(r'fatal: HEAD does not point to a branch').hasMatch(errorString)) {
+        throwToolExit(
+          'You are not currently on a release branch. Use git to '
+          'check out an official branch\n(\'stable\', \'beta\', \'dev\', or \'master\') '
+          'and retry, for example \'git checkout stable\'.'
+        );
+      } else if (RegExp(r'fatal: no upstream configured for branch').hasMatch(errorString)) {
+        throwToolExit('Unable to upgrade Flutter: no origin repository configured. '
+          'Run \'git remote add origin '
+          'https://github.com/flutter/flutter\' in $workingDirectory');
+      } else {
+        throwToolExit(errorString);
+      }
     }
     return revision;
   }


### PR DESCRIPTION
## Description

If the user's git repo is in a detached HEAD state (which happens after using `flutter version <tag>` or `git checkout <tag>`) and they try to `flutter upgrade`, they will receive in an incorrect error message: `Unable to upgrade Flutter: no origin repository configured`.

This PR catches the process exception, and throws specific tool exits if either their head is detached or they don't have an upstream configured, else the original git error message is surfaced.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/56853.

## Tests

I added two new unit tests to validate the new tool exit messages.