### PR TITLE
change default kotlin version to 1.3.72

### DIFF
--- a/dev/integration_tests/abstract_method_smoke_test/android/build.gradle
+++ b/dev/integration_tests/abstract_method_smoke_test/android/build.gradle
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.3.72'
     repositories {
         google()
         jcenter()

--- a/dev/integration_tests/android_embedding_v2_smoke_test/android/build.gradle
+++ b/dev/integration_tests/android_embedding_v2_smoke_test/android/build.gradle
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.3.72'
     repositories {
         google()
         jcenter()

--- a/dev/integration_tests/flutter_driver_screenshot_test/android/build.gradle
+++ b/dev/integration_tests/flutter_driver_screenshot_test/android/build.gradle
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.3.72'
     repositories {
         google()
         jcenter()

--- a/dev/integration_tests/non_nullable/android/build.gradle
+++ b/dev/integration_tests/non_nullable/android/build.gradle
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.3.72'
     repositories {
         google()
         jcenter()

--- a/dev/manual_tests/android/build.gradle
+++ b/dev/manual_tests/android/build.gradle
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.3.72'
     repositories {
         google()
         jcenter()

--- a/packages/flutter_tools/templates/app/android-kotlin.tmpl/build.gradle
+++ b/packages/flutter_tools/templates/app/android-kotlin.tmpl/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.3.72'
     repositories {
         google()
         jcenter()

--- a/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.tmpl
@@ -2,7 +2,7 @@ group '{{androidIdentifier}}'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.3.72'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
The 1.3.50 compiler has various kotlin coroutine issues that resolves to the wrong class or produces `java.lang.VerifyError: Verifier rejected class` errors. They're fixed in 1.3.72.