### PR TITLE
Make it possible to remove nodes from traversal sort.

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -256,16 +256,16 @@ abstract class FocusTraversalPolicy with Diagnosticable {
   /// node that is a descendant of the given scope, then the user will be unable
   /// to use next/previous keyboard traversal to reach that node.
   ///
-  /// If a removed node is used as the originator of a call to next/previous
-  /// (i.e. supplied as the argument to [next] or [previous]), then the next or
-  /// previous node will not be able to be determined and the focus will not
-  /// change, and [next] or [previous] will return false.
+  /// The node used to initiate the traversal (the one passed to [next] or
+  /// [previous]) is passed as `currentNode`.
+  ///
+  /// Having the current node in the list is what allows the algorithm to
+  /// determine which nodes are adjacent to the current node. If the
+  /// `currentNode` is removed from the list, then the focus will be unchanged
+  /// when [next] or [previous] are called, and they will return false.
   ///
   /// This is not used for directional focus ([inDirection]), only for
   /// determining the focus order for [next] and [previous].
-  ///
-  /// The node used to initiate the traversal (the one passed to [next] or
-  /// [previous]) is passed as `currentNode`.
   ///
   /// When implementing an override for this function, be sure to use
   /// [mergeSort] instead of Dart's default list sorting algorithm when sorting

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -167,7 +167,7 @@ abstract class FocusTraversalPolicy with Diagnosticable {
     final FocusScopeNode scope = currentNode.nearestScope;
     FocusNode candidate = scope.focusedChild;
     if (candidate == null && scope.descendants.isNotEmpty) {
-      final Iterable<FocusNode> sorted = _sortAllDescendants(scope);
+      final Iterable<FocusNode> sorted = _sortAllDescendants(scope, currentNode);
       if (sorted.isEmpty) {
         candidate = null;
       } else {
@@ -254,13 +254,18 @@ abstract class FocusTraversalPolicy with Diagnosticable {
   /// Subclasses should override this to implement a different sort for [next]
   /// and [previous] to use in their ordering. If the returned iterable omits a
   /// node that is a descendant of the given scope, then the user will be unable
-  /// to use next/previous keyboard traversal to reach that node, and if that
-  /// node is used as the originator of a call to next/previous (i.e. supplied
-  /// as the argument to [next] or [previous]), then the next or previous node
-  /// will not be able to be determined and the focus will not change.
+  /// to use next/previous keyboard traversal to reach that node.
+  ///
+  /// If a removed node is used as the originator of a call to next/previous
+  /// (i.e. supplied as the argument to [next] or [previous]), then the next or
+  /// previous node will not be able to be determined and the focus will not
+  /// change, and [next] or [previous] will return false.
   ///
   /// This is not used for directional focus ([inDirection]), only for
   /// determining the focus order for [next] and [previous].
+  ///
+  /// The node used to initiate the traversal (the one passed to [next] or
+  /// [previous]) is passed as `currentNode`.
   ///
   /// When implementing an override for this function, be sure to use
   /// [mergeSort] instead of Dart's default list sorting algorithm when sorting
@@ -268,7 +273,7 @@ abstract class FocusTraversalPolicy with Diagnosticable {
   /// can appear in arbitrary order, and change positions between sorts), whereas
   /// [mergeSort] is stable.
   @protected
-  Iterable<FocusNode> sortDescendants(Iterable<FocusNode> descendants);
+  Iterable<FocusNode> sortDescendants(Iterable<FocusNode> descendants, FocusNode currentNode);
 
   _FocusTraversalGroupMarker _getMarker(BuildContext context) {
     return context?.getElementForInheritedWidgetOfExactType<_FocusTraversalGroupMarker>()?.widget as _FocusTraversalGroupMarker;
@@ -276,7 +281,7 @@ abstract class FocusTraversalPolicy with Diagnosticable {
 
   // Sort all descendants, taking into account the FocusTraversalGroup
   // that they are each in, and filtering out non-traversable/focusable nodes.
-  List<FocusNode> _sortAllDescendants(FocusScopeNode scope) {
+  List<FocusNode> _sortAllDescendants(FocusScopeNode scope, FocusNode currentNode) {
     assert(scope != null);
     final _FocusTraversalGroupMarker scopeGroupMarker = _getMarker(scope.context);
     final FocusTraversalPolicy defaultPolicy = scopeGroupMarker?.policy ?? ReadingOrderTraversalPolicy();
@@ -314,7 +319,7 @@ abstract class FocusTraversalPolicy with Diagnosticable {
     // Sort the member lists using the individual policy sorts.
     final Set<FocusNode> groupKeys = groups.keys.toSet();
     for (final FocusNode key in groups.keys) {
-      final List<FocusNode> sortedMembers = groups[key].policy.sortDescendants(groups[key].members).toList();
+      final List<FocusNode> sortedMembers = groups[key].policy.sortDescendants(groups[key].members, currentNode).toList();
       groups[key].members.clear();
       groups[key].members.addAll(sortedMembers);
     }
@@ -336,12 +341,8 @@ abstract class FocusTraversalPolicy with Diagnosticable {
 
     visitGroups(groups[scopeGroupMarker?.focusNode]);
     assert(
-      sortedDescendants.toSet().difference(scope.traversalDescendants.toSet()).isEmpty,
+      sortedDescendants.length <= scope.traversalDescendants.length && sortedDescendants.toSet().difference(scope.traversalDescendants.toSet()).isEmpty,
       'sorted descendants contains more nodes than it should: (${sortedDescendants.toSet().difference(scope.traversalDescendants.toSet())})'
-    );
-    assert(
-      scope.traversalDescendants.toSet().difference(sortedDescendants.toSet()).isEmpty,
-      'sorted descendants are missing some nodes: (${scope.traversalDescendants.toSet().difference(sortedDescendants.toSet())})'
     );
     return sortedDescendants;
   }
@@ -379,7 +380,7 @@ abstract class FocusTraversalPolicy with Diagnosticable {
         return true;
       }
     }
-    final List<FocusNode> sortedNodes = _sortAllDescendants(nearestScope);
+    final List<FocusNode> sortedNodes = _sortAllDescendants(nearestScope, currentNode);
     if (forward && focusedChild == sortedNodes.last) {
       _focusAndEnsureVisible(sortedNodes.first, alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd);
       return true;
@@ -830,7 +831,7 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
 ///    explicitly using [FocusTraversalOrder] widgets.
 class WidgetOrderTraversalPolicy extends FocusTraversalPolicy with DirectionalFocusTraversalPolicyMixin {
   @override
-  Iterable<FocusNode> sortDescendants(Iterable<FocusNode> descendants) => descendants;
+  Iterable<FocusNode> sortDescendants(Iterable<FocusNode> descendants, FocusNode currentNode) => descendants;
 }
 
 // This class exists mainly for efficiency reasons: the rect is copied out of
@@ -1084,7 +1085,7 @@ class ReadingOrderTraversalPolicy extends FocusTraversalPolicy with DirectionalF
   // Sorts the list of nodes based on their geometry into the desired reading
   // order based on the directionality of the context for each node.
   @override
-  Iterable<FocusNode> sortDescendants(Iterable<FocusNode> descendants) {
+  Iterable<FocusNode> sortDescendants(Iterable<FocusNode> descendants, FocusNode currentNode) {
     assert(descendants != null);
     if (descendants.length <= 1) {
       return descendants;
@@ -1368,9 +1369,9 @@ class OrderedTraversalPolicy extends FocusTraversalPolicy with DirectionalFocusT
   final FocusTraversalPolicy secondary;
 
   @override
-  Iterable<FocusNode> sortDescendants(Iterable<FocusNode> descendants) {
+  Iterable<FocusNode> sortDescendants(Iterable<FocusNode> descendants, FocusNode currentNode) {
     final FocusTraversalPolicy secondaryPolicy = secondary ?? ReadingOrderTraversalPolicy();
-    final Iterable<FocusNode> sortedDescendants = secondaryPolicy.sortDescendants(descendants);
+    final Iterable<FocusNode> sortedDescendants = secondaryPolicy.sortDescendants(descendants, currentNode);
     final List<FocusNode> unordered = <FocusNode>[];
     final List<_OrderedFocusInfo> ordered = <_OrderedFocusInfo>[];
     for (final FocusNode node in sortedDescendants) {

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -275,6 +275,7 @@ class ShortcutManager extends ChangeNotifier with Diagnosticable {
   Map<LogicalKeySet, Intent> get shortcuts => _shortcuts;
   Map<LogicalKeySet, Intent> _shortcuts;
   set shortcuts(Map<LogicalKeySet, Intent> value) {
+    assert(value != null);
     if (!mapEquals<LogicalKeySet, Intent>(_shortcuts, value)) {
       _shortcuts = value;
       notifyListeners();
@@ -349,16 +350,18 @@ class ShortcutManager extends ChangeNotifier with Diagnosticable {
 ///    invoked.
 ///  * [Action], a class for defining an invocation of a user action.
 class Shortcuts extends StatefulWidget {
-  /// Creates a ActionManager object.
+  /// Creates a const [Shortcuts] widget.
   ///
-  /// The [child] argument must not be null.
+  /// The [child] and [shortcuts] arguments are required and must not be null.
   const Shortcuts({
     Key key,
     this.manager,
-    this.shortcuts,
-    this.child,
+    @required this.shortcuts,
+    @required this.child,
     this.debugLabel,
-  }) : super(key: key);
+  }) : assert(shortcuts != null),
+       assert(child != null),
+       super(key: key);
 
   /// The [ShortcutManager] that will manage the mapping between key
   /// combinations and [Action]s.

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -191,18 +191,24 @@ void main() {
         LogicalKeyboardKey.keyB,
       ).debugFillProperties(builder);
 
-      final List<String> description = builder.properties
-          .where((DiagnosticsNode node) {
-            return !node.isFiltered(DiagnosticLevel.info);
-          })
-          .map((DiagnosticsNode node) => node.toString())
-          .toList();
+      final List<String> description = builder.properties.where((DiagnosticsNode node) {
+        return !node.isFiltered(DiagnosticLevel.info);
+      }).map((DiagnosticsNode node) => node.toString()).toList();
 
       expect(description.length, equals(1));
       expect(description[0], equals('keys: Key A + Key B'));
     });
   });
   group(Shortcuts, () {
+    testWidgets('Default constructed Shortcuts has empty shortcuts', (WidgetTester tester) async {
+      final ShortcutManager manager = ShortcutManager();
+      expect(manager.shortcuts, isNotNull);
+      expect(manager.shortcuts, isEmpty);
+      const Shortcuts shortcuts = Shortcuts(shortcuts: <LogicalKeySet, Intent>{}, child: SizedBox());
+      await tester.pumpWidget(shortcuts);
+      expect(shortcuts.shortcuts, isNotNull);
+      expect(shortcuts.shortcuts, isEmpty);
+    });
     testWidgets('ShortcutManager handles shortcuts', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       final List<LogicalKeyboardKey> pressedKeys = <LogicalKeyboardKey>[];
@@ -317,21 +323,23 @@ void main() {
     test('Shortcuts diagnostics work.', () {
       final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
 
-      Shortcuts(shortcuts: <LogicalKeySet, Intent>{LogicalKeySet(
-        LogicalKeyboardKey.shift,
-        LogicalKeyboardKey.keyA,
-      ) : const ActivateIntent(),
-        LogicalKeySet(
-        LogicalKeyboardKey.shift,
-        LogicalKeyboardKey.arrowRight,
-      ) : const DirectionalFocusIntent(TraversalDirection.right)}).debugFillProperties(builder);
+      Shortcuts(
+        shortcuts: <LogicalKeySet, Intent>{
+          LogicalKeySet(
+            LogicalKeyboardKey.shift,
+            LogicalKeyboardKey.keyA,
+          ): const ActivateIntent(),
+          LogicalKeySet(
+            LogicalKeyboardKey.shift,
+            LogicalKeyboardKey.arrowRight,
+          ): const DirectionalFocusIntent(TraversalDirection.right)
+        },
+        child: const SizedBox(),
+      ).debugFillProperties(builder);
 
-      final List<String> description = builder.properties
-          .where((DiagnosticsNode node) {
+      final List<String> description = builder.properties.where((DiagnosticsNode node) {
         return !node.isFiltered(DiagnosticLevel.info);
-      })
-          .map((DiagnosticsNode node) => node.toString())
-          .toList();
+      }).map((DiagnosticsNode node) => node.toString()).toList();
 
       expect(description.length, equals(1));
       expect(
@@ -350,14 +358,12 @@ void main() {
             LogicalKeyboardKey.keyB,
           ): const ActivateIntent(),
         },
+        child: const SizedBox(),
       ).debugFillProperties(builder);
 
-      final List<String> description = builder.properties
-          .where((DiagnosticsNode node) {
+      final List<String> description = builder.properties.where((DiagnosticsNode node) {
         return !node.isFiltered(DiagnosticLevel.info);
-      })
-          .map((DiagnosticsNode node) => node.toString())
-          .toList();
+      }).map((DiagnosticsNode node) => node.toString()).toList();
 
       expect(description.length, equals(1));
       expect(description[0], equals('shortcuts: <Debug Label>'));
@@ -373,14 +379,12 @@ void main() {
             LogicalKeyboardKey.keyB,
           ): const ActivateIntent(),
         },
+        child: const SizedBox(),
       ).debugFillProperties(builder);
 
-      final List<String> description = builder.properties
-          .where((DiagnosticsNode node) {
+      final List<String> description = builder.properties.where((DiagnosticsNode node) {
         return !node.isFiltered(DiagnosticLevel.info);
-      })
-          .map((DiagnosticsNode node) => node.toString())
-          .toList();
+      }).map((DiagnosticsNode node) => node.toString()).toList();
 
       expect(description.length, equals(2));
       expect(description[0], equalsIgnoringHashCodes('manager: ShortcutManager#00000(shortcuts: {})'));


### PR DESCRIPTION
## Description

Removes an assert to allow a `FocusTraversalPolicy` subclass to remove nodes when `sortDescendants` is called so that they can control which nodes are traversed to just by removing them from the list.

Also added an additional parameter to `sortDescendants` to give the `currentNode` that was passed to next or previous so that the sort algorithm can be sure to place the `currentNode` in the list even if it is removing other nodes. Having the current node in the list allows the algorithm to determine which nodes are adjacent to it. If the `currentNode` is removed from the list, then the focus will be unchanged when next or previous are called.

## Tests

- Added a test that removes results from the `sortDescendants` list.

## Breaking Change

- [X] No, this is *not* a breaking change, as no submitted customer tests override `sortDescendants`.