### PR TITLE
[e2e] make test bindings friendlier to integration tests

### DIFF
--- a/packages/flutter_test/lib/src/_binding_web.dart
+++ b/packages/flutter_test/lib/src/_binding_web.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
- import 'package:flutter/widgets.dart';
+import 'package:flutter/widgets.dart';
 
- import 'binding.dart';
+import 'binding.dart';
 
  /// Ensure the [WidgetsBinding] is initialized.
 WidgetsBinding ensureInitialized([@visibleForTesting Map<String, String> environment]) {

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -205,6 +205,27 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   @protected
   bool get disableShadows => false;
 
+  /// Determines whether the Dart [HttpClient] class should be overriden to
+  /// always return a failure response.
+  ///
+  /// By default, this value is true, so that unit tests will not become flaky
+  /// due to intermitten network errors. The value may be overriden by a binding
+  /// intended for use in integration tests that do end to end application
+  /// testing, including working with real network responses.
+  @protected
+  bool get overrideHttpClient => true;
+
+  /// Determines whether the binding automatically registers [testTextInput].
+  ///
+  /// Unit tests make use of this to mock out text input communication for
+  /// widgets. An integration test would set this to false, to test real IME
+  /// or keyboard input.
+  ///
+  /// [TestTextInput.isRegistered] reports whether the text input mock is
+  /// registered or not.
+  @protected
+  bool get registerTestTextInput => true;
+
   /// Increase the timeout for the current test by the given duration.
   ///
   /// This only matters if the test has an `initialTimeout` set on
@@ -269,8 +290,13 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   void initInstances() {
     super.initInstances();
     timeDilation = 1.0; // just in case the developer has artificially changed it for development
-    binding.setupHttpOverrides();
-    _testTextInput = TestTextInput(onCleared: _resetFocusedEditable)..register();
+    if (overrideHttpClient) {
+      binding.setupHttpOverrides();
+    }
+    _testTextInput = TestTextInput(onCleared: _resetFocusedEditable);
+    if (registerTestTextInput) {
+      _testTextInput.register();
+    }
   }
 
   @override

--- a/packages/flutter_test/test/bindings_test.dart
+++ b/packages/flutter_test/test/bindings_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -23,5 +25,12 @@ void main() {
       binding.defaultTestTimeout = const test_package.Timeout(Duration(minutes: 5));
       expect(binding.defaultTestTimeout.duration, const Duration(minutes: 5));
     });
+  });
+
+  test('Initializes httpOverrides and testTextInput', () async {
+    expect(HttpOverrides.current, null);
+    final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized() as TestWidgetsFlutterBinding;
+    expect(binding.testTextInput.isRegistered, true);
+    expect(HttpOverrides.current, isNotNull);
   });
 }

--- a/packages/flutter_test/test/bindings_test.dart
+++ b/packages/flutter_test/test/bindings_test.dart
@@ -28,7 +28,6 @@ void main() {
   });
 
   test('Initializes httpOverrides and testTextInput', () async {
-    expect(HttpOverrides.current, null);
     final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized() as TestWidgetsFlutterBinding;
     expect(binding.testTextInput.isRegistered, true);
     expect(HttpOverrides.current, isNotNull);

--- a/packages/flutter_test/test/integration_bindings_test.dart
+++ b/packages/flutter_test/test/integration_bindings_test.dart
@@ -1,0 +1,26 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Initializes httpOverrides and testTextInput', () async {
+    expect(HttpOverrides.current, null);
+    final TestWidgetsFlutterBinding binding = CustomBindings();
+    expect(WidgetsBinding.instance, isA<CustomBindings>());
+    expect(binding.testTextInput.isRegistered, false);
+    expect(HttpOverrides.current, null);
+  });
+}
+
+class CustomBindings extends AutomatedTestWidgetsFlutterBinding {
+  @override
+  bool get overrideHttpClient => false;
+
+  @override
+  bool get registerTestTextInput => false;
+}


### PR DESCRIPTION
## Description

Integration tests may not want to override testTextInput or HttpClient. This lets binding subclasses for tests achieve that.

## Related Issues

Part of https://github.com/flutter/flutter/issues/51885
Part of https://github.com/flutter/flutter/issues/57623

## Tests

I added the following tests:

Test that the default bindings _do_ override HttpClient and register TestTextInput.
Test that custom bindings using the new properties do not override/register.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
