### PR TITLE
[flutter tools] Add Logger.dispose()

### DIFF
--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -15,7 +15,6 @@ import 'src/base/file_system.dart';
 import 'src/base/io.dart';
 import 'src/base/logger.dart';
 import 'src/base/process.dart';
-import 'src/base/signals.dart';
 import 'src/context_runner.dart';
 import 'src/doctor.dart';
 import 'src/globals.dart' as globals;
@@ -55,11 +54,8 @@ Future<int> run(
     );
 
     String getVersion() => flutterVersion ?? globals.flutterVersion.getVersionString(redactUnknownBranches: true);
-    Future<void> disposeLogger(ProcessSignal signal) => globals.logger.dispose();
 
-    for (final ProcessSignal exitSignal in Signals.defaultExitSignals) {
-      globals.signals.addHandler(exitSignal, disposeLogger);
-    }
+    globals.logger.registerForDisposal(shutdownHooks: shutdownHooks, signals: globals.signals);
 
     Object firstError;
     StackTrace firstStackTrace;
@@ -247,8 +243,6 @@ Future<int> _exit(int code) async {
   await shutdownHooks.runShutdownHooks();
 
   final Completer<void> completer = Completer<void>();
-
-  await globals.logger.dispose();
 
   // Give the task / timer queue one cycle through before we hard exit.
   Timer.run(() {

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -70,9 +70,6 @@ abstract class Logger {
   @mustCallSuper
   Future<void> dispose() async {}
 
-  /// If the [Logger] is writing to a file, flushes pending output.
-  Future<void> flush() async {}
-
   /// Display an error `message` to the user. Commands should use this if they
   /// fail in some way.
   ///

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -64,6 +64,15 @@ abstract class Logger {
 
   TimeoutConfiguration get _timeoutConfiguration;
 
+  /// Closes any resources used by the [Logger].
+  ///
+  /// This should be idempotent.
+  @mustCallSuper
+  Future<void> dispose() async {}
+
+  /// If the [Logger] is writing to a file, flushes pending output.
+  Future<void> flush() async {}
+
   /// Display an error `message` to the user. Commands should use this if they
   /// fail in some way.
   ///

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -13,6 +13,8 @@ import '../base/context.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
+import '../base/process.dart';
+import '../base/signals.dart';
 import '../base/terminal.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
@@ -986,7 +988,11 @@ class NotifyingLogger extends Logger {
   }
 
   @override
-  void registerForDisposal(Signals signals) {}
+  void registerForDisposal({
+    @required ShutdownHooks shutdownHooks,
+    @required Signals signals,
+    List<ProcessSignal> fatalSignals,
+  }) {}
 
   @override
   void sendEvent(String name, [Map<String, dynamic> args]) { }

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -986,6 +986,9 @@ class NotifyingLogger extends Logger {
   }
 
   @override
+  void registerForDisposal(Signals signals) {}
+
+  @override
   void sendEvent(String name, [Map<String, dynamic> args]) { }
 
   @override

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -979,8 +979,10 @@ class NotifyingLogger extends Logger {
     );
   }
 
-  void dispose() {
+  @override
+  Future<void> dispose() {
     _messageController.close();
+    return super.dispose();
   }
 
   @override

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1543,7 +1543,6 @@ class TerminalHandler {
       rethrow;
     } finally {
       _processingUserRequest = false;
-      await globals.logger.flush();
     }
   }
 

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1543,6 +1543,7 @@ class TerminalHandler {
       rethrow;
     } finally {
       _processingUserRequest = false;
+      await globals.logger.flush();
     }
   }
 

--- a/packages/flutter_tools/test/general.shard/base/logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/logger_test.dart
@@ -978,8 +978,8 @@ void main() {
   });
 
   testUsingContext('Registered Logger is disposed of on a fatal signal', () async {
-    MockIoProcessSignal mockSignal = MockIoProcessSignal();
-    StreamController<ProcessSignal> controller = StreamController<ProcessSignal>();
+    final MockIoProcessSignal mockSignal = MockIoProcessSignal();
+    final StreamController<ProcessSignal> controller = StreamController<ProcessSignal>();
 
     when(mockSignal.watch()).thenAnswer((Invocation invocation) => controller.stream);
 
@@ -991,7 +991,7 @@ void main() {
     testLogger.registerForDisposal(
       shutdownHooks: MockShutdownHooks(),
       signals: signals,
-      fatalSignals: [mockSignal],
+      fatalSignals: <ProcessSignal>[mockSignal],
     );
 
     signals.addHandler(mockSignal, (ProcessSignal s) => completer.complete());

--- a/packages/flutter_tools/test/src/testbed.dart
+++ b/packages/flutter_tools/test/src/testbed.dart
@@ -782,6 +782,9 @@ class DelegateLogger implements Logger {
   Future<void> dispose() => delegate.dispose();
 
   @override
+  void registerForDisposal(Signals signals) => delegate.registerForDisposal(signals);
+
+  @override
   void printError(String message, {StackTrace stackTrace, bool emphasis, TerminalColor color, int indent, int hangingIndent, bool wrap}) {
     delegate.printError(
       message,

--- a/packages/flutter_tools/test/src/testbed.dart
+++ b/packages/flutter_tools/test/src/testbed.dart
@@ -782,7 +782,17 @@ class DelegateLogger implements Logger {
   Future<void> dispose() => delegate.dispose();
 
   @override
-  void registerForDisposal(Signals signals) => delegate.registerForDisposal(signals);
+  void registerForDisposal({
+    @required ShutdownHooks shutdownHooks,
+    @required Signals signals,
+    List<ProcessSignal> fatalSignals,
+  }) {
+    delegate.registerForDisposal(
+      shutdownHooks: shutdownHooks,
+      signals: signals,
+      fatalSignals: fatalSignals,
+    );
+  }
 
   @override
   void printError(String message, {StackTrace stackTrace, bool emphasis, TerminalColor color, int indent, int hangingIndent, bool wrap}) {

--- a/packages/flutter_tools/test/src/testbed.dart
+++ b/packages/flutter_tools/test/src/testbed.dart
@@ -779,6 +779,12 @@ class DelegateLogger implements Logger {
   bool get isVerbose => delegate.isVerbose;
 
   @override
+  Future<void> dispose() => delegate.dispose();
+
+  @override
+  Future<void> flush() => delegate.flush();
+
+  @override
   void printError(String message, {StackTrace stackTrace, bool emphasis, TerminalColor color, int indent, int hangingIndent, bool wrap}) {
     delegate.printError(
       message,

--- a/packages/flutter_tools/test/src/testbed.dart
+++ b/packages/flutter_tools/test/src/testbed.dart
@@ -782,9 +782,6 @@ class DelegateLogger implements Logger {
   Future<void> dispose() => delegate.dispose();
 
   @override
-  Future<void> flush() => delegate.flush();
-
-  @override
   void printError(String message, {StackTrace stackTrace, bool emphasis, TerminalColor color, int indent, int hangingIndent, bool wrap}) {
     delegate.printError(
       message,


### PR DESCRIPTION
[flutter tools] Add  Logger.dispose()

I would like to override the default `Logger` in google3 with an
implementation that logs all output to a file.  I'd prefer not to use
`File.writeAsStringSync` to avoid opening and closing the log file on
every write.  For correctness, however, if we keep an open file handle
around, we should close it too.

Add a `.dispose()` method to the `Logger` interface and call it in a few
key places before calling `exit()`.

## Tests

None.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
