### PR TITLE
fix navigator observer announcement order

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:collection';
 import 'dart:convert';
 import 'dart:developer' as developer;
 
@@ -2335,7 +2336,7 @@ class _RouteEntry extends RouteTransitionRecord {
     return page.canUpdate(routePage);
   }
 
-  void handleAdd({ @required NavigatorState navigator}) {
+  void handleAdd({ @required NavigatorState navigator, @required Route<dynamic> previousPresent }) {
     assert(currentState == _RouteLifecycle.add);
     assert(navigator != null);
     assert(navigator._debugLocked);
@@ -2344,6 +2345,9 @@ class _RouteEntry extends RouteTransitionRecord {
     route.install();
     assert(route.overlayEntries.isNotEmpty);
     currentState = _RouteLifecycle.adding;
+    navigator._observedRouteAdditions.add(
+      _NavigatorObservation(route, previousPresent, _ObservedAction.push)
+    );
   }
 
   void handlePush({ @required NavigatorState navigator, @required bool isNewFirst, @required Route<dynamic> previous, @required Route<dynamic> previousPresent }) {
@@ -2377,12 +2381,14 @@ class _RouteEntry extends RouteTransitionRecord {
     }
 
     if (previousState == _RouteLifecycle.replace || previousState == _RouteLifecycle.pushReplace) {
-      for (final NavigatorObserver observer in navigator.widget.observers)
-        observer.didReplace(newRoute: route, oldRoute: previousPresent);
+      navigator._observedRouteAdditions.add(
+        _NavigatorObservation(route, previousPresent, _ObservedAction.replace)
+      );
     } else {
       assert(previousState == _RouteLifecycle.push);
-      for (final NavigatorObserver observer in navigator.widget.observers)
-        observer.didPush(route, previousPresent);
+      navigator._observedRouteAdditions.add(
+        _NavigatorObservation(route, previousPresent, _ObservedAction.push)
+      );
     }
   }
 
@@ -2396,8 +2402,9 @@ class _RouteEntry extends RouteTransitionRecord {
     assert(navigator._debugLocked);
     assert(route._navigator == navigator);
     currentState = _RouteLifecycle.popping;
-    for (final NavigatorObserver observer in navigator.widget.observers)
-      observer.didPop(route, previousPresent);
+    navigator._observedRouteDeletions.add(
+      _NavigatorObservation(route, previousPresent, _ObservedAction.pop)
+    );
   }
 
   void handleRemoval({ @required NavigatorState navigator, @required Route<dynamic> previousPresent }) {
@@ -2406,21 +2413,20 @@ class _RouteEntry extends RouteTransitionRecord {
     assert(route._navigator == navigator);
     currentState = _RouteLifecycle.removing;
     if (_reportRemovalToObserver) {
-      for (final NavigatorObserver observer in navigator.widget.observers)
-        observer.didRemove(route, previousPresent);
+      navigator._observedRouteDeletions.add(
+        _NavigatorObservation(route, previousPresent, _ObservedAction.remove)
+      );
     }
   }
 
   bool doingPop = false;
 
-  void didAdd({ @required NavigatorState navigator, @required bool isNewFirst, @required Route<dynamic> previous, @required Route<dynamic> previousPresent }) {
+  void didAdd({ @required NavigatorState navigator, @required bool isNewFirst}) {
     route.didAdd();
     currentState = _RouteLifecycle.idle;
     if (isNewFirst) {
       route.didChangeNext(null);
     }
-    for (final NavigatorObserver observer in navigator.widget.observers)
-      observer.didPush(route, previousPresent);
   }
 
   void pop<T>(T result) {
@@ -2579,10 +2585,30 @@ class _RouteEntry extends RouteTransitionRecord {
   }
 }
 
+enum _ObservedAction {
+  push,
+  pop,
+  remove,
+  replace,
+}
+
+class _NavigatorObservation {
+  _NavigatorObservation(
+    this.targetRoute,
+    this.previousRoute,
+    this.action,
+  );
+  final Route<dynamic> targetRoute;
+  final Route<dynamic> previousRoute;
+  final _ObservedAction action;
+}
+
 /// The state for a [Navigator] widget.
 class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
   final GlobalKey<OverlayState> _overlayKey = GlobalKey<OverlayState>();
   List<_RouteEntry> _history = <_RouteEntry>[];
+  final Queue<_NavigatorObservation> _observedRouteAdditions = Queue<_NavigatorObservation>();
+  final Queue<_NavigatorObservation> _observedRouteDeletions = Queue<_NavigatorObservation>();
 
   /// The [FocusScopeNode] for the [FocusScope] that encloses the routes.
   final FocusScopeNode focusScopeNode = FocusScopeNode(debugLabel: 'Navigator Scope');
@@ -2984,6 +3010,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
           assert(rearrangeOverlay);
           entry.handleAdd(
             navigator: this,
+            previousPresent: _getRouteBefore(index - 1, _RouteEntry.isPresentPredicate)?.route,
           );
           assert(entry.currentState == _RouteLifecycle.adding);
           continue;
@@ -2991,8 +3018,6 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
           if (canRemoveOrAdd || next == null) {
             entry.didAdd(
               navigator: this,
-              previous: previous?.route,
-              previousPresent: _getRouteBefore(index - 1, _RouteEntry.isPresentPredicate)?.route,
               isNewFirst: next == null
             );
             assert(entry.currentState == _RouteLifecycle.idle);
@@ -3079,6 +3104,10 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
       entry = previous;
       previous = index > 0 ? _history[index - 1] : null;
     }
+
+    // Inform navigator observers about route changes.
+    _informObservers();
+
     // Now that the list is clean, send the didChangeNext/didChangePrevious
     // notifications.
     _flushRouteAnnouncement();
@@ -3100,6 +3129,44 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
     }
     if (rearrangeOverlay)
       overlay?.rearrange(_allRouteOverlayEntries);
+  }
+
+  void _informObservers() {
+    if (widget.observers.isEmpty) {
+      _observedRouteDeletions.clear();
+      _observedRouteAdditions.clear();
+      return;
+    }
+    while (_observedRouteAdditions.isNotEmpty)
+      _announceObservation(_observedRouteAdditions.removeLast());
+
+    while (_observedRouteDeletions.isNotEmpty)
+      _announceObservation(_observedRouteDeletions.removeFirst());
+  }
+
+  void _announceObservation(_NavigatorObservation observation) {
+    switch(observation.action) {
+      case _ObservedAction.push:
+        for (final NavigatorObserver observer in widget.observers) {
+          observer.didPush(observation.targetRoute, observation.previousRoute);
+        }
+        break;
+      case _ObservedAction.pop:
+        for (final NavigatorObserver observer in widget.observers) {
+          observer.didPop(observation.targetRoute, observation.previousRoute);
+        }
+        break;
+      case _ObservedAction.remove:
+        for (final NavigatorObserver observer in widget.observers) {
+          observer.didRemove(observation.targetRoute, observation.previousRoute);
+        }
+        break;
+      case _ObservedAction.replace:
+        for (final NavigatorObserver observer in widget.observers) {
+          observer.didReplace(newRoute: observation.targetRoute, oldRoute: observation.previousRoute);
+        }
+        break;
+    }
   }
 
   void _flushRouteAnnouncement() {

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -3146,8 +3146,8 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
       previous = index > 0 ? _history[index - 1] : null;
     }
 
-    // Inform navigator observers about route changes.
-    _informObservers();
+    // Informs navigator observers about route changes.
+    _flushObserverNotifications();
 
     // Now that the list is clean, send the didChangeNext/didChangePrevious
     // notifications.
@@ -3172,7 +3172,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
       overlay?.rearrange(_allRouteOverlayEntries);
   }
 
-  void _informObservers() {
+  void _flushObserverNotifications() {
     if (widget.observers.isEmpty) {
       _observedRouteDeletions.clear();
       _observedRouteAdditions.clear();

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -3179,12 +3179,12 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
       return;
     }
     while (_observedRouteAdditions.isNotEmpty) {
-      _NavigatorObservation observation = _observedRouteAdditions.removeLast();
+      final _NavigatorObservation observation = _observedRouteAdditions.removeLast();
       widget.observers.forEach(observation.notify);
     }
 
     while (_observedRouteDeletions.isNotEmpty) {
-      _NavigatorObservation observation = _observedRouteDeletions.removeFirst();
+      final _NavigatorObservation observation = _observedRouteDeletions.removeFirst();
       widget.observers.forEach(observation.notify);
     }
   }

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -454,6 +454,45 @@ void main() {
     expect(isPopped, isFalse);
   });
 
+  testWidgets('initial route trigger observer in the right order', (WidgetTester tester) async {
+    final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
+      '/' : (BuildContext context) => const Text('/'),
+      '/A': (BuildContext context) => const Text('A'),
+      '/A/B': (BuildContext context) => const Text('B'),
+    };
+    final List<NavigatorObservation> observations = <NavigatorObservation>[];
+    final TestObserver observer = TestObserver()
+      ..onPushed = (Route<dynamic> route, Route<dynamic> previousRoute) {
+        // Pushes the initial route.
+        observations.add(
+          NavigatorObservation(
+            current: route?.settings?.name,
+            previous: previousRoute?.settings?.name,
+            operation: 'push'
+          )
+        );
+      };
+
+    await tester.pumpWidget(MaterialApp(
+      routes: routes,
+      initialRoute: '/A/B',
+      navigatorObservers: <NavigatorObserver>[observer],
+    ));
+
+    expect(observations.length, 3);
+    expect(observations[0].operation, 'push');
+    expect(observations[0].current, '/');
+    expect(observations[0].previous, isNull);
+
+    expect(observations[1].operation, 'push');
+    expect(observations[1].current, '/A');
+    expect(observations[1].previous, '/');
+
+    expect(observations[2].operation, 'push');
+    expect(observations[2].current, '/A/B');
+    expect(observations[2].previous, '/A');
+  });
+
   testWidgets('replaceNamed replaces', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
       '/' : (BuildContext context) => OnTapPage(id: '/', onTap: () { Navigator.pushReplacementNamed(context, '/A'); }),
@@ -1892,12 +1931,13 @@ void main() {
   });
 
   group('Page api', (){
-    Widget buildNavigator(
+    Widget buildNavigator({
       List<Page<dynamic>> pages,
-      PopPageCallback onPopPage, [
-        GlobalKey<NavigatorState> key,
-        TransitionDelegate<dynamic> transitionDelegate
-      ]) {
+      PopPageCallback onPopPage,
+      GlobalKey<NavigatorState> key,
+      TransitionDelegate<dynamic> transitionDelegate,
+      List<NavigatorObserver> observers = const <NavigatorObserver>[],
+    }) {
       return MediaQuery(
         data: MediaQueryData.fromWindow(WidgetsBinding.instance.window),
         child: Localizations(
@@ -1912,6 +1952,7 @@ void main() {
               key: key,
               pages: pages,
               onPopPage: onPopPage,
+              observers: observers,
               transitionDelegate: transitionDelegate ?? const DefaultTransitionDelegate<dynamic>(),
             ),
           ),
@@ -1932,7 +1973,9 @@ void main() {
         return route.didPop(result);
       }
 
-      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator));
+      await tester.pumpWidget(
+        buildNavigator(pages: myPages, onPopPage: onPopPage, key: navigator)
+      );
       expect(find.text('third'), findsOneWidget);
       expect(find.text('second'), findsNothing);
       expect(find.text('initial'), findsNothing);
@@ -1980,7 +2023,9 @@ void main() {
         return route.didPop(result);
       }
 
-      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator));
+      await tester.pumpWidget(
+        buildNavigator(pages: myPages, onPopPage: onPopPage, key: navigator)
+      );
       expect(find.text('initial'), findsOneWidget);
 
       myPages = <Page<dynamic>>[
@@ -2028,7 +2073,9 @@ void main() {
         )
       ];
 
-      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator));
+      await tester.pumpWidget(
+        buildNavigator(pages: myPages, onPopPage: onPopPage, key: navigator)
+      );
       // The third page is transitioning, and the secondary animation of first
       // page should chain with the third page. The animation of second page
       // won't start until the third page finishes transition.
