### PR TITLE
[release] remove .dart_tool directory from uploaded zip

### DIFF
--- a/dev/bots/prepare_package.dart
+++ b/dev/bots/prepare_package.dart
@@ -368,6 +368,8 @@ class ArchiveCreator {
     // the archive, but some are checked in, and we don't want to skip
     // those.
     await _runGit(<String>['clean', '-f', '-X', '**/.packages']);
+    /// Remove package_config files and any contents in .dart_tool
+    await _runGit(<String>['clean', '-f', '-X', '**/.dart_tool']);
   }
 
   /// Write the archive to the given output file.

--- a/dev/bots/test/prepare_package_test.dart
+++ b/dev/bots/test/prepare_package_test.dart
@@ -122,6 +122,7 @@ void main() {
           '$flutter create --template=package ${createBase}package': null,
           '$flutter create --template=plugin ${createBase}plugin': null,
           'git clean -f -X **/.packages': null,
+          'git clean -f -X **/.dart_tool': null,
           if (platform.isWindows) 'attrib -h .git': null,
           if (platform.isWindows) '7za a -tzip -mx=9 $archiveName flutter': null
           else if (platform.isMacOS) 'zip -r -9 $archiveName flutter': null
@@ -157,6 +158,7 @@ void main() {
           '$flutter create --template=package ${createBase}package': null,
           '$flutter create --template=plugin ${createBase}plugin': null,
           'git clean -f -X **/.packages': null,
+          'git clean -f -X **/.dart_tool': null,
           if (platform.isWindows) 'attrib -h .git': null,
           if (platform.isWindows) '7za a -tzip -mx=9 $archiveName flutter': null
           else if (platform.isMacOS) 'zip -r -9 $archiveName flutter': null
@@ -206,6 +208,7 @@ void main() {
           '$flutter create --template=package ${createBase}package': null,
           '$flutter create --template=plugin ${createBase}plugin': null,
           'git clean -f -X **/.packages': null,
+          'git clean -f -X **/.dart_tool': null,
           if (platform.isWindows) 'attrib -h .git': null,
           if (platform.isWindows) '7za a -tzip -mx=9 $archiveName flutter': null
           else if (platform.isMacOS) 'zip -r -9 $archiveName flutter': null


### PR DESCRIPTION
## Description

Fixes https://github.com/flutter/flutter/issues/58003


The .dart_tool directory can contain build assets, as well as the package_config.json file - the replacement for .packages. Remove it for the same reason we remove .packages