### PR TITLE
[flutter] Fix for ScrollController async access exception in Scrollbar Widget.

### DIFF
--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -62,7 +62,7 @@ class CupertinoScrollbar extends StatefulWidget {
     this.controller,
     this.isAlwaysShown = false,
     @required this.child,
-  }) : assert(!isAlwaysShown || controller != null, 'When isAlwaysShown is true, must pass a controller that is attached to a scroll view'),
+  }) : assert(!isAlwaysShown || controller != null, 'When isAlwaysShown is true, must pass a controller'),
        super(key: key);
 
   /// The subtree to place inside the [CupertinoScrollbar].
@@ -278,7 +278,9 @@ class _CupertinoScrollbarState extends State<CupertinoScrollbar> with TickerProv
     WidgetsBinding.instance.addPostFrameCallback((Duration duration) {
       if (widget.isAlwaysShown) {
         _fadeoutTimer?.cancel();
-        widget.controller.position.didUpdateScrollPositionBy(0);
+        if (mounted && widget.controller.hasClients) {
+          widget.controller.position.didUpdateScrollPositionBy(0);
+        }
       }
     });
   }

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -38,7 +38,7 @@ class Scrollbar extends StatefulWidget {
     @required this.child,
     this.controller,
     this.isAlwaysShown = false,
-  }) : assert(!isAlwaysShown || controller != null, 'When isAlwaysShown is true, must pass a controller that is attached to a scroll view'),
+  }) : assert(!isAlwaysShown || controller != null, 'When isAlwaysShown is true, must pass a controller'),
        super(key: key);
 
   /// The widget below this widget in the tree.
@@ -133,7 +133,9 @@ class _ScrollbarState extends State<Scrollbar> with TickerProviderStateMixin {
     WidgetsBinding.instance.addPostFrameCallback((Duration duration) {
       if (widget.isAlwaysShown) {
         _fadeoutTimer?.cancel();
-        widget.controller.position.didUpdateScrollPositionBy(0);
+        if (mounted && widget.controller.hasClients) {
+          widget.controller.position.didUpdateScrollPositionBy(0);
+        }
       }
     });
   }

--- a/packages/flutter/test/cupertino/scrollbar_test.dart
+++ b/packages/flutter/test/cupertino/scrollbar_test.dart
@@ -189,7 +189,7 @@ void main() {
     }, throwsAssertionError);
   });
 
-  testWidgets('When isAlwaysShown is true, must pass a controller that is attached to a scroll view',
+  testWidgets('When isAlwaysShown is true, controller does not need to be attached to a scroll view',
       (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     Widget viewWithScroll() {
@@ -213,7 +213,7 @@ void main() {
 
     await tester.pumpWidget(viewWithScroll());
     final dynamic exception = tester.takeException();
-    expect(exception, isAssertionError);
+    expect(exception, null);
   });
 
   testWidgets('On first render with isAlwaysShown: true, the thumb shows',


### PR DESCRIPTION
## Description

An exception is thrown when the Scrollbar tries to access the controllers positions after the controller has been detached from the scroll view for only 1 frame.

**This is executed in a addPostFrameCallback but can happen after the controller has no positions.**

https://github.com/flutter/flutter/blob/7d17c53992932fad100f03e24030fc5a53c03aaa/packages/flutter/lib/src/material/scrollbar.dart#L136

```
══╡ EXCEPTION CAUGHT BY SCHEDULER LIBRARY ╞═════════════════════════════════════════════════════════
The following assertion was thrown during a scheduler callback:
Assertion failed:
file:///C:/Android/flutter/packages/flutter/lib/src/widgets/scroll_controller.dart:110:12
_positions.isNotEmpty
"ScrollController not attached to any scroll views."

When the exception was thrown, this was the stack:
C:/b/s/w/ir/cache/builder/src/out/host_debug/dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart 216:49  throw_
C:/b/s/w/ir/cache/builder/src/out/host_debug/dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart 26:3    assertFailed
packages/flutter/src/widgets/scroll_controller.dart 110:23                                                                 get position
packages/flutter/src/material/scrollbar.dart 115:40                                                                        <fn>
```

## Related Issues

* Fixes #55432 - Failed assertion: line 110 pos 12: '_positions.isNotEmpty'

## Tests

I added the following tests:

Updated: `When isAlwaysShown is true, controller does not need to be attached to a scroll view`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
