### PR TITLE
Fix overlooked break due to removal of Overflow

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -42,6 +42,7 @@ export 'package:flutter/rendering.dart' show
   MainAxisAlignment,
   MainAxisSize,
   MultiChildLayoutDelegate,
+  Overflow,
   PaintingContext,
   PointerCancelEvent,
   PointerCancelEventListener,


### PR DESCRIPTION

## Description

Introduced in https://github.com/flutter/flutter/commit/cd593dae#diff-7f71460835520a1820d69cd0b6994c01L45 removed Overflow enum but added it back to make it a non-breaking change. However, during that process, author forgot to add back the removed export.

## Related Issues

## Tests

None.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
