### PR TITLE
Improve error message when using popuntil with bad predicate

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -3641,15 +3641,12 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   /// ```
   /// {@end-tool}
   void popUntil(RoutePredicate predicate) {
-    int index = _history.length - 1;
-    while(index >= 0) {
-      if (_history[index].isPresent) {
-        if (predicate(_history[index].route))
-          return;
-        pop();
-      } else {
-        index -= 1;
-      }
+    _RouteEntry candidate = _history.lastWhere(_RouteEntry.isPresentPredicate, orElse: () => null);
+    while(candidate != null) {
+      if (predicate(candidate.route))
+        return;
+      pop();
+      candidate = _history.lastWhere(_RouteEntry.isPresentPredicate, orElse: () => null);
     }
     // We have popped all routes and still can't find a match.
     assert(

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -3641,9 +3641,21 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   /// ```
   /// {@end-tool}
   void popUntil(RoutePredicate predicate) {
-    while (!predicate(_history.lastWhere(_RouteEntry.isPresentPredicate).route)) {
-      pop();
+    int index = _history.length - 1;
+    while(index >= 0) {
+      if (_history[index].isPresent) {
+        if (predicate(_history[index].route))
+          return;
+        pop();
+      } else {
+        index -= 1;
+      }
     }
+    // We have popped all routes and still can't find a match.
+    assert(
+      false,
+      'All routes have been popped because none of them matches the predicate.'
+    );
   }
 
   /// Immediately remove `route` from the navigator, and [Route.dispose] it.

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -3648,11 +3648,6 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
       pop();
       candidate = _history.lastWhere(_RouteEntry.isPresentPredicate, orElse: () => null);
     }
-    // We have popped all routes and still can't find a match.
-    assert(
-      false,
-      'All routes have been popped because none of them matches the predicate.'
-    );
   }
 
   /// Immediately remove `route` from the navigator, and [Route.dispose] it.

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -696,6 +696,35 @@ void main() {
     expect(find.text('C'), isOnstage);
   });
 
+  testWidgets('accidentally pops all routes should have better error message', (WidgetTester tester) async {
+    final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
+      '/' : (BuildContext context) => const OnTapPage(
+        id: '/',
+      ),
+      '/A': (BuildContext context) => const OnTapPage(
+        id: 'A',
+      ),
+      '/A/B': (BuildContext context) => OnTapPage(
+        id: 'B',
+        onTap: (){
+          // Pops all routes with bad predicate.
+          Navigator.of(context).popUntil((Route<dynamic> route) => false);
+        },
+      ),
+    };
+    await tester.pumpWidget(
+      MaterialApp(
+        routes: routes,
+        initialRoute: '/A/B',
+      )
+    );
+    await tester.tap(find.text('B'));
+    final dynamic exception = tester.takeException();
+    expect(exception is AssertionError, isTrue);
+    final AssertionError assertionError = exception as AssertionError;
+    expect(assertionError.message, 'All routes have been popped because none of them matches the predicate.');
+  });
+
   testWidgets('pushAndRemoveUntil triggers secondaryAnimation', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
       '/' : (BuildContext context) => OnTapPage(

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -696,7 +696,7 @@ void main() {
     expect(find.text('C'), isOnstage);
   });
 
-  testWidgets('accidentally pops all routes should have better error message', (WidgetTester tester) async {
+  testWidgets('Able to pop all routes', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
       '/' : (BuildContext context) => const OnTapPage(
         id: '/',
@@ -719,10 +719,8 @@ void main() {
       )
     );
     await tester.tap(find.text('B'));
-    final dynamic exception = tester.takeException();
-    expect(exception is AssertionError, isTrue);
-    final AssertionError assertionError = exception as AssertionError;
-    expect(assertionError.message, 'All routes have been popped because none of them matches the predicate.');
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('pushAndRemoveUntil triggers secondaryAnimation', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

If developers accidentally write a wrong predicate in popUntil, the navigator will pop all the routes and leave a weird error message. This pr makes the error message more readable.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/16602

## Tests

I added the following tests:

see files

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
