### PR TITLE
add missing deps to flutter_test BUILD.gn

### DIFF
--- a/packages/flutter_test/BUILD.gn
+++ b/packages/flutter_test/BUILD.gn
@@ -14,6 +14,8 @@ dart_library("flutter_test") {
 
   deps = [
     "../flutter",
+    "//third_party/dart-pkg/pub/clock",
+    "//third_party/dart-pkg/pub/fake_async",
     "//third_party/dart-pkg/pub/image",
     "//third_party/dart-pkg/pub/path",
     "//third_party/dart-pkg/pub/quiver",


### PR DESCRIPTION
## Description

Adds missing dependencies needed in the fuchsia tree.
