### PR TITLE
Remove already covered devicelab test: tiles_scroll_perf_iphonexs__timeline_summary

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -445,13 +445,6 @@ tasks:
     stage: devicelab_ios
     required_agent_capabilities: ["mac/ios"]
 
-  tiles_scroll_perf_iphonexs__timeline_summary:
-    description: >
-      Measures the runtime performance of the tiles tab in the Complex Layout sample app on iPhone XS.
-    stage: devicelab_ios
-    # TODO(keyonghan): change with https://github.com/flutter/flutter/issues/50383
-    required_agent_capabilities: ["mac/ios"]
-
   platform_views_scroll_perf_ios__timeline_summary:
     description: >
       Measures the runtime performance of platform views in the Complex Layout sample app on iPhone 6.


### PR DESCRIPTION
## Description

DeviceLab test `tiles_scroll_perf_iphonexs__timeline_summary` has been running on 6s for months, and `tiles_scroll__perf_ios` is already covering the same test on iPhone 6s.

This PR removes that test.

## Related Issues

https://github.com/flutter/flutter/issues/50383
