### PR TITLE
Fix CMake invocation for 3.10 compat

### DIFF
--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
+++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
@@ -81,20 +81,20 @@ Future<void> buildLinux(
 Future<void> _runCmake(String buildModeName, Directory sourceDir, Directory buildDir) async {
   final Stopwatch sw = Stopwatch()..start();
 
+  await buildDir.create(recursive: true);
+
   final String buildFlag = toTitleCase(buildModeName);
   int result;
   try {
     result = await processUtils.stream(
       <String>[
         'cmake',
-        '-S',
-        sourceDir.path,
-        '-B',
-        buildDir.path,
         '-G',
         'Ninja',
         '-DCMAKE_BUILD_TYPE=$buildFlag',
+        sourceDir.path,
       ],
+      workingDirectory: buildDir.path,
       environment: <String, String>{
         'CC': 'clang',
         'CXX': 'clang++'


### PR DESCRIPTION
## Description

The -S/-B format of specifying source and build directories wasn't added
until 3.13. For 3.10 compatibility, use the older form of having the
working directory as the build directory, and the last argument as the
source directory.

## Related Issues

Fixes #57409

## Tests

I added the following tests: None; updated existing tests to expect the older command line format.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
