### PR TITLE
add rasterizer start times to timeline summaries

### DIFF
--- a/packages/flutter_driver/lib/src/driver/timeline_summary.dart
+++ b/packages/flutter_driver/lib/src/driver/timeline_summary.dart
@@ -98,6 +98,18 @@ class TimelineSummary {
     final SceneDisplayLagSummarizer sceneDisplayLagSummarizer = _sceneDisplayLagSummarizer();
 
     return <String, dynamic>{
+      'average_frame_build_time_millis': computeAverageFrameBuildTimeMillis(),
+      '90th_percentile_frame_build_time_millis': computePercentileFrameBuildTimeMillis(90.0),
+      '99th_percentile_frame_build_time_millis': computePercentileFrameBuildTimeMillis(99.0),
+      'worst_frame_build_time_millis': computeWorstFrameBuildTimeMillis(),
+      'missed_frame_build_budget_count': computeMissedFrameBuildBudgetCount(),
+      'average_frame_rasterizer_time_millis': computeAverageFrameRasterizerTimeMillis(),
+      '90th_percentile_frame_rasterizer_time_millis': computePercentileFrameRasterizerTimeMillis(90.0),
+      '99th_percentile_frame_rasterizer_time_millis': computePercentileFrameRasterizerTimeMillis(99.0),
+      'worst_frame_rasterizer_time_millis': computeWorstFrameRasterizerTimeMillis(),
+      'missed_frame_rasterizer_budget_count': computeMissedFrameRasterizerBudgetCount(),
+      'frame_count': countFrames(),
+      'frame_rasterizer_count': countRasterizations(),
       'frame_build_times': _extractFrameDurations()
           .map<int>((Duration duration) => duration.inMicroseconds)
           .toList(),
@@ -110,21 +122,9 @@ class TimelineSummary {
       'frame_rasterizer_begin_times': _extractBeginTimestamps(kRasterizeFrameEventName)
           .map<int>((Duration duration) => duration.inMicroseconds)
           .toList(),
-      'frame_count': countFrames(),
-      'frame_rasterizer_count': countRasterizations(),
-      'average_frame_build_time_millis': computeAverageFrameBuildTimeMillis(),
-      '90th_percentile_frame_build_time_millis': computePercentileFrameBuildTimeMillis(90.0),
-      '99th_percentile_frame_build_time_millis': computePercentileFrameBuildTimeMillis(99.0),
-      'worst_frame_build_time_millis': computeWorstFrameBuildTimeMillis(),
-      'missed_frame_build_budget_count': computeMissedFrameBuildBudgetCount(),
-      'average_frame_rasterizer_time_millis': computeAverageFrameRasterizerTimeMillis(),
-      '90th_percentile_frame_rasterizer_time_millis': computePercentileFrameRasterizerTimeMillis(90.0),
-      '99th_percentile_frame_rasterizer_time_millis': computePercentileFrameRasterizerTimeMillis(99.0),
-      'worst_frame_rasterizer_time_millis': computeWorstFrameRasterizerTimeMillis(),
-      'missed_frame_rasterizer_budget_count': computeMissedFrameRasterizerBudgetCount(),
       'average_vsync_transitions_missed': sceneDisplayLagSummarizer.computeAverageVsyncTransitionsMissed(),
       '90th_percentile_vsync_transitions_missed': sceneDisplayLagSummarizer.computePercentileVsyncTransitionsMissed(90.0),
-      '99th_percentile_vsync_transitions_missed': sceneDisplayLagSummarizer.computePercentileVsyncTransitionsMissed(99.0)
+      '99th_percentile_vsync_transitions_missed': sceneDisplayLagSummarizer.computePercentileVsyncTransitionsMissed(99.0),
     };
   }
 

--- a/packages/flutter_driver/test/src/real_tests/timeline_summary_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/timeline_summary_test.dart
@@ -372,9 +372,11 @@ void main() {
             'worst_frame_rasterizer_time_millis': 20.0,
             'missed_frame_rasterizer_budget_count': 2,
             'frame_count': 3,
+            'frame_rasterizer_count': 3,
             'frame_build_times': <int>[17000, 9000, 19000],
             'frame_rasterizer_times': <int>[18000, 10000, 20000],
             'frame_begin_times': <int>[0, 18000, 28000],
+            'frame_rasterizer_begin_times': <int>[0, 18000, 28000],
             'average_vsync_transitions_missed': 0.0,
             '90th_percentile_vsync_transitions_missed': 0.0,
             '99th_percentile_vsync_transitions_missed': 0.0
@@ -431,9 +433,11 @@ void main() {
           'worst_frame_rasterizer_time_millis': 20.0,
           'missed_frame_rasterizer_budget_count': 2,
           'frame_count': 3,
+          'frame_rasterizer_count': 3,
           'frame_build_times': <int>[17000, 9000, 19000],
           'frame_rasterizer_times': <int>[18000, 10000, 20000],
           'frame_begin_times': <int>[0, 18000, 28000],
+          'frame_rasterizer_begin_times': <int>[0, 18000, 28000],
           'average_vsync_transitions_missed': 8.0,
           '90th_percentile_vsync_transitions_missed': 12.0,
           '99th_percentile_vsync_transitions_missed': 12.0


### PR DESCRIPTION
I also rearranged the map output so that the final screenful of data includes the averages. No more scrolling back in the output to look for useful numbers after running a benchmark.