### PR TITLE
[flutter_tools] don't use verbose when in doctor or help command

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -126,7 +126,7 @@ Future<void> main(List<String> args) async {
        TemplateRenderer: () => const MustacheTemplateRenderer(),
        if (daemon)
         Logger: () => NotifyingLogger(verbose: verbose)
-       else if (verbose)
+       else if (verbose && !doctor)
         Logger: () => VerboseLogger(StdoutLogger(
           timeoutConfiguration: timeoutConfiguration,
           stdio: globals.stdio,

--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -126,7 +126,7 @@ Future<void> main(List<String> args) async {
        TemplateRenderer: () => const MustacheTemplateRenderer(),
        if (daemon)
         Logger: () => NotifyingLogger(verbose: verbose)
-       else if (verbose && !doctor)
+       else if (verbose && !muteCommandLogging)
         Logger: () => VerboseLogger(StdoutLogger(
           timeoutConfiguration: timeoutConfiguration,
           stdio: globals.stdio,

--- a/packages/flutter_tools/test/integration.shard/command_output_test.dart
+++ b/packages/flutter_tools/test/integration.shard/command_output_test.dart
@@ -9,16 +9,30 @@ import 'package:process/process.dart';
 import '../src/common.dart';
 
 void main() {
-  test('All development tools are hidden', () async {
-      final String flutterBin = globals.fs.path.join(getFlutterRoot(), 'bin', 'flutter');
-      final ProcessResult result = await const LocalProcessManager().run(<String>[
-        flutterBin,
-        '-h',
-        '-v',
-      ]);
+  test('All development tools are hidden and help text is not verbose', () async {
+    final String flutterBin = globals.fs.path.join(getFlutterRoot(), 'bin', 'flutter');
+    final ProcessResult result = await const LocalProcessManager().run(<String>[
+      flutterBin,
+      '-h',
+      '-v',
+    ]);
 
-      expect(result.stdout, isNot(contains('ide-config')));
-      expect(result.stdout, isNot(contains('update-packages')));
-      expect(result.stdout, isNot(contains('inject-plugins')));
+    expect(result.stdout, isNot(contains('ide-config')));
+    expect(result.stdout, isNot(contains('update-packages')));
+    expect(result.stdout, isNot(contains('inject-plugins')));
+    // Only printed by verbose tool.
+    expect(result.stdout, isNot(contains('exiting with code 0')));
+  });
+
+  test('flutter doctor is not verbose', () async {
+    final String flutterBin = globals.fs.path.join(getFlutterRoot(), 'bin', 'flutter');
+    final ProcessResult result = await const LocalProcessManager().run(<String>[
+      flutterBin,
+      'doctor',
+      '-v',
+    ]);
+
+    // Only printed by verbose tool.
+    expect(result.stdout, isNot(contains('exiting with code 0')));
   });
 }


### PR DESCRIPTION
## Description

Since flutter doctor -v means something different than flutter any-other-command -v

Fixes https://github.com/flutter/flutter/issues/58759