### PR TITLE
Scale input decorator label width 

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -17,6 +17,7 @@ import 'theme_data.dart';
 
 const Duration _kTransitionDuration = Duration(milliseconds: 200);
 const Curve _kTransitionCurve = Curves.fastOutSlowIn;
+const double _kFinalLabelScale = 0.75;
 
 // Defines the gap in the InputDecorator's outline border where the
 // floating label will appear.
@@ -981,9 +982,11 @@ class _RenderDecoration extends RenderBox {
       + _boxSize(suffix).width
       + _boxSize(suffixIcon).width
       + contentPadding.right));
+    // Increase the available width for the label when it is scaled down.
+    final double invertedLabelScale = lerpDouble(1.00, 1/_kFinalLabelScale, decoration.floatingLabelProgress);
     boxToBaseline[label] = _layoutLineBox(
       label,
-      boxConstraints.copyWith(maxWidth: inputWidth),
+      boxConstraints.copyWith(maxWidth: inputWidth * invertedLabelScale),
     );
     boxToBaseline[hint] = _layoutLineBox(
       hint,
@@ -1452,11 +1455,10 @@ class _RenderDecoration extends RenderBox {
       final bool isOutlineBorder = decoration.border != null && decoration.border.isOutline;
       // Temporary opt-in fix for https://github.com/flutter/flutter/issues/54028
       // Center the scaled label relative to the border.
-      const double finalLabelScale = 0.75;
       final double floatingY = decoration.fixTextFieldOutlineLabel
-        ? isOutlineBorder ? (-labelHeight * finalLabelScale) / 2.0 + borderWeight / 2.0 : contentPadding.top
+        ? isOutlineBorder ? (-labelHeight * _kFinalLabelScale) / 2.0 + borderWeight / 2.0 : contentPadding.top
         : isOutlineBorder ? -labelHeight * 0.25 : contentPadding.top;
-      final double scale = lerpDouble(1.0, finalLabelScale, t);
+      final double scale = lerpDouble(1.0, _kFinalLabelScale, t);
       double dx;
       switch (textDirection) {
         case TextDirection.rtl:

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -983,7 +983,7 @@ class _RenderDecoration extends RenderBox {
       + _boxSize(suffixIcon).width
       + contentPadding.right));
     // Increase the available width for the label when it is scaled down.
-    final double invertedLabelScale = lerpDouble(1.00, 1/_kFinalLabelScale, decoration.floatingLabelProgress);
+    final double invertedLabelScale = lerpDouble(1.00, 1 / _kFinalLabelScale, decoration.floatingLabelProgress);
     boxToBaseline[label] = _layoutLineBox(
       label,
       boxConstraints.copyWith(maxWidth: inputWidth * invertedLabelScale),

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -4119,7 +4119,7 @@ void main() {
       // 133.3 is approximately 100 / 0.75 (_kFinalLabelScale)
       paints..clipRect(rect: const Rect.fromLTWH(0, 0, 133.0, 16.0)),
     );
-  }, skip: isBrowser);  // TODO(yjbanov): https://github.com/flutter/flutter/issues/44020);
+  }, skip: isBrowser);  // TODO(yjbanov): https://github.com/flutter/flutter/issues/44020
 
   testWidgets('textAlignVertical can be updated', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/56933

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -4069,36 +4069,56 @@ void main() {
     expect(tester.getTopLeft(find.text('label')).dy, 20.0);
   });
 
-  testWidgets('InputDecorator floating label width scales', (WidgetTester tester) async {
+  testWidgets('InputDecorator floating label width scales when focused', (WidgetTester tester) async {
+    final String longStringA = String.fromCharCodes(List<int>.generate(200, (_) => 65));
+    final String longStringB = String.fromCharCodes(List<int>.generate(200, (_) => 66));
+
     await tester.pumpWidget(
-      buildInputDecorator(
-        // isFocused: false (default)
-        isEmpty: true,
-        decoration: const InputDecoration(
-          labelText: 'label',
+      Center(
+        child: Container(
+          width: 100,
+          height: 100,
+          child: buildInputDecorator(
+            // isFocused: false (default)
+            isEmpty: true,
+            decoration: InputDecoration(
+              labelText: longStringA,
+            ),
+          ),
         ),
       ),
     );
 
     await tester.pumpAndSettle();
 
-    final double labelWidth = tester.getSize(find.text('label')).width;
+    expect(
+      find.text(longStringA),
+      paints..clipRect(rect: const Rect.fromLTWH(0, 0, 100.0, 16.0)),
+    );
 
     await tester.pumpWidget(
-      buildInputDecorator(
-        isFocused: true,
-        isEmpty: true,
-        decoration: const InputDecoration(
-          labelText: 'focusedLabel',
+      Center(
+        child: Container(
+          width: 100,
+          height: 100,
+          child: buildInputDecorator(
+            isFocused: true,
+            isEmpty: true,
+            decoration: InputDecoration(
+              labelText: longStringB,
+            ),
+          ),
         ),
       ),
     );
 
     await tester.pumpAndSettle();
 
-    final double focusedLabelWidth = tester.getSize(find.text('focusedLabel')).width;
-
-    expect(labelWidth, focusedLabelWidth);
+    expect(
+      find.text(longStringB),
+      // 133.3 is approximately 100 / 0.75 (_kFinalLabelScale)
+      paints..clipRect(rect: const Rect.fromLTWH(0, 0, 133.0, 16.0)),
+    );
   });
 
   testWidgets('textAlignVertical can be updated', (WidgetTester tester) async {

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -4119,7 +4119,7 @@ void main() {
       // 133.3 is approximately 100 / 0.75 (_kFinalLabelScale)
       paints..clipRect(rect: const Rect.fromLTWH(0, 0, 133.0, 16.0)),
     );
-  });
+  }, skip: isBrowser);  // TODO(yjbanov): https://github.com/flutter/flutter/issues/44020);
 
   testWidgets('textAlignVertical can be updated', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/56933

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -4069,6 +4069,38 @@ void main() {
     expect(tester.getTopLeft(find.text('label')).dy, 20.0);
   });
 
+  testWidgets('InputDecorator floating label width scales', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      buildInputDecorator(
+        // isFocused: false (default)
+        isEmpty: true,
+        decoration: const InputDecoration(
+          labelText: 'label',
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    final double labelWidth = tester.getSize(find.text('label')).width;
+
+    await tester.pumpWidget(
+      buildInputDecorator(
+        isFocused: true,
+        isEmpty: true,
+        decoration: const InputDecoration(
+          labelText: 'focusedLabel',
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    final double focusedLabelWidth = tester.getSize(find.text('focusedLabel')).width;
+
+    expect(labelWidth, focusedLabelWidth);
+  });
+
   testWidgets('textAlignVertical can be updated', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/56933
     const String hintText = 'hint';


### PR DESCRIPTION
## Description

When a text field is empty and unfocused, a label will be truncated with ellipsis if it is too long. 

When the text field is focused, a floating label will be scaled down by a factor of 0.75, but so is its width. This means the label doesn't use available space. This PR fixes this behavior by scaling the label width.

Before:
<img width="261" alt="Screenshot 2020-06-08 at 22 07 46" src="https://user-images.githubusercontent.com/6655696/84075476-82bff300-a9d4-11ea-90ad-b2339920e700.png">

After:
<img width="255" alt="Screenshot 2020-06-08 at 22 07 14" src="https://user-images.githubusercontent.com/6655696/84075483-86537a00-a9d4-11ea-9205-1bcb4e1a7f2d.png">

## Related Issues

Closes #56848 

## Tests

Added a test to verify that the label width scales when focused 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
