### PR TITLE
Add Android device build/OS/API Level information to logs.

### DIFF
--- a/dev/devicelab/lib/framework/adb.dart
+++ b/dev/devicelab/lib/framework/adb.dart
@@ -73,6 +73,9 @@ abstract class DeviceDiscovery {
 
 /// A proxy for one specific device.
 abstract class Device {
+  // Const constructor so subclasses may be const.
+  const Device();
+
   /// A unique device identifier.
   String get deviceId;
 
@@ -110,6 +113,11 @@ abstract class Device {
 
   /// Stop a process.
   Future<void> stop(String packageName);
+
+  @override
+  String toString() {
+    return 'device: $deviceId';
+  }
 }
 
 class AndroidDeviceDiscovery implements DeviceDiscovery {
@@ -150,6 +158,7 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
 
     // TODO(yjbanov): filter out and warn about those with low battery level
     _workingDevice = allDevices[math.Random().nextInt(allDevices.length)];
+    print('Device chosen: $_workingDevice');
   }
 
   @override
@@ -249,6 +258,7 @@ class FuchsiaDeviceDiscovery implements DeviceDiscovery {
       throw Exception('No Fuchsia devices detected');
     }
     _workingDevice = allDevices.first;
+    print('Device chosen: $_workingDevice');
   }
 
   @override
@@ -296,11 +306,14 @@ class FuchsiaDeviceDiscovery implements DeviceDiscovery {
   Future<void> performPreflightTasks() async {}
 }
 
-class AndroidDevice implements Device {
-  AndroidDevice({@required this.deviceId});
+class AndroidDevice extends Device {
+  AndroidDevice({@required this.deviceId}) {
+    _updateDeviceInfo();
+  }
 
   @override
   final String deviceId;
+  String deviceInfo = '';
 
   /// Whether the device is awake.
   @override
@@ -358,19 +371,37 @@ class AndroidDevice implements Device {
     return wakefulness;
   }
 
+  Future<void> _updateDeviceInfo() async {
+    final String info = await shellEval(
+      'getprop',
+      <String>[
+        'ro.bootimage.build.fingerprint', ';',
+        'getprop', 'ro.build.version.release', ';',
+        'getprop', 'ro.build.version.sdk',
+      ],
+      silent: true,
+    );
+    final List<String> list = info.split('\n');
+    if (list.length == 3) {
+      deviceInfo = 'fingerprint: ${list[0]} os: ${list[1]}  api-level: ${list[2]}';
+    } else {
+      deviceInfo = '';
+    }
+  }
+
   /// Executes [command] on `adb shell` and returns its exit code.
-  Future<void> shellExec(String command, List<String> arguments, { Map<String, String> environment }) async {
-    await adb(<String>['shell', command, ...arguments], environment: environment);
+  Future<void> shellExec(String command, List<String> arguments, { Map<String, String> environment, bool silent = false }) async {
+    await adb(<String>['shell', command, ...arguments], environment: environment, silent: silent);
   }
 
   /// Executes [command] on `adb shell` and returns its standard output as a [String].
-  Future<String> shellEval(String command, List<String> arguments, { Map<String, String> environment }) {
-    return adb(<String>['shell', command, ...arguments], environment: environment);
+  Future<String> shellEval(String command, List<String> arguments, { Map<String, String> environment, bool silent = false }) {
+    return adb(<String>['shell', command, ...arguments], environment: environment, silent: silent);
   }
 
   /// Runs `adb` with the given [arguments], selecting this device.
-  Future<String> adb(List<String> arguments, { Map<String, String> environment }) {
-    return eval(adbPath, <String>['-s', deviceId, ...arguments], environment: environment, canFail: false);
+  Future<String> adb(List<String> arguments, { Map<String, String> environment, bool silent = false }) {
+    return eval(adbPath, <String>['-s', deviceId, ...arguments], environment: environment, canFail: false, printStdout: !silent, printStderr: !silent);
   }
 
   @override
@@ -453,6 +484,11 @@ class AndroidDevice implements Device {
   Future<void> stop(String packageName) async {
     return shellExec('am', <String>['force-stop', packageName]);
   }
+
+  @override
+  String toString() {
+    return '$deviceId $deviceInfo';
+  }
 }
 
 class IosDeviceDiscovery implements DeviceDiscovery {
@@ -488,6 +524,7 @@ class IosDeviceDiscovery implements DeviceDiscovery {
 
     // TODO(yjbanov): filter out and warn about those with low battery level
     _workingDevice = allDevices[math.Random().nextInt(allDevices.length)];
+    print('Device chosen: $_workingDevice');
   }
 
   // Returns a colon-separated environment variable that contains the paths
@@ -532,7 +569,7 @@ class IosDeviceDiscovery implements DeviceDiscovery {
 }
 
 /// iOS device.
-class IosDevice implements Device {
+class IosDevice extends Device {
   const IosDevice({ @required this.deviceId });
 
   @override
@@ -581,7 +618,7 @@ class IosDevice implements Device {
 }
 
 /// Fuchsia device.
-class FuchsiaDevice implements Device {
+class FuchsiaDevice extends Device {
   const FuchsiaDevice({ @required this.deviceId });
 
   @override

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -475,11 +475,11 @@ void cd(dynamic directory) {
     cwd = directory.path;
     d = directory;
   } else {
-    throw 'Unsupported type ${directory.runtimeType} of $directory';
+    throw FileSystemException('Unsupported directory type ${directory.runtimeType}', directory.toString());
   }
 
   if (!d.existsSync())
-    throw 'Cannot cd into directory that does not exist: $directory';
+    throw FileSystemException('Cannot cd into directory that does not exist', d.toString());
 }
 
 Directory get flutterDirectory => Directory.current.parent.parent;

--- a/dev/devicelab/test/adb_test.dart
+++ b/dev/devicelab/test/adb_test.dart
@@ -42,6 +42,7 @@ void main() {
       test('sends power event', () async {
         await device.togglePower();
         expectLog(<CommandArgs>[
+          cmd(command: 'getprop', arguments: <String>['ro.bootimage.build.fingerprint', ';', 'getprop', 'ro.build.version.release', ';', 'getprop', 'ro.build.version.sdk'], environment: null),
           cmd(command: 'input', arguments: <String>['keyevent', '26']),
         ]);
       });
@@ -52,6 +53,7 @@ void main() {
         FakeDevice.pretendAwake();
         await device.wakeUp();
         expectLog(<CommandArgs>[
+          cmd(command: 'getprop', arguments: <String>['ro.bootimage.build.fingerprint', ';', 'getprop', 'ro.build.version.release', ';', 'getprop', 'ro.build.version.sdk'], environment: null),
           cmd(command: 'dumpsys', arguments: <String>['power']),
         ]);
       });
@@ -60,6 +62,7 @@ void main() {
         FakeDevice.pretendAsleep();
         await device.wakeUp();
         expectLog(<CommandArgs>[
+          cmd(command: 'getprop', arguments: <String>['ro.bootimage.build.fingerprint', ';', 'getprop', 'ro.build.version.release', ';', 'getprop', 'ro.build.version.sdk'], environment: null),
           cmd(command: 'dumpsys', arguments: <String>['power']),
           cmd(command: 'input', arguments: <String>['keyevent', '26']),
         ]);
@@ -71,6 +74,7 @@ void main() {
         FakeDevice.pretendAsleep();
         await device.sendToSleep();
         expectLog(<CommandArgs>[
+          cmd(command: 'getprop', arguments: <String>['ro.bootimage.build.fingerprint', ';', 'getprop', 'ro.build.version.release', ';', 'getprop', 'ro.build.version.sdk'], environment: null),
           cmd(command: 'dumpsys', arguments: <String>['power']),
         ]);
       });
@@ -79,6 +83,7 @@ void main() {
         FakeDevice.pretendAwake();
         await device.sendToSleep();
         expectLog(<CommandArgs>[
+          cmd(command: 'getprop', arguments: <String>['ro.bootimage.build.fingerprint', ';', 'getprop', 'ro.build.version.release', ';', 'getprop', 'ro.build.version.sdk'], environment: null),
           cmd(command: 'dumpsys', arguments: <String>['power']),
           cmd(command: 'input', arguments: <String>['keyevent', '26']),
         ]);
@@ -90,6 +95,7 @@ void main() {
         FakeDevice.pretendAwake();
         await device.unlock();
         expectLog(<CommandArgs>[
+          cmd(command: 'getprop', arguments: <String>['ro.bootimage.build.fingerprint', ';', 'getprop', 'ro.build.version.release', ';', 'getprop', 'ro.build.version.sdk'], environment: null),
           cmd(command: 'dumpsys', arguments: <String>['power']),
           cmd(command: 'input', arguments: <String>['keyevent', '82']),
         ]);
@@ -100,6 +106,7 @@ void main() {
       test('tap', () async {
         await device.tap(100, 200);
         expectLog(<CommandArgs>[
+          cmd(command: 'getprop', arguments: <String>['ro.bootimage.build.fingerprint', ';', 'getprop', 'ro.build.version.release', ';', 'getprop', 'ro.build.version.sdk'], environment: null),
           cmd(command: 'input', arguments: <String>['tap', '100', '200']),
         ]);
       });
@@ -183,7 +190,7 @@ class FakeDevice extends AndroidDevice {
   }
 
   @override
-  Future<String> shellEval(String command, List<String> arguments, { Map<String, String> environment }) async {
+  Future<String> shellEval(String command, List<String> arguments, { Map<String, String> environment, bool silent = false }) async {
     commandLog.add(CommandArgs(
       command: command,
       arguments: arguments,
@@ -193,7 +200,7 @@ class FakeDevice extends AndroidDevice {
   }
 
   @override
-  Future<void> shellExec(String command, List<String> arguments, { Map<String, String> environment }) async {
+  Future<void> shellExec(String command, List<String> arguments, { Map<String, String> environment, bool silent = false }) async {
     commandLog.add(CommandArgs(
       command: command,
       arguments: arguments,


### PR DESCRIPTION
## Description

This adds some information about the chosen device to the output log so that we can tell what type of device/OS Level/API Level the test is running on when doing a postmortem on a failed test.

## Related Issues

- https://github.com/flutter/flutter/issues/58691

## Tests

- Updated adb_test.dart