### PR TITLE
Remove callback asserts on FocusableActionDetector

### DIFF
--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -985,7 +985,6 @@ class _FocusableActionDetectorState extends State<FocusableActionDetector> {
 
   bool _hovering = false;
   void _handleMouseEnter(PointerEnterEvent event) {
-    assert(widget.onShowHoverHighlight != null);
     if (!_hovering) {
       _mayTriggerCallback(task: () {
         _hovering = true;
@@ -994,7 +993,6 @@ class _FocusableActionDetectorState extends State<FocusableActionDetector> {
   }
 
   void _handleMouseExit(PointerExitEvent event) {
-    assert(widget.onShowHoverHighlight != null);
     if (_hovering) {
       _mayTriggerCallback(task: () {
         _hovering = false;


### PR DESCRIPTION
## Description

This makes the callback arguments to `FocusableActionDetector` optional, if you (for instance) only want to define shortcuts and actions and a focus node for something.

## Tests

- Added a test to make sure that the `FocusableActionDetector` can be used without callbacks.

## Breaking Change

- [X] No, this is *not* a breaking change.