### PR TITLE
Send text error in JSON and print in tools

### DIFF
--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -929,6 +929,13 @@ mixin WidgetInspectorService {
     );
 
     errorJson['errorsSinceReload'] = _errorsSinceReload;
+    errorJson['renderedErrorText'] = TextTreeRenderer(
+      wrapWidth: FlutterError.wrapWidth,
+      wrapWidthProperties: FlutterError.wrapWidth,
+      maxDescendentsTruncatableNode: 5,
+    )
+        .render(details.toDiagnosticsNode(style: DiagnosticsTreeStyle.error))
+        .trimRight();
     _errorsSinceReload += 1;
 
     postEvent('Flutter.Error', errorJson);

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -933,9 +933,7 @@ mixin WidgetInspectorService {
       wrapWidth: FlutterError.wrapWidth,
       wrapWidthProperties: FlutterError.wrapWidth,
       maxDescendentsTruncatableNode: 5,
-    )
-        .render(details.toDiagnosticsNode(style: DiagnosticsTreeStyle.error))
-        .trimRight();
+    ).render(details.toDiagnosticsNode(style: DiagnosticsTreeStyle.error)).trimRight();
     _errorsSinceReload += 1;
 
     postEvent('Flutter.Error', errorJson);

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -929,13 +929,17 @@ mixin WidgetInspectorService {
     );
 
     errorJson['errorsSinceReload'] = _errorsSinceReload;
-    errorJson['renderedErrorText'] = TextTreeRenderer(
-      wrapWidth: FlutterError.wrapWidth,
-      wrapWidthProperties: FlutterError.wrapWidth,
-      maxDescendentsTruncatableNode: 5,
-    ).render(details.toDiagnosticsNode(style: DiagnosticsTreeStyle.error)).trimRight();
-    _errorsSinceReload += 1;
+    if (_errorsSinceReload == 0) {
+      errorJson['renderedErrorText'] = TextTreeRenderer(
+        wrapWidth: FlutterError.wrapWidth,
+        wrapWidthProperties: FlutterError.wrapWidth,
+        maxDescendentsTruncatableNode: 5,
+      ).render(details.toDiagnosticsNode(style: DiagnosticsTreeStyle.error)).trimRight();
+    } else {
+      errorJson['renderedErrorText'] = 'Another exception was thrown: ${details.summary}';
+    }
 
+    _errorsSinceReload += 1;
     postEvent('Flutter.Error', errorJson);
   }
 

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -2254,6 +2254,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
         // Validate that we received an error count.
         expect(error['errorsSinceReload'], 0);
