### PR TITLE
Slider value indicator gets disposed if it is activated

### DIFF
--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -466,16 +466,16 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
 
   @override
   void dispose() {
-    if (overlayEntry != null) {
-      overlayEntry.remove();
-      overlayEntry = null;
-    }
     interactionTimer?.cancel();
     overlayController.dispose();
     valueIndicatorController.dispose();
     enableController.dispose();
     startPositionController.dispose();
     endPositionController.dispose();
+    if (overlayEntry != null) {
+      overlayEntry.remove();
+      overlayEntry = null;
+    }
 //    print((overlayEntry == null) ? 'overlay entry is null' : 'overlay entry is not null');
 
     super.dispose();
@@ -1196,7 +1196,10 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
   }
 
   void _endInteraction() {
-    _state.overlayController.reverse();
+    if (!_state.mounted) {
+      return;
+    }
+
     if (showValueIndicator && _state.interactionTimer == null) {
       _state.valueIndicatorController.reverse();
     }
@@ -1208,6 +1211,7 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
       }
       _active = false;
     }
+    _state.overlayController.reverse();
   }
 
   void _handleDragStart(DragStartDetails details) {

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -476,7 +476,6 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
       overlayEntry.remove();
       overlayEntry = null;
     }
-//    print((overlayEntry == null) ? 'overlay entry is null' : 'overlay entry is not null');
 
     super.dispose();
   }

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -476,7 +476,6 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
       overlayEntry.remove();
       overlayEntry = null;
     }
-
     super.dispose();
   }
 
@@ -1397,22 +1396,24 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
 
     if (shouldPaintValueIndicators) {
       _state.paintBottomValueIndicator = (PaintingContext context, Offset offset) {
-        _sliderTheme.rangeValueIndicatorShape.paint(
-          context,
-          bottomThumbCenter,
-          activationAnimation: _valueIndicatorAnimation,
-          enableAnimation: _enableAnimation,
-          isDiscrete: isDiscrete,
-          isOnTop: false,
-          labelPainter: bottomLabelPainter,
-          parentBox: this,
-          sliderTheme: _sliderTheme,
-          textDirection: _textDirection,
-          thumb: bottomThumb,
-          value: bottomValue,
-          textScaleFactor: textScaleFactor,
-          sizeWithOverflow: resolvedscreenSize,
-        );
+        if (attached) {
+          _sliderTheme.rangeValueIndicatorShape.paint(
+            context,
+            bottomThumbCenter,
+            activationAnimation: _valueIndicatorAnimation,
+            enableAnimation: _enableAnimation,
+            isDiscrete: isDiscrete,
+            isOnTop: false,
+            labelPainter: bottomLabelPainter,
+            parentBox: this,
+            sliderTheme: _sliderTheme,
+            textDirection: _textDirection,
+            thumb: bottomThumb,
+            value: bottomValue,
+            textScaleFactor: textScaleFactor,
+            sizeWithOverflow: resolvedscreenSize,
+          );
+        }
       };
     }
 
