### PR TITLE
[flutter_tools] remove deprecation warning on flutter format

### DIFF
--- a/packages/flutter_tools/lib/src/commands/format.dart
+++ b/packages/flutter_tools/lib/src/commands/format.dart
@@ -35,10 +35,6 @@ class FormatCommand extends FlutterCommand {
   @override
   Future<FlutterCommandResult> runCommand() async {
     final String dartBinary = globals.artifacts.getArtifactPath(Artifact.engineDartBinary);
-    globals.printError(
-      '"flutter format" is deprecated and will be removed in a'
-      ' future release, use "dart format" instead.'
-    );
     final List<String> command = <String>[
       dartBinary,
       'format',

--- a/packages/flutter_tools/test/general.shard/commands/format_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/format_test.dart
@@ -19,7 +19,6 @@ void main() {
       ..addCommand(FormatCommand());
     await runner.run(<String>['format', 'a', 'b', 'c']);
 
-    expect(testLogger.errorText, contains('"flutter format" is deprecated'));
     expect((globals.processManager as FakeProcessManager).hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem.test(),


### PR DESCRIPTION
## Description

So that we have a release where both are available without a deprecation warning.