### PR TITLE
[flutter_tools] ensure package_config is re-created if pub get is run

### DIFF
--- a/packages/flutter_tools/lib/src/template.dart
+++ b/packages/flutter_tools/lib/src/template.dart
@@ -249,14 +249,19 @@ Future<Directory> _templateImageDirectory(String name, FileSystem fileSystem) as
   if (!fileSystem.file(packageFilePath).existsSync()) {
     await _ensurePackageDependencies(toolPackagePath);
   }
-  final PackageConfig packageConfig = await loadPackageConfigWithLogging(
+  PackageConfig packageConfig = await loadPackageConfigWithLogging(
     fileSystem.file(packageFilePath),
     logger: globals.logger,
   );
-  final Uri imagePackageLibDir = packageConfig['flutter_template_images']?.packageUriRoot;
+  Uri imagePackageLibDir = packageConfig['flutter_template_images']?.packageUriRoot;
   // Ensure that the template image package is present.
   if (imagePackageLibDir == null || !fileSystem.directory(imagePackageLibDir).existsSync()) {
     await _ensurePackageDependencies(toolPackagePath);
+    packageConfig = await loadPackageConfigWithLogging(
+      fileSystem.file(packageFilePath),
+      logger: globals.logger,
+    );
+    imagePackageLibDir = packageConfig['flutter_template_images']?.packageUriRoot;
   }
   return fileSystem.directory(imagePackageLibDir)
       .parent

--- a/packages/flutter_tools/test/template_test.dart
+++ b/packages/flutter_tools/test/template_test.dart
@@ -5,6 +5,7 @@
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/template.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:mockito/mockito.dart';
@@ -77,12 +78,21 @@ void main() {
         .childDirectory('flutter_tools')
         .childFile('.packages');
     packagesFile.createSync(recursive: true);
-    packagesFile.writeAsStringSync('flutter_template_images:file:///flutter_template_images');
+    packagesFile.writeAsStringSync('\n');
 
-    // Attempting to run pub in a test throws.
-    await expectLater(Template.fromName('app', fileSystem: fileSystem),
-      throwsUnsupportedError);
+    when(pub.get(
+      context: PubContext.pubGet,
+      directory: anyNamed('directory'),
+    )).thenAnswer((Invocation invocation) async {
+      // Create valid package entry.
+      packagesFile.writeAsStringSync('flutter_template_images:file:///flutter_template_images');
+    });
+
+    await Template.fromName('app', fileSystem: fileSystem);
+  }, overrides: <Type, Generator>{
+    Pub: () => MockPub(),
   }));
 }
 
+class MockPub extends Mock implements Pub {}
 class MockDirectory extends Mock implements Directory {}


### PR DESCRIPTION
## Description

Fixes path is null crasher on stable:

```
Thread 0 main thread CRASHEDArgumentError: Invalid argument(s): Invalid type for "path": null
at FileSystem.getPath(file_system.dart:162)
at LocalFileSystem.directory(local_file_system.dart:25)
at ForwardingFileSystem.directory(forwarding_file_system.dart:23)
at _templateImageDirectory(template.dart:256)
at <asynchronous gap>(async)
at Template.fromName(template.dart:63)
at CreateCommand._renderTemplate(create.dart:629)
at CreateCommand._generateApp(create.dart:543)
at CreateCommand.runCommand(create.dart:380)
at _rootRunUnary(zone.dart:1192)
at _CustomZone.runUnary(zone.dart:1085)
at _FutureListener.handleValue(future_impl.dart:141)
at Future._propagateToListeners.handleValueCallback(future_impl.dart:682)
at Future._propagateToListeners(future_impl.dart:711)
at Future._completeWithValue(future_impl.dart:526)
at _AsyncAwaitCompleter.complete(async_patch.dart:36)
at _completeOnAsyncReturn(async_patch.dart:298)
at FlutterProject.organizationNames(project.dart)
at _rootRunUnary(zone.dart:1192)
at _CustomZone.runUnary(zone.dart:1085)
at _FutureListener.handleValue(future_impl.dart:141)
at Future._propagateToListeners.handleValueCallback(future_impl.dart:682)
at Future._propagateToListeners(future_impl.dart:711)
at Future._completeWithValue(future_impl.dart:526)
at _AsyncAwaitCompleter.complete(async_patch.dart:36)
at _completeOnAsyncReturn(async_patch.dart:298)
at IosProject.productBundleIdentifier(project.dart)
at _rootRunUnary(zone.dart:1192)
at _CustomZone.runUnary(zone.dart:1085)
at _FutureListener.handleValue(future_impl.dart:141)
at Future._propagateToListeners.handleValueCallback(future_impl.dart:682)
at Future._propagateToListeners(future_impl.dart:711)
at Future._completeWithValue(future_impl.dart:526)
at Future._asyncComplete.<anonymous closure>(future_impl.dart:556)
at _rootRun(zone.dart:1184)
at _CustomZone.run(zone.dart:1077)
at _CustomZone.runGuarded(zone.dart:979)
at _CustomZone.bindCallbackGuarded.<anonymous closure>(zone.dart:1019)
at _microtaskLoop(schedule_microtask.dart:43)
at _startMicrotaskLoop(schedule_microtask.dart:52)
at _runPendingImmediateCallback(isolate_patch.dart:118)
at _Timer._runTimers(timer_impl.dart:405)
at _Timer._handleMessage(timer_impl.dart:429)
at _RawReceivePortImpl._handleMessage(isolate_patch.dart:168)
```