### PR TITLE
Report the accurate local position in (sliding)segmented control hit testing 

### DIFF
--- a/packages/flutter/lib/src/cupertino/segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/segmented_control.dart
@@ -718,13 +718,12 @@ class _RenderSegmentedControl<T> extends RenderBox
     while (child != null) {
       final _SegmentedControlContainerBoxParentData childParentData = child.parentData as _SegmentedControlContainerBoxParentData;
       if (childParentData.surroundingRect.contains(position)) {
-        final Offset center = (Offset.zero & child.size).center;
-        return result.addWithRawTransform(
-          transform: MatrixUtils.forceToPoint(center),
-          position: center,
-          hitTest: (BoxHitTestResult result, Offset position) {
-            assert(position == center);
-            return child.hitTest(result, position: center);
+        return result.addWithPaintOffset(
+          offset: childParentData.offset,
+          position: position,
+          hitTest: (BoxHitTestResult result, Offset localOffset) {
+            assert(localOffset == position - childParentData.offset);
+            return child.hitTest(result, position: localOffset);
           },
         );
       }

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -1025,13 +1025,12 @@ class _RenderSegmentedControl<T> extends RenderBox
       final _SegmentedControlContainerBoxParentData childParentData =
         child.parentData as _SegmentedControlContainerBoxParentData;
       if ((childParentData.offset & child.size).contains(position)) {
-        final Offset center = (Offset.zero & child.size).center;
-        return result.addWithRawTransform(
-          transform: MatrixUtils.forceToPoint(center),
-          position: center,
-          hitTest: (BoxHitTestResult result, Offset position) {
-            assert(position == center);
-            return child.hitTest(result, position: center);
+        return result.addWithPaintOffset(
+          offset: childParentData.offset,
+          position: position,
+          hitTest: (BoxHitTestResult result, Offset localOffset) {
+            assert(localOffset == position - childParentData.offset);
+            return child.hitTest(result, position: localOffset);
           },
         );
       }

--- a/packages/flutter/test/cupertino/segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/segmented_control_test.dart
@@ -926,6 +926,46 @@ void main() {
     expect(sharedValue, 0);
   });
 
+  testWidgets('Hit-tests report accurate local position in segments', (WidgetTester tester) async {
+    final Map<int, Widget> children = <int, Widget>{};
+    TapDownDetails tapDownDetails;
+    children[0] = GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTapDown: (TapDownDetails details) { tapDownDetails = details; },
+      child: const SizedBox(width: 200, height: 200),
+    );
+    children[1] = const Text('Child 2');
+
+    int sharedValue = 1;
+
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          return boilerplate(
+            child: CupertinoSegmentedControl<int>(
+              key: const ValueKey<String>('Segmented Control'),
+              children: children,
+              onValueChanged: (int newValue) {
+                setState(() {
+                  sharedValue = newValue;
+                });
+              },
+              groupValue: sharedValue,
+            ),
+          );
+        },
+      ),
+    );
+
+    expect(sharedValue, 1);
+
+    final Offset segment0GlobalOffset = tester.getTopLeft(find.byWidget(children[0]));
+    await tester.tapAt(segment0GlobalOffset + const Offset(7, 11));
+
+    expect(tapDownDetails.localPosition, const Offset(7, 11));
+    expect(tapDownDetails.globalPosition, segment0GlobalOffset + const Offset(7, 11));
+  });
+
   testWidgets(
     'Segment still hittable with a child that has no hitbox',
     (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
@@ -783,6 +783,38 @@ void main() {
     expect(groupValue, 1);
   });
 
+  testWidgets('Hit-tests report accurate local position in segments', (WidgetTester tester) async {
+    final Map<int, Widget> children = <int, Widget>{};
+    TapDownDetails tapDownDetails;
+    children[0] = GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTapDown: (TapDownDetails details) { tapDownDetails = details; },
+      child: const SizedBox(width: 200, height: 200),
+    );
+    children[1] = const Text('Child 2');
+
+    await tester.pumpWidget(
+      boilerplate(
+        builder: (BuildContext context) {
+          return CupertinoSlidingSegmentedControl<int>(
+            key: const ValueKey<String>('Segmented Control'),
+            children: children,
+            groupValue: groupValue,
+            onValueChanged: defaultCallback,
+          );
+        },
+      ),
+    );
+
+    expect(groupValue, 0);
+
+    final Offset segment0GlobalOffset = tester.getTopLeft(find.byWidget(children[0]));
+    await tester.tapAt(segment0GlobalOffset + const Offset(7, 11));
+
+    expect(tapDownDetails.localPosition, const Offset(7, 11));
+    expect(tapDownDetails.globalPosition, segment0GlobalOffset + const Offset(7, 11));
+  });
+
   testWidgets('Thumb animation is correct when the selected segment changes', (WidgetTester tester) async {
     await tester.pumpWidget(setupSimpleSegmentedControl());
 


### PR DESCRIPTION
## Description

Same as #57504. I think I messed up the remote in that PR.

Ideally `forceToPoint` shouldn't be used in non-leaf widgets whose children may also be interested in the locations of the pointer events and can be properly hit-tested.

The remaining render objects that use `forceToPoint` for hit-testing are: `_RenderChipRedirectingHitDetection` (chip), `_RenderChip`, and `_RenderInputPadding` (button). They all seem to be deliberately redirecting the hit tests to their descendants.

## Related Issues

prompted by https://github.com/flutter/flutter/issues/57326

## Tests

I added the following tests:

- Hit-tests report accurate local position in segments

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.