### PR TITLE
Update the requirements for applying the elevation overlay.

### DIFF
--- a/packages/flutter/lib/src/material/elevation_overlay.dart
+++ b/packages/flutter/lib/src/material/elevation_overlay.dart
@@ -14,19 +14,19 @@ import 'theme.dart';
 /// This is an internal implementation class and should not be exported by
 /// the material package.
 class ElevationOverlay {
-  // This class is not meant to be instatiated or extended; this constructor
+  // This class is not meant to be instantiated or extended; this constructor
   // prevents instantiation and extension.
   // ignore: unused_element
   ElevationOverlay._();
 
-  /// Applies an elevation overlay color to a surface color to indicate
+  /// Applies an elevation overlay color to a given color to indicate
   /// the level of elevation in a dark theme.
   ///
-  /// If the surrounding [Theme.applyElevationOverlayColor] is true, and
-  /// [color] is [Theme.colorScheme.surface] then this will return
-  /// a version of the given color with a semi-transparent [Theme.colorScheme.onSurface]
-  /// overlaid on top of it. The opacity of the overlay is controlled by the
-  /// [elevation].
+  /// If the ambient [ThemeData.applyElevationOverlayColor] is true,
+  /// and [ThemeData.brightness] is [Brightness.dark] then this will return
+  /// a version of the given color with a semi-transparent
+  /// [ThemeData.colorScheme.onSurface] overlaid on top of it. The opacity
+  /// of the overlay is computed based on the [elevation].
   ///
   /// Otherwise it will just return the [color] unmodified.
   ///
@@ -39,7 +39,7 @@ class ElevationOverlay {
     final ThemeData theme = Theme.of(context);
     if (elevation > 0.0 &&
         theme.applyElevationOverlayColor &&
-        color == theme.colorScheme.surface) {
+        theme.brightness == Brightness.dark) {
 
       return Color.alphaBlend(overlayColor(context, elevation), color);
     }

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -227,9 +227,9 @@ class Material extends StatefulWidget {
   /// [MaterialType.transparency].
   ///
   /// To support dark themes, if the surrounding
-  /// [ThemeData.applyElevationOverlayColor] is true then a semi-transparent
-  /// overlay color will be composited on top this color to indicate
-  /// the elevation.
+  /// [ThemeData.applyElevationOverlayColor] is true and [ThemeData.brightness]
+  /// is [Brightness.dark] then a semi-transparent overlay color will be
+  /// composited on top of this color to indicate the elevation.
   ///
   /// By default, the color is derived from the [type] of material.
   final Color color;

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -933,12 +933,13 @@ class ThemeData with Diagnosticable {
   /// elevation of a surface should be portrayed with an "overlay" in addition
   /// to the shadow. As the elevation of the component increases, the
   /// overlay increases in opacity. [applyElevationOverlayColor] turns the
-  /// application of this overlay on or off.
+  /// application of this overlay on or off for dark themes.
   ///
-  /// If [true] a semi-transparent version of [colorScheme.onSurface] will be
-  /// applied on top of the color of [Material] widgets when their [Material.color]
-  /// is [colorScheme.surface]. The level of transparency is based on
-  /// [Material.elevation] as per the Material Dark theme specification.
+  /// If [true] and [brightness] is [Brightness.dark], a
+  /// semi-transparent version of [colorScheme.onSurface] will be
+  /// applied on top of the color of [Material] widgets. The level of
+  /// transparency is based on [Material.elevation] as per the
+  /// Material Dark theme specification.
   ///
   /// If [false] the surface color will be used unmodified.
   ///
@@ -951,9 +952,9 @@ class ThemeData with Diagnosticable {
   ///
   /// See also:
   ///
-  ///  * [Material.elevation], which effects how transparent the white overlay is.
-  ///  * [Material.color], the white color overlay will only be applied of the
-  ///    material's color is [colorScheme.surface].
+  ///  * [Material.elevation], which effects the level of transparency of the
+  ///    overlay color.
+  ///  * [Material.color], the elevation overlay will be applied to this color.
   ///  * <https://material.io/design/color/dark-theme.html>, which specifies how
   ///    the overlay should be applied.
   final bool applyElevationOverlayColor;

--- a/packages/flutter/test/material/material_test.dart
+++ b/packages/flutter/test/material/material_test.dart
@@ -273,7 +273,7 @@ void main() {
       }
     });
 
-    testWidgets('overlay will not apply to to materials using a light theme', (WidgetTester tester) async {
+    testWidgets('overlay will not apply to materials using a light theme', (WidgetTester tester) async {
       await tester.pumpWidget(
           Theme(
             data: ThemeData(

--- a/packages/flutter/test/material/material_test.dart
+++ b/packages/flutter/test/material/material_test.dart
@@ -273,20 +273,21 @@ void main() {
       }
     });
 
-    testWidgets('overlay will only apply to materials using colorScheme.surface', (WidgetTester tester) async {
+    testWidgets('overlay will not apply to to materials using a light theme', (WidgetTester tester) async {
       await tester.pumpWidget(
           Theme(
             data: ThemeData(
               applyElevationOverlayColor: true,
-              colorScheme: const ColorScheme.dark().copyWith(surface: const Color(0xFF121212)),
+              colorScheme: const ColorScheme.light(),
             ),
             child: buildMaterial(
-                color: Colors.cyan,
-                elevation: 8.0,
+              color: Colors.cyan,
+              elevation: 8.0,
             ),
           ),
       );
       final RenderPhysicalShape model = getModel(tester);
+      // Shouldn't change, as it was under a light color scheme.
       expect(model.color, equals(Colors.cyan));
     });
 


### PR DESCRIPTION
## Description

The initial implementation of the elevation overlay for dark themes was both too loose and too restrictive in when the overlay was applied. It would only be applied if `ThemeData.applyElevationOverlay` was true, and the color it was applied to was exactly `ThemeData.colorScheme.surface`. This led to some confusion when people tried to have it apply to a `Material` widget with a color other than the color scheme's surface color.

In addition, it would apply this overlay to the color regardless of the brightness of the ambient theme. It was documented that way, but the feature really only makes sense for dark themes.

This PR updates the conditions for applying an elevation overlay to when both of the following are true:

- The ambient `ThemeData.applyElevationOverlay` is true
- The ambient `ThemeData.brightness` is `Brightness.dark`

And the color of the `Material` it is being applied to no longer matters.

## Related Issues

Fixes: #40482
Fixes: #55060

## Tests

I added the following tests:

I updated the tests to include checking these new requirements.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them?

- [x] No, no existing tests failed, so this is *not* a breaking change.
