### PR TITLE
Helpful assertion for isAlwaysShown error

### DIFF
--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -62,7 +62,8 @@ class CupertinoScrollbar extends StatefulWidget {
     this.controller,
     this.isAlwaysShown = false,
     @required this.child,
-  }) : super(key: key);
+  }) : assert(!isAlwaysShown || controller != null, 'When isAlwaysShown is true, must pass a controller that is attached to a scroll view'),
+       super(key: key);
 
   /// The subtree to place inside the [CupertinoScrollbar].
   ///
@@ -276,7 +277,6 @@ class _CupertinoScrollbarState extends State<CupertinoScrollbar> with TickerProv
   void _triggerScrollbar() {
     WidgetsBinding.instance.addPostFrameCallback((Duration duration) {
       if (widget.isAlwaysShown) {
-        assert(widget.controller != null);
         _fadeoutTimer?.cancel();
         widget.controller.position.didUpdateScrollPositionBy(0);
       }

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -38,7 +38,8 @@ class Scrollbar extends StatefulWidget {
     @required this.child,
     this.controller,
     this.isAlwaysShown = false,
-  }) : super(key: key);
+  }) : assert(!isAlwaysShown || controller != null, 'When isAlwaysShown is true, must pass a controller that is attached to a scroll view'),
+       super(key: key);
 
   /// The widget below this widget in the tree.
   ///
@@ -131,7 +132,6 @@ class _ScrollbarState extends State<Scrollbar> with TickerProviderStateMixin {
   void _triggerScrollbar() {
     WidgetsBinding.instance.addPostFrameCallback((Duration duration) {
       if (widget.isAlwaysShown) {
-        assert(widget.controller != null);
         _fadeoutTimer?.cancel();
         widget.controller.position.didUpdateScrollPositionBy(0);
       }

--- a/packages/flutter/test/cupertino/scrollbar_test.dart
+++ b/packages/flutter/test/cupertino/scrollbar_test.dart
@@ -164,6 +164,58 @@ void main() {
     await tester.pump(_kScrollbarFadeDuration);
   });
 
+  testWidgets('When isAlwaysShown is truew, must pass a controller',
+      (WidgetTester tester) async {
+    Widget viewWithScroll() {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: CupertinoScrollbar(
+            isAlwaysShown: true,
+            child: const SingleChildScrollView(
+              child: SizedBox(
+                width: 4000.0,
+                height: 4000.0,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    expect(() async {
+      await tester.pumpWidget(viewWithScroll());
+    }, throwsAssertionError);
+  });
+
+  testWidgets('When isAlwaysShown is true, must pass a controller that is attached to a scroll view',
+      (WidgetTester tester) async {
+    final ScrollController controller = ScrollController();
+    Widget viewWithScroll() {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: CupertinoScrollbar(
+            controller: controller,
+            isAlwaysShown: true,
+            child: const SingleChildScrollView(
+              child: SizedBox(
+                width: 4000.0,
+                height: 4000.0,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(viewWithScroll());
+    final dynamic exception = tester.takeException();
+    expect(exception, isAssertionError);
+  });
+
   testWidgets('On first render with isAlwaysShown: true, the thumb shows',
       (WidgetTester tester) async {
     final ScrollController controller = ScrollController();

--- a/packages/flutter/test/cupertino/scrollbar_test.dart
+++ b/packages/flutter/test/cupertino/scrollbar_test.dart
@@ -164,7 +164,7 @@ void main() {
     await tester.pump(_kScrollbarFadeDuration);
   });
 
-  testWidgets('When isAlwaysShown is truew, must pass a controller',
+  testWidgets('When isAlwaysShown is true, must pass a controller',
       (WidgetTester tester) async {
     Widget viewWithScroll() {
       return Directionality(

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -201,6 +201,56 @@ void main() {
     expect(scrollbar.controller, isNotNull);
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
+  testWidgets('When isAlwaysShown is truew, must pass a controller',
+      (WidgetTester tester) async {
+    Widget viewWithScroll() {
+      return _buildBoilerplate(
+        child: Theme(
+          data: ThemeData(),
+          child: Scrollbar(
+            isAlwaysShown: true,
+            child: const SingleChildScrollView(
+              child: SizedBox(
+                width: 4000.0,
+                height: 4000.0,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    expect(() async {
+      await tester.pumpWidget(viewWithScroll());
+    }, throwsAssertionError);
+  });
+
+  testWidgets('When isAlwaysShown is true, must pass a controller that is attached to a scroll view',
+      (WidgetTester tester) async {
+    final ScrollController controller = ScrollController();
+    Widget viewWithScroll() {
+      return _buildBoilerplate(
+        child: Theme(
+          data: ThemeData(),
+          child: Scrollbar(
+            isAlwaysShown: true,
+            controller: controller,
+            child: const SingleChildScrollView(
+              child: SizedBox(
+                width: 4000.0,
+                height: 4000.0,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(viewWithScroll());
+    final dynamic exception = tester.takeException();
+    expect(exception, isAssertionError);
+  });
+
   testWidgets('On first render with isAlwaysShown: true, the thumb shows',
       (WidgetTester tester) async {
     final ScrollController controller = ScrollController();

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -201,7 +201,7 @@ void main() {
     expect(scrollbar.controller, isNotNull);
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
-  testWidgets('When isAlwaysShown is truew, must pass a controller',
+  testWidgets('When isAlwaysShown is true, must pass a controller',
       (WidgetTester tester) async {
     Widget viewWithScroll() {
       return _buildBoilerplate(


### PR DESCRIPTION
## Description

When a scrollbar's isAlwaysShown is true, it must have a controller that's attached to a scrollview. Previously, an assertion deeper in the framework would get triggered if this wasn't the case, with an error message that's not so informative.  This PR adds an assertion directly in the constructor with a more helpful error message.

## Related Issues

Closes https://github.com/flutter/flutter/issues/53771

## Tests

I added the following tests:
  * Check that an assertion is triggered when no controller at all.
  * Check that an assertion is triggered when the controller isn't attached to a scroll view.
  * The two above tests for material and cupertino.