### PR TITLE
Restore some typography tests

### DIFF
--- a/packages/flutter/test/material/typography_test.dart
+++ b/packages/flutter/test/material/typography_test.dart
@@ -154,16 +154,14 @@ void main() {
     // Body1 Roboto regular 16 0.5
     expect(theme.bodyText1.fontFamily, 'Roboto');
     expect(theme.bodyText1.fontWeight, regular);
-    // TODO(hansmuller): restore after englishLike2018 has been updated per #38904.
-    //expect(theme.bodyText1.fontSize, 16);
-    //expect(theme.bodyText1.letterSpacing, 0.5);
+    expect(theme.bodyText1.fontSize, 16);
+    expect(theme.bodyText1.letterSpacing, 0.5);
 
     // Body2 Roboto regular 14 0.25
     expect(theme.bodyText2.fontFamily, 'Roboto');
     expect(theme.bodyText2.fontWeight, regular);
-    // TODO(hansmuller): restore after englishLike2018 has been updated per #38904.
-    //expect(theme.bodyText2.fontSize, 14);
-    //expect(theme.bodyText2.letterSpacing, 0.25);
+    expect(theme.bodyText2.fontSize, 14);
+    expect(theme.bodyText2.letterSpacing, 0.25);
 
     // BUTTON Roboto medium 14 1.25
     expect(theme.button.fontFamily, 'Roboto');


### PR DESCRIPTION
Restore a few Typography tests that had been commented out. These tests should have been restored as part of https://github.com/flutter/flutter/pull/49756.

