### PR TITLE
Change release archive check to warning

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -87,17 +87,10 @@ BuildApp() {
       exit -1;;
   esac
 
-  # Archive builds (ACTION=install) should always run in release mode.
+  # Warn the user if not archiving (ACTION=install) in release mode.
   if [[ "$ACTION" == "install" && "$build_mode" != "release" ]]; then
-    EchoError "========================================================================"
-    EchoError "ERROR: Flutter archive builds must be run in Release mode."
-    EchoError ""
-    EchoError "To correct, ensure FLUTTER_BUILD_MODE is set to release or run:"
-    EchoError "flutter build ios --release"
-    EchoError ""
-    EchoError "then re-run Archive from Xcode."
-    EchoError "========================================================================"
-    exit -1
+    echo "warning: Flutter archive not built in Release mode. Ensure FLUTTER_BUILD_MODE \
+is set to release or run \"flutter build ios --release\", then re-run Archive from Xcode."
   fi
 
   local framework_path="${FLUTTER_ROOT}/bin/cache/artifacts/engine/${artifact_variant}"


### PR DESCRIPTION
## Description

I believe we've [tracked down most of the issues](https://github.com/flutter/flutter/pull/42029) related to accidentally archiving with a Debug version of Flutter.  Switch the error to a warning to accommodate users who want to distribute Debug versions to QA, etc.

`echo`ing the message with a `warning:` prefix makes it a real Xcode warning.

Before:
![Screen Shot 2020-05-20 at 12 41 53 PM](https://user-images.githubusercontent.com/682784/82492138-92fe4580-9a9a-11ea-884e-0328a0a74a30.png)
After:
![Screen Shot 2020-05-20 at 12 55 22 PM](https://user-images.githubusercontent.com/682784/82492152-972a6300-9a9a-11ea-830a-eadafecfebd1.png)
![Screen Shot 2020-05-20 at 12 55 14 PM](https://user-images.githubusercontent.com/682784/82492154-97c2f980-9a9a-11ea-94d8-c3c5364958cf.png)


## Related Issues

Fixes https://github.com/flutter/flutter/issues/57557.

## Tests

We don't archive anywhere, not sure how to test this...

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*