### PR TITLE
Revert "Don't elapse real time during IOSDevice.startApp tests"

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -300,7 +300,6 @@ class IOSDevice extends Device {
     Map<String, dynamic> platformArgs,
     bool prebuiltApplication = false,
     bool ipv6 = false,
-    @visibleForTesting Duration fallbackPollingDelay,
   }) async {
     String packageId;
 
@@ -417,7 +416,6 @@ class IOSDevice extends Device {
         portForwarder: portForwarder,
         protocolDiscovery: observatoryDiscovery,
         flutterUsage: globals.flutterUsage,
-        pollingDelay: fallbackPollingDelay,
       );
       final Uri localUri = await fallbackDiscovery.discover(
         assumedDevicePort: assumedObservatoryPort,

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -129,7 +129,6 @@ void main() {
       prebuiltApplication: true,
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
       platformArgs: <String, dynamic>{},
-      fallbackPollingDelay: Duration.zero,
     );
 
     verify(globals.flutterUsage.sendEvent('ios-handshake', 'mdns-success')).called(1);
@@ -174,7 +173,6 @@ void main() {
       prebuiltApplication: true,
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
       platformArgs: <String, dynamic>{},
-      fallbackPollingDelay: Duration.zero,
     );
 
     expect(launchResult.started, true);
@@ -221,7 +219,6 @@ void main() {
       prebuiltApplication: true,
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
       platformArgs: <String, dynamic>{},
-      fallbackPollingDelay: Duration.zero,
     );
 
     expect(launchResult.started, false);
@@ -260,7 +257,6 @@ void main() {
       prebuiltApplication: true,
       debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
       platformArgs: <String, dynamic>{},
-      fallbackPollingDelay: Duration.zero,
     );
 
     expect(launchResult.started, true);
@@ -351,7 +347,6 @@ void main() {
         verboseSystemLogs: true,
       ),
       platformArgs: <String, dynamic>{},
-      fallbackPollingDelay: Duration.zero,
     );
 
     expect(launchResult.started, true);


### PR DESCRIPTION
Reverts flutter/flutter#58538

Missing null check:
```
2020-06-03T09:44:17.491336: stderr: Oops; flutter has exited unexpectedly: "NoSuchMethodError: The getter 'inMilliseconds' was called on null.
stderr: Receiver: null
stderr: Tried calling: inMilliseconds".
```
[platform_views_scroll_perf_ios__timeline_summary_27186c7_2.log](https://github.com/flutter/flutter/files/4725429/platform_views_scroll_perf_ios__timeline_summary_27186c7_2.log)
