### PR TITLE
Add Android private keystore to project gitignore

### DIFF
--- a/packages/flutter_tools/templates/app/android.tmpl/.gitignore
+++ b/packages/flutter_tools/templates/app/android.tmpl/.gitignore
@@ -5,3 +5,4 @@ gradle-wrapper.jar
 /gradlew.bat
 /local.properties
 GeneratedPluginRegistrant.java
+key.properties

--- a/packages/flutter_tools/templates/app/android.tmpl/.gitignore
+++ b/packages/flutter_tools/templates/app/android.tmpl/.gitignore
@@ -5,4 +5,7 @@ gradle-wrapper.jar
 /gradlew.bat
 /local.properties
 GeneratedPluginRegistrant.java
+
+# Remember to never publicly share your keystore.
+# See https://flutter.dev/docs/deployment/android#reference-the-keystore-from-the-app
 key.properties


### PR DESCRIPTION
## Description

gitignore the private keystore file per documentation https://flutter.dev/docs/deployment/android#reference-the-keystore-from-the-app

## Related Issues

Fixes https://github.com/flutter/flutter/issues/57401

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*