### PR TITLE
add @factory to create* methods

### DIFF
--- a/packages/flutter/lib/foundation.dart
+++ b/packages/flutter/lib/foundation.dart
@@ -10,6 +10,7 @@
 library foundation;
 
 export 'package:meta/meta.dart' show
+  factory,
   immutable,
   mustCallSuper,
   nonVirtual,

--- a/packages/flutter/lib/src/gestures/multidrag.dart
+++ b/packages/flutter/lib/src/gestures/multidrag.dart
@@ -220,6 +220,7 @@ abstract class MultiDragGestureRecognizer<T extends MultiDragPointerState> exten
   /// Subclasses should override this method to create per-pointer state
   /// objects to track the pointer associated with the given event.
   @protected
+  @factory
   T createNewPointerState(PointerDownEvent event);
 
   void _handleEvent(PointerEvent event) {

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -159,6 +159,7 @@ abstract class InteractiveInkFeatureFactory {
   ///
   /// Subclasses should override this method to return a new instance of an
   /// [InteractiveInkFeature].
+  @factory
   InteractiveInkFeature create({
     @required MaterialInkController controller,
     @required RenderBox referenceBox,

--- a/packages/flutter/lib/src/painting/decoration.dart
+++ b/packages/flutter/lib/src/painting/decoration.dart
@@ -164,6 +164,7 @@ abstract class Decoration with Diagnosticable {
   /// The `onChanged` argument configures [BoxPainter.onChanged]. It can be
   /// omitted if there is no chance that the painter will change (for example,
   /// if it is a [BoxDecoration] with definitely no [DecorationImage]).
+  @factory
   BoxPainter createBoxPainter([ VoidCallback onChanged ]);
 
   /// Returns a closed [Path] that describes the outer edge of this decoration.

--- a/packages/flutter/lib/src/painting/gradient.dart
+++ b/packages/flutter/lib/src/painting/gradient.dart
@@ -201,6 +201,7 @@ abstract class Gradient {
   ///
   /// The shader's transform will be resolved from the [transform] of this
   /// gradient.
+  @factory
   Shader createShader(Rect rect, { TextDirection textDirection });
 
   /// Returns a new gradient with its properties scaled by the given factor.

--- a/packages/flutter/lib/src/rendering/mouse_cursor.dart
+++ b/packages/flutter/lib/src/rendering/mouse_cursor.dart
@@ -213,6 +213,7 @@ abstract class MouseCursor with Diagnosticable {
   /// cursor. A given cursor can be displayed by multiple devices at the same
   /// time, in which case this method will be called separately for each device.
   @protected
+  @factory
   MouseCursorSession createSession(int device);
 
   /// A very short description of the mouse cursor.

--- a/packages/flutter/lib/src/scheduler/ticker.dart
+++ b/packages/flutter/lib/src/scheduler/ticker.dart
@@ -35,6 +35,7 @@ abstract class TickerProvider {
   /// Creates a ticker with the given callback.
   ///
   /// The kind of ticker provided depends on the kind of ticker provider.
+  @factory
   Ticker createTicker(TickerCallback onTick);
 }
 

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -16,6 +16,7 @@ import 'inherited_model.dart';
 export 'dart:ui' show hashValues, hashList;
 
 export 'package:flutter/foundation.dart' show
+  factory,
   immutable,
   mustCallSuper,
   optionalTypeArgs,
@@ -488,6 +489,7 @@ abstract class Widget extends DiagnosticableTree {
   /// widget that is incorporated into the tree multiple times will be inflated
   /// multiple times.
   @protected
+  @factory
   Element createElement();
 
   /// A short, textual description of this widget.
@@ -911,6 +913,7 @@ abstract class StatefulWidget extends Widget {
   /// again to create a fresh [State] object, simplifying the lifecycle of
   /// [State] objects.
   @protected
+  @factory
   State createState();
 }
 
@@ -1730,6 +1733,7 @@ abstract class RenderObjectWidget extends Widget {
 
   /// RenderObjectWidgets always inflate to a [RenderObjectElement] subclass.
   @override
+  @factory
   RenderObjectElement createElement();
 
   /// Creates an instance of the [RenderObject] class that this
@@ -1742,6 +1746,7 @@ abstract class RenderObjectWidget extends Widget {
   /// [createElement] method. See, for example,
   /// [SingleChildRenderObjectElement.mount].
   @protected
+  @factory
   RenderObject createRenderObject(BuildContext context);
 
   /// Copies the configuration described by this [RenderObjectWidget] to the

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -524,6 +524,7 @@ abstract class Page<T> extends RouteSettings {
   /// Creates the [Route] that corresponds to this page.
   ///
   /// The created [Route] must have its [Route.settings] property set to this [Page].
+  @factory
   Route<T> createRoute(BuildContext context);
 
   @override

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -31,6 +31,7 @@ abstract class OverlayRoute<T> extends Route<T> {
   }) : super(settings: settings);
 
   /// Subclasses should override this getter to return the builders for the overlay.
+  @factory
   Iterable<OverlayEntry> createOverlayEntries();
 
   @override


### PR DESCRIPTION
## Description

Add [`@factory`](https://pub.dev/documentation/meta/latest/meta/factory-constant.html) to `create*` methods (not returning void).

## Related Issues

* #57259

## Tests

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
