### PR TITLE
correctly dispose listeners by image widget

### DIFF
--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -1080,8 +1080,7 @@ class _ImageState extends State<Image> with WidgetsBindingObserver {
     if (_isListeningToStream &&
         (widget.loadingBuilder == null) != (oldWidget.loadingBuilder == null)) {
       _imageStream.removeListener(_getListener());
-      _resetListener();
-      _imageStream.addListener(_getListener());
+      _imageStream.addListener(_getListener(recreateListener: true));
     }
     if (widget.image != oldWidget.image)
       _resolveImage();
@@ -1121,8 +1120,8 @@ class _ImageState extends State<Image> with WidgetsBindingObserver {
   }
 
   ImageStreamListener _imageStreamListener;
-  ImageStreamListener _getListener() {
-    if(_imageStreamListener == null) {
+  ImageStreamListener _getListener({bool recreateListener = false}) {
+    if(_imageStreamListener == null || recreateListener) {
       _lastException = null;
       _lastStack = null;
       _imageStreamListener = ImageStreamListener(
@@ -1139,10 +1138,6 @@ class _ImageState extends State<Image> with WidgetsBindingObserver {
       );
     }
     return _imageStreamListener;
-  }
-
-  void _resetListener(){
-    _imageStreamListener = null;
   }
 
   void _handleImageFrame(ImageInfo imageInfo, bool synchronousCall) {

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -1129,11 +1129,11 @@ class _ImageState extends State<Image> with WidgetsBindingObserver {
         onChunk: widget.loadingBuilder == null ? null : _handleImageChunk,
         onError: widget.errorBuilder != null
             ? (dynamic error, StackTrace stackTrace) {
-          setState(() {
-            _lastException = error;
-            _lastStack = stackTrace;
-          });
-        }
+                setState(() {
+                  _lastException = error;
+                  _lastStack = stackTrace;
+                });
+              }
             : null,
       );
     }

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -1331,6 +1331,73 @@ void main() {
     expect(tester.binding.hasScheduledFrame, isFalse);
   }, skip: isBrowser);
 
+  testWidgets('Verify Image resets its ImageListeners', (WidgetTester tester) async {
+    final GlobalKey key = GlobalKey();
+    final TestImageStreamCompleter imageStreamCompleter = TestImageStreamCompleter();
+    final TestImageProvider imageProvider1 = TestImageProvider(streamCompleter: imageStreamCompleter);
+    await tester.pumpWidget(
+      Container(
+        key: key,
+        child: Image(
+          image: imageProvider1,
+        ),
+      ),
+    );
+    // listener from resolveStreamForKey is always added.
+    expect(imageStreamCompleter.listeners.length, 2);
+
+
+    final TestImageProvider imageProvider2 = TestImageProvider();
+    await tester.pumpWidget(
+      Container(
+        key: key,
+        child: Image(
+          image: imageProvider2,
+          excludeFromSemantics: true,
+        ),
+      ),
+      null,
+      EnginePhase.layout,
+    );
+
+    // only listener from resolveStreamForKey is left.
+    expect(imageStreamCompleter.listeners.length, 1);
+  });
+
+  testWidgets('Verify Image resets its ErrorListeners', (WidgetTester tester) async {
+    final GlobalKey key = GlobalKey();
+    final TestImageStreamCompleter imageStreamCompleter = TestImageStreamCompleter();
+    final TestImageProvider imageProvider1 = TestImageProvider(streamCompleter: imageStreamCompleter);
+    await tester.pumpWidget(
+      Container(
+        key: key,
+        child: Image(
+          image: imageProvider1,
+          errorBuilder: (_,__,___) => Container(),
+        ),
+      ),
+    );
+    // listener from resolveStreamForKey is always added.
+    expect(imageStreamCompleter.listeners.length, 2);
+
+
+    final TestImageProvider imageProvider2 = TestImageProvider();
+    await tester.pumpWidget(
+      Container(
+        key: key,
+        child: Image(
+          image: imageProvider2,
+          excludeFromSemantics: true,
+        ),
+      ),
+      null,
+      EnginePhase.layout,
+    );
+
+    // only listener from resolveStreamForKey is left.
+    expect(imageStreamCompleter.listeners.length, 1);
+  });
+
   testWidgets('Image defers loading while fast scrolling', (WidgetTester tester) async {
     const int gridCells = 1000;
     final List<TestImageProvider> imageProviders = <TestImageProvider>[];


### PR DESCRIPTION
## Description

BugFix:

The imageStreamListener was recreated every time it was used by the image widget. 
While building the streamListener the functions for onImage and onChunk were kept the same, but the onError made a new function every time, which means the equality check on the ImageStreamListener failed on that one. 

There are two possible fixes. Make a function like _handleError and pass the old ErrorBuilder just like it was done with ImageLoadingBuilder, but that still rebuilds the imagestreamlistener very often (which I don't think is nice) and you risk the same mistake when you add a new type of listener.

I decided to not recreate the ImageStreamListener, but just keep a reference after building it once. In the didUpdateWidget the listener is reset (set to null) and a new one is made.

## Related Issues
#56454

## Tests

I added the following tests:

To demonstrate the issue and fix I added 2 tests.
The first test ('Verify Image resets its ImageListeners') is successful before and after the code change.
The second test ('Verify Image resets its ErrorListeners') fails before code change and is successful after code change.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
