### PR TITLE
Allow FLUTTER_APPLICATION_PATH to be null for misconfigured Xcode projects

### DIFF
--- a/dev/devicelab/bin/tasks/ios_content_validation_test.dart
+++ b/dev/devicelab/bin/tasks/ios_content_validation_test.dart
@@ -24,19 +24,32 @@ Future<void> main() async {
             '--release',
             '--obfuscate',
             '--split-debug-info=foo/',
+            '--no-codesign',
           ]);
         });
+        final String buildPath = path.join(
+          flutterProject.rootPath,
+          'build',
+          'ios',
+          'iphoneos',
+        );
         final String outputAppPath = path.join(
-          flutterProject.rootPath,
-          'build/ios/iphoneos/Runner.app',
+          buildPath,
+          'Runner.app',
         );
-        final String outputAppFramework = path.join(
-          flutterProject.rootPath,
+        final Directory outputAppFramework = Directory(path.join(
           outputAppPath,
-          'Frameworks/App.framework/App',
-        );
-        if (!File(outputAppFramework).existsSync()) {
-          fail('Failed to produce expected output at $outputAppFramework');
+          'Frameworks',
+          'App.framework',
+        ));
+
+        final File outputAppFrameworkBinary = File(path.join(
+          outputAppFramework.path,
+          'App',
+        ));
+
+        if (!outputAppFrameworkBinary.existsSync()) {
+          fail('Failed to produce expected output at ${outputAppFrameworkBinary.path}');
         }
 
         section('Validate obfuscation');
@@ -46,7 +59,7 @@ Future<void> main() async {
         await inDirectory(flutterProject.rootPath, () async {
           final String response = await eval(
             'grep',
-            <String>[flutterProject.name, outputAppFramework],
+            <String>[flutterProject.name, outputAppFrameworkBinary.path],
             canFail: true,
           );
           if (response.trim().contains('matches')) {
@@ -56,16 +69,63 @@ Future<void> main() async {
 
         section('Validate bitcode');
 
-        final String outputFlutterFramework = path.join(
+        final Directory outputFlutterFramework = Directory(path.join(
           flutterProject.rootPath,
           outputAppPath,
-          'Frameworks/Flutter.framework/Flutter',
+          'Frameworks',
+          'Flutter.framework',
+        ));
+        final File outputFlutterFrameworkBinary = File(path.join(
+          outputFlutterFramework.path,
+          'Flutter',
+        ));
+
+        if (!outputFlutterFrameworkBinary.existsSync()) {
+          fail('Failed to produce expected output at ${outputFlutterFrameworkBinary.path}');
+        }
+        bitcode = await containsBitcode(outputFlutterFrameworkBinary.path);
+
+        section('Xcode backend script');
+
+        outputFlutterFramework.deleteSync(recursive: true);
+        outputAppFramework.deleteSync(recursive: true);
+        if (outputFlutterFramework.existsSync() || outputAppFramework.existsSync()) {
+          fail('Failed to delete embedded frameworks');
+        }
+
+        final String xcodeBackendPath = path.join(
+          flutterDirectory.path,
+          'packages',
+          'flutter_tools',
+          'bin',
+          'xcode_backend.sh'
         );
 
-        if (!File(outputFlutterFramework).existsSync()) {
-          fail('Failed to produce expected output at $outputFlutterFramework');
+        // Simulate a commonly Xcode build setting misconfiguration
+        // where FLUTTER_APPLICATION_PATH is missing
+        final int result = await exec(
+          xcodeBackendPath,
+          <String>['embed_and_thin'],
+          environment: <String, String>{
+            'SOURCE_ROOT': flutterProject.iosPath,
+            'TARGET_BUILD_DIR': buildPath,
+            'FRAMEWORKS_FOLDER_PATH': 'Runner.app/Frameworks',
+            'VERBOSE_SCRIPT_LOGGING': '1',
+            'ACTION': 'install', // Skip bitcode stripping since we just checked that above.
+          },
+        );
+
+        if (result != 0) {
+          fail('xcode_backend embed_and_thin failed');
         }
-        bitcode = await containsBitcode(outputFlutterFramework);
+
+        if (!outputFlutterFrameworkBinary.existsSync()) {
+          fail('Failed to re-embed ${outputFlutterFrameworkBinary.path}');
+        }
+
+        if (!outputAppFrameworkBinary.existsSync()) {
+          fail('Failed to re-embed ${outputAppFrameworkBinary.path}');
+        }
       });
 
       if (foundProjectName) {

--- a/dev/devicelab/lib/framework/apk_utils.dart
+++ b/dev/devicelab/lib/framework/apk_utils.dart
@@ -226,6 +226,7 @@ class FlutterProject {
 
   String get rootPath => path.join(parent.path, name);
   String get androidPath => path.join(rootPath, 'android');
+  String get iosPath => path.join(rootPath, 'ios');
 
   Future<void> addCustomBuildType(String name, {String initWith}) async {
     final File buildScript = File(

--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -264,15 +264,18 @@ ThinAppFrameworks() {
 # Adds the App.framework as an embedded binary and the flutter_assets as
 # resources.
 EmbedFlutterFrameworks() {
-  AssertExists "${FLUTTER_APPLICATION_PATH}"
+  local project_path="${SOURCE_ROOT}/.."
+  if [[ -n "$FLUTTER_APPLICATION_PATH" ]]; then
+    project_path="${FLUTTER_APPLICATION_PATH}"
+  fi
 
   # Prefer the hidden .ios folder, but fallback to a visible ios folder if .ios
   # doesn't exist.
-  local flutter_ios_out_folder="${FLUTTER_APPLICATION_PATH}/.ios/Flutter"
-  local flutter_ios_engine_folder="${FLUTTER_APPLICATION_PATH}/.ios/Flutter/engine"
+  local flutter_ios_out_folder="${project_path}/.ios/Flutter"
+  local flutter_ios_engine_folder="${project_path}/.ios/Flutter/engine"
   if [[ ! -d ${flutter_ios_out_folder} ]]; then
-    flutter_ios_out_folder="${FLUTTER_APPLICATION_PATH}/ios/Flutter"
-    flutter_ios_engine_folder="${FLUTTER_APPLICATION_PATH}/ios/Flutter"
+    flutter_ios_out_folder="${project_path}/ios/Flutter"
+    flutter_ios_engine_folder="${project_path}/ios/Flutter"
   fi
 
   AssertExists "${flutter_ios_out_folder}"


### PR DESCRIPTION
## Description

Some users have misconfigured Xcode projects base build configurations and incorrectly swapped to Pods-Runner.debug.xcconfig instead of Debug.xcconfig.  They were getting around this by following Stack Overflow-quality advice and manually adding a `FLUTTER_ROOT` build setting.

https://github.com/flutter/flutter/pull/51453 started calling the embed function in `xcode_backend`, which checks if `FLUTTER_APPLICATION_PATH` exists.  That variable isn't set for these misconfigured users.
https://github.com/flutter/flutter/blob/2a5690f0979ffe7e9c117422704b7d59ed93111b/packages/flutter_tools/bin/xcode_backend.sh#L267

As a workaround, copy the build check behavior that falls back to `SOURCE_ROOT`.  Keep the same `.ios` and `ios` dance to make this as minimum a change as possible.
https://github.com/flutter/flutter/blob/2a5690f0979ffe7e9c117422704b7d59ed93111b/packages/flutter_tools/bin/xcode_backend.sh#L42-L45

They still have misconfigured Xcode projects, but at least they won't be worse off than before https://github.com/flutter/flutter/pull/51453.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/56507
Would have been never been needed with https://github.com/flutter/flutter/issues/12749 or https://github.com/flutter/flutter/issues/12751.

## Tests

I tested this by misconfiguring my base configuration to the Pod variants, and adding a `FLUTTER_ROOT` build setting.  I get the `The path  does not exist` before this change, and a successful build after.  The existing integration tests will prove that the default and correctly configured `flutter create` project still works.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*