### PR TITLE
Step 3 of 3: Remove opt-in for useMaterialBorderRadius on Dialogs

### DIFF
--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -2,10 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(shihaohong-Piinks): remove ignoring deprecated member use analysis
-//   * when AlertDialog.scrollable parameter is removed. See
-//     https://flutter.dev/go/scrollable-alert-dialog for more details.
-//   * when Dialog.useMaterialBorderRadius parameter is removed.
+// TODO(shihaohong): remove ignoring deprecated member use analysis
+// when AlertDialog.scrollable parameter is removed. See
+// https://flutter.dev/go/scrollable-alert-dialog for more details.
 // ignore_for_file: deprecated_member_use_from_same_package
 
 import 'dart:async';
@@ -56,9 +55,7 @@ class Dialog extends StatelessWidget {
     this.clipBehavior = Clip.none,
     this.shape,
     this.child,
-    bool useMaterialBorderRadius,
   }) : assert(clipBehavior != null),
-       useMaterialBorderRadius = useMaterialBorderRadius ?? true,
        super(key: key);
 
   /// {@template flutter.material.dialog.backgroundColor}
@@ -120,8 +117,7 @@ class Dialog extends StatelessWidget {
   ///
   /// Defines the dialog's [Material.shape].
   ///
-  /// The default shape is a [RoundedRectangleBorder] with a radius of 2.0
-  /// (temporarily, set [useMaterialBorderRadius] to match Material guidelines).
+  /// The default shape is a [RoundedRectangleBorder] with a radius of 4.0
   /// {@endtemplate}
   final ShapeBorder shape;
 
@@ -130,20 +126,8 @@ class Dialog extends StatelessWidget {
   /// {@macro flutter.widgets.child}
   final Widget child;
 
-  /// Indicates whether the [Dialog.shape]'s default [RoundedRectangleBorder]
-  /// should have a radius of 4.0 pixels to match Material Design, or use the
-  /// prior default of 2.0 pixels.
-  @Deprecated(
-    'Set useMaterialBorderRadius to `true`. This parameter will be removed and '
-    'was introduced to migrate Dialog to the correct border radius by default. '
-    'This feature was deprecated after v1.18.0.'
-  )
-  final bool useMaterialBorderRadius;
-
   static const RoundedRectangleBorder _defaultDialogShape =
     RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4.0)));
-  static const RoundedRectangleBorder _oldDefaultDialogShape =
-    RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(2.0)));
   static const double _defaultElevation = 24.0;
 
   @override
@@ -166,11 +150,7 @@ class Dialog extends StatelessWidget {
             child: Material(
               color: backgroundColor ?? dialogTheme.backgroundColor ?? Theme.of(context).dialogBackgroundColor,
               elevation: elevation ?? dialogTheme.elevation ?? _defaultElevation,
-              shape: shape ?? dialogTheme.shape ?? (
-                useMaterialBorderRadius ?
-                  _defaultDialogShape :
-                  _oldDefaultDialogShape
-              ),
+              shape: shape ?? dialogTheme.shape ?? _defaultDialogShape,
               type: MaterialType.card,
               clipBehavior: clipBehavior,
               child: child,
@@ -279,10 +259,8 @@ class AlertDialog extends StatelessWidget {
     this.clipBehavior = Clip.none,
     this.shape,
     this.scrollable = false,
-    bool useMaterialBorderRadius,
   }) : assert(contentPadding != null),
        assert(clipBehavior != null),
-       useMaterialBorderRadius = useMaterialBorderRadius ?? true,
        super(key: key);
 
   /// The (optional) title of the dialog is displayed in a large font at the top
@@ -470,16 +448,6 @@ class AlertDialog extends StatelessWidget {
   )
   final bool scrollable;
 
-  /// Indicates whether the [Dialog.shape]'s default [RoundedRectangleBorder]
-  /// should have a radius of 4.0 pixels to match Material Design, or use the
-  /// prior default of 2.0 pixels.
-  @Deprecated(
-    'Set useMaterialBorderRadius to `true`. This parameter will be removed and '
-    'was introduced to migrate Dialog to the correct border radius by default. '
-    'This feature was deprecated after v1.18.0.'
-  )
-  final bool useMaterialBorderRadius;
-
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterialLocalizations(context));
@@ -591,7 +559,6 @@ class AlertDialog extends StatelessWidget {
       clipBehavior: clipBehavior,
       shape: shape,
       child: dialogChild,
-      useMaterialBorderRadius: useMaterialBorderRadius,
     );
   }
 }
@@ -751,10 +718,8 @@ class SimpleDialog extends StatelessWidget {
     this.elevation,
     this.semanticLabel,
     this.shape,
-    bool useMaterialBorderRadius,
   }) : assert(titlePadding != null),
        assert(contentPadding != null),
-       useMaterialBorderRadius = useMaterialBorderRadius ?? true,
        super(key: key);
 
   /// The (optional) title of the dialog is displayed in a large font at the top
@@ -823,16 +788,6 @@ class SimpleDialog extends StatelessWidget {
   /// {@macro flutter.material.dialog.shape}
   final ShapeBorder shape;
 
-  /// Indicates whether the [Dialog.shape]'s default [RoundedRectangleBorder]
-  /// should have a radius of 4.0 pixels to match Material Design, or use the
-  /// prior default of 2.0 pixels.
-  @Deprecated(
-    'Set useMaterialBorderRadius to `true`. This parameter will be removed and '
-    'was introduced to migrate Dialog to the correct border radius by default. '
-    'This feature was deprecated after v1.18.0.'
-  )
-  final bool useMaterialBorderRadius;
-
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterialLocalizations(context));
@@ -892,7 +847,6 @@ class SimpleDialog extends StatelessWidget {
       elevation: elevation,
       shape: shape,
       child: dialogChild,
-      useMaterialBorderRadius: useMaterialBorderRadius,
     );
   }
 }

