### PR TITLE
Send text error in JSON and print in tools

### DIFF
--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -929,8 +929,17 @@ mixin WidgetInspectorService {
     );
 
     errorJson['errorsSinceReload'] = _errorsSinceReload;
-    _errorsSinceReload += 1;
+    if (_errorsSinceReload == 0) {
+      errorJson['renderedErrorText'] = TextTreeRenderer(
+        wrapWidth: FlutterError.wrapWidth,
+        wrapWidthProperties: FlutterError.wrapWidth,
+        maxDescendentsTruncatableNode: 5,
+      ).render(details.toDiagnosticsNode(style: DiagnosticsTreeStyle.error)).trimRight();
+    } else {
+      errorJson['renderedErrorText'] = 'Another exception was thrown: ${details.summary}';
+    }
 
+    _errorsSinceReload += 1;
     postEvent('Flutter.Error', errorJson);
   }
 

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -2254,6 +2254,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
         // Validate that we received an error count.
         expect(error['errorsSinceReload'], 0);
+        expect(
+            error['renderedErrorText'],
+            startsWith(
+                '══╡ EXCEPTION CAUGHT BY RENDERING LIBRARY ╞════════════'));
 
         // Send a second error.
         FlutterError.reportError(FlutterErrorDetailsForRendering(
@@ -2267,6 +2271,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         expect(flutterErrorEvents, hasLength(2));
         error = flutterErrorEvents.last;
         expect(error['errorsSinceReload'], 1);
+        expect(error['renderedErrorText'], startsWith('Another exception was thrown:'));
 
         // Reloads the app.
         final FlutterExceptionHandler oldHandler = FlutterError.onError;

--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -112,6 +112,7 @@ abstract class ResidentWebRunner extends ResidentRunner {
   ConnectionResult _connectionResult;
   StreamSubscription<vmservice.Event> _stdOutSub;
   StreamSubscription<vmservice.Event> _stdErrSub;
+  StreamSubscription<vmservice.Event> _extensionEventSub;
   bool _exited = false;
   WipConnection _wipConnection;
   ChromiumLauncher _chromiumLauncher;
@@ -150,6 +151,7 @@ abstract class ResidentWebRunner extends ResidentRunner {
     }
     await _stdOutSub?.cancel();
     await _stdErrSub?.cancel();
+    await _extensionEventSub?.cancel();
     await device.device.stopApp(null);
     try {
       _generatedEntrypointDirectory?.deleteSync(recursive: true);
@@ -675,6 +677,8 @@ class _ResidentWebRunner extends ResidentWebRunner {
         final String message = utf8.decode(base64.decode(log.bytes));
         globals.printStatus(message, newline: false);
       });
+      _extensionEventSub =
+          _vmService.onExtensionEvent.listen(printStructuredErrorLog);
       try {
         await _vmService.streamListen(vmservice.EventStreams.kStdout);
       } on vmservice.RPCError {
@@ -689,6 +693,12 @@ class _ResidentWebRunner extends ResidentWebRunner {
       }
       try {
         await _vmService.streamListen(vmservice.EventStreams.kIsolate);
+      } on vmservice.RPCError {
+        // It is safe to ignore this error because we expect an error to be
+        // thrown if we're not already subscribed.
+      }
+      try {
+        await _vmService.streamListen(vmservice.EventStreams.kExtension);
       } on vmservice.RPCError {
         // It is safe to ignore this error because we expect an error to be
         // thrown if we're not already subscribed.

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -188,6 +188,7 @@ class FlutterDevice {
     CompileExpression compileExpression,
     ReloadMethod reloadMethod,
     GetSkSLMethod getSkSLMethod,
+    PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
   }) {
     final Completer<void> completer = Completer<void>();
     StreamSubscription<void> subscription;
@@ -207,6 +208,7 @@ class FlutterDevice {
           compileExpression: compileExpression,
           reloadMethod: reloadMethod,
           getSkSLMethod: getSkSLMethod,
+          printStructuredErrorLogMethod: printStructuredErrorLogMethod,
           device: device,
         );
       } on Exception catch (exception) {
@@ -1061,8 +1063,20 @@ abstract class ResidentRunner {
       final String copyPath = getDefaultCachedKernelPath(
         trackWidgetCreation: trackWidgetCreation,
       );
-      globals.fs.file(copyPath).parent.createSync(recursive: true);
+      globals.fs
+          .file(copyPath)
+          .parent
+          .createSync(recursive: true);
       outputDill.copySync(copyPath);
+    }
+  }
+
+  void printStructuredErrorLog(vm_service.Event event) {
+    if (event.extensionKind == 'Flutter.Error') {
+      final Map<dynamic, dynamic> json = event.extensionData?.data;
+      if (json != null && json.containsKey('renderedErrorText')) {
+        globals.printStatus('\n${json['renderedErrorText']}');
+      }
     }
   }
 
@@ -1090,7 +1104,8 @@ abstract class ResidentRunner {
         restart: restart,
         compileExpression: compileExpression,
         reloadMethod: reloadMethod,
-        getSkSLMethod: getSkSLMethod
+        getSkSLMethod: getSkSLMethod,
+        printStructuredErrorLogMethod: printStructuredErrorLog,
       );
       // This will wait for at least one flutter view before returning.
       final Status status = globals.logger.startProgress(

--- a/packages/flutter_tools/lib/src/tracing.dart
+++ b/packages/flutter_tools/lib/src/tracing.dart
@@ -46,7 +46,12 @@ class Tracing {
       );
       try {
         final Completer<void> whenFirstFrameRendered = Completer<void>();
-        await vmService.streamListen('Extension');
+        try {
+          await vmService.streamListen(vm_service.EventStreams.kExtension);
+        } on vm_service.RPCError {
+          // It is safe to ignore this error because we expect an error to be
+          // thrown if we're already subscribed.
+        }
         vmService.onExtensionEvent.listen((vm_service.Event event) {
           if (event.extensionKind == 'Flutter.FirstFrame') {
             whenFirstFrameRendered.complete();

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -31,6 +31,8 @@ const int kIsolateReloadBarred = 1005;
 /// for [WebSocket]s (used by tests).
 typedef WebSocketConnector = Future<io.WebSocket> Function(String url, {io.CompressionOptions compression});
 
+typedef PrintStructuredErrorLogMethod = void Function(vm_service.Event);
+
 WebSocketConnector _openChannel = _defaultOpenChannel;
 
 /// The error codes for the JSON-RPC standard.
@@ -149,6 +151,7 @@ typedef VMServiceConnector = Future<vm_service.VmService> Function(Uri httpUri, 
   CompileExpression compileExpression,
   ReloadMethod reloadMethod,
   GetSkSLMethod getSkSLMethod,
+  PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
   io.CompressionOptions compression,
   Device device,
 });
@@ -175,6 +178,7 @@ vm_service.VmService setUpVmService(
   Device device,
   ReloadMethod reloadMethod,
   GetSkSLMethod skSLMethod,
+  PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
   vm_service.VmService vmService
 ) {
   if (reloadSources != null) {
@@ -293,6 +297,15 @@ vm_service.VmService setUpVmService(
     });
     vmService.registerService('flutterGetSkSL', 'Flutter Tools');
   }
+  if (printStructuredErrorLogMethod != null) {
+    try {
+      vmService.streamListen(vm_service.EventStreams.kExtension);
+    } on vm_service.RPCError {
+      // It is safe to ignore this error because we expect an error to be
+      // thrown if we're already subscribed.
+    }
+    vmService.onExtensionEvent.listen(printStructuredErrorLogMethod);
+  }
   return vmService;
 }
 
@@ -311,6 +324,7 @@ Future<vm_service.VmService> connectToVmService(
     CompileExpression compileExpression,
     ReloadMethod reloadMethod,
     GetSkSLMethod getSkSLMethod,
+    PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
     io.CompressionOptions compression = io.CompressionOptions.compressionDefault,
     Device device,
   }) async {
@@ -323,6 +337,7 @@ Future<vm_service.VmService> connectToVmService(
     device: device,
     reloadMethod: reloadMethod,
     getSkSLMethod: getSkSLMethod,
+    printStructuredErrorLogMethod: printStructuredErrorLogMethod,
   );
 }
 
@@ -333,6 +348,7 @@ Future<vm_service.VmService> _connect(
   CompileExpression compileExpression,
   ReloadMethod reloadMethod,
   GetSkSLMethod getSkSLMethod,
+  PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
   io.CompressionOptions compression = io.CompressionOptions.compressionDefault,
   Device device,
 }) async {
@@ -354,6 +370,7 @@ Future<vm_service.VmService> _connect(
     device,
     reloadMethod,
     getSkSLMethod,
+    printStructuredErrorLogMethod,
     delegateService,
   );
   _httpAddressExpando[service] = httpUri;

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -705,6 +705,7 @@ VMServiceConnector getFakeVmServiceFactory({
     CompileExpression compileExpression,
     ReloadMethod reloadMethod,
     GetSkSLMethod getSkSLMethod,
+    PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
     CompressionOptions compression,
     Device device,
   }) async {

--- a/packages/flutter_tools/test/general.shard/cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/cold_test.dart
@@ -135,6 +135,7 @@ class TestFlutterDevice extends FlutterDevice {
     CompileExpression compileExpression,
     ReloadMethod reloadMethod,
     GetSkSLMethod getSkSLMethod,
+    PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
   }) async {
     throw exception;
   }

--- a/packages/flutter_tools/test/general.shard/hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/hot_test.dart
@@ -510,6 +510,7 @@ class TestFlutterDevice extends FlutterDevice {
     CompileExpression compileExpression,
     ReloadMethod reloadMethod,
     GetSkSLMethod getSkSLMethod,
+    PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
   }) async {
     throw exception;
   }

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -1357,6 +1357,7 @@ void main() {
       CompileExpression compileExpression,
       ReloadMethod reloadMethod,
       GetSkSLMethod getSkSLMethod,
+      PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
       io.CompressionOptions compression,
       Device device,
     }) async => mockVMService,

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:dwds/dwds.dart';
 import 'package:flutter_tools/src/base/common.dart';
@@ -55,6 +56,12 @@ const List<VmServiceExpectation> kAttachIsolateExpectations = <VmServiceExpectat
     args: <String, Object>{
       'streamId': 'Isolate'
     }
+  ),
+  FakeVmServiceRequest(
+    method: 'streamListen',
+    args: <String, Object>{
+      'streamId': 'Extension',
+    },
   ),
   FakeVmServiceRequest(
     method: 'registerService',
@@ -338,6 +345,68 @@ void main() {
 
     expect(testLogger.statusText, contains('THIS MESSAGE IS IMPORTANT'));
     expect(testLogger.statusText, contains('SO IS THIS'));
+  }));
+
+  test('Listens to extension events with structured errors', () => testbed.run(() async {
+    final Map<String, String> extensionData = <String, String>{
+      'test': 'data',
+      'renderedErrorText': 'error text',
+    };
+    final Map<String, String> emptyExtensionData = <String, String>{
+      'test': 'data',
+      'renderedErrorText': '',
+    };
+    final Map<String, String> nonStructuredErrorData = <String, String>{
+      'other': 'other stuff',
+    };
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
+      ...kAttachExpectations,
+      FakeVmServiceStreamResponse(
+        streamId: 'Extension',
+        event: vm_service.Event(
+          timestamp: 0,
+          extensionKind: 'Flutter.Error',
+          extensionData: vm_service.ExtensionData.parse(extensionData),
+          kind: vm_service.EventStreams.kExtension,
+        ),
+      ),
+      // Empty error text should not break anything.
+      FakeVmServiceStreamResponse(
+        streamId: 'Extension',
+        event: vm_service.Event(
+          timestamp: 0,
+          extensionKind: 'Flutter.Error',
+          extensionData: vm_service.ExtensionData.parse(emptyExtensionData),
+          kind: vm_service.EventStreams.kExtension,
+        ),
+      ),
+      // This is not Flutter.Error kind data, so it should not be logged.
+      FakeVmServiceStreamResponse(
+        streamId: 'Extension',
+        event: vm_service.Event(
+          timestamp: 0,
+          extensionKind: 'Other',
+          extensionData: vm_service.ExtensionData.parse(nonStructuredErrorData),
+          kind: vm_service.EventStreams.kExtension,
+        ),
+      ),
+    ]);
+
+    _setupMocks();
+    final Completer<DebugConnectionInfo> connectionInfoCompleter = Completer<DebugConnectionInfo>();
+    unawaited(residentWebRunner.run(
+      connectionInfoCompleter: connectionInfoCompleter,
+    ));
+    await connectionInfoCompleter.future;
+
+    // Need these to run events, otherwise expect statements below run before
+    // structured errors are processed.
+    await null;
+    await null;
+    await null;
+
+    expect(testLogger.statusText, contains('\nerror text'));
+    expect(testLogger.statusText, isNot(contains('other stuff')));
   }));
 
   test('Does not run main with --start-paused', () => testbed.run(() async {
@@ -1073,19 +1142,7 @@ void main() {
   test('Sends launched app.webLaunchUrl event for Chrome device', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       ...kAttachLogExpectations,
-      const FakeVmServiceRequest(
-        method: 'streamListen',
-        args: <String, Object>{
-          'streamId': 'Isolate'
-        }
-      ),
-      const FakeVmServiceRequest(
-        method: 'registerService',
-        args: <String, Object>{
-          'service': 'reloadSources',
-          'alias': 'FlutterTools',
-        }
-      )
+      ...kAttachIsolateExpectations,
     ]);
     _setupMocks();
     final ChromiumLauncher chromiumLauncher = MockChromeLauncher();

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -104,6 +104,7 @@ void main() {
       null,
       null,
       null,
+      null,
       mockVMService,
     );
 
@@ -122,6 +123,7 @@ void main() {
       null,
       null,
       reloadMethod,
+      null,
       null,
       mockVMService,
     );
@@ -142,6 +144,7 @@ void main() {
       mockDevice,
       null,
       null,
+      null,
       mockVMService,
     );
 
@@ -159,6 +162,7 @@ void main() {
       null,
       null,
       () async => 'hello',
+      null,
       mockVMService,
     );
 
@@ -167,9 +171,30 @@ void main() {
     Logger: () => BufferLogger.test()
   });
 
+  testUsingContext('VmService registers flutterPrintStructuredErrorLogMethod', () async {
+    final MockVMService mockVMService = MockVMService();
+    when(mockVMService.onExtensionEvent).thenAnswer((Invocation invocation) {
+      return const Stream<vm_service.Event>.empty();
+    });
+    setUpVmService(
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      (vm_service.Event event) async => 'hello',
+      mockVMService,
+    );
+    verify(mockVMService.streamListen(vm_service.EventStreams.kExtension)).called(1);
+  }, overrides: <Type, Generator>{
+    Logger: () => BufferLogger.test()
+  });
+
   testUsingContext('VMService returns correct FlutterVersion', () async {
     final MockVMService mockVMService = MockVMService();
     setUpVmService(
+      null,
       null,
       null,
       null,


### PR DESCRIPTION
Another retry of reverted commit from https://github.com/flutter/flutter/pull/59002

This change additionally wraps an extension event listen in a try/catch; this seems to be the problem based on logging output. I think tracer sometimes listens for extension events after vm service, and seems to consistently do this in some of the integration tests (e.g. `flutter_gallery__start_up`). I am unable to reproduce the test failure on an Android device but waiting to see if someone else can confirm for one of the iOS tests.

Alternative Android test steps to verify that this is likely the problem:
- Add an extra `await vmService.streamListen(vm_service.EventStreams.kExtension);` (no try/catch) before [extension listen line](https://github.com/flutter/flutter/blob/534b0608ce38a30b1ed5eb085f0ff64fb1c4c8b0/packages/flutter_tools/lib/src/tracing.dart#L50) without these changes
- Run `dart bin/run.dart -t flutter_gallery__start_up` and verify that error occurs in similar place as integration test error logs ([complex_layout_ios__start_up_8863133_2 (1).log](https://github.com/flutter/flutter/files/4749112/complex_layout_ios__start_up_8863133_2.1.log))
- Apply these changes but add an extra try/catch block copying the [change in tracing.dart](https://github.com/flutter/flutter/pull/59018/files#diff-7acdf231e1d141b5a6301dc969c76edeL49-R54)
- Run the same test and verify that it passes