### PR TITLE
Various bits of trivial cleanup

### DIFF
--- a/packages/flutter/lib/src/gestures/hit_test.dart
+++ b/packages/flutter/lib/src/gestures/hit_test.dart
@@ -65,8 +65,8 @@ class HitTestEntry {
   ///
   /// See also:
   ///
-  ///  * [HitTestResult.pushTransform], which is used during hit
-  ///    testing to build up the transform returned by this method.
+  ///  * [HitTestResult.addWithPaintTransform], which is used during hit testing
+  ///    to build up this transform.
   Matrix4 get transform => _transform;
   Matrix4 _transform;
 }

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -691,7 +691,7 @@ class BoxHitTestResult extends HitTestResult {
   /// parent don't share the same origin.
   ///
   /// ```dart
-  /// abstract class Foo extends RenderBox {
+  /// abstract class RenderFoo extends RenderBox {
   ///
   ///   final Matrix4 _effectiveTransform = Matrix4.rotationZ(50);
   ///
@@ -752,7 +752,7 @@ class BoxHitTestResult extends HitTestResult {
   ///
   /// A null value for `offset` is treated as if [Offset.zero] was provided.
   ///
-  /// Se also:
+  /// See also:
   ///
   ///  * [addWithPaintTransform], which takes a generic paint transform matrix and
   ///    documents the intended usage of this API in more detail.
@@ -789,7 +789,7 @@ class BoxHitTestResult extends HitTestResult {
   /// the child speaks a different hit test protocol then the parent and the
   /// position is not required to do the actual hit testing in that protocol.
   ///
-  /// Se also:
+  /// See also:
   ///
   ///  * [addWithPaintTransform], which accomplishes the same thing, but takes a
   ///    _paint_ transform matrix.

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2732,12 +2732,14 @@ class _OffstageElement extends SingleChildRenderObjectElement {
 class AspectRatio extends SingleChildRenderObjectWidget {
   /// Creates a widget with a specific aspect ratio.
   ///
-  /// The [aspectRatio] argument must not be null.
+  /// The [aspectRatio] argument must be a finite number greater than zero.
   const AspectRatio({
     Key key,
     @required this.aspectRatio,
     Widget child,
   }) : assert(aspectRatio != null),
+       assert(aspectRatio > 0.0),
+       // can't test isFinite because that's not a constant expression
        super(key: key, child: child);
 
   /// The aspect ratio to attempt to use.


### PR DESCRIPTION
AspectRatio can test the ratio isn't zero. (The render object will
complain anyway, this just moves the exception earlier.)
