### PR TITLE
Update TextTheme.button.letterSpacing from 0.75 to 1.25 per spec

### DIFF
--- a/packages/flutter/lib/src/material/typography.dart
+++ b/packages/flutter/lib/src/material/typography.dart
@@ -526,7 +526,7 @@ class Typography with Diagnosticable {
     bodyText2 : TextStyle(debugLabel: 'englishLike bodyText2 2018', fontSize: 14.0, fontWeight: FontWeight.w400, textBaseline: TextBaseline.alphabetic, letterSpacing: 0.25),
     subtitle1 : TextStyle(debugLabel: 'englishLike subtitle1 2018', fontSize: 16.0, fontWeight: FontWeight.w400, textBaseline: TextBaseline.alphabetic, letterSpacing: 0.15),
     subtitle2 : TextStyle(debugLabel: 'englishLike subtitle2 2018', fontSize: 14.0, fontWeight: FontWeight.w500, textBaseline: TextBaseline.alphabetic, letterSpacing: 0.1),
-    button    : TextStyle(debugLabel: 'englishLike button 2018',    fontSize: 14.0, fontWeight: FontWeight.w500, textBaseline: TextBaseline.alphabetic, letterSpacing: 0.75),
+    button    : TextStyle(debugLabel: 'englishLike button 2018',    fontSize: 14.0, fontWeight: FontWeight.w500, textBaseline: TextBaseline.alphabetic, letterSpacing: 1.25),
     caption   : TextStyle(debugLabel: 'englishLike caption 2018',   fontSize: 12.0, fontWeight: FontWeight.w400, textBaseline: TextBaseline.alphabetic, letterSpacing: 0.4),
     overline  : TextStyle(debugLabel: 'englishLike overline 2018',  fontSize: 10.0, fontWeight: FontWeight.w400, textBaseline: TextBaseline.alphabetic, letterSpacing: 1.5),
   );

--- a/packages/flutter/test/material/typography_test.dart
+++ b/packages/flutter/test/material/typography_test.dart
@@ -167,8 +167,7 @@ void main() {
     expect(theme.button.fontFamily, 'Roboto');
     expect(theme.button.fontWeight, medium);
     expect(theme.button.fontSize, 14);
-    // TODO(hansmuller): restore after englishLike2018 has been updated, per #38904.
-    //expect(theme.button.letterSpacing, 1.25);
+    expect(theme.button.letterSpacing, 1.25);
 
     // Caption Roboto regular 12 0.4
     expect(theme.caption.fontFamily, 'Roboto');


### PR DESCRIPTION
This is the last change needed to bring Flutter's Typography in line with the 2018 Material spec.

Fixes https://github.com/flutter/flutter/issues/38904

This change has a small impact on buttons' default width.  The top button's letterSpacing has the new default value (1.25), the lower button has the original default value (0.75).

![button_layout](https://user-images.githubusercontent.com/1377460/84167030-8e3e0900-aa2a-11ea-9cfb-75592c7eea25.png)

It's easy enough to restore the original letterSpacing value for the TextTheme's button TextStyle by configuring the app's Theme.

```dart
import 'package:flutter/foundation.dart';
import 'package:flutter/material.dart';

void main() {
  final ThemeData theme = ThemeData.from(colorScheme: ColorScheme.light());
  runApp(
    MaterialApp(
      theme: theme.copyWith(
        typography: Typography.material2018(platform: defaultTargetPlatform),
        // The following override reverts the default letterSpacing change
        textTheme: theme.textTheme.copyWith(
          button: theme.textTheme.button.copyWith(letterSpacing: 0.75),
        ),
      ),
      home: Home(),
    )
  );
}

class Home extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    print(Theme.of(context).textTheme.button.letterSpacing);
    return Scaffold(
      body: Center(
        child: Column(
          mainAxisSize: MainAxisSize.min,
          children: <Widget>[
            // Rendered with the default 2018 button letterSpacing change.
            RaisedButton(
              color: Theme.of(context).colorScheme.primary,
              textColor: Theme.of(context).colorScheme.onPrimary,
              onPressed: () { },
              child: Text(
                'BUTTON',
              ),
            ),
            // Rendered as it would be without the letterSpacing change.
            RaisedButton(
              onPressed: () { },
              color: Theme.of(context).colorScheme.primary,
              child: Text(
                'BUTTON',
                style: Theme.of(context).textTheme.button.copyWith(
                  letterSpacing: 0.75,
                  color: Theme.of(context).colorScheme.onPrimary,
                ),
              ),
            ),
          ],
        ),
      ),
    );
  }
}
```