### PR TITLE
Turn off flaky indicator for flutter_gallery__back_button_memory and flutter_gallery__memory_nav

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -744,14 +744,12 @@ tasks:
       Measures memory usage after repeated navigation in Gallery.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
-    flaky: true
 
   flutter_gallery__back_button_memory:
     description: >
       Measures memory usage after Android app suspend and resume.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
-    flaky: true
 
   flutter_gallery__image_cache_memory:
     description: >


### PR DESCRIPTION
## Description

After updating the GBoard on the devicelab machines, these tests are no longer flaky.

## Related Issues
 - Fixes https://github.com/flutter/flutter/issues/58691
 - Fixes https://github.com/flutter/flutter/issues/58690
 - Fixes https://github.com/flutter/flutter/issues/58338