### PR TITLE
Make sure setUp and tearDown functions run in the same test binding

### DIFF
--- a/dev/manual_tests/test/card_collection_test.dart
+++ b/dev/manual_tests/test/card_collection_test.dart
@@ -12,7 +12,7 @@ import 'mock_image_http.dart';
 
 void main() {
   testWidgets('Card Collection smoke test', (WidgetTester tester) async {
-    HttpOverrides.runZoned<Future<void>>(() async {
+    await HttpOverrides.runZoned<Future<void>>(() async {
       card_collection.main(); // builds the app and schedules a frame but doesn't trigger one
       await tester.pump(); // see https://github.com/flutter/flutter/issues/1865
       await tester.pump(); // triggers a frame

--- a/dev/manual_tests/test/color_testing_demo_test.dart
+++ b/dev/manual_tests/test/color_testing_demo_test.dart
@@ -12,7 +12,7 @@ import 'mock_image_http.dart';
 
 void main() {
   testWidgets('Color testing demo smoke test', (WidgetTester tester) async {
-    HttpOverrides.runZoned<Future<void>>(() async {
+    await HttpOverrides.runZoned<Future<void>>(() async {
       color_testing_demo.main(); // builds the app and schedules a frame but doesn't trigger one
       await tester.pump(); // see https://github.com/flutter/flutter/issues/1865
       await tester.pump(); // triggers a frame

--- a/packages/flutter/test/cupertino/refresh_test.dart
+++ b/packages/flutter/test/cupertino/refresh_test.dart
@@ -356,7 +356,7 @@ void main() {
         final FlutterError error = FlutterError('Oops');
         double errorCount = 0;
 
-        runZoned(
+        await runZoned(
           () async {
             refreshCompleter = Completer<void>.sync();
 

--- a/packages/flutter/test/widgets/image_headers_test.dart
+++ b/packages/flutter/test/widgets/image_headers_test.dart
@@ -18,7 +18,7 @@ void main() {
   final MockHttpHeaders headers = MockHttpHeaders();
 
   testWidgets('Headers', (WidgetTester tester) async {
-    HttpOverrides.runZoned<Future<void>>(() async {
+    await HttpOverrides.runZoned<Future<void>>(() async {
       await tester.pumpWidget(Image.network(
         'https://www.example.com/images/frame.png',
         headers: const <String, String>{'flutter': 'flutter'},

--- a/packages/flutter_test/lib/flutter_test.dart
+++ b/packages/flutter_test/lib/flutter_test.dart
@@ -11,9 +11,9 @@
 ///
 /// ### Per test or per file
 ///
-/// Due to its use of `package:test` as a foundation, the testing library
-/// allows for tests to be initialized using the existing constructs found in
-/// `package:test`. These include the [setUp] and [setUpAll] methods.
+/// The testing library allows for tests to be configured using [setUp] and
+/// [tearDown] functions. It is inadvisable for developers to use the equivalent
+/// functions in `package:test` as it might lead to unpredictable behavior.
 ///
 /// ### Per directory hierarchy
 ///

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -540,6 +540,20 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     _teardowns.add(callback);
   }
 
+  /// Executes all setup functions registered via [addSetup].
+  Future<void> runTestSetups() async {
+    while (_setups.isNotEmpty) {
+      await _setups.removeAt(0)();
+    }
+  }
+
+  /// Executes all teardown functions registered via [addTeardown].
+  Future<void> runTestTeardowns() async {
+    while (_teardowns.isNotEmpty) {
+      await _teardowns.removeLast()();
+    }
+  }
+
   /// Runs `testBody` with the configuration specified in the binding.
   ///
   /// Returns a future which completes when the test has run.
@@ -731,14 +745,8 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     final TestExceptionReporter reportTestExceptionBeforeTest = reportTestException;
     final ErrorWidgetBuilder errorWidgetBuilderBeforeTest = ErrorWidget.builder;
 
-    // run the test including the setup and teardown code that was requested
-    while (_setups.isNotEmpty) {
-      await _setups.removeAt(0)();
-    }
+    // run the test
     await testBody();
-    while (_teardowns.isNotEmpty) {
-      await _teardowns.removeLast()();
-    }
     asyncBarrier(); // drains the microtasks in `flutter test` mode (when using AutomatedTestWidgetsFlutterBinding)
 
     if (_pendingExceptionDetails == null) {

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -517,8 +517,8 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   /// test failures.
   bool showAppDumpInErrors = false;
 
-  final List<Future<void> Function()> _setups = <Future<void> Function()>[];
-  final List<Future<void> Function()> _teardowns = <Future<void> Function()>[];
+  final List<dynamic Function()> _setups = <dynamic Function()>[];
+  final List<dynamic Function()> _teardowns = <dynamic Function()>[];
 
   /// Adds `callback` to be executed prior to test with the configuration
   /// specified in the binding.
@@ -526,7 +526,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   /// Callbacks registered via [addSetup] and [addTeardown] should be executed
   /// within [runTest] to minimize surprising behavior with respect to state
   /// and zone cleanup.
-  void addSetup(Future<void> callback()) {
+  void addSetup(dynamic callback()) {
     _setups.add(callback);
   }
 
@@ -536,7 +536,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   /// Callbacks registered via [addSetup] and [addTeardown] should be executed
   /// within [runTest] to minimize surprising behavior with respect to state
   /// and zone cleanup.
-  void addTeardown(Future<void> callback()) {
+  void addTeardown(dynamic callback()) {
     _teardowns.add(callback);
   }
 

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -547,9 +547,6 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   /// Called by the [testWidgets] and [benchmarkWidgets] functions to
   /// run a test.
   ///
-  /// [runSetup] and [runTest] should execute code in the same [Zone] to
-  /// minimize behavioral differences between setup and test code.
-  ///
   /// The `invariantTester` argument is called after the `testBody`'s [Future]
   /// completes. If it throws, then the test is marked as failed.
   ///

--- a/packages/flutter_test/lib/src/test_compat.dart
+++ b/packages/flutter_test/lib/src/test_compat.dart
@@ -226,38 +226,6 @@ void group(Object description, void Function() body, { dynamic skip }) {
   _declarer.group(description.toString(), body, skip: skip);
 }
 
-/// Registers a function to be run before tests.
-///
-/// This function will be called before each test is run. [callback] may be
-/// asynchronous; if so, it must return a [Future].
-///
-/// If this is called within a test group, it applies only to tests in that
-/// group. [callback] will be run after any set-up callbacks in parent groups or
-/// at the top level.
-///
-/// Each callback at the top level or in a given group will be run in the order
-/// they were declared.
-void setUp(dynamic Function() body) {
-  _declarer.setUp(body);
-}
-
-/// Registers a function to be run after tests.
-///
-/// This function will be called after each test is run. [callback] may be
-/// asynchronous; if so, it must return a [Future].
-///
-/// If this is called within a test group, it applies only to tests in that
-/// group. [callback] will be run before any tear-down callbacks in parent
-/// groups or at the top level.
-///
-/// Each callback at the top level or in a given group will be run in the
-/// reverse of the order they were declared.
-///
-/// See also [addTearDown], which adds tear-downs to a running test.
-void tearDown(dynamic Function() body) {
-  _declarer.tearDown(body);
-}
-
 /// Registers a function to be run once before all tests.
 ///
 /// [callback] may be asynchronous; if so, it must return a [Future].

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -53,39 +53,37 @@ typedef WidgetTesterCallback = Future<void> Function(WidgetTester widgetTester);
 /// This is useful if you would like to run [setUp] code that needs to execute
 /// in the same async zone as the test code.
 ///
-/// The following test code would never complete without using [setUpWidgets]
-/// because the `foo` Future would be created outside of the FakeAsync zone that
-/// [testWidgets] sets up. By using [setUpWidgets], we ensure the setup code
-/// runs in the same [FakeAsync] zone which allows us to advance the clock and
-/// let the Future resolve during [testWidgets].
+/// The following test code would never complete without using [setUp] because
+/// the `foo` Future would be created outside of the FakeAsync zone that
+/// [testWidgets] sets up. By using [setUp], we ensure the setup code runs in
+/// the same [FakeAsync] zone which allows us to advance the clock and let the
+/// Future resolve during [testWidgets].
 ///
 /// ```dart
 /// void main() {
 ///   Future<int> five;
-///   setUpWidgets((WidgetTester tester) async {
+///   setUp(() async {
 ///     five = Future.delayed(const Duration(seconds: 5), () => 5);
-///     await tester.pump(const Duration(seconds: 5));
 ///   });
 ///
 ///   testWidgets('Hello world smoke test', (WidgetTester tester) async {
+///     await tester.pump(const Duration(seconds: 5));
 ///     expect(await five, 5);
 ///   });
 /// }
 /// ```
-void setUpWidgets(WidgetTesterCallback callback) {
+void setUp(dynamic Function() callback) {
   final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized() as TestWidgetsFlutterBinding;
-  final WidgetTester tester = WidgetTester._(binding);
-  setUp(() => binding.addSetup(() async => await callback(tester)));
+  test_package.setUp(() => binding.addSetup(callback));
 }
 
 /// Runs the teardown [callback] inside the Flutter test environment.
 ///
 /// This is useful if you would like to run [tearDown] code that needs to execute
 /// in the same async zone as the test code.
-void tearDownWidgets(WidgetTesterCallback callback) {
+void tearDown(dynamic Function() callback) {
   final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized() as TestWidgetsFlutterBinding;
-  final WidgetTester tester = WidgetTester._(binding);
-  setUp(() => binding.addTeardown(() async => await callback(tester)));
+  test_package.setUp(() => binding.addTeardown(callback));
 }
 
 /// Runs the test [callback] inside the Flutter test environment.

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -181,7 +181,9 @@ void testWidgets(
             Object memento;
             try {
               memento = await variant.setUp(value);
+              await binding.runTestSetups();
               await callback(tester);
+              await binding.runTestTeardowns();
             } finally {
               await variant.tearDown(value, memento);
             }

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -75,7 +75,17 @@ typedef WidgetTesterCallback = Future<void> Function(WidgetTester widgetTester);
 void setUpWidgets(WidgetTesterCallback callback) {
   final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized() as TestWidgetsFlutterBinding;
   final WidgetTester tester = WidgetTester._(binding);
-  setUp(() => binding.runSetup(() async => await callback(tester)));
+  setUp(() => binding.addSetup(() async => await callback(tester)));
+}
+
+/// Runs the teardown [callback] inside the Flutter test environment.
+///
+/// This is useful if you would like to run [tearDown] code that needs to execute
+/// in the same async zone as the test code.
+void tearDownWidgets(WidgetTesterCallback callback) {
+  final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized() as TestWidgetsFlutterBinding;
+  final WidgetTester tester = WidgetTester._(binding);
+  setUp(() => binding.addTeardown(() async => await callback(tester)));
 }
 
 /// Runs the test [callback] inside the Flutter test environment.

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -777,19 +777,9 @@ void main() {
   });
 
   group('Pending timer', () {
-    TestExceptionReporter currentExceptionReporter;
-    TestWidgetsFlutterBinding binding;
-    setUp(() {
-      currentExceptionReporter = reportTestException;
-      binding = TestWidgetsFlutterBinding.ensureInitialized() as TestWidgetsFlutterBinding;
-    });
-
-    tearDown(() {
-      reportTestException = currentExceptionReporter;
-      binding.postTest();
-    });
-
     test('Throws assertion message without code', () async {
+      final TestExceptionReporter currentExceptionReporter = reportTestException;
+      final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized() as TestWidgetsFlutterBinding;
       FlutterErrorDetails flutterErrorDetails;
       reportTestException = (FlutterErrorDetails details, String testDescription) {
         flutterErrorDetails = details;
@@ -802,59 +792,16 @@ void main() {
 
       expect(flutterErrorDetails?.exception, isA<AssertionError>());
       expect(flutterErrorDetails?.exception?.message, 'A Timer is still pending even after the widget tree was disposed.');
+      reportTestException = currentExceptionReporter;
+      binding.postTest();
     });
   });
 
-  group('setupWidgets', () {
-    setUpWidgets((WidgetTester tester) async {
-      await tester.pumpWidget(MaterialApp(
-        home: Builder(
-          builder: (BuildContext context) => GestureDetector(
-            onTap: () => Navigator.of(context).push(
-              MaterialPageRoute<void>(
-                builder: (BuildContext context) => const Text('page 2'),
-              ),
-            ),
-            child: const Text('page 1'),
-          ),
-        ),
-      ));
-    });
-
-    testWidgets('sets up the first page', (WidgetTester tester) async {
-      expect(find.text('page 1'), findsOneWidget);
-    });
-
-    group('tapping the text', () {
-      setUpWidgets((WidgetTester tester) async {
-        await tester.tap(find.text('page 1'));
-        await tester.pump();
-        await tester.pump();
-      });
-
-      testWidgets('shows the second page', (WidgetTester tester) async {
-        expect(find.text('page 2'), findsOneWidget);
-      });
-
-      group('popping the second page', () {
-        setUpWidgets((WidgetTester tester) async {
-          tester.state<NavigatorState>(find.byType(Navigator)).pop();
-          await tester.pump();
-        });
-
-        testWidgets('makes page 1 visible again', (WidgetTester tester) async {
-          expect(find.text('page 2'), findsNothing);
-          expect(find.text('page 1'), findsOneWidget);
-        });
-      });
-    });
-  });
-
-  group('setupWidgets with Futures', () {
+  group('setup zone with Futures', () {
     Future<int> future;
 
     group('with an inner group', () {
-      setUpWidgets((WidgetTester tester) async {
+      setUp(() {
         future = Future<int>.delayed(const Duration(seconds: 1), () => 5);
       });
 
@@ -863,9 +810,7 @@ void main() {
         expect(await future, 5);
       });
 
-      tearDownWidgets((WidgetTester tester) async {
-        future = null;
-      });
+      tearDown(() => future = null);
     });
     test('makes sure future is cleaned up during teardown', () {
       expect(future, isNull);

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -778,12 +778,15 @@ void main() {
 
   group('Pending timer', () {
     TestExceptionReporter currentExceptionReporter;
+    TestWidgetsFlutterBinding binding;
     setUp(() {
       currentExceptionReporter = reportTestException;
+      binding = TestWidgetsFlutterBinding.ensureInitialized() as TestWidgetsFlutterBinding;
     });
 
     tearDown(() {
       reportTestException = currentExceptionReporter;
+      binding.postTest();
     });
 
     test('Throws assertion message without code', () async {
@@ -792,7 +795,6 @@ void main() {
         flutterErrorDetails = details;
       };
 
-      final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized() as TestWidgetsFlutterBinding;
       await binding.runTest(() async {
         final Timer timer = Timer(const Duration(seconds: 1), () {});
         expect(timer.isActive, true);


### PR DESCRIPTION
## Description

In the implementation of https://api.flutter.dev/flutter/flutter_test/testWidgets.html, test() method runs in an outer zone (normal async) whereas `binding.runTest` might create an inner zone with fake async.

This leads to very undesirable behavior when apps try to use normal test `setUp` functions to initialize a framework that happens to rely on Future's. Their tests start timing out since widgets cannot await Future's created in setup functions.

This PR introduces a new `setUpWidgets` fn that also accepts a `WidgetTesterCallback` and allows tests to initialize frameworks in the same `FakeAsync` zone. This is better than the current workaround employed on this issue (use `realAsync`).

## Related Issues

Resolves https://github.com/flutter/flutter/issues/57600 and https://github.com/flutter/flutter/issues/58172.

## Tests

Tests are not yet added; want to get a conceptual review on the PR first.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
