### PR TITLE
Revert "[flutter_tools] Put a heap size limit on the frontend_server"

### DIFF
--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -263,11 +263,6 @@ class KernelCompiler {
     }
     final List<String> command = <String>[
       engineDartPath,
-      '--disable-dart-dev',
-      // This limit is in place to help track down
-      // https://github.com/flutter/flutter/issues/54420. It should be removed
-      // when the underlying issue is identified and fixed.
-      '--old_gen_heap_size=2000',
       frontendServer,
       '--sdk-root',
       sdkRoot,
@@ -653,11 +648,6 @@ class DefaultResidentCompiler implements ResidentCompiler {
     );
     final List<String> command = <String>[
       globals.artifacts.getArtifactPath(Artifact.engineDartBinary),
-      '--disable-dart-dev',
-      // This limit is in place to help track down
-      // https://github.com/flutter/flutter/issues/54420. It should be removed
-      // when the underlying issue is identified and fixed.
-      '--old_gen_heap_size=2000',
       frontendServer,
       '--sdk-root',
       sdkRoot,

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+
 import 'dart:async';
 
 import 'package:meta/meta.dart';

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
 import 'dart:async';
 
 import 'package:meta/meta.dart';

--- a/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
@@ -86,8 +86,6 @@ void main() {
     processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(command: <String>[
         artifacts.getArtifactPath(Artifact.engineDartBinary),
-        '--disable-dart-dev',
-        '--old_gen_heap_size=2000',
         artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
         '--sdk-root',
         artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath) + '/',
@@ -117,8 +115,6 @@ void main() {
     processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(command: <String>[
         artifacts.getArtifactPath(Artifact.engineDartBinary),
-        '--disable-dart-dev',
-        '--old_gen_heap_size=2000',
         artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
         '--sdk-root',
         artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath) + '/',
@@ -148,8 +144,6 @@ void main() {
     processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(command: <String>[
         artifacts.getArtifactPath(Artifact.engineDartBinary),
-        '--disable-dart-dev',
-        '--old_gen_heap_size=2000',
         artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
         '--sdk-root',
         artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath) + '/',
@@ -180,8 +174,6 @@ void main() {
     processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(command: <String>[
         artifacts.getArtifactPath(Artifact.engineDartBinary),
-        '--disable-dart-dev',
-        '--old_gen_heap_size=2000',
         artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
         '--sdk-root',
         artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath) + '/',
@@ -214,8 +206,6 @@ void main() {
     processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(command: <String>[
         artifacts.getArtifactPath(Artifact.engineDartBinary),
-        '--disable-dart-dev',
-        '--old_gen_heap_size=2000',
         artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
         '--sdk-root',
         artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath) + '/',
@@ -246,8 +236,6 @@ void main() {
     processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(command: <String>[
         artifacts.getArtifactPath(Artifact.engineDartBinary),
-        '--disable-dart-dev',
-        '--old_gen_heap_size=2000',
         artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
         '--sdk-root',
         artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath) + '/',
@@ -290,8 +278,6 @@ void main() {
     processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(command: <String>[
         artifacts.getArtifactPath(Artifact.engineDartBinary),
-        '--disable-dart-dev',
-        '--old_gen_heap_size=2000',
         artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
         '--sdk-root',
         artifacts.getArtifactPath(Artifact.flutterPatchedSdkPath) + '/',

--- a/packages/flutter_tools/test/general.shard/compile_batch_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_batch_test.dart
@@ -76,37 +76,6 @@ void main() {
     Platform: kNoColorTerminalPlatform,
   });
 
-  testUsingContext('passes VM heap size limit', () async {
-    when(mockFrontendServer.stdout)
-        .thenAnswer((Invocation invocation) => Stream<List<int>>.fromFuture(
-          Future<List<int>>.value(utf8.encode(
-            'result abc\nline1\nline2\nabc\nabc /path/to/main.dart.dill 0'
-          ))
-        ));
-    final KernelCompiler kernelCompiler = await kernelCompilerFactory.create(null);
-    final CompilerOutput output = await kernelCompiler.compile(sdkRoot: '/path/to/sdkroot',
-      mainPath: '/path/to/main.dart',
-      buildMode: BuildMode.debug,
-      trackWidgetCreation: false,
-      dartDefines: const <String>[],
-      packageConfig: PackageConfig.empty,
-      packagesPath: '.packages',
-    );
-
-    expect(mockFrontendServerStdIn.getAndClear(), isEmpty);
-    expect(testLogger.errorText, equals('\nCompiler message:\nline1\nline2\n'));
-    expect(output.outputFilename, equals('/path/to/main.dart.dill'));
-    final VerificationResult argVerification = verify(mockProcessManager.start(captureAny));
-    expect(argVerification.captured.single, containsAll(<String>[
-      '--disable-dart-dev',
-      '--old_gen_heap_size=2000',
-    ]));
-  }, overrides: <Type, Generator>{
-    ProcessManager: () => mockProcessManager,
-    OutputPreferences: () => OutputPreferences(showColor: false),
-    Platform: kNoColorTerminalPlatform,
-  });
-
   testUsingContext('passes correct AOT config to kernel compiler in aot/profile mode', () async {
     when(mockFrontendServer.stdout)
       .thenAnswer((Invocation invocation) => Stream<List<int>>.fromFuture(


### PR DESCRIPTION
Reverts flutter/flutter#58039

This breaks some google3 applications: https://critique-ng.corp.google.com/cl/314394744 .

Since the cause/mitigation has landed, this should be safe to roll back?