### PR TITLE
Have _warpToCurrentIndex() shortcut logic behave properly

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1269,10 +1269,8 @@ class _TabBarViewState extends State<TabBarView> {
     if ((_currentIndex - previousIndex).abs() == 1) {
       _warpUnderwayCount += 1;
       await _pageController.animateToPage(_currentIndex, duration: kTabScrollDuration, curve: Curves.ease);
-      if (!mounted)
-        return Future<void>.value();
       _warpUnderwayCount -= 1;
-      return;
+      return Future<void>.value();
     }
 
     assert((_currentIndex - previousIndex).abs() > 1);

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1266,8 +1266,14 @@ class _TabBarViewState extends State<TabBarView> {
       return Future<void>.value();
 
     final int previousIndex = _controller.previousIndex;
-    if ((_currentIndex - previousIndex).abs() == 1)
-      return _pageController.animateToPage(_currentIndex, duration: kTabScrollDuration, curve: Curves.ease);
+    if ((_currentIndex - previousIndex).abs() == 1) {
+      _warpUnderwayCount += 1;
+      await _pageController.animateToPage(_currentIndex, duration: kTabScrollDuration, curve: Curves.ease);
+      if (!mounted)
+        return Future<void>.value();
+      _warpUnderwayCount -= 1;
+      return;
+    }
 
     assert((_currentIndex - previousIndex).abs() > 1);
     final int initialPage = _currentIndex > previousIndex

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2475,4 +2475,71 @@ void main() {
 
     expect(tabBarWithText.preferredSize, tabBarWithTextChild.preferredSize);
    });
+
+  testWidgets('Setting TabController index should make TabBar indicator immediately pop into the position', (WidgetTester tester) async {
+    const List<Tab> tabs = <Tab>[
+      Tab(text: 'A'), Tab(text: 'B'), Tab(text: 'C')
+    ];
+    const Color indicatorColor = Color(0xFFFF0000);
+    TabController tabController;
+
+    Widget buildTabControllerFrame(BuildContext context, TabController controller) {
+      tabController = controller;
+      return MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(
+            bottom: TabBar(
+              controller: controller,
+              tabs: tabs,
+              indicatorColor: indicatorColor,
+            ),
+          ),
+          body: TabBarView(
+            controller: controller,
+            children: tabs.map((Tab tab) {
+              return Center(child: Text(tab.text));
+            }).toList(),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(TabControllerFrame(
+      builder: buildTabControllerFrame,
+      length: tabs.length,
+      initialIndex: 0,
+    ));
+
+    final RenderBox box = tester.renderObject(find.byType(TabBar));
+    final TabIndicatorRecordingCanvas canvas = TabIndicatorRecordingCanvas(indicatorColor);
+    final TestRecordingPaintingContext context = TestRecordingPaintingContext(canvas);
+
+    box.paint(context, Offset.zero);
+    double expectedIndicatorLeft = canvas.indicatorRect.left;
+
+    final PageView pageView = tester.widget(find.byType(PageView));
+    final PageController pageController = pageView.controller;
+    void pageControllerListener() {
+      // Whenever TabBarView scrolls due to changing TabController's index,
+      // check if indicator stays idle in its expectedIndicatorLeft
+      box.paint(context, Offset.zero);
+      expect(canvas.indicatorRect.left, expectedIndicatorLeft);
+    }
+
+    // Moving from index 0 to 2 (distanced tabs)
+    tabController.index = 2;
+    box.paint(context, Offset.zero);
+    expectedIndicatorLeft = canvas.indicatorRect.left;
+    pageController.addListener(pageControllerListener);
+    await tester.pumpAndSettle();
+    pageController.removeListener(pageControllerListener);
+
+    // Moving fromm index 2 to 1 (neighboring tabs)
+    tabController.index = 1;
+    box.paint(context, Offset.zero);
+    expectedIndicatorLeft = canvas.indicatorRect.left;
+    pageController.addListener(pageControllerListener);
+    await tester.pumpAndSettle();
+    pageController.removeListener(pageControllerListener);
+  });
 }

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2532,13 +2532,11 @@ void main() {
     expectedIndicatorLeft = canvas.indicatorRect.left;
     pageController.addListener(pageControllerListener);
     await tester.pumpAndSettle();
-    pageController.removeListener(pageControllerListener);
 
     // Moving fromm index 2 to 1 (neighboring tabs)
     tabController.index = 1;
     box.paint(context, Offset.zero);
     expectedIndicatorLeft = canvas.indicatorRect.left;
-    pageController.addListener(pageControllerListener);
     await tester.pumpAndSettle();
     pageController.removeListener(pageControllerListener);
   });

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2533,7 +2533,7 @@ void main() {
     pageController.addListener(pageControllerListener);
     await tester.pumpAndSettle();
 
-    // Moving fromm index 2 to 1 (neighboring tabs)
+    // Moving from index 2 to 1 (neighboring tabs)
     tabController.index = 1;
     box.paint(context, Offset.zero);
     expectedIndicatorLeft = canvas.indicatorRect.left;


### PR DESCRIPTION
## Description

### Before
<img src="https://user-images.githubusercontent.com/4879766/82321330-a1ebe600-9a0f-11ea-80e1-f7f61a746e33.gif" width="250" />
The tab indicator shows stuttering animation most of the times when calling `tabController.index = 0` from second tab. Rather, it should immediately pop into the first tab and stay, like calling `tabController.index = 0` from the third tab (not in the gif though sorry :()

### After
<img src="https://user-images.githubusercontent.com/4879766/82321629-1a52a700-9a10-11ea-87c1-149a84bb6860.gif" width="250" />
The tab indicator shows consistent behavior when calling `tabController.index = 0` from any tab.

### What changed

In `TabBarView`'s `_warpToCurrentIndex()` method, there's a shortcut logic when warping to the neighboring tabs. However, in this shortcut, it's missing to call `warpUnderwayCount += 1` before calling `_pageController.animateToPage(...)`. So that's what I added!

## Related Issues

#57413 

## Tests

e95850e

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
