### PR TITLE
[flutter_tools] attempt to not copy partial dill file

### DIFF
--- a/packages/flutter_tools/lib/src/codegen.dart
+++ b/packages/flutter_tools/lib/src/codegen.dart
@@ -214,6 +214,9 @@ class CodeGeneratingResidentCompiler implements ResidentCompiler {
   void addFileSystemRoot(String root) {
     _residentCompiler.addFileSystemRoot(root);
   }
+
+  @override
+  bool get pendingWrite => _residentCompiler.pendingWrite;
 }
 
 /// The current status of a codegen build.

--- a/packages/flutter_tools/test/general.shard/compile_incremental_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_incremental_test.dart
@@ -58,12 +58,22 @@ void main() {
           ))
         ));
 
-    final CompilerOutput output = await generator.recompile(
+    expect(generator.pendingWrite, false);
+
+    final Future<CompilerOutput> pendingOutput = generator.recompile(
       Uri.parse('/path/to/main.dart'),
         null /* invalidatedFiles */,
       outputPath: '/build/',
       packageConfig: PackageConfig.empty,
     );
+    // Wait one event-turn for the request to be received.
+    await null;
+    expect(generator.pendingWrite, true);
+
+    final CompilerOutput output = await pendingOutput;
+
+    expect(generator.pendingWrite, false);
+
     expect(mockFrontendServerStdIn.getAndClear(), 'compile /path/to/main.dart\n');
     verifyNoMoreInteractions(mockFrontendServerStdIn);
     expect(testLogger.errorText, equals('\nCompiler message:\nline1\nline2\n'));

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -1015,6 +1015,9 @@ void main() {
       connectionInfoCompleter: connectionInfoCompleter,
     ));
     await connectionInfoCompleter.future;
+    final MockResidentCompiler compiler = MockResidentCompiler();
+    when(compiler.pendingWrite).thenReturn(false);
+    when(residentWebRunner.flutterDevices.first.generator).thenReturn(compiler);
 
     await residentWebRunner.exit();
     await residentWebRunner.exit();

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -672,6 +672,9 @@ class MockResidentCompiler extends BasicMock implements ResidentCompiler {
 
   @override
   void addFileSystemRoot(String root) { }
+
+  @override
+  bool get pendingWrite => false;
 }
 
 /// A fake implementation of [ProcessResult].


### PR DESCRIPTION
## Description

Fixes https://github.com/flutter/flutter/issues/58109

If the tool is expecting the frontend_server to output a new file, don't attempt to copy the dill when exiting. This does not distinguish between full/incremental dills to simplify the implementation.