### PR TITLE
EditableText.bringIntoView calls showOnScreen

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -5,7 +5,6 @@
 import 'dart:math' as math;
 import 'dart:ui' as ui show TextBox, lerpDouble, BoxHeightStyle, BoxWidthStyle;
 
-import 'package:flutter/animation.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/semantics.dart';
@@ -1504,47 +1503,6 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     return rect.shift(_getPixelPerfectCursorOffset(rect));
   }
-
-  //@override
-  //void showOnScreen({
-  //  RenderObject descendant,
-  //  Rect rect,
-  //  Duration duration = Duration.zero,
-  //  Curve curve = Curves.ease,
-  //}) {
-  //  assert(descendant == null);
-
-  //  Rect newRect = rect;
-  //  if (rect != null && offset.allowImplicitScrolling) {
-  //    double shift;
-  //    switch (_viewportAxis) {
-  //      case Axis.horizontal:
-  //        shift = rect.width >= size.width
-  //          // Center `rect` if it's oversized
-  //          ? size.width / 2 - rect.center.dx
-  //          // The valid additional offset ranges from (rect.right - size.width)
-  //          // to (rect.left).
-  //          : 0.0.clamp(rect.right - size.width, rect.left) as double;
-  //        newRect = rect.translate(-shift, 0);
-  //        break;
-  //      case Axis.vertical:
-  //        shift = rect.height >= size.height
-  //          ? size.height / 2 - rect.center.dy
-  //          : 0.0.clamp(rect.bottom - size.height, rect.top) as double;
-  //        newRect = rect.translate(0, -shift);
-  //        break;
-  //    }
-
-  //    offset.moveTo(offset.pixels + shift, duration: duration, curve: curve);
-  //  }
-
-  //  return super.showOnScreen(
-  //    rect: newRect,
-  //    descendant: this,
-  //    duration: duration,
-  //    curve: curve,
-  //  );
-  //}
 
   @override
   double computeMinIntrinsicWidth(double height) {

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -5,6 +5,7 @@
 import 'dart:math' as math;
 import 'dart:ui' as ui show TextBox, lerpDouble, BoxHeightStyle, BoxWidthStyle;
 
+import 'package:flutter/animation.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/semantics.dart';
@@ -1503,6 +1504,47 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     return rect.shift(_getPixelPerfectCursorOffset(rect));
   }
