### PR TITLE
Fake out DeviceManager.getDevices in test

### DIFF
--- a/packages/flutter_tools/test/general.shard/device_test.dart
+++ b/packages/flutter_tools/test/general.shard/device_test.dart
@@ -19,10 +19,12 @@ import '../src/mocks.dart';
 void main() {
   group('DeviceManager', () {
     testUsingContext('getDevices', () async {
-      // Test that DeviceManager.getDevices() doesn't throw.
-      final DeviceManager deviceManager = DeviceManager();
-      final List<Device> devices = await deviceManager.getDevices();
-      expect(devices, isList);
+      final FakeDevice device1 = FakeDevice('Nexus 5', '0553790d0a4e726f');
+      final FakeDevice device2 = FakeDevice('Nexus 5X', '01abfc49119c410e');
+      final FakeDevice device3 = FakeDevice('iPod touch', '82564b38861a9a5');
+      final List<Device> devices = <Device>[device1, device2, device3];
+      final DeviceManager deviceManager = TestDeviceManager(devices);
+      expect(await deviceManager.getDevices(), devices);
     });
 
     testUsingContext('getDeviceById', () async {


### PR DESCRIPTION
## Description

Used `TestDeviceManager` instead of real `DeviceManager.getDevices` which actually calls underlying device discovery.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/58540

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*