### PR TITLE
 add similar to the z-index function of CSS to positioned

### DIFF
--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -601,7 +601,7 @@ class RenderStack extends RenderBox
   ///
   /// This function is called by [paint] after potentially applying
   /// a clip to contain visual overflow.
-  /// children are sorted by child's zIndex in an ascending order then painted 
+  /// children are sorted by child's zIndex in an ascending order then painted
   @protected
   void paintStack(PaintingContext context, Offset offset) {
     RenderBox child = firstChild;

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -599,8 +599,9 @@ class RenderStack extends RenderBox
 
   /// Override in subclasses to customize how the stack paints.
   ///
-  /// By default, the stack uses [defaultPaint]. This function is called by
-  /// [paint] after potentially applying a clip to contain visual overflow.
+  /// This function is called by [paint] after potentially applying
+  /// a clip to contain visual overflow.
+  /// children are sorted by child's zIndex in an ascending order then painted 
   @protected
   void paintStack(PaintingContext context, Offset offset) {
     RenderBox child = firstChild;

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3404,7 +3404,7 @@ class Positioned extends ParentDataWidget<StackParentData> {
   Positioned.fromRect({
     Key key,
     Rect rect,
-    int zIndex,
+    this.zIndex,
     @required Widget child,
   }) : left = rect.left,
        top = rect.top,
@@ -3421,7 +3421,7 @@ class Positioned extends ParentDataWidget<StackParentData> {
   Positioned.fromRelativeRect({
     Key key,
     RelativeRect rect,
-    int zIndex,
+    this.zIndex,
     @required Widget child,
   }) : left = rect.left,
        top = rect.top,

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3390,6 +3390,7 @@ class Positioned extends ParentDataWidget<StackParentData> {
     this.bottom,
     this.width,
     this.height,
+    this.zIndex,
     @required Widget child,
   }) : assert(left == null || right == null || width == null),
        assert(top == null || bottom == null || height == null),
@@ -3403,6 +3404,7 @@ class Positioned extends ParentDataWidget<StackParentData> {
   Positioned.fromRect({
     Key key,
     Rect rect,
+    int zIndex,
     @required Widget child,
   }) : left = rect.left,
        top = rect.top,
@@ -3419,6 +3421,7 @@ class Positioned extends ParentDataWidget<StackParentData> {
   Positioned.fromRelativeRect({
     Key key,
     RelativeRect rect,
+    int zIndex,
     @required Widget child,
   }) : left = rect.left,
        top = rect.top,
@@ -3436,6 +3439,7 @@ class Positioned extends ParentDataWidget<StackParentData> {
     this.top = 0.0,
     this.right = 0.0,
     this.bottom = 0.0,
+    this.zIndex,
     @required Widget child,
   }) : width = null,
        height = null,
@@ -3468,6 +3472,7 @@ class Positioned extends ParentDataWidget<StackParentData> {
     double bottom,
     double width,
     double height,
+    int zIndex,
     @required Widget child,
   }) {
     assert(textDirection != null);
@@ -3491,6 +3496,7 @@ class Positioned extends ParentDataWidget<StackParentData> {
       bottom: bottom,
       width: width,
       height: height,
+      zIndex: zIndex,
       child: child,
     );
   }
@@ -3549,6 +3555,12 @@ class Positioned extends ParentDataWidget<StackParentData> {
   /// vertically.
   final double height;
 
+  /// The child's Z-index
+  /// 
+  /// This integer is the stack level of the child in the current stacking
+  ///  context.
+  final int zIndex;
+
   @override
   void applyParentData(RenderObject renderObject) {
     assert(renderObject.parentData is StackParentData);
@@ -3585,6 +3597,11 @@ class Positioned extends ParentDataWidget<StackParentData> {
       needsLayout = true;
     }
 
+    if (parentData.zIndex!= zIndex) {
+      parentData.zIndex = zIndex;
+      needsLayout = true;
+    }
+
     if (needsLayout) {
       final AbstractNode targetParent = renderObject.parent;
       if (targetParent is RenderObject)
@@ -3604,6 +3621,7 @@ class Positioned extends ParentDataWidget<StackParentData> {
     properties.add(DoubleProperty('bottom', bottom, defaultValue: null));
     properties.add(DoubleProperty('width', width, defaultValue: null));
     properties.add(DoubleProperty('height', height, defaultValue: null));
+    properties.add(IntProperty('zIndex', zIndex, defaultValue: null));
   }
 }
 
@@ -3659,6 +3677,7 @@ class PositionedDirectional extends StatelessWidget {
     this.bottom,
     this.width,
     this.height,
+    this.zIndex,
     @required this.child,
   }) : super(key: key);
 
@@ -3705,6 +3724,12 @@ class PositionedDirectional extends StatelessWidget {
   /// {@macro flutter.widgets.child}
   final Widget child;
 
+  /// The child's Z-index
+  /// 
+  /// This integer is the stack level of the child in the current stacking
+  ///  context.
+  final int zIndex;
+
   @override
   Widget build(BuildContext context) {
     return Positioned.directional(
@@ -3715,6 +3740,7 @@ class PositionedDirectional extends StatelessWidget {
       bottom: bottom,
       width: width,
       height: height,
+      zIndex: zIndex,
       child: child,
     );
   }

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3556,7 +3556,7 @@ class Positioned extends ParentDataWidget<StackParentData> {
   final double height;
 
   /// The child's Z-index
-  /// 
+  ///
   /// This integer is the stack level of the child in the current stacking
   ///  context.
   final int zIndex;
@@ -3725,7 +3725,7 @@ class PositionedDirectional extends StatelessWidget {
   final Widget child;
 
   /// The child's Z-index
-  /// 
+  ///
   /// This integer is the stack level of the child in the current stacking
   ///  context.
   final int zIndex;

--- a/packages/flutter/test/rendering/stack_test.dart
+++ b/packages/flutter/test/rendering/stack_test.dart
@@ -97,7 +97,7 @@ void main() {
       ..right = 0.0
       ..left = 0.0
       ..height = 200.0
-      ..zIndex = 1;  
+      ..zIndex = 1;
 
     layout(stack, phase: EnginePhase.paint);
 

--- a/packages/flutter/test/rendering/stack_test.dart
+++ b/packages/flutter/test/rendering/stack_test.dart
@@ -49,6 +49,61 @@ void main() {
     expect(green.size.height, equals(100.0));
   });
 
+  test('Stack paint child in order according to child zIndex', () {
+    int index = 0, redPaintIndex, greenPaintIndex;
+    final RenderBox size = RenderConstrainedBox(
+      additionalConstraints: BoxConstraints.tight(const Size(100.0, 300.0))
+    );
+
+    final RenderBox red = RenderCustomPaint(
+            painter: TestCallbackPainter(
+              onPaint: () { redPaintIndex = index ++; },
+            ),
+            child: RenderDecoratedBox(
+              decoration: const BoxDecoration(
+                color: Color(0xFFFF0000),
+              ),
+              child: size,
+            ),
+          );
+
+    final RenderBox green = RenderCustomPaint(
+          painter: TestCallbackPainter(
+            onPaint: () { greenPaintIndex = index ++; },
+          ),
+          child: RenderDecoratedBox(
+            decoration: const BoxDecoration(
+              color: Color(0xFF00FF00),
+            ),
+          ),
+        );
+
+    final RenderBox stack = RenderStack(
+      textDirection: TextDirection.ltr,
+      children: <RenderBox>[red, green],
+    );
+
+    final StackParentData redParentData = red.parentData as StackParentData;
+    redParentData
+      ..top = 0.0
+      ..right = 0.0
+      ..left = 0.0
+      ..height = 200
+      ..zIndex = 2;
+
+    final StackParentData greenParentData = green.parentData as StackParentData;
+    greenParentData
+      ..top = 100.0
+      ..right = 0.0
+      ..left = 0.0
+      ..height = 200.0
+      ..zIndex = 1;  
+
+    layout(stack, phase: EnginePhase.paint);
+
+    expect(redPaintIndex, greaterThan(greenPaintIndex));
+  });
+
   test('Stack can layout with no children', () {
     final RenderBox stack = RenderStack(
       textDirection: TextDirection.ltr,


### PR DESCRIPTION
## Description

 add similar to the z-index function of CSS to positioned

## Related Issues

[50763](https://github.com/flutter/flutter/issues/50763)
## Tests

I added the following tests:
- Stack paint child in order according to child zIndex

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
