### PR TITLE
remove pending timers list code out of assert message

### DIFF
--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1117,8 +1117,8 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
     super._verifyInvariants();
 
     bool timersPending = false;
-    if (   _currentFakeAsync.periodicTimerCount != 0
-        || _currentFakeAsync.nonPeriodicTimerCount != 0) {
+    if (_currentFakeAsync.periodicTimerCount != 0 ||
+        _currentFakeAsync.nonPeriodicTimerCount != 0) {
 
         debugPrint('Pending timers:');
         for (final FakeTimer timer in _currentFakeAsync.pendingTimers) {

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1116,23 +1116,23 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   void _verifyInvariants() {
     super._verifyInvariants();
 
-    assert(() {
-      if (   _currentFakeAsync.periodicTimerCount == 0
-          && _currentFakeAsync.nonPeriodicTimerCount == 0) {
-        return true;
-      }
+    bool timersPending = false;
+    if (   _currentFakeAsync.periodicTimerCount != 0
+        || _currentFakeAsync.nonPeriodicTimerCount != 0) {
 
-      debugPrint('Pending timers:');
-      for (final FakeTimer timer in _currentFakeAsync.pendingTimers) {
-        debugPrint(
-          'Timer (duration: ${timer.duration}, '
-          'periodic: ${timer.isPeriodic}), created:');
-        debugPrintStack(stackTrace: timer.creationStackTrace);
-        debugPrint('');
-      }
-      return false;
-    }(), 'A Timer is still pending even after the widget tree was disposed.');
+        debugPrint('Pending timers:');
+        for (final FakeTimer timer in _currentFakeAsync.pendingTimers) {
+          debugPrint(
+            'Timer (duration: ${timer.duration}, '
+            'periodic: ${timer.isPeriodic}), created:');
+          debugPrintStack(stackTrace: timer.creationStackTrace);
+          debugPrint('');
+        }
 
+        timersPending = true;
+    }
+
+    assert(!timersPending ? true : throw 'A Timer is still pending even after the widget tree was disposed.');
     assert(_currentFakeAsync.microtaskCount == 0); // Shouldn't be possible.
   }
 

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1128,7 +1128,6 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
           debugPrintStack(stackTrace: timer.creationStackTrace);
           debugPrint('');
         }
-
         timersPending = true;
     }
 

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1119,7 +1119,6 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
     bool timersPending = false;
     if (_currentFakeAsync.periodicTimerCount != 0 ||
         _currentFakeAsync.nonPeriodicTimerCount != 0) {
-
         debugPrint('Pending timers:');
         for (final FakeTimer timer in _currentFakeAsync.pendingTimers) {
           debugPrint(
@@ -1130,7 +1129,6 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
         }
         timersPending = true;
     }
-
     assert(!timersPending, 'A Timer is still pending even after the widget tree was disposed.');
     assert(_currentFakeAsync.microtaskCount == 0); // Shouldn't be possible.
   }

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -753,6 +753,15 @@ void main() {
   });
 
   group('Pending timer', () {
+    TestExceptionReporter currentExceptionReporter;
+    setUp(() {
+      currentExceptionReporter = reportTestException;
+    });
+
+    tearDown(() {
+      reportTestException = currentExceptionReporter;
+    });
+
     test('Throws assertion message without code', () async {
       FlutterErrorDetails flutterErrorDetails;
       reportTestException = (FlutterErrorDetails details, String testDescription) {

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -751,6 +751,23 @@ void main() {
       expect(desktop.values.union(mobile.values), equals(all.values));
     });
   });
+
+  group('no timers pending after widget tree disposal', () {
+    testWidgets('timer pending check', (WidgetTester tester) async {
+      final Timer timer = Timer(const Duration(seconds: 1), () {});
+      expect(timer.isActive, true);
+      timer.cancel();
+      expect(timer.isActive, false);
+
+    });
+
+    testWidgets('periodic timer pending check', (WidgetTester tester) async {
+      final Timer timer = Timer.periodic(Duration(seconds: 1), (Timer t) => print(t));
+      expect(timer.isActive, true);
+      timer.cancel();
+      expect(timer.isActive, false);
+    });
+  });
 }
 
 class FakeMatcher extends AsyncMatcher {


### PR DESCRIPTION
## Description

Updates the assertion message printed out when a timer is pending after a widget tree has been disposed. The current exception caught displays code nested in an assert statement, which is unnecessary and verbose. 

## Related Issues

flutter/flutter#53296

## Tests

I added the following tests:

```
testWidgets('timer pending after widget tree disposal', (WidgetTester tester) async {
    Timer(const Duration(seconds: 5), () {});
});
```

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