+        expect(
+            error['renderedErrorText'],
+            startsWith(
+                '══╡ EXCEPTION CAUGHT BY RENDERING LIBRARY ╞════════════'));
 
         // Send a second error.
         FlutterError.reportError(FlutterErrorDetailsForRendering(

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -2271,6 +2271,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         expect(flutterErrorEvents, hasLength(2));
         error = flutterErrorEvents.last;
         expect(error['errorsSinceReload'], 1);
+        expect(error['renderedErrorText'], startsWith('Another exception was thrown:'));
 
         // Reloads the app.
         final FlutterExceptionHandler oldHandler = FlutterError.onError;

--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -112,6 +112,7 @@ abstract class ResidentWebRunner extends ResidentRunner {
   ConnectionResult _connectionResult;
   StreamSubscription<vmservice.Event> _stdOutSub;
   StreamSubscription<vmservice.Event> _stdErrSub;
+  StreamSubscription<vmservice.Event> _extensionEventSub;
   bool _exited = false;
   WipConnection _wipConnection;
   ChromiumLauncher _chromiumLauncher;
@@ -150,6 +151,7 @@ abstract class ResidentWebRunner extends ResidentRunner {
     }
     await _stdOutSub?.cancel();
     await _stdErrSub?.cancel();
+    await _extensionEventSub?.cancel();
     await device.device.stopApp(null);
     try {
       _generatedEntrypointDirectory?.deleteSync(recursive: true);
@@ -675,6 +677,8 @@ class _ResidentWebRunner extends ResidentWebRunner {
         final String message = utf8.decode(base64.decode(log.bytes));
         globals.printStatus(message, newline: false);
       });
+      _extensionEventSub =
+          _vmService.onExtensionEvent.listen(printErrorEvent);
       try {
         await _vmService.streamListen(vmservice.EventStreams.kStdout);
       } on vmservice.RPCError {
@@ -689,6 +693,12 @@ class _ResidentWebRunner extends ResidentWebRunner {
       }
       try {
         await _vmService.streamListen(vmservice.EventStreams.kIsolate);
+      } on vmservice.RPCError {
+        // It is safe to ignore this error because we expect an error to be
+        // thrown if we're not already subscribed.
+      }
+      try {
+        await _vmService.streamListen(vmservice.EventStreams.kExtension);
       } on vmservice.RPCError {
         // It is safe to ignore this error because we expect an error to be
         // thrown if we're not already subscribed.

--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -678,7 +678,7 @@ class _ResidentWebRunner extends ResidentWebRunner {
         globals.printStatus(message, newline: false);
       });
       _extensionEventSub =
-          _vmService.onExtensionEvent.listen(printErrorEvent);
+          _vmService.onExtensionEvent.listen(printStructuredErrorLog);
       try {
         await _vmService.streamListen(vmservice.EventStreams.kStdout);
       } on vmservice.RPCError {

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1115,7 +1115,7 @@ abstract class ResidentRunner {
     if (event.extensionKind == 'Flutter.Error') {
       final Map<dynamic, dynamic> json = event.extensionData?.data;
       if (json != null && json.containsKey('renderedErrorText')) {
-        globals.printStatus('\n' + json['renderedErrorText'].toString());
+        globals.printStatus('\n${json['renderedErrorText']}');
       }
     }
   }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -217,11 +217,7 @@ class FlutterDevice {
         }
         return;
       }
-      try {
-        await service.streamListen(EventStreams.kExtension);
-      } on Exception catch (exception) {
-        globals.printTrace('Fail to listen to extension stream: $observatoryUri: $exception');
-      }
+      await service.streamListen(EventStreams.kExtension);
       if (printStructuredErrorLogMethod != null) {
         service.onExtensionEvent.listen(printStructuredErrorLogMethod);
       }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -38,8 +38,6 @@ import 'run_cold.dart';
 import 'run_hot.dart';
 import 'vmservice.dart';
 
-typedef PrintStructuredErrorLogMethod = void Function(vm_service.Event);
-
 class FlutterDevice {
   FlutterDevice(
     this.device, {

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -39,7 +39,7 @@ import 'run_cold.dart';
 import 'run_hot.dart';
 import 'vmservice.dart';
 
-typedef PrintErrorEventMethod = void Function(vm_service.Event);
+typedef PrintStructuredErrorLogMethod = void Function(vm_service.Event);
 
 class FlutterDevice {
   FlutterDevice(
@@ -188,7 +188,7 @@ class FlutterDevice {
     CompileExpression compileExpression,
     ReloadMethod reloadMethod,
     GetSkSLMethod getSkSLMethod,
-    PrintErrorEventMethod printErrorEventMethod,
+    PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
   }) {
     final Completer<void> completer = Completer<void>();
     StreamSubscription<void> subscription;
@@ -222,8 +222,8 @@ class FlutterDevice {
       } on Exception catch (exception) {
         globals.printTrace('Fail to listen to extension stream: $observatoryUri: $exception');
       }
-      if (printErrorEventMethod != null) {
-        service.onExtensionEvent.listen(printErrorEventMethod);
+      if (printStructuredErrorLogMethod != null) {
+        service.onExtensionEvent.listen(printStructuredErrorLogMethod);
       }
       if (completer.isCompleted) {
         return;
@@ -1111,7 +1111,7 @@ abstract class ResidentRunner {
     }
   }
 
-  void printErrorEvent(vm_service.Event event) {
+  void printStructuredErrorLog(vm_service.Event event) {
     if (event.extensionKind == 'Flutter.Error') {
       final Map<dynamic, dynamic> json = event.extensionData?.data;
       if (json != null && json.containsKey('renderedErrorText')) {
@@ -1145,7 +1145,7 @@ abstract class ResidentRunner {
         compileExpression: compileExpression,
         reloadMethod: reloadMethod,
         getSkSLMethod: getSkSLMethod,
-        printErrorEventMethod: printErrorEvent,
+        printStructuredErrorLogMethod: printStructuredErrorLog,
       );
       // This will wait for at least one flutter view before returning.
       final Status status = globals.logger.startProgress(

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -210,7 +210,7 @@ class FlutterDevice {
         await service.streamListen(EventStreams.kExtension);
         service.onExtensionEvent.listen((vm_service.Event event) {
           if (event.extensionKind == 'Flutter.Error') {
-            Map json = event.extensionData?.data;
+            final Map<dynamic, dynamic> json = event.extensionData?.data;
             if (json != null && json.containsKey('renderedErrorText')) {
               print('\n' + json['renderedErrorText'].toString());
             }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -8,7 +8,6 @@ import 'package:devtools_server/devtools_server.dart' as devtools_server;
 import 'package:meta/meta.dart';
 import 'package:package_config/package_config.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
-import 'package:vm_service/vm_service.dart';
 
 import 'application_package.dart';
 import 'artifacts.dart';
@@ -208,6 +207,7 @@ class FlutterDevice {
           compileExpression: compileExpression,
           reloadMethod: reloadMethod,
           getSkSLMethod: getSkSLMethod,
+          printStructuredErrorLogMethod: printStructuredErrorLogMethod,
           device: device,
         );
       } on Exception catch (exception) {
@@ -216,10 +216,6 @@ class FlutterDevice {
           completer.completeError('failed to connect to $observatoryUri');
         }
         return;
-      }
-      await service.streamListen(EventStreams.kExtension);
-      if (printStructuredErrorLogMethod != null) {
-        service.onExtensionEvent.listen(printStructuredErrorLogMethod);
       }
       if (completer.isCompleted) {
         return;

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -8,6 +8,7 @@ import 'package:devtools_server/devtools_server.dart' as devtools_server;
 import 'package:meta/meta.dart';
 import 'package:package_config/package_config.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
+import 'package:vm_service/vm_service.dart';
 
 import 'application_package.dart';
 import 'artifacts.dart';
@@ -206,6 +207,15 @@ class FlutterDevice {
           getSkSLMethod: getSkSLMethod,
           device: device,
         );
+        await service.streamListen(EventStreams.kExtension);
+        service.onExtensionEvent.listen((vm_service.Event event) {
+          if (event.extensionKind == 'Flutter.Error') {
+            Map json = event.extensionData?.data;
+            if (json != null && json.containsKey('renderedErrorText')) {
+              print('\n' + json['renderedErrorText'].toString());
+            }
+          }
+        });
       } on Exception catch (exception) {
         globals.printTrace('Fail to connect to service protocol: $observatoryUri: $exception');
         if (!completer.isCompleted && !_isListeningForObservatoryUri) {

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -207,15 +207,6 @@ class FlutterDevice {
           getSkSLMethod: getSkSLMethod,
           device: device,
         );
-        await service.streamListen(EventStreams.kExtension);
-        service.onExtensionEvent.listen((vm_service.Event event) {
-          if (event.extensionKind == 'Flutter.Error') {
-            final Map<dynamic, dynamic> json = event.extensionData?.data;
-            if (json != null && json.containsKey('renderedErrorText')) {
-              print('\n' + json['renderedErrorText'].toString());
-            }
-          }
-        });
       } on Exception catch (exception) {
         globals.printTrace('Fail to connect to service protocol: $observatoryUri: $exception');
         if (!completer.isCompleted && !_isListeningForObservatoryUri) {
@@ -223,6 +214,19 @@ class FlutterDevice {
         }
         return;
       }
+      try {
+        await service.streamListen(EventStreams.kExtension);
+      } on Exception catch (exception) {
+        globals.printTrace('Fail to listen to extension stream: $observatoryUri: $exception');
+      }
+      service.onExtensionEvent.listen((vm_service.Event event) {
+        if (event.extensionKind == 'Flutter.Error') {
+          final Map<dynamic, dynamic> json = event.extensionData?.data;
+          if (json != null && json.containsKey('renderedErrorText')) {
+            globals.printStatus('\n' + json['renderedErrorText'].toString());
+          }
+        }
+      });
       if (completer.isCompleted) {
         return;
       }

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:meta/meta.dart' show required, visibleForTesting;
 import 'package:vm_service/vm_service.dart' as vm_service;
 
@@ -146,6 +147,7 @@ typedef VMServiceConnector = Future<vm_service.VmService> Function(Uri httpUri, 
   CompileExpression compileExpression,
   ReloadMethod reloadMethod,
   GetSkSLMethod getSkSLMethod,
+  PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
   io.CompressionOptions compression,
   Device device,
 });
@@ -172,6 +174,7 @@ vm_service.VmService setUpVmService(
   Device device,
   ReloadMethod reloadMethod,
   GetSkSLMethod skSLMethod,
+  PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
   vm_service.VmService vmService
 ) {
   if (reloadSources != null) {
@@ -290,6 +293,10 @@ vm_service.VmService setUpVmService(
     });
     vmService.registerService('flutterGetSkSL', 'Flutter Tools');
   }
+  if (printStructuredErrorLogMethod != null) {
+    vmService.streamListen(vm_service.EventStreams.kExtension);
+    vmService.onExtensionEvent.listen(printStructuredErrorLogMethod);
+  }
   return vmService;
 }
 
@@ -308,6 +315,7 @@ Future<vm_service.VmService> connectToVmService(
     CompileExpression compileExpression,
     ReloadMethod reloadMethod,
     GetSkSLMethod getSkSLMethod,
+    PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
     io.CompressionOptions compression = io.CompressionOptions.compressionDefault,
     Device device,
   }) async {
@@ -320,6 +328,7 @@ Future<vm_service.VmService> connectToVmService(
     device: device,
     reloadMethod: reloadMethod,
     getSkSLMethod: getSkSLMethod,
+    printStructuredErrorLogMethod: printStructuredErrorLogMethod,
   );
 }
 
@@ -330,6 +339,7 @@ Future<vm_service.VmService> _connect(
   CompileExpression compileExpression,
   ReloadMethod reloadMethod,
   GetSkSLMethod getSkSLMethod,
+  PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
   io.CompressionOptions compression = io.CompressionOptions.compressionDefault,
   Device device,
 }) async {
@@ -357,6 +367,7 @@ Future<vm_service.VmService> _connect(
     device,
     reloadMethod,
     getSkSLMethod,
+    printStructuredErrorLogMethod,
     delegateService,
   );
   _httpAddressExpando[service] = httpUri;

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:meta/meta.dart' show required, visibleForTesting;
 import 'package:vm_service/vm_service.dart' as vm_service;
 
@@ -28,6 +27,8 @@ const int kIsolateReloadBarred = 1005;
 /// Override `WebSocketConnector` in [context] to use a different constructor
 /// for [WebSocket]s (used by tests).
 typedef WebSocketConnector = Future<io.WebSocket> Function(String url, {io.CompressionOptions compression});
+
+typedef PrintStructuredErrorLogMethod = void Function(vm_service.Event);
 
 WebSocketConnector _openChannel = _defaultOpenChannel;
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -679,6 +679,7 @@ VMServiceConnector getFakeVmServiceFactory({
     CompileExpression compileExpression,
     ReloadMethod reloadMethod,
     GetSkSLMethod getSkSLMethod,
+    PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
     CompressionOptions compression,
     Device device,
   }) async {

--- a/packages/flutter_tools/test/general.shard/cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/cold_test.dart
@@ -135,6 +135,7 @@ class TestFlutterDevice extends FlutterDevice {
     CompileExpression compileExpression,
     ReloadMethod reloadMethod,
     GetSkSLMethod getSkSLMethod,
+    PrintErrorEventMethod printErrorEventMethod,
   }) async {
     throw exception;
   }

--- a/packages/flutter_tools/test/general.shard/cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/cold_test.dart
@@ -135,7 +135,7 @@ class TestFlutterDevice extends FlutterDevice {
     CompileExpression compileExpression,
     ReloadMethod reloadMethod,
     GetSkSLMethod getSkSLMethod,
-    PrintErrorEventMethod printErrorEventMethod,
+    PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
   }) async {
     throw exception;
   }

--- a/packages/flutter_tools/test/general.shard/hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/hot_test.dart
@@ -510,6 +510,7 @@ class TestFlutterDevice extends FlutterDevice {
     CompileExpression compileExpression,
     ReloadMethod reloadMethod,
     GetSkSLMethod getSkSLMethod,
+    PrintErrorEventMethod printErrorEventMethod,
   }) async {
     throw exception;
   }

--- a/packages/flutter_tools/test/general.shard/hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/hot_test.dart
@@ -510,7 +510,7 @@ class TestFlutterDevice extends FlutterDevice {
     CompileExpression compileExpression,
     ReloadMethod reloadMethod,
     GetSkSLMethod getSkSLMethod,
-    PrintErrorEventMethod printErrorEventMethod,
+    PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
   }) async {
     throw exception;
   }

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -1355,6 +1355,7 @@ void main() {
       CompileExpression compileExpression,
       ReloadMethod reloadMethod,
       GetSkSLMethod getSkSLMethod,
+      PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
       io.CompressionOptions compression,
       Device device,
     }) async => mockVMService,

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -352,6 +352,10 @@ void main() {
       'test': 'data',
       'renderedErrorText': 'error text',
     };
+    final Map<String, String> emptyExtensionData = <String, String>{
+      'test': 'data',
+      'renderedErrorText': '',
+    };
     final Map<String, String> nonStructuredErrorData = <String, String>{
       'other': 'other stuff',
     };
@@ -363,6 +367,16 @@ void main() {
           timestamp: 0,
           extensionKind: 'Flutter.Error',
           extensionData: vm_service.ExtensionData.parse(extensionData),
+          kind: vm_service.EventStreams.kExtension,
+        ),
+      ),
+      // Empty error text should not break anything.
+      FakeVmServiceStreamResponse(
+        streamId: 'Extension',
+        event: vm_service.Event(
+          timestamp: 0,
+          extensionKind: 'Flutter.Error',
+          extensionData: vm_service.ExtensionData.parse(emptyExtensionData),
           kind: vm_service.EventStreams.kExtension,
         ),
       ),

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -57,6 +57,12 @@ const List<VmServiceExpectation> kAttachIsolateExpectations = <VmServiceExpectat
     }
   ),
   FakeVmServiceRequest(
+    method: 'streamListen',
+    args: <String, Object>{
+      'streamId': 'Extension',
+    },
+  ),
+  FakeVmServiceRequest(
     method: 'registerService',
     args: <String, Object>{
       'service': 'reloadSources',
@@ -1073,19 +1079,7 @@ void main() {
   test('Sends launched app.webLaunchUrl event for Chrome device', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachLogExpectations,
-      const FakeVmServiceRequest(
-        method: 'streamListen',
-        args: <String, Object>{
-          'streamId': 'Isolate'
-        }
-      ),
-      const FakeVmServiceRequest(
-        method: 'registerService',
-        args: <String, Object>{
-          'service': 'reloadSources',
-          'alias': 'FlutterTools',
-        }
-      )
+      ...kAttachIsolateExpectations,
     ]);
     _setupMocks();
     final ChromiumLauncher chromiumLauncher = MockChromeLauncher();

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -348,11 +348,11 @@ void main() {
   }));
 
   test('Listens to extension events with structured errors', () => testbed.run(() async {
-    final Map<String, String> extensionData = {
+    final Map<String, String> extensionData = <String, String>{
       'test': 'data',
       'renderedErrorText': 'error text',
     };
-    final Map<String, String> nonStructuredErrorData = {
+    final Map<String, String> nonStructuredErrorData = <String, String>{
       'other': 'other stuff',
     };
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -406,7 +406,7 @@ void main() {
     await null;
 
     expect(testLogger.statusText, contains('\nerror text'));
-    expect(testLogger.statusText.contains('other stuff'), false);
+    expect(testLogger.statusText, isNot(contains('other stuff')));
   }));
 
   test('Does not run main with --start-paused', () => testbed.run(() async {

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -174,7 +174,7 @@ void main() {
   testUsingContext('VmService registers flutterPrintStructuredErrorLogMethod', () async {
     final MockVMService mockVMService = MockVMService();
     when(mockVMService.onExtensionEvent).thenAnswer((Invocation invocation) {
-      return const Stream.empty();
+      return const Stream<vm_service.Event>.empty();
     });
     setUpVmService(
       null,

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -104,6 +104,7 @@ void main() {
       null,
       null,
       null,
+      null,
       mockVMService,
     );
 
@@ -122,6 +123,7 @@ void main() {
       null,
       null,
       reloadMethod,
+      null,
       null,
       mockVMService,
     );
@@ -142,6 +144,7 @@ void main() {
       mockDevice,
       null,
       null,
+      null,
       mockVMService,
     );
 
@@ -159,6 +162,7 @@ void main() {
       null,
       null,
       () async => 'hello',
+      null,
       mockVMService,
     );
 
@@ -167,9 +171,30 @@ void main() {
     Logger: () => BufferLogger.test()
   });
 
+  testUsingContext('VmService registers flutterPrintStructuredErrorLogMethod', () async {
+    final MockVMService mockVMService = MockVMService();
+    when(mockVMService.onExtensionEvent).thenAnswer((Invocation invocation) {
+      return const Stream.empty();
+    });
+    setUpVmService(
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      (vm_service.Event event) async => 'hello',
+      mockVMService,
+    );
+    verify(mockVMService.streamListen(vm_service.EventStreams.kExtension)).called(1);
+  }, overrides: <Type, Generator>{
+    Logger: () => BufferLogger.test()
+  });
+
   testUsingContext('VMService returns correct FlutterVersion', () async {
     final MockVMService mockVMService = MockVMService();
     setUpVmService(
+      null,
       null,
       null,
       null,


### PR DESCRIPTION
## Description

This is a follow up to https://github.com/flutter/flutter/pull/58118.
Currently, calling `flutter run --dart-define=flutter.inspector.structuredErrors=true` on the command line will result in errors not being printed because they are captured as structured errors and sent out as JSON. This change lets flutter_tools display the text of errors.

Result if running on phone emulator:
```
helinx-macbookpro:gallery helinx$ flutter run --dart-define=flutter.inspector.structuredErrors=true
Building flutter tool...
Launching lib/main.dart on iPhone SE (2nd generation) in debug mode...
Running pod install...                                              1.5s
Running Xcode build...

 └─Compiling, linking and signing...                         9.6s
Xcode build done.                                           22.9s
Waiting for iPhone SE (2nd generation) to report its views...          3ms

══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════
The following FormatException was thrown building GalleryApp(dirty):
FormatException

The relevant error-causing widget was:
  GalleryApp file:///Users/helinx/Documents/gallery/lib/main.dart:22:16

When the exception was thrown, this was the stack:
#0      GalleryApp.build (package:gallery/main.dart:37:5)
#1      StatelessElement.build (package:flutter/src/widgets/framework.dart:4585:28)
#2      ComponentElement.performRebuild (package:flutter/src/widgets/framework.dart:4511:15)
#3      Element.rebuild (package:flutter/src/widgets/framework.dart:4227:5)
#4      ComponentElement._firstBuild (package:flutter/src/widgets/framework.dart:4490:5)
#5      ComponentElement.mount (package:flutter/src/widgets/framework.dart:4485:5)
#6      Element.inflateWidget (package:flutter/src/widgets/framework.dart:3455:14)
#7      Element.updateChild (package:flutter/src/widgets/framework.dart:3223:18)
#8      RenderObjectToWidgetElement._rebuild (package:flutter/src/widgets/binding.dart:1132:16)
#9      RenderObjectToWidgetElement.mount (package:flutter/src/widgets/binding.dart:1103:5)
#10     RenderObjectToWidgetAdapter.attachToRenderTree.<anonymous closure> (package:flutter/src/widgets/binding.dart:1045:17)
#11     BuildOwner.buildScope (package:flutter/src/widgets/framework.dart:2612:19)
#12     RenderObjectToWidgetAdapter.attachToRenderTree (package:flutter/src/widgets/binding.dart:1044:13)
#13     WidgetsBinding.attachRootWidget (package:flutter/src/widgets/binding.dart:925:7)
#14     WidgetsBinding.scheduleAttachRootWidget.<anonymous closure> (package:flutter/src/widgets/binding.dart:906:7)
(elided 11 frames from class _RawReceivePortImpl, class _Timer, dart:async, and dart:async-patch)

════════════════════════════════════════════════════════════════════════════════════════════════════
Syncing files to device iPhone SE (2nd generation)...
 3,146ms (!)

Flutter run key commands.
r Hot reload. 🔥🔥🔥
R Hot restart.
h Repeat this help message.
d Detach (terminate "flutter run" but leave application running).
c Clear the screen
q Quit (terminate the application on the device).
An Observatory debugger and profiler on iPhone SE (2nd generation) is available at: http://127.0.0.1:55386/u1U7kvczBtQ=/
```

Result if running application on web:
```
helinx-macbookpro:gallery helinx$ flutter run -d chrome --dart-define=flutter.inspector.structuredErrors=true
Building flutter tool...
Launching lib/main.dart on Chrome in debug mode...
Syncing files to device Chrome...
33,968ms (!)
Debug service listening on ws://127.0.0.1:52335/jW7qQNB-U8w=

Warning: Flutter's support for web development is not stable yet and hasn't
been thoroughly tested in production environments.
For more information see https://flutter.dev/web

🔥  To hot restart changes while running, press "r" or "R".
For a more detailed help message, press "h". To quit, press "q".

══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════
The following FormatException was thrown building GalleryApp(dirty):
FormatException

The relevant error-causing widget was:
  GalleryApp file:///Users/helinx/Documents/gallery/lib/main.dart:22:16

When the exception was thrown, this was the stack:
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart 214:49  throw_
packages/gallery/main.dart 37:5                                               build
packages/flutter/src/widgets/framework.dart 4585:28                           build
packages/flutter/src/widgets/framework.dart 4511:15                           performRebuild
packages/flutter/src/widgets/framework.dart 4227:5                            rebuild
packages/flutter/src/widgets/framework.dart 4490:5                            [_firstBuild]
packages/flutter/src/widgets/framework.dart 4485:5                            mount
packages/flutter/src/widgets/framework.dart 3455:13                           inflateWidget
packages/flutter/src/widgets/framework.dart 3223:18                           updateChild
packages/flutter/src/widgets/binding.dart 1132:16                             [_rebuild]
packages/flutter/src/widgets/binding.dart 1103:5                              mount
packages/flutter/src/widgets/binding.dart 1045:16                             <fn>
packages/flutter/src/widgets/framework.dart 2612:19                           buildScope
packages/flutter/src/widgets/binding.dart 1044:12                             attachToRenderTree
packages/flutter/src/widgets/binding.dart 924:24                              attachRootWidget
packages/flutter/src/widgets/binding.dart 906:7                               <fn>
dart-sdk/lib/_internal/js_dev_runtime/private/isolate_helper.dart 48:19       internalCallback

════════════════════════════════════════════════════════════════════════════════════════════════════
```

## Related Issues
None

## Tests

I added the following tests:
- Verify that the start of text is returned from the structured error JSON.
- Verify that extension stream is listened for
- Verify that `resident_web_runner` listens for extension events

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
