### PR TITLE
[flutter] allow loading either NOTICES or LICENSE

### DIFF
--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -102,7 +102,8 @@ mixin ServicesBinding on BindingBase, SchedulerBinding {
     final Completer<String> rawLicenses = Completer<String>();
     scheduleTask(() async {
       // TODO(jonahwilliams): temporary catch to allow migrating LICENSE to NOTICES.
-      // Once both the tool and google3 use notices this can be removed.
+      // Once both the tool and google3 use notices this can be removed after PR:
+      // https://github.com/flutter/flutter/pull/57871
       try {
         rawLicenses.complete(await rootBundle.loadString('NOTICES', cache: false));
       } on FlutterError {

--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -101,7 +101,13 @@ mixin ServicesBinding on BindingBase, SchedulerBinding {
     // TODO(ianh): Remove this complexity once these bugs are fixed.
     final Completer<String> rawLicenses = Completer<String>();
     scheduleTask(() async {
-      rawLicenses.complete(rootBundle.loadString('LICENSE', cache: false));
+      // TODO(jonahwilliams): temporary catch to allow migrating LICENSE to NOTICES.
+      // Once both the tool and google3 use notices this can be removed.
+      try {
+        rawLicenses.complete(await rootBundle.loadString('NOTICES', cache: false));
+      } on FlutterError {
+        rawLicenses.complete(await rootBundle.loadString('LICENSE', cache: false));
+      }
     }, Priority.animation);
     await rawLicenses.future;
     final Completer<List<LicenseEntry>> parsedLicenses = Completer<List<LicenseEntry>>();

--- a/packages/flutter/test/services/binding_test.dart
+++ b/packages/flutter/test/services/binding_test.dart
@@ -44,7 +44,7 @@ class TestBinding extends BindingBase with SchedulerBinding, ServicesBinding {
   BinaryMessenger createBinaryMessenger() {
     return super.createBinaryMessenger()
       ..setMockMessageHandler('flutter/assets', (ByteData message) async {
-        if (const StringCodec().decodeMessage(message) == 'LICENSE') {
+        if (const StringCodec().decodeMessage(message) == 'LICENSE' || const StringCodec().decodeMessage(message) == 'NOTICES') {
           return const StringCodec().encodeMessage(licenses);
         }
         return null;

--- a/packages/flutter/test/services/binding_test.dart
+++ b/packages/flutter/test/services/binding_test.dart
@@ -44,6 +44,9 @@ class TestBinding extends BindingBase with SchedulerBinding, ServicesBinding {
   BinaryMessenger createBinaryMessenger() {
     return super.createBinaryMessenger()
       ..setMockMessageHandler('flutter/assets', (ByteData message) async {
+        // Temporarily check for both LICENSE and NOTICES
+        // Once both the tool and google3 use notices this can be removed after PR:
+        // https://github.com/flutter/flutter/pull/57871
         if (const StringCodec().decodeMessage(message) == 'LICENSE' || const StringCodec().decodeMessage(message) == 'NOTICES') {
           return const StringCodec().encodeMessage(licenses);
         }


### PR DESCRIPTION
## Description

To make https://github.com/flutter/flutter/pull/57871 easier to land, add support for loading either LICENSES or NOTICES, preferring the later.