### PR TITLE
Add option for ExpansionTile to maintain the state of its children when collapsed

### DIFF
--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -41,10 +41,12 @@ class ExpansionTile extends StatefulWidget {
     this.children = const <Widget>[],
     this.trailing,
     this.initiallyExpanded = false,
+    this.maintainState = false,
     this.tilePadding,
     this.expandedCrossAxisAlignment,
     this.expandedAlignment,
   }) : assert(initiallyExpanded != null),
+       assert(maintainState != null),
        assert(
        expandedCrossAxisAlignment != CrossAxisAlignment.baseline,
        'CrossAxisAlignment.baseline is not supported since the expanded children '
@@ -87,6 +89,13 @@ class ExpansionTile extends StatefulWidget {
 
   /// Specifies if the list tile is initially expanded (true) or collapsed (false, the default).
   final bool initiallyExpanded;
+
+  /// Specifies whether the state of the children is maintained when the tile expands and collapses.
+  ///
+  /// When true, the children are kept in the tree while the tile is collapsed.
+  /// When false (default), the children are removed from the tree when the tile is
+  /// collapsed and recreated upon expansion.
+  final bool maintainState;
 
   /// Specifies padding for the [ListTile].
   ///
@@ -253,13 +262,23 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
   @override
   Widget build(BuildContext context) {
     final bool closed = !_isExpanded && _controller.isDismissed;
+    final bool shouldRemoveChildren = closed && !widget.maintainState;
+
+    final Widget result = Offstage(
+      child: TickerMode(
+        child: Column(
+          crossAxisAlignment: widget.expandedCrossAxisAlignment ?? CrossAxisAlignment.center,
+          children: widget.children,
+        ),
+        enabled: !closed,
+      ),
+      offstage: closed
+    );
+
     return AnimatedBuilder(
       animation: _controller.view,
       builder: _buildChildren,
-      child: closed ? null : Column(
-        crossAxisAlignment: widget.expandedCrossAxisAlignment ?? CrossAxisAlignment.center,
-        children: widget.children,
-      ),
+      child: shouldRemoveChildren ? null : result,
     );
 
   }

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -230,6 +230,46 @@ void main() {
     expect(find.text('Subtitle'), findsOneWidget);
   });
 
+  testWidgets('ExpansionTile maintainState', (WidgetTester tester) async {
+     await tester.pumpWidget(
+       MaterialApp(
+         theme: ThemeData(
+           platform: TargetPlatform.iOS,
+           dividerColor: _dividerColor,
+         ),
+         home: Material(
+           child: SingleChildScrollView(
+             child: Column(
+               children: const <Widget>[
+                 ExpansionTile(
+                   title: Text('Tile 1'),
+                   initiallyExpanded: false,
+                   maintainState: true,
+                   children: <Widget>[
+                     Text('Maintaining State'),
+                   ],
+                 ),
+                 ExpansionTile(
+                   title: Text('Title 2'),
+                   initiallyExpanded: false,
+                   maintainState: false,
+                   children: <Widget>[
+                     Text('Discarding State'),
+                   ],
+                 ),
+               ],
+             ),
+           ),
+         ),
+     ));
+
+     // This text should be offstage while ExpansionTile collapsed
+     expect(find.text('Maintaining State', skipOffstage: false), findsOneWidget);
+     expect(find.text('Maintaining State'), findsNothing);
+     // This text shouldn't be there while ExpansionTile collapsed
+     expect(find.text('Discarding State'), findsNothing);
+   });
+
   testWidgets('ExpansionTile padding test', (WidgetTester tester) async {
     await tester.pumpWidget(const MaterialApp(
       home: Material(


### PR DESCRIPTION
This is an updated PR for #51709 and #41886 that fixes a rebase issue. Below is the original description for reference.

## Description
Currently, `ExpansionTile` rebuilds its children upon every expansion and removes the children when collapsed, resetting any state contained in the children. When building a Flutter app a couple months ago, I encountered this issue when placing a `TextFormField` inside an ExpansionTile, and any edited text would be deleted when the user collapsed the ExpansionTile. #37520 further describes the specific issue and includes sample code to reproduce it. I made this change to the `ExpansionTile` widget to make my app work correctly.
### Changes overview:
- Added a `maintainState` property to `ExpansionTile` of type `bool`
- Set `maintainState` default value to `false` for the existing behavior
- Add `!maintainState` as a condition for setting the child of the `AnimatedBuilder` to `null`

Now, an `ExpansionTile` like this maintains the state of its children while collapsed:
```dart
ExpansionTile(
  maintainState: true,
  key: PageStorageKey("test"),
  title: Text("Click to expand"),
  children: [
    TextFormField(
      key: PageStorageKey("test2"),
      validator: (value) {
        if (value.isEmpty) {
          return 'Please enter some text';
        }
        return null;
      },
    ),
  ]
)
```

## Related Issues

Fixes #37520

## Tests

I added the following tests:
- 'ExpansionTile maintainState' - creates two collapsed ExpansionTile widgets with different `maintainState` values and tests if a child widget is present in each.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