@@ -2091,7 +2138,9 @@ void main() {
         ),
       ];
 
-      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator));
+      await tester.pumpWidget(
+        buildNavigator(pages: myPages, onPopPage: onPopPage, key: navigator)
+      );
       await tester.pump(const Duration(milliseconds: 30));
       expect(secondaryAnimationOfRouteOne.value, primaryAnimationOfRouteTwo.value);
       expect(primaryAnimationOfRouteOne.status, AnimationStatus.completed);
@@ -2164,7 +2213,9 @@ void main() {
         myPages.removeWhere((Page<dynamic> page) => route.settings == page);
         return route.didPop(result);
       }
-      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator));
+      await tester.pumpWidget(
+        buildNavigator(pages: myPages, onPopPage: onPopPage, key: navigator)
+      );
       expect(find.text('third'), findsOneWidget);
       expect(find.text('second'), findsNothing);
       expect(find.text('initial'), findsNothing);
@@ -2176,7 +2227,9 @@ void main() {
       expect(primaryAnimationOfRouteThree.status, AnimationStatus.completed);
 
       myPages = myPages.reversed.toList();
-      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator));
+      await tester.pumpWidget(
+        buildNavigator(pages: myPages, onPopPage: onPopPage, key: navigator)
+      );
       // Reversed routes are still chained up correctly.
       expect(secondaryAnimationOfRouteThree.value, primaryAnimationOfRouteTwo.value);
       expect(primaryAnimationOfRouteThree.status, AnimationStatus.completed);
