### PR TITLE
Revert "Send text error in JSON and print in tools"

### DIFF
--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -929,17 +929,8 @@ mixin WidgetInspectorService {
     );
 
     errorJson['errorsSinceReload'] = _errorsSinceReload;
-    if (_errorsSinceReload == 0) {
-      errorJson['renderedErrorText'] = TextTreeRenderer(
-        wrapWidth: FlutterError.wrapWidth,
-        wrapWidthProperties: FlutterError.wrapWidth,
-        maxDescendentsTruncatableNode: 5,
-      ).render(details.toDiagnosticsNode(style: DiagnosticsTreeStyle.error)).trimRight();
-    } else {
-      errorJson['renderedErrorText'] = 'Another exception was thrown: ${details.summary}';
-    }
-
     _errorsSinceReload += 1;
+
     postEvent('Flutter.Error', errorJson);
   }
 

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -2254,10 +2254,6 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
         // Validate that we received an error count.
         expect(error['errorsSinceReload'], 0);
-        expect(
-            error['renderedErrorText'],
-            startsWith(
-                '══╡ EXCEPTION CAUGHT BY RENDERING LIBRARY ╞════════════'));
 
         // Send a second error.
         FlutterError.reportError(FlutterErrorDetailsForRendering(
@@ -2271,7 +2267,6 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         expect(flutterErrorEvents, hasLength(2));
         error = flutterErrorEvents.last;
         expect(error['errorsSinceReload'], 1);
-        expect(error['renderedErrorText'], startsWith('Another exception was thrown:'));
 
         // Reloads the app.
         final FlutterExceptionHandler oldHandler = FlutterError.onError;

--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -112,7 +112,6 @@ abstract class ResidentWebRunner extends ResidentRunner {
   ConnectionResult _connectionResult;
   StreamSubscription<vmservice.Event> _stdOutSub;
   StreamSubscription<vmservice.Event> _stdErrSub;
-  StreamSubscription<vmservice.Event> _extensionEventSub;
   bool _exited = false;
   WipConnection _wipConnection;
   ChromiumLauncher _chromiumLauncher;
@@ -151,7 +150,6 @@ abstract class ResidentWebRunner extends ResidentRunner {
     }
     await _stdOutSub?.cancel();
     await _stdErrSub?.cancel();
-    await _extensionEventSub?.cancel();
     await device.device.stopApp(null);
     try {
       _generatedEntrypointDirectory?.deleteSync(recursive: true);
@@ -677,8 +675,6 @@ class _ResidentWebRunner extends ResidentWebRunner {
         final String message = utf8.decode(base64.decode(log.bytes));
         globals.printStatus(message, newline: false);
       });
-      _extensionEventSub =
-          _vmService.onExtensionEvent.listen(printStructuredErrorLog);
       try {
         await _vmService.streamListen(vmservice.EventStreams.kStdout);
       } on vmservice.RPCError {
@@ -693,12 +689,6 @@ class _ResidentWebRunner extends ResidentWebRunner {
       }
       try {
         await _vmService.streamListen(vmservice.EventStreams.kIsolate);
-      } on vmservice.RPCError {
-        // It is safe to ignore this error because we expect an error to be
-        // thrown if we're not already subscribed.
-      }
-      try {
-        await _vmService.streamListen(vmservice.EventStreams.kExtension);
       } on vmservice.RPCError {
         // It is safe to ignore this error because we expect an error to be
         // thrown if we're not already subscribed.

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -184,7 +184,6 @@ class FlutterDevice {
     CompileExpression compileExpression,
     ReloadMethod reloadMethod,
     GetSkSLMethod getSkSLMethod,
-    PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
   }) {
     final Completer<void> completer = Completer<void>();
     StreamSubscription<void> subscription;
@@ -204,7 +203,6 @@ class FlutterDevice {
           compileExpression: compileExpression,
           reloadMethod: reloadMethod,
           getSkSLMethod: getSkSLMethod,
-          printStructuredErrorLogMethod: printStructuredErrorLogMethod,
           device: device,
         );
       } on Exception catch (exception) {
@@ -1057,20 +1055,8 @@ abstract class ResidentRunner {
       final String copyPath = getDefaultCachedKernelPath(
         trackWidgetCreation: trackWidgetCreation,
       );
-      globals.fs
-          .file(copyPath)
-          .parent
-          .createSync(recursive: true);
+      globals.fs.file(copyPath).parent.createSync(recursive: true);
       outputDill.copySync(copyPath);
-    }
-  }
-
-  void printStructuredErrorLog(vm_service.Event event) {
-    if (event.extensionKind == 'Flutter.Error') {
-      final Map<dynamic, dynamic> json = event.extensionData?.data;
-      if (json != null && json.containsKey('renderedErrorText')) {
-        globals.printStatus('\n${json['renderedErrorText']}');
-      }
     }
   }
 
@@ -1098,8 +1084,7 @@ abstract class ResidentRunner {
         restart: restart,
         compileExpression: compileExpression,
         reloadMethod: reloadMethod,
-        getSkSLMethod: getSkSLMethod,
-        printStructuredErrorLogMethod: printStructuredErrorLog,
+        getSkSLMethod: getSkSLMethod
       );
       // This will wait for at least one flutter view before returning.
       final Status status = globals.logger.startProgress(

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -31,8 +31,6 @@ const int kIsolateReloadBarred = 1005;
 /// for [WebSocket]s (used by tests).
 typedef WebSocketConnector = Future<io.WebSocket> Function(String url, {io.CompressionOptions compression});
 
-typedef PrintStructuredErrorLogMethod = void Function(vm_service.Event);
-
 WebSocketConnector _openChannel = _defaultOpenChannel;
 
 /// The error codes for the JSON-RPC standard.
@@ -151,7 +149,6 @@ typedef VMServiceConnector = Future<vm_service.VmService> Function(Uri httpUri, 
   CompileExpression compileExpression,
   ReloadMethod reloadMethod,
   GetSkSLMethod getSkSLMethod,
-  PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
   io.CompressionOptions compression,
   Device device,
 });
@@ -178,7 +175,6 @@ vm_service.VmService setUpVmService(
   Device device,
   ReloadMethod reloadMethod,
   GetSkSLMethod skSLMethod,
-  PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
   vm_service.VmService vmService
 ) {
   if (reloadSources != null) {
@@ -297,10 +293,6 @@ vm_service.VmService setUpVmService(
     });
     vmService.registerService('flutterGetSkSL', 'Flutter Tools');
   }
-  if (printStructuredErrorLogMethod != null) {
-    vmService.streamListen(vm_service.EventStreams.kExtension);
-    vmService.onExtensionEvent.listen(printStructuredErrorLogMethod);
-  }
   return vmService;
 }
 
@@ -319,7 +311,6 @@ Future<vm_service.VmService> connectToVmService(
     CompileExpression compileExpression,
     ReloadMethod reloadMethod,
     GetSkSLMethod getSkSLMethod,
-    PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
     io.CompressionOptions compression = io.CompressionOptions.compressionDefault,
     Device device,
   }) async {
@@ -332,7 +323,6 @@ Future<vm_service.VmService> connectToVmService(
     device: device,
     reloadMethod: reloadMethod,
     getSkSLMethod: getSkSLMethod,
-    printStructuredErrorLogMethod: printStructuredErrorLogMethod,
   );
 }
 
@@ -343,7 +333,6 @@ Future<vm_service.VmService> _connect(
   CompileExpression compileExpression,
   ReloadMethod reloadMethod,
   GetSkSLMethod getSkSLMethod,
-  PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
   io.CompressionOptions compression = io.CompressionOptions.compressionDefault,
   Device device,
 }) async {
@@ -365,7 +354,6 @@ Future<vm_service.VmService> _connect(
     device,
     reloadMethod,
     getSkSLMethod,
-    printStructuredErrorLogMethod,
     delegateService,
   );
   _httpAddressExpando[service] = httpUri;

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -679,7 +679,6 @@ VMServiceConnector getFakeVmServiceFactory({
     CompileExpression compileExpression,
     ReloadMethod reloadMethod,
     GetSkSLMethod getSkSLMethod,
-    PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
     CompressionOptions compression,
     Device device,
   }) async {

--- a/packages/flutter_tools/test/general.shard/cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/cold_test.dart
@@ -135,7 +135,6 @@ class TestFlutterDevice extends FlutterDevice {
     CompileExpression compileExpression,
     ReloadMethod reloadMethod,
     GetSkSLMethod getSkSLMethod,
-    PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
   }) async {
     throw exception;
   }

--- a/packages/flutter_tools/test/general.shard/hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/hot_test.dart
@@ -510,7 +510,6 @@ class TestFlutterDevice extends FlutterDevice {
     CompileExpression compileExpression,
     ReloadMethod reloadMethod,
     GetSkSLMethod getSkSLMethod,
-    PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
   }) async {
     throw exception;
   }

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -1355,7 +1355,6 @@ void main() {
       CompileExpression compileExpression,
       ReloadMethod reloadMethod,
       GetSkSLMethod getSkSLMethod,
-      PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
       io.CompressionOptions compression,
       Device device,
     }) async => mockVMService,

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:dwds/dwds.dart';
 import 'package:flutter_tools/src/base/common.dart';
