### PR TITLE
Fix non-local-engine Linux release builds

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/linux.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/linux.dart
@@ -23,8 +23,6 @@ const List<String> _kLinuxArtifacts = <String>[
   'flutter_glfw.h',
   // GTK. Not yet used by the template.
   'libflutter_linux_gtk.so',
-  // Shared.
-  'icudtl.dat',
 ];
 
 const String _kLinuxDepfile = 'linux_engine_sources.d';
@@ -86,6 +84,10 @@ class UnpackLinux extends Target {
       outputDirectory: outputDirectory,
       artifacts: _kLinuxArtifacts,
       clientSourcePaths: <String>[clientSourcePath, headersPath],
+      icuDataPath: environment.artifacts.getArtifactPath(
+        Artifact.icuData,
+        platform: TargetPlatform.linux_x64
+      )
     );
     final DepfileService depfileService = DepfileService(
       fileSystem: environment.fileSystem,

--- a/packages/flutter_tools/lib/src/build_system/targets/linux.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/linux.dart
@@ -86,7 +86,7 @@ class UnpackLinux extends Target {
       clientSourcePaths: <String>[clientSourcePath, headersPath],
       icuDataPath: environment.artifacts.getArtifactPath(
         Artifact.icuData,
-        platform: TargetPlatform.linux_x64
+        platform: TargetPlatform.linux_x64,
       )
     );
     final DepfileService depfileService = DepfileService(

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -1392,7 +1392,11 @@ const List<List<String>> _windowsDesktopBinaryDirs = <List<String>>[
 const List<List<String>> _linuxDesktopBinaryDirs = <List<String>>[
   <String>['linux-x64', 'linux-x64/linux-x64-flutter-glfw.zip'],
   <String>['linux-x64', 'linux-x64/flutter-cpp-client-wrapper-glfw.zip'],
+  <String>['linux-x64-profile', 'linux-x64-profile/linux-x64-flutter-glfw.zip'],
+  <String>['linux-x64-release', 'linux-x64-release/linux-x64-flutter-glfw.zip'],
   <String>['linux-x64', 'linux-x64/linux-x64-flutter-gtk.zip'],
+  <String>['linux-x64-profile', 'linux-x64-profile/linux-x64-flutter-gtk.zip'],
+  <String>['linux-x64-release', 'linux-x64-release/linux-x64-flutter-gtk.zip'],
 ];
 
 const List<List<String>> _macOSDesktopBinaryDirs = <List<String>>[

--- a/packages/flutter_tools/test/general.shard/build_system/targets/linux_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/linux_test.dart
@@ -39,7 +39,7 @@ void main() {
     when(mockArtifacts.getArtifactPath(
       Artifact.icuData,
       mode: anyNamed('mode'),
-      platform: anyNamed('platform')
+      platform: anyNamed('platform'),
     )).thenReturn(r'linux-x64/icudtl.dat');
 
     final Environment testEnvironment = Environment.test(

--- a/packages/flutter_tools/test/general.shard/build_system/targets/linux_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/linux_test.dart
@@ -36,6 +36,11 @@ void main() {
       mode: anyNamed('mode'),
       platform: anyNamed('platform'),
     )).thenReturn('linux-x64/flutter_linux');
+    when(mockArtifacts.getArtifactPath(
+      Artifact.icuData,
+      mode: anyNamed('mode'),
+      platform: anyNamed('platform')
+    )).thenReturn(r'linux-x64/icudtl.dat');
 
     final Environment testEnvironment = Environment.test(
       fileSystem.currentDirectory,

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -611,6 +611,19 @@ void main() {
 
     expect(artifacts.getBinaryDirs(), isNotEmpty);
   });
+
+  testWithoutContext('Linux desktop artifacts include profile and release artifacts', () {
+    final MockCache mockCache = MockCache();
+    final WindowsEngineArtifacts artifacts = LinuxEngineArtifacts(
+      mockCache,
+      platform: FakePlatform(operatingSystem: 'linux'),
+    );
+
+    expect(artifacts.getBinaryDirs(), containsAll(<Matcher>[
+      contains(contains('profile')),
+      contains(contains('release')),
+    ]));
+  });
 }
 
 class FakeCachedArtifact extends EngineCachedArtifact {

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -614,7 +614,7 @@ void main() {
 
   testWithoutContext('Linux desktop artifacts include profile and release artifacts', () {
     final MockCache mockCache = MockCache();
-    final WindowsEngineArtifacts artifacts = LinuxEngineArtifacts(
+    final LinuxEngineArtifacts artifacts = LinuxEngineArtifacts(
       mockCache,
       platform: FakePlatform(operatingSystem: 'linux'),
     );


### PR DESCRIPTION
## Description

Downloads the necessary artifacts for release mode and profile mode on Linux. #57135 turns out to have only worked with `--local-engine`.

This uses applies the same artifact changes that were made to support Windows release mode to Linux.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/58365

## Tests

I added the following tests: Verifies that profile/release artifacts are listed.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
