### PR TITLE
iOS mid-drag activity indicator

### DIFF
--- a/packages/flutter/lib/src/cupertino/activity_indicator.dart
+++ b/packages/flutter/lib/src/cupertino/activity_indicator.dart
@@ -162,6 +162,10 @@ class _CupertinoActivityIndicatorPainter extends CustomPainter {
     final Paint paint = Paint();
 
     canvas.save();
+    
+    // It is important that we translate by a fixed amount (ie. the radius), rather
+    // than size.height, because size.height changes as the user drags downward. If
+    // we use size.height, the spinner moves as the user drags down.
     canvas.translate(size.width / 2.0, radius);
 
     final int activeTick = (_kTickCount * position.value).floor();

--- a/packages/flutter/lib/src/cupertino/activity_indicator.dart
+++ b/packages/flutter/lib/src/cupertino/activity_indicator.dart
@@ -113,7 +113,8 @@ const int _kTickCount = 12;
 
 // Alpha values extracted from the native component (for both dark and light mode).
 // The list has a length of 12.
-const List<int> _alphaValues = <int>[147, 131, 114, 97, 81, 64, 47, 47, 47, 47, 47, 47];
+const List<int> _alphaValues = <int>[47, 47, 47, 47, 47, 47, 147, 131, 114, 97, 81, 64];
+const int _progressiveRevealAlpha = 131;
 
 class _CupertinoActivityIndicatorPainter extends CustomPainter {
   _CupertinoActivityIndicatorPainter({
@@ -122,10 +123,10 @@ class _CupertinoActivityIndicatorPainter extends CustomPainter {
     double radius,
     @required this.progress,
   }) : tickFundamentalRRect = RRect.fromLTRBXY(
-         -radius,
-         radius / _kDefaultIndicatorRadius,
-         -radius / 2.0,
          -radius / _kDefaultIndicatorRadius,
+         -radius / 2.0,
+         radius / _kDefaultIndicatorRadius,
+         -radius,
          radius / _kDefaultIndicatorRadius,
          radius / _kDefaultIndicatorRadius,
        ),
@@ -143,14 +144,11 @@ class _CupertinoActivityIndicatorPainter extends CustomPainter {
     canvas.save();
     canvas.translate(size.width / 2.0, size.height / 2.0);
 
-    // Rotate so that the top tick is the first to be drawn.
-    canvas.rotate(math.pi / 2);
-
     final int activeTick = (_kTickCount * position.value).floor();
 
     for (int i = ((_kTickCount - 1) * progress).toInt(); i >= 0; --i) {
       final int t = (i + activeTick) % _kTickCount;
-      paint.color = activeColor.withAlpha(progress < 1 ? _alphaValues[0] : _alphaValues[t]);
+      paint.color = activeColor.withAlpha(progress < 1 ? _progressiveRevealAlpha : _alphaValues[t]);
       canvas.drawRRect(tickFundamentalRRect, paint);
       canvas.rotate(_kTwoPI / _kTickCount);
     }
@@ -160,6 +158,6 @@ class _CupertinoActivityIndicatorPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(_CupertinoActivityIndicatorPainter oldPainter) {
-    return oldPainter.position != position || oldPainter.activeColor != activeColor;
+    return oldPainter.position != position || oldPainter.activeColor != activeColor || oldPainter.progress != progress;
   }
 }

--- a/packages/flutter/lib/src/cupertino/activity_indicator.dart
+++ b/packages/flutter/lib/src/cupertino/activity_indicator.dart
@@ -37,7 +37,7 @@ class CupertinoActivityIndicator extends StatefulWidget {
   /// a partial count of ticks based on the value of [progress].
   ///
   /// When provided, the value of [progress] must be between 0.0 (zero ticks
-  /// will be shown) and 1.0 (all ticks will be shown) inclusive. Defaults 
+  /// will be shown) and 1.0 (all ticks will be shown) inclusive. Defaults
   /// to 1.0.
   const CupertinoActivityIndicator.partiallyRevealed({
     Key key,

--- a/packages/flutter/lib/src/cupertino/activity_indicator.dart
+++ b/packages/flutter/lib/src/cupertino/activity_indicator.dart
@@ -127,8 +127,10 @@ const double _kTwoPI = math.pi * 2.0;
 const int _kTickCount = 12;
 
 // Alpha values extracted from the native component (for both dark and light mode) to
-// draw the spinning ticks. The list must have a length of _kTickCount.
-const List<int> _alphaValues = <int>[47, 47, 47, 47, 47, 47, 64, 81, 97, 114, 131, 147];
+// draw the spinning ticks. The list must have a length of _kTickCount. The order of
+// these values is designed to match the first frame of the iOS activity indicator which
+// has the most prominent tick at 9 o'clock.
+const List<int> _alphaValues = <int>[47, 47, 47, 47, 64, 81, 97, 114, 131, 147, 47, 47];
 
 // The alpha value that is used to draw the partially revealed ticks.
 const int _partiallyRevealedAlpha = 147;

--- a/packages/flutter/lib/src/cupertino/activity_indicator.dart
+++ b/packages/flutter/lib/src/cupertino/activity_indicator.dart
@@ -137,7 +137,7 @@ class _CupertinoActivityIndicatorPainter extends CustomPainter {
   _CupertinoActivityIndicatorPainter({
     @required this.position,
     @required this.activeColor,
-    double radius,
+    @required this.radius,
     @required this.progress,
   }) : tickFundamentalRRect = RRect.fromLTRBXY(
          -radius / _kDefaultIndicatorRadius,
@@ -152,6 +152,7 @@ class _CupertinoActivityIndicatorPainter extends CustomPainter {
   final Animation<double> position;
   final RRect tickFundamentalRRect;
   final Color activeColor;
+  final double radius;
   final double progress;
 
   @override
@@ -159,7 +160,7 @@ class _CupertinoActivityIndicatorPainter extends CustomPainter {
     final Paint paint = Paint();
 
     canvas.save();
-    canvas.translate(size.width / 2.0, size.height / 2.0);
+    canvas.translate(size.width / 2.0, radius);
 
     final int activeTick = (_kTickCount * position.value).floor();
 

--- a/packages/flutter/lib/src/cupertino/activity_indicator.dart
+++ b/packages/flutter/lib/src/cupertino/activity_indicator.dart
@@ -162,7 +162,7 @@ class _CupertinoActivityIndicatorPainter extends CustomPainter {
     final Paint paint = Paint();
 
     canvas.save();
-    
+
     // It is important that we translate by a fixed amount (ie. the radius), rather
     // than size.height, because size.height changes as the user drags downward. If
     // we use size.height, the spinner moves as the user drags down.

--- a/packages/flutter/lib/src/cupertino/activity_indicator.dart
+++ b/packages/flutter/lib/src/cupertino/activity_indicator.dart
@@ -27,13 +27,28 @@ class CupertinoActivityIndicator extends StatefulWidget {
     Key key,
     this.animating = true,
     this.radius = _kDefaultIndicatorRadius,
-    this.progress = 1.0,
   }) : assert(animating != null),
        assert(radius != null),
+       assert(radius > 0.0),
+       progress = 1.0,
+       super(key: key);
+
+  /// Creates a non-animated iOS-style activity indicator that displays
+  /// a partial count of ticks based on the value of [progress].
+  ///
+  /// When provided, the value of [progress] must be between 0.0 (zero ticks
+  /// will be shown) and 1.0 (all ticks will be shown) inclusive. Defaults 
+  /// to 1.0.
+  const CupertinoActivityIndicator.partiallyRevealed({
+    Key key,
+    this.radius = _kDefaultIndicatorRadius,
+    this.progress = 1.0,
+  }) : assert(radius != null),
        assert(radius > 0.0),
        assert(progress != null),
        assert(progress >= 0.0),
        assert(progress <= 1.0),
+       animating = false,
        super(key: key);
 
   /// Whether the activity indicator is running its animation.
@@ -46,9 +61,9 @@ class CupertinoActivityIndicator extends StatefulWidget {
   /// Defaults to 10px. Must be positive and cannot be null.
   final double radius;
 
-  /// Determines the number of spinner segments that will be show. Typical usage would
-  /// display all segments, however, this allows for more fine-grained control such as
-  /// during pull-to-refresh when the drag-down action shows one segment at a time as
+  /// Determines the percentage of spinner ticks that will be shown. Typical usage would
+  /// display all ticks, however, this allows for more fine-grained control such as
+  /// during pull-to-refresh when the drag-down action shows one tick at a time as
   /// the user continues to drag down.
   ///
   /// Defaults to 1.0. Must be between 0.0 and 1.0 inclusive, and cannot be null.
@@ -111,10 +126,12 @@ class _CupertinoActivityIndicatorState extends State<CupertinoActivityIndicator>
 const double _kTwoPI = math.pi * 2.0;
 const int _kTickCount = 12;
 
-// Alpha values extracted from the native component (for both dark and light mode).
-// The list has a length of 12.
-const List<int> _alphaValues = <int>[47, 47, 47, 47, 47, 47, 147, 131, 114, 97, 81, 64];
-const int _progressiveRevealAlpha = 131;
+// Alpha values extracted from the native component (for both dark and light mode) to
+// draw the spinning ticks. The list must have a length of _kTickCount.
+const List<int> _alphaValues = <int>[47, 47, 47, 47, 47, 47, 64, 81, 97, 114, 131, 147];
+
+// The alpha value that is used to draw the partially revealed ticks.
+const int _partiallyRevealedAlpha = 147;
 
 class _CupertinoActivityIndicatorPainter extends CustomPainter {
   _CupertinoActivityIndicatorPainter({
@@ -146,9 +163,9 @@ class _CupertinoActivityIndicatorPainter extends CustomPainter {
 
     final int activeTick = (_kTickCount * position.value).floor();
 
-    for (int i = ((_kTickCount - 1) * progress).toInt(); i >= 0; --i) {
-      final int t = (i + activeTick) % _kTickCount;
-      paint.color = activeColor.withAlpha(progress < 1 ? _progressiveRevealAlpha : _alphaValues[t]);
+    for (int i = 0; i < _kTickCount * progress; ++i) {
+      final int t = (i - activeTick) % _kTickCount;
+      paint.color = activeColor.withAlpha(progress < 1 ? _partiallyRevealedAlpha : _alphaValues[t]);
       canvas.drawRRect(tickFundamentalRRect, paint);
       canvas.rotate(_kTwoPI / _kTickCount);
     }

--- a/packages/flutter/lib/src/cupertino/activity_indicator.dart
+++ b/packages/flutter/lib/src/cupertino/activity_indicator.dart
@@ -162,11 +162,7 @@ class _CupertinoActivityIndicatorPainter extends CustomPainter {
     final Paint paint = Paint();
 
     canvas.save();
-
-    // It is important that we translate by a fixed amount (ie. the radius), rather
-    // than size.height, because size.height changes as the user drags downward. If
-    // we use size.height, the spinner moves as the user drags down.
-    canvas.translate(size.width / 2.0, radius);
+    canvas.translate(size.width / 2.0, size.height / 2.0);
 
     final int activeTick = (_kTickCount * position.value).floor();
 

--- a/packages/flutter/lib/src/cupertino/activity_indicator.dart
+++ b/packages/flutter/lib/src/cupertino/activity_indicator.dart
@@ -30,10 +30,10 @@ class CupertinoActivityIndicator extends StatefulWidget {
     this.progress = 1.0,
   }) : assert(animating != null),
        assert(radius != null),
-       assert(radius > 0),
+       assert(radius > 0.0),
        assert(progress != null),
-       assert(progress >= 0),
-       assert(progress <= 1),
+       assert(progress >= 0.0),
+       assert(progress <= 1.0),
        super(key: key);
 
   /// Whether the activity indicator is running its animation.
@@ -143,8 +143,7 @@ class _CupertinoActivityIndicatorPainter extends CustomPainter {
     canvas.save();
     canvas.translate(size.width / 2.0, size.height / 2.0);
 
-    // The standard iOS implementation has the top tick appearing first,
-    // so need to rotate so that that is the first one that gets drawn
+    // Rotate so that the top tick is the first to be drawn.
     canvas.rotate(math.pi / 2);
 
     final int activeTick = (_kTickCount * position.value).floor();

--- a/packages/flutter/lib/src/cupertino/refresh.dart
+++ b/packages/flutter/lib/src/cupertino/refresh.dart
@@ -359,43 +359,6 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
     return state.refreshState;
   }
 
-  /// Builds a simple refresh indicator that fades in a bottom aligned down
-  /// arrow before the refresh is triggered, a [CupertinoActivityIndicator]
-  /// during the refresh and fades the [CupertinoActivityIndicator] away when
-  /// the refresh is done.
-  static Widget buildSimpleRefreshIndicator(
-    BuildContext context,
-    RefreshIndicatorMode refreshState,
-    double pulledExtent,
-    double refreshTriggerPullDistance,
-    double refreshIndicatorExtent,
-  ) {
-    const Curve opacityCurve = Interval(0.4, 0.8, curve: Curves.easeInOut);
-    return Align(
-      alignment: Alignment.bottomCenter,
-      child: Padding(
-        padding: const EdgeInsets.only(bottom: 16.0),
-        child: refreshState == RefreshIndicatorMode.drag
-            ? Opacity(
-                opacity: opacityCurve.transform(
-                  min(pulledExtent / refreshTriggerPullDistance, 1.0)
-                ),
-                child: Icon(
-                  CupertinoIcons.down_arrow,
-                  color: CupertinoDynamicColor.resolve(CupertinoColors.inactiveGray, context),
-                  size: 36.0,
-                ),
-              )
-            : Opacity(
-                opacity: opacityCurve.transform(
-                  min(pulledExtent / refreshIndicatorExtent, 1.0)
-                ),
-                child: const CupertinoActivityIndicator(radius: 14.0),
-              ),
-      ),
-    );
-  }
-
   static Widget buildAppleRefreshIndicator(
     BuildContext context,
     RefreshIndicatorMode refreshState,

--- a/packages/flutter/lib/src/cupertino/refresh.dart
+++ b/packages/flutter/lib/src/cupertino/refresh.dart
@@ -368,11 +368,21 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
     double refreshTriggerPullDistance,
     double refreshIndicatorExtent,
   ) {
-    final double percentageComplete = min(pulledExtent / refreshTriggerPullDistance, 1.0);
+    // The activity indicator only appears once the user has dragged further than
+    // dragThreshold. The percentage complete calculations are made after discounting
+    // the dragThreshold from both the distance the user has dragged and the distance
+    // required to trigger the refresh.
+    const double dragThreshold = 16.0;
+    
+    if (pulledExtent < dragThreshold) {
+      return Container();
+    }
+
+    final double percentageComplete = min((pulledExtent - dragThreshold) / (refreshTriggerPullDistance - dragThreshold), 1.0);
     return Align(
       alignment: Alignment.topCenter,
       child: Padding(
-        padding: const EdgeInsets.only(top: 16.0),
+        padding: const EdgeInsets.only(top: dragThreshold),
         child: _buildIndicatorForRefreshState(refreshState, 14.0, percentageComplete),
       ),
     );

--- a/packages/flutter/lib/src/cupertino/refresh.dart
+++ b/packages/flutter/lib/src/cupertino/refresh.dart
@@ -373,7 +373,7 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
     // the dragThreshold from both the distance the user has dragged and the distance
     // required to trigger the refresh.
     const double dragThreshold = 16.0;
-    
+
     if (pulledExtent < dragThreshold) {
       return Container();
     }

--- a/packages/flutter/lib/src/cupertino/refresh.dart
+++ b/packages/flutter/lib/src/cupertino/refresh.dart
@@ -11,8 +11,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 import 'activity_indicator.dart';
-import 'colors.dart';
-import 'icons.dart';
 
 class _CupertinoSliverRefresh extends SingleChildRenderObjectWidget {
   const _CupertinoSliverRefresh({
@@ -366,7 +364,7 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
     double refreshTriggerPullDistance,
     double refreshIndicatorExtent,
   ) {
-    final percentageComplete = min(pulledExtent / refreshTriggerPullDistance, 1.0);
+    final double percentageComplete = min(pulledExtent / refreshTriggerPullDistance, 1.0);
     return Align(
       alignment: Alignment.topCenter,
       child: Padding(

--- a/packages/flutter/lib/src/cupertino/refresh.dart
+++ b/packages/flutter/lib/src/cupertino/refresh.dart
@@ -392,11 +392,9 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
     switch (refreshState) {
       case RefreshIndicatorMode.drag:
         // While we're dragging, we draw individual ticks of the spinner while simultaneously
-        // easing the opacity in. Note that the opacity curve values here were derived from
-        // visual inspection of a screen recording of Mail.app on iOS 13.4.1. It seems that the 1st
-        // and 2nd ticks slowly fade in and by the time the third tick is shown, the ticks should
-        // all be at their final constant opacity level.
-        const Curve opacityCurve = Interval(0.0, 0.2, curve: Curves.easeInOut);
+        // easing the opacity in. Note that the opacity curve values here were derived using
+        // Xcode through inspecting a native app running on iOS 13.5.
+        const Curve opacityCurve = Interval(0.0, 0.35, curve: Curves.easeInOut);
         return Opacity(
           opacity: opacityCurve.transform(percentageComplete),
           child: CupertinoActivityIndicator.partiallyRevealed(radius: radius, progress: percentageComplete),

--- a/packages/flutter/lib/src/cupertino/refresh.dart
+++ b/packages/flutter/lib/src/cupertino/refresh.dart
@@ -326,9 +326,6 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
   /// A builder that's called as this sliver's size changes, and as the state
   /// changes.
   ///
-  /// A default simple Twitter-style pull-to-refresh indicator is provided if
-  /// not specified.
-  ///
   /// Can be set to null, in which case nothing will be drawn in the overscrolled
   /// space.
   ///
@@ -384,12 +381,12 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
   static Widget _buildIndicatorForRefreshState(RefreshIndicatorMode refreshState, double radius, double percentageComplete) {
     switch (refreshState) {
       case RefreshIndicatorMode.drag:
-        // While we're dragging, we draw individual segments of the spinner while simultaneously
+        // While we're dragging, we draw individual ticks of the spinner while simultaneously
         // easing the opacity in.
         const Curve opacityCurve = Interval(0.0, 0.2, curve: Curves.easeInOut);
         return Opacity(
           opacity: opacityCurve.transform(percentageComplete),
-          child: CupertinoActivityIndicator(radius: radius, animating: false, progress: percentageComplete),
+          child: CupertinoActivityIndicator.partiallyRevealed(radius: radius, progress: percentageComplete),
         );
       case RefreshIndicatorMode.armed:
       case RefreshIndicatorMode.refresh:

--- a/packages/flutter/lib/src/cupertino/refresh.dart
+++ b/packages/flutter/lib/src/cupertino/refresh.dart
@@ -392,7 +392,10 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
     switch (refreshState) {
       case RefreshIndicatorMode.drag:
         // While we're dragging, we draw individual ticks of the spinner while simultaneously
-        // easing the opacity in.
+        // easing the opacity in. Note that the opacity curve values here were derived from
+        // visual inspection of a screen recording of Mail.app on iOS 13.4.1. It seems that the 1st
+        // and 2nd ticks slowly fade in and by the time the third tick is shown, the ticks should
+        // all be at their final constant opacity level.
         const Curve opacityCurve = Interval(0.0, 0.2, curve: Curves.easeInOut);
         return Opacity(
           opacity: opacityCurve.transform(percentageComplete),

--- a/packages/flutter/lib/src/cupertino/refresh.dart
+++ b/packages/flutter/lib/src/cupertino/refresh.dart
@@ -357,6 +357,13 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
     return state.refreshState;
   }
 
+  /// Builds a refresh indicator that reflects the standard iOS pull-to-refresh 
+  /// behaviour. Specifically, this entails presenting an activity indicator that 
+  /// changes depending on the current refreshState. As the user initially drags 
+  /// down, the indicator will gradually reveal individual ticks until the refresh 
+  /// becomes armed. At this point, the animated activity indicator will begin rotating. 
+  /// Once the refresh has completed, the activity indicator shrinks away as the 
+  /// space allocation animated back to closed.
   static Widget buildAppleRefreshIndicator(
     BuildContext context,
     RefreshIndicatorMode refreshState,

--- a/packages/flutter/lib/src/cupertino/refresh.dart
+++ b/packages/flutter/lib/src/cupertino/refresh.dart
@@ -290,7 +290,7 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
     Key key,
     this.refreshTriggerPullDistance = _defaultRefreshTriggerPullDistance,
     this.refreshIndicatorExtent = _defaultRefreshIndicatorExtent,
-    this.builder = buildAppleRefreshIndicator,
+    this.builder = buildRefreshIndicator,
     this.onRefresh,
   }) : assert(refreshTriggerPullDistance != null),
        assert(refreshTriggerPullDistance > 0.0),
@@ -364,7 +364,7 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
   /// becomes armed. At this point, the animated activity indicator will begin rotating.
   /// Once the refresh has completed, the activity indicator shrinks away as the
   /// space allocation animated back to closed.
-  static Widget buildAppleRefreshIndicator(
+  static Widget buildRefreshIndicator(
     BuildContext context,
     RefreshIndicatorMode refreshState,
     double pulledExtent,

--- a/packages/flutter/lib/src/cupertino/refresh.dart
+++ b/packages/flutter/lib/src/cupertino/refresh.dart
@@ -358,12 +358,12 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
   }
 
   /// Builds a refresh indicator that reflects the standard iOS pull-to-refresh
-  /// behaviour. Specifically, this entails presenting an activity indicator that
+  /// behavior. Specifically, this entails presenting an activity indicator that
   /// changes depending on the current refreshState. As the user initially drags
   /// down, the indicator will gradually reveal individual ticks until the refresh
   /// becomes armed. At this point, the animated activity indicator will begin rotating.
   /// Once the refresh has completed, the activity indicator shrinks away as the
-  /// space allocation animated back to closed.
+  /// space allocation animates back to closed.
   static Widget buildRefreshIndicator(
     BuildContext context,
     RefreshIndicatorMode refreshState,
@@ -393,13 +393,13 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
         );
       case RefreshIndicatorMode.armed:
       case RefreshIndicatorMode.refresh:
-        // Once we're armed or performing the refresh, we just show the normal spinner
+        // Once we're armed or performing the refresh, we just show the normal spinner.
         return CupertinoActivityIndicator(radius: radius);
       case RefreshIndicatorMode.done:
-        // When the user let's go, the standard transition is to shrink the spinner
+        // When the user lets go, the standard transition is to shrink the spinner.
         return CupertinoActivityIndicator(radius: radius * percentageComplete);
       default:
-        // Anything else doesn't show anything
+        // Anything else doesn't show anything.
         return Container();
     }
   }

--- a/packages/flutter/lib/src/cupertino/refresh.dart
+++ b/packages/flutter/lib/src/cupertino/refresh.dart
@@ -292,7 +292,7 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
     Key key,
     this.refreshTriggerPullDistance = _defaultRefreshTriggerPullDistance,
     this.refreshIndicatorExtent = _defaultRefreshIndicatorExtent,
-    this.builder = buildSimpleRefreshIndicator,
+    this.builder = buildAppleRefreshIndicator,
     this.onRefresh,
   }) : assert(refreshTriggerPullDistance != null),
        assert(refreshTriggerPullDistance > 0.0),
@@ -394,6 +394,46 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
               ),
       ),
     );
+  }
+
+  static Widget buildAppleRefreshIndicator(
+    BuildContext context,
+    RefreshIndicatorMode refreshState,
+    double pulledExtent,
+    double refreshTriggerPullDistance,
+    double refreshIndicatorExtent,
+  ) {
+    final percentageComplete = min(pulledExtent / refreshTriggerPullDistance, 1.0);
+    return Align(
+      alignment: Alignment.topCenter,
+      child: Padding(
+        padding: const EdgeInsets.only(top: 16.0),
+        child: _buildIndicatorForRefreshState(refreshState, 14.0, percentageComplete),
+      ),
+    );
+  }
+
+  static Widget _buildIndicatorForRefreshState(RefreshIndicatorMode refreshState, double radius, double percentageComplete) {
+    switch (refreshState) {
+      case RefreshIndicatorMode.drag:
+        // While we're dragging, we draw individual segments of the spinner while simultaneously
+        // easing the opacity in.
+        const Curve opacityCurve = Interval(0.0, 0.2, curve: Curves.easeInOut);
+        return Opacity(
+          opacity: opacityCurve.transform(percentageComplete),
+          child: CupertinoActivityIndicator(radius: radius, animating: false, progress: percentageComplete),
+        );
+      case RefreshIndicatorMode.armed:
+      case RefreshIndicatorMode.refresh:
+        // Once we're armed or performing the refresh, we just show the normal spinner
+        return CupertinoActivityIndicator(radius: radius);
+      case RefreshIndicatorMode.done:
+        // When the user let's go, the standard transition is to shrink the spinner
+        return CupertinoActivityIndicator(radius: radius * percentageComplete);
+      default:
+        // Anything else doesn't show anything
+        return Container();
+    }
   }
 
   @override

--- a/packages/flutter/lib/src/cupertino/refresh.dart
+++ b/packages/flutter/lib/src/cupertino/refresh.dart
@@ -357,12 +357,12 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
     return state.refreshState;
   }
 
-  /// Builds a refresh indicator that reflects the standard iOS pull-to-refresh 
-  /// behaviour. Specifically, this entails presenting an activity indicator that 
-  /// changes depending on the current refreshState. As the user initially drags 
-  /// down, the indicator will gradually reveal individual ticks until the refresh 
-  /// becomes armed. At this point, the animated activity indicator will begin rotating. 
-  /// Once the refresh has completed, the activity indicator shrinks away as the 
+  /// Builds a refresh indicator that reflects the standard iOS pull-to-refresh
+  /// behaviour. Specifically, this entails presenting an activity indicator that
+  /// changes depending on the current refreshState. As the user initially drags
+  /// down, the indicator will gradually reveal individual ticks until the refresh
+  /// becomes armed. At this point, the animated activity indicator will begin rotating.
+  /// Once the refresh has completed, the activity indicator shrinks away as the
   /// space allocation animated back to closed.
   static Widget buildAppleRefreshIndicator(
     BuildContext context,

--- a/packages/flutter/lib/src/cupertino/refresh.dart
+++ b/packages/flutter/lib/src/cupertino/refresh.dart
@@ -12,7 +12,8 @@ import 'package:flutter/widgets.dart';
 
 import 'activity_indicator.dart';
 
-const double _activityIndicatorRadius = 14.0;
+const double _kActivityIndicatorRadius = 14.0;
+const double _kActivityIndicatorMargin = 16.0;
 
 class _CupertinoSliverRefresh extends SingleChildRenderObjectWidget {
   const _CupertinoSliverRefresh({
@@ -384,10 +385,10 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
         overflow: Overflow.visible,
         children: <Widget>[
           Positioned(
-            top: 16.0,
-            left: 0,
-            right: 0,
-            child: _buildIndicatorForRefreshState(refreshState, _activityIndicatorRadius, percentageComplete),
+            top: _kActivityIndicatorMargin,
+            left: 0.0,
+            right: 0.0,
+            child: _buildIndicatorForRefreshState(refreshState, _kActivityIndicatorRadius, percentageComplete),
           ),
         ],
       ),

--- a/packages/flutter/lib/src/cupertino/refresh.dart
+++ b/packages/flutter/lib/src/cupertino/refresh.dart
@@ -370,17 +370,7 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
     double refreshTriggerPullDistance,
     double refreshIndicatorExtent,
   ) {
-    // The activity indicator only appears once the user has dragged further than
-    // dragThreshold. The percentage complete calculations are made after discounting
-    // the dragThreshold from both the distance the user has dragged and the distance
-    // required to trigger the refresh.
-    const double dragThreshold = 16.0;
-
-    if (pulledExtent < dragThreshold) {
-      return Container();
-    }
-
-    final double percentageComplete = min((pulledExtent - dragThreshold) / (refreshTriggerPullDistance - dragThreshold), 1.0);
+    final double percentageComplete = pulledExtent / refreshTriggerPullDistance;
 
     // Place the indicator at the top of the sliver that opens up. Note that we're using
     // a Stack/Positioned widget because the CupertinoActivityIndicator does some internal
@@ -394,7 +384,7 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
         overflow: Overflow.visible,
         children: <Widget>[
           Positioned(
-            top: dragThreshold,
+            top: 16.0,
             left: 0,
             right: 0,
             child: _buildIndicatorForRefreshState(refreshState, _activityIndicatorRadius, percentageComplete),

--- a/packages/flutter/test/cupertino/activity_indicator_test.dart
+++ b/packages/flutter/test/cupertino/activity_indicator_test.dart
@@ -77,7 +77,7 @@ void main() {
           key: key,
           child: Container(
             color: CupertinoColors.white,
-            child: const CupertinoActivityIndicator(animating: false, progress: 0),
+            child: const CupertinoActivityIndicator.partiallyRevealed(progress: 0),
           ),
         ),
       ),
@@ -97,7 +97,7 @@ void main() {
           key: key,
           child: Container(
             color: CupertinoColors.white,
-            child: const CupertinoActivityIndicator(animating: false, progress: 0.5),
+            child: const CupertinoActivityIndicator.partiallyRevealed(progress: 0.5),
           ),
         ),
       ),
@@ -117,7 +117,7 @@ void main() {
           key: key,
           child: Container(
             color: CupertinoColors.white,
-            child: const CupertinoActivityIndicator(animating: false, progress: 1),
+            child: const CupertinoActivityIndicator.partiallyRevealed(progress: 1),
           ),
         ),
       ),
@@ -135,9 +135,13 @@ void main() {
       const CupertinoActivityIndicator(animating: false, radius: 100),
     );
 
+    // An early implementation for the activity indicator starting drawing
+    // the ticks at 9 o'clock, however, in order to support partially revealed
+    // indicator (https://github.com/flutter/flutter/issues/29159), the
+    // first tick was changed to be at 12 o'clock.
     expect(
       find.byType(CupertinoActivityIndicator),
-      paints..rrect(rrect: const RRect.fromLTRBXY(-100, 10, -50, -10, 10, 10)),
+      paints..rrect(rrect: const RRect.fromLTRBXY(-10, -50, 10, -100, 10, 10)),
     );
   });
 }

--- a/packages/flutter/test/cupertino/activity_indicator_test.dart
+++ b/packages/flutter/test/cupertino/activity_indicator_test.dart
@@ -135,7 +135,7 @@ void main() {
       const CupertinoActivityIndicator(animating: false, radius: 100),
     );
 
-    // An early implementation for the activity indicator starting drawing
+    // An earlier implementation for the activity indicator started drawing
     // the ticks at 9 o'clock, however, in order to support partially revealed
     // indicator (https://github.com/flutter/flutter/issues/29159), the
     // first tick was changed to be at 12 o'clock.

--- a/packages/flutter/test/cupertino/activity_indicator_test.dart
+++ b/packages/flutter/test/cupertino/activity_indicator_test.dart
@@ -69,6 +69,66 @@ void main() {
     );
   });
 
+  testWidgets('Activity indicator 0% in progress', (WidgetTester tester) async {
+    final Key key = UniqueKey();
+    await tester.pumpWidget(
+      Center(
+        child: RepaintBoundary(
+          key: key,
+          child: Container(
+            color: CupertinoColors.white,
+            child: const CupertinoActivityIndicator(animating: false, progress: 0),
+          ),
+        ),
+      ),
+    );
+
+    await expectLater(
+      find.byKey(key),
+      matchesGoldenFile('activityIndicator.inprogress.0.0.png'),
+    );
+  });
+
+  testWidgets('Activity indicator 30% in progress', (WidgetTester tester) async {
+    final Key key = UniqueKey();
+    await tester.pumpWidget(
+      Center(
+        child: RepaintBoundary(
+          key: key,
+          child: Container(
+            color: CupertinoColors.white,
+            child: const CupertinoActivityIndicator(animating: false, progress: 0.5),
+          ),
+        ),
+      ),
+    );
+
+    await expectLater(
+      find.byKey(key),
+      matchesGoldenFile('activityIndicator.inprogress.0.3.png'),
+    );
+  });
+
+  testWidgets('Activity indicator 100% in progress', (WidgetTester tester) async {
+    final Key key = UniqueKey();
+    await tester.pumpWidget(
+      Center(
+        child: RepaintBoundary(
+          key: key,
+          child: Container(
+            color: CupertinoColors.white,
+            child: const CupertinoActivityIndicator(animating: false, progress: 1),
+          ),
+        ),
+      ),
+    );
+
+    await expectLater(
+      find.byKey(key),
+      matchesGoldenFile('activityIndicator.inprogress.1.0.png'),
+    );
+  });
+
   // Regression test for https://github.com/flutter/flutter/issues/41345.
   testWidgets('has the correct corner radius', (WidgetTester tester) async {
     await tester.pumpWidget(

--- a/packages/flutter/test/cupertino/refresh_test.dart
+++ b/packages/flutter/test/cupertino/refresh_test.dart
@@ -1363,7 +1363,7 @@ void main() {
       );
 
       // The calculations here are subtle. Because the default drag threshold before showing
-      // the indicator is 16.0, this distance gets subtracted from both the dragged distance (26.0) 
+      // the indicator is 16.0, this distance gets subtracted from both the dragged distance (26.0)
       // and the expected distance (100.0) in order to perform the percentage calculation.
       expect(tester.widget<CupertinoActivityIndicator>(find.byType(CupertinoActivityIndicator)).progress, 10.0 / 84.0);
 

--- a/packages/flutter/test/cupertino/refresh_test.dart
+++ b/packages/flutter/test/cupertino/refresh_test.dart
@@ -1327,13 +1327,13 @@ void main() {
         );
     }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
-    testWidgets('buildAppleRefreshIndicator progress', (WidgetTester tester) async {
+    testWidgets('buildRefreshIndicator progress', (WidgetTester tester) async {
       await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
           child: Builder(
             builder: (BuildContext context) {
-              return CupertinoSliverRefreshControl.buildAppleRefreshIndicator(
+              return CupertinoSliverRefreshControl.buildRefreshIndicator(
                 context,
                 RefreshIndicatorMode.drag,
                 10, 100, 10,
@@ -1350,7 +1350,7 @@ void main() {
           textDirection: TextDirection.ltr,
           child: Builder(
             builder: (BuildContext context) {
-              return CupertinoSliverRefreshControl.buildAppleRefreshIndicator(
+              return CupertinoSliverRefreshControl.buildRefreshIndicator(
                 context,
                 RefreshIndicatorMode.drag,
                 100, 100, 10,

--- a/packages/flutter/test/cupertino/refresh_test.dart
+++ b/packages/flutter/test/cupertino/refresh_test.dart
@@ -466,9 +466,11 @@ void main() {
       ));
 
       // Given a box constraint of 150, the Center will occupy all that height.
+      // Note: vertical boundaries include an additional 16 margin pixels due to
+      // paintOrigin manipulation in the sliver.
       expect(
         tester.getRect(find.widgetWithText(Center, '-1')),
-        const Rect.fromLTRB(0.0, 0.0, 800.0, 150.0),
+        const Rect.fromLTRB(0.0, 16.0, 800.0, 166.0),
       );
 
       await tester.drag(find.text('0'), const Offset(0.0, -300.0), touchSlopY: 0);
@@ -484,13 +486,15 @@ void main() {
       ));
 
       // Now the sliver is scrolled off screen.
+      // Note: vertical boundaries include an additional 16 margin pixels due to
+      // paintOrigin manipulation in the sliver.
       expect(
         tester.getTopLeft(find.widgetWithText(Center, '-1', skipOffstage: false)).dy,
-        moreOrLessEquals(-175.38461538461536),
+        moreOrLessEquals(-159.38461538461536),
       );
       expect(
         tester.getBottomLeft(find.widgetWithText(Center, '-1', skipOffstage: false)).dy,
-        moreOrLessEquals(-115.38461538461536),
+        moreOrLessEquals(-99.38461538461536),
       );
       expect(
         tester.getTopLeft(find.widgetWithText(Center, '0')).dy,
@@ -502,9 +506,11 @@ void main() {
       await tester.drag(find.text('1'), const Offset(0.0, 200.0));
       await tester.pump();
       await tester.pump(const Duration(seconds: 2));
+      // Note: vertical boundaries include an additional 16 margin pixels due to
+      // paintOrigin manipulation in the sliver.
       expect(
         tester.getRect(find.widgetWithText(Center, '-1')),
-        const Rect.fromLTRB(0.0, 0.0, 800.0, 60.0),
+        const Rect.fromLTRB(0.0, 16.0, 800.0, 76.0),
       );
       expect(
         tester.getRect(find.widgetWithText(Center, '0')),
@@ -539,9 +545,11 @@ void main() {
         100.0, // Default value.
         60.0, // Default value.
       ));
+      // Note: vertical boundaries include an additional 16 margin pixels due to
+      // paintOrigin manipulation in the sliver.
       expect(
         tester.getRect(find.widgetWithText(Center, '-1')),
-        const Rect.fromLTRB(0.0, 0.0, 800.0, 150.0),
+        const Rect.fromLTRB(0.0, 16.0, 800.0, 166.0),
       );
       verify(mockHelper.refreshTask());
 
@@ -556,9 +564,11 @@ void main() {
         100.0, // Default value.
         60.0, // Default value.
       ));
+      // Note: vertical boundaries include an additional 16 margin pixels due to
+      // paintOrigin manipulation in the sliver.
       expect(
         tester.getRect(find.widgetWithText(Center, '-1')),
-        const Rect.fromLTRB(0.0, 0.0, 800.0, 60.0),
+        const Rect.fromLTRB(0.0, 16.0, 800.0, 76.0),
       );
       expect(
         tester.getRect(find.widgetWithText(Center, '0')),
@@ -610,9 +620,11 @@ void main() {
         100.0, // Default value.
         60.0, // Default value.
       ));
+      // Note: vertical boundaries include an additional 16 margin pixels due to
+      // paintOrigin manipulation in the sliver.
       expect(
         tester.getRect(find.widgetWithText(Center, '-1')),
-        const Rect.fromLTRB(0.0, 0.0, 800.0, 150.0),
+        const Rect.fromLTRB(0.0, 16.0, 800.0, 166.0),
       );
       verify(mockHelper.refreshTask());
 
@@ -627,9 +639,11 @@ void main() {
         100.0, // Default value.
         60.0, // Default value.
       ));
+      // Note: vertical boundaries include an additional 16 margin pixels due to
+      // paintOrigin manipulation in the sliver.
       expect(
         tester.getRect(find.widgetWithText(Center, '-1')),
-        const Rect.fromLTRB(0.0, 0.0, 800.0, 60.0),
+        const Rect.fromLTRB(0.0, 16.0, 800.0, 76.0),
       );
       expect(
         tester.getRect(find.widgetWithText(Center, '0')),
@@ -711,9 +725,11 @@ void main() {
           100.0, // Default value.
           60.0, // Default value.
         ));
+        // Note: vertical boundaries include an additional 16 margin pixels due to
+        // paintOrigin manipulation in the sliver.
         expect(
           tester.getBottomLeft(find.widgetWithText(Center, '-1')).dy,
-          moreOrLessEquals(91.311809131992776),
+          moreOrLessEquals(107.311809131992776),
         );
 
         // Start another drag by an amount that would have been enough to

--- a/packages/flutter/test/cupertino/refresh_test.dart
+++ b/packages/flutter/test/cupertino/refresh_test.dart
@@ -1327,48 +1327,40 @@ void main() {
         );
     }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
-    testWidgets('buildSimpleRefreshIndicator dark mode', (WidgetTester tester) async {
-      const CupertinoDynamicColor color = CupertinoColors.inactiveGray;
-
+    testWidgets('buildAppleRefreshIndicator progress', (WidgetTester tester) async {
       await tester.pumpWidget(
-        MediaQuery(
-          data: const MediaQueryData(platformBrightness: Brightness.light),
-          child: Directionality(
-            textDirection: TextDirection.ltr,
-            child: Builder(
-              builder: (BuildContext context) {
-                return CupertinoSliverRefreshControl.buildSimpleRefreshIndicator(
-                  context,
-                  RefreshIndicatorMode.drag,
-                  10, 10, 10,
-                );
-              },
-            ),
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Builder(
+            builder: (BuildContext context) {
+              return CupertinoSliverRefreshControl.buildAppleRefreshIndicator(
+                context,
+                RefreshIndicatorMode.drag,
+                10, 100, 10,
+              );
+            },
           ),
         ),
       );
 
-      expect(tester.widget<Icon>(find.byType(Icon)).color.value, color.color.value);
+      expect(tester.widget<CupertinoActivityIndicator>(find.byType(CupertinoActivityIndicator)).progress, 0.1);
 
       await tester.pumpWidget(
-        MediaQuery(
-          data: const MediaQueryData(platformBrightness: Brightness.dark),
-          child: Directionality(
-            textDirection: TextDirection.ltr,
-            child: Builder(
-              builder: (BuildContext context) {
-                return CupertinoSliverRefreshControl.buildSimpleRefreshIndicator(
-                  context,
-                  RefreshIndicatorMode.drag,
-                  10, 10, 10,
-                );
-              },
-            ),
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Builder(
+            builder: (BuildContext context) {
+              return CupertinoSliverRefreshControl.buildAppleRefreshIndicator(
+                context,
+                RefreshIndicatorMode.drag,
+                100, 100, 10,
+              );
+            },
           ),
         ),
       );
 
-      expect(tester.widget<Icon>(find.byType(Icon)).color.value, color.darkColor.value);
+      expect(tester.widget<CupertinoActivityIndicator>(find.byType(CupertinoActivityIndicator)).progress, 1.0);
     });
   };
 

--- a/packages/flutter/test/cupertino/refresh_test.dart
+++ b/packages/flutter/test/cupertino/refresh_test.dart
@@ -1343,7 +1343,29 @@ void main() {
         ),
       );
 
-      expect(tester.widget<CupertinoActivityIndicator>(find.byType(CupertinoActivityIndicator)).progress, 0.1);
+      // If the user has dragged less than the threshold, there is no activity indicator
+      // returned. Instead, an empty container is returned until the threshold is passed.
+      expect(find.byType(Container), findsOneWidget);
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Builder(
+            builder: (BuildContext context) {
+              return CupertinoSliverRefreshControl.buildRefreshIndicator(
+                context,
+                RefreshIndicatorMode.drag,
+                26, 100, 10,
+              );
+            },
+          ),
+        ),
+      );
+
+      // The calculations here are subtle. Because the default drag threshold before showing
+      // the indicator is 16.0, this distance gets subtracted from both the dragged distance (26.0) 
+      // and the expected distance (100.0) in order to perform the percentage calculation.
+      expect(tester.widget<CupertinoActivityIndicator>(find.byType(CupertinoActivityIndicator)).progress, 10.0 / 84.0);
 
       await tester.pumpWidget(
         Directionality(

--- a/packages/flutter/test/cupertino/refresh_test.dart
+++ b/packages/flutter/test/cupertino/refresh_test.dart
@@ -466,11 +466,9 @@ void main() {
       ));
 
       // Given a box constraint of 150, the Center will occupy all that height.
-      // Note: vertical boundaries include an additional 16 margin pixels due to
-      // paintOrigin manipulation in the sliver.
       expect(
         tester.getRect(find.widgetWithText(Center, '-1')),
-        const Rect.fromLTRB(0.0, 16.0, 800.0, 166.0),
+        const Rect.fromLTRB(0.0, 0.0, 800.0, 150.0),
       );
 
       await tester.drag(find.text('0'), const Offset(0.0, -300.0), touchSlopY: 0);
@@ -486,15 +484,13 @@ void main() {
       ));
 
       // Now the sliver is scrolled off screen.
-      // Note: vertical boundaries include an additional 16 margin pixels due to
-      // paintOrigin manipulation in the sliver.
       expect(
         tester.getTopLeft(find.widgetWithText(Center, '-1', skipOffstage: false)).dy,
-        moreOrLessEquals(-159.38461538461536),
+        moreOrLessEquals(-175.38461538461536),
       );
       expect(
         tester.getBottomLeft(find.widgetWithText(Center, '-1', skipOffstage: false)).dy,
-        moreOrLessEquals(-99.38461538461536),
+        moreOrLessEquals(-115.38461538461536),
       );
       expect(
         tester.getTopLeft(find.widgetWithText(Center, '0')).dy,
@@ -506,11 +502,9 @@ void main() {
       await tester.drag(find.text('1'), const Offset(0.0, 200.0));
       await tester.pump();
       await tester.pump(const Duration(seconds: 2));
-      // Note: vertical boundaries include an additional 16 margin pixels due to
-      // paintOrigin manipulation in the sliver.
       expect(
         tester.getRect(find.widgetWithText(Center, '-1')),
-        const Rect.fromLTRB(0.0, 16.0, 800.0, 76.0),
+        const Rect.fromLTRB(0.0, 0.0, 800.0, 60.0),
       );
       expect(
         tester.getRect(find.widgetWithText(Center, '0')),
@@ -545,11 +539,9 @@ void main() {
         100.0, // Default value.
         60.0, // Default value.
       ));
-      // Note: vertical boundaries include an additional 16 margin pixels due to
-      // paintOrigin manipulation in the sliver.
       expect(
         tester.getRect(find.widgetWithText(Center, '-1')),
-        const Rect.fromLTRB(0.0, 16.0, 800.0, 166.0),
+        const Rect.fromLTRB(0.0, 0.0, 800.0, 150.0),
       );
       verify(mockHelper.refreshTask());
 
@@ -564,11 +556,9 @@ void main() {
         100.0, // Default value.
         60.0, // Default value.
       ));
-      // Note: vertical boundaries include an additional 16 margin pixels due to
-      // paintOrigin manipulation in the sliver.
       expect(
         tester.getRect(find.widgetWithText(Center, '-1')),
-        const Rect.fromLTRB(0.0, 16.0, 800.0, 76.0),
+        const Rect.fromLTRB(0.0, 0.0, 800.0, 60.0),
       );
       expect(
         tester.getRect(find.widgetWithText(Center, '0')),
@@ -620,11 +610,9 @@ void main() {
         100.0, // Default value.
         60.0, // Default value.
       ));
-      // Note: vertical boundaries include an additional 16 margin pixels due to
-      // paintOrigin manipulation in the sliver.
       expect(
         tester.getRect(find.widgetWithText(Center, '-1')),
-        const Rect.fromLTRB(0.0, 16.0, 800.0, 166.0),
+        const Rect.fromLTRB(0.0, 0.0, 800.0, 150.0),
       );
       verify(mockHelper.refreshTask());
 
@@ -639,11 +627,9 @@ void main() {
         100.0, // Default value.
         60.0, // Default value.
       ));
-      // Note: vertical boundaries include an additional 16 margin pixels due to
-      // paintOrigin manipulation in the sliver.
       expect(
         tester.getRect(find.widgetWithText(Center, '-1')),
-        const Rect.fromLTRB(0.0, 16.0, 800.0, 76.0),
+        const Rect.fromLTRB(0.0, 0.0, 800.0, 60.0),
       );
       expect(
         tester.getRect(find.widgetWithText(Center, '0')),
@@ -725,11 +711,9 @@ void main() {
           100.0, // Default value.
           60.0, // Default value.
         ));
-        // Note: vertical boundaries include an additional 16 margin pixels due to
-        // paintOrigin manipulation in the sliver.
         expect(
           tester.getBottomLeft(find.widgetWithText(Center, '-1')).dy,
-          moreOrLessEquals(107.311809131992776),
+          moreOrLessEquals(91.311809131992776),
         );
 
         // Start another drag by an amount that would have been enough to

--- a/packages/flutter/test/cupertino/refresh_test.dart
+++ b/packages/flutter/test/cupertino/refresh_test.dart
@@ -1342,10 +1342,7 @@ void main() {
           ),
         ),
       );
-
-      // If the user has dragged less than the threshold, there is no activity indicator
-      // returned. Instead, an empty container is returned until the threshold is passed.
-      expect(find.byType(Container), findsOneWidget);
+      expect(tester.widget<CupertinoActivityIndicator>(find.byType(CupertinoActivityIndicator)).progress, 10.0 / 100.0);
 
       await tester.pumpWidget(
         Directionality(
@@ -1361,11 +1358,7 @@ void main() {
           ),
         ),
       );
-
-      // The calculations here are subtle. Because the default drag threshold before showing
-      // the indicator is 16.0, this distance gets subtracted from both the dragged distance (26.0)
-      // and the expected distance (100.0) in order to perform the percentage calculation.
-      expect(tester.widget<CupertinoActivityIndicator>(find.byType(CupertinoActivityIndicator)).progress, 10.0 / 84.0);
+      expect(tester.widget<CupertinoActivityIndicator>(find.byType(CupertinoActivityIndicator)).progress, 26.0 / 100.0);
 
       await tester.pumpWidget(
         Directionality(
@@ -1381,8 +1374,7 @@ void main() {
           ),
         ),
       );
-
-      expect(tester.widget<CupertinoActivityIndicator>(find.byType(CupertinoActivityIndicator)).progress, 1.0);
+      expect(tester.widget<CupertinoActivityIndicator>(find.byType(CupertinoActivityIndicator)).progress, 100.0 / 100.0);
     });
   };
 


### PR DESCRIPTION
## Description

The current iOS pull-to-refresh action renders a down-arrow as the user is pulling downwards, but this is not how iOS behaves. Rather, it should progressively reveal the activity ticks one-by-one until the refresh action is triggered, at which point the activity indicator starts animating.

![pull-to-refresh](https://user-images.githubusercontent.com/1574429/83365609-abe8ee00-a3ec-11ea-9838-a038c0c3ddd1.gif)

This PR modifies `CupertinoActivityIndicator` to add the ability to pass a `progress` value so that the indicator ticks can be revealed one-by-one.

I'm currently asserting that the value of progress is non-null and between 0.0 and 1.0 (inclusive), however I'm not sure whether a better approach could be to just ensure that it is non-null and clamp internally.

It also modifies the default builder in `CupertinoSliverRefreshControl` to selectively render a different version of the activity indicator depending on the current pull-to-refresh state.

Note that there is a subtle change in the way the activity indicator is drawn that results in a breaking golden image. In the old code, the first frame of the animation used to draw the brightest tick at 9 o'clock. However, the iOS in-progress tick reveal starts at 12 o'clock, so I added an initial 90 degree rotation to make the maths cleaner in the loop. See the different golden images below:

| Original first frame | New first frame |
|---|---|
| ![cupertino activityIndicator paused light_masterImage_466c7c9de2328f439a349dfe957ce4f6](https://user-images.githubusercontent.com/1574429/83364948-485cc180-a3e8-11ea-8d99-fa5e84d1f08a.png) | ![cupertino activityIndicator paused light_testImage_466c7c9de2328f439a349dfe957ce4f6](https://user-images.githubusercontent.com/1574429/83364951-498dee80-a3e8-11ea-94af-c1a152d3ef33.png) |

As part of my tests, I also added three new golden images:

| One | Two | Three |
|---|---|---|
| ![activityIndicator inprogress 0 0](https://user-images.githubusercontent.com/1574429/83364958-53afed00-a3e8-11ea-874d-55a155a4ef6e.png) | ![activityIndicator inprogress 0 3](https://user-images.githubusercontent.com/1574429/83364960-54488380-a3e8-11ea-8292-9024553fc15d.png) | ![activityIndicator inprogress 1 0](https://user-images.githubusercontent.com/1574429/83364962-54e11a00-a3e8-11ea-8d2e-875bf7d2d663.png) |

One last comment... the original code use to render all 12 ticks anti-clockwise, however, the iOS in-progress ticks are revealed clockwise. This is why I switched the loop from ascending to descending.

## Related Issues

There is (at least) one issue tracking this at #29159

## Tests

I added the following tests:

* Added golden file tests for several cases to catch future regressions.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [x] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

I've ticked that it is breaking, because of the golden image change. However, given this image is part of a rotating animation, I don't believe that it is truly "breaking".

@Piinks This is my first contribution using golden files, so looping you in per guidance in the Golden Test page. Apologies if I have missed any steps or done them incorrectly.