@@ -2232,7 +2285,9 @@ void main() {
         return route.didPop(result);
       }
 
-      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator));
+      await tester.pumpWidget(
+        buildNavigator(pages: myPages, onPopPage: onPopPage, key: navigator)
+      );
       expect(find.text('second'), findsOneWidget);
       expect(find.text('initial'), findsNothing);
       // Pushes two pageless routes to second page route
@@ -2261,7 +2316,9 @@ void main() {
         const TestPage(key: ValueKey<String>('2'), name:'second'),
         const TestPage(key: ValueKey<String>('3'), name:'third'),
       ];
-      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator));
+      await tester.pumpWidget(
+        buildNavigator(pages: myPages, onPopPage: onPopPage, key: navigator)
+      );
       await tester.pumpAndSettle();
       expect(find.text('initial'), findsNothing);
       expect(find.text('second'), findsNothing);
@@ -2291,7 +2348,9 @@ void main() {
         const TestPage(key: ValueKey<String>('3'), name:'third'),
         const TestPage(key: ValueKey<String>('2'), name:'second'),
       ];
-      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator));
+      await tester.pumpWidget(
+        buildNavigator(pages: myPages, onPopPage: onPopPage, key: navigator)
+      );
       // Swaps the order without any adding or removing should not trigger any
       // transition. The routes should update without a pumpAndSettle
       // Now the history should look like
