### PR TITLE
Always show device discovery diagnostics in "flutter devices"

### DIFF
--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -60,32 +60,37 @@ class DevicesCommand extends FlutterCommand {
 
     if (boolArg('machine')) {
       await printDevicesAsJson(devices);
-    } else if (devices.isEmpty) {
-      final StringBuffer status = StringBuffer('No devices detected.');
-      status.writeln();
-      status.writeln();
-      status.writeln('Run "flutter emulators" to list and start any available device emulators.');
-      status.writeln();
-      status.write('If you expected your device to be detected, please run "flutter doctor" to diagnose potential issues. ');
-      if (timeout == null) {
-        status.write('You may also try increasing the time to wait for connected devices with the --timeout flag. ');
-      }
-      status.write('Visit https://flutter.dev/setup/ for troubleshooting tips.');
-
-      globals.printStatus(status.toString());
-      final List<String> diagnostics = await deviceManager.getDeviceDiagnostics();
-      if (diagnostics.isNotEmpty) {
-        globals.printStatus('');
-        for (final String diagnostic in diagnostics) {
-          globals.printStatus('• $diagnostic', hangingIndent: 2);
-        }
-      }
     } else {
-      globals.printStatus('${devices.length} connected ${pluralize('device', devices.length)}:\n');
-      await Device.printDevices(devices);
-    }
+      if (devices.isEmpty) {
+        final StringBuffer status = StringBuffer('No devices detected.');
+        status.writeln();
+        status.writeln();
+        status.writeln('Run "flutter emulators" to list and start any available device emulators.');
+        status.writeln();
+        status.write('If you expected your device to be detected, please run "flutter doctor" to diagnose potential issues. ');
+        if (timeout == null) {
+          status.write('You may also try increasing the time to wait for connected devices with the --timeout flag. ');
+        }
+        status.write('Visit https://flutter.dev/setup/ for troubleshooting tips.');
 
+        globals.printStatus(status.toString());
+      } else {
+        globals.printStatus('${devices.length} connected ${pluralize('device', devices.length)}:\n');
+        await Device.printDevices(devices);
+      }
+      await _printDiagnostics();
+    }
     return FlutterCommandResult.success();
+  }
+
+  Future<void> _printDiagnostics() async {
+    final List<String> diagnostics = await deviceManager.getDeviceDiagnostics();
+    if (diagnostics.isNotEmpty) {
+      globals.printStatus('');
+      for (final String diagnostic in diagnostics) {
+        globals.printStatus('• $diagnostic', hangingIndent: 2);
+      }
+    }
   }
 
   Future<void> printDevicesAsJson(List<Device> devices) async {

--- a/packages/flutter_tools/test/commands.shard/hermetic/devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/devices_test.dart
@@ -84,6 +84,25 @@ void main() {
       DeviceManager: () => _FakeDeviceManager(),
       ProcessManager: () => MockProcessManager(),
     });
+
+    testUsingContext('available devices and diagnostics', () async {
+      final DevicesCommand command = DevicesCommand();
+      await createTestCommandRunner(command).run(<String>['devices']);
+      expect(
+        testLogger.statusText,
+        '''
+2 connected devices:
+
+ephemeral • ephemeral • android-arm    • Test SDK (1.2.3) (emulator)
+webby     • webby     • web-javascript • Web SDK (1.2.4) (emulator)
+
+• Cannot connect to device ABC
+'''
+      );
+    }, overrides: <Type, Generator>{
+      DeviceManager: () => _FakeDeviceManager(),
+      ProcessManager: () => MockProcessManager(),
+    });
   });
 }
 
@@ -126,4 +145,8 @@ class _FakeDeviceManager extends DeviceManager {
   Future<List<Device>> refreshAllConnectedDevices({Duration timeout}) =>
     getAllConnectedDevices();
 
+  @override
+  Future<List<String>> getDeviceDiagnostics() => Future<List<String>>.value(
+    <String>['Cannot connect to device ABC']
+  );
 }


### PR DESCRIPTION
## Description

Always show diagnostics in `flutter devices`.  Currently only shown if no devices are found (not great when you have desktop and web features on and devices are permanently available).
```
flutter$ flutter devices
1 connected device:

Pixel 4 • 98281FFAZ005T6 • android-arm64 • Android 10 (API 29)
```
vs
```
$ flutter devices
1 connected device:

Pixel 4 • 98281FFAZ005T6 • android-arm64 • Android 10 (API 29)

• Error: iPhone is not paired with your computer. To use iPhone with Xcode, unlock it and choose to trust this computer when prompted. (code -9)
```

## Related Issues

Fixes https://github.com/flutter/flutter/issues/54388

## Tests

devices_test

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*