### PR TITLE
[flutter_tools] reland: copy dill after startup

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -21,6 +21,7 @@ import '../base/net.dart';
 import '../base/terminal.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
+import '../bundle.dart';
 import '../cache.dart';
 import '../convert.dart';
 import '../dart/pub.dart';
@@ -434,6 +435,15 @@ class _ResidentWebRunner extends ResidentWebRunner {
             return 1;
           }
           device.generator.accept();
+          globals.logger.printTrace('caching compiled dill...');
+          final File outputDill = globals.fs.file(dillOutputPath);
+          if (outputDill.existsSync()) {
+            final String copyPath = getDefaultCachedKernelPath(
+              trackWidgetCreation: trackWidgetCreation,
+            );
+            globals.fs.file(copyPath).parent.createSync(recursive: true);
+            outputDill.copySync(copyPath);
+          }
         } else {
           await buildWeb(
             flutterProject,

--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -21,7 +21,6 @@ import '../base/net.dart';
 import '../base/terminal.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
-import '../bundle.dart';
 import '../cache.dart';
 import '../convert.dart';
 import '../dart/pub.dart';
@@ -435,15 +434,7 @@ class _ResidentWebRunner extends ResidentWebRunner {
             return 1;
           }
           device.generator.accept();
-          globals.logger.printTrace('caching compiled dill...');
-          final File outputDill = globals.fs.file(dillOutputPath);
-          if (outputDill.existsSync()) {
-            final String copyPath = getDefaultCachedKernelPath(
-              trackWidgetCreation: trackWidgetCreation,
-            );
-            globals.fs.file(copyPath).parent.createSync(recursive: true);
-            outputDill.copySync(copyPath);
-          }
+          cacheInitialDillCompilation();
         } else {
           await buildWeb(
             flutterProject,

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1099,6 +1099,9 @@ abstract class ResidentRunner {
 
   @protected
   void cacheInitialDillCompilation() {
+    if (_dillOutputPath != null) {
+      return;
+    }
     globals.logger.printTrace('Caching compiled dill');
     final File outputDill = globals.fs.file(dillOutputPath);
     if (outputDill.existsSync()) {

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1205,18 +1205,7 @@ abstract class ResidentRunner {
   }
 
   @mustCallSuper
-  Future<void> preExit() async {
-    // If _dillOutputPath is null, we created a temporary directory for the dill.
-    if (_dillOutputPath == null && artifactDirectory.existsSync()) {
-      final File outputDill = globals.fs.file(dillOutputPath);
-      if (outputDill.existsSync()) {
-        outputDill.copySync(getDefaultCachedKernelPath(
-          trackWidgetCreation: trackWidgetCreation,
-        ));
-      }
-      artifactDirectory.deleteSync(recursive: true);
-    }
-  }
+  Future<void> preExit() async { }
 
   Future<void> exitApp() async {
     final List<Future<void>> futures = <Future<void>>[

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1097,6 +1097,19 @@ abstract class ResidentRunner {
     );
   }
 
+  @protected
+  void cacheInitialDillCompilation() {
+    globals.logger.printTrace('Caching compiled dill');
+    final File outputDill = globals.fs.file(dillOutputPath);
+    if (outputDill.existsSync()) {
+      final String copyPath = getDefaultCachedKernelPath(
+        trackWidgetCreation: trackWidgetCreation,
+      );
+      globals.fs.file(copyPath).parent.createSync(recursive: true);
+      outputDill.copySync(copyPath);
+    }
+  }
+
   /// If the [reloadSources] parameter is not null the 'reloadSources' service
   /// will be registered.
   //

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1218,7 +1218,13 @@ abstract class ResidentRunner {
   }
 
   @mustCallSuper
-  Future<void> preExit() async { }
+  Future<void> preExit() async {
+    // If _dillOutputPath is null, the tool created a temporary directory for
+    // the dill.
+    if (_dillOutputPath == null && artifactDirectory.existsSync()) {
+      artifactDirectory.deleteSync(recursive: true);
+    }
+  }
 
   Future<void> exitApp() async {
     final List<Future<void>> futures = <Future<void>>[

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -387,16 +387,7 @@ class HotRunner extends ResidentRunner {
       if (!results.every((bool passed) => passed)) {
         return 1;
       }
-      globals.logger.printTrace('Caching compiled dill');
-
-      final File outputDill = globals.fs.file(dillOutputPath);
-      if (outputDill.existsSync()) {
-        final String copyPath = getDefaultCachedKernelPath(
-          trackWidgetCreation: trackWidgetCreation,
-        );
-        globals.fs.file(copyPath).parent.createSync(recursive: true);
-        outputDill.copySync(copyPath);
-      }
+      cacheInitialDillCompilation();
     } on Exception catch (err) {
       globals.printError(err.toString());
       return 1;

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -63,7 +63,6 @@ class DeviceReloadReport {
   List<vm_service.ReloadReport> reports; // List has one report per Flutter view.
 }
 
-// TODO(mklim): Test this, flutter/flutter#23031.
 class HotRunner extends ResidentRunner {
   HotRunner(
     List<FlutterDevice> devices, {
@@ -387,6 +386,16 @@ class HotRunner extends ResidentRunner {
       final List<bool> results = await Future.wait(startupTasks);
       if (!results.every((bool passed) => passed)) {
         return 1;
+      }
+      globals.logger.printTrace('Caching compiled dill');
+
+      final File outputDill = globals.fs.file(dillOutputPath);
+      if (outputDill.existsSync()) {
+        final String copyPath = getDefaultCachedKernelPath(
+          trackWidgetCreation: trackWidgetCreation,
+        );
+        globals.fs.file(copyPath).parent.createSync(recursive: true);
+        outputDill.copySync(copyPath);
       }
     } on Exception catch (err) {
       globals.printError(err.toString());

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -521,6 +521,14 @@ void main() {
     expect(otherRunner.artifactDirectory.path, contains('foobar'));
   }));
 
+  test('ResidentRunner deletes artifact directory on preExit', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    residentRunner.artifactDirectory.childFile('app.dill').createSync();
+    await residentRunner.preExit();
+
+    expect(residentRunner.artifactDirectory, isNot(exists));
+  }));
+
   test('ResidentRunner can run source generation', () => testbed.run(() async {
     final FakeProcessManager processManager = globals.processManager as FakeProcessManager;
     final Directory dependencies = globals.fs.directory(

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -521,24 +521,6 @@ void main() {
     expect(otherRunner.artifactDirectory.path, contains('foobar'));
   }));
 
-  test('ResidentRunner copies output dill to cache location during preExit', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('hello');
-    await residentRunner.preExit();
-    final File cacheDill = globals.fs.file(globals.fs.path.join(getBuildDirectory(), 'cache.dill'));
-
-    expect(cacheDill, exists);
-    expect(cacheDill.readAsStringSync(), 'hello');
-  }));
-
-  test('ResidentRunner handles output dill missing during preExit', () => testbed.run(() async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    await residentRunner.preExit();
-    final File cacheDill = globals.fs.file(globals.fs.path.join(getBuildDirectory(), 'cache.dill'));
-
-    expect(cacheDill, isNot(exists));
-  }));
-
   test('ResidentRunner can run source generation', () => testbed.run(() async {
     final FakeProcessManager processManager = globals.processManager as FakeProcessManager;
     final Directory dependencies = globals.fs.directory(
@@ -1059,6 +1041,64 @@ void main() {
 
     expect(await globals.fs.file('foo').readAsString(), testUri.toString());
   }));
+
+  test('HotRunner copies compiled app.dill to cache during startup', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ]);
+    setWsAddress(testUri, fakeVmServiceHost.vmService);
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        mockFlutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+    );
+    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
+    when(mockFlutterDevice.runHot(
+      hotRunner: anyNamed('hotRunner'),
+      route: anyNamed('route'),
+    )).thenAnswer((Invocation invocation) async {
+      return 0;
+    });
+    await residentRunner.run();
+
+    expect(await globals.fs.file(globals.fs.path.join('build', 'cache.dill')).readAsString(), 'ABC');
+  }));
+
+  test('HotRunner copies compiled app.dill to cache during startup with --track-widget-creation', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      listViews,
+      listViews,
+    ]);
+    setWsAddress(testUri, fakeVmServiceHost.vmService);
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        mockFlutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(const BuildInfo(
+        BuildMode.debug,
+        '',
+        treeShakeIcons: false,
+        trackWidgetCreation: true,
+      )),
+    );
+    residentRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
+    when(mockFlutterDevice.runHot(
+      hotRunner: anyNamed('hotRunner'),
+      route: anyNamed('route'),
+    )).thenAnswer((Invocation invocation) async {
+      return 0;
+    });
+    await residentRunner.run();
+
+    expect(await globals.fs.file(globals.fs.path.join('build', 'cache.dill.track.dill')).readAsString(), 'ABC');
+  }));
+
 
   test('HotRunner unforwards device ports', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -257,13 +257,21 @@ void main() {
     expect(bufferLogger.statusText, contains('Debug service listening on ws://127.0.0.1/abcd/'));
     expect(debugConnectionInfo.wsUri.toString(), 'ws://127.0.0.1/abcd/');
   }, overrides: <Type, Generator>{
-    Logger: () => DelegateLogger(BufferLogger(
-      terminal: AnsiTerminal(
-        stdio: null,
-        platform: const LocalPlatform(),
-      ),
-      outputPreferences: OutputPreferences.test(),
-    )),
+    Logger: () => DelegateLogger(BufferLogger.test()),
+  }));
+
+  test('WebRunner copies compiled app.dill to cache during startup', () => testbed.run(() async {
+    fakeVmServiceHost = FakeVmServiceHost(requests: kAttachExpectations.toList());
+    _setupMocks();
+
+    residentWebRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
+    final Completer<DebugConnectionInfo> connectionInfoCompleter = Completer<DebugConnectionInfo>();
+    unawaited(residentWebRunner.run(
+      connectionInfoCompleter: connectionInfoCompleter,
+    ));
+    await connectionInfoCompleter.future;
+
+    expect(await globals.fs.file(globals.fs.path.join('build', 'cache.dill')).readAsString(), 'ABC');
   }));
 
   test('Can successfully run without an index.html including status warning', () => testbed.run(() async {


### PR DESCRIPTION
## Description

remove copying from the shutdown stage since that seems risky (and Android Studio behavior is unlikely to change). If we copy the first compilation we'll still get a decent dill for initialization.

Fixes #58109 (indirectly)

Reland of https://github.com/flutter/flutter/pull/58188