### PR TITLE
#14790: Adding CrossfadeImage

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -55,3 +55,4 @@ Michel Feinstein <michel@feinstein.com.br>
 Michael Lee <ckmichael8@gmail.com>
 Katarina Sheremet <katarina@sheremet.ch>
 Mikhail Zotyev <mbixjkee1392@gmail.com>
+Ryan Wells <ryaanwells@googlemail.com>

--- a/packages/flutter/lib/src/widgets/crossfade_image.dart
+++ b/packages/flutter/lib/src/widgets/crossfade_image.dart
@@ -1,0 +1,384 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+import 'animated_cross_fade.dart';
+import 'basic.dart';
+import 'framework.dart';
+import 'image.dart';
+
+// Examples can assume:
+// Uint8List bytes;
+
+/// An image that shows a [placeholder] image while the target [image] is
+/// loading, then crossfades in the new image when it loads.
+///
+/// Use this class to display long-loading images, such as [new NetworkImage],
+/// so that the image appears on screen with a graceful animation rather than
+/// abruptly popping onto the screen.
+///
+/// If the [image] emits an [ImageInfo] synchronously, such as when the image
+/// has been loaded and cached, the [image] is displayed immediately, and the
+/// [placeholder] is never displayed.
+///
+/// The [crossfadeDuration] and [crossfadeCurve] properties control the
+/// crossfade animation of the target [image].
+///
+/// Prefer a [placeholder] that's already cached so that it is displayed
+/// immediately. This prevents it from popping onto the screen.
+///
+/// When [image] changes, it is resolved to a new [ImageStream]. If the new
+/// [ImageStream.key] is different, this widget subscribes to the new stream and
+/// replaces the displayed image with images emitted by the new stream.
+///
+/// When [placeholder] changes and the [image] has not yet emitted an
+/// [ImageInfo], then [placeholder] is resolved to a new [ImageStream]. If the
+/// new [ImageStream.key] is different, this widget subscribes to the new stream
+/// and replaces the displayed image to images emitted by the new stream.
+///
+/// When either [placeholder] or [image] changes, this widget continues showing
+/// the previously loaded image (if any) until the new image provider provides a
+/// different image. This is known as "gapless playback" (see also
+/// [Image.gaplessPlayback]).
+///
+/// {@tool snippet}
+///
+/// ```dart
+/// CrossfadeImage(
+///   // here `bytes` is a Uint8List containing the bytes for the in-memory image
+///   placeholder: MemoryImage(bytes),
+///   image: NetworkImage('https://backend.example.com/image.png'),
+/// )
+/// ```
+/// {@end-tool}
+class CrossfadeImage extends StatelessWidget {
+  /// Creates a widget that displays a [placeholder] while an [image] is loading,
+  /// then crossfades between the placeholder and the image.
+  ///
+  /// The [placeholder] and [image] may be composed in a [ResizeImage] to provide
+  /// a custom decode/cache size.
+  ///
+  /// The [placeholder], [image], [crossfadeDuration], [crossfadeCurve],
+  /// [alignment], [repeat], and [matchTextDirection] arguments must not be null.
+  ///
+  /// If [excludeFromSemantics] is true, then [imageSemanticLabel] will be ignored.
+  const CrossfadeImage({
+    Key key,
+    @required this.placeholder,
+    this.placeholderErrorBuilder,
+    @required this.image,
+    this.imageErrorBuilder,
+    this.excludeFromSemantics = false,
+    this.imageSemanticLabel,
+    this.crossfadeDuration = const Duration(milliseconds: 700),
+    this.crossfadeCurve = Curves.easeInOut,
+    this.width,
+    this.height,
+    this.fit,
+    this.alignment = Alignment.center,
+    this.repeat = ImageRepeat.noRepeat,
+    this.matchTextDirection = false,
+  }) : assert(placeholder != null),
+       assert(image != null),
+       assert(crossfadeDuration != null),
+       assert(crossfadeCurve != null),
+       assert(alignment != null),
+       assert(repeat != null),
+       assert(matchTextDirection != null),
+       super(key: key);
+
+  /// Creates a widget that uses a placeholder image stored in memory while
+  /// loading the final image from the network.
+  ///
+  /// The `placeholder` argument contains the bytes of the in-memory image.
+  ///
+  /// The `image` argument is the URL of the final image.
+  ///
+  /// The `placeholderScale` and `imageScale` arguments are passed to their
+  /// respective [ImageProvider]s (see also [ImageInfo.scale]).
+  ///
+  /// If [placeholderCacheWidth], [placeholderCacheHeight], [imageCacheWidth],
+  /// or [imageCacheHeight] are provided, it indicates to the
+  /// engine that the respective image should be decoded at the specified size.
+  /// The image will be rendered to the constraints of the layout or [width]
+  /// and [height] regardless of these parameters. These parameters are primarily
+  /// intended to reduce the memory usage of [ImageCache].
+  ///
+  /// The [placeholder], [image], [placeholderScale], [imageScale],
+  /// [crossfadeDuration], [crossfadeCurve], [alignment], [repeat], and
+  /// [matchTextDirection] arguments must not be null.
+  ///
+  /// See also:
+  ///
+  ///  * [new Image.memory], which has more details about loading images from
+  ///    memory.
+  ///  * [new Image.network], which has more details about loading images from
+  ///    the network.
+  CrossfadeImage.memoryNetwork({
+    Key key,
+    @required Uint8List placeholder,
+    this.placeholderErrorBuilder,
+    @required String image,
+    this.imageErrorBuilder,
+    double placeholderScale = 1.0,
+    double imageScale = 1.0,
+    this.excludeFromSemantics = false,
+    this.imageSemanticLabel,
+    this.crossfadeDuration = const Duration(milliseconds: 700),
+    this.crossfadeCurve = Curves.easeInOut,
+    this.width,
+    this.height,
+    this.fit,
+    this.alignment = Alignment.center,
+    this.repeat = ImageRepeat.noRepeat,
+    this.matchTextDirection = false,
+    int placeholderCacheWidth,
+    int placeholderCacheHeight,
+    int imageCacheWidth,
+    int imageCacheHeight,
+  }) : assert(placeholder != null),
+       assert(image != null),
+       assert(placeholderScale != null),
+       assert(imageScale != null),
+       assert(crossfadeDuration != null),
+       assert(crossfadeCurve != null),
+       assert(alignment != null),
+       assert(repeat != null),
+       assert(matchTextDirection != null),
+       placeholder = ResizeImage.resizeIfNeeded(placeholderCacheWidth, placeholderCacheHeight, MemoryImage(placeholder, scale: placeholderScale)),
+       image = ResizeImage.resizeIfNeeded(imageCacheWidth, imageCacheHeight, NetworkImage(image, scale: imageScale)),
+       super(key: key);
+
+  /// Creates a widget that uses a placeholder image stored in an asset bundle
+  /// while loading the final image from the network.
+  ///
+  /// The `placeholder` argument is the key of the image in the asset bundle.
+  ///
+  /// The `image` argument is the URL of the final image.
+  ///
+  /// The `placeholderScale` and `imageScale` arguments are passed to their
+  /// respective [ImageProvider]s (see also [ImageInfo.scale]).
+  ///
+  /// If `placeholderScale` is omitted or is null, pixel-density-aware asset
+  /// resolution will be attempted for the [placeholder] image. Otherwise, the
+  /// exact asset specified will be used.
+  ///
+  /// If [placeholderCacheWidth], [placeholderCacheHeight], [imageCacheWidth],
+  /// or [imageCacheHeight] are provided, it indicates to the
+  /// engine that the respective image should be decoded at the specified size.
+  /// The image will be rendered to the constraints of the layout or [width]
+  /// and [height] regardless of these parameters. These parameters are primarily
+  /// intended to reduce the memory usage of [ImageCache].
+  ///
+  /// The [placeholder], [image], [imageScale], [crossfadeDuration],
+  /// [crossfadeCurve], [alignment], [repeat], and [matchTextDirection]
+  /// arguments must not be null.
+  ///
+  /// See also:
+  ///
+  ///  * [new Image.asset], which has more details about loading images from
+  ///    asset bundles.
+  ///  * [new Image.network], which has more details about loading images from
+  ///    the network.
+  CrossfadeImage.assetNetwork({
+    Key key,
+    @required String placeholder,
+    this.placeholderErrorBuilder,
+    @required String image,
+    this.imageErrorBuilder,
+    AssetBundle bundle,
+    double placeholderScale,
+    double imageScale = 1.0,
+    this.excludeFromSemantics = false,
+    this.imageSemanticLabel,
+    this.crossfadeDuration = const Duration(milliseconds: 700),
+    this.crossfadeCurve = Curves.easeInOut,
+    this.width,
+    this.height,
+    this.fit,
+    this.alignment = Alignment.center,
+    this.repeat = ImageRepeat.noRepeat,
+    this.matchTextDirection = false,
+    int placeholderCacheWidth,
+    int placeholderCacheHeight,
+    int imageCacheWidth,
+    int imageCacheHeight,
+  }) : assert(placeholder != null),
+       assert(image != null),
+       placeholder = placeholderScale != null
+         ? ResizeImage.resizeIfNeeded(placeholderCacheWidth, placeholderCacheHeight, ExactAssetImage(placeholder, bundle: bundle, scale: placeholderScale))
+         : ResizeImage.resizeIfNeeded(placeholderCacheWidth, placeholderCacheHeight, AssetImage(placeholder, bundle: bundle)),
+       assert(imageScale != null),
+       assert(crossfadeDuration != null),
+       assert(crossfadeCurve != null),
+       assert(alignment != null),
+       assert(repeat != null),
+       assert(matchTextDirection != null),
+       image = ResizeImage.resizeIfNeeded(imageCacheWidth, imageCacheHeight, NetworkImage(image, scale: imageScale)),
+       super(key: key);
+
+  /// Image displayed while the target [image] is loading.
+  final ImageProvider placeholder;
+
+  /// A builder function that is called if an error occurs during placeholder
+  /// image loading.
+  ///
+  /// If this builder is not provided, any exceptions will be reported to
+  /// [FlutterError.onError]. If it is provided, the caller should either handle
+  /// the exception by providing a replacement widget, or rethrow the exception.
+  final ImageErrorWidgetBuilder placeholderErrorBuilder;
+
+  /// The target image that is displayed once it has loaded.
+  final ImageProvider image;
+
+  /// A builder function that is called if an error occurs during image loading.
+  ///
+  /// If this builder is not provided, any exceptions will be reported to
+  /// [FlutterError.onError]. If it is provided, the caller should either handle
+  /// the exception by providing a replacement widget, or rethrow the exception.
+  final ImageErrorWidgetBuilder imageErrorBuilder;
+
+  /// The duration of the crossfade animation for the [image].
+  final Duration crossfadeDuration;
+
+  /// The curve of the crossfade animation for the [image].
+  final Curve crossfadeCurve;
+
+  /// If non-null, require the image to have this width.
+  ///
+  /// If null, the image will pick a size that best preserves its intrinsic
+  /// aspect ratio. This may result in a sudden change if the size of the
+  /// placeholder image does not match that of the target image. The size is
+  /// also affected by the scale factor.
+  final double width;
+
+  /// If non-null, require the image to have this height.
+  ///
+  /// If null, the image will pick a size that best preserves its intrinsic
+  /// aspect ratio. This may result in a sudden change if the size of the
+  /// placeholder image does not match that of the target image. The size is
+  /// also affected by the scale factor.
+  final double height;
+
+  /// How to inscribe the image into the space allocated during layout.
+  ///
+  /// The default varies based on the other fields. See the discussion at
+  /// [paintImage].
+  final BoxFit fit;
+
+  /// How to align the image within its bounds.
+  ///
+  /// The alignment aligns the given position in the image to the given position
+  /// in the layout bounds. For example, an [Alignment] alignment of (-1.0,
+  /// -1.0) aligns the image to the top-left corner of its layout bounds, while an
+  /// [Alignment] alignment of (1.0, 1.0) aligns the bottom right of the
+  /// image with the bottom right corner of its layout bounds. Similarly, an
+  /// alignment of (0.0, 1.0) aligns the bottom middle of the image with the
+  /// middle of the bottom edge of its layout bounds.
+  ///
+  /// If the [alignment] is [TextDirection]-dependent (i.e. if it is a
+  /// [AlignmentDirectional]), then an ambient [Directionality] widget
+  /// must be in scope.
+  ///
+  /// Defaults to [Alignment.center].
+  ///
+  /// See also:
+  ///
+  ///  * [Alignment], a class with convenient constants typically used to
+  ///    specify an [AlignmentGeometry].
+  ///  * [AlignmentDirectional], like [Alignment] for specifying alignments
+  ///    relative to text direction.
+  final AlignmentGeometry alignment;
+
+  /// How to paint any portions of the layout bounds not covered by the image.
+  final ImageRepeat repeat;
+
+  /// Whether to paint the image in the direction of the [TextDirection].
+  ///
+  /// If this is true, then in [TextDirection.ltr] contexts, the image will be
+  /// drawn with its origin in the top left (the "normal" painting direction for
+  /// images); and in [TextDirection.rtl] contexts, the image will be drawn with
+  /// a scaling factor of -1 in the horizontal direction so that the origin is
+  /// in the top right.
+  ///
+  /// This is occasionally used with images in right-to-left environments, for
+  /// images that were designed for left-to-right locales. Be careful, when
+  /// using this, to not flip images with integral shadows, text, or other
+  /// effects that will look incorrect when flipped.
+  ///
+  /// If this is true, there must be an ambient [Directionality] widget in
+  /// scope.
+  final bool matchTextDirection;
+
+  /// Whether to exclude this image from semantics.
+  ///
+  /// This is useful for images which do not contribute meaningful information
+  /// to an application.
+  final bool excludeFromSemantics;
+
+  /// A semantic description of the [image].
+  ///
+  /// Used to provide a description of the [image] to TalkBack on Android, and
+  /// VoiceOver on iOS.
+  ///
+  /// This description will be used both while the [placeholder] is shown and
+  /// once the image has loaded.
+  final String imageSemanticLabel;
+
+  Image _image({
+    @required ImageProvider image,
+    ImageErrorWidgetBuilder errorBuilder,
+    ImageFrameBuilder frameBuilder,
+  }) {
+    assert(image != null);
+    return Image(
+      image: image,
+      errorBuilder: errorBuilder,
+      frameBuilder: frameBuilder,
+      width: width,
+      height: height,
+      fit: fit,
+      alignment: alignment,
+      repeat: repeat,
+      matchTextDirection: matchTextDirection,
+      gaplessPlayback: true,
+      excludeFromSemantics: true,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Widget result = _image(
+      image: image,
+      errorBuilder: imageErrorBuilder,
+      frameBuilder: (BuildContext context, Widget child, int frame, bool wasSynchronouslyLoaded) {
+        if (wasSynchronouslyLoaded)
+          return child;
+        return AnimatedCrossFade(
+          firstChild: _image(image: placeholder, errorBuilder: placeholderErrorBuilder),
+          secondChild: child,
+          crossFadeState: frame == null ? CrossFadeState.showFirst : CrossFadeState.showSecond,
+          duration: crossfadeDuration,
+          firstCurve: crossfadeCurve,
+          secondCurve: crossfadeCurve,
+        );
+      },
+    );
+
+    if (!excludeFromSemantics) {
+      result = Semantics(
+        container: imageSemanticLabel != null,
+        image: true,
+        label: imageSemanticLabel ?? '',
+        child: result,
+      );
+    }
+
+    return result;
+  }
+}

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -30,6 +30,7 @@ export 'src/widgets/binding.dart';
 export 'src/widgets/bottom_navigation_bar_item.dart';
 export 'src/widgets/color_filter.dart';
 export 'src/widgets/container.dart';
+export 'src/widgets/crossfade_image.dart';
 export 'src/widgets/debug.dart';
 export 'src/widgets/dismissible.dart';
 export 'src/widgets/disposable_build_context.dart';

--- a/packages/flutter/test/widgets/crossfade_image_test.dart
+++ b/packages/flutter/test/widgets/crossfade_image_test.dart
@@ -1,0 +1,327 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/src/widgets/crossfade_image.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+import '../painting/image_data.dart';
+import '../painting/image_test_utils.dart';
+
+const Duration animationDuration = Duration(milliseconds: 50);
+
+class CrossfadeImageParts {
+  const CrossfadeImageParts(this.crossfadeImageElement, this.animatedCrossFadeElement, this.placeholder, this.target)
+      : assert(crossfadeImageElement != null);
+
+  final ComponentElement crossfadeImageElement;
+  final AnimatedCrossFade animatedCrossFadeElement;
+  final Image placeholder;
+  final RawImage target;
+
+  State get state {
+    StatefulElement animatedCrossfadeElement;
+    crossfadeImageElement.visitChildren((Element child) {
+      expect(animatedCrossfadeElement, isNull);
+      animatedCrossfadeElement = child as StatefulElement;
+    });
+    expect(animatedCrossfadeElement, isNotNull);
+    return animatedCrossfadeElement.state;
+  }
+}
+
+class LoadTestImageProvider extends ImageProvider<dynamic> {
+  LoadTestImageProvider(this.provider);
+
+  final ImageProvider provider;
+
+  ImageStreamCompleter testLoad(dynamic key, DecoderCallback decode) {
+    return provider.load(key, decode);
+  }
+
+  @override
+  Future<dynamic> obtainKey(ImageConfiguration configuration) {
+    return null;
+  }
+
+  @override
+  ImageStreamCompleter load(dynamic key, DecoderCallback decode) {
+    return null;
+  }
+}
+
+CrossfadeImageParts findCrossfadeImage(WidgetTester tester) {
+  final ComponentElement crossfadeImageElement = tester.element(find.byType(CrossfadeImage));
+
+  final AnimatedCrossFade animatedCrossFade = tester.widget(find.byType(AnimatedCrossFade));
+  final Image firstChild = animatedCrossFade.firstChild as Image;
+  final RawImage secondChild = animatedCrossFade.secondChild as RawImage;
+
+  return CrossfadeImageParts(crossfadeImageElement, animatedCrossFade, firstChild, secondChild);
+}
+
+Future<void> main() async {
+  // These must run outside test zone to complete
+  final ui.Image targetImage = await createTestImage();
+  final ui.Image placeholderImage = await createTestImage();
+  final ui.Image replacementImage = await createTestImage();
+
+  group('CrossfadeImage', () {
+    testWidgets('animates an uncached image', (WidgetTester tester) async {
+      final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);
+      final TestImageProvider imageProvider = TestImageProvider(targetImage);
+
+      await tester.pumpWidget(Directionality(
+        textDirection: TextDirection.ltr,
+        child: CrossfadeImage(
+          placeholder: placeholderProvider,
+          image: imageProvider,
+          crossfadeDuration: animationDuration,
+          crossfadeCurve: Curves.linear,
+          excludeFromSemantics: true,
+        ),
+      ));
+
+      // Verify initial state before any loading.
+      expect(findCrossfadeImage(tester).placeholder.image, placeholderProvider);
+      expect(findCrossfadeImage(tester).target.image, null);
+      expect(findCrossfadeImage(tester).animatedCrossFadeElement.crossFadeState, same(CrossFadeState.showFirst));
+
+      // Verify state after placeholder has loaded.
+      placeholderProvider.complete();
+      await tester.pump();
+      expect(findCrossfadeImage(tester).placeholder.image, placeholderProvider);
+      expect(findCrossfadeImage(tester).target.image, null);
+      expect(findCrossfadeImage(tester).animatedCrossFadeElement.crossFadeState, same(CrossFadeState.showFirst));
+
+      // Verify state after target has loaded but before animation has completed.
+      imageProvider.complete();
+      await tester.pump();
+      expect(findCrossfadeImage(tester).placeholder.image, placeholderProvider);
+      expect(findCrossfadeImage(tester).target.image, same(targetImage));
+      expect(findCrossfadeImage(tester).animatedCrossFadeElement.crossFadeState, same(CrossFadeState.showSecond));
+
+      // Verify state after the animation has completed. (Not verifying the details of the animation here.)
+      await tester.pump(animationDuration);
+      expect(findCrossfadeImage(tester).placeholder.image, placeholderProvider);
+      expect(findCrossfadeImage(tester).target.image, same(targetImage));
+      expect(findCrossfadeImage(tester).animatedCrossFadeElement.crossFadeState, same(CrossFadeState.showSecond));
+
+      // Verify the state after rebuilding with both placeholder and target fully resolved.
+      await tester.pumpWidget(Directionality(
+        textDirection: TextDirection.ltr,
+        child: CrossfadeImage(
+          placeholder: placeholderProvider,
+          image: imageProvider,
+          crossfadeDuration: animationDuration,
+          crossfadeCurve: Curves.linear,
+          excludeFromSemantics: true,
+        ),
+      ));
+      expect(findCrossfadeImage(tester).placeholder.image, placeholderProvider);
+      expect(findCrossfadeImage(tester).target.image, same(targetImage));
+      expect(findCrossfadeImage(tester).animatedCrossFadeElement.crossFadeState, same(CrossFadeState.showSecond));
+    });
+
+    testWidgets('shows a cached image immediately when skipFadeOnSynchronousLoad=true', (WidgetTester tester) async {
+      final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);
+      final TestImageProvider imageProvider = TestImageProvider(targetImage);
+      imageProvider.resolve(FakeImageConfiguration());
+      imageProvider.complete();
+
+      await tester.pumpWidget(Directionality(
+        textDirection: TextDirection.ltr,
+        child: CrossfadeImage(
+          placeholder: placeholderProvider,
+          image: imageProvider,
+        ),
+      ));
+
+      expect(find.byType(RawImage), findsNWidgets(1));
+
+      final RawImage rawImage = tester.widget(find.byType(RawImage));
+      expect(rawImage.image, same(targetImage));
+    });
+
+    testWidgets('handles updating the placeholder image', (WidgetTester tester) async {
+      final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);
+      final TestImageProvider secondPlaceholderProvider = TestImageProvider(replacementImage);
+      final TestImageProvider imageProvider = TestImageProvider(targetImage);
+
+      await tester.pumpWidget(Directionality(
+        textDirection: TextDirection.ltr,
+        child: CrossfadeImage(
+          placeholder: placeholderProvider,
+          image: imageProvider,
+          crossfadeDuration: animationDuration,
+          excludeFromSemantics: true,
+        ),
+      ));
+
+      final State state = findCrossfadeImage(tester).state;
+      placeholderProvider.complete();
+      await tester.pump();
+      expect(findCrossfadeImage(tester).placeholder.image, placeholderProvider);
+
+      await tester.pumpWidget(Directionality(
+        textDirection: TextDirection.ltr,
+        child: CrossfadeImage(
+          placeholder: secondPlaceholderProvider,
+          image: imageProvider,
+          crossfadeDuration: animationDuration,
+          excludeFromSemantics: true,
+        ),
+      ));
+
+      secondPlaceholderProvider.complete();
+      await tester.pump();
+      expect(findCrossfadeImage(tester).placeholder.image, secondPlaceholderProvider);
+      expect(findCrossfadeImage(tester).state, same(state));
+    });
+
+    group('ImageProvider', () {
+
+      testWidgets('memory placeholder cacheWidth and cacheHeight is passed through', (WidgetTester tester) async {
+        final Uint8List testBytes = Uint8List.fromList(kTransparentImage);
+        final CrossfadeImage image = CrossfadeImage.memoryNetwork(
+          placeholder: testBytes,
+          image: 'test.com',
+          placeholderCacheWidth: 20,
+          placeholderCacheHeight: 30,
+          imageCacheWidth: 40,
+          imageCacheHeight: 50,
+        );
+
+        bool called = false;
+        final DecoderCallback decode = (Uint8List bytes, {int cacheWidth, int cacheHeight}) {
+          expect(cacheWidth, 20);
+          expect(cacheHeight, 30);
+          called = true;
+          return PaintingBinding.instance.instantiateImageCodec(bytes, cacheWidth: cacheWidth, cacheHeight: cacheHeight);
+        };
+        final ImageProvider resizeImage = image.placeholder;
+        expect(image.placeholder, isA<ResizeImage>());
+        expect(called, false);
+        final LoadTestImageProvider testProvider = LoadTestImageProvider(image.placeholder);
+        testProvider.testLoad(await resizeImage.obtainKey(ImageConfiguration.empty), decode);
+        expect(called, true);
+      });
+
+      testWidgets('do not resize when null cache dimensions', (WidgetTester tester) async {
+        final Uint8List testBytes = Uint8List.fromList(kTransparentImage);
+        final CrossfadeImage image = CrossfadeImage.memoryNetwork(
+          placeholder: testBytes,
+          image: 'test.com',
+        );
+
+        bool called = false;
+        final DecoderCallback decode = (Uint8List bytes, {int cacheWidth, int cacheHeight}) {
+          expect(cacheWidth, null);
+          expect(cacheHeight, null);
+          called = true;
+          return PaintingBinding.instance.instantiateImageCodec(bytes, cacheWidth: cacheWidth, cacheHeight: cacheHeight);
+        };
+        // image.placeholder should be an instance of MemoryImage instead of ResizeImage
+        final ImageProvider memoryImage = image.placeholder;
+        expect(image.placeholder, isA<MemoryImage>());
+        expect(called, false);
+        final LoadTestImageProvider testProvider = LoadTestImageProvider(image.placeholder);
+        testProvider.testLoad(await memoryImage.obtainKey(ImageConfiguration.empty), decode);
+        expect(called, true);
+      });
+    });
+
+    group('semantics', () {
+      testWidgets('only one Semantics node appears within CrossfadeImage', (WidgetTester tester) async {
+        final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);
+        final TestImageProvider imageProvider = TestImageProvider(targetImage);
+
+        await tester.pumpWidget(Directionality(
+          textDirection: TextDirection.ltr,
+          child: CrossfadeImage(
+            placeholder: placeholderProvider,
+            image: imageProvider,
+          ),
+        ));
+
+        expect(find.byType(Semantics), findsOneWidget);
+      });
+
+      testWidgets('is excluded if excludeFromSemantics is true', (WidgetTester tester) async {
+        final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);
+        final TestImageProvider imageProvider = TestImageProvider(targetImage);
+
+        await tester.pumpWidget(Directionality(
+          textDirection: TextDirection.ltr,
+          child: CrossfadeImage(
+            placeholder: placeholderProvider,
+            image: imageProvider,
+            excludeFromSemantics: true,
+          ),
+        ));
+
+        expect(find.byType(Semantics), findsNothing);
+      });
+
+      group('label', () {
+        const String imageSemanticText = 'Test image semantic label';
+
+        testWidgets('defaults to image label if placeholder label is unspecified', (WidgetTester tester) async {
+          Semantics semanticsWidget() => tester.widget(find.byType(Semantics));
+
+          final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);
+          final TestImageProvider imageProvider = TestImageProvider(targetImage);
+
+          await tester.pumpWidget(Directionality(
+            textDirection: TextDirection.ltr,
+            child: CrossfadeImage(
+              placeholder: placeholderProvider,
+              image: imageProvider,
+              crossfadeDuration: animationDuration,
+              imageSemanticLabel: imageSemanticText,
+            ),
+          ));
+
+          placeholderProvider.complete();
+          await tester.pump();
+          expect(semanticsWidget().properties.label, imageSemanticText);
+
+          imageProvider.complete();
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 51));
+          expect(semanticsWidget().properties.label, imageSemanticText);
+        });
+
+        testWidgets('is empty without any specified semantics labels', (WidgetTester tester) async {
+          Semantics semanticsWidget() => tester.widget(find.byType(Semantics));
+
+          final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);
+          final TestImageProvider imageProvider = TestImageProvider(targetImage);
+
+          await tester.pumpWidget(Directionality(
+            textDirection: TextDirection.ltr,
+            child: CrossfadeImage(
+              placeholder: placeholderProvider,
+              image: imageProvider,
+              crossfadeDuration: animationDuration,
+            ),
+          ));
+
+          placeholderProvider.complete();
+          await tester.pump();
+          expect(semanticsWidget().properties.label, isEmpty);
+
+          imageProvider.complete();
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 51));
+          expect(semanticsWidget().properties.label, isEmpty);
+        });
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description