@@ -1471,22 +1472,24 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
       }
 
       _state.paintTopValueIndicator = (PaintingContext context, Offset offset) {
-        _sliderTheme.rangeValueIndicatorShape.paint(
-          context,
-          topThumbCenter,
-          activationAnimation: _valueIndicatorAnimation,
-          enableAnimation: _enableAnimation,
-          isDiscrete: isDiscrete,
-          isOnTop: thumbDelta < innerOverflow,
-          labelPainter: topLabelPainter,
-          parentBox: this,
-          sliderTheme: _sliderTheme,
-          textDirection: _textDirection,
-          thumb: topThumb,
-          value: topValue,
-          textScaleFactor: textScaleFactor,
-          sizeWithOverflow: resolvedscreenSize,
-        );
+        if (attached) {
+          _sliderTheme.rangeValueIndicatorShape.paint(
+            context,
+            topThumbCenter,
+            activationAnimation: _valueIndicatorAnimation,
+            enableAnimation: _enableAnimation,
+            isDiscrete: isDiscrete,
+            isOnTop: thumbDelta < innerOverflow,
+            labelPainter: topLabelPainter,
+            parentBox: this,
+            sliderTheme: _sliderTheme,
+            textDirection: _textDirection,
+            thumb: topThumb,
+            value: topValue,
+            textScaleFactor: textScaleFactor,
+            sizeWithOverflow: resolvedscreenSize,
+          );
+        }
       };
     }
 

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -466,12 +466,18 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
 
   @override
   void dispose() {
+    if (overlayEntry != null) {
+      overlayEntry.remove();
+      overlayEntry = null;
+    }
     interactionTimer?.cancel();
     overlayController.dispose();
     valueIndicatorController.dispose();
     enableController.dispose();
     startPositionController.dispose();
     endPositionController.dispose();
+//    print((overlayEntry == null) ? 'overlay entry is null' : 'overlay entry is not null');
+
     super.dispose();
   }
 

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -1158,6 +1158,10 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
   }
 
   void _handleDragUpdate(DragUpdateDetails details) {
+    if (!_state.mounted) {
+      return;
+    }
+
     final double dragValue = _getValueFromGlobalPosition(details.globalPosition);
 
     // If no selection has been made yet, test for thumb selection again now

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -507,15 +507,15 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
 
   @override
   void dispose() {
-    if (overlayEntry != null) {
-      overlayEntry.remove();
-      overlayEntry = null;
-    }
     interactionTimer?.cancel();
     overlayController.dispose();
     valueIndicatorController.dispose();
     enableController.dispose();
     positionController.dispose();
+    if (overlayEntry != null) {
+      overlayEntry.remove();
+      overlayEntry = null;
+    }
     super.dispose();
   }
 

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -1404,20 +1404,22 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     if (isInteractive && label != null && !_valueIndicatorAnimation.isDismissed) {
       if (showValueIndicator) {
         _state.paintValueIndicator = (PaintingContext context, Offset offset) {
-          _sliderTheme.valueIndicatorShape.paint(
-            context,
-            offset + thumbCenter,
-            activationAnimation: _valueIndicatorAnimation,
-            enableAnimation: _enableAnimation,
-            isDiscrete: isDiscrete,
-            labelPainter: _labelPainter,
-            parentBox: this,
-            sliderTheme: _sliderTheme,
-            textDirection: _textDirection,
-            value: _value,
-            textScaleFactor: textScaleFactor,
-            sizeWithOverflow: screenSize.isEmpty ? size : screenSize,
-          );
+          if (attached) {
+            _sliderTheme.valueIndicatorShape.paint(
+              context,
+              offset + thumbCenter,
+              activationAnimation: _valueIndicatorAnimation,
+              enableAnimation: _enableAnimation,
+              isDiscrete: isDiscrete,
+              labelPainter: _labelPainter,
+              parentBox: this,
+              sliderTheme: _sliderTheme,
+              textDirection: _textDirection,
+              value: _value,
+              textScaleFactor: textScaleFactor,
+              sizeWithOverflow: screenSize.isEmpty ? size : screenSize,
+            );
+          }
         };
       }
     }

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -1242,6 +1242,10 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   }
 
   void _endInteraction() {
+    if (!_state.mounted) {
+      return;
+    }
+
     if (_active && _state.mounted) {
       if (onChangeEnd != null) {
         onChangeEnd(_discretize(_currentDragValue));

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -507,6 +507,10 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
 
   @override
   void dispose() {
+    if (overlayEntry != null) {
+      overlayEntry.remove();
+      overlayEntry = null;
+    }
     interactionTimer?.cancel();
     overlayController.dispose();
     valueIndicatorController.dispose();

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -1263,6 +1263,10 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   void _handleDragStart(DragStartDetails details) => _startInteraction(details.globalPosition);
 
   void _handleDragUpdate(DragUpdateDetails details) {
+    if (!_state.mounted) {
+      return;
+    }
+
     if (isInteractive) {
       final double valueDelta = details.primaryDelta / _trackRect.width;
       switch (textDirection) {

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -2791,6 +2791,12 @@ class _RectangularSliderValueIndicatorPathPainter {
     double scale,
   }) {
     assert(!sizeWithOverflow.isEmpty);
+    /// If parentBox is null this means that the Slider was removed without
+    /// disposing value indicator.
+    if (!parentBox.attached) {
+      return 0.0;
+    }
+
     const double edgePadding = 8.0;
     final double rectangleWidth = _upperRectangleWidth(labelPainter, scale, textScaleFactor);
     /// Value indicator draws on the Overlay and by using the global Offset

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -2791,11 +2791,6 @@ class _RectangularSliderValueIndicatorPathPainter {
     double scale,
   }) {
     assert(!sizeWithOverflow.isEmpty);
-    /// If parentBox is null this means that the Slider was removed without
-    /// disposing value indicator.
-    if (!parentBox.attached) {
-      return 0.0;
-    }
 
     const double edgePadding = 8.0;
     final double rectangleWidth = _upperRectangleWidth(labelPainter, scale, textScaleFactor);

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -1366,7 +1366,7 @@ void main() {
                         values: values,
                         labels: RangeLabels(values.start.toStringAsFixed(2),
                             values.end.toStringAsFixed(2)),
-                        divisions: 3,
+                        divisions: divisions,
                         onChanged: onChanged,
                       ),
                     ),

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -1338,6 +1338,111 @@ void main() {
 
   });
 
+  testWidgets('Range Slider removes value indicator from overlay if Slider gets disposed without value indicator animation completing.', (WidgetTester tester) async {
+    final ThemeData theme = _buildTheme();
+    final SliderThemeData sliderTheme = theme.sliderTheme;
+    RangeValues values = const RangeValues(0.5, 0.75);
+
+    Widget buildApp({
+      Color activeColor,
+      Color inactiveColor,
+      int divisions,
+      bool enabled = true,
+    }) {
+      final ValueChanged<RangeValues> onChanged = (RangeValues newValues) {
+        values = newValues;
+      };
+      return MaterialApp(
+        home: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Material(
+            child: Navigator(onGenerateRoute: (RouteSettings settings) {
+              return MaterialPageRoute<void>(builder: (BuildContext context) {
+                return Column(
+                  children: <Widget>[
+                    Theme(
+                      data: theme,
+                      child: RangeSlider(
+                        values: values,
+                        labels: RangeLabels(values.start.toStringAsFixed(2),
+                            values.end.toStringAsFixed(2)),
+                        divisions: 3,
+                        onChanged: onChanged,
+                      ),
+                    ),
+                    RaisedButton(
+                      child: const Text('Next'),
+                      onPressed: () {
+                        Navigator.of(context).pushReplacement(
+                          MaterialPageRoute<void>(
+                            builder: (BuildContext context) {
+                              return RaisedButton(
+                                child: const Text('Inner page'),
+                                onPressed: () => Navigator.of(context).pop(),
+                              );
+                            },
+                          ),
+                        );
+                      },
+                    ),
+                  ],
+                );
+              });
+            }),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp(divisions: 3));
+
+    final RenderBox valueIndicatorBox = tester.firstRenderObject(find.byType(Overlay));
+    RenderBox sliderBox = tester.firstRenderObject<RenderBox>(find.byType(RangeSlider));
+
+    final Offset topRight = tester.getTopRight(find.byType(RangeSlider)).translate(-24, 0);
+    final TestGesture gesture = await tester.startGesture(topRight);
+    // Wait for value indicator animation to finish.
+    await tester.pumpAndSettle();
+    expect(values.end, equals(1));
+    expect(
+      valueIndicatorBox,
+      paints
+        ..path()
+        ..path(color: sliderTheme.valueIndicatorColor)
+        ..path(color: sliderTheme.valueIndicatorColor),
+    );
+
+    expect(sliderBox, isNotNull);
+
+    await tester.tap(find.text('Next'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(
+      tester.getTopLeft(find.text('Next')),
+      paints..path(),
+    );
+
+    sliderBox = tester.firstRenderObject<RenderBox>(find.byType(RangeSlider));
+
+    expect(sliderBox,
+        paints
+          ..path(),
+    );
+
+    expect(values.end, equals(1));
+    expect(
+      valueIndicatorBox,
+      paints
+        ..path()
+    );
+
+    // Don't stop holding the value indicator.
+    await gesture.up();
+    // Wait for value indicator animation to finish.
+    await tester.pumpAndSettle();
+
+  });
+
   testWidgets('Range Slider top thumb gets stroked when overlapping', (WidgetTester tester) async {
     RangeValues values = const RangeValues(0.3, 0.7);
 

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -1397,50 +1397,37 @@ void main() {
     await tester.pumpWidget(buildApp(divisions: 3));
 
     final RenderBox valueIndicatorBox = tester.firstRenderObject(find.byType(Overlay));
-    RenderBox sliderBox = tester.firstRenderObject<RenderBox>(find.byType(RangeSlider));
-
     final Offset topRight = tester.getTopRight(find.byType(RangeSlider)).translate(-24, 0);
     final TestGesture gesture = await tester.startGesture(topRight);
     // Wait for value indicator animation to finish.
     await tester.pumpAndSettle();
-    expect(values.end, equals(1));
+
+    expect(find.byType(RangeSlider), isNotNull);
     expect(
       valueIndicatorBox,
       paints
-        ..path()
-        ..path(color: sliderTheme.valueIndicatorColor)
-        ..path(color: sliderTheme.valueIndicatorColor),
+        ..rrect(color: sliderTheme.inactiveTrackColor)
+        ..rect(color: sliderTheme.activeTrackColor)
+        ..rrect(color: sliderTheme.inactiveTrackColor),
     );
-
-    expect(sliderBox, isNotNull);
 
     await tester.tap(find.text('Next'));
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
-    expect(
-      tester.getTopLeft(find.text('Next')),
-      paints..path(),
-    );
+    await tester.pumpAndSettle();
 
-    sliderBox = tester.firstRenderObject<RenderBox>(find.byType(RangeSlider));
-
-    expect(sliderBox,
-        paints
-          ..path(),
-    );
-
-    expect(values.end, equals(1));
+    expect(find.byType(RangeSlider), findsNothing);
     expect(
       valueIndicatorBox,
-      paints
-        ..path()
+      isNot(
+         paints
+           ..rrect(color: sliderTheme.inactiveTrackColor)
+           ..rect(color: sliderTheme.activeTrackColor)
+           ..rrect(color: sliderTheme.inactiveTrackColor)
+      ),
     );
 
     // Don't stop holding the value indicator.
     await gesture.up();
-    // Wait for value indicator animation to finish.
     await tester.pumpAndSettle();
-
   });
 
   testWidgets('Range Slider top thumb gets stroked when overlapping', (WidgetTester tester) async {

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -1396,6 +1396,9 @@ void main() {
 
     await tester.pumpWidget(buildApp(divisions: 3));
 
+    /// The value indicator is added to the overlay when it is clicked or dragged.
+    /// Because both of these gestures are occurring then it adds same value indicator
+    /// twice into the overlay.
     final RenderBox valueIndicatorBox = tester.firstRenderObject(find.byType(Overlay));
     final Offset topRight = tester.getTopRight(find.byType(RangeSlider)).translate(-24, 0);
     final TestGesture gesture = await tester.startGesture(topRight);

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -1972,7 +1972,7 @@ void main() {
                       key: sliderKey,
                       min: 0.0,
                       max: 100.0,
-                      divisions: 10,
+                      divisions: divisions,
                       label: '${value.round()}',
                       value: value,
                       onChanged: (double newValue) {
@@ -2015,8 +2015,8 @@ void main() {
     expect(
       valueIndicatorBox,
       paints
-        ..rrect(color: const Color(0xff2196f3)) // active track
-        ..rrect(color: const Color(0x3d2196f3)), // inactive
+        ..rrect(color: const Color(0xff2196f3)) // Active track.
+        ..rrect(color: const Color(0x3d2196f3)), // Inactive track.
     );
 
     await tester.tap(find.text('Next'));
@@ -2027,9 +2027,9 @@ void main() {
       valueIndicatorBox,
       isNot(
           paints
-            ..rrect(color: const Color(0xff2196f3)) // active track
-            ..rrect(color: const Color(0x3d2196f3))
-      ), //inactive
+            ..rrect(color: const Color(0xff2196f3)) // Active track.
+            ..rrect(color: const Color(0x3d2196f3)) // Inactive track.
+      ),
     );
 
     // Don't stop holding the value indicator.

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -1949,6 +1949,94 @@ void main() {
     await gesture.up();
   });
 
+  testWidgets('Slider removes value indicator from overlay if Slider gets disposed without value indicator animation completing.', (WidgetTester tester) async {
+    final Key sliderKey = UniqueKey();
+    double value = 0.0;
+
+
+    Widget buildApp({
+      Color activeColor,
+      Color inactiveColor,
+      int divisions,
+      bool enabled = true,
+    }) {
+      return MaterialApp(
+        home: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Material(
+            child: Navigator(onGenerateRoute: (RouteSettings settings) {
+              return MaterialPageRoute<void>(builder: (BuildContext context) {
+                return Column(
+                  children: <Widget>[
+                    Slider(
+                      key: sliderKey,
+                      min: 0.0,
+                      max: 100.0,
+                      divisions: 10,
+                      label: '${value.round()}',
+                      value: value,
+                      onChanged: (double newValue) {
+                        value = newValue;
+                      },
+                    ),
+                    RaisedButton(
+                      child: const Text('Next'),
+                      onPressed: () {
+                        Navigator.of(context).pushReplacement(
+                          MaterialPageRoute<void>(
+                            builder: (BuildContext context) {
+                              return RaisedButton(
+                                child: const Text('Inner page'),
+                                onPressed: () => Navigator.of(context).pop(),
+                              );
+                            },
+                          ),
+                        );
+                      },
+                    ),
+                  ],
+                );
+              });
+            }),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp(divisions: 3));
+
+    final RenderBox valueIndicatorBox = tester.firstRenderObject(find.byType(Overlay));
+    final Offset topRight = tester.getTopRight(find.byType(Slider)).translate(-24, 0);
+    final TestGesture gesture = await tester.startGesture(topRight);
+    // Wait for value indicator animation to finish.
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Slider), isNotNull);
+    expect(
+      valueIndicatorBox,
+      paints
+        ..rrect(color: const Color(0xff2196f3)) // active track
+        ..rrect(color: const Color(0x3d2196f3)), // inactive
+    );
+
+    await tester.tap(find.text('Next'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Slider), findsNothing);
+    expect(
+      valueIndicatorBox,
+      isNot(
+          paints
+            ..rrect(color: const Color(0xff2196f3)) // active track
+            ..rrect(color: const Color(0x3d2196f3))
+      ), //inactive
+    );
+
+    // Don't stop holding the value indicator.
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+
   testWidgets('Slider.adaptive', (WidgetTester tester) async {
     double value = 0.5;
 

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -1953,7 +1953,6 @@ void main() {
     final Key sliderKey = UniqueKey();
     double value = 0.0;
 
-
     Widget buildApp({
       Color activeColor,
       Color inactiveColor,

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -2004,6 +2004,9 @@ void main() {
 
     await tester.pumpWidget(buildApp(divisions: 3));
 
+    /// The value indicator is added to the overlay when it is clicked or dragged.
+    /// Because both of these gestures are occurring then it adds same value indicator
+    /// twice into the overlay.
     final RenderBox valueIndicatorBox = tester.firstRenderObject(find.byType(Overlay));
     final Offset topRight = tester.getTopRight(find.byType(Slider)).translate(-24, 0);
     final TestGesture gesture = await tester.startGesture(topRight);


### PR DESCRIPTION
## Description

Slider value indicator gets disposed even if the value indicator is active. Currently if the Slider gets removed while it is activated than the value indicator remains on the Overlay.

## Related Issues

Closes https://github.com/flutter/flutter/issues/55787

## Tests

I added the following tests:

`flutter/packages/flutter/test/material/slider_test.dart`

test using context 'Slider removes value indicator from overlay if Slider gets disposed without value indicator animation completing.'

`flutter/packages/flutter/test/material/range_slider_test.dart`

test using context 'Range Slider removes value indicator from overlay if Slider gets disposed without value indicator animation completing.'

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
