### PR TITLE
Functionality to check handlers set on platform channels

### DIFF
--- a/packages/flutter/lib/src/services/binary_messenger.dart
+++ b/packages/flutter/lib/src/services/binary_messenger.dart
@@ -41,20 +41,35 @@ abstract class BinaryMessenger {
   /// argument.
   ///
   /// The handler's return value, if non-null, is sent as a response, unencoded.
-  void setMessageHandler(String channel, Future<ByteData> handler(ByteData message));
+  void setMessageHandler(String channel, MessageHandler handler);
+
+  /// Returns true if the `handler` argument matches the `handler` previously
+  /// passed to [setMessageHandler].
+  ///
+  /// This method is useful for tests or test harnesses that want to assert the
+  /// handler for the vspecified channel has not been altered by a previous test.
+  bool checkMessageHandler(String channel, MessageHandler handler);
 
   /// Set a mock callback for intercepting messages from the [send] method on
   /// this class, on the given channel, without decoding them.
   ///
   /// The given callback will replace the currently registered mock callback for
   /// that channel, if any. To remove the mock handler, pass null as the
-  /// [handler] argument.
+  /// `handler` argument.
   ///
   /// The handler's return value, if non-null, is used as a response, unencoded.
   ///
   /// This is intended for testing. Messages intercepted in this manner are not
   /// sent to platform plugins.
-  void setMockMessageHandler(String channel, Future<ByteData> handler(ByteData message));
+  void setMockMessageHandler(String channel, MessageHandler handler);
+
+  /// Returns true if the `handler` argument matches the `handler` previously
+  /// passed to [setMockMessageHandler].
+  ///
+  /// This method is useful for tests or test harnesses that want to assert the
+  /// mock handler for the specified channel has not been altered by a previous
+  /// test.
+  bool checkMockMessageHandler(String channel, MessageHandler handler);
 }
 
 /// The default instance of [BinaryMessenger].

--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -294,10 +294,16 @@ class _DefaultBinaryMessenger extends BinaryMessenger {
   }
 
   @override
+  bool checkMessageHandler(String channel, MessageHandler handler) => _handlers[channel] == handler;
+
+  @override
   void setMockMessageHandler(String channel, MessageHandler handler) {
     if (handler == null)
       _mockHandlers.remove(channel);
     else
       _mockHandlers[channel] = handler;
   }
+
+  @override
+  bool checkMockMessageHandler(String channel, MessageHandler handler) => _mockHandlers[channel] == handler;
 }

--- a/packages/flutter/test/services/autofill_test.dart
+++ b/packages/flutter/test/services/autofill_test.dart
@@ -212,7 +212,13 @@ class FakeTextChannel implements MethodChannel {
   }
 
   @override
+  bool checkMethodCallHandler(Future<void> Function(MethodCall call) handler) => throw UnimplementedError();
+
+  @override
   void setMockMethodCallHandler(Future<void> Function(MethodCall call) handler)  => throw UnimplementedError();
+
+  @override
+  bool checkMockMethodCallHandler(Future<void> Function(MethodCall call) handler) => throw UnimplementedError();
 
   void validateOutgoingMethodCalls(List<MethodCall> calls) {
     expect(outgoingCalls.length, calls.length);

--- a/packages/flutter/test/services/default_binary_messenger_test.dart
+++ b/packages/flutter/test/services/default_binary_messenger_test.dart
@@ -34,4 +34,26 @@ void main() {
     });
     expect(count, equals(1));
   });
+
+  test('can check the handler', () {
+    Future<ByteData> handler(ByteData call) => Future<ByteData>.value(null);
+    final BinaryMessenger messenger = ServicesBinding.instance.defaultBinaryMessenger;
+
+    expect(messenger.checkMessageHandler('test_channel', null), true);
+    expect(messenger.checkMessageHandler('test_channel', handler), false);
+    messenger.setMessageHandler('test_channel', handler);
+    expect(messenger.checkMessageHandler('test_channel', handler), true);
+    messenger.setMessageHandler('test_channel', null);
+  });
+
+  test('can check the mock handler', () {
+    Future<ByteData> handler(ByteData call) => Future<ByteData>.value(null);
+    final BinaryMessenger messenger = ServicesBinding.instance.defaultBinaryMessenger;
+
+    expect(messenger.checkMockMessageHandler('test_channel', null), true);
+    expect(messenger.checkMockMessageHandler('test_channel', handler), false);
+    messenger.setMockMessageHandler('test_channel', handler);
+    expect(messenger.checkMockMessageHandler('test_channel', handler), true);
+    messenger.setMockMessageHandler('test_channel', null);
+  });
 }

--- a/packages/flutter/test/services/platform_channel_test.dart
+++ b/packages/flutter/test/services/platform_channel_test.dart
@@ -58,6 +58,7 @@ void main() {
       final String result = await channel.invokeMethod('sayHello', 'hello');
       expect(result, equals('hello world'));
     });
+
     test('can invoke list method and get result', () async {
       ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
         'ch7',
@@ -88,7 +89,6 @@ void main() {
       );
       expect(await channel.invokeListMethod<String>('sayHello', 'hello'), null);
     });
