### PR TITLE
[flutter_tools] throw if asked to build release for x86_64

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -58,7 +58,13 @@ abstract class AotAssemblyBase extends Target {
       ?.toList()
       ?? <DarwinArch>[DarwinArch.arm64];
     if (targetPlatform != TargetPlatform.ios) {
-      throw Exception('aot_assembly is only supported for iOS applications');
+      throw Exception('aot_assembly is only supported for iOS applications.');
+    }
+    if (iosArchs.contains(DarwinArch.x86_64)) {
+      throw Exception(
+        'release/profile builds are only supported for physical devices. '
+        'attempted to build for $iosArchs.'
+      );
     }
 
     // If we're building multiple iOS archs the binaries need to be lipo'd


### PR DESCRIPTION
## Description

Fixes https://github.com/flutter/flutter/issues/57859
Fixes https://github.com/flutter/flutter/issues/57929

While there are checks for this on the flutter run/build side of things, we likely don't go through these if built directly from xcode. Verify we're not trying to build x86_64 release and throw with an error message if that is the case.