### PR TITLE
write test to convince self of lack of timing issue

### DIFF
--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -1196,47 +1196,47 @@ void main() {
     }) async => mockVMService,
   }));
 
+  group('Timing test', () {
+    Completer<MockVMService> completer;
 
-  // Don't use this outside of the test below.
-  Completer<MockVMService> completer;
+    test('Can connect to observatory stream after receiving done event.', () => testbed.run(() async {
+      completer = Completer<MockVMService>();
+      fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+      final MockDevice mockDevice = MockDevice();
+      final MockDeviceLogReader mockLogReader = MockDeviceLogReader();
+      when(mockDevice.getLogReader(app: anyNamed('app'))).thenReturn(mockLogReader);
+      final StreamController<Uri> controller = StreamController<Uri>();
 
-  test('Can connect to observatory stream after receiving done event.', () => testbed.run(() async {
-    completer = Completer<MockVMService>();
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    final MockDevice mockDevice = MockDevice();
-    final MockDeviceLogReader mockLogReader = MockDeviceLogReader();
-    when(mockDevice.getLogReader(app: anyNamed('app'))).thenReturn(mockLogReader);
-    final StreamController<Uri> controller = StreamController<Uri>();
+      final TestFlutterDevice flutterDevice = TestFlutterDevice(
+        mockDevice,
+        observatoryUris: controller.stream,
+      );
 
-    final TestFlutterDevice flutterDevice = TestFlutterDevice(
-      mockDevice,
-      observatoryUris: controller.stream,
-    );
+      final Future<void> connectResult = flutterDevice.connect();
 
-    final Future<void> connectResult = flutterDevice.connect();
+      // First add the observatory URI to connect to.
+      controller.add(testUri);
 
-    // First add the observatory URI to connect to.
-    controller.add(testUri);
+      // Then close the stream.
+      await controller.close();
 
-    // Then close the stream.
-    await controller.close();
+      // Then complete the VM service connection.
+      completer.complete(mockVMService);
 
-    // Then complete the VM service connection.
-    completer.complete(mockVMService);
+      await connectResult;
 
-    await connectResult;
-
-    verify(mockLogReader.connectedVMService = mockVMService);
-  }, overrides: <Type, Generator>{
-    VMServiceConnector: () => (Uri httpUri, {
-      ReloadSources reloadSources,
-      Restart restart,
-      CompileExpression compileExpression,
-      ReloadMethod reloadMethod,
-      io.CompressionOptions compression,
-      Device device,
-    }) async => completer.future,
-  }));
+      verify(mockLogReader.connectedVMService = mockVMService);
+    }, overrides: <Type, Generator>{
+      VMServiceConnector: () => (Uri httpUri, {
+        ReloadSources reloadSources,
+        Restart restart,
+        CompileExpression compileExpression,
+        ReloadMethod reloadMethod,
+        io.CompressionOptions compression,
+        Device device,
+      }) async => completer.future,
+    }));
+  });
 
   test('nextPlatform moves through expected platforms', () {
     expect(nextPlatform('android', TestFeatureFlags()), 'iOS');

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -1196,6 +1196,48 @@ void main() {
     }) async => mockVMService,
   }));
 
+
+  // Don't use this outside of the test below.
+  Completer<MockVMService> completer;
+
+  test('Can connect to observatory stream after receiving done event.', () => testbed.run(() async {
+    completer = Completer<MockVMService>();
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    final MockDevice mockDevice = MockDevice();
+    final MockDeviceLogReader mockLogReader = MockDeviceLogReader();
+    when(mockDevice.getLogReader(app: anyNamed('app'))).thenReturn(mockLogReader);
+    final StreamController<Uri> controller = StreamController<Uri>();
+
+    final TestFlutterDevice flutterDevice = TestFlutterDevice(
+      mockDevice,
+      observatoryUris: controller.stream,
+    );
+
+    final Future<void> connectResult = flutterDevice.connect();
+
+    // First add the observatory URI to connect to.
+    controller.add(testUri);
+
+    // Then close the stream.
+    await controller.close();
+
+    // Then complete the VM service connection.
+    completer.complete(mockVMService);
+
+    await connectResult;
+
+    verify(mockLogReader.connectedVMService = mockVMService);
+  }, overrides: <Type, Generator>{
+    VMServiceConnector: () => (Uri httpUri, {
+      ReloadSources reloadSources,
+      Restart restart,
+      CompileExpression compileExpression,
+      ReloadMethod reloadMethod,
+      io.CompressionOptions compression,
+      Device device,
+    }) async => completer.future,
+  }));
+
   test('nextPlatform moves through expected platforms', () {
     expect(nextPlatform('android', TestFeatureFlags()), 'iOS');
     expect(nextPlatform('iOS', TestFeatureFlags()), 'fuchsia');


### PR DESCRIPTION
## Description

In https://github.com/flutter/flutter/issues/55864 a race condition was described where a done event is received before we finish connecting. This cannot happen, since `async` functions begin synchronously and the flag `isWaitingForVm` is tripped immediately, keeping `onDone` from exiting.

Closes https://github.com/flutter/flutter/issues/55864

At any rate, this test will keep things working.