-
 
     test('can invoke map method and get result', () async {
       ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
@@ -143,6 +143,7 @@ void main() {
         fail('PlatformException expected');
       }
     });
+
     test('can invoke unimplemented method', () async {
       ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
         'ch7',
@@ -158,6 +159,7 @@ void main() {
         fail('MissingPluginException expected');
       }
     });
+
     test('can invoke unimplemented method (optional)', () async {
       ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
         'ch8',
@@ -166,6 +168,7 @@ void main() {
       final String result = await optionalMethodChannel.invokeMethod<String>('sayHello', 'hello');
       expect(result, isNull);
     });
+
     test('can handle method call with no registered plugin', () async {
       channel.setMethodCallHandler(null);
       final ByteData call = jsonMethod.encodeMethodCall(const MethodCall('sayHello', 'hello'));
@@ -175,6 +178,7 @@ void main() {
       });
       expect(envelope, isNull);
     });
+
     test('can handle method call of unimplemented method', () async {
       channel.setMethodCallHandler((MethodCall call) async {
         throw MissingPluginException();
@@ -186,6 +190,7 @@ void main() {
       });
       expect(envelope, isNull);
     });
+
     test('can handle method call with successful result', () async {
       channel.setMethodCallHandler((MethodCall call) async => '${call.arguments}, world');
       final ByteData call = jsonMethod.encodeMethodCall(const MethodCall('sayHello', 'hello'));
@@ -195,6 +200,7 @@ void main() {
       });
       expect(jsonMethod.decodeEnvelope(envelope), equals('hello, world'));
     });