@@ -2361,7 +2420,9 @@ void main() {
       }
 
       // Add initial page route with one pageless route.
-      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator));
+      await tester.pumpWidget(
+        buildNavigator(pages: myPages, onPopPage: onPopPage, key: navigator)
+      );
       bool initialPageless1Completed = false;
       navigator.currentState.push(
         MaterialPageRoute<void>(
@@ -2376,7 +2437,9 @@ void main() {
         const TestPage(key: ValueKey<String>('1'), name: 'initial'),
         const TestPage(key: ValueKey<String>('2'), name: 'second'),
       ];
-      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator));
+      await tester.pumpWidget(
+        buildNavigator(pages: myPages, onPopPage: onPopPage, key: navigator)
+      );
       await tester.pumpAndSettle();
       bool secondPageless1Completed = false;
       navigator.currentState.push(
@@ -2401,7 +2464,9 @@ void main() {
         const TestPage(key: ValueKey<String>('2'), name: 'second'),
         const TestPage(key: ValueKey<String>('3'), name: 'third'),
       ];
-      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator));
+      await tester.pumpWidget(
+        buildNavigator(pages: myPages, onPopPage: onPopPage, key: navigator)
+      );
       await tester.pumpAndSettle();
       bool thirdPageless1Completed = false;
       navigator.currentState.push(
@@ -2423,7 +2488,9 @@ void main() {
         const TestPage(key: ValueKey<String>('3'), name: 'third'),
         const TestPage(key: ValueKey<String>('2'), name: 'second'),
       ];
-      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator));
+      await tester.pumpWidget(
+        buildNavigator(pages: myPages, onPopPage: onPopPage, key: navigator)
+      );
       // The pageless route of initial page route should be completed.
       expect(initialPageless1Completed, true);
       expect(secondPageless1Completed, false);
