### PR TITLE
Do not assume imageCache is created when handleMemoryPressure is called

### DIFF
--- a/packages/flutter/lib/src/painting/binding.dart
+++ b/packages/flutter/lib/src/painting/binding.dart
@@ -102,7 +102,7 @@ mixin PaintingBinding on BindingBase, ServicesBinding {
   @override
   void handleMemoryPressure() {
     super.handleMemoryPressure();
-    imageCache.clear();
+    imageCache?.clear();
   }
 
   /// Listenable that notifies when the available fonts on the system have

--- a/packages/flutter/test/painting/image_cache_binding_test.dart
+++ b/packages/flutter/test/painting/image_cache_binding_test.dart
@@ -1,0 +1,75 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/painting.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/services.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+
+void main() {
+  test('PaintingBinding with memory pressure before initInstances', () {
+    final PaintingBinding binding = TestPaintingBinding();
+    expect(binding.imageCache, null);
+    binding.handleMemoryPressure();
+    expect(binding.imageCache, null);
+    binding.initInstances();
+    expect(binding.imageCache, isNotNull);
+    expect(binding.imageCache.currentSize, 0);
+  });
+}
+
+class TestBindingBase implements BindingBase {
+  @override
+  void initInstances() {}
+
+  @override
+  void initServiceExtensions() {}
+
+  @override
+  Future<void> lockEvents(Future<void> Function() callback) async {}
+
+  @override
+  bool get locked => throw UnimplementedError();
+
+  @override
+  Future<void> performReassemble() {
+    throw UnimplementedError();
+  }
+
+  @override
+  void postEvent(String eventKind, Map<String, dynamic> eventData) {}
+
+  @override
+  Future<void> reassembleApplication() {
+    throw UnimplementedError();
+  }
+
+  @override
+  void registerBoolServiceExtension({String name, AsyncValueGetter<bool> getter, AsyncValueSetter<bool> setter}) {}
+
+  @override
+  void registerNumericServiceExtension({String name, AsyncValueGetter<double> getter, AsyncValueSetter<double> setter}) {}
+
+  @override
+  void registerServiceExtension({String name, ServiceExtensionCallback callback}) {}
+
+  @override
+  void registerSignalServiceExtension({String name, AsyncCallback callback}) {}
+
+  @override
+  void registerStringServiceExtension({String name, AsyncValueGetter<String> getter, AsyncValueSetter<String> setter}) {}
+
+  @override
+  void unlocked() {}
+
+  @override
+  ui.Window get window => TestWindow(window: ui.window);
+}
+
+class TestPaintingBinding extends TestBindingBase with SchedulerBinding, ServicesBinding, PaintingBinding {}

--- a/packages/flutter/test/painting/image_cache_binding_test.dart
+++ b/packages/flutter/test/painting/image_cache_binding_test.dart
@@ -14,6 +14,9 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('PaintingBinding with memory pressure before initInstances', () {
+    // Observed in devicelab: the device sends a memory pressure event to us
+    // after PaintingBinding has been created but before initInstances called,
+    // meaning the imageCache member is still null.
     final PaintingBinding binding = TestPaintingBinding();
     expect(binding.imageCache, null);
     binding.handleMemoryPressure();


### PR DESCRIPTION
## Description

Apparently memory pressure can come before we finish initializing the binding, as described in the linked issue. In that case, we should not assume the imageCache has been created.

## Related Issues

https://github.com/flutter/flutter/issues/58453

## Tests

I added the following tests:

Create a fake PaintingBinding that we can manipulate before calling initInstances, make sure we can call `handleMemoryPressure` without crashing.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
