### PR TITLE
Make debugSemantics available to profile mode

### DIFF
--- a/dev/integration_tests/flutter_gallery/test_driver/transitions_perf_test.dart
+++ b/dev/integration_tests/flutter_gallery/test_driver/transitions_perf_test.dart
@@ -190,6 +190,7 @@ Future<void> runDemos(List<String> demos, FlutterDriver driver) async {
 }
 
 void main([List<String> args = const <String>[]]) {
+  final bool withSemantics = args.contains('--with_semantics');
   group('flutter gallery transitions', () {
     FlutterDriver driver;
     setUpAll(() async {
@@ -197,8 +198,7 @@ void main([List<String> args = const <String>[]]) {
 
       // Wait for the first frame to be rasterized.
       await driver.waitUntilFirstFrameRasterized();
-
-      if (args.contains('--with_semantics')) {
+      if (withSemantics) {
         print('Enabeling semantics...');
         await driver.setSemantics(true);
       }
@@ -213,6 +213,12 @@ void main([List<String> args = const <String>[]]) {
       if (driver != null)
         await driver.close();
     });
+
+    test('find.bySemanticsLabel', () async {
+      // Assert that we can use semantics related finders in profile mode.
+      final int id = await driver.getSemanticsId(find.bySemanticsLabel('Material'));
+      expect(id, greaterThan(-1));
+    }, skip: !withSemantics);
 
     test('all demos', () async {
       // Collect timeline data for just a limited set of demos to avoid OOMs.

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2482,15 +2482,13 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   /// render objects in production, obtain a [SemanticsHandle] from
   /// [PipelineOwner.ensureSemantics].
   ///
-  /// Only valid when asserts are enabled. In release builds, always returns
+  /// Only valid in debug and profile mode. In release builds, always returns
   /// null.
   SemanticsNode get debugSemantics {
-    SemanticsNode result;
-    assert(() {
-      result = _semantics;
-      return true;
-    }());
-    return result;
+    if (!kReleaseMode) {
+      return _semantics;
+    }
+    return null;
   }
 
   /// Removes all semantics from this render object and its descendants.


### PR DESCRIPTION
## Description

`debugSemantics` on `RenderObject` only works when asserts are enabled - this means on device testing in profile mode isn't working for finders like `bySemanticsLabel` or `driver.getSemanticsId`. This changes that so it's based on `kReleaseMode` instead, and adds another test to a semantic enabled driver test running in profile mode.

/cc @albertwang0116

## Related Issues

Fixes https://github.com/flutter/flutter/issues/58612

## Tests

I added the following tests:

Added a test for transition perf with semantics, which runs in profile mode.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