@@ -2433,7 +2500,9 @@ void main() {
       myPages = <TestPage>[
         const TestPage(key: ValueKey<String>('3'), name: 'third'),
       ];
-      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator));
+      await tester.pumpWidget(
+        buildNavigator(pages: myPages, onPopPage: onPopPage, key: navigator)
+      );
       await tester.pumpAndSettle();
       expect(secondPageless1Completed, true);
       expect(secondPageless2Completed, true);
@@ -2442,7 +2511,9 @@ void main() {
       myPages = <TestPage>[
         const TestPage(key: ValueKey<String>('4'), name: 'forth'),
       ];
-      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator));
+      await tester.pumpWidget(
+        buildNavigator(pages: myPages, onPopPage: onPopPage, key: navigator)
+      );
       expect(thirdPageless1Completed, true);
       await tester.pumpAndSettle();
       expect(find.text('forth'), findsOneWidget);
@@ -2460,7 +2531,14 @@ void main() {
       }
 
       // Add initial page route with one pageless route.
-      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator, transitionDelegate));
+      await tester.pumpWidget(
+        buildNavigator(
+          pages: myPages,
+          onPopPage: onPopPage,
+          key: navigator,
+          transitionDelegate: transitionDelegate
+        )
+      );
       bool initialPageless1Completed = false;
       navigator.currentState.push(
         MaterialPageRoute<void>(
@@ -2475,7 +2553,14 @@ void main() {
         const TestPage(key: ValueKey<String>('1'), name: 'initial'),
         const TestPage(key: ValueKey<String>('2'), name: 'second'),
       ];
-      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator, transitionDelegate));
+      await tester.pumpWidget(
+        buildNavigator(
+          pages: myPages,
+          onPopPage: onPopPage,
+          key: navigator,
+          transitionDelegate: transitionDelegate
+        )
+      );
       bool secondPageless1Completed = false;
       navigator.currentState.push(
         MaterialPageRoute<void>(
@@ -2499,7 +2584,14 @@ void main() {
         const TestPage(key: ValueKey<String>('2'), name: 'second'),
         const TestPage(key: ValueKey<String>('3'), name: 'third'),
       ];
-      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator, transitionDelegate));
+      await tester.pumpWidget(
+        buildNavigator(
+          pages: myPages,
+          onPopPage: onPopPage,
+          key: navigator,
+          transitionDelegate: transitionDelegate
+        )
+      );
       bool thirdPageless1Completed = false;
       navigator.currentState.push(
         MaterialPageRoute<void>(
@@ -2520,7 +2612,14 @@ void main() {
         const TestPage(key: ValueKey<String>('3'), name: 'third'),
         const TestPage(key: ValueKey<String>('2'), name: 'second'),
       ];
-      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator, transitionDelegate));
+      await tester.pumpWidget(
+        buildNavigator(
+          pages: myPages,
+          onPopPage: onPopPage,
+          key: navigator,
+          transitionDelegate: transitionDelegate
+        )
+      );
       // The pageless route of initial page route should be removed without complete.
       expect(initialPageless1Completed, false);
       expect(secondPageless1Completed, false);
