### PR TITLE
Change iOS device discovery from polling to long-running observation

### DIFF
--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -104,6 +104,13 @@ class ItemListNotifier<T> {
     removedItems.forEach(_removedController.add);
   }
 
+  void removeItem(T item) {
+    if (_items.contains(item)) {
+      _items.remove(item);
+      _removedController.add(item);
+    }
+  }
+
   /// Close the streams.
   void dispose() {
     _addedController.close();

--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -105,8 +105,7 @@ class ItemListNotifier<T> {
   }
 
   void removeItem(T item) {
-    if (_items.contains(item)) {
-      _items.remove(item);
+    if (_items.remove(item)) {
       _removedController.add(item);
     }
   }

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -790,18 +790,20 @@ class DeviceDomain extends Domain {
 
   /// Enable device events.
   Future<void> enable(Map<String, dynamic> args) {
+    final List<Future<void>> calls = <Future<void>>[];
     for (final PollingDeviceDiscovery discoverer in _discoverers) {
-      discoverer.startPolling();
+      calls.add(discoverer.startPolling());
     }
-    return Future<void>.value();
+    return Future.wait<void>(calls);
   }
 
   /// Disable device events.
-  Future<void> disable(Map<String, dynamic> args) {
+  Future<void> disable(Map<String, dynamic> args) async {
+    final List<Future<void>> calls = <Future<void>>[];
     for (final PollingDeviceDiscovery discoverer in _discoverers) {
-      discoverer.stopPolling();
+      calls.add(discoverer.stopPolling());
     }
-    return Future<void>.value();
+    return Future.wait<void>(calls);
   }
 
   /// Forward a host port to a device port.

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -16,6 +16,7 @@ import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/platform.dart';
 import '../base/process.dart';
+import '../base/utils.dart';
 import '../build_info.dart';
 import '../convert.dart';
 import '../device.dart';
@@ -35,20 +36,83 @@ class IOSDevices extends PollingDeviceDiscovery {
     Platform platform,
     XCDevice xcdevice,
     IOSWorkflow iosWorkflow,
+    Logger logger,
   }) : _platform = platform ?? globals.platform,
        _xcdevice = xcdevice ?? globals.xcdevice,
        _iosWorkflow = iosWorkflow ?? globals.iosWorkflow,
+       _logger = logger ?? globals.logger,
        super('iOS devices');
+
+  @override
+  void dispose() {
+    _observedDeviceEventsSubscription?.cancel();
+  }
 
   final Platform _platform;
   final XCDevice _xcdevice;
   final IOSWorkflow _iosWorkflow;
+  final Logger _logger;
 
   @override
   bool get supportsPlatform => _platform.isMacOS;
 
   @override
   bool get canListAnything => _iosWorkflow.canListDevices;
+
+  StreamSubscription<Map<XCDeviceEvent, String>> _observedDeviceEventsSubscription;
+
+  @override
+  Future<void> startPolling() async {
+    if (!_platform.isMacOS) {
+      throw UnsupportedError(
+        'Control of iOS devices or simulators only supported on macOS.'
+      );
+    }
+
+    deviceNotifier ??= ItemListNotifier<Device>();
+
+    // Start by populating all currently attached devices.
+    deviceNotifier.updateWithNewList(await pollingGetDevices());
+
+    _observedDeviceEventsSubscription ??= _xcdevice.observedDeviceEvents().listen(
+      _onDeviceEvent,
+      onError: (dynamic error, StackTrace stack) {
+        _logger.printTrace('Process exception running xcdevice observe:\n$error');
+      }, onDone: () {
+      // If the xcdevice process is killed, restart it.
+      _logger.printTrace('xcdevice observe stopped, restarting');
+      startPolling();
+    },
+      // Don't reset the device subscription on an exception.
+      // If the call to xcdevice asserts, more calls won't fix it.
+      // Avoid hammering on it. If the user runs "flutter doctor"
+      // they may get a real recovery message.
+      cancelOnError: false
+    );
+  }
+
+  Future<void> _onDeviceEvent(Map<XCDeviceEvent, String> event) async {
+    final XCDeviceEvent eventType = event.containsKey(XCDeviceEvent.attach) ? XCDeviceEvent.attach : XCDeviceEvent.detach;
+    final String deviceIdentifier = event[eventType];
+    final Device knownDevice = deviceNotifier.items
+      .firstWhere((Device device) => device.id == deviceIdentifier, orElse: () => null);
+
+    // Ignore already discovered devices (maybe populated at the beginning).
+    if (eventType == XCDeviceEvent.attach && knownDevice == null) {
+      // There's no way to get details for an individual attached device,
+      // so repopulate them all.
+      final List<Device> devices = await pollingGetDevices();
+      deviceNotifier.updateWithNewList(devices);
+    } else if (eventType == XCDeviceEvent.detach && knownDevice != null) {
+      deviceNotifier.removeItem(knownDevice);
+    }
+  }
+
+  @override
+  Future<void> stopPolling() async {
+    await _observedDeviceEventsSubscription?.cancel();
+    _observedDeviceEventsSubscription = null;
+  }
 
   @override
   Future<List<Device>> pollingGetDevices({ Duration timeout }) async {

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -79,11 +79,11 @@ class IOSDevices extends PollingDeviceDiscovery {
     _observedDeviceEventsSubscription = _xcdevice.observedDeviceEvents().listen(
       _onDeviceEvent,
       onError: (dynamic error, StackTrace stack) {
-        _logger.printTrace('Process exception running xcdevice observe:\n$error');
+        _logger.printTrace('Process exception running xcdevice observe:\n$error\n$stack');
       }, onDone: () {
         // If xcdevice is killed or otherwise dies, polling will be stopped.
         // No retry is attempted and the polling client will have to restart polling
-        // (restart the browser). Avoid hammering on a process that is
+        // (restart the IDE). Avoid hammering on a process that is
         // continuously failing.
         _logger.printTrace('xcdevice observe stopped');
       },

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -372,9 +372,6 @@ class XCDevice {
         _logger.printTrace('xcdevice observe error: $line');
       });
       unawaited(_deviceObservationProcess.exitCode.whenComplete(() {
-        if (_deviceIdentifierByEvent.hasListener) {
-          _deviceIdentifierByEvent.close();
-        }
         _deviceObservationProcess = null;
       }));
     } on ProcessException catch (exception) {

--- a/packages/flutter_tools/test/general.shard/base_utils_test.dart
+++ b/packages/flutter_tools/test/general.shard/base_utils_test.dart
@@ -18,19 +18,25 @@ void main() {
       final Future<List<String>> removedStreamItems = list.onRemoved.toList();
 
       list.updateWithNewList(<String>['aaa']);
-      list.updateWithNewList(<String>['aaa', 'bbb']);
-      list.updateWithNewList(<String>['bbb']);
+      list.removeItem('bogus');
+      list.updateWithNewList(<String>['aaa', 'bbb', 'ccc']);
+      list.updateWithNewList(<String>['bbb', 'ccc']);
+      list.removeItem('bbb');
+
+      expect(list.items, <String>['ccc']);
       list.dispose();
 
       final List<String> addedItems = await addedStreamItems;
       final List<String> removedItems = await removedStreamItems;
 
-      expect(addedItems.length, 2);
+      expect(addedItems.length, 3);
       expect(addedItems.first, 'aaa');
       expect(addedItems[1], 'bbb');
+      expect(addedItems[2], 'ccc');
 
-      expect(removedItems.length, 1);
+      expect(removedItems.length, 2);
       expect(removedItems.first, 'aaa');
+      expect(removedItems[1], 'bbb');
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/device_test.dart
+++ b/packages/flutter_tools/test/general.shard/device_test.dart
@@ -66,9 +66,9 @@ void main() {
 
   group('PollingDeviceDiscovery', () {
     testUsingContext('startPolling', () async {
-      FakeAsync().run((FakeAsync time) {
+      FakeAsync().run((FakeAsync time) async {
         final FakePollingDeviceDiscovery pollingDeviceDiscovery = FakePollingDeviceDiscovery();
-        pollingDeviceDiscovery.startPolling();
+        await pollingDeviceDiscovery.startPolling();
         time.elapse(const Duration(milliseconds: 4001));
         time.flushMicrotasks();
         // First check should use the default polling timeout
@@ -79,7 +79,7 @@ void main() {
         time.flushMicrotasks();
         // Subsequent polling should be much longer.
         expect(pollingDeviceDiscovery.lastPollingTimeout, const Duration(seconds: 30));
-        pollingDeviceDiscovery.stopPolling();
+        await pollingDeviceDiscovery.stopPolling();
       });
     });
   });

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -262,15 +262,17 @@ void main() {
     });
   });
 
-  group('pollingGetDevices', () {
+  group('polling', () {
     MockXcdevice mockXcdevice;
     MockArtifacts mockArtifacts;
     MockCache mockCache;
     FakeProcessManager fakeProcessManager;
-    Logger logger;
+    BufferLogger logger;
     IOSDeploy iosDeploy;
     IMobileDevice iMobileDevice;
     IOSWorkflow mockIosWorkflow;
+    IOSDevice device1;
+    IOSDevice device2;
 
     setUp(() {
       mockXcdevice = MockXcdevice();
@@ -292,33 +294,8 @@ void main() {
         processManager: fakeProcessManager,
         logger: logger,
       );
-    });
 
-    final List<Platform> unsupportedPlatforms = <Platform>[linuxPlatform, windowsPlatform];
-    for (final Platform unsupportedPlatform in unsupportedPlatforms) {
-      testWithoutContext('throws Unsupported Operation exception on ${unsupportedPlatform.operatingSystem}', () async {
-        final IOSDevices iosDevices = IOSDevices(
-          platform: unsupportedPlatform,
-          xcdevice: mockXcdevice,
-          iosWorkflow: mockIosWorkflow,
-        );
-        when(mockXcdevice.isInstalled).thenReturn(false);
-        expect(
-            () async { await iosDevices.pollingGetDevices(); },
-            throwsA(isA<UnsupportedError>()),
-        );
-      });
-    }
-
-    testWithoutContext('returns attached devices', () async {
-      final IOSDevices iosDevices = IOSDevices(
-        platform: macPlatform,
-        xcdevice: mockXcdevice,
-        iosWorkflow: mockIosWorkflow,
-      );
-      when(mockXcdevice.isInstalled).thenReturn(true);
-
-      final IOSDevice device = IOSDevice(
+      device1 = IOSDevice(
         'd83d5bc53967baa0ee18626ba87b6254b2ab5418',
         name: 'Paired iPhone',
         sdkVersion: '13.3',
@@ -331,22 +308,194 @@ void main() {
         fileSystem: MemoryFileSystem.test(),
         interfaceType: IOSDeviceInterface.usb,
       );
+
+      device2 = IOSDevice(
+        '43ad2fda7991b34fe1acbda82f9e2fd3d6ddc9f7',
+        name: 'iPhone 6s',
+        sdkVersion: '13.3',
+        cpuArchitecture: DarwinArch.arm64,
+        artifacts: mockArtifacts,
+        iosDeploy: iosDeploy,
+        iMobileDevice: iMobileDevice,
+        logger: logger,
+        platform: macPlatform,
+        fileSystem: MemoryFileSystem.test(),
+        interfaceType: IOSDeviceInterface.usb,
+      );
+    });
+
+    testWithoutContext('start polling', () async {
+      final IOSDevices iosDevices = IOSDevices(
+        platform: macPlatform,
+        xcdevice: mockXcdevice,
+        iosWorkflow: mockIosWorkflow,
+        logger: logger,
+      );
+      when(mockXcdevice.isInstalled).thenReturn(true);
+
+      int fetchDevicesCount = 0;
       when(mockXcdevice.getAvailableIOSDevices())
-          .thenAnswer((Invocation invocation) => Future<List<IOSDevice>>.value(<IOSDevice>[device]));
+        .thenAnswer((Invocation invocation) {
+          if (fetchDevicesCount == 0) {
+            // Initial time, no devices.
+            fetchDevicesCount++;
+            return Future<List<IOSDevice>>.value(<IOSDevice>[]);
+          } else if (fetchDevicesCount == 1) {
+            // Simulate 2 devices added later.
+            fetchDevicesCount++;
+            return Future<List<IOSDevice>>.value(<IOSDevice>[device1, device2]);
+          }
+          fail('Too many calls to getAvailableTetheredIOSDevices');
+      });
+
+      int addedCount = 0;
+      final Completer<void> added = Completer<void>();
+      iosDevices.onAdded.listen((Device device) {
+        addedCount++;
+        // 2 devices will be added.
+        // Will throw over-completion if called more than twice.
+        if (addedCount >= 2) {
+          added.complete();
+        }
+      });
+
+      final Completer<void> removed = Completer<void>();
+      iosDevices.onRemoved.listen((Device device) {
+        // Will throw over-completion if called more than once.
+        removed.complete();
+      });
+
+      final StreamController<Map<XCDeviceEvent, String>> eventStream = StreamController<Map<XCDeviceEvent, String>>();
+      when(mockXcdevice.observedDeviceEvents()).thenAnswer((_) => eventStream.stream);
+
+      await iosDevices.startPolling();
+      verify(mockXcdevice.getAvailableIOSDevices()).called(1);
+
+      expect(iosDevices.deviceNotifier.items, isEmpty);
+      expect(eventStream.hasListener, isTrue);
+
+      eventStream.add(<XCDeviceEvent, String>{
+        XCDeviceEvent.attach: 'd83d5bc53967baa0ee18626ba87b6254b2ab5418'
+      });
+      await added.future;
+      expect(iosDevices.deviceNotifier.items.length, 2);
+      expect(iosDevices.deviceNotifier.items, contains(device1));
+      expect(iosDevices.deviceNotifier.items, contains(device2));
+
+      eventStream.add(<XCDeviceEvent, String>{
+        XCDeviceEvent.detach: 'd83d5bc53967baa0ee18626ba87b6254b2ab5418'
+      });
+      await removed.future;
+      expect(iosDevices.deviceNotifier.items, <Device>[device2]);
+
+      // Remove stream will throw over-completion if called more than once
+      // which proves this is ignored.
+      eventStream.add(<XCDeviceEvent, String>{
+        XCDeviceEvent.detach: 'bogus'
+      });
+
+      expect(addedCount, 2);
+
+      await iosDevices.stopPolling();
+
+      expect(eventStream.hasListener, isFalse);
+    });
+
+    testWithoutContext('polling restarts if stream is closed', () async {
+      final IOSDevices iosDevices = IOSDevices(
+        platform: macPlatform,
+        xcdevice: mockXcdevice,
+        iosWorkflow: mockIosWorkflow,
+        logger: logger,
+      );
+      when(mockXcdevice.isInstalled).thenReturn(true);
+
+      int fetchDevicesCount = 0;
+      when(mockXcdevice.getAvailableIOSDevices())
+        .thenAnswer((Invocation invocation) {
+        if (fetchDevicesCount == 0) {
+          // Initial time, no devices.
+          fetchDevicesCount++;
+          return Future<List<IOSDevice>>.value(<IOSDevice>[]);
+        } else if (fetchDevicesCount == 1) {
+          // Simulate a device added later.
+          fetchDevicesCount++;
+          return Future<List<IOSDevice>>.value(<IOSDevice>[device1]);
+        }
+        fail('Too many calls to getAvailableTetheredIOSDevices');
+      });
+
+      final StreamController<Map<XCDeviceEvent, String>> eventStream = StreamController<Map<XCDeviceEvent, String>>();
+      when(mockXcdevice.observedDeviceEvents()).thenAnswer((_) => eventStream.stream);
+
+      final Completer<void> added = Completer<void>();
+      iosDevices.onAdded.listen((Device device) {
+        added.complete();
+      });
+
+      await iosDevices.startPolling();
+      verify(mockXcdevice.getAvailableIOSDevices()).called(1);
+
+      expect(iosDevices.deviceNotifier.items, isEmpty);
+      expect(eventStream.hasListener, isTrue);
+
+      // Pretend xcdevice crashed.
+      await eventStream.close();
+
+      // Polling should restart and add the "new" device.
+      await added.future;
+      expect(iosDevices.deviceNotifier.items, <Device>[device1]);
+      expect(logger.traceText, contains('xcdevice observe stopped, restarting'));
+
+      await iosDevices.stopPolling();
+
+      expect(eventStream.hasListener, isFalse);
+    });
+
+    final List<Platform> unsupportedPlatforms = <Platform>[linuxPlatform, windowsPlatform];
+    for (final Platform unsupportedPlatform in unsupportedPlatforms) {
+      testWithoutContext('pollingGetDevices throws Unsupported Operation exception on ${unsupportedPlatform.operatingSystem}', () async {
+        final IOSDevices iosDevices = IOSDevices(
+          platform: unsupportedPlatform,
+          xcdevice: mockXcdevice,
+          iosWorkflow: mockIosWorkflow,
+          logger: logger,
+        );
+        when(mockXcdevice.isInstalled).thenReturn(false);
+        expect(
+            () async { await iosDevices.pollingGetDevices(); },
+            throwsA(isA<UnsupportedError>()),
+        );
+      });
+    }
+
+    testWithoutContext('pollingGetDevices returns attached devices', () async {
+      final IOSDevices iosDevices = IOSDevices(
+        platform: macPlatform,
+        xcdevice: mockXcdevice,
+        iosWorkflow: mockIosWorkflow,
+        logger: logger,
+      );
+      when(mockXcdevice.isInstalled).thenReturn(true);
+
+      when(mockXcdevice.getAvailableIOSDevices())
+          .thenAnswer((Invocation invocation) => Future<List<IOSDevice>>.value(<IOSDevice>[device1]));
 
       final List<Device> devices = await iosDevices.pollingGetDevices();
       expect(devices, hasLength(1));
-      expect(identical(devices.first, device), isTrue);
+      expect(identical(devices.first, device1), isTrue);
     });
   });
 
   group('getDiagnostics', () {
     MockXcdevice mockXcdevice;
     IOSWorkflow mockIosWorkflow;
+    Logger logger;
 
     setUp(() {
       mockXcdevice = MockXcdevice();
       mockIosWorkflow = MockIOSWorkflow();
+      logger = BufferLogger.test();
     });
 
     final List<Platform> unsupportedPlatforms = <Platform>[linuxPlatform, windowsPlatform];
@@ -356,6 +505,7 @@ void main() {
           platform: unsupportedPlatform,
           xcdevice: mockXcdevice,
           iosWorkflow: mockIosWorkflow,
+          logger: logger,
         );
         when(mockXcdevice.isInstalled).thenReturn(false);
         expect((await iosDevices.getDiagnostics()).first, 'Control of iOS devices or simulators only supported on macOS.');
@@ -367,6 +517,7 @@ void main() {
         platform: macPlatform,
         xcdevice: mockXcdevice,
         iosWorkflow: mockIosWorkflow,
+        logger: logger,
       );
       when(mockXcdevice.isInstalled).thenReturn(true);
       when(mockXcdevice.getDiagnostics())

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -432,9 +432,6 @@ void main() {
 
       // Pretend xcdevice crashed.
       await eventStream.close();
-
-      // Give it a tick for the close handlers to run.
-      FakeAsync().flushMicrotasks();
       expect(logger.traceText, contains('xcdevice observe stopped'));
 
       // Confirm a restart still gets streamed events.

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -21,7 +21,6 @@ import 'package:flutter_tools/src/ios/ios_workflow.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
 import 'package:mockito/mockito.dart';
-import 'package:quiver/testing/async.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/io.dart' show ProcessException, ProcessResult;
@@ -19,7 +21,7 @@ import '../../src/common.dart';
 import '../../src/context.dart';
 
 void main() {
-  Logger logger;
+  BufferLogger logger;
 
   setUp(() {
     logger = BufferLogger.test();
@@ -350,6 +352,59 @@ void main() {
 
           expect(xcdevice.isInstalled, true);
           expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        });
+      });
+
+      group('observe device events', () {
+        testWithoutContext('Xcode not installed', () async {
+          when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(false);
+
+          expect(xcdevice.observedDeviceEvents(), isNull);
+          expect(logger.traceText, contains("Xcode not found. Run 'flutter doctor' for more information."));
+        });
+
+
+        testUsingContext('relays events', () async {
+          when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
+          fakeProcessManager.addCommand(const FakeCommand(
+            command: <String>['xcrun', '--find', 'xcdevice'],
+            stdout: '/path/to/xcdevice',
+          ));
+
+          fakeProcessManager.addCommand(const FakeCommand(
+            command: <String>[
+              'script',
+              '-t',
+              '0',
+              '/dev/null',
+              'xcrun',
+              'xcdevice',
+              'observe',
+              '--usb',
+            ], stdout: 'Attach: d83d5bc53967baa0ee18626ba87b6254b2ab5418\n'
+            'Detach: d83d5bc53967baa0ee18626ba87b6254b2ab5418',
+            stderr: 'Some error',
+          ));
+
+          final Completer<void> attach = Completer<void>();
+          final Completer<void> detach = Completer<void>();
+
+          // Attach: d83d5bc53967baa0ee18626ba87b6254b2ab5418
+          // Detach: d83d5bc53967baa0ee18626ba87b6254b2ab5418
+          xcdevice.observedDeviceEvents().listen((Map<XCDeviceEvent, String> event) {
+            expect(event.length, 1);
+            if (event.containsKey(XCDeviceEvent.attach)) {
+              expect(event[XCDeviceEvent.attach], 'd83d5bc53967baa0ee18626ba87b6254b2ab5418');
+              attach.complete();
+            } else if (event.containsKey(XCDeviceEvent.detach)) {
+              expect(event[XCDeviceEvent.detach], 'd83d5bc53967baa0ee18626ba87b6254b2ab5418');
+              detach.complete();
+            }
+            fail('Unexpected event');
+          });
+          await attach.future;
+          await detach.future;
+          expect(logger.traceText, contains('Some error'));
         });
       });
 

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -380,7 +380,7 @@ void main() {
               'xcrun',
               'xcdevice',
               'observe',
-              '--usb',
+              '--both',
             ], stdout: 'Attach: d83d5bc53967baa0ee18626ba87b6254b2ab5418\n'
             'Detach: d83d5bc53967baa0ee18626ba87b6254b2ab5418',
             stderr: 'Some error',

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -399,8 +399,9 @@ void main() {
             } else if (event.containsKey(XCDeviceEvent.detach)) {
               expect(event[XCDeviceEvent.detach], 'd83d5bc53967baa0ee18626ba87b6254b2ab5418');
               detach.complete();
+            } else {
+              fail('Unexpected event');
             }
-            fail('Unexpected event');
           });
           await attach.future;
           await detach.future;

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -363,7 +363,6 @@ void main() {
           expect(logger.traceText, contains("Xcode not found. Run 'flutter doctor' for more information."));
         });
 
-
         testUsingContext('relays events', () async {
           when(mockXcode.isInstalledAndMeetsVersionCheck).thenReturn(true);
           fakeProcessManager.addCommand(const FakeCommand(
@@ -405,7 +404,7 @@ void main() {
           });
           await attach.future;
           await detach.future;
-          expect(logger.traceText, contains('Some error'));
+          expect(logger.traceText, contains('xcdevice observe error: Some error'));
         });
       });
 


### PR DESCRIPTION
## Description

For daemon iOS device polling, change periodic `xcdevice list` calls to a long-running `xcdevice observe` call.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/56826

## Tests
- xcdevice.observedDeviceEvents tests
- start polling devices test
- ItemListNotifier tests

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*