### PR TITLE
Enabling the ImageFiltered(ImageFilter.matrix) page of macrobenchmark

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/common.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/common.dart
@@ -15,4 +15,4 @@ const String kColorFilterAndFadeRouteName = '/color_filter_and_fade';
 const String kFadingChildAnimationRouteName = '/fading_child_animation';
 const String kImageFilteredTransformAnimationRouteName = '/imagefiltered_transform_animation';
 
-const String kScrollableName = "/macrobenchmark_listview";
+const String kScrollableName = '/macrobenchmark_listview';

--- a/dev/benchmarks/macrobenchmarks/lib/common.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/common.dart
@@ -13,3 +13,6 @@ const String kTextRouteName = '/text';
 const String kAnimatedPlaceholderRouteName = '/animated_placeholder';
 const String kColorFilterAndFadeRouteName = '/color_filter_and_fade';
 const String kFadingChildAnimationRouteName = '/fading_child_animation';
+const String kImageFilteredTransformAnimationRouteName = '/imagefiltered_transform_animation';
+
+const String kScrollableName = "/macrobenchmark_listview";

--- a/dev/benchmarks/macrobenchmarks/lib/main.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/main.dart
@@ -42,6 +42,7 @@ class MacrobenchmarksApp extends StatelessWidget {
         kAnimatedPlaceholderRouteName: (BuildContext context) => AnimatedPlaceholderPage(),
         kColorFilterAndFadeRouteName: (BuildContext context) => ColorFilterAndFadePage(),
         kFadingChildAnimationRouteName: (BuildContext context) => const FilteredChildAnimationPage(FilterType.opacity),
+        kImageFilteredTransformAnimationRouteName: (BuildContext context) => const FilteredChildAnimationPage(FilterType.rotateFilter),
       },
     );
   }
@@ -55,6 +56,7 @@ class HomePage extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(title: const Text(kMacrobenchmarks)),
       body: ListView(
+        key: const Key(kScrollableName),
         children: <Widget>[
           RaisedButton(
             key: const Key(kCullOpacityRouteName),
@@ -131,6 +133,13 @@ class HomePage extends StatelessWidget {
             child: const Text('Fading Child Animation'),
             onPressed: () {
               Navigator.pushNamed(context, kFadingChildAnimationRouteName);
+            },
+          ),
+          RaisedButton(
+            key: const Key(kImageFilteredTransformAnimationRouteName),
+            child: const Text('ImageFiltered Transform Animation'),
+            onPressed: () {
+              Navigator.pushNamed(context, kImageFilteredTransformAnimationRouteName);
             },
           ),
         ],

--- a/dev/benchmarks/macrobenchmarks/lib/src/filtered_child_animation.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/filtered_child_animation.dart
@@ -42,8 +42,7 @@ class _FilteredChildAnimationPageState extends State<FilteredChildAnimationPage>
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final RenderBox childBox = _childKey.currentContext.findRenderObject() as RenderBox;
-      final Offset localCenter = childBox.paintBounds.center;
-      _childCenter = childBox.localToGlobal(localCenter);
+      _childCenter = childBox.paintBounds.center;
     });
     _controller = AnimationController(vsync: this, duration: const Duration(seconds: 2));
     _controller.repeat();

--- a/dev/benchmarks/macrobenchmarks/test_driver/imagefiltered_transform_animation_perf.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/imagefiltered_transform_animation_perf.dart
@@ -1,0 +1,11 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_driver/driver_extension.dart';
+import 'package:macrobenchmarks/main.dart' as app;
+
+void main() {
+  enableFlutterDriverExtension();
+  app.main();
+}

--- a/dev/benchmarks/macrobenchmarks/test_driver/imagefiltered_transform_animation_perf_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/imagefiltered_transform_animation_perf_test.dart
@@ -1,0 +1,16 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:macrobenchmarks/common.dart';
+
+import 'util.dart';
+
+void main() {
+  macroPerfTest(
+    'imagefiltered_transform_animation_perf',
+    kImageFilteredTransformAnimationRouteName,
+    pageDelay: const Duration(seconds: 1),
+    duration: const Duration(seconds: 10),
+  );
+}

--- a/dev/benchmarks/macrobenchmarks/test_driver/util.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/util.dart
@@ -7,6 +7,8 @@ import 'dart:async';
 import 'package:flutter_driver/flutter_driver.dart';
 import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 
+import 'package:macrobenchmarks/common.dart';
+
 void macroPerfTest(
     String testName,
     String routeName,
@@ -27,8 +29,11 @@ void macroPerfTest(
 
     await driver.forceGC();
 
+    final SerializableFinder scrollable = find.byValueKey(kScrollableName);
+    expect(scrollable, isNotNull);
     final SerializableFinder button = find.byValueKey(routeName);
     expect(button, isNotNull);
+    await driver.scrollUntilVisible(scrollable, button, dyScroll: -50.0);
     await driver.tap(button);
 
     if (pageDelay != null) {

--- a/dev/devicelab/bin/tasks/imagefiltered_transform_animation_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/imagefiltered_transform_animation_perf__timeline_summary.dart
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+import 'package:flutter_devicelab/framework/adb.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.android;
+  await task(createImageFilteredTransformAnimationPerfTest());
+}

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -217,6 +217,14 @@ TaskFunction createFadingChildAnimationPerfTest() {
   ).run;
 }
 
+TaskFunction createImageFilteredTransformAnimationPerfTest() {
+  return PerfTest(
+    '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
+    'test_driver/imagefiltered_transform_animation_perf.dart',
+    'imagefiltered_transform_animation_perf',
+  ).run;
+}
+
 /// Measure application startup performance.
 class StartupTest {
   const StartupTest(this.testDirectory, { this.reportMetrics = true });

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -213,6 +213,12 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
 
+  imagefiltered_transform_animation_perf__timeline_summary:
+    description: >
+      Measures the runtime performance of imagefiltered widget with transform on Android.
+    stage: devicelab
+    required_agent_capabilities: ["mac/android"]
+
   flavors_test:
     description: >
       Checks that flavored builds work on Android.


### PR DESCRIPTION
This change enables the ImageFiltered benchmark variant of the existing filtered child benchmark page in preparation for measuring the impact of some upcoming performance enhancements targeted at that widget.