### PR TITLE
Fix plugins path

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -96,13 +96,13 @@ class AndroidStudio implements Comparable<AndroidStudio> {
     } on Exception {
       // ignored, installPath will be null, which is handled below
     }
-      
+
     // The plugins path is different when installed via Jetbrains Toolbox
     String pluginsPath;
     if(globals.fs.isDirectorySync(installPath + '.plugins')){
       pluginsPath = installPath + '.plugins';
     }
-      
+
     if (installPath != null && globals.fs.isDirectorySync(installPath)) {
       return AndroidStudio(
           installPath,

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -98,7 +98,7 @@ class AndroidStudio implements Comparable<AndroidStudio> {
     }
       
     // The plugins path is different when installed via Jetbrains Toolbox
-    String pluginsPath = null;
+    String pluginsPath;
     if(globals.fs.isDirectorySync(installPath + '.plugins')){
       pluginsPath = installPath + '.plugins';
     }

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -96,11 +96,19 @@ class AndroidStudio implements Comparable<AndroidStudio> {
     } on Exception {
       // ignored, installPath will be null, which is handled below
     }
+      
+    // The plugins path is different when installed via Jetbrains Toolbox
+    String pluginsPath = null;
+    if(globals.fs.isDirectorySync(installPath + '.plugins')){
+      pluginsPath = installPath + '.plugins';
+    }
+      
     if (installPath != null && globals.fs.isDirectorySync(installPath)) {
       return AndroidStudio(
           installPath,
           version: version,
           studioAppName: studioAppName,
+          presetPluginsPath: pluginsPath,
       );
     }
     return null;

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -818,7 +818,12 @@ class IntelliJValidatorOnLinuxAndWindows extends IntelliJValidator {
             // ignored
           }
           if (installPath != null && globals.fs.isDirectorySync(installPath)) {
-            final String pluginsPath = globals.fs.path.join(dir.path, 'config', 'plugins');
+            // Needed if the app has been installed via JetBrains Toolbox
+            final String pluginsPath =
+                globals.fs.isDirectorySync(installPath + '.plugins')
+                    ? installPath + '.plugins'
+                    : globals.fs.path.join(dir.path, 'config', 'plugins');
+
             addValidator(title, version, installPath, pluginsPath);
           }
         }


### PR DESCRIPTION
## Description
 When Android Studio is installed via on Windows via JetBrains Toolbox, the path to the plugins folder is different. This causes issues with (at least) flutter doctor.  These commits reconcile that by checking for a '.plugins' folder corresponding to a Toolbox install and using that.  Additionally, tests were updated to resolve conflicts with the fs stub being used across groups.

## Related Issues

Addresses issue #57642

## Tests
I added the following tests:

`flutter\packages\flutter_tools\test\general.shard\android\android_studio_test.dart`
  - group('pluginsPath on Windows')
  - testUsingContext('extracts plugins path when installed via Toolbox')
  - testUsingContext('extracts plugins paths from home path when installed separately.')

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
