### PR TITLE
Add doc and test for Container's hitTest behavior

### DIFF
--- a/packages/flutter/lib/src/widgets/container.dart
+++ b/packages/flutter/lib/src/widgets/container.dart
@@ -184,6 +184,10 @@ class DecoratedBox extends SingleChildRenderObjectWidget {
 /// `width`, `height`, and [constraints] arguments to the constructor override
 /// this.
 ///
+/// A container by itself is hittable during a hit test if and only if it has
+/// [color], [decoration], or [foregroundDecoration]. By using decorations,
+/// the hittability will be decided by [Decoration.hitTest].
+///
 /// ## Layout behavior
 ///
 /// _See [BoxConstraints] for an introduction to box layout models._

--- a/packages/flutter/lib/src/widgets/container.dart
+++ b/packages/flutter/lib/src/widgets/container.dart
@@ -184,9 +184,10 @@ class DecoratedBox extends SingleChildRenderObjectWidget {
 /// `width`, `height`, and [constraints] arguments to the constructor override
 /// this.
 ///
-/// A container by itself is hittable during a hit test if and only if it has
-/// [color], [decoration], or [foregroundDecoration]. By using decorations,
-/// the hittability will be decided by [Decoration.hitTest].
+/// By default, containers return false for all hit tests. If the [color]
+/// property is specified, the hit testing is handled by [ColoredBox], which
+/// always returns true. If the [decoration] or [foregroundDecoration] properties
+/// are specified, hit testing is handled by [Decoration.hitTest].
 ///
 /// ## Layout behavior
 ///

--- a/packages/flutter/test/widgets/container_test.dart
+++ b/packages/flutter/test/widgets/container_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 import 'package:mockito/mockito.dart';
@@ -501,6 +502,60 @@ void main() {
       find.byType(ClipPath),
       findsOneWidget,
     );
+  });
+
+  testWidgets('Container is hittable only when having decorations', (WidgetTester tester) async {
+    bool tapped = false;
+    await tester.pumpWidget(GestureDetector(
+      onTap: () { tapped = true; },
+      child: Container(
+        decoration: const BoxDecoration(color: Colors.black),
+      ),
+    ));
+
+    await tester.tap(find.byType(Container));
+    expect(tapped, true);
+    tapped = false;
+
+    await tester.pumpWidget(GestureDetector(
+      onTap: () { tapped = true; },
+      child: Container(
+        foregroundDecoration: const BoxDecoration(color: Colors.black),
+      ),
+    ));
+
+    await tester.tap(find.byType(Container));
+    expect(tapped, true);
+    tapped = false;
+
+    await tester.pumpWidget(GestureDetector(
+      onTap: () { tapped = true; },
+      child: Container(
+        color: Colors.black,
+      ),
+    ));
+
+    await tester.tap(find.byType(Container));
+    expect(tapped, true);
+    tapped = false;
+
+    // Everything but color or decorations
+    await tester.pumpWidget(GestureDetector(
+      onTap: () { tapped = true; },
+      child: Center(
+        child: Container(
+          alignment: Alignment.bottomRight,
+          padding: const EdgeInsets.all(2),
+          width: 50,
+          height: 50,
+          margin: const EdgeInsets.all(2),
+          transform: Matrix4.rotationZ(1),
+        ),
+      ),
+    ));
+
+    await tester.tap(find.byType(Container));
+    expect(tapped, false);
   });
 }
 


### PR DESCRIPTION
## Description

A lot of people use Container as a hit test target. This PR adds docs and tests for container's hit test behavior.

## Related Issues

- Raised by https://github.com/flutter/flutter/issues/49919
- We plan to make hittesting transparent Container an assertion (https://github.com/flutter/flutter/issues/51000)

## Tests

I added the following tests:

- Container is hittable if and only if it has color or any decorations

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
