### PR TITLE
Fix Linux plugin template build visibility

### DIFF
--- a/packages/flutter_tools/templates/app/linux.tmpl/CMakeLists.txt.tmpl
+++ b/packages/flutter_tools/templates/app/linux.tmpl/CMakeLists.txt.tmpl
@@ -3,6 +3,8 @@ project(runner LANGUAGES CXX)
 
 set(BINARY_NAME "{{projectName}}")
 
+cmake_policy(SET CMP0063 NEW)
+
 set(CMAKE_INSTALL_RPATH "\$ORIGIN")
 
 # Configure build options.

--- a/packages/flutter_tools/templates/app/linux.tmpl/flutter/CMakeLists.txt
+++ b/packages/flutter_tools/templates/app/linux.tmpl/flutter/CMakeLists.txt
@@ -65,6 +65,8 @@ add_library(flutter_wrapper_plugin STATIC
 apply_standard_settings(flutter_wrapper_plugin)
 set_target_properties(flutter_wrapper_plugin PROPERTIES
   POSITION_INDEPENDENT_CODE ON)
+set_target_properties(flutter_wrapper_plugin PROPERTIES
+  CXX_VISIBILITY_PRESET hidden)
 target_link_libraries(flutter_wrapper_plugin PUBLIC flutter)
 target_include_directories(flutter_wrapper_plugin PUBLIC
   "${WRAPPER_ROOT}/include"

--- a/packages/flutter_tools/templates/plugin/linux.tmpl/CMakeLists.txt.tmpl
+++ b/packages/flutter_tools/templates/plugin/linux.tmpl/CMakeLists.txt.tmpl
@@ -8,6 +8,9 @@ add_library(${PLUGIN_NAME} SHARED
   "${PLUGIN_NAME}.cc"
 )
 apply_standard_settings(${PLUGIN_NAME})
+set_target_properties(${PLUGIN_NAME} PROPERTIES
+  CXX_VISIBILITY_PRESET hidden)
+target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
 target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)


### PR DESCRIPTION
## Description

The CMake plugin build wasn't setting visibility to hidden by default,
which meant that plugins exported everything by default. This would make
bad interactions between plugins much more likely; only the intended API
should be exported by the shared library.

## Related Issues

None

## Tests

I added the following tests: None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