+
     test('can handle method call with expressive error result', () async {
       channel.setMethodCallHandler((MethodCall call) async {
         throw PlatformException(code: 'bad', message: 'sayHello failed', details: null);
@@ -214,6 +220,7 @@ void main() {
         fail('PlatformException expected');
       }
     });
+
     test('can handle method call with other error result', () async {
       channel.setMethodCallHandler((MethodCall call) async {
         throw ArgumentError('bad');
@@ -232,6 +239,26 @@ void main() {
       } catch (e) {
         fail('PlatformException expected');
       }
+    });
+
+    test('can check the handler', () {
+      Future<dynamic> handler(MethodCall call) => Future<dynamic>.value(null);
+
+      const MethodChannel channel = MethodChannel('test_handler');
+      expect(channel.checkMethodCallHandler(null), true);
+      expect(channel.checkMethodCallHandler(handler), false);
+      channel.setMethodCallHandler(handler);
+      expect(channel.checkMethodCallHandler(handler), true);
+    });
+
+    test('can check the mock handler', () {
+      Future<dynamic> handler(MethodCall call) => Future<dynamic>.value(null);
+
+      const MethodChannel channel = MethodChannel('test_handler');
+      expect(channel.checkMockMethodCallHandler(null), true);
+      expect(channel.checkMockMethodCallHandler(handler), false);
+      channel.setMockMethodCallHandler(handler);
+      expect(channel.checkMockMethodCallHandler(handler), true);
     });
   });
   group('EventChannel', () {

--- a/packages/flutter/test/services/text_input_test.dart
+++ b/packages/flutter/test/services/text_input_test.dart
@@ -267,7 +267,14 @@ class FakeTextChannel implements MethodChannel {
   }
 
   @override
+  bool checkMethodCallHandler(Future<void> Function(MethodCall call) handler) => throw UnimplementedError();
+
+
+  @override
   void setMockMethodCallHandler(Future<void> Function(MethodCall call) handler)  => throw UnimplementedError();
+
+  @override
+  bool checkMockMethodCallHandler(Future<void> Function(MethodCall call) handler) => throw UnimplementedError();
 
   void validateOutgoingMethodCalls(List<MethodCall> calls) {
     expect(outgoingCalls.length, calls.length);

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -135,8 +135,18 @@ class TestDefaultBinaryMessenger extends BinaryMessenger {
   }
 
   @override
+  bool checkMessageHandler(String channel, MessageHandler handler) {
+    return delegate.checkMessageHandler(channel, handler);
+  }
+
+  @override
   void setMockMessageHandler(String channel, MessageHandler handler) {
     delegate.setMockMessageHandler(channel, handler);
+  }
+
+  @override
+  bool checkMockMessageHandler(String channel, MessageHandler handler) {
+    return delegate.checkMockMessageHandler(channel, handler);
   }
 }
 

--- a/packages/flutter_test/lib/src/test_text_input.dart
+++ b/packages/flutter_test/lib/src/test_text_input.dart
@@ -52,20 +52,14 @@ class TestTextInput {
     register();
   }
   /// Installs this object as a mock handler for [SystemChannels.textInput].
-  void register() {
-    SystemChannels.textInput.setMockMethodCallHandler(_handleTextInputCall);
-    _isRegistered = true;
-  }
+  void register() => SystemChannels.textInput.setMockMethodCallHandler(_handleTextInputCall);
 
   /// Removes this object as a mock handler for [SystemChannels.textInput].
   ///
   /// After calling this method, the channel will exchange messages with the
   /// Flutter engine. Use this with [FlutterDriver] tests that need to display
   /// on-screen keyboard provided by the operating system.
-  void unregister() {
-    SystemChannels.textInput.setMockMethodCallHandler(null);
-    _isRegistered = false;
-  }
+  void unregister() => SystemChannels.textInput.setMockMethodCallHandler(null);
 
   /// Log for method calls.
   ///
@@ -76,12 +70,13 @@ class TestTextInput {
   /// Whether this [TestTextInput] is registered with [SystemChannels.textInput].
   ///
   /// Use [register] and [unregister] methods to control this value.
-  // TODO(dnfield): This is unreliable. https://github.com/flutter/flutter/issues/47180
-  bool get isRegistered => _isRegistered;
-  bool _isRegistered = false;
+  bool get isRegistered => SystemChannels.textInput.checkMockMethodCallHandler(_handleTextInputCall);
 
   /// Whether there are any active clients listening to text input.
-  bool get hasAnyClients => _client > 0;
+  bool get hasAnyClients {
+    assert(isRegistered);
+    return _client > 0;
+  }
 
   int _client = 0;
 
@@ -122,11 +117,15 @@ class TestTextInput {
   }
 
   /// Whether the onscreen keyboard is visible to the user.
-  bool get isVisible => _isVisible;
+  bool get isVisible {
+    assert(isRegistered);
+    return _isVisible;
+  }
   bool _isVisible = false;
 
   /// Simulates the user changing the [TextEditingValue] to the given value.
   void updateEditingValue(TextEditingValue value) {
+    assert(isRegistered);
     // Not using the `expect` function because in the case of a FlutterDriver
     // test this code does not run in a package:test test zone.
     if (_client == 0)
@@ -149,6 +148,7 @@ class TestTextInput {
   /// - User pressed the home button and sent the application to background.
   /// - User closed the virtual keyboard.
   void closeConnection() {
+    assert(isRegistered);
     // Not using the `expect` function because in the case of a FlutterDriver
     // test this code does not run in a package:test test zone.
     if (_client == 0)
@@ -167,6 +167,7 @@ class TestTextInput {
 
   /// Simulates the user typing the given text.
   void enterText(String text) {
+    assert(isRegistered);
     updateEditingValue(TextEditingValue(
       text: text,
     ));
@@ -176,6 +177,7 @@ class TestTextInput {
   /// Does not check that the [TextInputAction] performed is an acceptable one
   /// based on the `inputAction` [setClientArgs].
   Future<void> receiveAction(TextInputAction action) async {
+    assert(isRegistered);
     return TestAsyncUtils.guard(() {
       // Not using the `expect` function because in the case of a FlutterDriver
       // test this code does not run in a package:test test zone.
@@ -215,6 +217,7 @@ class TestTextInput {
 
   /// Simulates the user hiding the onscreen keyboard.
   void hide() {
+    assert(isRegistered);
     _isVisible = false;
   }
 }

--- a/packages/flutter_web_plugins/lib/src/plugin_registry.dart
+++ b/packages/flutter_web_plugins/lib/src/plugin_registry.dart
@@ -135,6 +135,12 @@ class _PlatformBinaryMessenger extends BinaryMessenger {
     throw FlutterError(
         'Setting mock handlers is not supported on the platform side.');
   }
+
+  @override
+  bool checkMockMessageHandler(String channel, MessageHandler handler) {
+    throw FlutterError(
+        'Setting mock handlers is not supported on the platform side.');
+  }
 }
 
 /// The default [BinaryMessenger] for Flutter Web plugins.

--- a/packages/flutter_web_plugins/lib/src/plugin_registry.dart
+++ b/packages/flutter_web_plugins/lib/src/plugin_registry.dart
@@ -118,8 +118,7 @@ class _PlatformBinaryMessenger extends BinaryMessenger {
   }
 
   @override
-  void setMessageHandler(
-      String channel, Future<ByteData> Function(ByteData message) handler) {
+  void setMessageHandler(String channel, MessageHandler handler) {
     if (handler == null)
       _handlers.remove(channel);
     else
@@ -128,6 +127,9 @@ class _PlatformBinaryMessenger extends BinaryMessenger {
       await handlePlatformMessage(channel, data, callback);
     });
   }
+
+  @override
+  bool checkMessageHandler(String channel, MessageHandler handler) => _handlers[channel] == handler;
 
   @override
   void setMockMessageHandler(


### PR DESCRIPTION
## Description

Adds functionality to MethodCall and MessageChannels to determine if the handler is the expected one or not. This is primarily intended for use in tests, but is not decorated as such because it's really test harness code mostly using it and I'd like to avoid adding a lot of ignores for that. 

This shores up the `isRegistered` functionality on the `TestTextInput`, with the ultimate goal being to let tests make sure that test text input is or isn't being used in a reliable manner.

## Related Issues

Fixes #47180
Part of https://github.com/flutter/flutter/issues/51885
Part of https://github.com/flutter/flutter/issues/57623

## Tests

I added the following tests:

- Asserts that `TestTextInput` is registered before using its methods
- Tests of new functionality on the messenger classes.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
