### PR TITLE
#14790: Extracting animation out of FadeInImage

### DIFF
--- a/packages/flutter/lib/src/widgets/animated_fade_out_fade_in.dart
+++ b/packages/flutter/lib/src/widgets/animated_fade_out_fade_in.dart
@@ -1,0 +1,135 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+
+import 'basic.dart';
+import 'framework.dart';
+import 'implicit_animations.dart';
+import 'transitions.dart';
+
+class AnimatedFadeOutFadeIn extends ImplicitlyAnimatedWidget {
+  const AnimatedFadeOutFadeIn({
+    Key key,
+    @required this.target,
+    @required this.placeholder,
+    @required this.isTargetLoaded,
+    @required this.fadeOutDuration,
+    @required this.fadeOutCurve,
+    @required this.fadeInDuration,
+    @required this.fadeInCurve,
+  }) : assert(target != null),
+       assert(placeholder != null),
+       assert(isTargetLoaded != null),
+       assert(fadeOutDuration != null),
+       assert(fadeOutCurve != null),
+       assert(fadeInDuration != null),
+       assert(fadeInCurve != null),
+       super(key: key, duration: fadeInDuration + fadeOutDuration);
+
+  final Widget target;
+  final Widget placeholder;
+  final bool isTargetLoaded;
+  final Duration fadeInDuration;
+  final Duration fadeOutDuration;
+  final Curve fadeInCurve;
+  final Curve fadeOutCurve;
+
+  @override
+  _AnimatedFadeOutFadeInState createState() => _AnimatedFadeOutFadeInState();
+}
+
+class _AnimatedFadeOutFadeInState extends ImplicitlyAnimatedWidgetState<AnimatedFadeOutFadeIn> {
+  Tween<double> _targetOpacity;
+  Tween<double> _placeholderOpacity;
+  Animation<double> _targetOpacityAnimation;
+  Animation<double> _placeholderOpacityAnimation;
+
+  @override
+  void forEachTween(TweenVisitor<dynamic> visitor) {
+    _targetOpacity = visitor(
+      _targetOpacity,
+      widget.isTargetLoaded ? 1.0 : 0.0,
+      (dynamic value) => Tween<double>(begin: value as double),
+    ) as Tween<double>;
+    _placeholderOpacity = visitor(
+      _placeholderOpacity,
+      widget.isTargetLoaded ? 0.0 : 1.0,
+      (dynamic value) => Tween<double>(begin: value as double),
+    ) as Tween<double>;
+  }
+
+  @override
+  void didUpdateTweens() {
+    _placeholderOpacityAnimation = animation.drive(TweenSequence<double>(<TweenSequenceItem<double>>[
+      TweenSequenceItem<double>(
+        tween: _placeholderOpacity.chain(CurveTween(curve: widget.fadeOutCurve)),
+        weight: widget.fadeOutDuration.inMilliseconds.toDouble(),
+      ),
+      TweenSequenceItem<double>(
+        tween: ConstantTween<double>(0),
+        weight: widget.fadeInDuration.inMilliseconds.toDouble(),
+      ),
+    ]))..addStatusListener((AnimationStatus status) {
+      if (_placeholderOpacityAnimation.isCompleted) {
+        // Need to rebuild to remove placeholder now that it is invisibile.
+        setState(() {});
+      }
+    });
+
+    _targetOpacityAnimation = animation.drive(TweenSequence<double>(<TweenSequenceItem<double>>[
+      TweenSequenceItem<double>(
+        tween: ConstantTween<double>(0),
+        weight: widget.fadeOutDuration.inMilliseconds.toDouble(),
+      ),
+      TweenSequenceItem<double>(
+        tween: _targetOpacity.chain(CurveTween(curve: widget.fadeInCurve)),
+        weight: widget.fadeInDuration.inMilliseconds.toDouble(),
+      ),
+    ]));
+    if (!widget.isTargetLoaded && _isValid(_placeholderOpacity) && _isValid(_targetOpacity)) {
+      // Jump (don't fade) back to the placeholder image, so as to be ready
+      // for the full animation when the new target image becomes ready.
+      controller.value = controller.upperBound;
+    }
+  }
+
+  bool _isValid(Tween<double> tween) {
+    return tween.begin != null && tween.end != null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Widget target = FadeTransition(
+      opacity: _targetOpacityAnimation,
+      child: widget.target,
+    );
+
+    if (_placeholderOpacityAnimation.isCompleted) {
+      return target;
+    }
+
+    return Stack(
+      fit: StackFit.passthrough,
+      alignment: AlignmentDirectional.center,
+      // Text direction is irrelevant here since we're using center alignment,
+      // but it allows the Stack to avoid a call to Directionality.of()
+      textDirection: TextDirection.ltr,
+      children: <Widget>[
+        target,
+        FadeTransition(
+          opacity: _placeholderOpacityAnimation,
+          child: widget.placeholder,
+        ),
+      ],
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Animation<double>>('targetOpacity', _targetOpacityAnimation));
+    properties.add(DiagnosticsProperty<Animation<double>>('placeholderOpacity', _placeholderOpacityAnimation));
+  }
+}

