### PR TITLE
Honor the InputDecoratorTheme in the text input fields used by the Date Pickers

### DIFF
--- a/packages/flutter/lib/src/material/pickers/input_date_picker.dart
+++ b/packages/flutter/lib/src/material/pickers/input_date_picker.dart
@@ -9,6 +9,7 @@ import '../input_border.dart';
 import '../input_decorator.dart';
 import '../material_localizations.dart';
 import '../text_form_field.dart';
+import '../theme.dart';
 
 import 'date_picker_common.dart';
 import 'date_utils.dart' as utils;
@@ -219,27 +220,24 @@ class _InputDatePickerFormFieldState extends State<InputDatePickerFormField> {
   @override
   Widget build(BuildContext context) {
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
-    return OrientationBuilder(builder: (BuildContext context, Orientation orientation) {
-      assert(orientation != null);
-
-      return TextFormField(
-        decoration: InputDecoration(
-          border: const UnderlineInputBorder(),
-          filled: true,
-          hintText: widget.fieldHintText ?? localizations.dateHelpText,
-          labelText: widget.fieldLabelText ?? localizations.dateInputLabel,
-        ),
-        validator: _validateDate,
-        inputFormatters: <TextInputFormatter>[
-          DateTextInputFormatter(localizations.dateSeparator),
-        ],
-        keyboardType: TextInputType.datetime,
-        onSaved: _handleSaved,
-        onFieldSubmitted: _handleSubmitted,
-        autofocus: widget.autofocus,
-        controller: _controller,
-      );
-    });
+    final InputDecorationTheme inputTheme = Theme.of(context).inputDecorationTheme;
+    return TextFormField(
+      decoration: InputDecoration(
+        border: inputTheme.border ?? const UnderlineInputBorder(),
+        filled: inputTheme.filled ?? true,
+        hintText: widget.fieldHintText ?? localizations.dateHelpText,
+        labelText: widget.fieldLabelText ?? localizations.dateInputLabel,
+      ),
+      validator: _validateDate,
+      inputFormatters: <TextInputFormatter>[
+        DateTextInputFormatter(localizations.dateSeparator),
+      ],
+      keyboardType: TextInputType.datetime,
+      onSaved: _handleSaved,
+      onFieldSubmitted: _handleSubmitted,
+      autofocus: widget.autofocus,
+      controller: _controller,
+    );
   }
 }
 

--- a/packages/flutter/lib/src/material/pickers/input_date_range_picker.dart
+++ b/packages/flutter/lib/src/material/pickers/input_date_range_picker.dart
@@ -9,6 +9,7 @@ import '../input_border.dart';
 import '../input_decorator.dart';
 import '../material_localizations.dart';
 import '../text_field.dart';
+import '../theme.dart';
 
 import 'date_utils.dart' as utils;
 import 'input_date_picker.dart' show DateTextInputFormatter;
@@ -230,6 +231,7 @@ class InputDateRangePickerState extends State<InputDateRangePicker> {
   @override
   Widget build(BuildContext context) {
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
+    final InputDecorationTheme inputTheme = Theme.of(context).inputDecorationTheme;
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
@@ -237,8 +239,8 @@ class InputDateRangePickerState extends State<InputDateRangePicker> {
           child: TextField(
             controller: _startController,
             decoration: InputDecoration(
-              border: const UnderlineInputBorder(),
-              filled: true,
+              border: inputTheme.border ?? const UnderlineInputBorder(),
+              filled: inputTheme.filled ?? true,
               hintText: widget.fieldStartHintText ?? localizations.dateHelpText,
               labelText: widget.fieldStartLabelText ?? localizations.dateRangeStartLabel,
               errorText: _startErrorText,
@@ -254,8 +256,8 @@ class InputDateRangePickerState extends State<InputDateRangePicker> {
           child: TextField(
             controller: _endController,
             decoration: InputDecoration(
-              border: const UnderlineInputBorder(),
-              filled: true,
+              border: inputTheme.border ?? const UnderlineInputBorder(),
+              filled: inputTheme.filled ?? true,
               hintText: widget.fieldEndHintText ?? localizations.dateHelpText,
               labelText: widget.fieldEndLabelText ?? localizations.dateRangeEndLabel,
               errorText: _endErrorText,

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -651,6 +651,63 @@ void main() {
         expect(find.text(errorInvalidText), findsOneWidget);
       });
     });
+
+    testWidgets('InputDecorationTheme is honored', (WidgetTester tester) async {
+      BuildContext buttonContext;
+      const InputBorder border = InputBorder.none;
+      await tester.pumpWidget(MaterialApp(
+        theme: ThemeData.light().copyWith(
+          inputDecorationTheme: const InputDecorationTheme(
+            filled: false,
+            border: border,
+          ),
+        ),
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return RaisedButton(
+                onPressed: () {
+                  buttonContext = context;
+                },
+                child: const Text('Go'),
+              );
+            },
+          ),
+        ),
+      ));
+
+      await tester.tap(find.text('Go'));
+      expect(buttonContext, isNotNull);
+
+      showDatePicker(
+        context: buttonContext,
+        initialDate: initialDate,
+        firstDate: firstDate,
+        lastDate: lastDate,
+        currentDate: today,
+        initialEntryMode: DatePickerEntryMode.input,
+      );
+
+      await tester.pumpAndSettle();
+
+      // Get the border and container color from the painter of the _BorderContainer
+      // (this was cribbed from input_decorator_test.dart).
+      final CustomPaint customPaint = tester.widget(find.descendant(
+        of: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_BorderContainer'),
+        matching: find.byWidgetPredicate((Widget w) => w is CustomPaint),
+      ));
+      final dynamic/*_InputBorderPainter*/ inputBorderPainter = customPaint.foregroundPainter;
+      final dynamic/*_InputBorderTween*/ inputBorderTween = inputBorderPainter.border;
+      final Animation<double> animation = inputBorderPainter.borderAnimation as Animation<double>;
+      final InputBorder actualBorder = inputBorderTween.evaluate(animation) as InputBorder;
+      final Color containerColor = inputBorderPainter.blendedColor as Color;
+
+      // Border should match
+      expect(actualBorder, equals(border));
+
+      // It shouldn't be filled, so the color should be transparent
+      expect(containerColor, equals(Colors.transparent));
+    });
   });
 
   group('Haptic feedback', () {


### PR DESCRIPTION
## Description

As @onemanstartup pointed out in a [comment](https://github.com/flutter/flutter/pull/55939#discussion_r422530585) on the Date Range picker PR, the date input text fields hard code the border and fill parameters of their `InputDecoration`. This PR updates this to only use these hard coded values if they aren't already specified in an ambient `InputDecoratorTheme`. This will allow apps to customize the look of these fields as they like, but by default they will match the Material Design spec.

## Tests

I added tests for both the Date Picker and Date Range Picker to verify that the theme settings will be honored properly.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them?

- [x] No, no existing tests failed, so this is *not* a breaking change.
