### PR TITLE
[flutter_tools] Put a heap size limit on the frontend_server

### DIFF
--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -263,6 +263,11 @@ class KernelCompiler {
     }
     final List<String> command = <String>[
       engineDartPath,
+      '--disable-dart-dev',
+      // This limit is in place to help track down
+      // https://github.com/flutter/flutter/issues/54420. It should be removed
+      // when the underlying issue is identified and fixed.
+      '--old_gen_heap_size=2000',
       frontendServer,
       '--sdk-root',
       sdkRoot,
@@ -648,6 +653,11 @@ class DefaultResidentCompiler implements ResidentCompiler {
     );
     final List<String> command = <String>[
       globals.artifacts.getArtifactPath(Artifact.engineDartBinary),
+      '--disable-dart-dev',
+      // This limit is in place to help track down
+      // https://github.com/flutter/flutter/issues/54420. It should be removed
+      // when the underlying issue is identified and fixed.
+      '--old_gen_heap_size=2000',
       frontendServer,
       '--sdk-root',
       sdkRoot,

--- a/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
@@ -86,6 +86,8 @@ void main() {
     processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(command: <String>[
         artifacts.getArtifactPath(Artifact.engineDartBinary),
+        '--disable-dart-dev',
+        '--old_gen_heap_size=2000',
         artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
         '--sdk-root',
         artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath) + '/',
@@ -115,6 +117,8 @@ void main() {
     processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(command: <String>[
         artifacts.getArtifactPath(Artifact.engineDartBinary),
+        '--disable-dart-dev',
+        '--old_gen_heap_size=2000',
         artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
         '--sdk-root',
         artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath) + '/',
@@ -144,6 +148,8 @@ void main() {
     processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(command: <String>[
         artifacts.getArtifactPath(Artifact.engineDartBinary),
+        '--disable-dart-dev',
+        '--old_gen_heap_size=2000',
         artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
         '--sdk-root',
         artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath) + '/',
@@ -174,6 +180,8 @@ void main() {
     processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(command: <String>[
         artifacts.getArtifactPath(Artifact.engineDartBinary),
+        '--disable-dart-dev',
+        '--old_gen_heap_size=2000',
         artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
         '--sdk-root',
         artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath) + '/',
@@ -206,6 +214,8 @@ void main() {
     processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(command: <String>[
         artifacts.getArtifactPath(Artifact.engineDartBinary),
+        '--disable-dart-dev',
+        '--old_gen_heap_size=2000',
         artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
         '--sdk-root',
         artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath) + '/',
@@ -236,6 +246,8 @@ void main() {
     processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(command: <String>[
         artifacts.getArtifactPath(Artifact.engineDartBinary),
+        '--disable-dart-dev',
+        '--old_gen_heap_size=2000',
         artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
         '--sdk-root',
         artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath) + '/',
@@ -278,6 +290,8 @@ void main() {
     processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(command: <String>[
         artifacts.getArtifactPath(Artifact.engineDartBinary),
+        '--disable-dart-dev',
+        '--old_gen_heap_size=2000',
         artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
         '--sdk-root',
         artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath) + '/',


### PR DESCRIPTION
## Description

In the issues below the frontend_server appears to be requesting large allocations for unknown reasons. This PR puts a limit of 2GB on the frontend_server's old gen heap size. When the limit is reached, or when an allocation request exceeds its size, the frontend_server will fail with an `OutOfMemory` exception rather than hitting a `FATAL` in the VM.

## Related Issues

https://github.com/flutter/flutter/issues/54420
https://github.com/dart-lang/sdk/issues/41862

## Tests

I added the following tests:

I added a test that the `KernelCompiler` passes the heap limit flags.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
