### PR TITLE
[flutter tools] Improve messages when we fail to connect to the Observatory

### DIFF
--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -91,17 +91,22 @@ Future<io.WebSocket> _defaultOpenChannel(String url, {
   Future<void> handleError(dynamic e) async {
     void Function(String) printVisibleTrace = globals.printTrace;
     if (attempts == 10) {
-      globals.printStatus('Connecting to the Observatory is taking longer than expected...');
+      globals.printStatus('Connecting to the VM Service is taking longer than expected...');
     } else if (attempts == 20) {
-      globals.printStatus('Still attempting to connect to the Observatory...');
+      globals.printStatus('Still attempting to connect to the VM Service...');
       globals.printStatus(
-        'Consider running with --host-vmservice-port to use a specific port '
-        'that is known to be available.');
+        'If you do NOT see the Flutter application running, it might have '
+        'crashed. The device logs (e.g. from adb or XCode) might have more '
+        'details.');
+      globals.printStatus(
+        'If you do see the Flutter application running on the device, try '
+        're-running with --host-vmservice-port to use a specific port known to '
+        'be available.');
     } else if (attempts % 50 == 0) {
       printVisibleTrace = globals.printStatus;
     }
 
-    printVisibleTrace('Exception attempting to connect to the Observatory: $e');
+    printVisibleTrace('Exception attempting to connect to the VM Service: $e');
     printVisibleTrace('This was attempt #$attempts. Will retry in $delay.');
 
     // Delay next attempt.

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -89,12 +89,20 @@ Future<io.WebSocket> _defaultOpenChannel(String url, {
   io.WebSocket socket;
 
   Future<void> handleError(dynamic e) async {
-    globals.printTrace('Exception attempting to connect to Observatory: $e');
-    globals.printTrace('This was attempt #$attempts. Will retry in $delay.');
-
+    void Function(String) printVisibleTrace = globals.printTrace;
     if (attempts == 10) {
-      globals.printStatus('This is taking longer than expected...');
+      globals.printStatus('Connecting to the Observatory is taking longer than expected...');
+    } else if (attempts == 20) {
+      globals.printStatus('Still attempting to connect to the Observatory...');
+      globals.printStatus(
+        'Consider running with --host-vmservice-port to use a specific port '
+        'that is known to be available.');
+    } else if (attempts % 50 == 0) {
+      printVisibleTrace = globals.printStatus;
     }
+
+    printVisibleTrace('Exception attempting to connect to the Observatory: $e');
+    printVisibleTrace('This was attempt #$attempts. Will retry in $delay.');
 
     // Delay next attempt.
     await Future<void>.delayed(delay);

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -163,7 +163,7 @@ void main() {
     FlutterVersion: () => MockFlutterVersion(),
   });
 
-  testUsingContext('VMService prints messages for Observatory connection failures', () {
+  testUsingContext('VMService prints messages for connection failures', () {
     FakeAsync().run((FakeAsync time) {
       final Uri uri = Uri.parse('ws://127.0.0.1:12345/QqL7EFEDNG0=/ws');
       unawaited(connectToVmService(uri));
@@ -176,15 +176,15 @@ void main() {
       final String statusText = testLogger.statusText;
       expect(
         statusText,
-        containsIgnoringWhitespace('Connecting to the Observatory is taking longer than expected...'),
+        containsIgnoringWhitespace('Connecting to the VM Service is taking longer than expected...'),
       );
       expect(
         statusText,
-        containsIgnoringWhitespace('Consider running with --host-vmservice-port'),
+        containsIgnoringWhitespace('try re-running with --host-vmservice-port'),
       );
       expect(
         statusText,
-        containsIgnoringWhitespace('Exception attempting to connect to the Observatory:'),
+        containsIgnoringWhitespace('Exception attempting to connect to the VM Service:'),
       );
       expect(
         statusText,

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:flutter_tools/src/base/common.dart';
+import 'package:flutter_tools/src/base/io.dart' as io;
 import 'package:flutter_tools/src/convert.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
 import 'package:mockito/mockito.dart';
@@ -12,6 +13,7 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/version.dart';
 import 'package:flutter_tools/src/vmservice.dart';
+import 'package:quiver/testing/async.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
@@ -159,6 +161,38 @@ void main() {
     verify(mockVMService.registerService('flutterVersion', 'Flutter Tools')).called(1);
   }, overrides: <Type, Generator>{
     FlutterVersion: () => MockFlutterVersion(),
+  });
+
+  testUsingContext('VMService prints messages for Observatory connection failures', () {
+    FakeAsync().run((FakeAsync time) {
+      final Uri uri = Uri.parse('ws://127.0.0.1:12345/QqL7EFEDNG0=/ws');
+      unawaited(connectToVmService(uri));
+
+      time.elapse(const Duration(seconds: 5));
+      expect(testLogger.statusText, isEmpty);
+
+      time.elapse(const Duration(minutes: 2));
+
+      final String statusText = testLogger.statusText;
+      expect(
+        statusText,
+        containsIgnoringWhitespace('Connecting to the Observatory is taking longer than expected...'),
+      );
+      expect(
+        statusText,
+        containsIgnoringWhitespace('Consider running with --host-vmservice-port'),
+      );
+      expect(
+        statusText,
+        containsIgnoringWhitespace('Exception attempting to connect to the Observatory:'),
+      );
+      expect(
+        statusText,
+        containsIgnoringWhitespace('This was attempt #50. Will retry'),
+      );
+    });
+  }, overrides: <Type, Generator>{
+    WebSocketConnector: () => failingWebSocketConnector,
   });
 
   testWithoutContext('setAssetDirectory forwards arguments correctly', () async {
@@ -322,4 +356,12 @@ class MockVMService extends Mock implements vm_service.VmService {}
 class MockFlutterVersion extends Mock implements FlutterVersion {
   @override
   Map<String, Object> toJson() => const <String, Object>{'Mock': 'Version'};
+}
+
+/// A [WebSocketConnector] that always throws an [io.SocketException].
+Future<io.WebSocket> failingWebSocketConnector(
+  String url, {
+  io.CompressionOptions compression,
+}) {
+  throw const io.SocketException('Failed WebSocket connection');
 }


### PR DESCRIPTION
## Description

If the `flutter` tool fails to connect the Observatory, it prints
"This is taking longer than expected..." and waits forever.  This
isn't very helpful.  I ran into this when using `flutter run` on a
remote host with a local emulator where I forwarded the ADB port
but forgot to forward an observatory port.

Make the tool:
* Print *what* is taking longer than expected: connecting to the
  Observatory.
* Increase in verbosity with an increase in the number of failed
  connection attempts.  Suggest using `--host-vmservice-port` to
  use a specific port.
* Print throttled error messages when run in non-verbose mode.

## Tests

I added the following tests:

* Test that `connectToVmService` prints expected messages after a delay.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*