--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -120,7 +120,7 @@ class FadeInImage extends StatelessWidget {
   /// null.
   ///
   /// If [excludeFromSemantics] is true, then [imageSemanticLabel] will be ignored.
-  FadeInImage({
+  const FadeInImage({
     Key key,
     @required this.placeholder,
     this.placeholderErrorBuilder,
@@ -138,13 +138,13 @@ class FadeInImage extends StatelessWidget {
     this.alignment = Alignment.center,
     this.repeat = ImageRepeat.noRepeat,
     this.matchTextDirection = false,
-    FadeInImageAnimationBuilder animationBuilder,
+    this.animationBuilder,
   }) : assert(placeholder != null),
        assert(image != null),
        assert(alignment != null),
        assert(repeat != null),
        assert(matchTextDirection != null),
-       animationBuilder = animationBuilder ?? _defaultAnimationBuilder(fadeOutDuration, fadeOutCurve, fadeInDuration, fadeInCurve),
+       assert(animationBuilder != null || (fadeOutDuration != null && fadeOutCurve != null && fadeInDuration != null && fadeInCurve != null)),
        super(key: key);
 
   /// Creates a widget that uses a placeholder image stored in memory while
@@ -202,7 +202,7 @@ class FadeInImage extends StatelessWidget {
     int placeholderCacheHeight,
     int imageCacheWidth,
     int imageCacheHeight,
-    FadeInImageAnimationBuilder animationBuilder,
+    this.animationBuilder,
   }) : assert(placeholder != null),
        assert(image != null),
        assert(placeholderScale != null),
@@ -210,9 +210,9 @@ class FadeInImage extends StatelessWidget {
        assert(alignment != null),
        assert(repeat != null),
        assert(matchTextDirection != null),
+       assert(animationBuilder != null || (fadeOutDuration != null && fadeOutCurve != null && fadeInDuration != null && fadeInCurve != null)),
        placeholder = ResizeImage.resizeIfNeeded(placeholderCacheWidth, placeholderCacheHeight, MemoryImage(placeholder, scale: placeholderScale)),
        image = ResizeImage.resizeIfNeeded(imageCacheWidth, imageCacheHeight, NetworkImage(image, scale: imageScale)),
-       animationBuilder = animationBuilder ?? _defaultAnimationBuilder(fadeOutDuration, fadeOutCurve, fadeInDuration, fadeInCurve),
        super(key: key);
 
   /// Creates a widget that uses a placeholder image stored in an asset bundle
@@ -274,7 +274,7 @@ class FadeInImage extends StatelessWidget {
     int placeholderCacheHeight,
     int imageCacheWidth,
     int imageCacheHeight,
-    FadeInImageAnimationBuilder animationBuilder,
+    this.animationBuilder,
   }) : assert(placeholder != null),
        assert(image != null),
        placeholder = placeholderScale != null
@@ -284,8 +284,8 @@ class FadeInImage extends StatelessWidget {
        assert(alignment != null),
        assert(repeat != null),
        assert(matchTextDirection != null),
+       assert(animationBuilder != null || (fadeOutDuration != null && fadeOutCurve != null && fadeInDuration != null && fadeInCurve != null)),
        image = ResizeImage.resizeIfNeeded(imageCacheWidth, imageCacheHeight, NetworkImage(image, scale: imageScale)),
-       animationBuilder = animationBuilder ?? _defaultAnimationBuilder(fadeOutDuration, fadeOutCurve, fadeInDuration, fadeInCurve),
        super(key: key);
 
   /// Image displayed while the target [image] is loading.
@@ -413,16 +413,7 @@ class FadeInImage extends StatelessWidget {
 
   /// The default animation used to maintain backwards compatibility used during
   /// construction. The parameters passed through the contructor for 
-  static FadeInImageAnimationBuilder _defaultAnimationBuilder(
-    Duration fadeOutDuration, 
-    Curve fadeOutCurve, 
-    Duration fadeInDuration, 
-    Curve fadeInCurve,
-  ){
-    assert(fadeOutDuration != null);
-    assert(fadeOutCurve != null);
-    assert(fadeInDuration != null);
-    assert(fadeInCurve != null);
+  FadeInImageAnimationBuilder _defaultAnimationBuilder() {
     return (Widget target, Widget placeholder, bool isTargetLoaded) => AnimatedFadeOutFadeIn(
       target: target,
       placeholder: placeholder,
@@ -463,7 +454,8 @@ class FadeInImage extends StatelessWidget {
       frameBuilder: (BuildContext context, Widget child, int frame, bool wasSynchronouslyLoaded) {
         if (wasSynchronouslyLoaded)
           return child;
-        return animationBuilder(child, _image(image: placeholder, errorBuilder: placeholderErrorBuilder), frame != null);
+        final FadeInImageAnimationBuilder builder = animationBuilder ?? _defaultAnimationBuilder();
+        return builder(child, _image(image: placeholder, errorBuilder: placeholderErrorBuilder), frame != null);
       },
     );
 

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -16,6 +16,7 @@ export 'package:vector_math/vector_math_64.dart' show Matrix4;
 
 export 'src/widgets/actions.dart';
 export 'src/widgets/animated_cross_fade.dart';
+export 'src/widgets/animated_fade_out_fade_in.dart';
 export 'src/widgets/animated_list.dart';
 export 'src/widgets/animated_size.dart';
 export 'src/widgets/animated_switcher.dart';


### PR DESCRIPTION
## Description

This is an alternate approach to #14790 (other PR is #57223). This is raised as an alternate PR to keep the ideas separate and facilitate discussion. I'm happy to close off either, as appropriate.

`FadeInImage` now has the animation strategy provided in a constructor parameter. This allows consumers of `FadeInImage` to decide how to fade between the placeholder and target image without requiring a class for each in the framework (which is effectively what #57223 is doing).

## Related Issues

- Issue #14790 
- PR (also raised by me) #57223 .

## Tests

I added the following tests:

- `FadeInImage` tests pass without modification, confirming backwards compatibility.
- None, yet, for `AnimatedFadeOutFadeIn`. This will be completed after discussion.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
