### PR TITLE
Revert "flutter.gradle: collect list of Android plugins from .flutter-plugins-dependencies"

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -372,28 +372,17 @@ class FlutterPlugin implements Plugin<Project> {
     }
 
     private Properties getPluginList() {
-
+        File pluginsFile = new File(project.projectDir.parentFile.parentFile, '.flutter-plugins')
+        Properties allPlugins = readPropertiesIfExist(pluginsFile)
         Properties androidPlugins = new Properties()
-
-        def flutterProjectRoot = project.projectDir.parentFile.parentFile
-        def pluginsFile = new File(flutterProjectRoot, '.flutter-plugins-dependencies')
-        if (!pluginsFile.exists()) {
-            return androidPlugins
+        allPlugins.each { name, path ->
+            if (doesSupportAndroidPlatform(path)) {
+                androidPlugins.setProperty(name, path)
+            }
+            // TODO(amirh): log an error if this plugin was specified to be an Android
+            // plugin according to the new schema, and was missing a build.gradle file.
+            // https://github.com/flutter/flutter/issues/40784
         }
-
-        def object = new JsonSlurper().parseText(pluginsFile.text)
-        assert object instanceof Map
-        assert object.plugins instanceof Map
-        assert object.plugins.android instanceof List
-        // Includes the Flutter plugins that support the Android platform.
-        object.plugins.android.each { androidPlugin ->
-            assert androidPlugin.name instanceof String
-            assert androidPlugin.path instanceof String
-            def pluginDirectory = new File(androidPlugin.path, 'android')
-            assert pluginDirectory.exists()
-            androidPlugins.setProperty(androidPlugin.name, androidPlugin.path)
-        }
-
         return androidPlugins
     }
 


### PR DESCRIPTION
Reverts flutter/flutter#57907

This is breaking new_gallery__transition_perf:


```
rtifacts.zip
2020-06-04T15:23:16.409930: stdout: [ +293 ms] Received response from server, collecting bytes...
2020-06-04T15:23:16.586335: stdout: [ +176 ms] Downloading darwin-x64-profile tools... (completed in 0.5s)
2020-06-04T15:23:16.586490: stdout: [        ] executing: unzip -o -q /Users/flutter/.cocoon/flutter/bin/cache/downloads/storage.googleapis.com/flutter_infra/flutter/859d892f1fca5d4e3195d6478bcafcfba9ec1e75/darwin-x64-profile/artifacts.zip -d /Users/flutter/.cocoon/flutter/bin/cache/artifacts/engine/darwin-x64-profile
2020-06-04T15:23:16.730084: stdout: [ +142 ms] Exit code 0 from: unzip -o -q /Users/flutter/.cocoon/flutter/bin/cache/downloads/storage.googleapis.com/flutter_infra/flutter/859d892f1fca5d4e3195d6478bcafcfba9ec1e75/darwin-x64-profile/artifacts.zip -d /Users/flutter/.cocoon/flutter/bin/cache/artifacts/engine/darwin-x64-profile
2020-06-04T15:23:16.764553: stdout: [  +34 ms] executing: unzip -o -q /Users/flutter/.cocoon/flutter/bin/cache/artifacts/engine/darwin-x64-profile/FlutterMacOS.framework.zip -d /Users/flutter/.cocoon/flutter/bin/cache/artifacts/engine/darwin-x64-profile/FlutterMacOS.framework
2020-06-04T15:23:17.162563: stdout: [ +397 ms] Exit code 0 from: unzip -o -q /Users/flutter/.cocoon/flutter/bin/cache/artifacts/engine/darwin-x64-profile/FlutterMacOS.framework.zip -d /Users/flutter/.cocoon/flutter/bin/cache/artifacts/engine/darwin-x64-profile/FlutterMacOS.framework
2020-06-04T15:23:17.164191: stdout: [   +2 ms] executing: unzip -t -qq /Users/flutter/.cocoon/flutter/bin/cache/downloads/storage.googleapis.com/flutter_infra/flutter/859d892f1fca5d4e3195d6478bcafcfba9ec1e75/darwin-x64-release/FlutterMacOS.framework.zip
2020-06-04T15:23:17.171889: stdout: [   +7 ms] Downloading darwin-x64-release/FlutterMacOS.framework tools...
2020-06-04T15:23:17.172778: stdout: [   +1 ms] Downloading: https://storage.googleapis.com/flutter_infra/flutter/859d892f1fca5d4e3195d6478bcafcfba9ec1e75/darwin-x64-release/FlutterMacOS.framework.zip
2020-06-04T15:23:17.301382: stdout: [ +128 ms] Received response from server, collecting bytes...
2020-06-04T15:23:17.606382: stdout: [ +305 ms] Downloading darwin-x64-release/FlutterMacOS.framework tools... (completed in 0.4s)
2020-06-04T15:23:17.606714: stdout: [        ] executing: unzip -o -q /Users/flutter/.cocoon/flutter/bin/cache/downloads/storage.googleapis.com/flutter_infra/flutter/859d892f1fca5d4e3195d6478bcafcfba9ec1e75/darwin-x64-release/FlutterMacOS.framework.zip -d /Users/flutter/.cocoon/flutter/bin/cache/artifacts/engine/darwin-x64-release
2020-06-04T15:23:17.734594: stdout: [ +127 ms] Exit code 0 from: unzip -o -q /Users/flutter/.cocoon/flutter/bin/cache/downloads/storage.googleapis.com/flutter_infra/flutter/859d892f1fca5d4e3195d6478bcafcfba9ec1e75/darwin-x64-release/FlutterMacOS.framework.zip -d /Users/flutter/.cocoon/flutter/bin/cache/artifacts/engine/darwin-x64-release
2020-06-04T15:23:17.741670: stdout: [   +7 ms] executing: unzip -o -q /Users/flutter/.cocoon/flutter/bin/cache/artifacts/engine/darwin-x64-release/FlutterMacOS.framework.zip -d /Users/flutter/.cocoon/flutter/bin/cache/artifacts/engine/darwin-x64-release/FlutterMacOS.framework
2020-06-04T15:23:18.151697: stdout: [ +409 ms] Exit code 0 from: unzip -o -q /Users/flutter/.cocoon/flutter/bin/cache/artifacts/engine/darwin-x64-release/FlutterMacOS.framework.zip -d /Users/flutter/.cocoon/flutter/bin/cache/artifacts/engine/darwin-x64-release/FlutterMacOS.framework
2020-06-04T15:23:18.153354: stdout: [   +2 ms] executing: unzip -t -qq /Users/flutter/.cocoon/flutter/bin/cache/downloads/storage.googleapis.com/flutter_infra/flutter/859d892f1fca5d4e3195d6478bcafcfba9ec1e75/darwin-x64-release/artifacts.zip
2020-06-04T15:23:18.160817: stdout: [   +7 ms] Downloading darwin-x64-release tools...
2020-06-04T15:23:18.161328: stdout: [        ] Downloading: https://storage.googleapis.com/flutter_infra/flutter/859d892f1fca5d4e3195d6478bcafcfba9ec1e75/darwin-x64-release/artifacts.zip
2020-06-04T15:23:18.409720: stdout: [ +247 ms] Received response from server, collecting bytes...
2020-06-04T15:23:18.598218: stdout: [ +188 ms] Downloading darwin-x64-release tools... (completed in 0.4s)
stdout: [        ] executing: unzip -o -q /Users/flutter/.cocoon/flutter/bin/cache/downloads/storage.googleapis.com/flutter_infra/flutter/859d892f1fca5d4e3195d6478bcafcfba9ec1e75/darwin-x64-release/artifacts.zip -d /Users/flutter/.cocoon/flutter/bin/cache/artifacts/engine/darwin-x64-release
2020-06-04T15:23:18.702602: stdout: [ +103 ms] Exit code 0 from: unzip -o -q /Users/flutter/.cocoon/flutter/bin/cache/downloads/storage.googleapis.com/flutter_infra/flutter/859d892f1fca5d4e3195d6478bcafcfba9ec1e75/darwin-x64-release/artifacts.zip -d /Users/flutter/.cocoon/flutter/bin/cache/artifacts/engine/darwin-x64-release
2020-06-04T15:23:18.734692: stdout: [  +32 ms] executing: unzip -o -q /Users/flutter/.cocoon/flutter/bin/cache/artifacts/engine/darwin-x64-release/FlutterMacOS.framework.zip -d /Users/flutter/.cocoon/flutter/bin/cache/artifacts/engine/darwin-x64-release/FlutterMacOS.framework
2020-06-04T15:23:19.063905: stdout: [ +328 ms] Exit code 0 from: unzip -o -q /Users/flutter/.cocoon/flutter/bin/cache/artifacts/engine/darwin-x64-release/FlutterMacOS.framework.zip -d /Users/flutter/.cocoon/flutter/bin/cache/artifacts/engine/darwin-x64-release/FlutterMacOS.framework
2020-06-04T15:23:19.072322: stdout: [   +9 ms] Artifact Instance of 'LinuxEngineArtifacts' is not required, skipping update.
stdout: [        ] Artifact Instance of 'LinuxFuchsiaSDKArtifacts' is not required, skipping update.
2020-06-04T15:23:19.072504: stdout: [        ] Artifact Instance of 'MacOSFuchsiaSDKArtifacts' is not required, skipping update.
2020-06-04T15:23:19.072649: stdout: [        ] Artifact Instance of 'FlutterRunnerSDKArtifacts' is not required, skipping update.
2020-06-04T15:23:19.072843: stdout: [        ] Artifact Instance of 'FlutterRunnerDebugSymbols' is not required, skipping update.
2020-06-04T15:23:19.289631: stdout: [ +216 ms] Found plugin package_info at /Users/flutter/.pub-cache/hosted/pub.dartlang.org/package_info-0.4.0+17/
2020-06-04T15:23:19.299389: stdout: [   +9 ms] Found plugin path_provider at /Users/flutter/.pub-cache/hosted/pub.dartlang.org/path_provider-1.6.7/
2020-06-04T15:23:19.301418: stdout: [   +2 ms] Found plugin path_provider_macos at /Users/flutter/.pub-cache/hosted/pub.dartlang.org/path_provider_macos-0.0.4+1/
2020-06-04T15:23:19.313363: stdout: [  +11 ms] Found plugin shared_preferences at /Users/flutter/.pub-cache/hosted/pub.dartlang.org/shared_preferences-0.5.7/
2020-06-04T15:23:19.315580: stdout: [   +2 ms] Found plugin shared_preferences_macos at /Users/flutter/.pub-cache/hosted/pub.dartlang.org/shared_preferences_macos-0.0.1+7/
2020-06-04T15:23:19.318619: stdout: [   +3 ms] Found plugin shared_preferences_web at /Users/flutter/.pub-cache/hosted/pub.dartlang.org/shared_preferences_web-0.1.2+4/
2020-06-04T15:23:19.337388: stdout: [  +18 ms] Found plugin url_launcher at /Users/flutter/.pub-cache/hosted/pub.dartlang.org/url_launcher-5.4.5/
2020-06-04T15:23:19.339341: stdout: [   +1 ms] Found plugin url_launcher_macos at /Users/flutter/.pub-cache/hosted/pub.dartlang.org/url_launcher_macos-0.0.1+5/
2020-06-04T15:23:19.342772: stdout: [   +3 ms] Found plugin url_launcher_web at /Users/flutter/.pub-cache/hosted/pub.dartlang.org/url_launcher_web-0.1.1+2/
2020-06-04T15:23:19.429605: stdout: [  +86 ms] Found plugin package_info at /Users/flutter/.pub-cache/hosted/pub.dartlang.org/package_info-0.4.0+17/
2020-06-04T15:23:19.431139: stdout: [   +1 ms] Found plugin path_provider at /Users/flutter/.pub-cache/hosted/pub.dartlang.org/path_provider-1.6.7/
2020-06-04T15:23:19.431984: stdout: [        ] Found plugin path_provider_macos at /Users/flutter/.pub-cache/hosted/pub.dartlang.org/path_provider_macos-0.0.4+1/
2020-06-04T15:23:19.438145: stdout: [   +5 ms] Found plugin shared_preferences at /Users/flutter/.pub-cache/hosted/pub.dartlang.org/shared_preferences-0.5.7/
2020-06-04T15:23:19.439295: stdout: [   +1 ms] Found plugin shared_preferences_macos at /Users/flutter/.pub-cache/hosted/pub.dartlang.org/shared_preferences_macos-0.0.1+7/
2020-06-04T15:23:19.441449: stdout: [   +2 ms] Found plugin shared_preferences_web at /Users/flutter/.pub-cache/hosted/pub.dartlang.org/shared_preferences_web-0.1.2+4/
2020-06-04T15:23:19.453077: stdout: [  +11 ms] Found plugin url_launcher at /Users/flutter/.pub-cache/hosted/pub.dartlang.org/url_launcher-5.4.5/
2020-06-04T15:23:19.454269: stdout: [   +1 ms] Found plugin url_launcher_macos at /Users/flutter/.pub-cache/hosted/pub.dartlang.org/url_launcher_macos-0.0.1+5/
2020-06-04T15:23:19.455912: stdout: [   +1 ms] Found plugin url_launcher_web at /Users/flutter/.pub-cache/hosted/pub.dartlang.org/url_launcher_web-0.1.1+2/
2020-06-04T15:23:19.545354: stdout: [  +89 ms] Generating /private/var/folders/yy/pps18z_125g_g5jp7rptrm1m0000gn/T/new_gallery_testDern03/gallery/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
2020-06-04T15:23:19.576043: stdout: [  +30 ms] executing: /usr/bin/xcodebuild -version
2020-06-04T15:23:19.582254: stdout: [   +5 ms] Exit code 1 from: /usr/bin/xcodebuild -version
stdout: [        ] xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance
2020-06-04T15:23:19.583037: stdout: [        ] executing: /usr/bin/xcodebuild -version
2020-06-04T15:23:19.588776: stdout: [   +4 ms] Exit code 1 from: /usr/bin/xcodebuild -version
stdout: [        ] xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance
2020-06-04T15:23:19.619163: stdout: [  +30 ms] Using device Moto G 4.
2020-06-04T15:23:19.623658: stdout: [   +4 ms] Starting application: test_driver/transitions_perf.dart
2020-06-04T15:23:19.626590: stdout: [   +2 ms] Stopping previously running application, if any.
2020-06-04T15:23:19.627814: stdout: [   +1 ms] Stopping application.
2020-06-04T15:23:19.645892: stdout: [  +17 ms] executing: /usr/local/share/android-sdk/platform-tools/adb -s ZY223HMWMJ shell am force-stop io.flutter.demo.gallery
2020-06-04T15:23:20.565095: stdout: [ +918 ms] Installing application package.
2020-06-04T15:23:20.567599: stdout: [   +2 ms] executing: /usr/local/share/android-sdk/platform-tools/adb -s ZY223HMWMJ shell pm list packages io.flutter.demo.gallery
2020-06-04T15:23:21.512253: stdout: [ +943 ms] package:io.flutter.demo.gallery
2020-06-04T15:23:21.517271: stdout: [   +5 ms] executing: /usr/local/share/android-sdk/platform-tools/adb version
2020-06-04T15:23:21.526096: stdout: [   +8 ms] Android Debug Bridge version 1.0.41
stdout:            Version 29.0.4-5871666
stdout:            Installed as /usr/local/share/android-sdk/platform-tools/adb
2020-06-04T15:23:21.529990: stdout: [   +4 ms] executing: /usr/local/share/android-sdk/platform-tools/adb start-server
2020-06-04T15:23:21.539381: stdout: [   +9 ms] executing: /usr/local/share/android-sdk/platform-tools/adb -s ZY223HMWMJ uninstall io.flutter.demo.gallery
2020-06-04T15:23:22.187093: stdout: [ +647 ms] Success
2020-06-04T15:23:22.198368: stderr: [   +9 ms] "build/app/outputs/flutter-apk/app.apk" does not exist.
2020-06-04T15:23:22.198524: stdout: [   +3 ms] Starting application.
2020-06-04T15:23:22.202895: stdout: [   +4 ms] executing: /usr/local/share/android-sdk/platform-tools/adb -s ZY223HMWMJ shell -x logcat -v time -t 1
2020-06-04T15:23:22.298645: stdout: [  +94 ms] Exit code 0 from: /usr/local/share/android-sdk/platform-tools/adb -s ZY223HMWMJ shell -x logcat -v time -t 1
2020-06-04T15:23:22.298951: stdout: [   +1 ms] --------- beginning of main
stdout:            06-04 15:22:36.684 D/CarrierSvcBindHelper( 3950): No carrier app for: 0
2020-06-04T15:23:22.320309: stdout: [  +21 ms] executing: /usr/local/share/android-sdk/platform-tools/adb version
2020-06-04T15:23:22.328630: stdout: [   +8 ms] Android Debug Bridge version 1.0.41
stdout:            Version 29.0.4-5871666
stdout:            Installed as /usr/local/share/android-sdk/platform-tools/adb
2020-06-04T15:23:22.329627: stdout: [   +1 ms] executing: /usr/local/share/android-sdk/platform-tools/adb start-server
2020-06-04T15:23:22.339174: stdout: [   +9 ms] Building APK
2020-06-04T15:23:22.368053: stdout: [  +28 ms] Invalid build-number: 020400 for Android, overridden by 20400.
stdout:            See versionCode at https://developer.android.com/studio/publish/versioning
2020-06-04T15:23:22.370491: stdout: [   +2 ms] Running Gradle task 'assembleProfile'...
2020-06-04T15:23:22.372343: stdout: [   +1 ms] gradle.properties already sets `android.enableR8`
2020-06-04T15:23:22.377521: stdout: [   +4 ms] /Users/flutter/.cocoon/flutter/bin/cache/artifacts/gradle_wrapper/gradle/wrapper/gradle-wrapper.jar mode: 33188 rw-r--r--.
2020-06-04T15:23:22.378433: stdout: [   +1 ms] /Users/flutter/.cocoon/flutter/bin/cache/artifacts/gradle_wrapper/gradlew mode: 33261 rwxr-xr-x.
2020-06-04T15:23:22.379418: stdout: [        ] /private/var/folders/yy/pps18z_125g_g5jp7rptrm1m0000gn/T/new_gallery_testDern03/gallery/android/gradlew mode: 33188 rw-r--r--.
stdout: [        ] Trying to give execute permission to /private/var/folders/yy/pps18z_125g_g5jp7rptrm1m0000gn/T/new_gallery_testDern03/gallery/android/gradlew.
2020-06-04T15:23:22.387290: stdout: [   +7 ms] /Users/flutter/.cocoon/flutter/bin/cache/artifacts/gradle_wrapper/gradlew.bat mode: 33188 rw-r--r--.
2020-06-04T15:23:22.387779: stdout: [        ] Using gradle from /private/var/folders/yy/pps18z_125g_g5jp7rptrm1m0000gn/T/new_gallery_testDern03/gallery/android/gradlew.
2020-06-04T15:23:22.387981: stdout: [        ] /private/var/folders/yy/pps18z_125g_g5jp7rptrm1m0000gn/T/new_gallery_testDern03/gallery/android/gradlew mode: 33261 rwxr-xr-x.
2020-06-04T15:23:22.398964: stdout: [  +10 ms] executing: [/private/var/folders/yy/pps18z_125g_g5jp7rptrm1m0000gn/T/new_gallery_testDern03/gallery/android/] /private/var/folders/yy/pps18z_125g_g5jp7rptrm1m0000gn/T/new_gallery_testDern03/gallery/android/gradlew -Pverbose=true -Ptarget-platform=android-arm -Ptarget=/private/var/folders/yy/pps18z_125g_g5jp7rptrm1m0000gn/T/new_gallery_testDern03/gallery/test_driver/transitions_perf.dart -Ptrack-widget-creation=true assembleProfile
2020-06-04T15:23:26.392193: stdout: [+3992 ms] > Configure project :app
2020-06-04T15:23:26.392808: stdout: [        ] WARNING: The option setting 'android.enableR8=true' is experimental and unsupported.
2020-06-04T15:23:26.393278: stdout: [        ] The current default is 'false'
2020-06-04T15:23:26.393587: stdout: [        ] Consider disabling R8 by removing 'android.enableR8=true' from your gradle.properties before publishing your app.
2020-06-04T15:23:27.270447: stdout: [ +876 ms] > Configure project :package_info
stdout: [        ] WARNING: The option setting 'android.enableR8=true' is experimental and unsupported.
2020-06-04T15:23:27.271464: stdout: [        ] The current default is 'false'
2020-06-04T15:23:27.272227: stdout: [        ] Consider disabling R8 by removing 'android.enableR8=true' from your gradle.properties before publishing your app.
stdout: [        ] > Configure project :path_provider
stdout: [        ] WARNING: The option setting 'android.enableR8=true' is experimental and unsupported.
2020-06-04T15:23:27.272466: stdout: [        ] The current default is 'false'
2020-06-04T15:23:27.272732: stdout: [        ] Consider disabling R8 by removing 'android.enableR8=true' from your gradle.properties before publishing your app.
2020-06-04T15:23:27.376016: stdout: [ +103 ms] > Configure project :path_provider_macos
2020-06-04T15:23:27.376216: stdout: [        ] WARNING: The option setting 'android.enableR8=true' is experimental and unsupported.
2020-06-04T15:23:27.376325: stdout: [        ] The current default is 'false'
2020-06-04T15:23:27.376744: stdout: [        ] Consider disabling R8 by removing 'android.enableR8=true' from your gradle.properties before publishing your app.
2020-06-04T15:23:27.569035: stdout: [ +191 ms] > Configure project :shared_preferences
2020-06-04T15:23:27.569208: stdout: [        ] WARNING: The option setting 'android.enableR8=true' is experimental and unsupported.
2020-06-04T15:23:27.569583: stdout: [        ] The current default is 'false'
2020-06-04T15:23:27.569853: stdout: [        ] Consider disabling R8 by removing 'android.enableR8=true' from your gradle.properties before publishing your app.
2020-06-04T15:23:27.670796: stdout: [ +100 ms] > Configure project :shared_preferences_macos
2020-06-04T15:23:27.670956: stdout: [        ] WARNING: The option setting 'android.enableR8=true' is experimental and unsupported.
2020-06-04T15:23:27.671317: stdout: [        ] The current default is 'false'
2020-06-04T15:23:27.671663: stdout: [        ] Consider disabling R8 by removing 'android.enableR8=true' from your gradle.properties before publishing your app.
2020-06-04T15:23:27.776568: stdout: [ +104 ms] > Configure project :shared_preferences_web
2020-06-04T15:23:27.776766: stdout: [        ] WARNING: The option setting 'android.enableR8=true' is experimental and unsupported.
2020-06-04T15:23:27.777201: stdout: [        ] The current default is 'false'
2020-06-04T15:23:27.777345: stdout: [        ] Consider disabling R8 by removing 'android.enableR8=true' from your gradle.properties before publishing your app.
2020-06-04T15:23:27.976192: stdout: [ +198 ms] > Configure project :url_launcher
2020-06-04T15:23:27.976364: stdout: [        ] WARNING: The option setting 'android.enableR8=true' is experimental and unsupported.
2020-06-04T15:23:27.976695: stdout: [        ] The current default is 'false'
2020-06-04T15:23:27.977252: stdout: [        ] Consider disabling R8 by removing 'android.enableR8=true' from your gradle.properties before publishing your app.
2020-06-04T15:23:27.978102: stdout: [        ] > Configure project :url_launcher_macos
stdout: [        ] WARNING: The option setting 'android.enableR8=true' is experimental and unsupported.
2020-06-04T15:23:27.978251: stdout: [        ] The current default is 'false'
stdout: [        ] Consider disabling R8 by removing 'android.enableR8=true' from your gradle.properties before publishing your app.
2020-06-04T15:23:28.076339: stdout: [  +97 ms] > Configure project :url_launcher_web
stdout: [        ] WARNING: The option setting 'android.enableR8=true' is experimental and unsupported.
2020-06-04T15:23:28.076985: stdout: [        ] The current default is 'false'
2020-06-04T15:23:28.077281: stdout: [        ] Consider disabling R8 by removing 'android.enableR8=true' from your gradle.properties before publishing your app.
2020-06-04T15:23:28.476491: stderr: [ +398 ms] FAILURE: Build failed with an exception.
stderr: [        ] * What went wrong:
2020-06-04T15:23:28.476703: stderr: [        ] Could not determine the dependencies of task ':path_provider:compileProfileAidl'.
stderr: [        ] > Could not resolve all task dependencies for configuration ':path_provider:profileCompileClasspath'.
2020-06-04T15:23:28.477184: stderr: [        ]    > Could not resolve project :path_provider_macos.
stderr: [        ]      Required by:
2020-06-04T15:23:28.477557: stderr: [        ]          project :path_provider
stderr: [        ]       > Unable to find a matching variant of project :path_provider_macos:
2020-06-04T15:23:28.477885: stderr: [        ]           - Variant 'debugApiElements':
2020-06-04T15:23:28.478229: stderr: [        ]               - Required com.android.build.api.attributes.BuildTypeAttr 'profile' and found incompatible value 'debug'.
2020-06-04T15:23:28.478552: stderr: [        ]               - Found com.android.build.api.attributes.VariantAttr 'debug' but wasn't required.
2020-06-04T15:23:28.478821: stderr: [        ]               - Required com.android.build.gradle.internal.dependency.AndroidTypeAttr 'Aar' and found compatible value 'Aar'.
2020-06-04T15:23:28.479181: stderr: [        ]               - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
2020-06-04T15:23:28.479414: stderr: [        ]           - Variant 'debugRuntimeElements':
2020-06-04T15:23:28.480006: stderr: [        ]               - Required com.android.build.api.attributes.BuildTypeAttr 'profile' and found incompatible value 'debug'.
2020-06-04T15:23:28.480230: stderr: [        ]               - Found com.android.build.api.attributes.VariantAttr 'debug' but wasn't required.
2020-06-04T15:23:28.480646: stderr: [        ]               - Required com.android.build.gradle.internal.dependency.AndroidTypeAttr 'Aar' and found compatible value 'Aar'.
2020-06-04T15:23:28.480994: stderr: [        ]               - Required org.gradle.usage 'java-api' and found incompatible value 'java-runtime'.
2020-06-04T15:23:28.481250: stderr: [        ]           - Variant 'releaseApiElements':
2020-06-04T15:23:28.481548: stderr: [        ]               - Required com.android.build.api.attributes.BuildTypeAttr 'profile' and found incompatible value 'release'.
2020-06-04T15:23:28.481815: stderr: [        ]               - Found com.android.build.api.attributes.VariantAttr 'release' but wasn't required.
2020-06-04T15:23:28.482193: stderr: [        ]               - Required com.android.build.gradle.internal.dependency.AndroidTypeAttr 'Aar' and found compatible value 'Aar'.
2020-06-04T15:23:28.482444: stderr: [        ]               - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
2020-06-04T15:23:28.482657: stderr: [        ]           - Variant 'releaseRuntimeElements':
2020-06-04T15:23:28.482977: stderr: [        ]               - Required com.android.build.api.attributes.BuildTypeAttr 'profile' and found incompatible value 'release'.
2020-06-04T15:23:28.483311: stderr: [        ]               - Found com.android.build.api.attributes.VariantAttr 'release' but wasn't required.
2020-06-04T15:23:28.483638: stderr: [        ]               - Required com.android.build.gradle.internal.dependency.AndroidTypeAttr 'Aar' and found compatible value 'Aar'.
2020-06-04T15:23:28.483889: stderr: [        ]               - Required org.gradle.usage 'java-api' and found incompatible value 'java-runtime'.
2020-06-04T15:23:28.484567: stderr: [        ] * Try:
2020-06-04T15:23:28.485001: stderr: [        ] Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
2020-06-04T15:23:28.485844: stderr: [        ] * Get more help at https://help.gradle.org
2020-06-04T15:23:28.486097: stderr: [        ] BUILD FAILED in 5s
2020-06-04T15:23:29.763136: stdout: [+1276 ms] Running Gradle task 'assembleProfile'... (completed in 7.4s)
2020-06-04T15:23:29.768599: stdout: [   +5 ms] "flutter drive" took 19,647ms.
2020-06-04T15:23:29.774176: stderr: Gradle task assembleProfile failed with exit code 1
2020-06-04T15:23:29.775052: stderr: 
stderr: #0      throwToolExit (package:flutter_tools/src/base/common.dart:14:3)
stderr: #1      buildGradleApp (package:flutter_tools/src/android/gradle.dart:411:7)
stderr: #2      _rootRunUnary (dart:async/zone.dart:1198:47)
stderr: #3      _CustomZone.runUnary (dart:async/zone.dart:1100:19)
stderr: #4      _FutureListener.handleValue (dart:async/future_impl.dart:143:18)
stderr: #5      Future._propagateToListeners.handleValueCallback (dart:async/future_impl.dart:696:45)
stderr: #6      Future._propagateToListeners (dart:async/future_impl.dart:725:32)
stderr: #7      Future._completeWithValue (dart:async/future_impl.dart:529:5)
stderr: #8      _AsyncAwaitCompleter.complete (dart:async-patch/async_patch.dart:40:15)
stderr: #9      _completeOnAsyncReturn (dart:async-patch/async_patch.dart:311:13)
stderr: #10     _DefaultProcessUtils.stream (package:flutter_tools/src/base/process.dart)
stderr: #11     _rootRunUnary (dart:async/zone.dart:1198:47)
stderr: #12     _CustomZone.runUnary (dart:async/zone.dart:1100:19)
stderr: #13     _FutureListener.handleValue (dart:async/future_impl.dart:143:18)
stderr: #14     Future._propagateToListeners.handleValueCallback (dart:async/future_impl.dart:696:45)
stderr: #15     Future._propagateToListeners (dart:async/future_impl.dart:725:32)
stderr: #16     Future._completeWithValue (dart:async/future_impl.dart:529:5)
stderr: #17     Future._asyncCompleteWithValue.<anonymous closure> (dart:async/future_impl.dart:567:7)
stderr: #18     _rootRun (dart:async/zone.dart:1190:13)
stderr: #19     _CustomZone.run (dart:async/zone.dart:1093:19)
stderr: #20     _CustomZone.runGuarded (dart:async/zone.dart:997:7)
stderr: #21     _CustomZone.bindCallbackGuarded.<anonymous closure> (dart:async/zone.dart:1037:23)
stderr: #22     _microtaskLoop (dart:async/schedule_microtask.dart:41:21)
stderr: #23     _startMicrotaskLoop (dart:async/schedule_microtask.dart:50:5)
stderr: #24     _runPendingImmediateCallback (dart:isolate-patch/isolate_patch.dart:118:13)
stderr: #25     _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:169:5)
stderr: 
stderr: 
2020-06-04T15:23:29.796828: "/Users/flutter/.cocoon/flutter/bin/flutter" exit code: 1
2020-06-04T15:23:29.810929: Task failed: Executable "/Users/flutter/.cocoon/flutter/bin/flutter" failed with exit code 1.2020-06-04T15:23:29.811091: 

Stack trace:
2020-06-04T15:23:29.836393: package:flutter_devicelab/framework/utils.dart 98:3        fail
package:flutter_devicelab/framework/utils.dart 332:5       exec
===== asynchronous gap ===========================
dart:async                                                 _asyncErrorWrapperHelper
package:flutter_devicelab/framework/framework.dart         _TaskRunner._performTask.<fn>
package:stack_trace                                        Chain.capture
package:flutter_devicelab/framework/framework.dart 169:11  _TaskRunner._performTask
package:flutter_devicelab/framework/framework.dart 101:41  _TaskRunner.run

2020-06-04T15:23:29.837700: 

```

TBR @blasten 