### PR TITLE
use Expand-Archive and Compress-Archive in windows os utils

### DIFF
--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -327,9 +327,9 @@ class _WindowsUtils extends OperatingSystemUtils {
       _activePowershell,
       'Compress-Archive',
       '-Path',
-      data.path,
+      '"${data.path}"',
       '-DestinationPath',
-      zipFile.path,
+      '"${zipFile.path}"',
     ]);
     if (result.stderr.isNotEmpty) {
       throw ProcessException(_activePowershell, <String>['Compress-Archive'], result.stderr);
@@ -342,9 +342,9 @@ class _WindowsUtils extends OperatingSystemUtils {
       _activePowershell,
       'Expand-Archive',
       '-Path',
-      file.path,
+      '"${file.path}"',
       '-DestinationPath',
-      targetDirectory.path,
+      '"${targetDirectory.path}"',
     ], throwOnError: true);
     if (result.stderr.isNotEmpty) {
       throw ProcessException(_activePowershell, <String>['Expand-Archive'], result.stderr);

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -325,11 +325,8 @@ class _WindowsUtils extends OperatingSystemUtils {
   void zip(Directory data, File zipFile) {
     final RunResult result = _processUtils.runSync(<String>[
       _activePowershell,
-      'Compress-Archive',
-      '-Path',
-      '"${data.path}"',
-      '-DestinationPath',
-      '"${zipFile.path}"',
+      '-command',
+      '"Compress-Archive ${data.path} -DestinationPath ${zipFile.path}"',
     ]);
     if (result.stderr.isNotEmpty) {
       throw ProcessException(_activePowershell, <String>['Compress-Archive'], result.stderr);
@@ -340,11 +337,8 @@ class _WindowsUtils extends OperatingSystemUtils {
   void unzip(File file, Directory targetDirectory) {
     final RunResult result = _processUtils.runSync(<String>[
       _activePowershell,
-      'Expand-Archive',
-      '-Path',
-      '"${file.path}"',
-      '-DestinationPath',
-      '"${targetDirectory.path}"',
+      '-command',
+      '"Expand-Archive ${file.path} -DestinationPath ${targetDirectory.path}"',
     ], throwOnError: true);
     if (result.stderr.isNotEmpty) {
       throw ProcessException(_activePowershell, <String>['Expand-Archive'], result.stderr);

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -323,7 +323,7 @@ class _WindowsUtils extends OperatingSystemUtils {
 
   @override
   void zip(Directory data, File zipFile) {
-    _processManager.runSync(<String>[
+    final RunResult result = _processUtils.runSync(<String>[
       _activePowershell,
       'Compress-Archive',
       '-Path',
@@ -331,31 +331,28 @@ class _WindowsUtils extends OperatingSystemUtils {
       '-DestinationPath',
       zipFile.path,
     ]);
+    if (result.stderr.isNotEmpty) {
+      throw ProcessException(_activePowershell, <String>['Compress-Archive'], result.stderr);
+    }
   }
 
   @override
   void unzip(File file, Directory targetDirectory) {
-    _processManager.runSync(<String>[
+    final RunResult result = _processUtils.runSync(<String>[
       _activePowershell,
       'Expand-Archive',
       '-Path',
       file.path,
       '-DestinationPath',
       targetDirectory.path,
-    ]);
+    ], throwOnError: true);
+    if (result.stderr.isNotEmpty) {
+      throw ProcessException(_activePowershell, <String>['Expand-Archive'], result.stderr);
+    }
   }
 
   @override
-  bool verifyZip(File zipFile) {
-    try {
-      ZipDecoder().decodeBytes(zipFile.readAsBytesSync(), verify: true);
-    } on FileSystemException catch (_) {
-      return false;
-    } on ArchiveException catch (_) {
-      return false;
-    }
-    return true;
-  }
+  bool verifyZip(File zipFile) => true;
 
   @override
   void unpack(File gzippedTarFile, Directory targetDirectory) {

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -164,11 +164,8 @@ void main() {
       const FakeCommand(
         command: <String>[
           'pwsh.exe',
-          'Expand-Archive',
-          '-Path',
-          '"a"',
-          '-DestinationPath',
-          '"b"'
+          '-command',
+          '"Expand-Archive a -DestinationPath b"',
         ],
       ),
     ]);
@@ -190,11 +187,8 @@ void main() {
       const FakeCommand(
         command: <String>[
           'pwsh.exe',
-          'Expand-Archive',
-          '-Path',
-          '"a"',
-          '-DestinationPath',
-          '"b"'
+          '-command',
+          '"Expand-Archive a -DestinationPath b"',
         ],
         stderr: kPowershellException,
       ),
@@ -218,11 +212,8 @@ void main() {
       const FakeCommand(
         command: <String>[
           'pwsh.exe',
-          'Compress-Archive',
-          '-Path',
-          '"b"',
-          '-DestinationPath',
-          '"a"'
+          '-command',
+          '"Compress-Archive b -DestinationPath a"',
         ],
       ),
     ]);
@@ -244,11 +235,8 @@ void main() {
       const FakeCommand(
         command: <String>[
           'pwsh.exe',
-          'Compress-Archive',
-          '-Path',
-          '"b"',
-          '-DestinationPath',
-          '"a"'
+          '-command',
+          '"Compress-Archive b -DestinationPath a"',
         ],
         stderr: kPowershellException,
       ),

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -166,9 +166,9 @@ void main() {
           'pwsh.exe',
           'Expand-Archive',
           '-Path',
-          'a',
+          '"a"',
           '-DestinationPath',
-          'b'
+          '"b"'
         ],
       ),
     ]);
@@ -192,9 +192,9 @@ void main() {
           'pwsh.exe',
           'Expand-Archive',
           '-Path',
-          'a',
+          '"a"',
           '-DestinationPath',
-          'b'
+          '"b"'
         ],
         stderr: kPowershellException,
       ),
@@ -220,9 +220,9 @@ void main() {
           'pwsh.exe',
           'Compress-Archive',
           '-Path',
-          'b',
+          '"b"',
           '-DestinationPath',
-          'a'
+          '"a"'
         ],
       ),
     ]);
@@ -246,9 +246,9 @@ void main() {
           'pwsh.exe',
           'Compress-Archive',
           '-Path',
-          'b',
+          '"b"',
           '-DestinationPath',
-          'a'
+          '"a"'
         ],
         stderr: kPowershellException,
       ),

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -21,6 +21,17 @@ const String kExecutable = 'foo';
 const String kPath1 = '/bar/bin/$kExecutable';
 const String kPath2 = '/another/bin/$kExecutable';
 
+const String kPowershellException = r'''
+New-Object : Exception calling ".ctor" with "3" argument(s): "End of Central Directory record could not be found."
+At
+C:\Windows\system32\WindowsPowerShell\v1.0\Modules\Microsoft.PowerShell.Archive\Microsoft.PowerShell.Archive.psm1:934
+char:23
++ ... ipArchive = New-Object -TypeName System.IO.Compression.ZipArchive -Ar ...
++                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : InvalidOperation: (:) [New-Object], MethodInvocationException
+    + FullyQualifiedErrorId : ConstructorInvokedThrowException,Microsoft.PowerShell.Commands.NewObjectCommand
+''';
+
 void main() {
   MockProcessManager mockProcessManager;
 
@@ -174,6 +185,34 @@ void main() {
     expect(processManager.hasRemainingExpectations, false);
   });
 
+  testWithoutContext('Windows PowerShell Expand-Archive with stderr', () async {
+    final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+      const FakeCommand(
+        command: <String>[
+          'pwsh.exe',
+          'Expand-Archive',
+          '-Path',
+          'a',
+          '-DestinationPath',
+          'b'
+        ],
+        stderr: kPowershellException,
+      ),
+    ]);
+    final FileSystem fileSystem = MemoryFileSystem.test(style: FileSystemStyle.windows);
+    final OperatingSystemUtils osUtils = OperatingSystemUtils(
+      fileSystem: fileSystem,
+      logger: BufferLogger.test(),
+      platform: FakePlatform(operatingSystem: 'windows'),
+      processManager: processManager,
+    );
+
+    expect(() => osUtils.unzip(fileSystem.file('a'), fileSystem.directory('b')),
+      throwsA(isA<ProcessException>()));
+
+    expect(processManager.hasRemainingExpectations, false);
+  });
+
   testWithoutContext('Windows PowerShell Compress-Archive', () {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
@@ -197,6 +236,48 @@ void main() {
 
     osUtils.zip(fileSystem.directory('b'), fileSystem.file('a'));
 
+    expect(processManager.hasRemainingExpectations, false);
+  });
+
+  testWithoutContext('Windows PowerShell Compress-Archive with stderr', () {
+    final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+      const FakeCommand(
+        command: <String>[
+          'pwsh.exe',
+          'Compress-Archive',
+          '-Path',
+          'b',
+          '-DestinationPath',
+          'a'
+        ],
+        stderr: kPowershellException,
+      ),
+    ]);
+    final FileSystem fileSystem = MemoryFileSystem.test(style: FileSystemStyle.windows);
+    final OperatingSystemUtils osUtils = OperatingSystemUtils(
+      fileSystem: fileSystem,
+      logger: BufferLogger.test(),
+      platform: FakePlatform(operatingSystem: 'windows'),
+      processManager: processManager,
+    );
+
+    expect(() => osUtils.zip(fileSystem.directory('b'), fileSystem.file('a')),
+      throwsA(isA<ProcessException>()));
+
+    expect(processManager.hasRemainingExpectations, false);
+  });
+
+   testWithoutContext('Windows PowerShell verifyZip is a no-op', () {
+    final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[]);
+    final FileSystem fileSystem = MemoryFileSystem.test(style: FileSystemStyle.windows);
+    final OperatingSystemUtils osUtils = OperatingSystemUtils(
+      fileSystem: fileSystem,
+      logger: BufferLogger.test(),
+      platform: FakePlatform(operatingSystem: 'windows'),
+      processManager: processManager,
+    );
+
+    expect(osUtils.verifyZip(fileSystem.file('a')), true);
     expect(processManager.hasRemainingExpectations, false);
   });
 


### PR DESCRIPTION
## Description

Work towards removal of package:archive and ideally more stable unzipping of artifacts. These commands are available in Powershell 5+, which we already require for windows.

https://github.com/flutter/flutter/issues/45278

Related to https://github.com/flutter/flutter/issues/48014 