### PR TITLE
[flutter_tools] minor cleanups to try catch

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/icon_tree_shaker.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/icon_tree_shaker.dart
@@ -24,11 +24,10 @@ const String kIconTreeShakerFlag = 'TreeShakeIcons';
 const bool kIconTreeShakerEnabledDefault = true;
 
 List<Map<String, dynamic>> _getList(dynamic object, String errorMessage) {
-  try {
-    return (object as List<dynamic>).cast<Map<String, dynamic>>();
-  } on TypeError catch (_) {
-    throw IconTreeShakerException._(errorMessage);
+  if (object is List<dynamic>) {
+    return object.cast<Map<String, dynamic>>();
   }
+  throw IconTreeShakerException._(errorMessage);
 }
 
 /// A class that wraps the functionality of the const finder package and the

--- a/packages/flutter_tools/lib/src/mdns_discovery.dart
+++ b/packages/flutter_tools/lib/src/mdns_discovery.dart
@@ -133,11 +133,6 @@ class MDnsObservatoryDiscovery {
         authCode += '/';
       }
       return MDnsObservatoryDiscoveryResult(srv.first.port, authCode);
-    } on OSError catch (e) {
-      // OSError is neither an Error nor and Exception, so we wrap it in a
-      // SocketException and rethrow.
-      // See: https://github.com/dart-lang/sdk/issues/40934
-      throw SocketException('mdns query failed', osError: e);
     } finally {
       client.stop();
     }

--- a/packages/flutter_tools/test/general.shard/mdns_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/mdns_discovery_test.dart
@@ -193,7 +193,7 @@ void main() {
       expect(port, isNull);
     });
 
-    testUsingContext('Throws SocketException when client throws OSError on start', () async {
+    testUsingContext('Throws Exception when client throws OSError on start', () async {
       final MDnsClient client = MockMDnsClient();
       when(client.start()).thenAnswer((_) {
         throw const OSError('Operation not suppoted on socket', 102);
@@ -204,7 +204,7 @@ void main() {
       );
       expect(
         () async => await portDiscovery.query(),
-        throwsA(isA<SocketException>()),
+        throwsA(isA<Exception>()),
       );
     });
   });


### PR DESCRIPTION
## Description

Clean up some minor try/catch issues found while browsing code.

- OsError now implements exception, remove workaround.
- Prefer `is` check to catching `TypeError`