### PR TITLE
Have TabBar indicator properly follow tabController animation value

### DIFF
--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -227,7 +227,6 @@ class TabController extends ChangeNotifier {
   set offset(double value) {
     assert(value != null);
     assert(value >= -1.0 && value <= 1.0);
-    assert(!indexIsChanging);
     if (value == offset)
       return;
     _animationController.value = value + _index.toDouble();

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -398,7 +398,8 @@ class _IndicatorPainter extends CustomPainter {
     if (controller.indexIsChanging) {
       // The user tapped on a tab, the tab controller's animation is running.
       final Rect targetRect = indicatorRect(size, controller.index);
-      _currentRect = Rect.lerp(targetRect, _currentRect ?? targetRect, _indexChangeProgress(controller));
+      final Rect prevRect = indicatorRect(size, controller.previousIndex);
+      _currentRect = Rect.lerp(targetRect, prevRect, _indexChangeProgress(controller));
     } else {
       // The user is dragging the TabBarView's PageView left or right.
       final int currentIndex = controller.index;

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1311,7 +1311,7 @@ class _TabBarViewState extends State<TabBarView> {
       return false;
 
     _warpUnderwayCount += 1;
-    if (notification is ScrollUpdateNotification && !_controller.indexIsChanging) {
+    if (notification is ScrollUpdateNotification) {
       if ((_pageController.page - _controller.index).abs() > 1.0) {
         _controller.index = _pageController.page.floor();
         _currentIndex =_controller.index;

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2546,4 +2546,54 @@ void main() {
     await tester.pumpAndSettle();
     pageController.removeListener(pageControllerListener);
   });
+
+  testWidgets('TabController animation stops immediately when user starts dragging TabBarView', (WidgetTester tester) async {
+    const List<Tab> tabs = <Tab>[
+      Tab(text: 'A'), Tab(text: 'B'), Tab(text: 'C')
+    ];
+    TabController tabController;
+
+    Widget buildTabControllerFrame(BuildContext context, TabController controller) {
+      tabController = controller;
+      return MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(
+            bottom: TabBar(
+              controller: controller,
+              tabs: tabs,
+            ),
+          ),
+          body: TabBarView(
+            controller: controller,
+            children: tabs.map((Tab tab) {
+              return Center(child: Text(tab.text));
+            }).toList(),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(TabControllerFrame(
+      builder: buildTabControllerFrame,
+      length: tabs.length,
+      initialIndex: 0,
+    ));
+
+    final PageView pageView = tester.widget(find.byType(PageView));
+    final PageController pageController = pageView.controller;
+
+    expect(tabController.index, 0);
+    tabController.animateTo(2, duration: const Duration(seconds: 1));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    // Drag the TabBarView while tabController is in animation
+    // and check if its value immediately starts following TarBarView's page value
+    final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byType(PageView)));
+    await gesture.moveBy(const Offset(1.0, 0.0));
+    expect(tabController.animation.value, pageController.page);
+    expect(tabController.indexIsChanging, false);
+
+    await tester.pumpAndSettle();
+  });
 }

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -1567,35 +1567,41 @@ void main() {
     expect(tabBarBox.size.height, tabBarHeight);
 
     // Tab 0 out of 100 selected
-    double indicatorLeft = 99.0 * 100.0 + indicatorWeight / 2.0;
-    double indicatorRight = 100.0 * 100.0 - indicatorWeight / 2.0;
+    const double startIndicatorLeft = 99.0 * 100.0 + indicatorWeight / 2.0;
+    const double startIndicatorRight = 100.0 * 100.0 - indicatorWeight / 2.0;
+
+    // Tab 99 out of 100 selected, appears on the far left because RTL
+    const double endIndicatorLeft = indicatorWeight / 2.0;
+    const double endIndicatorRight = 100.0 - indicatorWeight / 2.0;
+
     const double indicatorY = 40.0 + indicatorWeight / 2.0;
+
     expect(tabBarBox, paints..line(
       strokeWidth: indicatorWeight,
-      p1: Offset(indicatorLeft, indicatorY),
-      p2: Offset(indicatorRight, indicatorY),
+      p1: const Offset(startIndicatorLeft, indicatorY),
+      p2: const Offset(startIndicatorRight, indicatorY),
     ));
 
     controller.animateTo(tabs.length - 1, duration: const Duration(seconds: 1), curve: Curves.linear);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
 
-    // The x coordinates of p1 and p2 were derived empirically, not analytically.
+    // The x coordinates of p1 and p2 are derived analytically.
+    const double midIndicatorLeft = (startIndicatorLeft + endIndicatorLeft) / 2;
+    const double midIndicatorRight = (startIndicatorRight + endIndicatorRight) / 2;
+
     expect(tabBarBox, paints..line(
       strokeWidth: indicatorWeight,
-      p1: const Offset(2476.0, indicatorY),
-      p2: const Offset(2574.0, indicatorY),
+      p1: const Offset(midIndicatorLeft, indicatorY),
+      p2: const Offset(midIndicatorRight, indicatorY),
     ));
 
     await tester.pump(const Duration(milliseconds: 501));
 
-    // Tab 99 out of 100 selected, appears on the far left because RTL
-    indicatorLeft = indicatorWeight / 2.0;
-    indicatorRight = 100.0 - indicatorWeight / 2.0;
     expect(tabBarBox, paints..line(
       strokeWidth: indicatorWeight,
-      p1: Offset(indicatorLeft, indicatorY),
-      p2: Offset(indicatorRight, indicatorY),
+      p1: const Offset(endIndicatorLeft, indicatorY),
+      p2: const Offset(endIndicatorRight, indicatorY),
     ));
   });
 


### PR DESCRIPTION
## Description

There are three parts that move in `TabBar` and `TabBarView` when we call `tabController.animateTo()`:
1. TabBar's indicator
2. TabBar's scroll position (if it's scrollable)
3. TabBarView's scroll position

Currently, none of them properly follow the duration and curve given to `tabController.animateTo()`. Whether we should change 2 and 3's behavior needs a consensus, I believe, but 1 was definitely a bug. There was a code intended to make the indicator follow `tabController.animation.value` but it wasn't exactly working as intended. So that's what I've tried to fix here.

<details>
  <summary>Reproducible code</summary>

```dart
class Main extends StatefulWidget {
  Main({Key key}) : super(key: key);

  @override
  _MainState createState() => _MainState();
}

class _MainState extends State<Main> with SingleTickerProviderStateMixin {
  final List<Tab> _tabs = <Tab>[
    Tab(text: 'Tab 1'),
    Tab(text: 'Tab 2'),
    Tab(text: 'Tab 3'),
  ];

  TabController _tabController;

  @override
  void initState() {
    super.initState();
    _tabController = TabController(vsync: this, length: _tabs.length);
  }

  @override
  void dispose() {
    _tabController.dispose();
    super.dispose();
  }

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      home: Scaffold(
        appBar: AppBar(
          bottom: TabBar(
            controller: _tabController,
            tabs: _tabs,
            isScrollable: true,
            labelPadding: const EdgeInsets.symmetric(horizontal: 56),
          ),
        ),
        body: TabBarView(
          controller: _tabController,
          children: _tabs.map((Tab tab) {
            return Center(
              child: Column(
                mainAxisSize: MainAxisSize.min,
                children: [
                  Text(tab.text),
                  RaisedButton(
                    child: Text('animate index to 0'),
                    onPressed: () {
                      _tabController.animateTo(0, duration: const Duration(seconds: 3));
                    },
                  ),
                ],
              ),
            );
          }).toList(),
        ),
      ),
    );
  }
}
```

</details>

**Before**

<img src="https://user-images.githubusercontent.com/4879766/82653816-be2f9300-9c5a-11ea-9383-6003ddb77455.gif" width="200" />

Just looking at the indicator, I've given **3 seconds** duration to the animation, but indicator moves much faster than that. Although it **looks like** the animation has finished early, when we drag the TabBarView, indicator doesn't respond  because it's actually still in animation.

**After**

<img src="https://user-images.githubusercontent.com/4879766/82654420-a99fca80-9c5b-11ea-8748-8c3aef75daea.gif" width="200" />

Now the indicator properly follows the animation value.

Actually, if you look at the second gif, there's one more behavior I've changed here: e7c9efc. Previously, while `tabController` is in animation, dragging the `TabBarView` doesn't interfere, i.e. `tabController` keeps animating. But I personally thought this could look more like a bug. Rather, if user starts dragging, `tabController`'s animation should stop and follow that value. If this change looks inappropriate, I'm happy to revert it.

## Related Issues

#55625
#19143

## Tests

I've modified one existing test and also added a new one, but it's not actually a breaking change.. The one I've modified was actually giving a **false positive**, i.e. giving ok sign to improperly acting logic. You can check it here: 304b1cf

So I'll first say no to _is it breaking change?_ checkbox below. Please tell me if there's an issue :)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
