### PR TITLE
Remove invalid `local` from macos_assemble.sh

### DIFF
--- a/packages/flutter_tools/bin/macos_assemble.sh
+++ b/packages/flutter_tools/bin/macos_assemble.sh
@@ -62,7 +62,7 @@ ephemeral_dir="${SOURCE_ROOT}/Flutter/ephemeral"
 build_inputs_path="${ephemeral_dir}/FlutterInputs.xcfilelist"
 build_outputs_path="${ephemeral_dir}/FlutterOutputs.xcfilelist"
 
-local performance_measurement_option=""
+performance_measurement_option=""
 if [[ -n "$PERFORMANCE_MEASUREMENT_FILE" ]]; then
   performance_measurement_option="--performance-measurement-file=${PERFORMANCE_MEASUREMENT_FILE}"
 fi


### PR DESCRIPTION
When you run this, bash complains that `local` is only valid in functions. Gets rid of that extraneous warning.
