### PR TITLE
Add FakeAsync to delay tests

### DIFF
--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -261,16 +261,19 @@ void main() {
         ])
       );
 
-      final LaunchResult launchResult = await iosDevice.startApp(
-        buildableIOSApp,
-        debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
-        platformArgs: <String, Object>{},
-      );
+      FakeAsync().run((FakeAsync time) async {
+        final LaunchResult launchResult = await iosDevice.startApp(
+          buildableIOSApp,
+          debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+          platformArgs: <String, Object>{},
+        );
+        time.elapse(const Duration(seconds: 2));
 
-      expect(logger.statusText,
-        contains('Xcode build failed due to concurrent builds, will retry in 2 seconds'));
-      expect(launchResult.started, true);
-      expect(processManager.hasRemainingExpectations, false);
+        expect(logger.statusText,
+          contains('Xcode build failed due to concurrent builds, will retry in 2 seconds'));
+        expect(launchResult.started, true);
+        expect(processManager.hasRemainingExpectations, false);
+      });
     }, overrides: <Type, Generator>{
       ProcessManager: () => processManager,
       FileSystem: () => fileSystem,


### PR DESCRIPTION
## Description

Track down more tests that are actually running delayed code, add `FakeAsync`. These tests now take in the 10-100s of ms instead of >2 seconds.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*