### PR TITLE
[flutter_tools] handle missing null check in manifest parser

### DIFF
--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -565,7 +565,9 @@ class ApkManifestData {
     }
 
     final _Element application = manifest.firstElement('application');
-    assert(application != null);
+    if (application == null) {
+      return null;
+    }
 
     final Iterable<_Element> activities = application.allElements('activity');
 

--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -206,6 +206,12 @@ void main() {
       expect(data.packageName, 'io.flutter.examples.hello_world');
       expect(data.launchableActivityName, 'io.flutter.examples.hello_world.MainActivity');
     }, overrides: noColorTerminalOverride);
+
+    testUsingContext('Parses manifest with missing application tag', () async {
+      final ApkManifestData data = ApkManifestData.parseFromXmlDump(_aaptDataWithoutApplication);
+
+      expect(data, isNull);
+    });
   });
 
   group('PrebuiltIOSApp', () {
@@ -642,6 +648,26 @@ N: android=http://schemas.android.com/apk/res/android
               A: android:name(0x01010003)="android.intent.action.MAIN" (Raw: "android.intent.action.MAIN")
             E: category (line=46)
               A: android:name(0x01010003)="android.intent.category.LAUNCHER" (Raw: "android.intent.category.LAUNCHER")
+''';
+
+const String _aaptDataWithoutApplication = '''
+N: android=http://schemas.android.com/apk/res/android
+  N: dist=http://schemas.android.com/apk/distribution
+    E: manifest (line=7)
+      A: android:versionCode(0x0101021b)=(type 0x10)0x1
+      A: android:versionName(0x0101021c)="1.0" (Raw: "1.0")
+      A: android:compileSdkVersion(0x01010572)=(type 0x10)0x1c
+      A: android:compileSdkVersionCodename(0x01010573)="9" (Raw: "9")
+      A: package="io.flutter.examples.hello_world" (Raw: "io.flutter.examples.hello_world")
+      A: platformBuildVersionCode=(type 0x10)0x1
+      A: platformBuildVersionName=(type 0x4)0x3f800000
+      E: uses-sdk (line=13)
+        A: android:minSdkVersion(0x0101020c)=(type 0x10)0x10
+        A: android:targetSdkVersion(0x01010270)=(type 0x10)0x1c
+      E: dist:module (line=17)
+        A: dist:instant=(type 0x12)0xffffffff
+      E: uses-permission (line=24)
+        A: android:name(0x01010003)="android.permission.INTERNET" (Raw: "android.permission.INTERNET")
 ''';
 
 


### PR DESCRIPTION
## Description

This assert should have been a null check to prevent an NPE when `<application>` is missing from the android manifest.

Fixes https://github.com/flutter/flutter/issues/57281