### PR TITLE
fix route annoucement for first route and last route

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -2294,7 +2294,7 @@ enum _RouteLifecycle {
 typedef _RouteEntryPredicate = bool Function(_RouteEntry entry);
 
 class _NotAnnounced extends Route<void> {
-  // A place holder for the lastAnnouncedPreviousRoute, the
+  // A placeholder for the lastAnnouncedPreviousRoute, the
   // lastAnnouncedPoppedNextRoute, and the lastAnnouncedNextRoute before any
   // change has been announced.
 }

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -2293,6 +2293,12 @@ enum _RouteLifecycle {
 
 typedef _RouteEntryPredicate = bool Function(_RouteEntry entry);
 
+class _NotAnnounced extends Route<void> {
+  // A place holder for the lastAnnouncedPreviousRoute, the
+  // lastAnnouncedPoppedNextRoute, and the lastAnnouncedNextRoute before any
+  // change has been announced.
+}
+
 class _RouteEntry extends RouteTransitionRecord {
   _RouteEntry(
     this.route, {
@@ -2311,10 +2317,12 @@ class _RouteEntry extends RouteTransitionRecord {
   @override
   final Route<dynamic> route;
 
+  static Route<dynamic> notAnnounced = _NotAnnounced();
+
   _RouteLifecycle currentState;
-  Route<dynamic> lastAnnouncedPreviousRoute; // last argument to Route.didChangePrevious
-  Route<dynamic> lastAnnouncedPoppedNextRoute; // last argument to Route.didPopNext
-  Route<dynamic> lastAnnouncedNextRoute; // last argument to Route.didChangeNext
+  Route<dynamic> lastAnnouncedPreviousRoute = notAnnounced; // last argument to Route.didChangePrevious
+  Route<dynamic> lastAnnouncedPoppedNextRoute = notAnnounced; // last argument to Route.didPopNext
+  Route<dynamic> lastAnnouncedNextRoute = notAnnounced; // last argument to Route.didChangeNext
 
   bool get hasPage => route.settings is Page;
 

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -1881,11 +1881,11 @@ void main() {
 
     expect(previousOfFirst, isNull);
     expect(nextOfFirst, secondRoute);
-    expect(popNextOfFirst is NotAnnounced, isTrue);
+    expect(popNextOfFirst, isA<NotAnnounced>());
 
     expect(previousOfSecond, firstRoute);
     expect(nextOfSecond, isNull);
-    expect(popNextOfSecond is NotAnnounced, isTrue);
+    expect(popNextOfSecond, isA<NotAnnounced>());
 
     navigator.currentState.pop();
     expect(popNextOfFirst, secondRoute);

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -1841,6 +1841,7 @@ void main() {
   });
 
   testWidgets('Route annouce correctly for first route and last route', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/57133.
     Route<void> previousOfFirst = NotAnnounced();
     Route<void> nextOfFirst = NotAnnounced();
     Route<void> popNextOfFirst = NotAnnounced();

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -1840,6 +1840,56 @@ void main() {
     expect(tickCount, 4);
   });
 
+  testWidgets('Route annouce correctly for first route and last route', (WidgetTester tester) async {
+    Route<void> previousOfFirst = NotAnnounced();
+    Route<void> nextOfFirst = NotAnnounced();
+    Route<void> popNextOfFirst = NotAnnounced();
+    Route<void> firstRoute;
+
+    Route<void> previousOfSecond = NotAnnounced();
+    Route<void> nextOfSecond = NotAnnounced();
+    Route<void> popNextOfSecond = NotAnnounced();
+    Route<void> secondRoute;
+
+    final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: navigator,
+        initialRoute: '/second',
+        onGenerateRoute: (RouteSettings settings) {
+          if (settings.name == '/') {
+            firstRoute = RouteAnnouncementSpy(
+              onDidChangeNext: (Route<void> next) => nextOfFirst = next,
+              onDidChangePrevious: (Route<void> previous) => previousOfFirst = previous,
+              onDidPopNext: (Route<void> next) => popNextOfFirst = next,
+              settings: settings,
+            );
+            return firstRoute;
+          }
+          secondRoute = RouteAnnouncementSpy(
+            onDidChangeNext: (Route<void> next) => nextOfSecond = next,
+            onDidChangePrevious: (Route<void> previous) => previousOfSecond = previous,
+            onDidPopNext: (Route<void> next) => popNextOfSecond = next,
+            settings: settings,
+          );
+          return secondRoute;
+        },
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(previousOfFirst, isNull);
+    expect(nextOfFirst, secondRoute);
+    expect(popNextOfFirst is NotAnnounced, isTrue);
+
+    expect(previousOfSecond, firstRoute);
+    expect(nextOfSecond, isNull);
+    expect(popNextOfSecond is NotAnnounced, isTrue);
+
+    navigator.currentState.pop();
+    expect(popNextOfFirst, secondRoute);
+  });
+
   group('Page api', (){
     Widget buildNavigator(
       List<Page<dynamic>> pages,
@@ -2559,6 +2609,50 @@ void main() {
       expect(find.text('initial'), findsOneWidget);
     });
   });
+}
+
+typedef AnnouncementCallBack = void Function(Route<dynamic>);
+
+class NotAnnounced extends Route<void> {/* A place holder for not announced route*/}
+
+class RouteAnnouncementSpy extends Route<void> {
+  RouteAnnouncementSpy({
+    this.onDidChangePrevious,
+    this.onDidChangeNext,
+    this.onDidPopNext,
+    RouteSettings settings,
+  }) : super(settings: settings);
+  final AnnouncementCallBack onDidChangePrevious;
+  final AnnouncementCallBack onDidChangeNext;
+  final AnnouncementCallBack onDidPopNext;
+
+  @override
+  List<OverlayEntry> get overlayEntries => <OverlayEntry>[
+    OverlayEntry(
+      builder: (BuildContext context) => const Placeholder(),
+    )
+  ];
+
+  @override
+  void didChangeNext(Route<dynamic> nextRoute) {
+    super.didChangeNext(nextRoute);
+    if (onDidChangeNext != null)
+      onDidChangeNext(nextRoute);
+  }
+
+  @override
+  void didChangePrevious(Route<dynamic> previousRoute) {
+    super.didChangePrevious(previousRoute);
+    if (onDidChangePrevious != null)
+      onDidChangePrevious(previousRoute);
+  }
+
+  @override
+  void didPopNext(Route<dynamic> nextRoute) {
+    super.didPopNext(nextRoute);
+    if (onDidPopNext != null)
+      onDidPopNext(nextRoute);
+  }
 }
 
 class _TickingWidget extends StatefulWidget {


### PR DESCRIPTION
## Description

The navigator refactor updates how we detect a previous or next route has changed. We keep track of the last announced previous and next route, and calls didChangePrevious or didChangeNext when it changes. However, the initial value of the cache is null which cause the first route stop reporting the didChangePrev because previous route of the first route is null. Same thing for the didChangeNext.


## Related Issues

Fixes https://github.com/flutter/flutter/issues/57133

## Tests

I added the following tests:

See files

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