--- a/packages/flutter/lib/src/material/pickers/date_picker_dialog.dart
+++ b/packages/flutter/lib/src/material/pickers/date_picker_dialog.dart
@@ -503,13 +503,7 @@ class _DatePickerDialogState extends State<_DatePickerDialog> {
         ),
       ),
       insetPadding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 24.0),
-      // TODO(Piinks): remove once border radius migration is complete
-      // The default dialog shape is radius 2 rounded rect, but the spec has
-      // been updated to 4, so we will use that here for the Date Picker, but
-      // only if there isn't one provided in the theme.
-      shape: dialogTheme.shape ?? const RoundedRectangleBorder(
-        borderRadius: BorderRadius.all(Radius.circular(4.0))
-      ),
+      shape: dialogTheme.shape,
       clipBehavior: Clip.antiAlias,
     );
   }

--- a/packages/flutter/lib/src/material/pickers/date_range_picker_dialog.dart
+++ b/packages/flutter/lib/src/material/pickers/date_range_picker_dialog.dart
@@ -407,10 +407,7 @@ class _DateRangePickerDialogState extends State<_DateRangePickerDialog> {
         final DialogTheme dialogTheme = Theme.of(context).dialogTheme;
         size = orientation == Orientation.portrait ? _inputPortraitDialogSize : _inputLandscapeDialogSize;
         insetPadding = const EdgeInsets.symmetric(horizontal: 16.0, vertical: 24.0);
-        // TODO(Piinks): remove once border radius migration is complete
-        shape = dialogTheme.shape ?? const RoundedRectangleBorder(
-          borderRadius: BorderRadius.all(Radius.circular(4.0))
-        );
+        shape = dialogTheme.shape;
         elevation = dialogTheme.elevation ?? 24;
         break;
     }

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -23,10 +23,6 @@ import 'theme.dart';
 import 'theme_data.dart';
 import 'time.dart';
 
-// TODO(Piinks): remove ignoring deprecated member use analysis
-//   * when Dialog.useMaterialBorderRadius parameter is removed.
-// ignore_for_file: deprecated_member_use_from_same_package
-
 // Examples can assume:
 // BuildContext context;
 
@@ -1505,23 +1501,11 @@ class _TimePickerDialog extends StatefulWidget {
   const _TimePickerDialog({
     Key key,
     @required this.initialTime,
-    bool useMaterialBorderRadius,
   }) : assert(initialTime != null),
-       useMaterialBorderRadius = useMaterialBorderRadius ?? true,
        super(key: key);
 
   /// The time initially selected when the dialog is shown.
   final TimeOfDay initialTime;
-
-  /// Indicates whether the [Dialog.shape]'s default [RoundedRectangleBorder]
-  /// should have a radius of 4.0 pixels to match Material Design, or use the
-  /// prior default of 2.0 pixels.
-  @Deprecated(
-    'Set useMaterialBorderRadius to `true`. This parameter will be removed and '
-    'was introduced to migrate Dialog to the correct border radius by default. '
-    'This feature was deprecated after v1.18.0.'
-  )
-  final bool useMaterialBorderRadius;
 
   @override
   _TimePickerDialogState createState() => _TimePickerDialogState();
@@ -1666,7 +1650,6 @@ class _TimePickerDialogState extends State<_TimePickerDialog> {
     );
 
     final Dialog dialog = Dialog(
-      useMaterialBorderRadius: widget.useMaterialBorderRadius,
       child: OrientationBuilder(
         builder: (BuildContext context, Orientation orientation) {
           final Widget header = _TimePickerHeader(
@@ -1761,11 +1744,6 @@ class _TimePickerDialogState extends State<_TimePickerDialog> {
 /// The returned Future resolves to the time selected by the user when the user
 /// closes the dialog. If the user cancels the dialog, null is returned.
 ///
-/// The [useMaterialBorderRadius] parameter specifies whether th default
-/// [Dialog.shape] of the time picker, a [RoundedRectangleBorder], should have a
-/// radius of 4.0 pixels to match Material Design, or use the prior default of
-/// 2.0 pixels.
-///
 /// {@tool snippet}
 /// Show a dialog with [initialTime] equal to the current time.
 ///
@@ -1828,22 +1806,13 @@ Future<TimeOfDay> showTimePicker({
   TransitionBuilder builder,
   bool useRootNavigator = true,
   RouteSettings routeSettings,
-  @Deprecated(
-    'Set useMaterialBorderRadius to `true`. This parameter will be removed and '
-    'was introduced to migrate Dialog to the correct border radius by default. '
-    'This feature was deprecated after v1.18.0.'
-  )
-  bool useMaterialBorderRadius,
 }) async {
   assert(context != null);
   assert(initialTime != null);
   assert(useRootNavigator != null);
   assert(debugCheckHasMaterialLocalizations(context));
 
-  final Widget dialog = _TimePickerDialog(
-    initialTime: initialTime,
-    useMaterialBorderRadius: useMaterialBorderRadius ?? true,
-  );
+  final Widget dialog = _TimePickerDialog(initialTime: initialTime);
   return await showDialog<TimeOfDay>(
     context: context,
     useRootNavigator: useRootNavigator,


### PR DESCRIPTION
## Description

Last step! Completing migration to match material spec for dialog border radii. This change removes the opt-in flag that was used during migration.
Step 1: #56084
Step 2: #57751
Migration Guide: https://github.com/flutter/website/pull/4056 - to land once this does

## Related Issues

Fixes #58839
#58841

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
