### PR TITLE
Use fake command in analytics test

### DIFF
--- a/packages/flutter_tools/test/general.shard/analytics_test.dart
+++ b/packages/flutter_tools/test/general.shard/analytics_test.dart
@@ -55,7 +55,10 @@ void main() {
 
       globals.flutterUsage.enabled = true;
       await runner.run(<String>['fake']);
-      expect(count, globals.flutterUsage.isFirstRun ? 0 : 4);
+      // LogToFileAnalytics isFirstRun is hardcoded to false
+      // so this usage will never act like the first run
+      // (which would not send usage).
+      expect(count, 4);
 
       count = 0;
       globals.flutterUsage.enabled = false;

--- a/packages/flutter_tools/test/general.shard/analytics_test.dart
+++ b/packages/flutter_tools/test/general.shard/analytics_test.dart
@@ -36,6 +36,7 @@ void main() {
     MockFlutterConfig mockFlutterConfig;
 
     setUp(() {
+      Cache.flutterRoot = '/flutter';
       fileSystem = MemoryFileSystem.test();
       mockFlutterConfig = MockFlutterConfig();
     });
@@ -107,7 +108,7 @@ void main() {
 
       final String featuresKey = cdKey(CustomDimensions.enabledFlutterFeatures);
 
-      expect(globals.fs.file('test').readAsStringSync(), contains('$featuresKey: enable-web'));
+      expect(fileSystem.file('test').readAsStringSync(), contains('$featuresKey: enable-web'));
     }, overrides: <Type, Generator>{
       FlutterVersion: () => FlutterVersion(const SystemClock()),
       Config: () => mockFlutterConfig,
@@ -131,7 +132,7 @@ void main() {
       final String featuresKey = cdKey(CustomDimensions.enabledFlutterFeatures);
 
       expect(
-        globals.fs.file('test').readAsStringSync(),
+        fileSystem.file('test').readAsStringSync(),
         contains('$featuresKey: enable-web,enable-linux-desktop,enable-macos-desktop'),
       );
     }, overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/general.shard/analytics_test.dart
+++ b/packages/flutter_tools/test/general.shard/analytics_test.dart
@@ -36,7 +36,6 @@ void main() {
     MockFlutterConfig mockFlutterConfig;
 
     setUp(() {
-      Cache.flutterRoot = '../..';
       fileSystem = MemoryFileSystem.test();
       mockFlutterConfig = MockFlutterConfig();
     });


### PR DESCRIPTION
## Description

This test was actually calling the `doctor` command without any fakes or mocks. Use a fake command instead.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/58543.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*