### PR TITLE
Remove obsolete UpdateCounted prefix

### DIFF
--- a/packages/flutter/test/widgets/clip_test.dart
+++ b/packages/flutter/test/widgets/clip_test.dart
@@ -52,26 +52,6 @@ class NotifyClipper<T> extends CustomClipper<T> {
   bool shouldReclip(NotifyClipper<T> oldClipper) => clip != oldClipper.clip;
 }
 
-class _UpdateCountedClipRect extends ClipRect {
-  const _UpdateCountedClipRect({Clip clipBehavior = Clip.antiAlias})
-    : super(clipBehavior: clipBehavior);
-}
-
-class _UpdateCountedClipRRect extends ClipRRect {
-  _UpdateCountedClipRRect({Clip clipBehavior = Clip.antiAlias})
-      : super(clipBehavior: clipBehavior, borderRadius: BorderRadius.circular(1.0));
-}
-
-class _UpdateCountedClipOval extends ClipOval {
-  const _UpdateCountedClipOval({Clip clipBehavior = Clip.antiAlias})
-      : super(clipBehavior: clipBehavior);
-}
-
-class _UpdateCountedClipPath extends ClipPath {
-  const _UpdateCountedClipPath({Clip clipBehavior = Clip.antiAlias})
-      : super(clipBehavior: clipBehavior);
-}
-
 void main() {
   testWidgets('ClipRect with a FittedBox child sized to zero works with semantics', (WidgetTester tester) async {
     await tester.pumpWidget(Directionality(
@@ -93,15 +73,15 @@ void main() {
   });
 
   testWidgets('ClipRect updates clipBehavior in updateRenderObject', (WidgetTester tester) async {
-    await tester.pumpWidget(const _UpdateCountedClipRect());
+    await tester.pumpWidget(const ClipRect());
 
     final RenderClipRect renderClip = tester.allRenderObjects.whereType<RenderClipRect>().first;
 
-    expect(renderClip.clipBehavior, equals(Clip.antiAlias));
-
-    await tester.pumpWidget(const _UpdateCountedClipRect(clipBehavior: Clip.hardEdge));
-
     expect(renderClip.clipBehavior, equals(Clip.hardEdge));
+
+    await tester.pumpWidget(const ClipRect(clipBehavior: Clip.antiAlias));
+
+    expect(renderClip.clipBehavior, equals(Clip.antiAlias));
   });
 
   test('ClipRRect constructs with the right default values', () {
@@ -111,37 +91,37 @@ void main() {
   });
 
   testWidgets('ClipRRect updates clipBehavior in updateRenderObject', (WidgetTester tester) async {
-    await tester.pumpWidget(_UpdateCountedClipRRect());
+    await tester.pumpWidget(const ClipRRect());
 
     final RenderClipRRect renderClip = tester.allRenderObjects.whereType<RenderClipRRect>().first;
 
     expect(renderClip.clipBehavior, equals(Clip.antiAlias));
 
-    await tester.pumpWidget(_UpdateCountedClipRRect(clipBehavior: Clip.hardEdge));
+    await tester.pumpWidget(const ClipRRect(clipBehavior: Clip.hardEdge));
 
     expect(renderClip.clipBehavior, equals(Clip.hardEdge));
   });
 
   testWidgets('ClipOval updates clipBehavior in updateRenderObject', (WidgetTester tester) async {
-    await tester.pumpWidget(const _UpdateCountedClipOval());
+    await tester.pumpWidget(const ClipOval());
 
     final RenderClipOval renderClip = tester.allRenderObjects.whereType<RenderClipOval>().first;
 
     expect(renderClip.clipBehavior, equals(Clip.antiAlias));
 
-    await tester.pumpWidget(const _UpdateCountedClipOval(clipBehavior: Clip.hardEdge));
+    await tester.pumpWidget(const ClipOval(clipBehavior: Clip.hardEdge));
 
     expect(renderClip.clipBehavior, equals(Clip.hardEdge));
   });
 
   testWidgets('ClipPath updates clipBehavior in updateRenderObject', (WidgetTester tester) async {
-    await tester.pumpWidget(const _UpdateCountedClipPath());
+    await tester.pumpWidget(const ClipPath());
 
     final RenderClipPath renderClip = tester.allRenderObjects.whereType<RenderClipPath>().first;
 
     expect(renderClip.clipBehavior, equals(Clip.antiAlias));
 
-    await tester.pumpWidget(const _UpdateCountedClipPath(clipBehavior: Clip.hardEdge));
+    await tester.pumpWidget(const ClipPath(clipBehavior: Clip.hardEdge));
 
     expect(renderClip.clipBehavior, equals(Clip.hardEdge));
   });

--- a/packages/flutter/test/widgets/physical_model_test.dart
+++ b/packages/flutter/test/widgets/physical_model_test.dart
@@ -9,20 +9,10 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class _UpdateCountedPhysicalModel extends PhysicalModel {
-  const _UpdateCountedPhysicalModel({Clip clipBehavior = Clip.none})
-    : super(clipBehavior: clipBehavior, color: Colors.red);
-}
-
-class _UpdateCountedPhysicalShape extends PhysicalShape {
-  const _UpdateCountedPhysicalShape({Clip clipBehavior = Clip.none})
-      : super(clipBehavior: clipBehavior, color: Colors.red, clipper: const ShapeBorderClipper(shape: CircleBorder()));
-}
-
 void main() {
   testWidgets('PhysicalModel updates clipBehavior in updateRenderObject', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(home: _UpdateCountedPhysicalModel()),
+      const MaterialApp(home: PhysicalModel(color: Colors.red)),
     );
 
     final RenderPhysicalModel renderPhysicalModel = tester.allRenderObjects.whereType<RenderPhysicalModel>().first;
@@ -30,7 +20,7 @@ void main() {
     expect(renderPhysicalModel.clipBehavior, equals(Clip.none));
 
     await tester.pumpWidget(
-      const MaterialApp(home: _UpdateCountedPhysicalModel(clipBehavior: Clip.antiAlias)),
+      const MaterialApp(home: PhysicalModel(clipBehavior: Clip.antiAlias, color: Colors.red)),
     );
 
     expect(renderPhysicalModel.clipBehavior, equals(Clip.antiAlias));
@@ -38,7 +28,7 @@ void main() {
 
   testWidgets('PhysicalShape updates clipBehavior in updateRenderObject', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(home: _UpdateCountedPhysicalShape()),
+      const MaterialApp(home: PhysicalShape(color: Colors.red, clipper: ShapeBorderClipper(shape: CircleBorder()))),
     );
 
     final RenderPhysicalShape renderPhysicalShape = tester.allRenderObjects.whereType<RenderPhysicalShape>().first;
@@ -46,7 +36,7 @@ void main() {
     expect(renderPhysicalShape.clipBehavior, equals(Clip.none));
 
     await tester.pumpWidget(
-      const MaterialApp(home: _UpdateCountedPhysicalShape(clipBehavior: Clip.antiAlias)),
+      const MaterialApp(home: PhysicalShape(clipBehavior: Clip.antiAlias, color: Colors.red, clipper: ShapeBorderClipper(shape: CircleBorder()))),
     );
 
     expect(renderPhysicalShape.clipBehavior, equals(Clip.antiAlias));


### PR DESCRIPTION
The UpdateCounted Mixin was removed due to
https://github.com/flutter/flutter/pull/31761#discussion_r279530786 so
those prefixes are obsolete.
