### PR TITLE
fix cupertino page route dismisses hero transition when swipe to the …

### DIFF
--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -533,7 +533,7 @@ class _HeroFlight {
   }
 
   void _handleAnimationUpdate(AnimationStatus status) {
-    // The animation will not finish until the user lift their finger, so we
+    // The animation will not finish until the user lifts their finger, so we
     // should ignore the status update if the gesture is in progress.
     //
     // This also relies on the animation to update its status at the end of the

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -533,6 +533,8 @@ class _HeroFlight {
   }
 
   void _handleAnimationUpdate(AnimationStatus status) {
+    if (manifest.fromRoute?.navigator?.userGestureInProgress == true)
+      return;
     if (status == AnimationStatus.completed || status == AnimationStatus.dismissed) {
       _proxyAnimation.parent = null;
 

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -533,6 +533,12 @@ class _HeroFlight {
   }
 
   void _handleAnimationUpdate(AnimationStatus status) {
+    // The animation will not finish until the user lift their finger, so we
+    // should ignore the status update if the gesture is in progress.
+    //
+    // This also relies on the animation to update its status at the end of the
+    // gesture. See the _CupertinoBackGestureController.dragEnd for how
+    // cupertino page route achieves that.
     if (manifest.fromRoute?.navigator?.userGestureInProgress == true)
       return;
     if (status == AnimationStatus.completed || status == AnimationStatus.dismissed) {

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -1181,8 +1181,8 @@ void main() {
     box = tester.renderObject(find.byKey(container)) as RenderBox;
     final double firstPosition = box.localToGlobal(Offset.zero).dx;
     // Checks the hero is in-transit.
-    expect(finalPosition > firstPosition, isTrue);
-    expect(firstPosition > initialPosition, isTrue);
+    expect(finalPosition, greaterThan(firstPosition));
+    expect(firstPosition, greaterThan(initialPosition));
 
     // Goes back to final position.
     await gesture.moveBy(const Offset(-200, 0));
@@ -1190,7 +1190,7 @@ void main() {
     box = tester.renderObject(find.byKey(container)) as RenderBox;
     final double secondPosition = box.localToGlobal(Offset.zero).dx;
     // There will be a small difference.
-    expect(finalPosition - secondPosition < 0.001, isTrue);
+    expect(finalPosition - secondPosition, lessThan(0.001));
 
     await gesture.moveBy(const Offset(400, 0));
     await tester.pump();
@@ -1198,9 +1198,9 @@ void main() {
     final double thirdPosition = box.localToGlobal(Offset.zero).dx;
     // Checks the hero is still in-transit and moves further away from the first
     // position.
-    expect(finalPosition > thirdPosition, isTrue);
-    expect(thirdPosition > initialPosition, isTrue);
-    expect(firstPosition > thirdPosition, isTrue);
+    expect(finalPosition, greaterThan(thirdPosition));
+    expect(thirdPosition, greaterThan(initialPosition));
+    expect(firstPosition, greaterThan(thirdPosition));
   });
 
   testWidgets('showCupertinoModalPopup uses nested navigator if useRootNavigator is false', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -1133,6 +1133,76 @@ void main() {
     expect(nestedObserver.popupCount, 0);
   });
 
+  testWidgets('back swipe to screen edges does not dismiss the hero animation', (WidgetTester tester) async {
+    final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
+    final UniqueKey container = UniqueKey();
+    await tester.pumpWidget(CupertinoApp(
+      navigatorKey: navigator,
+      routes: <String, WidgetBuilder>{
+        '/': (BuildContext context) {
+          return CupertinoPageScaffold(
+            child: Center(
+              child: Hero(
+                tag: 'tag',
+                transitionOnUserGestures: true,
+                child: Container(key: container, height: 150.0, width: 150.0)
+              ),
+            )
+          );
+        },
+        '/page2': (BuildContext context) {
+          return CupertinoPageScaffold(
+            child: Center(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(100.0, 0.0, 0.0, 0.0),
+                child: Hero(
+                  tag: 'tag',
+                  transitionOnUserGestures: true,
+                  child: Container(key: container, height: 150.0, width: 150.0)
+                )
+              ),
+            )
+          );
+        }
+      },
+    ));
+
+    RenderBox box = tester.renderObject(find.byKey(container)) as RenderBox;
+    final double initialPosition = box.localToGlobal(Offset.zero).dx;
+
+    navigator.currentState.pushNamed('/page2');
+    await tester.pumpAndSettle();
+    box = tester.renderObject(find.byKey(container)) as RenderBox;
+    final double finalPosition = box.localToGlobal(Offset.zero).dx;
+
+    final TestGesture gesture = await tester.startGesture(const Offset(5, 300));
+    await gesture.moveBy(const Offset(200, 0));
+    await tester.pump();
+    box = tester.renderObject(find.byKey(container)) as RenderBox;
+    final double firstPosition = box.localToGlobal(Offset.zero).dx;
+    // Checks the hero is in-transit.
+    expect(finalPosition > firstPosition, isTrue);
+    expect(firstPosition > initialPosition, isTrue);
+
+    // Goes back to final position.
+    await gesture.moveBy(const Offset(-200, 0));
+    await tester.pump();
+    box = tester.renderObject(find.byKey(container)) as RenderBox;
+    final double secondPosition = box.localToGlobal(Offset.zero).dx;
+    // There will be a small difference.
+    expect(finalPosition - secondPosition < 0.001, isTrue);
+
+    await gesture.moveBy(const Offset(400, 0));
+    await tester.pump();
+    box = tester.renderObject(find.byKey(container)) as RenderBox;
+    final double thirdPosition = box.localToGlobal(Offset.zero).dx;
+    // Checks the hero is still in-transit and moves further away from the first
+    // position.
+    expect(finalPosition > thirdPosition, isTrue);
+    expect(thirdPosition > initialPosition, isTrue);
+    expect(firstPosition > thirdPosition, isTrue);
+  });
+
   testWidgets('showCupertinoModalPopup uses nested navigator if useRootNavigator is false', (WidgetTester tester) async {
     final PopupObserver rootObserver = PopupObserver();
     final PopupObserver nestedObserver = PopupObserver();


### PR DESCRIPTION
…edge

## Description

When doing cupertino back swipe, the page animation will be dismissed/completed when the gesture reach either end of the screen. This will cause the hero controller to remove the overlay entry of the flighting hero. If the user keep holding the finger and swipe, the hero animation will not respond because it is no longer in the overlay

## Related Issues

Fixes https://github.com/flutter/flutter/issues/57581

## Tests

I added the following tests:

See files

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