👋 This is my first PR, feedback and pointers greatly appreciated.

There is an alternate approach to this PR, #57385, where I have extracted the animation builder out instead of creating a new class. This is raised as an alternate PR to keep the ideas separate and facilitate discussion. I'm happy to close off either, as appropriate.

I've implemented a variant of [FadeInImage](https://github.com/ryaanwells/flutter/blob/master/packages/flutter/lib/src/widgets/fade_in_image.dart) that provides a crossfade animation instead of a fade out/fade in animation. These changes are directly based on the existing [FadeInImage](https://github.com/ryaanwells/flutter/blob/master/packages/flutter/lib/src/widgets/fade_in_image.dart) class (particularly the tests) and the animation behaviour for the crossfade is provided by [AnimatedCrossFade](https://github.com/ryaanwells/flutter/blob/master/packages/flutter/lib/src/widgets/animated_cross_fade.dart).

I believe we could invest in this area to make the separation of responsibility cleaner. The behaviour of both [FadeInImage](https://github.com/ryaanwells/flutter/blob/master/packages/flutter/lib/src/widgets/fade_in_image.dart) and CrossfadeImage are very similar: load two images in a stack and fade to the second image using a given animation strategy when the second image has loaded. I'm imagining a way where we supply the animation strategy as a constructor argument to [FadeInImage](https://github.com/ryaanwells/flutter/blob/master/packages/flutter/lib/src/widgets/fade_in_image.dart) but I couldn't work out a way to separate this sensibly and maintain a good signature (each animation type could require different parameters), is there an approach I could try?

Happy to incorporate feedback, thank you for reviewing :) 

## Related Issues

- Fixes #14790

## Tests

I added the following tests:

- Tests are heavily inspired by the [existing tests for FadeInImage](https://github.com/ryaanwells/flutter/blob/master/packages/flutter/test/widgets/fade_in_image_test.dart) but specific animation checks are removed as the animation details are the responsibility of [AnimatedCrossFade](https://github.com/ryaanwells/flutter/blob/master/packages/flutter/lib/src/widgets/animated_cross_fade.dart).

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
