### PR TITLE
Add Container.max to set both width and height as infinity by default

### DIFF
--- a/packages/flutter/lib/src/widgets/container.dart
+++ b/packages/flutter/lib/src/widgets/container.dart
@@ -340,27 +340,14 @@ class Container extends StatelessWidget {
     this.color,
     this.decoration,
     this.foregroundDecoration,
-    double width: double.infinity,
-    double height: double.infinity,
+    double width = double.infinity,
+    double height = double.infinity,
     BoxConstraints constraints,
     this.margin,
     this.transform,
     this.child,
     this.clipBehavior = Clip.none,
-  })  : assert(margin == null || margin.isNonNegative),
-        assert(padding == null || padding.isNonNegative),
-        assert(decoration == null || decoration.debugAssertIsValid()),
-        assert(constraints == null || constraints.debugAssertIsValid()),
-        assert(clipBehavior != null),
-        assert(
-            color == null || decoration == null,
-            'Cannot provide both a color and a decoration\n'
-            'To provide both, use "decoration: BoxDecoration(color: color)".'),
-        constraints = (width != null || height != null)
-            ? constraints?.tighten(width: width, height: height) ??
-                BoxConstraints.tightFor(width: width, height: height)
-            : constraints,
-        super(key: key);
+  });
 
   /// The [child] contained by the container.
   ///

--- a/packages/flutter/lib/src/widgets/container.dart
+++ b/packages/flutter/lib/src/widgets/container.dart
@@ -107,9 +107,9 @@ class DecoratedBox extends SingleChildRenderObjectWidget {
     @required this.decoration,
     this.position = DecorationPosition.background,
     Widget child,
-  }) : assert(decoration != null),
-       assert(position != null),
-       super(key: key, child: child);
+  })  : assert(decoration != null),
+        assert(position != null),
+        super(key: key, child: child);
 
   /// What decoration to paint.
   ///
@@ -129,7 +129,8 @@ class DecoratedBox extends SingleChildRenderObjectWidget {
   }
 
   @override