@@ -2530,7 +2629,14 @@ void main() {
       myPages = <TestPage>[
         const TestPage(key: ValueKey<String>('3'), name: 'third'),
       ];
-      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator, transitionDelegate));
+      await tester.pumpWidget(
+        buildNavigator(
+          pages: myPages,
+          onPopPage: onPopPage,
+          key: navigator,
+          transitionDelegate: transitionDelegate
+        )
+      );
       await tester.pumpAndSettle();
       expect(initialPageless1Completed, false);
       expect(secondPageless1Completed, false);
@@ -2540,7 +2646,14 @@ void main() {
       myPages = <TestPage>[
         const TestPage(key: ValueKey<String>('4'), name: 'forth'),
       ];
-      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator, transitionDelegate));
+      await tester.pumpWidget(
+        buildNavigator(
+          pages: myPages,
+          onPopPage: onPopPage,
+          key: navigator,
+          transitionDelegate: transitionDelegate
+        )
+      );
       await tester.pump();
       expect(initialPageless1Completed, false);
       expect(secondPageless1Completed, false);
@@ -2559,20 +2672,26 @@ void main() {
         myPages.removeWhere((Page<dynamic> page) => route.settings == page);
         return route.didPop(result);
       }
-      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator));
+      await tester.pumpWidget(
+        buildNavigator(pages: myPages, onPopPage: onPopPage, key: navigator)
+      );
 
       // Pops the second page route.
       myPages = <TestPage>[
         const TestPage(key: ValueKey<String>('1'), name: 'initial'),
       ];
-      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator));
+      await tester.pumpWidget(
+        buildNavigator(pages: myPages, onPopPage: onPopPage, key: navigator)
+      );
 
       // Re-push the second page again before it finishes popping.
       myPages = <TestPage>[
         const TestPage(key: ValueKey<String>('1'), name: 'initial'),
         const TestPage(key: ValueKey<String>('2'), name: 'second'),
       ];
-      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator));
+      await tester.pumpWidget(
+        buildNavigator(pages: myPages, onPopPage: onPopPage, key: navigator)
+      );
 
       // It should not crash the app.
       expect(tester.takeException(), isNull);
@@ -2590,24 +2709,120 @@ void main() {
         myPages.removeWhere((Page<dynamic> page) => route.settings == page);
         return route.didPop(result);
       }
-      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator));
+      await tester.pumpWidget(
+        buildNavigator(pages: myPages, onPopPage: onPopPage, key: navigator)
+      );
 
       // Pops the second page route.
       myPages = <TestPage>[
         const TestPage(key: ValueKey<String>('1'), name: 'initial'),
       ];
-      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator));
+      await tester.pumpWidget(
+        buildNavigator(pages: myPages, onPopPage: onPopPage, key: navigator)
+      );
 
       // Updates the pages again before second page finishes popping.
       myPages = <TestPage>[
         const TestPage(key: ValueKey<String>('1'), name: 'initial'),
       ];
