### PR TITLE
Error message when size has not been set in RenderBox's performLayout should be well versed

### DIFF
--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -1927,7 +1927,6 @@ abstract class RenderBox extends RenderObject {
     assert(constraints != null);
     assert(() {
       if (!hasSize) {
-        assert(!debugNeedsLayout); // this is called in the size= setter during layout, but in that case we have a size
         DiagnosticsNode contract;
         if (sizedByParent)
           contract = ErrorDescription('Because this RenderBox has sizedByParent set to true, it must set its size in performResize().');

--- a/packages/flutter/test/rendering/box_test.dart
+++ b/packages/flutter/test/rendering/box_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -28,6 +29,11 @@ class FakeMissingSizeRenderBox extends RenderBox {
   bool get hasSize => !fakeMissingSize && super.hasSize;
 
   bool fakeMissingSize = false;
+}
+
+class MissingSetSizeRenderBox extends RenderBox {
+  @override
+  void performLayout() { }
 }
 
 void main() {
@@ -1013,6 +1019,34 @@ void main() {
     expect(() => BoxConstraints(maxWidth: null), throwsAssertionError);
     expect(() => BoxConstraints(minHeight: null), throwsAssertionError);
     expect(() => BoxConstraints(maxHeight: null), throwsAssertionError);
+  });
+
+  test('Error message when size has not been set in RenderBox performLayout should be well versed', () {
+    FlutterErrorDetails errorDetails;
+    final FlutterExceptionHandler oldHandler = FlutterError.onError;
+    FlutterError.onError = (FlutterErrorDetails details) {
+      errorDetails = details;
+    };
+    try {
+      MissingSetSizeRenderBox().layout(const BoxConstraints());
+    } finally {
+      FlutterError.onError = oldHandler;
+    }
+
+    expect(errorDetails, isNotNull);
+
+    // Check the ErrorDetails without the stack trace
+    final List<String> lines =  errorDetails.toString().split('\n');
+    expect(
+      lines.take(5).join('\n'),
+      equalsIgnoringHashCodes(
+        '══╡ EXCEPTION CAUGHT BY RENDERING LIBRARY ╞══════════════════════\n'
+          'The following assertion was thrown during performLayout():\n'
+          'RenderBox did not set its size during layout.\n'
+          'Because this RenderBox has sizedByParent set to false, it must\n'
+          'set its size in performLayout().'
+      ),
+    );
   });
 }
 

--- a/packages/flutter/test/rendering/box_test.dart
+++ b/packages/flutter/test/rendering/box_test.dart
@@ -1035,7 +1035,7 @@ void main() {
 
     expect(errorDetails, isNotNull);
 
-    // Check the ErrorDetails without the stack trace
+    // Check the ErrorDetails without the stack trace.
     final List<String> lines =  errorDetails.toString().split('\n');
     expect(
       lines.take(5).join('\n'),


### PR DESCRIPTION
## Description

Previously, when RenderBox subclasses didn't set size in `performLayout`, the error message was`'!debugNeedsLayout': is not true.`, which was not very helpful. That was because of one liner assertion in the middle of `debugAssertDoesMeetConstraints()`. I think it is now better to remove this because it only prevents us from getting more detailed error message.

Now, we get a message: `RenderBox did not set its size during layout.`

## Related Issues

#40002

## Tests

7630f3e

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
