### PR TITLE
Fixes Image.errorBuilder called after disposed

### DIFF
--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -1128,10 +1128,12 @@ class _ImageState extends State<Image> with WidgetsBindingObserver {
       onChunk: loadingBuilder == null ? null : _handleImageChunk,
       onError: widget.errorBuilder != null
         ? (dynamic error, StackTrace stackTrace) {
-            setState(() {
-              _lastException = error;
-              _lastStack = stackTrace;
-            });
+            if (mounted) {
+              setState(() {
+                _lastException = error;
+                _lastStack = stackTrace;
+              });
+            }
           }
         : null,
     );

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -1610,6 +1610,25 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('errorBuilder is not called if disposed', (WidgetTester tester) async {
+    final TestImageProvider imageProvider = TestImageProvider();
+
+    await tester.pumpWidget(Image(
+      image: imageProvider,
+      errorBuilder: (BuildContext context, Object error, StackTrace stackTrace) {
+        assert(false);
+        return null;
+      },
+    ));
+
+    await tester.pumpWidget(const SizedBox()); // Remove Image from tree
+
+    imageProvider.fail('failed', null);
+
+    await tester.idle(); // Resolve the failed future
+    await tester.pump(null, EnginePhase.layout);
+  });
+
   testWidgets('no errorBuilder - failure reported to FlutterError', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Image(


### PR DESCRIPTION
## Description

When the `Image` widget was already removed from the widget tree, and its `ImageProvider` was still going if an error occurred during the load, the callback is called and an exception is thrown:

```
════════ Exception caught by image resource service ════════════════════════════════════════════════
The following assertion was thrown when reporting an error to an image listener:
setState() called after dispose(): _ImageState#8c9bc(lifecycle state: defunct, not mounted, stream: ImageStream#3736e(unresolved, 1 listener), pixels: [1000×1000] @ 1.0x, loadingProgress: null, frameNumber: 0, wasSynchronouslyLoaded: true)

This error happens if you call setState() on a State object for a widget that no longer appears in the widget tree (e.g., whose parent widget no longer includes the widget in its build). This error can occur when code calls setState() from a timer or an animation callback.

The preferred solution is to cancel the timer or stop listening to the animation in the dispose() callback. Another solution is to check the "mounted" property of this object before calling setState() to ensure the object is still in the tree.
This error might indicate a memory leak if setState() is being called because another object is retaining a reference to this State object after it has been removed from the tree. To avoid memory leaks, consider breaking the reference to this object during dispose().

When the exception was thrown, this was the stack: 
#0      State.setState.<anonymous closure> (package:flutter/src/widgets/framework.dart:1197:9)
#1      State.setState (package:flutter/src/widgets/framework.dart:1232:6)
#2      _ImageState._getListener.<anonymous closure> (package:flutter/src/widgets/image.dart:1116:13)
#3      ImageStreamCompleter.reportError (package:flutter/src/painting/image_stream.dart:504:24)
#4      ImageStreamCompleter.addListener (package:flutter/src/painting/image_stream.dart:366:9)
...
════════════════════════════════════════════════════════════════════════════════════════════════════
```

This makes sure the errorBuilder callback is only called if it is still mounted on the tree.

## Related Issues

## Tests

Not sure how to go about testing this behavior. I'd have to pump a widget, then replace it (or just remove it) before `ImageProvider.load` finishes (maybe using a `Completer`).
Any suggestions?

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
