### PR TITLE
Use pub inside the Flutter directory

### DIFF
--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -437,6 +437,9 @@ Future<String> evalFlutter(String command, {
 String get dartBin =>
     path.join(flutterDirectory.path, 'bin', 'cache', 'dart-sdk', 'bin', 'dart');
 
+String get pubBin =>
+    path.join(flutterDirectory.path, 'bin', 'cache', 'dart-sdk', 'bin', 'pub');
+
 Future<int> dart(List<String> args) => exec(dartBin, args);
 
 /// Returns a future that completes with a path suitable for JAVA_HOME

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -780,14 +780,14 @@ class DevToolsMemoryTest {
   }
 
   Future<void> _launchDevTools() async {
-    await exec('pub', <String>[
+    await exec(pubBin, <String>[
       'global',
       'activate',
       'devtools',
       '0.2.5',
     ]);
     _devToolsProcess = await startProcess(
-      'pub',
+      pubBin,
       <String>[
         'global',
         'run',


### PR DESCRIPTION
This should fix the version issue in the failed test.

Here's the related error in [an example failure log][1]

```
Executing: pub global activate devtools 0.2.5 in /home/flutter/.cocoon/flutter/dev/benchmarks/complex_layout
--
  | 2020-05-20T13:34:55.628211: stdout: Resolving dependencies...
  | 2020-05-20T13:34:56.302033: stderr: The current Dart SDK version is 2.5.2.
  | stderr:
  | stderr: Because devtools >=0.2.5 depends on devtools_server >=0.1.14 which requires SDK version >=2.6.0 <3.0.0, devtools >=0.2.5 is forbidden.
  | stderr: So, because pub global activate depends on devtools 0.2.5, version solving failed.
```

[1]: https://flutter-dashboard.appspot.com/api/get-log?ownerKey=ahFmbHV0dGVyLWRhc2hib2FyZHJfCxIJQ2hlY2tsaXN0Ij9mbHV0dGVyL2ZsdXR0ZXIvbWFzdGVyL2U5MmFmYzE2YjY0NDU2MTFiMzJmZTE5Nzk1NzY4ZDE2YWNjZDJjMWQMCxIEVGFzaxiAgMje1cfSCAw