### PR TITLE
Add iOS new gallery perf test

### DIFF
--- a/dev/devicelab/bin/tasks/new_gallery_ios__transition_perf.dart
+++ b/dev/devicelab/bin/tasks/new_gallery_ios__transition_perf.dart
@@ -1,0 +1,25 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_devicelab/framework/utils.dart';
+import 'package:flutter_devicelab/tasks/new_gallery.dart';
+import 'package:flutter_devicelab/framework/adb.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:path/path.dart' as path;
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.ios;
+
+  final Directory galleryParentDir = Directory.systemTemp.createTempSync('new_gallery_test');
+  final Directory galleryDir = Directory(path.join(galleryParentDir.path, 'gallery'));
+
+  try {
+    await task(NewGalleryPerfTest(galleryDir).run);
+  } finally {
+    rmTree(galleryParentDir);
+  }
+}

--- a/dev/devicelab/lib/tasks/new_gallery.dart
+++ b/dev/devicelab/lib/tasks/new_gallery.dart
@@ -19,7 +19,7 @@ class NewGalleryPerfTest extends PerfTest {
     // Manually roll the new gallery version for now. If the new gallery repo
     // turns out to be updated frequently in the future, we can set up an auto
     // roller to update this version.
-    await getNewGallery('c1682ac4b35dc239f023eaf0238a98910b3a2d6c', galleryDir);
+    await getNewGallery('62e633b9e9360ee57dafaaeabbb7fbf85e7642d1', galleryDir);
     return await super.run();
   }
 

--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -765,6 +765,13 @@ tasks:
     stage: devicelab
     required_agent_capabilities: ["mac/android"]
 
+  new_gallery_ios__transition_perf:
+    description: >
+      Measures the performance of screen transitions in the new Flutter Gallery on iOS.
+    stage: devicelab
+    required_agent_capabilities: ["mac/ios"]
+    flaky: true
+
   fast_scroll_large_images__memory:
     description: >
       Measures memory usage for scrolling through a list of large images.


### PR DESCRIPTION
This is a follow up of https://github.com/flutter/flutter/pull/55181 to add the same test to iOS.

Related issue: https://github.com/flutter/gallery/issues/45