### PR TITLE
Protect the deletion of the local engine temp dir in case it is alrea…

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -1001,8 +1001,11 @@ Directory _getLocalEngineRepo({
     .createTempSync('flutter_tool_local_engine_repo.');
 
   // Remove the local engine repo before the tool exits.
-  shutdownHooks.addShutdownHook(
-    () => localEngineRepo.deleteSync(recursive: true),
+  shutdownHooks.addShutdownHook(() {
+      if (localEngineRepo.existsSync()) {
+        localEngineRepo.deleteSync(recursive: true);
+      }
+    },
     ShutdownStage.CLEANUP,
   );
 


### PR DESCRIPTION
The new automatic temp-dir deletion mechanism was more aggressive than the gradle shutdown hook, so this fix adds protection to the shutdown hook so it doesn't try to delete the directory if some other mechanism beat it to the punch.