### PR TITLE
Fix custom physics application in TabBarView

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1179,7 +1179,7 @@ class TabBarView extends StatefulWidget {
   _TabBarViewState createState() => _TabBarViewState();
 }
 
-final PageScrollPhysics _kTabBarViewPhysics = const PageScrollPhysics().applyTo(const ClampingScrollPhysics());
+const PageScrollPhysics _kTabBarViewPhysics = PageScrollPhysics();
 
 class _TabBarViewState extends State<TabBarView> {
   TabController _controller;
@@ -1349,7 +1349,9 @@ class _TabBarViewState extends State<TabBarView> {
       child: PageView(
         dragStartBehavior: widget.dragStartBehavior,
         controller: _pageController,
-        physics: widget.physics == null ? _kTabBarViewPhysics : _kTabBarViewPhysics.applyTo(widget.physics),
+        physics: widget.physics == null
+          ? _kTabBarViewPhysics.applyTo(const ClampingScrollPhysics())
+          : _kTabBarViewPhysics.applyTo(widget.physics),
         children: _childrenWithKey,
       ),
     );

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2582,6 +2582,20 @@ void main() {
   });
 
   testWidgets('Setting BouncingScrollPhysics on TabView does not create glow', (WidgetTester tester) async {
-    
+    // Regression test for https://github.com/flutter/flutter/issues/57708
+    await tester.pumpWidget(MaterialApp(
+      home: DefaultTabController(
+        length: 10,
+        child: Scaffold(
+          body: TabBarView(
+            physics: const BouncingScrollPhysics(),
+            children: List<Widget>.generate(10, (int i) => Center(child: Text('index $i'))),
+          ),
+        ),
+      )
+    ));
+
+    final PageView pageView = tester.widget<PageView>(find.byType(PageView));
+    expect(pageView.physics.toString().contains('ClampingScrollPhysics'), isFalse);
   });
 }

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2580,4 +2580,8 @@ void main() {
     await tester.pumpAndSettle();
     pageController.removeListener(pageControllerListener);
   });
+
+  testWidgets('Setting BouncingScrollPhysics on TabView does not create glow', (WidgetTester tester) async {
+    
+  });
 }

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2581,7 +2581,7 @@ void main() {
     pageController.removeListener(pageControllerListener);
   });
 
-  testWidgets('Setting BouncingScrollPhysics on TabView does not create glow', (WidgetTester tester) async {
+  testWidgets('Setting BouncingScrollPhysics on TabBarView does not include ClampingScrollPhysics', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/57708
     await tester.pumpWidget(MaterialApp(
       home: DefaultTabController(


### PR DESCRIPTION
## Description

This PR fixes the default TabBarView physics and how custom physics are instantiated. Prior to this change, when setting a custom scroll physics in a TabBar View, it would be applied to _kTabBarViewPhysics, which by default is the combination of PageScrollPhysics and ClampingScrollPhysics. Specifying TabBarView.physics applies your custom physics to the default, including the ClampingScrollPhysics. This is undesirable when someone tries to use BouncingScrollPhysics, as it will still clamp and draw a glowing overscroll indicator.

## Related Issues

Fixes #57708

## Tests

Specifying BouncingScrollPhysics does not include ClampingScrollPhysics

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
