### PR TITLE
[flutter tools] Change the desktop device names and IDs

### DIFF
--- a/packages/flutter_tools/lib/src/linux/linux_device.dart
+++ b/packages/flutter_tools/lib/src/linux/linux_device.dart
@@ -17,7 +17,7 @@ import 'linux_workflow.dart';
 /// A device that represents a desktop Linux target.
 class LinuxDevice extends DesktopDevice {
   LinuxDevice() : super(
-      'linux-embedding',
+      'linux',
       platformType: PlatformType.linux,
       ephemeral: false,
   );

--- a/packages/flutter_tools/lib/src/linux/linux_device.dart
+++ b/packages/flutter_tools/lib/src/linux/linux_device.dart
@@ -17,7 +17,7 @@ import 'linux_workflow.dart';
 /// A device that represents a desktop Linux target.
 class LinuxDevice extends DesktopDevice {
   LinuxDevice() : super(
-      'Linux',
+      'linux-embedding',
       platformType: PlatformType.linux,
       ephemeral: false,
   );
@@ -26,7 +26,7 @@ class LinuxDevice extends DesktopDevice {
   bool isSupported() => true;
 
   @override
-  String get name => 'Linux';
+  String get name => 'Linux desktop';
 
   @override
   Future<TargetPlatform> get targetPlatform async => TargetPlatform.linux_x64;

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -15,7 +15,7 @@ import 'macos_workflow.dart';
 /// A device that represents a desktop MacOS target.
 class MacOSDevice extends DesktopDevice {
   MacOSDevice() : super(
-      'macos-embedding',
+      'macos',
       platformType: PlatformType.macos,
       ephemeral: false,
   );

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -15,7 +15,7 @@ import 'macos_workflow.dart';
 /// A device that represents a desktop MacOS target.
 class MacOSDevice extends DesktopDevice {
   MacOSDevice() : super(
-      'macOS',
+      'macos-embedding',
       platformType: PlatformType.macos,
       ephemeral: false,
   );
@@ -24,7 +24,7 @@ class MacOSDevice extends DesktopDevice {
   bool isSupported() => true;
 
   @override
-  String get name => 'macOS';
+  String get name => 'macOS desktop';
 
   @override
   Future<TargetPlatform> get targetPlatform async => TargetPlatform.darwin_x64;

--- a/packages/flutter_tools/lib/src/windows/windows_device.dart
+++ b/packages/flutter_tools/lib/src/windows/windows_device.dart
@@ -18,7 +18,7 @@ import 'windows_workflow.dart';
 /// A device that represents a desktop Windows target.
 class WindowsDevice extends DesktopDevice {
   WindowsDevice() : super(
-      'Windows',
+      'windows-embedding',
       platformType: PlatformType.windows,
       ephemeral: false,
   );
@@ -27,7 +27,7 @@ class WindowsDevice extends DesktopDevice {
   bool isSupported() => true;
 
   @override
-  String get name => 'Windows';
+  String get name => 'Windows desktop';
 
   @override
   Future<TargetPlatform> get targetPlatform async => TargetPlatform.windows_x64;

--- a/packages/flutter_tools/lib/src/windows/windows_device.dart
+++ b/packages/flutter_tools/lib/src/windows/windows_device.dart
@@ -18,7 +18,7 @@ import 'windows_workflow.dart';
 /// A device that represents a desktop Windows target.
 class WindowsDevice extends DesktopDevice {
   WindowsDevice() : super(
-      'windows-embedding',
+      'windows',
       platformType: PlatformType.windows,
       ephemeral: false,
   );

--- a/packages/flutter_tools/test/general.shard/linux/linux_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/linux/linux_device_test.dart
@@ -28,7 +28,7 @@ void main() {
   testWithoutContext('LinuxDevice defaults', () async {
     final PrebuiltLinuxApp linuxApp = PrebuiltLinuxApp(executable: 'foo');
     expect(await device.targetPlatform, TargetPlatform.linux_x64);
-    expect(device.name, 'Linux');
+    expect(device.name, 'Linux desktop');
     expect(await device.installApp(linuxApp), true);
     expect(await device.uninstallApp(linuxApp), true);
     expect(await device.isLatestBuildInstalled(linuxApp), true);

--- a/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
@@ -40,7 +40,7 @@ void main() {
     testUsingContext('defaults', () async {
       final MockMacOSApp mockMacOSApp = MockMacOSApp();
       expect(await device.targetPlatform, TargetPlatform.darwin_x64);
-      expect(device.name, 'macOS');
+      expect(device.name, 'macOS desktop');
       expect(await device.installApp(mockMacOSApp), true);
       expect(await device.uninstallApp(mockMacOSApp), true);
       expect(await device.isLatestBuildInstalled(mockMacOSApp), true);

--- a/packages/flutter_tools/test/general.shard/windows/windows_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/windows_device_test.dart
@@ -32,7 +32,7 @@ void main() {
     testUsingContext('defaults', () async {
       final PrebuiltWindowsApp windowsApp = PrebuiltWindowsApp(executable: 'foo');
       expect(await device.targetPlatform, TargetPlatform.windows_x64);
-      expect(device.name, 'Windows');
+      expect(device.name, 'Windows desktop');
       expect(await device.installApp(windowsApp), true);
       expect(await device.uninstallApp(windowsApp), true);
       expect(await device.isLatestBuildInstalled(windowsApp), true);


### PR DESCRIPTION
In google3, the Linux device is always available, and it has confused
people who run the Flutter doctor and see
"• Linux • Linux • linux-x64 • Linux" listed.

Rename the Linux device name to "Linux desktop" and the device ID to
be "linux".  Make similar changes to the Windows and macOS
devices for consistency.

The device ID change shouldn't be break `-d` usage since that does a
case-insensitive prefix match.

## Related Issues

Internal b/153516059.

## Tests

None.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

I did need to modify existing tests, but my understanding is that flutter_tools does not strictly follow the breaking change policy.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