-  void updateRenderObject(BuildContext context, RenderDecoratedBox renderObject) {
+  void updateRenderObject(
+      BuildContext context, RenderDecoratedBox renderObject) {
     renderObject
       ..decoration = decoration
       ..configuration = createLocalImageConfiguration(context)
@@ -152,7 +153,9 @@ class DecoratedBox extends SingleChildRenderObjectWidget {
     } else {
       label = 'decoration';
     }
-    properties.add(EnumProperty<DecorationPosition>('position', position, level: position != null ? DiagnosticLevel.hidden : DiagnosticLevel.info));
+    properties.add(EnumProperty<DecorationPosition>('position', position,
+        level:
+            position != null ? DiagnosticLevel.hidden : DiagnosticLevel.info));
     properties.add(DiagnosticsProperty<Decoration>(
       label,
       decoration,
@@ -312,21 +315,52 @@ class Container extends StatelessWidget {
     this.transform,
     this.child,
     this.clipBehavior = Clip.none,
-  }) : assert(margin == null || margin.isNonNegative),
-       assert(padding == null || padding.isNonNegative),
-       assert(decoration == null || decoration.debugAssertIsValid()),
-       assert(constraints == null || constraints.debugAssertIsValid()),
-       assert(clipBehavior != null),
-       assert(color == null || decoration == null,
-         'Cannot provide both a color and a decoration\n'
-         'To provide both, use "decoration: BoxDecoration(color: color)".'
-       ),
-       constraints =
-        (width != null || height != null)
-          ? constraints?.tighten(width: width, height: height)
-            ?? BoxConstraints.tightFor(width: width, height: height)
-          : constraints,
-       super(key: key);
+  })  : assert(margin == null || margin.isNonNegative),
+        assert(padding == null || padding.isNonNegative),
+        assert(decoration == null || decoration.debugAssertIsValid()),
+        assert(constraints == null || constraints.debugAssertIsValid()),
+        assert(clipBehavior != null),
+        assert(
+            color == null || decoration == null,
+            'Cannot provide both a color and a decoration\n'
+            'To provide both, use "decoration: BoxDecoration(color: color)".'),
+        constraints = (width != null || height != null)
+            ? constraints?.tighten(width: width, height: height) ??
+                BoxConstraints.tightFor(width: width, height: height)
+            : constraints,
+        super(key: key);
+
+  /// Creates a common Container widget that uses all available space.
+  ///
+  /// The `height` and `width` values are setted to infinity.
+  Container.max({
+    Key key,
+    this.alignment,
+    this.padding,
+    this.color,
+    this.decoration,
+    this.foregroundDecoration,
+    double width: double.infinity,
+    double height: double.infinity,
+    BoxConstraints constraints,
+    this.margin,
+    this.transform,
+    this.child,
+    this.clipBehavior = Clip.none,
+  })  : assert(margin == null || margin.isNonNegative),
+        assert(padding == null || padding.isNonNegative),
+        assert(decoration == null || decoration.debugAssertIsValid()),
+        assert(constraints == null || constraints.debugAssertIsValid()),
+        assert(clipBehavior != null),
+        assert(
+            color == null || decoration == null,
+            'Cannot provide both a color and a decoration\n'
+            'To provide both, use "decoration: BoxDecoration(color: color)".'),
+        constraints = (width != null || height != null)
+            ? constraints?.tighten(width: width, height: height) ??
+                BoxConstraints.tightFor(width: width, height: height)
+            : constraints,
+        super(key: key);
 
   /// The [child] contained by the container.
   ///
@@ -403,11 +437,9 @@ class Container extends StatelessWidget {
   final Clip clipBehavior;
 
   EdgeInsetsGeometry get _paddingIncludingDecoration {
-    if (decoration == null || decoration.padding == null)
-      return padding;
+    if (decoration == null || decoration.padding == null) return padding;
     final EdgeInsetsGeometry decorationPadding = decoration.padding;
-    if (padding == null)
-      return decorationPadding;
+    if (padding == null) return decorationPadding;
     return padding.add(decorationPadding);
   }
 
@@ -430,8 +462,7 @@ class Container extends StatelessWidget {
     if (effectivePadding != null)
       current = Padding(padding: effectivePadding, child: current);
 
-    if (color != null)
-      current = ColoredBox(color: color, child: current);
+    if (color != null) current = ColoredBox(color: color, child: current);
 
     if (decoration != null)
       current = DecoratedBox(decoration: decoration, child: current);
@@ -447,8 +478,7 @@ class Container extends StatelessWidget {
     if (constraints != null)
       current = ConstrainedBox(constraints: constraints, child: current);
 
-    if (margin != null)
-      current = Padding(padding: margin, child: current);
+    if (margin != null) current = Padding(padding: margin, child: current);
 
     if (transform != null)
       current = Transform(transform: transform, child: current);
@@ -456,9 +486,7 @@ class Container extends StatelessWidget {
     if (clipBehavior != Clip.none) {
       current = ClipPath(
         clipper: _DecorationClipper(
-          textDirection: Directionality.of(context),
-          decoration: decoration
-        ),
+            textDirection: Directionality.of(context), decoration: decoration),
         clipBehavior: clipBehavior,
         child: current,
       );
@@ -470,27 +498,34 @@ class Container extends StatelessWidget {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<AlignmentGeometry>('alignment', alignment, showName: false, defaultValue: null));
-    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding, defaultValue: null));
-    properties.add(DiagnosticsProperty<Clip>('clipBehavior', clipBehavior, defaultValue: Clip.none));
+    properties.add(DiagnosticsProperty<AlignmentGeometry>(
+        'alignment', alignment,
+        showName: false, defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding,
+        defaultValue: null));
+    properties.add(DiagnosticsProperty<Clip>('clipBehavior', clipBehavior,
+        defaultValue: Clip.none));
     if (color != null)
       properties.add(DiagnosticsProperty<Color>('bg', color));
     else
-      properties.add(DiagnosticsProperty<Decoration>('bg', decoration, defaultValue: null));
-    properties.add(DiagnosticsProperty<Decoration>('fg', foregroundDecoration, defaultValue: null));
-    properties.add(DiagnosticsProperty<BoxConstraints>('constraints', constraints, defaultValue: null));
-    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('margin', margin, defaultValue: null));
+      properties.add(DiagnosticsProperty<Decoration>('bg', decoration,
+          defaultValue: null));
+    properties.add(DiagnosticsProperty<Decoration>('fg', foregroundDecoration,
+        defaultValue: null));
+    properties.add(DiagnosticsProperty<BoxConstraints>(
+        'constraints', constraints,
+        defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('margin', margin,
+        defaultValue: null));
     properties.add(ObjectFlagProperty<Matrix4>.has('transform', transform));
   }
 }
 
 /// A clipper that uses [Decoration.getClipPath] to clip.
 class _DecorationClipper extends CustomClipper<Path> {
-  _DecorationClipper({
-    TextDirection textDirection,
-    @required this.decoration
-  }) : assert (decoration != null),
-       textDirection = textDirection ?? TextDirection.ltr;
+  _DecorationClipper({TextDirection textDirection, @required this.decoration})
+      : assert(decoration != null),
+        textDirection = textDirection ?? TextDirection.ltr;
 
   final TextDirection textDirection;
   final Decoration decoration;
@@ -502,7 +537,7 @@ class _DecorationClipper extends CustomClipper<Path> {
 
   @override
   bool shouldReclip(_DecorationClipper oldClipper) {
-    return oldClipper.decoration != decoration
-        || oldClipper.textDirection != textDirection;
+    return oldClipper.decoration != decoration ||
+        oldClipper.textDirection != textDirection;
   }
 }


### PR DESCRIPTION
## Description

Improve Container using a static max method (Container.max) that creates a Container with both height and width set to double.infinity. This setting differs from Expanded on my projects because Expanded goes of screen, while Container(width: double.infinity, height: double.infinity) doesn't do that!

## Related Issues

This is a issue I have found while I was making my personal projects, so I don't found any issues it may get into!

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behaviour with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