+
+  //@override
+  //void showOnScreen({
+  //  RenderObject descendant,
+  //  Rect rect,
+  //  Duration duration = Duration.zero,
+  //  Curve curve = Curves.ease,
+  //}) {
+  //  assert(descendant == null);
+
+  //  Rect newRect = rect;
+  //  if (rect != null && offset.allowImplicitScrolling) {
+  //    double shift;
+  //    switch (_viewportAxis) {
+  //      case Axis.horizontal:
+  //        shift = rect.width >= size.width
+  //          // Center `rect` if it's oversized
+  //          ? size.width / 2 - rect.center.dx
+  //          // The valid additional offset ranges from (rect.right - size.width)
+  //          // to (rect.left).
+  //          : 0.0.clamp(rect.right - size.width, rect.left) as double;
+  //        newRect = rect.translate(-shift, 0);
+  //        break;
+  //      case Axis.vertical:
+  //        shift = rect.height >= size.height
+  //          ? size.height / 2 - rect.center.dy
+  //          : 0.0.clamp(rect.bottom - size.height, rect.top) as double;
+  //        newRect = rect.translate(0, -shift);
+  //        break;
+  //    }
+
+  //    offset.moveTo(offset.pixels + shift, duration: duration, curve: curve);
+  //  }
+
+  //  return super.showOnScreen(
+  //    rect: newRect,
+  //    descendant: this,
+  //    duration: duration,
+  //    curve: curve,
+  //  );
+  //}
 
   @override
   double computeMinIntrinsicWidth(double height) {

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1487,45 +1487,56 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   bool get _hasFocus => widget.focusNode.hasFocus;
   bool get _isMultiline => widget.maxLines != 1;
 
-  // Calculate the new scroll offset so the cursor remains visible.
-  double _getScrollOffsetForCaret(Rect caretRect) {
-    double caretStart;
-    double caretEnd;
-    if (_isMultiline) {
-      // The caret is vertically centered within the line. Expand the caret's
-      // height so that it spans the line because we're going to ensure that the entire
-      // expanded caret is scrolled into view.
-      final double lineHeight = renderEditable.preferredLineHeight;
-      final double caretOffset = (lineHeight - caretRect.height) / 2;
-      caretStart = caretRect.top - caretOffset;
-      caretEnd = caretRect.bottom + caretOffset;
+  // Finds the closest scroll offset to the current scroll offset that fully
+  // reveals the given caret rect. If the given rect's main axis extent is too
+  // large to be fully revealed in `renderEditable`, it will be centered along
+  // the main axis.
+  //
+  // If the main axis is Axis.horizontal (which means this is a multiline
+  // EditableText), the given rect's height will first be extended to match
+  // `renderEditable.preferredLineHeight`, before the target scroll offset is
+  // computed.
+  RevealedOffset _getOffsetToRevealCaret(Rect rect) {
+    if (!_scrollController.position.allowImplicitScrolling)
+      return RevealedOffset(offset: _scrollController.offset, rect: rect);
+
+    final Size editableSize = renderEditable.size;
+    double additionalOffset;
+    Offset unitOffset;
+
+    if (!_isMultiline) {
+      additionalOffset = rect.width >= editableSize.width
+        // Center `rect` if it's oversized
+        ? editableSize.width / 2 - rect.center.dx
+        // The valid additional offset ranges from (rect.right - size.width)
+        // to (rect.left). Pick the closest one if out of range.
+        : 0.0.clamp(rect.right - editableSize.width, rect.left) as double;
+      unitOffset = const Offset(1, 0);
     } else {
-      // Scrolls horizontally for single-line fields.
-      caretStart = caretRect.left;
-      caretEnd = caretRect.right;
+      // The caret is vertically centered within the line. Expand the caret's
+      // height so that it spans the line because we're going to ensure that the
+      // entire expanded caret is scrolled into view.
+      final Rect expandedRect = Rect.fromCenter(
+        center: rect.center,
+        width: rect.width,
+        height: math.max(rect.height, renderEditable.preferredLineHeight),
+      );
+
+      additionalOffset = expandedRect.height >= editableSize.height
+        ? editableSize.height / 2 - expandedRect.center.dy
+        : 0.0.clamp(expandedRect.bottom - editableSize.height, expandedRect.top) as double;
+      unitOffset = const Offset(0, 1);
     }
 
-    double scrollOffset = _scrollController.offset;
-    final double viewportExtent = _scrollController.position.viewportDimension;
-    if (caretStart < 0.0) { // cursor before start of bounds
-      scrollOffset += caretStart;
-    } else if (caretEnd >= viewportExtent) { // cursor after end of bounds
-      scrollOffset += caretEnd - viewportExtent;
-    }
+    // No overscrolling.
+    final double targetOffset = (additionalOffset + _scrollController.offset)
+      .clamp(
+        _scrollController.position.minScrollExtent,
+        _scrollController.position.maxScrollExtent,
+      ) as double;
 
-    if (_isMultiline) {
-      // Clamp the final results to prevent programmatically scrolling to
-      // out-of-paragraph-bounds positions when encountering tall fonts/scripts that
-      // extend past the ascent.
-      scrollOffset = scrollOffset.clamp(0.0, renderEditable.maxScrollExtent) as double;
-    }
-    return scrollOffset;
-  }
-
-  // Calculates where the `caretRect` would be if `_scrollController.offset` is set to `scrollOffset`.
-  Rect _getCaretRectAtScrollOffset(Rect caretRect, double scrollOffset) {
-    final double offsetDiff = _scrollController.offset - scrollOffset;
-    return _isMultiline ? caretRect.translate(0.0, offsetDiff) : caretRect.translate(offsetDiff, 0.0);
+    final double offsetDelta = _scrollController.offset - targetOffset;
+    return RevealedOffset(rect: rect.shift(unitOffset * offsetDelta), offset: targetOffset);
   }
 
   bool get _hasInputConnection => _textInputConnection != null && _textInputConnection.attached;
@@ -1684,19 +1695,15 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       if (_currentCaretRect == null || !_scrollController.hasClients) {
         return;
       }
-      final double scrollOffsetForCaret = _getScrollOffsetForCaret(_currentCaretRect);
-      _scrollController.animateTo(
-        scrollOffsetForCaret,
-        duration: _caretAnimationDuration,
-        curve: _caretAnimationCurve,
-      );
-      final Rect newCaretRect = _getCaretRectAtScrollOffset(_currentCaretRect, scrollOffsetForCaret);
-      // Enlarge newCaretRect by scrollPadding to ensure that caret is not
+
+      final double lineHeight = renderEditable.preferredLineHeight;
+
+      // Enlarge the target rect by scrollPadding to ensure that caret is not
       // positioned directly at the edge after scrolling.
       double bottomSpacing = widget.scrollPadding.bottom;
       if (_selectionOverlay?.selectionControls != null) {
         final double handleHeight = _selectionOverlay.selectionControls
-          .getHandleSize(renderEditable.preferredLineHeight).height;
+          .getHandleSize(lineHeight).height;
         final double interactiveHandleHeight = math.max(
           handleHeight,
           kMinInteractiveDimension,
@@ -1704,7 +1711,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         final Offset anchor = _selectionOverlay.selectionControls
           .getHandleAnchor(
             TextSelectionHandleType.collapsed,
-            renderEditable.preferredLineHeight,
+            lineHeight,
           );
         final double handleCenter = handleHeight / 2 - anchor.dy;
         bottomSpacing = math.max(
@@ -1712,14 +1719,20 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
           bottomSpacing,
         );
       }
-      final Rect inflatedRect = Rect.fromLTRB(
-          newCaretRect.left - widget.scrollPadding.left,
-          newCaretRect.top - widget.scrollPadding.top,
-          newCaretRect.right + widget.scrollPadding.right,
-          newCaretRect.bottom + bottomSpacing,
+
+      final EdgeInsets caretPadding = widget.scrollPadding
+        .copyWith(bottom: bottomSpacing);
+
+      final RevealedOffset targetOffset = _getOffsetToRevealCaret(_currentCaretRect);
+
+      _scrollController.animateTo(
+        targetOffset.offset,
+        duration: _caretAnimationDuration,
+        curve: _caretAnimationCurve,
       );
-      _editableKey.currentContext.findRenderObject().showOnScreen(
-        rect: inflatedRect,
+
+      renderEditable.showOnScreen(
+        rect: caretPadding.inflateRect(targetOffset.rect),
         duration: _caretAnimationDuration,
         curve: _caretAnimationCurve,
       );
@@ -1928,7 +1941,11 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
 
   @override
   void bringIntoView(TextPosition position) {
-    _scrollController.jumpTo(_getScrollOffsetForCaret(renderEditable.getLocalRectForCaret(position)));
+    final Rect localRect = renderEditable.getLocalRectForCaret(position);
+    final RevealedOffset targetOffset = _getOffsetToRevealCaret(localRect);
+
+    _scrollController.jumpTo(targetOffset.offset);
+    renderEditable.showOnScreen(rect: targetOffset.rect);
   }
 
   /// Shows the selection toolbar at the location of the current cursor.

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1492,10 +1492,10 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   // large to be fully revealed in `renderEditable`, it will be centered along
   // the main axis.
   //
-  // If the main axis is Axis.horizontal (which means this is a multiline
-  // EditableText), the given rect's height will first be extended to match
+  // If this is a multiline EditableText (which means the Editable can only
+  // scroll vertically), the given rect's height will first be extended to match
   // `renderEditable.preferredLineHeight`, before the target scroll offset is
-  // computed.
+  // calculated.
   RevealedOffset _getOffsetToRevealCaret(Rect rect) {
     if (!_scrollController.position.allowImplicitScrolling)
       return RevealedOffset(offset: _scrollController.offset, rect: rect);
@@ -1506,9 +1506,9 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
 
     if (!_isMultiline) {
       additionalOffset = rect.width >= editableSize.width
-        // Center `rect` if it's oversized
+        // Center `rect` if it's oversized.
         ? editableSize.width / 2 - rect.center.dx
-        // The valid additional offset ranges from (rect.right - size.width)
+        // Valid additional offsets range from (rect.right - size.width)
         // to (rect.left). Pick the closest one if out of range.
         : 0.0.clamp(rect.right - editableSize.width, rect.left) as double;
       unitOffset = const Offset(1, 0);
@@ -1528,7 +1528,8 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       unitOffset = const Offset(0, 1);
     }
 
-    // No overscrolling.
+    // No overscrolling when encountering tall fonts/scripts that extend past
+    // the ascent.
     final double targetOffset = (additionalOffset + _scrollController.offset)
       .clamp(
         _scrollController.position.minScrollExtent,


### PR DESCRIPTION
## Description

- Call `showOnScreen` in `EditableText.bringIntoView`, so it works in a viewport
- Prevent `Editable` implicit scrolling if enforced by the scroll physics 

## Related Issues

Fixes https://github.com/flutter/flutter/issues/55547

## Tests

I added the following tests:

- bringIntoView brings the caret into view when in a viewport
- bringIntoView does nothing if the physics prohibits implicit scrolling

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.


<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
