### PR TITLE
Make _RenderSlider not be a semantics container

### DIFF
--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -712,32 +712,36 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
     // in range_slider.dart.
     Size _screenSize() => MediaQuery.of(context).size;
 
-    return FocusableActionDetector(
-      actions: _actionMap,
-      shortcuts: _shortcutMap,
-      focusNode: widget.focusNode,
-      autofocus: widget.autofocus,
-      enabled: _enabled,
-      onShowFocusHighlight: _handleFocusHighlightChanged,
-      onShowHoverHighlight: _handleHoverChanged,
-      mouseCursor: effectiveMouseCursor,
-      child: CompositedTransformTarget(
-        link: _layerLink,
-        child: _SliderRenderObjectWidget(
-          key: _renderObjectKey,
-          value: _unlerp(widget.value),
-          divisions: widget.divisions,
-          label: widget.label,
-          sliderTheme: sliderTheme,
-          textScaleFactor: MediaQuery.of(context).textScaleFactor,
-          screenSize: _screenSize(),
-          onChanged: (widget.onChanged != null) && (widget.max > widget.min) ? _handleChanged : null,
-          onChangeStart: widget.onChangeStart != null ? _handleDragStart : null,
-          onChangeEnd: widget.onChangeEnd != null ? _handleDragEnd : null,
-          state: this,
-          semanticFormatterCallback: widget.semanticFormatterCallback,
-          hasFocus: _focused,
-          hovering: _hovering,
+    return Semantics(
+      container: true,
+      explicitChildNodes: false,
+      child: FocusableActionDetector(
+        actions: _actionMap,
+        shortcuts: _shortcutMap,
+        focusNode: widget.focusNode,
+        autofocus: widget.autofocus,
+        enabled: _enabled,
+        onShowFocusHighlight: _handleFocusHighlightChanged,
+        onShowHoverHighlight: _handleHoverChanged,
+        mouseCursor: effectiveMouseCursor,
+        child: CompositedTransformTarget(
+          link: _layerLink,
+          child: _SliderRenderObjectWidget(
+            key: _renderObjectKey,
+            value: _unlerp(widget.value),
+            divisions: widget.divisions,
+            label: widget.label,
+            sliderTheme: sliderTheme,
+            textScaleFactor: MediaQuery.of(context).textScaleFactor,
+            screenSize: _screenSize(),
+            onChanged: (widget.onChanged != null) && (widget.max > widget.min) ? _handleChanged : null,
+            onChangeStart: widget.onChangeStart != null ? _handleDragStart : null,
+            onChangeEnd: widget.onChangeEnd != null ? _handleDragEnd : null,
+            state: this,
+            semanticFormatterCallback: widget.semanticFormatterCallback,
+            hasFocus: _focused,
+            hovering: _hovering,
+          ),
         ),
       ),
     );
@@ -1110,6 +1114,7 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return;
     _hasFocus = value;
     _updateForFocusOrHover(_hasFocus);
+    markNeedsSemanticsUpdate();
   }
 
   /// True if this slider is being hovered over by a pointer.
@@ -1136,6 +1141,7 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       }
     }
   }
