### PR TITLE
[flutter_tools] Support IntelliJ 2020.1 and later on Linux and Windows

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -67,3 +67,4 @@ Ram Navan <hiramprasad@gmail.com>
 meritozh <ah841814092@gmail.com>
 Terrence Addison Tandijono(flotilla) <terrenceaddison32@gmail.com>
 YeungKC <flutter@yeungkc.com>
+Nobuhiro Tabuki <japanese.around30@gmail.com>

--- a/packages/flutter_tools/test/general.shard/intellij/intellij_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/intellij/intellij_validator_test.dart
@@ -347,15 +347,17 @@ class IntelliJValidatorTestTarget extends IntelliJValidator {
   String get version => 'test.test.test';
 }
 
+/// A helper to create a Intellij Flutter plugin jar.
+///
+/// These file contents were derived from the META-INF/plugin.xml from an Intellij Flutter
+/// plugin installation.
+///
+/// The file is located in a plugin JAR, which can be located by looking at the plugin
+/// path for the Intellij and Android Studio validators.
+///
+/// If more XML contents are needed, prefer modifying these contents over checking
+/// in another JAR.
 void createIntellijFlutterPluginJar(String pluginJarPath, FileSystem fileSystem, {String version = '0.1.3'}) {
-  /// These file contents were derived from the META-INF/plugin.xml from an Intellij Flutter
-  /// plugin installation.
-  ///
-  /// The file is loacted in a plugin JAR, which can be located by looking at the plugin
-  /// path for the Intellij and Android Studio validators.
-  ///
-  /// If more XML contents are needed, prefer modifying these contents over checking
-  /// in another JAR.
   final String intellijFlutterPluginXml = '''
 <idea-plugin version="2">
   <id>io.flutter</id>
@@ -380,15 +382,18 @@ void createIntellijFlutterPluginJar(String pluginJarPath, FileSystem fileSystem,
 
 }
 
+/// A helper to create a Intellij Dart plugin jar.
+///
+/// This jar contains META-INF/plugin.xml.
+/// Its contents were derived from the META-INF/plugin.xml from an Intellij Dart
+/// plugin installation.
+///
+/// The file is located in a plugin JAR, which can be located by looking at the plugin
+/// path for the Intellij and Android Studio validators.
+///
+/// If more XML contents are needed, prefer modifying these contents over checking
+/// in another JAR.
 void createIntellijDartPluginJar(String pluginJarPath, FileSystem fileSystem) {
-  /// These file contents were derived from the META-INF/plugin.xml from an Intellij Dart
-  /// plugin installation.
-  ///
-  /// The file is loacted in a plugin JAR, which can be located by looking at the plugin
-  /// path for the Intellij and Android Studio validators.
-  ///
-  /// If more XML contents are needed, prefer modifying these contents over checking
-  /// in another JAR.
   const String intellijDartPluginXml = r'''
 <idea-plugin version="2">
   <name>Dart</name>

--- a/packages/flutter_tools/test/general.shard/intellij/intellij_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/intellij/intellij_validator_test.dart
@@ -26,6 +26,14 @@ final Platform linuxPlatform = FakePlatform(
     'HOME': '/foo/bar'
   },
 );
