### PR TITLE
[devicelab] mark ios transition_perf as non-flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -491,7 +491,6 @@ tasks:
       32-bit iOS (iPhone 4S).
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios32"]
-    flaky: true # TODO(jmagman): https://github.com/flutter/flutter/issues/57225
 
   flavors_test_ios:
     description: >
@@ -572,7 +571,6 @@ tasks:
       iOS.
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
-    flaky: true # TODO(jmagman): https://github.com/flutter/flutter/issues/57225
 
   hello_world_ios__compile:
     description: >


### PR DESCRIPTION
## Description

These tests are no-longer flaky since https://github.com/flutter/flutter/commit/cd7dfd0a0a60233de737cee8008fe4463acb6785 reduced timeline memory usage. https://github.com/flutter/flutter/issues/57225 might still be happening, but is much less frequent. 

https://github.com/flutter/flutter/issues/58338

Fixes https://github.com/flutter/flutter/issues/57756