### PR TITLE
Remove DiagnosticableMixin in favor of Diagnosticable

### DIFF
--- a/dev/manual_tests/lib/actions.dart
+++ b/dev/manual_tests/lib/actions.dart
@@ -22,7 +22,7 @@ void main() {
 ///
 /// Instances of this class are returned from [UndoableAction]s and placed on
 /// the undo stack when they are invoked.
-class Memento extends Object with DiagnosticableMixin implements Diagnosticable {
+class Memento extends Object with Diagnosticable {
   const Memento({
     @required this.name,
     @required this.undo,

--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -2913,7 +2913,7 @@ class DiagnosticsProperty<T> extends DiagnosticsNode {
 /// [DiagnosticsNode] that lazily calls the associated [Diagnosticable] [value]
 /// to implement [getChildren] and [getProperties].
 class DiagnosticableNode<T extends Diagnosticable> extends DiagnosticsNode {
-  /// Create a diagnostics describing a [DiagnosticableMixin] value.
+  /// Create a diagnostics describing a [Diagnosticable] value.
   ///
   /// The [value] argument must not be null.
   DiagnosticableNode({
@@ -3040,7 +3040,7 @@ String describeEnum(Object enumEntry) {
 }
 
 /// Builder to accumulate properties and configuration used to assemble a
-/// [DiagnosticsNode] from a [DiagnosticableMixin] object.
+/// [DiagnosticsNode] from a [Diagnosticable] object.
 class DiagnosticPropertiesBuilder {
   /// Creates a [DiagnosticPropertiesBuilder] with [properties] initialize to
   /// an empty array.
@@ -3065,48 +3065,6 @@ class DiagnosticPropertiesBuilder {
 
   /// Description to show if the node has no displayed properties or children.
   String emptyBodyDescription;
-}
-
-// TODO(gspencergoog): Remove DiagnosticableMixin once the mixin Diagnosticable is in stable.
-// https://github.com/flutter/flutter/issues/50498
-
-/// A mixin class implementing the [Diagnosticable] interface that provides
-/// string and [DiagnosticsNode] debug representations describing the properties
-/// of an object.
-///
-/// _This mixin exists only to support plugins and packages that require older
-/// Flutter versions: Use the identical mixin [Diagnosticable] instead for all
-/// new code. If you are authoring code that needs to work on the stable branch
-/// as well as master (in a package, for instance), mix this in instead of
-/// extending [Diagnosticable]. Once [Diagnosticable] as a mixin reaches the
-/// stable channel, this class will be deprecated._
-mixin DiagnosticableMixin implements Diagnosticable {
-  @override
-  String toStringShort() => describeIdentity(this);
-
-  @override
-  String toString({ DiagnosticLevel minLevel = DiagnosticLevel.info }) {
-    String fullString;
-    assert(() {
-      fullString = toDiagnosticsNode(style: DiagnosticsTreeStyle.singleLine).toString(minLevel: minLevel);
-      return true;
-    }());
-    return fullString ?? toStringShort();
-  }
-
-  @override
-  DiagnosticsNode toDiagnosticsNode({ String name, DiagnosticsTreeStyle style }) {
-    return DiagnosticableNode<Diagnosticable>(
-      name: name,
-      value: this,
-      style: style,
-    );
-  }
-
-  @override
-  @protected
-  @mustCallSuper
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) { }
 }
 
 // Examples can assume:
@@ -3395,7 +3353,7 @@ mixin Diagnosticable {
 /// See also:
 ///
 ///  * [DiagnosticableTreeMixin], a mixin that implements this class.
-///  * [DiagnosticableMixin], which should be used instead of this class to
+///  * [Diagnosticable], which should be used instead of this class to
 ///    provide diagnostics for objects without children.
 abstract class DiagnosticableTree with Diagnosticable {
   /// Abstract const constructor. This constructor enables subclasses to provide
@@ -3712,7 +3670,7 @@ abstract class DiagnosticsSerializationDelegate {
   ///    will be included.
   bool get includeProperties;
 
-  /// Whether properties that have a [DiagnosticableMixin] as value should be
+  /// Whether properties that have a [Diagnosticable] as value should be
   /// expanded.
   bool get expandPropertyValues;
 

--- a/packages/flutter/lib/src/scheduler/ticker.dart
+++ b/packages/flutter/lib/src/scheduler/ticker.dart
@@ -41,7 +41,7 @@ abstract class TickerProvider {
   Ticker createTicker(TickerCallback onTick);
 }
 
-// TODO(jacobr): make Ticker use DiagnosticableMixin to simplify reporting errors
+// TODO(jacobr): make Ticker use Diagnosticable to simplify reporting errors
 // related to a ticker.
 /// Calls its callback once per animation frame.
 ///


### PR DESCRIPTION
## Description

This removes `DiagnosticableMixin`, since it is a duplicate implementation of `Diagnosticable`. It existed in order to support plugins that wanted to support both master and stable, but now `Diagnosticable` is a mixin on stable, so we don't need it anymore.

## Related Issues

- Fixes https://github.com/flutter/flutter/issues/50498

## Breaking Change

- [X] No, this is not a breaking change, since no submitted customer tests use `DiagnosticableMixin`.