### PR TITLE
Add per-test timeout to Cirrus tool general tests

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -326,6 +326,8 @@ Future<void> _runToolTests() async {
         testPaths: <String>[path.join(kTest, '$subshard$kDotShard', suffix)],
         tableData: bigqueryApi?.tabledata,
         enableFlutterToolAsserts: true,
+        // Detect unit test time regressions (poor time delay handling, etc).
+        perTestTimeout: (subshard == 'general') ? const Duration(seconds: 2) : null,
       );
     },
   );
@@ -933,6 +935,7 @@ Future<void> _pubRunTest(String workingDirectory, {
   String coverage,
   bq.TabledataResourceApi tableData,
   bool forceSingleCore = false,
+  Duration perTestTimeout,
 }) async {
   int cpus;
   final String cpuVariable = Platform.environment['CPU']; // CPU is set in cirrus.yml
@@ -964,6 +967,8 @@ Future<void> _pubRunTest(String workingDirectory, {
       '--no-color',
     if (coverage != null)
       '--coverage=$coverage',
+    if (perTestTimeout != null)
+      '--timeout=${perTestTimeout.inMilliseconds.toString()}ms',
     if (testPaths != null)
       for (final String testPath in testPaths)
         testPath,


### PR DESCRIPTION
## Description

Test timeouts can cause flakiness, but it would be great to catch time delay regressions and mock/fake leaks in pre-submission. An individual unit test in the general shard (versus the integration-ish tests in commands/integration.shard) should take a few hundred ms, max.

## Related Issues
Recently fixed a few:
https://github.com/flutter/flutter/pull/58544
https://github.com/flutter/flutter/pull/58644
https://github.com/flutter/flutter/pull/58622
https://github.com/flutter/flutter/pull/59026

Related https://github.com/flutter/flutter/pull/58645

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*