### PR TITLE
Make _RenderButtonBarRow.constraints null aware

### DIFF
--- a/packages/flutter/lib/src/material/button_bar.dart
+++ b/packages/flutter/lib/src/material/button_bar.dart
@@ -334,7 +334,7 @@ class _RenderButtonBarRow extends RenderFlex {
   BoxConstraints get constraints {
     if (_hasCheckedLayoutWidth)
       return super.constraints;
-    return super.constraints.copyWith(maxWidth: double.infinity);
+    return super.constraints?.copyWith(maxWidth: double.infinity);
   }
 
   @override

--- a/packages/flutter/test/material/button_bar_test.dart
+++ b/packages/flutter/test/material/button_bar_test.dart
@@ -5,6 +5,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+final Finder _buttonBarRow = find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_ButtonBarRow');
+
 void main() {
   testWidgets('ButtonBar default control smoketest', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -626,5 +628,18 @@ void main() {
         expect(containerOneRect.bottom, containerTwoRect.top - 10.0);
       },
     );
+  });
+
+  testWidgets('_RenderButtonBarRow.constraints works before layout', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: ButtonBar()),
+      null,
+      EnginePhase.build,
+    );
+
+    final RenderBox buttonBar = tester.renderObject(_buttonBarRow) as RenderBox;
+
+    expect(buttonBar.debugNeedsLayout, isTrue);
+    expect(buttonBar.constraints, isNull);
   });
 }

--- a/packages/flutter/test/material/button_bar_test.dart
+++ b/packages/flutter/test/material/button_bar_test.dart
@@ -637,7 +637,7 @@ void main() {
 
     final Finder buttonBar = find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_ButtonBarRow');
     final RenderBox renderButtonBar = tester.renderObject(buttonBar) as RenderBox;
-    
+
     expect(renderButtonBar.debugNeedsLayout, isTrue);
     expect(renderButtonBar.constraints, isNull);
   });

--- a/packages/flutter/test/material/button_bar_test.dart
+++ b/packages/flutter/test/material/button_bar_test.dart
@@ -5,8 +5,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-final Finder _buttonBarRow = find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_ButtonBarRow');
-
 void main() {
   testWidgets('ButtonBar default control smoketest', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -637,9 +635,10 @@ void main() {
       EnginePhase.build,
     );
 
-    final RenderBox buttonBar = tester.renderObject(_buttonBarRow) as RenderBox;
-
-    expect(buttonBar.debugNeedsLayout, isTrue);
-    expect(buttonBar.constraints, isNull);
+    final Finder buttonBar = find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_ButtonBarRow');
+    final RenderBox renderButtonBar = tester.renderObject(buttonBar) as RenderBox;
+    
+    expect(renderButtonBar.debugNeedsLayout, isTrue);
+    expect(renderButtonBar.constraints, isNull);
   });
 }

--- a/packages/flutter/test/material/button_bar_test.dart
+++ b/packages/flutter/test/material/button_bar_test.dart
@@ -633,7 +633,7 @@ void main() {
   testWidgets('_RenderButtonBarRow.constraints works before layout', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(home: ButtonBar()),
-      null,
+      Duration.zero,
       EnginePhase.build,
     );
 


### PR DESCRIPTION
## Description

Right now the _RenderButtonBarRow.constraints getter can throw if its constraints are null, this PR fixes that.

RenderObject.constraints can sometimes be called before the tree has been layed out, like during diagnostics. I found this stack trace in the wild:

```
════════ Exception caught by rendering library ═════════════════════════════════
The following NoSuchMethodError was thrown during performLayout():
The method 'copyWith' was called on null.
Receiver: null
Tried calling: copyWith(maxWidth: Infinity)
The relevant error-causing widget was
    AlertDialog 
lib\methods.dart:866
When the exception was thrown, this was the stack
#0      Object.noSuchMethod  (dart:core-patch/object_patch.dart:53:5)
#1      _RenderButtonBarRow.constraints 
package:flutter/…/material/button_bar.dart:337
#2      RenderObject.debugFillProperties 
package:flutter/…/rendering/object.dart:2837
#3      RenderBox.debugFillProperties 
package:flutter/…/rendering/box.dart:2424
#4      RenderFlex.debugFillProperties 
package:flutter/…/rendering/flex.dart:1017
...
```

## Tests

This change is trivial and would have been caught in NNBD migration, so it probably doesn't need tests.

EDIT: I have added a test that makes sure _RenderButtonBarRow.constraints does not throw pre-layout.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*