+final Platform windowsPlatform = FakePlatform(
+  operatingSystem: 'windows',
+  environment: <String, String>{
+    'USERPROFILE': 'C:\\Users\\foo',
+    'APPDATA': 'C:\\Users\\foo\\AppData\\Roaming',
+    'LOCALAPPDATA': 'C:\\Users\\foo\\AppData\\Local'
+  },
+);
 
 void main() {
   testWithoutContext('Intellij validator can parse plugin manifest from plugin JAR', () async {
@@ -147,6 +155,114 @@ void main() {
     final Iterable<DoctorValidator> installed = IntelliJValidatorOnLinux.installed(
       fileSystem: fileSystem,
       fileSystemUtils: FileSystemUtils(fileSystem: fileSystem, platform: linuxPlatform),
+      userMessages: UserMessages(),
+    );
+    expect(1, installed.length);
+    final ValidationResult result = await installed.toList()[0].validate();
+    expect(ValidationType.installed, result.type);
+  });
+
+  testWithoutContext('legacy intellij(<2020) plugins check on windows', () async {
+    const String cachePath   = 'C:\\Users\\foo\\.IntelliJIdea2019.10\\system';
+    const String installPath = 'C:\\Program Files\\JetBrains\\IntelliJ IDEA Ultimate Edition 2019.10.1';
+    const String pluginPath  = 'C:\\Users\\foo\\.IntelliJIdea2019.10\\config\\plugins';
+    final FileSystem fileSystem = MemoryFileSystem.test(style: FileSystemStyle.windows);
+
+    final Directory cacheDirectory = fileSystem.directory(cachePath)
+      ..createSync(recursive: true);
+    cacheDirectory
+        .childFile('.home')
+        .writeAsStringSync(installPath, flush: true);
+    final Directory installedDirectory = fileSystem.directory(installPath);
+    installedDirectory.createSync(recursive: true);
+    createIntellijFlutterPluginJar(pluginPath + '/flutter-intellij/lib/flutter-intellij.jar', fileSystem, version: '50.0');
+    createIntellijDartPluginJar(pluginPath + '/Dart/lib/Dart.jar', fileSystem);
+
+    final Iterable<DoctorValidator> installed = IntelliJValidatorOnWindows.installed(
+      fileSystem: fileSystem,
+      fileSystemUtils: FileSystemUtils(fileSystem: fileSystem, platform: windowsPlatform),
+      platform: windowsPlatform,
+      userMessages: UserMessages(),
+    );
+    expect(1, installed.length);
+    final ValidationResult result = await installed.toList()[0].validate();
+    expect(ValidationType.installed, result.type);
+  });
+
+  testWithoutContext('intellij(2020.1 ~ 2020.2) plugins check on windows (installed via JetBrains ToolBox app)', () async {
+    const String cachePath   = 'C:\\Users\\foo\\AppData\\Local\\JetBrains\\IntelliJIdea2020.10';
+    const String installPath = 'C:\\Users\\foo\\AppData\\Local\\JetBrains\\Toolbox\\apps\\IDEA-U\\ch-0\\201.0000.00';
+    const String pluginPath  = 'C:\\Users\\foo\\AppData\\Roaming\\JetBrains\\IntelliJIdea2020.10\\plugins';
+    final FileSystem fileSystem = MemoryFileSystem.test(style: FileSystemStyle.windows);
+
+    final Directory cacheDirectory = fileSystem.directory(cachePath)
+      ..createSync(recursive: true);
+    cacheDirectory
+        .childFile('.home')
+        .writeAsStringSync(installPath, flush: true);
+    final Directory installedDirectory = fileSystem.directory(installPath);
+    installedDirectory.createSync(recursive: true);
+    createIntellijFlutterPluginJar(pluginPath + '\\flutter-intellij\\lib\\flutter-intellij.jar', fileSystem, version: '50.0');
+    createIntellijDartPluginJar(pluginPath + '\\Dart\\lib\\Dart.jar', fileSystem);
+
+    final Iterable<DoctorValidator> installed = IntelliJValidatorOnWindows.installed(
+      fileSystem: fileSystem,
+      fileSystemUtils: FileSystemUtils(fileSystem: fileSystem, platform: windowsPlatform),
+      platform: windowsPlatform,
+      userMessages: UserMessages(),
+    );
+    expect(1, installed.length);
+    final ValidationResult result = await installed.toList()[0].validate();
+    expect(ValidationType.installed, result.type);
+  });
+
+  testWithoutContext('intellij(>=2020.3) plugins check on windows (installed via JetBrains ToolBox app and plugins)', () async {
+    const String cachePath   = 'C:\\Users\\foo\\AppData\\Local\\JetBrains\\IntelliJIdea2020.10';
+    const String installPath = 'C:\\Users\\foo\\AppData\\Local\\JetBrains\\Toolbox\\apps\\IDEA-U\\ch-0\\201.0000.00';
+    const String pluginPath  = 'C:\\Users\\foo\\AppData\\Local\\JetBrains\\Toolbox\\apps\\IDEA-U\\ch-0\\201.0000.00.plugins';
+    final FileSystem fileSystem = MemoryFileSystem.test(style: FileSystemStyle.windows);
+
+    final Directory cacheDirectory = fileSystem.directory(cachePath)
+      ..createSync(recursive: true);
+    cacheDirectory
+        .childFile('.home')
+        .writeAsStringSync(installPath, flush: true);
+    final Directory installedDirectory = fileSystem.directory(installPath);
+    installedDirectory.createSync(recursive: true);
+    createIntellijFlutterPluginJar(pluginPath + '\\flutter-intellij\\lib\\flutter-intellij.jar', fileSystem, version: '50.0');
+    createIntellijDartPluginJar(pluginPath + '\\Dart\\lib\\Dart.jar', fileSystem);
+
+    final Iterable<DoctorValidator> installed = IntelliJValidatorOnWindows.installed(
+      fileSystem: fileSystem,
+      fileSystemUtils: FileSystemUtils(fileSystem: fileSystem, platform: windowsPlatform),
+      platform: windowsPlatform,
+      userMessages: UserMessages(),
+    );
+    expect(1, installed.length);
+    final ValidationResult result = await installed.toList()[0].validate();
+    expect(ValidationType.installed, result.type);
+  });
+
+  testWithoutContext('intellij(2020.1~) plugins check on windows (installed via installer)', () async {
+    const String cachePath   = 'C:\\Users\\foo\\AppData\\Local\\JetBrains\\IdeaIC2020.10';
+    const String installPath = 'C:\\Program Files\\JetBrains\\IntelliJ IDEA Community Edition 2020.10.1';
+    const String pluginPath  = 'C:\\Users\\foo\\AppData\\Roaming\\JetBrains\\IdeaIC2020.10\\plugins';
+    final FileSystem fileSystem = MemoryFileSystem.test(style: FileSystemStyle.windows);
+
+    final Directory cacheDirectory = fileSystem.directory(cachePath)
+      ..createSync(recursive: true);
+    cacheDirectory
+        .childFile('.home')
+        .writeAsStringSync(installPath, flush: true);
+    final Directory installedDirectory = fileSystem.directory(installPath);
+    installedDirectory.createSync(recursive: true);
+    createIntellijFlutterPluginJar(pluginPath + '\\flutter-intellij\\lib\\flutter-intellij.jar', fileSystem, version: '50.0');
+    createIntellijDartPluginJar(pluginPath + '\\Dart\\lib\\Dart.jar', fileSystem);
+
+    final Iterable<DoctorValidator> installed = IntelliJValidatorOnWindows.installed(
+      fileSystem: fileSystem,
+      fileSystemUtils: FileSystemUtils(fileSystem: fileSystem, platform: windowsPlatform),
+      platform: windowsPlatform,
       userMessages: UserMessages(),
     );
     expect(1, installed.length);


### PR DESCRIPTION
## Description

Even after PR #57963 merged, Flutter tools do not recognize IntelliJ IDEA/Community 2020.1 on Linux and Windows.

This PR will update IntelliJ IDEA/Community validation logic for 2020.1 and later on Linux and Windows.

## Related Issues

Ref: #57963
Ref: #57684
Ref: #54867
Ref: #58384

## Tests

I added the following tests:
`packages/flutter_tools/test/general.shard/intellij/intellij_validator_test.dart`

- 'legacy intellij(<2020) plugins check on linux'
- 'intellij(2020.1) plugins check on linux (installed via JetBrains ToolBox app)'
- 'intellij(>=2020.2) plugins check on linux (installed via JetBrains ToolBox app)'
- 'intellij(2020.1~) plugins check on linux (installed via tar.gz)'
- 'legacy intellij(<2020) plugins check on windows'
- 'intellij(2020.1 ~ 2020.2) plugins check on windows (installed via JetBrains ToolBox app)'
- 'intellij(>=2020.3) plugins check on windows (installed via JetBrains ToolBox app and plugins)'
- 'intellij(2020.1~) plugins check on windows (installed via installer)'


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
