### PR TITLE
Don't elapse real time during IOSDevice.startApp tests

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -300,6 +300,7 @@ class IOSDevice extends Device {
     Map<String, dynamic> platformArgs,
     bool prebuiltApplication = false,
     bool ipv6 = false,
+    Duration fallbackPollingDelay,
   }) async {
     String packageId;
 
@@ -416,6 +417,7 @@ class IOSDevice extends Device {
         portForwarder: portForwarder,
         protocolDiscovery: observatoryDiscovery,
         flutterUsage: globals.flutterUsage,
+        pollingDelay: fallbackPollingDelay,
       );
       final Uri localUri = await fallbackDiscovery.discover(
         assumedDevicePort: assumedObservatoryPort,

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -300,7 +300,7 @@ class IOSDevice extends Device {
     Map<String, dynamic> platformArgs,
     bool prebuiltApplication = false,
     bool ipv6 = false,
-    Duration fallbackPollingDelay,
+    @visibleForTesting Duration fallbackPollingDelay,
   }) async {
     String packageId;
 

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -129,6 +129,7 @@ void main() {
       prebuiltApplication: true,
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
       platformArgs: <String, dynamic>{},
+      fallbackPollingDelay: Duration.zero,
     );
 
     verify(globals.flutterUsage.sendEvent('ios-handshake', 'mdns-success')).called(1);
@@ -173,6 +174,7 @@ void main() {
       prebuiltApplication: true,
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
       platformArgs: <String, dynamic>{},
+      fallbackPollingDelay: Duration.zero,
     );
 
     expect(launchResult.started, true);
@@ -219,6 +221,7 @@ void main() {
       prebuiltApplication: true,
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
       platformArgs: <String, dynamic>{},
+      fallbackPollingDelay: Duration.zero,
     );
 
     expect(launchResult.started, false);
@@ -257,6 +260,7 @@ void main() {
       prebuiltApplication: true,
       debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
       platformArgs: <String, dynamic>{},
+      fallbackPollingDelay: Duration.zero,
     );
 
     expect(launchResult.started, true);
@@ -347,6 +351,7 @@ void main() {
         verboseSystemLogs: true,
       ),
       platformArgs: <String, dynamic>{},
+      fallbackPollingDelay: Duration.zero,
     );
 
     expect(launchResult.started, true);


### PR DESCRIPTION
## Description

Pass through fallback_discovery delay into `startApp`.  See https://github.com/flutter/flutter/pull/54717.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/58537

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*