### PR TITLE
SnackBarAction.createState() should have return type State<SnackBarAction>

### DIFF
--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -107,7 +107,7 @@ class SnackBarAction extends StatefulWidget {
   final VoidCallback onPressed;
 
   @override
-  _SnackBarActionState createState() => _SnackBarActionState();
+  State<SnackBarAction> createState() => _SnackBarActionState();
 }
 
 class _SnackBarActionState extends State<SnackBarAction> {


### PR DESCRIPTION
## Description

I propose to return a generic `State` object, because returning a concrete `_SnackBarActionState` class makes `SnackBarAction` non-extendable. The subclass would want to have its own `State` impementation.

For example, the user wants to have `IconButton` instead of `FlatButton` in `SnackBarAction`. With the proposed change, he would create his own custom `SnackBarAction`:

```dart
class IconSnackBarAction extends StatefulWidget implements SnackBarAction {
  const IconSnackBarAction({
    Key key,
    this.textColor,
    this.disabledTextColor,
    @required this.label,
    @required this.onPressed,
  })  : assert(label != null),
        assert(onPressed != null),
        super(key: key);

  final Color textColor;
  final Color disabledTextColor;
  final String label;
  final VoidCallback onPressed;

  @override
  State<SnackBarAction> createState() => _IconSnackBarActionState();
}

class _IconSnackBarActionState extends State<SnackBarAction> {
  bool _haveTriggeredAction = false;

  void _handlePressed() {
    if (_haveTriggeredAction) return;
    setState(() {
      _haveTriggeredAction = true;
    });
    widget.onPressed();
    Scaffold.of(context)
        .hideCurrentSnackBar(reason: SnackBarClosedReason.action);
  }

  @override
  Widget build(BuildContext context) {
    return IconButton(
      onPressed: _haveTriggeredAction ? null : _handlePressed,
      icon: Icon(
        Icons.check_circle,
        color: Colors.red,
      ),
    );
  }
}
```

Usage:

![Simulator Screen Shot - iPhone 11 Pro - 2020-05-12 at 13 18 12](https://user-images.githubusercontent.com/2883524/81672623-12649700-9453-11ea-833f-5f63cccd5f07.png)

## Related Issues

No related issues found by me.

## Tests

I didn't add any tests because no behavior changed.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (Please read [Handling breaking changes]). *Replace this with a link to the e-mail where you asked for input on this proposed change.*
- [x] No, this is *not* a breaking change.


@HansMuller can you please review?