+
   bool get showValueIndicator {
     bool showValueIndicator;
     switch (_sliderTheme.showValueIndicator) {
@@ -1472,20 +1478,30 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   void describeSemanticsConfiguration(SemanticsConfiguration config) {
     super.describeSemanticsConfiguration(config);
 
-    config.isSemanticBoundary = isInteractive;
-    if (isInteractive) {
-      config.textDirection = textDirection;
-      config.onIncrease = increaseAction;
-      config.onDecrease = decreaseAction;
-      if (semanticFormatterCallback != null) {
-        config.value = semanticFormatterCallback(_state._lerp(value));
-        config.increasedValue = semanticFormatterCallback(_state._lerp((value + _semanticActionUnit).clamp(0.0, 1.0) as double));
-        config.decreasedValue = semanticFormatterCallback(_state._lerp((value - _semanticActionUnit).clamp(0.0, 1.0) as double));
-      } else {
-        config.value = '${(value * 100).round()}%';
-        config.increasedValue = '${((value + _semanticActionUnit).clamp(0.0, 1.0) * 100).round()}%';
-        config.decreasedValue = '${((value - _semanticActionUnit).clamp(0.0, 1.0) * 100).round()}%';
-      }
+    // The Slider widget has its own Focus widget with semantics information,
+    // and we want that semantics node to collect the semantics information here
+    // so that it's all in the same node: otherwise Talkback sees that the node
+    // has focusable children, and it won't focus the Slider's Focus widget
+    // because it thinks the Focus widget's node doesn't have anything to say
+    // (which it doesn't, but this child does). Aggregating the semantic
+    // information into one node means that Talkback will recognize that it has
+    // something to say and focus it when it receives keyboard focus.
+    // (See https://github.com/flutter/flutter/issues/57038 for context).
+    config.isSemanticBoundary = false;
+
+    config.isEnabled = isInteractive;
+    config.textDirection = textDirection;
+    config.onIncrease = increaseAction;
+    config.onDecrease = decreaseAction;
+    config.label = _label ?? '';
+    if (semanticFormatterCallback != null) {
+      config.value = semanticFormatterCallback(_state._lerp(value));
+      config.increasedValue = semanticFormatterCallback(_state._lerp((value + _semanticActionUnit).clamp(0.0, 1.0) as double));
+      config.decreasedValue = semanticFormatterCallback(_state._lerp((value - _semanticActionUnit).clamp(0.0, 1.0) as double));
+    } else {
+      config.value = '${(value * 100).round()}%';
+      config.increasedValue = '${((value + _semanticActionUnit).clamp(0.0, 1.0) * 100).round()}%';
+      config.decreasedValue = '${((value - _semanticActionUnit).clamp(0.0, 1.0) * 100).round()}%';
     }
   }
 

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -714,7 +714,6 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
 
     return Semantics(
       container: true,
-      explicitChildNodes: false,
       child: FocusableActionDetector(
         actions: _actionMap,
         shortcuts: _shortcutMap,
@@ -1491,8 +1490,10 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     config.isEnabled = isInteractive;
     config.textDirection = textDirection;
-    config.onIncrease = increaseAction;
-    config.onDecrease = decreaseAction;
+    if (isInteractive) {
+      config.onIncrease = increaseAction;
+      config.onDecrease = decreaseAction;
+    }
     config.label = _label ?? '';
     if (semanticFormatterCallback != null) {
       config.value = semanticFormatterCallback(_state._lerp(value));

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -1347,17 +1347,12 @@ void main() {
                   children: <TestSemantics>[
                     TestSemantics(
                       id: 3,
-                      flags: <SemanticsFlag>[SemanticsFlag.isFocusable],
-                      children: <TestSemantics>[
-                        TestSemantics(
-                          id: 4,
-                          value: '50%',
-                          increasedValue: '55%',
-                          decreasedValue: '45%',
-                          textDirection: TextDirection.ltr,
-                          actions: SemanticsAction.decrease.index | SemanticsAction.increase.index,
-                        ),
-                      ],
+                      flags: <SemanticsFlag>[SemanticsFlag.hasEnabledState, SemanticsFlag.isEnabled, SemanticsFlag.isFocusable],
+                      actions: <SemanticsAction>[SemanticsAction.increase, SemanticsAction.decrease],
+                      value: '50%',
+                      increasedValue: '55%',
+                      decreasedValue: '45%',
+                      textDirection: TextDirection.ltr,
                     ),
                   ],
                 ),
@@ -1400,7 +1395,13 @@ void main() {
                   flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
                   children: <TestSemantics>[
                     TestSemantics(
-                      id: 5,
+                      id: 3,
+                      flags: <SemanticsFlag>[SemanticsFlag.hasEnabledState],
+                      actions: <SemanticsAction>[SemanticsAction.increase, SemanticsAction.decrease],
+                      value: '50%',
+                      increasedValue: '55%',
+                      decreasedValue: '45%',
+                      textDirection: TextDirection.ltr,
                     ),
                   ],
                 ),
@@ -1455,17 +1456,61 @@ void main() {
                   children: <TestSemantics>[
                     TestSemantics(
                       id: 3,
-                      flags: <SemanticsFlag>[SemanticsFlag.isFocusable],
-                      children: <TestSemantics>[
-                        TestSemantics(
-                          id: 4,
-                          value: '50%',
-                          increasedValue: '60%',
-                          decreasedValue: '40%',
-                          textDirection: TextDirection.ltr,
-                          actions: SemanticsAction.decrease.index | SemanticsAction.increase.index,
-                        ),
-                      ],
+                      flags: <SemanticsFlag>[SemanticsFlag.hasEnabledState, SemanticsFlag.isEnabled, SemanticsFlag.isFocusable],
+                      actions: <SemanticsAction>[SemanticsAction.increase, SemanticsAction.decrease],
+                      value: '50%',
+                      increasedValue: '60%',
+                      decreasedValue: '40%',
+                      textDirection: TextDirection.ltr,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+        ignoreRect: true,
+        ignoreTransform: true,
+      ),
+    );
+
+    // Disable slider
+    await tester.pumpWidget(MaterialApp(
+      home: Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: MediaQueryData.fromWindow(window),
+          child: const Material(
+            child: Slider(
+              value: 0.5,
+              onChanged: null,
+            ),
+          ),
+        ),
+      ),
+    ));
+
+    expect(
+      semantics,
+      hasSemantics(
+        TestSemantics.root(
+          children: <TestSemantics>[
+            TestSemantics(
+              id: 1,
+              textDirection: TextDirection.ltr,
+              children: <TestSemantics>[
+                TestSemantics(
+                  id: 2,
+                  flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
+                  children: <TestSemantics>[
+                    TestSemantics(
+                      id: 4,
+                      flags: <SemanticsFlag>[SemanticsFlag.hasEnabledState],
+                      actions: <SemanticsAction>[SemanticsAction.increase, SemanticsAction.decrease],
+                      value: '50%',
+                      increasedValue: '60%',
+                      decreasedValue: '40%',
+                      textDirection: TextDirection.ltr,
                     ),
                   ],
                 ),
@@ -1517,17 +1562,12 @@ void main() {
                   children: <TestSemantics>[
                     TestSemantics(
                       id: 3,
-                      flags: <SemanticsFlag>[SemanticsFlag.isFocusable],
-                      children: <TestSemantics>[
-                        TestSemantics(
-                          id: 4,
-                          value: '40',
-                          increasedValue: '60',
-                          decreasedValue: '20',
-                          textDirection: TextDirection.ltr,
-                          actions: SemanticsAction.decrease.index | SemanticsAction.increase.index,
-                        ),
-                      ],
+                      flags: <SemanticsFlag>[SemanticsFlag.hasEnabledState, SemanticsFlag.isEnabled, SemanticsFlag.isFocusable],
+                      actions: <SemanticsAction>[SemanticsAction.increase, SemanticsAction.decrease],
+                      value: '40',
+                      increasedValue: '60',
+                      decreasedValue: '20',
+                      textDirection: TextDirection.ltr,
                     ),
                   ],
                 ),

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -1397,7 +1397,6 @@ void main() {
                     TestSemantics(
                       id: 3,
                       flags: <SemanticsFlag>[SemanticsFlag.hasEnabledState],
-                      actions: <SemanticsAction>[SemanticsAction.increase, SemanticsAction.decrease],
                       value: '50%',
                       increasedValue: '55%',
                       decreasedValue: '45%',
@@ -1506,7 +1505,6 @@ void main() {
                     TestSemantics(
                       id: 4,
                       flags: <SemanticsFlag>[SemanticsFlag.hasEnabledState],
-                      actions: <SemanticsAction>[SemanticsAction.increase, SemanticsAction.decrease],
                       value: '50%',
                       increasedValue: '60%',
                       decreasedValue: '40%',


### PR DESCRIPTION
## Description

This PR makes `_RenderSlider` not be a semantics container. This is so that the `FocusableActionDetector` in the Slider widget will get to aggregate the semantics information, since otherwise Talkback won't focus the slider because it thinks that the focus node doesn't have anything to say (which it doesn't but the `_RenderSlider` child does).  If the `_RenderSlider` is a semantics container, then it keeps its speakable information to itself, but it isn't the `Focus` widget, so when the keyboard focus goes to the focus node, the accessibility focus doesn't move.

Since the `_RenderSlider` is always wrapped by the Slider widget, there's nothing lost in making it not be a container.


## Related Issues

- Fixes #57038

## Tests

- Updated slider semantics tests.

## Breaking Change

- [X] No, this is *not* a breaking change.