@@ -56,12 +55,6 @@ const List<VmServiceExpectation> kAttachIsolateExpectations = <VmServiceExpectat
     args: <String, Object>{
       'streamId': 'Isolate'
     }
-  ),
-  FakeVmServiceRequest(
-    method: 'streamListen',
-    args: <String, Object>{
-      'streamId': 'Extension',
-    },
   ),
   FakeVmServiceRequest(
     method: 'registerService',
@@ -345,68 +338,6 @@ void main() {
 
     expect(testLogger.statusText, contains('THIS MESSAGE IS IMPORTANT'));
     expect(testLogger.statusText, contains('SO IS THIS'));
-  }));
-
-  test('Listens to extension events with structured errors', () => testbed.run(() async {
-    final Map<String, String> extensionData = <String, String>{
-      'test': 'data',
-      'renderedErrorText': 'error text',
-    };
-    final Map<String, String> emptyExtensionData = <String, String>{
-      'test': 'data',
-      'renderedErrorText': '',
-    };
-    final Map<String, String> nonStructuredErrorData = <String, String>{
-      'other': 'other stuff',
-    };
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
-      ...kAttachExpectations,
-      FakeVmServiceStreamResponse(
-        streamId: 'Extension',
-        event: vm_service.Event(
-          timestamp: 0,
-          extensionKind: 'Flutter.Error',
-          extensionData: vm_service.ExtensionData.parse(extensionData),
-          kind: vm_service.EventStreams.kExtension,
-        ),
-      ),
-      // Empty error text should not break anything.
-      FakeVmServiceStreamResponse(
-        streamId: 'Extension',
-        event: vm_service.Event(
-          timestamp: 0,
-          extensionKind: 'Flutter.Error',
-          extensionData: vm_service.ExtensionData.parse(emptyExtensionData),
-          kind: vm_service.EventStreams.kExtension,
-        ),
-      ),
-      // This is not Flutter.Error kind data, so it should not be logged.
-      FakeVmServiceStreamResponse(
-        streamId: 'Extension',
-        event: vm_service.Event(
-          timestamp: 0,
-          extensionKind: 'Other',
-          extensionData: vm_service.ExtensionData.parse(nonStructuredErrorData),
-          kind: vm_service.EventStreams.kExtension,
-        ),
-      ),
-    ]);
-
-    _setupMocks();
-    final Completer<DebugConnectionInfo> connectionInfoCompleter = Completer<DebugConnectionInfo>();
-    unawaited(residentWebRunner.run(
-      connectionInfoCompleter: connectionInfoCompleter,
-    ));
-    await connectionInfoCompleter.future;
-
-    // Need these to run events, otherwise expect statements below run before
-    // structured errors are processed.
-    await null;
-    await null;
-    await null;
-
-    expect(testLogger.statusText, contains('\nerror text'));
-    expect(testLogger.statusText, isNot(contains('other stuff')));
   }));
 
   test('Does not run main with --start-paused', () => testbed.run(() async {
@@ -1142,7 +1073,19 @@ void main() {
   test('Sends launched app.webLaunchUrl event for Chrome device', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachLogExpectations,
-      ...kAttachIsolateExpectations,
+      const FakeVmServiceRequest(
+        method: 'streamListen',
+        args: <String, Object>{
+          'streamId': 'Isolate'
+        }
+      ),
+      const FakeVmServiceRequest(
+        method: 'registerService',
+        args: <String, Object>{
+          'service': 'reloadSources',
+          'alias': 'FlutterTools',
+        }
+      )
     ]);
     _setupMocks();
     final ChromiumLauncher chromiumLauncher = MockChromeLauncher();

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -104,7 +104,6 @@ void main() {
       null,
       null,
       null,
-      null,
       mockVMService,
     );
 
@@ -123,7 +122,6 @@ void main() {
       null,
       null,
       reloadMethod,
-      null,
       null,
       mockVMService,
     );
@@ -144,7 +142,6 @@ void main() {
       mockDevice,
       null,
       null,
-      null,
       mockVMService,
     );
 
@@ -162,7 +159,6 @@ void main() {
       null,
       null,
       () async => 'hello',
-      null,
       mockVMService,
     );
 
@@ -171,30 +167,9 @@ void main() {
     Logger: () => BufferLogger.test()
   });
 
-  testUsingContext('VmService registers flutterPrintStructuredErrorLogMethod', () async {
-    final MockVMService mockVMService = MockVMService();
-    when(mockVMService.onExtensionEvent).thenAnswer((Invocation invocation) {
-      return const Stream<vm_service.Event>.empty();
-    });
-    setUpVmService(
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      (vm_service.Event event) async => 'hello',
-      mockVMService,
-    );
-    verify(mockVMService.streamListen(vm_service.EventStreams.kExtension)).called(1);
-  }, overrides: <Type, Generator>{
-    Logger: () => BufferLogger.test()
-  });
-
   testUsingContext('VMService returns correct FlutterVersion', () async {
     final MockVMService mockVMService = MockVMService();
     setUpVmService(
-      null,
       null,
       null,
       null,


### PR DESCRIPTION
Reverts flutter/flutter#58284

```
2020-06-05T19:18:55.701337: stdout: [        ] Application running.
2020-06-05T19:18:55.706521: stdout: [   +4 ms] Connected to iPhone
2020-06-05T19:18:55.706657: stdout: [        ] Tracing startup on iPhone.
2020-06-05T19:18:55.709378: stdout: [   +2 ms] Waiting for application to render first frame...
2020-06-05T19:18:55.713914: stdout: [   +4 ms] Waiting for application to render first frame... (completed in 4ms)
2020-06-05T19:18:55.714586: stdout: [   +1 ms] "flutter run" took 89,426ms.
2020-06-05T19:18:55.718105: stderr: 
2020-06-05T19:18:55.721575: stderr: [   +6 ms] Oops; flutter has exited unexpectedly: "streamListen: (103) Stream already subscribed".
2020-06-05T19:18:55.746695: stdout: [  +24 ms] executing: [/Users/flutter/.cocoon/flutter/] git -c log.showSignature=false log -n 1 --pretty=format:%ar
2020-06-05T19:18:55.756660: stdout: [   +9 ms] Exit code 0 from: git -c log.showSignature=false log -n 1 --pretty=format:%ar
stdout: [        ] 11 minutes ago
2020-06-05T19:18:55.768786: stdout: [  +11 ms] executing: /Users/flutter/.cocoon/flutter/bin/cache/artifacts/engine/android-arm-profile/darwin-x64/gen_snapshot
2020-06-05T19:18:55.782537: stdout: [  +13 ms] Exit code 255 from: /Users/flutter/.cocoon/flutter/bin/cache/artifacts/engine/android-arm-profile/darwin-x64/gen_snapshot
2020-06-05T19:18:55.782760: stdout: [        ] At least one input is required
stdout:            Usage: gen_snapshot [<vm-flags>] [<options>] <dart-kernel-file>             
```


TBR @helin24 