### PR TITLE
[flutter_tools] ensure emulator command does not crash with missing avdmanager

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -44,17 +44,23 @@ final RegExp licenseNotAccepted = RegExp(r'licenses? not accepted', caseSensitiv
 final RegExp licenseAccepted = RegExp(r'All SDK package licenses accepted.');
 
 class AndroidWorkflow implements Workflow {
+  AndroidWorkflow({
+    @required AndroidSdk androidSdk,
+  }) : _androidSdk = androidSdk;
+
+  final AndroidSdk _androidSdk;
+
   @override
   bool get appliesToHostPlatform => true;
 
   @override
-  bool get canListDevices => getAdbPath(globals.androidSdk) != null;
+  bool get canListDevices => getAdbPath(_androidSdk) != null;
 
   @override
-  bool get canLaunchDevices => globals.androidSdk != null && globals.androidSdk.validateSdkWellFormed().isEmpty;
+  bool get canLaunchDevices => _androidSdk != null && _androidSdk.validateSdkWellFormed().isEmpty;
 
   @override
-  bool get canListEmulators => getEmulatorPath(globals.androidSdk) != null;
+  bool get canListEmulators => getEmulatorPath(_androidSdk) != null;
 }
 
 class AndroidValidator extends DoctorValidator {

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 import 'package:uuid/uuid.dart';
 
+import '../android/android_workflow.dart';
 import '../base/common.dart';
 import '../base/context.dart';
 import '../base/file_system.dart';
@@ -1039,7 +1040,13 @@ class EmulatorDomain extends Domain {
     registerHandler('create', create);
   }
 
-  EmulatorManager emulators = EmulatorManager();
+  EmulatorManager emulators = EmulatorManager(
+    fileSystem: globals.fs,
+    logger: globals.logger,
+    androidSdk: globals.androidSdk,
+    processManager: globals.processManager,
+    androidWorkflow: androidWorkflow,
+  );
 
   Future<List<Map<String, dynamic>>> getEmulators([ Map<String, dynamic> args ]) async {
     final List<Emulator> list = await emulators.getAllAvailableEmulators();

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -104,7 +104,7 @@ class EmulatorsCommand extends FlutterCommand {
 
   void _printEmulatorList(List<Emulator> emulators, String message) {
     globals.printStatus('$message\n');
-    Emulator.printEmulators(emulators);
+    Emulator.printEmulators(emulators, globals.logger);
     _printAdditionalInfo(showCreateInstruction: true, showRunInstruction: true);
   }
 

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -79,7 +79,9 @@ Future<T> runInContext<T>(
         processManager: globals.processManager,
         userMessages: globals.userMessages,
       ),
-      AndroidWorkflow: () => AndroidWorkflow(),
+      AndroidWorkflow: () => AndroidWorkflow(
+        androidSdk: globals.androidSdk,
+      ),
       ApplicationPackageFactory: () => ApplicationPackageFactory(),
       Artifacts: () => CachedArtifacts(
         fileSystem: globals.fs,
@@ -125,7 +127,13 @@ Future<T> runInContext<T>(
       DeviceManager: () => DeviceManager(),
       Doctor: () => Doctor(logger: globals.logger),
       DoctorValidatorsProvider: () => DoctorValidatorsProvider.defaultInstance,
-      EmulatorManager: () => EmulatorManager(),
+      EmulatorManager: () => EmulatorManager(
+        androidSdk: globals.androidSdk,
+        processManager: globals.processManager,
+        logger: globals.logger,
+        fileSystem: globals.fs,
+        androidWorkflow: androidWorkflow,
+      ),
       FeatureFlags: () => const FeatureFlags(),
       FlutterVersion: () => FlutterVersion(const SystemClock()),
       FuchsiaArtifacts: () => FuchsiaArtifacts.find(),

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -6,28 +6,49 @@ import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:meta/meta.dart';
+import 'package:process/process.dart';
 
 import 'android/android_emulator.dart';
 import 'android/android_sdk.dart';
+import 'android/android_workflow.dart';
 import 'base/context.dart';
+import 'base/file_system.dart';
+import 'base/logger.dart';
 import 'base/process.dart';
 import 'device.dart';
-import 'globals.dart' as globals;
 import 'ios/ios_emulators.dart';
 
 EmulatorManager get emulatorManager => context.get<EmulatorManager>();
 
 /// A class to get all available emulators.
 class EmulatorManager {
-  /// Constructing EmulatorManager is cheap; they only do expensive work if some
-  /// of their methods are called.
-  EmulatorManager() {
-    // Register the known discoverers.
-    _emulatorDiscoverers.add(AndroidEmulators());
-    _emulatorDiscoverers.add(IOSEmulators());
+  EmulatorManager({
+    @required AndroidSdk androidSdk,
+    @required Logger logger,
+    @required ProcessManager processManager,
+    @required AndroidWorkflow androidWorkflow,
+    @required FileSystem fileSystem,
+  }) : _androidSdk = androidSdk,
+       _processUtils = ProcessUtils(logger: logger, processManager: processManager),
+       _androidEmulators = AndroidEmulators(
+        androidSdk: androidSdk,
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        androidWorkflow: androidWorkflow
+      ) {
+    _emulatorDiscoverers.add(_androidEmulators);
   }
 
-  final List<EmulatorDiscovery> _emulatorDiscoverers = <EmulatorDiscovery>[];
+  final AndroidSdk _androidSdk;
+  final AndroidEmulators _androidEmulators;
+  final ProcessUtils _processUtils;
+
+  // Constructing EmulatorManager is cheap; they only do expensive work if some
+  // of their methods are called.
+  final List<EmulatorDiscovery> _emulatorDiscoverers = <EmulatorDiscovery>[
+    IOSEmulators(),
+  ];
 
   Future<List<Emulator>> getEmulatorsMatching(String searchText) async {
     final List<Emulator> emulators = await getAllAvailableEmulators();
@@ -64,7 +85,7 @@ class EmulatorManager {
 
   /// Return the list of all available emulators.
   Future<CreateEmulatorResult> createEmulator({ String name }) async {
-    if (name == null || name == '') {
+    if (name == null || name.isEmpty) {
       const String autoName = 'flutter_emulator';
       // Don't use getEmulatorsMatching here, as it will only return one
       // if there's an exact match and we need all those with this prefix
@@ -79,6 +100,11 @@ class EmulatorManager {
       while (takenNames.contains(name)) {
         name = '${autoName}_${++suffix}';
       }
+    }
+    if (!_androidEmulators.canLaunchAnything) {
+      return CreateEmulatorResult(name,
+        success: false, error: 'avdmanager is missing from the Android SDK'
+      );
     }
 
     final String device = await _getPreferredAvailableDevice();
@@ -113,17 +139,15 @@ class EmulatorManager {
           .join('\n')
           .trim();
     }
-
-    final List<String> args = <String>[
-      getAvdManagerPath(globals.androidSdk),
-      'create',
-      'avd',
-      '-n', name,
-      '-k', sdkId,
-      '-d', device,
-    ];
-    final RunResult runResult = processUtils.runSync(args,
-        environment: globals.androidSdk?.sdkManagerEnv);
+    final RunResult runResult = await _processUtils.run(<String>[
+      getAvdManagerPath(_androidSdk),
+        'create',
+        'avd',
+        '-n', name,
+        '-k', sdkId,
+        '-d', device,
+      ], environment: _androidSdk?.sdkManagerEnv,
+    );
     return CreateEmulatorResult(
       name,
       success: runResult.exitCode == 0,
@@ -136,15 +160,16 @@ class EmulatorManager {
     'pixel',
     'pixel_xl',
   ];
+
   Future<String> _getPreferredAvailableDevice() async {
     final List<String> args = <String>[
-      getAvdManagerPath(globals.androidSdk),
+      getAvdManagerPath(_androidSdk),
       'list',
       'device',
       '-c',
     ];
-    final RunResult runResult = processUtils.runSync(args,
-        environment: globals.androidSdk?.sdkManagerEnv);
+    final RunResult runResult = await _processUtils.run(args,
+        environment: _androidSdk?.sdkManagerEnv);
     if (runResult.exitCode != 0) {
       return null;
     }
@@ -160,29 +185,30 @@ class EmulatorManager {
     );
   }
 
-  RegExp androidApiVersion = RegExp(r';android-(\d+);');
+  static final RegExp _androidApiVersion = RegExp(r';android-(\d+);');
+
   Future<String> _getPreferredSdkId() async {
     // It seems that to get the available list of images, we need to send a
     // request to create without the image and it'll provide us a list :-(
     final List<String> args = <String>[
-      getAvdManagerPath(globals.androidSdk),
+      getAvdManagerPath(_androidSdk),
       'create',
       'avd',
       '-n', 'temp',
     ];
-    final RunResult runResult = processUtils.runSync(args,
-        environment: globals.androidSdk?.sdkManagerEnv);
+    final RunResult runResult = await _processUtils.run(args,
+        environment: _androidSdk?.sdkManagerEnv);
 
     // Get the list of IDs that match our criteria
     final List<String> availableIDs = runResult.stderr
         .split('\n')
-        .where((String l) => androidApiVersion.hasMatch(l))
+        .where((String l) => _androidApiVersion.hasMatch(l))
         .where((String l) => l.contains('system-images'))
         .where((String l) => l.contains('google_apis_playstore'))
         .toList();
 
     final List<int> availableApiVersions = availableIDs
-        .map<String>((String id) => androidApiVersion.firstMatch(id).group(1))
+        .map<String>((String id) => _androidApiVersion.firstMatch(id).group(1))
         .map<int>((String apiVersion) => int.parse(apiVersion))
         .toList();
 
@@ -209,9 +235,11 @@ class EmulatorManager {
 abstract class EmulatorDiscovery {
   bool get supportsPlatform;
 
-  /// Whether this emulator discovery is capable of listing any emulators given the
-  /// current environment configuration.
+  /// Whether this emulator discovery is capable of listing any emulators.
   bool get canListAnything;
+
+  /// Whether this emulator discovery is capabale of launching new emulators.
+  bool get canLaunchAnything;
 
   Future<List<Emulator>> get emulators;
 }
@@ -280,8 +308,8 @@ abstract class Emulator {
         .toList();
   }
 
-  static void printEmulators(List<Emulator> emulators) {
-    descriptions(emulators).forEach(globals.printStatus);
+  static void printEmulators(List<Emulator> emulators, Logger logger) {
+    descriptions(emulators).forEach(logger.printStatus);
   }
 }
 

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -19,6 +19,9 @@ class IOSEmulators extends EmulatorDiscovery {
 
   @override
   Future<List<Emulator>> get emulators async => getEmulators();
+
+  @override
+  bool get canLaunchAnything => canListAnything;
 }
 
 class IOSEmulator extends Emulator {

--- a/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
@@ -20,7 +20,9 @@ void main() {
     final AndroidDevices androidDevices = AndroidDevices(
       androidSdk: MockAndroidSdk(null),
       logger: BufferLogger.test(),
-      androidWorkflow: AndroidWorkflow(),
+      androidWorkflow: AndroidWorkflow(
+        androidSdk: MockAndroidSdk(null),
+      ),
       processManager: FakeProcessManager.list(<FakeCommand>[]),
     );
 
@@ -39,7 +41,9 @@ void main() {
     final AndroidDevices androidDevices = AndroidDevices(
       androidSdk: MockAndroidSdk(),
       logger: BufferLogger.test(),
-      androidWorkflow: AndroidWorkflow(),
+      androidWorkflow: AndroidWorkflow(
+        androidSdk: MockAndroidSdk(),
+      ),
       processManager: processManager,
     );
 
@@ -57,7 +61,9 @@ void main() {
     final AndroidDevices androidDevices = AndroidDevices(
       androidSdk: MockAndroidSdk(),
       logger: BufferLogger.test(),
-      androidWorkflow: AndroidWorkflow(),
+      androidWorkflow: AndroidWorkflow(
+        androidSdk: MockAndroidSdk(),
+      ),
       processManager: processManager,
     );
 

--- a/packages/flutter_tools/test/general.shard/android/android_emulator_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_emulator_test.dart
@@ -52,6 +52,7 @@ void main() {
       expect(emulator.id, emulatorID);
       expect(emulator.hasConfig, true);
     });
+
     testWithoutContext('reads expected metadata', () {
       const String emulatorID = '1234';
       const String manufacturer = 'Me';
@@ -203,7 +204,8 @@ void main() {
         time.flushMicrotasks();
       });
       await completer.future;
-      expect(testLogger.errorText, isEmpty);
+
+      expect(logger.errorText, isEmpty);
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/android/android_emulator_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_emulator_test.dart
@@ -4,12 +4,11 @@
 
 import 'dart:async';
 
-import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_tools/src/android/android_sdk.dart'
-  show getEmulatorPath, AndroidSdk;
+  show getEmulatorPath;
 import 'package:flutter_tools/src/android/android_emulator.dart';
 import 'package:flutter_tools/src/base/common.dart';
+import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:mockito/mockito.dart';
 import 'package:quiver/testing/async.dart';
@@ -19,24 +18,41 @@ import '../../src/context.dart';
 import '../../src/fake_process_manager.dart';
 import '../../src/mocks.dart' show MockAndroidSdk;
 
+const String emulatorID = 'i1234';
+const String errorText = '[Android emulator test error]';
+const List<String> kEmulatorLaunchCommand = <String>[
+  'emulator', '-avd', emulatorID,
+];
+
 void main() {
   group('android_emulator', () {
-    testUsingContext('flags emulators without config', () {
+    testWithoutContext('flags emulators without config', () {
       const String emulatorID = '1234';
-      final AndroidEmulator emulator = AndroidEmulator(emulatorID);
+
+      final AndroidEmulator emulator = AndroidEmulator(
+        emulatorID,
+        logger: BufferLogger.test(),
+        processManager: FakeProcessManager.any(),
+        androidSdk: MockAndroidSdk(),
+      );
       expect(emulator.id, emulatorID);
       expect(emulator.hasConfig, false);
     });
-    testUsingContext('flags emulators with config', () {
+
+    testWithoutContext('flags emulators with config', () {
       const String emulatorID = '1234';
       final AndroidEmulator emulator = AndroidEmulator(
         emulatorID,
-        const <String, String>{'name': 'test'},
+        properties: const <String, String>{'name': 'test'},
+        logger: BufferLogger.test(),
+        processManager: FakeProcessManager.any(),
+        androidSdk: MockAndroidSdk(),
       );
+
       expect(emulator.id, emulatorID);
       expect(emulator.hasConfig, true);
     });
-    testUsingContext('reads expected metadata', () {
+    testWithoutContext('reads expected metadata', () {
       const String emulatorID = '1234';
       const String manufacturer = 'Me';
       const String displayName = 'The best one';
@@ -44,33 +60,57 @@ void main() {
         'hw.device.manufacturer': manufacturer,
         'avd.ini.displayname': displayName,
       };
-      final AndroidEmulator emulator = AndroidEmulator(emulatorID, properties);
+      final AndroidEmulator emulator = AndroidEmulator(
+        emulatorID,
+        properties: properties,
+        logger: BufferLogger.test(),
+        processManager: FakeProcessManager.any(),
+        androidSdk: MockAndroidSdk(),
+      );
+
       expect(emulator.id, emulatorID);
       expect(emulator.name, displayName);
       expect(emulator.manufacturer, manufacturer);
       expect(emulator.category, Category.mobile);
       expect(emulator.platformType, PlatformType.android);
     });
-    testUsingContext('prefers displayname for name', () {
+
+    testWithoutContext('prefers displayname for name', () {
       const String emulatorID = '1234';
       const String displayName = 'The best one';
       final Map<String, String> properties = <String, String>{
         'avd.ini.displayname': displayName,
       };
-      final AndroidEmulator emulator = AndroidEmulator(emulatorID, properties);
+      final AndroidEmulator emulator = AndroidEmulator(
+        emulatorID,
+        properties: properties,
+        logger: BufferLogger.test(),
+        processManager: FakeProcessManager.any(),
+        androidSdk: MockAndroidSdk(),
+      );
+
       expect(emulator.name, displayName);
     });
-    testUsingContext('uses cleaned up ID if no displayname is set', () {
+
+    testWithoutContext('uses cleaned up ID if no displayname is set', () {
       // Android Studio uses the ID with underscores replaced with spaces
       // for the name if displayname is not set so we do the same.
       const String emulatorID = 'This_is_my_ID';
       final Map<String, String> properties = <String, String>{
         'avd.ini.notadisplayname': 'this is not a display name',
       };
-      final AndroidEmulator emulator = AndroidEmulator(emulatorID, properties);
+      final AndroidEmulator emulator = AndroidEmulator(
+        emulatorID,
+        properties: properties,
+        logger: BufferLogger.test(),
+        processManager: FakeProcessManager.any(),
+        androidSdk: MockAndroidSdk(),
+      );
+
       expect(emulator.name, 'This is my ID');
     });
-    testUsingContext('parses ini files', () {
+
+    testWithoutContext('parses ini files', () {
       const String iniFile = '''
         hw.device.name=My Test Name
         #hw.device.name=Bad Name
@@ -79,6 +119,7 @@ void main() {
         avd.ini.displayname = dispName
       ''';
       final Map<String, String> results = parseIniLines(iniFile.split('\n'));
+
       expect(results['hw.device.name'], 'My Test Name');
       expect(results['hw.device.manufacturer'], 'Me');
       expect(results['avd.ini.displayname'], 'dispName');
@@ -86,51 +127,49 @@ void main() {
   });
 
   group('Android emulator launch ', () {
-    const String emulatorID = 'i1234';
-    const String errorText = '[Android emulator test error]';
     MockAndroidSdk mockSdk;
-    FakeProcessManager successProcessManager;
-    FakeProcessManager errorProcessManager;
-    FakeProcessManager lateFailureProcessManager;
-    MemoryFileSystem fs;
 
     setUp(() {
-      fs = MemoryFileSystem();
       mockSdk = MockAndroidSdk();
       when(mockSdk.emulatorPath).thenReturn('emulator');
-
-      const List<String> command = <String>[
-        'emulator', '-avd', emulatorID,
-      ];
-
-      successProcessManager = FakeProcessManager.list(<FakeCommand>[
-        const FakeCommand(command: command),
-      ]);
-
-      errorProcessManager = FakeProcessManager.list(<FakeCommand>[
-        const FakeCommand(
-          command: command,
-          exitCode: 1,
-          stderr: errorText,
-          stdout: 'dummy text',
-          duration: Duration(seconds: 1),
-        ),
-      ]);
-
-      lateFailureProcessManager = FakeProcessManager.list(<FakeCommand>[
-        const FakeCommand(
-          command: command,
-          exitCode: 1,
-          stderr: '',
-          stdout: 'dummy text',
-          duration: Duration(seconds: 4),
-        ),
-      ]);
     });
 
-    testUsingContext('succeeds', () async {
-      final AndroidEmulator emulator = AndroidEmulator(emulatorID);
+    testWithoutContext('succeeds', () async {
+      final AndroidEmulator emulator = AndroidEmulator(emulatorID,
+        processManager: FakeProcessManager.list(<FakeCommand>[
+          const FakeCommand(command: kEmulatorLaunchCommand),
+        ]),
+        androidSdk: mockSdk,
+        logger: BufferLogger.test(),
+      );
+
       expect(getEmulatorPath(mockSdk), mockSdk.emulatorPath);
+
+      final Completer<void> completer = Completer<void>();
+      FakeAsync().run((FakeAsync time) {
+        unawaited(emulator.launch().whenComplete(completer.complete));
+        time.elapse(const Duration(seconds: 5));
+        time.flushMicrotasks();
+      });
+      await completer.future;
+    });
+
+    testWithoutContext('prints error on failure', () async {
+      final BufferLogger logger =  BufferLogger.test();
+      final AndroidEmulator emulator = AndroidEmulator(emulatorID,
+        processManager: FakeProcessManager.list(<FakeCommand>[
+          const FakeCommand(
+            command: kEmulatorLaunchCommand,
+            exitCode: 1,
+            stderr: errorText,
+            stdout: 'dummy text',
+            duration: Duration(seconds: 1),
+          ),
+        ]),
+        androidSdk: mockSdk,
+        logger: logger,
+      );
+
       final Completer<void> completer = Completer<void>();
       FakeAsync().run((FakeAsync time) {
         unawaited(emulator.launch().whenComplete(completer.complete));
@@ -139,31 +178,24 @@ void main() {
       });
       await completer.future;
 
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => successProcessManager,
-      AndroidSdk: () => mockSdk,
-      FileSystem: () => fs,
+      expect(logger.errorText, contains(errorText));
     });
 
-    testUsingContext('prints error on failure', () async {
-      final AndroidEmulator emulator = AndroidEmulator(emulatorID);
-      final Completer<void> completer = Completer<void>();
-      FakeAsync().run((FakeAsync time) {
-        unawaited(emulator.launch().whenComplete(completer.complete));
-        time.elapse(const Duration(seconds: 5));
-        time.flushMicrotasks();
-      });
-      await completer.future;
-
-      expect(testLogger.errorText, contains(errorText));
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => errorProcessManager,
-      AndroidSdk: () => mockSdk,
-      FileSystem: () => fs,
-    });
-
-    testUsingContext('prints nothing on late failure with empty stderr', () async {
-      final AndroidEmulator emulator = AndroidEmulator(emulatorID);
+    testWithoutContext('prints nothing on late failure with empty stderr', () async {
+      final BufferLogger logger =  BufferLogger.test();
+      final AndroidEmulator emulator = AndroidEmulator(emulatorID,
+        processManager: FakeProcessManager.list(<FakeCommand>[
+          const FakeCommand(
+            command: kEmulatorLaunchCommand,
+            exitCode: 1,
+            stderr: '',
+            stdout: 'dummy text',
+            duration: Duration(seconds: 4),
+          ),
+        ]),
+        androidSdk: mockSdk,
+        logger: logger,
+      );
       final Completer<void> completer = Completer<void>();
       FakeAsync().run((FakeAsync time) async {
         unawaited(emulator.launch().whenComplete(completer.complete));
@@ -172,10 +204,6 @@ void main() {
       });
       await completer.future;
       expect(testLogger.errorText, isEmpty);
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => lateFailureProcessManager,
-      AndroidSdk: () => mockSdk,
-      FileSystem: () => fs,
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/emulator_test.dart
+++ b/packages/flutter_tools/test/general.shard/emulator_test.dart
@@ -93,6 +93,29 @@ void main() {
       expect(await testEmulatorManager.getEmulatorsMatching('ios'),  <Emulator>[emulator3]);
     });
 
+    testUsingContext('create emulator with a missing avdmanager does not crash.', () async {
+      when(mockSdk.avdManagerPath).thenReturn(null);
+      when(mockSdk.getAvdManagerPath()).thenReturn(null);
+      final EmulatorManager emulatorManager = EmulatorManager(
+        fileSystem: MemoryFileSystem.test(),
+        logger: BufferLogger.test(),
+        processManager: FakeProcessManager.list(<FakeCommand>[
+          const FakeCommand(
+            command: <String>['emulator', '-list-avds'],
+            stdout: 'existing-avd-1',
+          ),
+        ]),
+        androidSdk: mockSdk,
+        androidWorkflow: AndroidWorkflow(
+          androidSdk: mockSdk,
+        ),
+      );
+      final CreateEmulatorResult result = await emulatorManager.createEmulator();
+
+      expect(result.success, false);
+      expect(result.error, contains('avdmanager is missing from the Android SDK'));
+    });
+
     // iOS discovery uses context.
     testUsingContext('create emulator with an empty name does not fail', () async {
       final EmulatorManager emulatorManager = EmulatorManager(

--- a/packages/flutter_tools/test/general.shard/emulator_test.dart
+++ b/packages/flutter_tools/test/general.shard/emulator_test.dart
@@ -5,10 +5,10 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:collection/collection.dart' show ListEquality;
-import 'package:flutter_tools/src/android/android_sdk.dart';
-import 'package:flutter_tools/src/base/config.dart';
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/android/android_workflow.dart';
 import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/emulator.dart';
 import 'package:flutter_tools/src/ios/ios_emulators.dart';
@@ -20,106 +20,229 @@ import '../src/common.dart';
 import '../src/context.dart';
 import '../src/mocks.dart';
 
+const FakeEmulator emulator1 = FakeEmulator('Nexus_5', 'Nexus 5', 'Google');
+const FakeEmulator emulator2 = FakeEmulator('Nexus_5X_API_27_x86', 'Nexus 5X', 'Google');
+const FakeEmulator emulator3 = FakeEmulator('iOS Simulator', 'iOS Simulator', 'Apple');
+const List<Emulator> emulators = <Emulator>[
+  emulator1,
+  emulator2,
+  emulator3,
+];
+
+// We have to send a command that fails in order to get the list of valid
+// system images paths. This is an example of the output to use in the mock.
+const String fakeCreateFailureOutput =
+  'Error: Package path (-k) not specified. Valid system image paths are:\n'
+  'system-images;android-27;google_apis;x86\n'
+  'system-images;android-P;google_apis;x86\n'
+  'system-images;android-27;google_apis_playstore;x86\n'
+  'null\n'; // Yep, these really end with null (on dantup's machine at least)
+
+const FakeCommand kListEmulatorsCommand = FakeCommand(
+  command: <String>['avdmanager', 'create', 'avd', '-n', 'temp'],
+  stderr: fakeCreateFailureOutput,
+  exitCode: 1,
+);
+
 void main() {
   MockProcessManager mockProcessManager;
-  MockConfig mockConfig;
   MockAndroidSdk mockSdk;
   MockXcode mockXcode;
 
   setUp(() {
     mockProcessManager = MockProcessManager();
-    mockConfig = MockConfig();
     mockSdk = MockAndroidSdk();
     mockXcode = MockXcode();
 
     when(mockSdk.avdManagerPath).thenReturn('avdmanager');
+    when(mockSdk.getAvdManagerPath()).thenReturn('avdmanager');
     when(mockSdk.emulatorPath).thenReturn('emulator');
   });
 
   group('EmulatorManager', () {
+    // iOS discovery uses context.
     testUsingContext('getEmulators', () async {
       // Test that EmulatorManager.getEmulators() doesn't throw.
-      final List<Emulator> emulators =
-          await emulatorManager.getAllAvailableEmulators();
-      expect(emulators, isList);
+      final EmulatorManager emulatorManager = EmulatorManager(
+        fileSystem: MemoryFileSystem.test(),
+        logger: BufferLogger.test(),
+        processManager: FakeProcessManager.list(<FakeCommand>[
+          const FakeCommand(
+            command: <String>['emulator', '-list-avds'],
+            stdout: 'existing-avd-1',
+          ),
+        ]),
+        androidSdk: mockSdk,
+        androidWorkflow: AndroidWorkflow(
+          androidSdk: mockSdk,
+        ),
+      );
+
+      await expectLater(() async => await emulatorManager.getAllAvailableEmulators(),
+        returnsNormally);
     });
 
-    testUsingContext('getEmulatorsById', () async {
-      const _MockEmulator emulator1 =
-          _MockEmulator('Nexus_5', 'Nexus 5', 'Google');
-      const _MockEmulator emulator2 =
-          _MockEmulator('Nexus_5X_API_27_x86', 'Nexus 5X', 'Google');
-      const _MockEmulator emulator3 =
-          _MockEmulator('iOS Simulator', 'iOS Simulator', 'Apple');
-      final List<Emulator> emulators = <Emulator>[
-        emulator1,
-        emulator2,
-        emulator3,
-      ];
-      final TestEmulatorManager testEmulatorManager =
-          TestEmulatorManager(emulators);
+    testWithoutContext('getEmulatorsById', () async {
+      final TestEmulatorManager testEmulatorManager = TestEmulatorManager(emulators);
 
-      Future<void> expectEmulator(String id, List<Emulator> expected) async {
-        expect(await testEmulatorManager.getEmulatorsMatching(id), expected);
-      }
-
-      await expectEmulator('Nexus_5', <Emulator>[emulator1]);
-      await expectEmulator('Nexus_5X', <Emulator>[emulator2]);
-      await expectEmulator('Nexus_5X_API_27_x86', <Emulator>[emulator2]);
-      await expectEmulator('Nexus', <Emulator>[emulator1, emulator2]);
-      await expectEmulator('iOS Simulator', <Emulator>[emulator3]);
-      await expectEmulator('ios', <Emulator>[emulator3]);
+      expect(await testEmulatorManager.getEmulatorsMatching('Nexus_5'), <Emulator>[emulator1]);
+      expect(await testEmulatorManager.getEmulatorsMatching('Nexus_5X'), <Emulator>[emulator2]);
+      expect(await testEmulatorManager.getEmulatorsMatching('Nexus_5X_API_27_x86'),  <Emulator>[emulator2]);
+      expect(await testEmulatorManager.getEmulatorsMatching('Nexus'), <Emulator>[emulator1, emulator2]);
+      expect(await testEmulatorManager.getEmulatorsMatching('iOS Simulator'), <Emulator>[emulator3]);
+      expect(await testEmulatorManager.getEmulatorsMatching('ios'),  <Emulator>[emulator3]);
     });
 
+    // iOS discovery uses context.
     testUsingContext('create emulator with an empty name does not fail', () async {
-      final CreateEmulatorResult res = await emulatorManager.createEmulator();
-      expect(res.success, equals(true));
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-      Config: () => mockConfig,
-      AndroidSdk: () => mockSdk,
+      final EmulatorManager emulatorManager = EmulatorManager(
+        fileSystem: MemoryFileSystem.test(),
+        logger: BufferLogger.test(),
+        processManager: FakeProcessManager.list(<FakeCommand>[
+          const FakeCommand(
+            command: <String>['emulator', '-list-avds'],
+            stdout: 'existing-avd-1',
+          ),
+          const FakeCommand(
+            command: <String>['avdmanager', 'list', 'device', '-c'],
+            stdout: 'test\ntest2\npixel\npixel-xl\n',
+          ),
+          kListEmulatorsCommand,
+          const FakeCommand(
+            command: <String>[
+              'avdmanager',
+              'create',
+              'avd',
+              '-n',
+              'flutter_emulator',
+              '-k',
+              'system-images;android-27;google_apis_playstore;x86',
+              '-d',
+              'pixel',
+            ],
+          )
+        ]),
+        androidSdk: mockSdk,
+        androidWorkflow: AndroidWorkflow(
+          androidSdk: mockSdk,
+        ),
+      );
+      final CreateEmulatorResult result = await emulatorManager.createEmulator();
+
+      expect(result.success, true);
     });
 
-    testUsingContext('create emulator with a unique name does not throw', () async {
-      final CreateEmulatorResult res =
-          await emulatorManager.createEmulator(name: 'test');
-      expect(res.success, equals(true));
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-      Config: () => mockConfig,
-      AndroidSdk: () => mockSdk,
+    testWithoutContext('create emulator with a unique name does not throw', () async {
+      final EmulatorManager emulatorManager = EmulatorManager(
+        fileSystem: MemoryFileSystem.test(),
+        logger: BufferLogger.test(),
+        processManager: FakeProcessManager.list(<FakeCommand>[
+          const FakeCommand(
+            command: <String>['avdmanager', 'list', 'device', '-c'],
+            stdout: 'test\ntest2\npixel\npixel-xl\n',
+          ),
+          kListEmulatorsCommand,
+          const FakeCommand(
+            command: <String>[
+              'avdmanager',
+              'create',
+              'avd',
+              // The specified name is given with the -n flag.
+              '-n',
+              'test',
+              '-k',
+              'system-images;android-27;google_apis_playstore;x86',
+              '-d',
+              'pixel',
+            ],
+          )
+        ]),
+        androidSdk: mockSdk,
+        androidWorkflow: AndroidWorkflow(
+          androidSdk: mockSdk,
+        ),
+      );
+      final CreateEmulatorResult result = await emulatorManager.createEmulator(name: 'test');
+
+      expect(result.success, true);
     });
 
-    testUsingContext('create emulator with an existing name errors', () async {
-      final CreateEmulatorResult res =
-          await emulatorManager.createEmulator(name: 'existing-avd-1');
-      expect(res.success, equals(false));
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-      Config: () => mockConfig,
-      AndroidSdk: () => mockSdk,
+    testWithoutContext('create emulator with an existing name errors', () async {
+      final EmulatorManager emulatorManager = EmulatorManager(
+        fileSystem: MemoryFileSystem.test(),
+        logger: BufferLogger.test(),
+        processManager: FakeProcessManager.list(<FakeCommand>[
+          const FakeCommand(
+            command: <String>['avdmanager', 'list', 'device', '-c'],
+            stdout: 'test\ntest2\npixel\npixel-xl\n',
+          ),
+          kListEmulatorsCommand,
+          const FakeCommand(
+            command: <String>[
+              'avdmanager',
+              'create',
+              'avd',
+              '-n',
+              'existing-avd-1',
+              '-k',
+              'system-images;android-27;google_apis_playstore;x86',
+              '-d',
+              'pixel',
+            ],
+            exitCode: 1,
+            stderr: "Error: Android Virtual Device 'existing-avd-1' already exists.\n"
+              'Use --force if you want to replace it.'
+          )
+        ]),
+        androidSdk: mockSdk,
+        androidWorkflow: AndroidWorkflow(
+          androidSdk: mockSdk,
+        ),
+      );
+      final CreateEmulatorResult result = await emulatorManager.createEmulator(name: 'existing-avd-1');
+
+      expect(result.success, false);
     });
 
+    // iOS discovery uses context.
     testUsingContext('create emulator without a name but when default exists adds a suffix', () async {
-      // First will get default name.
-      CreateEmulatorResult res = await emulatorManager.createEmulator();
-      expect(res.success, equals(true));
+      final EmulatorManager emulatorManager = EmulatorManager(
+        fileSystem: MemoryFileSystem.test(),
+        logger: BufferLogger.test(),
+        processManager: FakeProcessManager.list(<FakeCommand>[
+          const FakeCommand(
+            command: <String>['emulator', '-list-avds'],
+            stdout: 'existing-avd-1\nflutter_emulator',
+          ),
+          const FakeCommand(
+            command: <String>['avdmanager', 'list', 'device', '-c'],
+            stdout: 'test\ntest2\npixel\npixel-xl\n',
+          ),
+          kListEmulatorsCommand,
+          const FakeCommand(
+            command: <String>[
+              'avdmanager',
+              'create',
+              'avd',
+              // a "_2" suffix is added to disambiguate from the existing emulator.
+              '-n',
+              'flutter_emulator_2',
+              '-k',
+              'system-images;android-27;google_apis_playstore;x86',
+              '-d',
+              'pixel',
+            ],
+          )
+        ]),
+        androidSdk: mockSdk,
+        androidWorkflow: AndroidWorkflow(
+          androidSdk: mockSdk,
+        ),
+      );
+      final CreateEmulatorResult result = await emulatorManager.createEmulator();
 
-      final String defaultName = res.emulatorName;
-
-      // Second...
-      res = await emulatorManager.createEmulator();
-      expect(res.success, equals(true));
-      expect(res.emulatorName, equals('${defaultName}_2'));
-
-      // Third...
-      res = await emulatorManager.createEmulator();
-      expect(res.success, equals(true));
-      expect(res.emulatorName, equals('${defaultName}_3'));
-    }, overrides: <Type, Generator>{
-      ProcessManager: () => mockProcessManager,
-      Config: () => mockConfig,
-      AndroidSdk: () => mockSdk,
+      expect(result.success, true);
+      expect(result.emulatorName, 'flutter_emulator_2');
     });
   });
 
@@ -142,7 +265,6 @@ void main() {
       expect(didAttemptToRunSimulator, equals(true));
     }, overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
-      Config: () => mockConfig,
       Xcode: () => mockXcode,
     });
   });
@@ -159,8 +281,8 @@ class TestEmulatorManager extends EmulatorManager {
   }
 }
 
-class _MockEmulator extends Emulator {
-  const _MockEmulator(String id, this.name, this.manufacturer)
+class FakeEmulator extends Emulator {
+  const FakeEmulator(String id, this.name, this.manufacturer)
     : super(id, true);
 
   @override
@@ -181,20 +303,7 @@ class _MockEmulator extends Emulator {
   }
 }
 
-class MockConfig extends Mock implements Config {}
-
 class MockProcessManager extends Mock implements ProcessManager {
-  /// We have to send a command that fails in order to get the list of valid
-  /// system images paths. This is an example of the output to use in the mock.
-  static const String mockCreateFailureOutput =
-      'Error: Package path (-k) not specified. Valid system image paths are:\n'
-      'system-images;android-27;google_apis;x86\n'
-      'system-images;android-P;google_apis;x86\n'
-      'system-images;android-27;google_apis_playstore;x86\n'
-      'null\n'; // Yep, these really end with null (on dantup's machine at least)
-
-  static const ListEquality<String> _equality = ListEquality<String>();
-  final List<String> _existingAvds = <String>['existing-avd-1'];
 
   @override
   ProcessResult runSync(
@@ -212,50 +321,8 @@ class MockProcessManager extends Mock implements ProcessManager {
       case '/usr/bin/xcode-select':
         throw ProcessException(program, args);
         break;
-      case 'emulator':
-        return _handleEmulator(args);
-      case 'avdmanager':
-        return _handleAvdManager(args);
     }
     throw StateError('Unexpected process call: $command');
-  }
-
-  ProcessResult _handleEmulator(List<String> args) {
-    if (_equality.equals(args, <String>['-list-avds'])) {
-      return ProcessResult(101, 0, '${_existingAvds.join('\n')}\n', '');
-    }
-    throw ProcessException('emulator', args);
-  }
-
-  ProcessResult _handleAvdManager(List<String> args) {
-    if (_equality.equals(args, <String>['list', 'device', '-c'])) {
-      return ProcessResult(101, 0, 'test\ntest2\npixel\npixel-xl\n', '');
-    }
-    if (_equality.equals(args, <String>['create', 'avd', '-n', 'temp'])) {
-      return ProcessResult(101, 1, '', mockCreateFailureOutput);
-    }
-    if (args.length == 8 &&
-        _equality.equals(args,
-            <String>['create', 'avd', '-n', args[3], '-k', args[5], '-d', args[7]])) {
-      // In order to support testing auto generation of names we need to support
-      // tracking any created emulators and reject when they already exist so this
-      // mock will compare the name of the AVD being created with the fake existing
-      // list and either reject if it exists, or add it to the list and return success.
-      final String name = args[3];
-      // Error if this AVD already existed
-      if (_existingAvds.contains(name)) {
-        return ProcessResult(
-            101,
-            1,
-            '',
-            "Error: Android Virtual Device '$name' already exists.\n"
-            'Use --force if you want to replace it.');
-      } else {
-        _existingAvds.add(name);
-        return ProcessResult(101, 0, '', '');
-      }
-    }
-    throw ProcessException('emulator', args);
   }
 }
 


### PR DESCRIPTION
## Description

The avdmanager is not currently verified as a part of the android doctor check. It also may not been in the initial android sdk download we recommend, and only downloaded later on by Android Studio. Update `flutter emulators` to check if it exists before attempting to launch an emulator.

https://github.com/flutter/flutter/issues/57483
https://github.com/flutter/flutter/issues/55971

As a follow up, a check for avdmanager needs to be added to flutter doctor along with download instructions.