### PR TITLE
Don't elapse real time during IOSDevice.startApp tests

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -300,6 +300,7 @@ class IOSDevice extends Device {
     Map<String, dynamic> platformArgs,
     bool prebuiltApplication = false,
     bool ipv6 = false,
+    @visibleForTesting Duration fallbackPollingDelay,
   }) async {
     String packageId;
 
@@ -416,6 +417,7 @@ class IOSDevice extends Device {
         portForwarder: portForwarder,
         protocolDiscovery: observatoryDiscovery,
         flutterUsage: globals.flutterUsage,
+        pollingDelay: fallbackPollingDelay,
       );
       final Uri localUri = await fallbackDiscovery.discover(
         assumedDevicePort: assumedObservatoryPort,

--- a/packages/flutter_tools/lib/src/ios/fallback_discovery.dart
+++ b/packages/flutter_tools/lib/src/ios/fallback_discovery.dart
@@ -46,14 +46,14 @@ class FallbackDiscovery {
     @required Usage flutterUsage,
     VmServiceConnector vmServiceConnectUri =
       vm_service_io.vmServiceConnectUri,
-    Duration pollingDelay = const Duration(seconds: 2),
+    Duration pollingDelay,
   }) : _logger = logger,
        _mDnsObservatoryDiscovery = mDnsObservatoryDiscovery,
        _portForwarder = portForwarder,
        _protocolDiscovery = protocolDiscovery,
        _flutterUsage = flutterUsage,
        _vmServiceConnectUri = vmServiceConnectUri,
-       _pollingDelay = pollingDelay;
+       _pollingDelay = pollingDelay ?? const Duration(seconds: 2);
 
   static const String _kEventName = 'ios-handshake';
 

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -129,6 +129,7 @@ void main() {
       prebuiltApplication: true,
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
       platformArgs: <String, dynamic>{},
+      fallbackPollingDelay: Duration.zero,
     );
 
     verify(globals.flutterUsage.sendEvent('ios-handshake', 'mdns-success')).called(1);
@@ -173,6 +174,7 @@ void main() {
       prebuiltApplication: true,
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
       platformArgs: <String, dynamic>{},
+      fallbackPollingDelay: Duration.zero,
     );
 
     expect(launchResult.started, true);
@@ -219,6 +221,7 @@ void main() {
       prebuiltApplication: true,
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
       platformArgs: <String, dynamic>{},
+      fallbackPollingDelay: Duration.zero,
     );
 
     expect(launchResult.started, false);
@@ -257,6 +260,7 @@ void main() {
       prebuiltApplication: true,
       debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
       platformArgs: <String, dynamic>{},
+      fallbackPollingDelay: Duration.zero,
     );
 
     expect(launchResult.started, true);
@@ -347,6 +351,7 @@ void main() {
         verboseSystemLogs: true,
       ),
       platformArgs: <String, dynamic>{},
+      fallbackPollingDelay: Duration.zero,
     );
 
     expect(launchResult.started, true);


### PR DESCRIPTION
## Description

Another attempt at https://github.com/flutter/flutter/pull/58538.