### PR TITLE
[flutter_tools] validate android arch and build number

### DIFF
--- a/packages/flutter_tools/lib/src/android/build_validation.dart
+++ b/packages/flutter_tools/lib/src/android/build_validation.dart
@@ -1,0 +1,38 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import '../base/common.dart';
+import '../build_info.dart';
+
+const String kGooglePlayVersioning = 'https://developer.android.com/studio/publish/versioning.html';
+
+/// Validates that the build mode and build number are valid for a given build.
+void validateBuild(AndroidBuildInfo androidBuildInfo) {
+  final BuildInfo buildInfo = androidBuildInfo.buildInfo;
+  if (buildInfo.mode.isPrecompiled && androidBuildInfo.targetArchs.contains(AndroidArch.x86)) {
+    throwToolExit('Cannot build ${androidBuildInfo.buildInfo.mode.name} mode for x86 ABI.');
+  }
+  if (buildInfo.buildNumber != null) {
+    final int result = int.tryParse(buildInfo.buildNumber);
+    if (result == null) {
+      throwToolExit(
+        'buildNumber: ${buildInfo.buildNumber} was not a valid integer value.\n'
+        'For more information see $kGooglePlayVersioning .'
+      );
+    }
+    if (result < 0) {
+      throwToolExit(
+        'buildNumber: ${buildInfo.buildNumber} must be a positive integer value.\n'
+        'For more information see $kGooglePlayVersioning .'
+      );
+    }
+    if (result > 2100000000) {
+      throwToolExit(
+        'buildNumber: ${buildInfo.buildNumber} is greater than the maximum '
+        'allowed value of 2100000000.\n'
+        'For more information see $kGooglePlayVersioning .'
+      );
+    }
+  }
+}

--- a/packages/flutter_tools/lib/src/android/build_validation.dart
+++ b/packages/flutter_tools/lib/src/android/build_validation.dart
@@ -6,12 +6,16 @@ import '../base/common.dart';
 import '../build_info.dart';
 
 const String kGooglePlayVersioning = 'https://developer.android.com/studio/publish/versioning.html';
+const String kSupportedAbis = 'https://flutter.dev/docs/deployment/android#what-are-the-supported-target-architectures';
 
 /// Validates that the build mode and build number are valid for a given build.
 void validateBuild(AndroidBuildInfo androidBuildInfo) {
   final BuildInfo buildInfo = androidBuildInfo.buildInfo;
   if (buildInfo.mode.isPrecompiled && androidBuildInfo.targetArchs.contains(AndroidArch.x86)) {
-    throwToolExit('Cannot build ${androidBuildInfo.buildInfo.mode.name} mode for x86 ABI.');
+    throwToolExit(
+      'Cannot build ${androidBuildInfo.buildInfo.mode.name} mode for x86 ABI.\n'
+      'For more information see $kSupportedAbis .'
+    );
   }
   if (buildInfo.buildNumber != null) {
     final int result = int.tryParse(buildInfo.buildNumber);

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import '../android/android_builder.dart';
+import '../android/build_validation.dart';
 import '../android/gradle_utils.dart';
 import '../base/terminal.dart';
 import '../build_info.dart';
@@ -95,6 +96,7 @@ class BuildApkCommand extends BuildSubCommand {
       targetArchs: stringsArg('target-platform').map<AndroidArch>(getAndroidArchForName),
       shrink: boolArg('shrink'),
     );
+    validateBuild(androidBuildInfo);
 
     if (buildInfo.isRelease && !androidBuildInfo.splitPerAbi && androidBuildInfo.targetArchs.length > 1) {
       final String targetPlatforms = stringsArg('target-platform').join(', ');

--- a/packages/flutter_tools/lib/src/commands/build_appbundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_appbundle.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import '../android/android_builder.dart';
+import '../android/build_validation.dart';
 import '../android/gradle_utils.dart';
 import '../build_info.dart';
 import '../cache.dart';
@@ -83,6 +84,7 @@ class BuildAppBundleCommand extends BuildSubCommand {
       targetArchs: stringsArg('target-platform').map<AndroidArch>(getAndroidArchForName),
       shrink: boolArg('shrink'),
     );
+    validateBuild(androidBuildInfo);
     await androidBuilder.buildAab(
       project: FlutterProject.current(),
       target: targetFile,

--- a/packages/flutter_tools/test/general.shard/android/build_validation_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/build_validation_test.dart
@@ -1,0 +1,64 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tools/src/android/build_validation.dart';
+import 'package:flutter_tools/src/build_info.dart';
+
+import '../../src/common.dart';
+
+void main() {
+  testWithoutContext('validateBuild throws if attempting to build release/profile on x86', () {
+    expect(() => validateBuild(
+      const AndroidBuildInfo(
+        BuildInfo.release,
+        targetArchs: <AndroidArch>[AndroidArch.x86],
+      ),
+    ), throwsToolExit(message: 'Cannot build release mode for x86 ABI.'));
+  });
+
+  testWithoutContext('validateBuild does not throw on AOT supported architectures', () {
+    expect(() => validateBuild(
+      const AndroidBuildInfo(
+        BuildInfo.release,
+        targetArchs: <AndroidArch>[AndroidArch.x86_64, AndroidArch.armeabi_v7a, AndroidArch.arm64_v8a],
+      ),
+    ), returnsNormally);
+  });
+
+  testWithoutContext('validateBuild throws if an invalid build number is specified', () {
+    expect(() => validateBuild(
+      const AndroidBuildInfo(
+        // Invalid number
+        BuildInfo(BuildMode.debug, '', treeShakeIcons: false, buildNumber: 'a'),
+        targetArchs: <AndroidArch>[AndroidArch.x86],
+      ),
+    ), throwsToolExit(message: 'buildNumber: a was not a valid integer value.'));
+
+    expect(() => validateBuild(
+      const AndroidBuildInfo(
+        // Negative number
+        BuildInfo(BuildMode.debug, '', treeShakeIcons: false, buildNumber: '-1'),
+        targetArchs: <AndroidArch>[AndroidArch.x86],
+      ),
+    ), throwsToolExit(message: 'buildNumber: -1 must be a positive integer value.'));
+
+    expect(() => validateBuild(
+      const AndroidBuildInfo(
+        // Nigger than maximum supported play store value
+        BuildInfo(BuildMode.debug, '', treeShakeIcons: false, buildNumber: '2100000001'),
+        targetArchs: <AndroidArch>[AndroidArch.x86],
+      ),
+    ), throwsToolExit(message: 'buildNumber: 2100000001 is greater than the maximum '
+        'allowed value of 2100000000.'));
+  });
+
+  testWithoutContext('validateBuild does not throw on positive number', () {
+    expect(() => validateBuild(
+      const AndroidBuildInfo(
+        BuildInfo(BuildMode.debug, '', treeShakeIcons: false, buildNumber: '2'),
+        targetArchs: <AndroidArch>[AndroidArch.x86],
+      ),
+    ), returnsNormally);
+  });
+}


### PR DESCRIPTION
## Description

Validate that the android arch and build number are valid before hitting gradle.

Fixes https://github.com/flutter/flutter/issues/57815
Fixes https://github.com/flutter/flutter/issues/45256

related to https://github.com/flutter/flutter/issues/57824