-      await tester.pumpWidget(buildNavigator(myPages, onPopPage, navigator));
+      await tester.pumpWidget(
+        buildNavigator(pages: myPages, onPopPage: onPopPage, key: navigator)
+      );
 
       // It should not crash the app.
       expect(tester.takeException(), isNull);
       await tester.pumpAndSettle();
       expect(find.text('initial'), findsOneWidget);
+    });
+
+    testWidgets('pages remove and add trigger observer in the right order', (WidgetTester tester) async {
+      final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+      List<TestPage> myPages = <TestPage>[
+        const TestPage(key: ValueKey<String>('1'), name:'first'),
+        const TestPage(key: ValueKey<String>('2'), name:'second'),
+        const TestPage(key: ValueKey<String>('3'), name:'third'),
+      ];
+      final List<NavigatorObservation> observations = <NavigatorObservation>[];
+      final TestObserver observer = TestObserver()
+        ..onPushed = (Route<dynamic> route, Route<dynamic> previousRoute) {
+          observations.add(
+            NavigatorObservation(
+              current: route?.settings?.name,
+              previous: previousRoute?.settings?.name,
+              operation: 'push'
+            )
+          );
+        }
+        ..onRemoved = (Route<dynamic> route, Route<dynamic> previousRoute) {
+          observations.add(
+            NavigatorObservation(
+              current: route?.settings?.name,
+              previous: previousRoute?.settings?.name,
+              operation: 'remove'
+            )
+          );
+        };
+      bool onPopPage(Route<dynamic> route, dynamic result) => false;
+
+      await tester.pumpWidget(
+        buildNavigator(
+          pages: myPages,
+          onPopPage: onPopPage,
+          key: navigator,
+          observers: <NavigatorObserver>[observer],
+        )
+      );
+      myPages = <TestPage>[
+        const TestPage(key: ValueKey<String>('4'), name:'forth'),
+        const TestPage(key: ValueKey<String>('5'), name:'fifth'),
+      ];
+
+      await tester.pumpWidget(
+        buildNavigator(
+          pages: myPages,
+          onPopPage: onPopPage,
+          key: navigator,
+          observers: <NavigatorObserver>[observer],
+        )
+      );
+
+      await tester.pumpAndSettle();
+      expect(observations.length, 8);
+      // Initial routes are pushed.
+      expect(observations[0].operation, 'push');
+      expect(observations[0].current, 'first');
+      expect(observations[0].previous, isNull);
+
+      expect(observations[1].operation, 'push');
+      expect(observations[1].current, 'second');
+      expect(observations[1].previous, 'first');
+
+      expect(observations[2].operation, 'push');
+      expect(observations[2].current, 'third');
+      expect(observations[2].previous, 'second');
+
+      // Pages are updated.
+      // New routes are pushed before removing the initial routes.
+      expect(observations[3].operation, 'push');
+      expect(observations[3].current, 'forth');
+      expect(observations[3].previous, 'third');
+
+      expect(observations[4].operation, 'push');
+      expect(observations[4].current, 'fifth');
+      expect(observations[4].previous, 'forth');
+
+      // Initial routes are removed.
+      expect(observations[5].operation, 'remove');
+      expect(observations[5].current, 'third');
+      expect(observations[5].previous, isNull);
+
+      expect(observations[6].operation, 'remove');
+      expect(observations[6].current, 'second');
+      expect(observations[6].previous, isNull);
+
+      expect(observations[7].operation, 'remove');
+      expect(observations[7].current, 'first');
+      expect(observations[7].previous, isNull);
     });
   });
 }


### PR DESCRIPTION
## Description

The navigator refactor accidentally changes the contract of navigator observer. If there are multiple route added in one history update (for example adding initial routes), the observer will receive the notifications from top-most route to bottm-most routes. It is the opposite of the order before the navigator observation.

This pr fixes it.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/57407#issuecomment-630384782

## Tests

I added the following tests:

See files

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
