### PR TITLE
Move iOS Podfile logic into tool

### DIFF
--- a/dev/integration_tests/flutter_driver_screenshot_test/ios/Podfile
+++ b/dev/integration_tests/flutter_driver_screenshot_test/ios/Podfile
@@ -19,14 +19,14 @@ end
 def flutter_root
   generated_xcode_build_settings_path = File.expand_path(File.join('Flutter', 'Generated.xcconfig'), ios_application_path)
   unless File.exist?(generated_xcode_build_settings_path)
-    raise "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first."
   end
 
   File.foreach(generated_xcode_build_settings_path) do |line|
     matches = line.match(/FLUTTER_ROOT\=(.*)/)
     return matches[1].strip if matches
   end
-  raise 'FLUTTER_ROOT not found in Generated.xcconfig. Try deleting Generated.xcconfig, then run flutter pub get'
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get."
 end
 
 require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)

--- a/dev/integration_tests/flutter_driver_screenshot_test/ios/Podfile
+++ b/dev/integration_tests/flutter_driver_screenshot_test/ios/Podfile
@@ -36,8 +36,6 @@ end
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|
-    target.build_configurations.each do |config|
-      flutter_additional_ios_build_settings(config)
-    end
+    flutter_additional_ios_build_settings(target)
   end
 end

--- a/dev/integration_tests/flutter_driver_screenshot_test/ios/Podfile
+++ b/dev/integration_tests/flutter_driver_screenshot_test/ios/Podfile
@@ -24,7 +24,7 @@ def flutter_root
 
   File.foreach(generated_xcode_build_settings_path) do |line|
     matches = line.match(/FLUTTER_ROOT\=(.*)/)
-    return matches[1] if matches
+    return matches[1].strip if matches
   end
   raise 'FLUTTER_ROOT not found in Generated.xcconfig. Try deleting Generated.xcconfig, then run flutter pub get'
 end

--- a/dev/integration_tests/flutter_driver_screenshot_test/ios/Podfile
+++ b/dev/integration_tests/flutter_driver_screenshot_test/ios/Podfile
@@ -10,78 +10,38 @@ project 'Runner', {
   'Release' => :release,
 }
 
-def parse_KV_file(file, separator='=')
-  file_abs_path = File.expand_path(file)
-  if !File.exists? file_abs_path
-    return [];
-  end
-  generated_key_values = {}
-  skip_line_start_symbols = ["#", "/"]
-  File.foreach(file_abs_path) do |line|
-    next if skip_line_start_symbols.any? { |symbol| line =~ /^\s*#{symbol}/ }
-    plugin = line.split(pattern=separator)
-    if plugin.length == 2
-      podname = plugin[0].strip()
-      path = plugin[1].strip()
-      podpath = File.expand_path("#{path}", file_abs_path)
-      generated_key_values[podname] = podpath
-    else
-      puts "Invalid plugin specification: #{line}"
-    end
-  end
-  generated_key_values
+def ios_application_path
+  ios_application_path = File.dirname(defined_in_file.realpath) if self.respond_to?(:defined_in_file)
+  ios_application_path ||= File.dirname(File.realpath(__FILE__))
+  ios_application_path
 end
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('Flutter', 'Generated.xcconfig'), ios_application_path)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1] if matches
+  end
+  raise 'FLUTTER_ROOT not found in Generated.xcconfig. Try deleting Generated.xcconfig, then run flutter pub get'
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
 
 target 'Runner' do
   use_frameworks!
   use_modular_headers!
 
-  # Flutter Pod
-
-  copied_flutter_dir = File.join(__dir__, 'Flutter')
-  copied_framework_path = File.join(copied_flutter_dir, 'Flutter.framework')
-  copied_podspec_path = File.join(copied_flutter_dir, 'Flutter.podspec')
-  unless File.exist?(copied_framework_path) && File.exist?(copied_podspec_path)
-    # Copy Flutter.framework and Flutter.podspec to Flutter/ to have something to link against if the xcode backend script has not run yet.
-    # That script will copy the correct debug/profile/release version of the framework based on the currently selected Xcode configuration.
-    # CocoaPods will not embed the framework on pod install (before any build phases can generate) if the dylib does not exist.
-
-    generated_xcode_build_settings_path = File.join(copied_flutter_dir, 'Generated.xcconfig')
-    unless File.exist?(generated_xcode_build_settings_path)
-      raise "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first"
-    end
-    generated_xcode_build_settings = parse_KV_file(generated_xcode_build_settings_path)
-    cached_framework_dir = generated_xcode_build_settings['FLUTTER_FRAMEWORK_DIR'];
-
-    unless File.exist?(copied_framework_path)
-      FileUtils.cp_r(File.join(cached_framework_dir, 'Flutter.framework'), copied_flutter_dir)
-    end
-    unless File.exist?(copied_podspec_path)
-      FileUtils.cp(File.join(cached_framework_dir, 'Flutter.podspec'), copied_flutter_dir)
-    end
-  end
-
-  # Keep pod path relative so it can be checked into Podfile.lock.
-  pod 'Flutter', :path => 'Flutter'
-
-  # Plugin Pods
-
-  # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
-  # referring to absolute paths on developers' machines.
-  system('rm -rf .symlinks')
-  system('mkdir -p .symlinks/plugins')
-  plugin_pods = parse_KV_file('../.flutter-plugins')
-  plugin_pods.each do |name, path|
-    symlink = File.join('.symlinks', 'plugins', name)
-    File.symlink(path, symlink)
-    pod name, :path => File.join(symlink, 'ios')
-  end
+  flutter_install_all_ios_pods ios_application_path
 end
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     target.build_configurations.each do |config|
-      config.build_settings['ENABLE_BITCODE'] = 'NO'
+      flutter_additional_ios_build_settings(config)
     end
   end
 end

--- a/dev/integration_tests/flutter_driver_screenshot_test/ios/Podfile
+++ b/dev/integration_tests/flutter_driver_screenshot_test/ios/Podfile
@@ -11,7 +11,7 @@ project 'Runner', {
 }
 
 def flutter_root
-  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__))
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
   unless File.exist?(generated_xcode_build_settings_path)
     raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
   end

--- a/dev/integration_tests/flutter_driver_screenshot_test/ios/Podfile
+++ b/dev/integration_tests/flutter_driver_screenshot_test/ios/Podfile
@@ -10,32 +10,28 @@ project 'Runner', {
   'Release' => :release,
 }
 
-def ios_application_path
-  ios_application_path = File.dirname(defined_in_file.realpath) if self.respond_to?(:defined_in_file)
-  ios_application_path ||= File.dirname(File.realpath(__FILE__))
-  ios_application_path
-end
-
 def flutter_root
-  generated_xcode_build_settings_path = File.expand_path(File.join('Flutter', 'Generated.xcconfig'), ios_application_path)
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__))
   unless File.exist?(generated_xcode_build_settings_path)
-    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first."
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
   end
 
   File.foreach(generated_xcode_build_settings_path) do |line|
     matches = line.match(/FLUTTER_ROOT\=(.*)/)
     return matches[1].strip if matches
   end
-  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get."
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
 end
 
 require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
 
 target 'Runner' do
   use_frameworks!
   use_modular_headers!
 
-  flutter_install_all_ios_pods ios_application_path
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end
 
 post_install do |installer|

--- a/dev/integration_tests/flutter_driver_screenshot_test/ios/Runner.xcodeproj/project.pbxproj
+++ b/dev/integration_tests/flutter_driver_screenshot_test/ios/Runner.xcodeproj/project.pbxproj
@@ -262,9 +262,14 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
+				"${PODS_ROOT}/../Flutter/Flutter.framework",
+				"${BUILT_PRODUCTS_DIR}/device_info/device_info.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/device_info.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/dev/integration_tests/flutter_gallery/ios/Podfile
+++ b/dev/integration_tests/flutter_gallery/ios/Podfile
@@ -19,14 +19,14 @@ end
 def flutter_root
   generated_xcode_build_settings_path = File.expand_path(File.join('Flutter', 'Generated.xcconfig'), ios_application_path)
   unless File.exist?(generated_xcode_build_settings_path)
-    raise "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first."
   end
 
   File.foreach(generated_xcode_build_settings_path) do |line|
     matches = line.match(/FLUTTER_ROOT\=(.*)/)
     return matches[1].strip if matches
   end
-  raise 'FLUTTER_ROOT not found in Generated.xcconfig. Try deleting Generated.xcconfig, then run flutter pub get'
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get."
 end
 
 require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)

--- a/dev/integration_tests/flutter_gallery/ios/Podfile
+++ b/dev/integration_tests/flutter_gallery/ios/Podfile
@@ -24,7 +24,7 @@ def flutter_root
 
   File.foreach(generated_xcode_build_settings_path) do |line|
     matches = line.match(/FLUTTER_ROOT\=(.*)/)
-    return matches[1] if matches
+    return matches[1].strip if matches
   end
   raise 'FLUTTER_ROOT not found in Generated.xcconfig. Try deleting Generated.xcconfig, then run flutter pub get'
 end

--- a/dev/integration_tests/flutter_gallery/ios/Podfile
+++ b/dev/integration_tests/flutter_gallery/ios/Podfile
@@ -10,76 +10,36 @@ project 'Runner', {
   'Release' => :release,
 }
 
-def parse_KV_file(file, separator='=')
-  file_abs_path = File.expand_path(file)
-  if !File.exists? file_abs_path
-    return [];
-  end
-  generated_key_values = {}
-  skip_line_start_symbols = ["#", "/"]
-  File.foreach(file_abs_path) do |line|
-    next if skip_line_start_symbols.any? { |symbol| line =~ /^\s*#{symbol}/ }
-    plugin = line.split(pattern=separator)
-    if plugin.length == 2
-      podname = plugin[0].strip()
-      path = plugin[1].strip()
-      podpath = File.expand_path("#{path}", file_abs_path)
-      generated_key_values[podname] = podpath
-    else
-      puts "Invalid plugin specification: #{line}"
-    end
-  end
-  generated_key_values
+def ios_application_path
+  ios_application_path = File.dirname(defined_in_file.realpath) if self.respond_to?(:defined_in_file)
+  ios_application_path ||= File.dirname(File.realpath(__FILE__))
+  ios_application_path
 end
 
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('Flutter', 'Generated.xcconfig'), ios_application_path)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1] if matches
+  end
+  raise 'FLUTTER_ROOT not found in Generated.xcconfig. Try deleting Generated.xcconfig, then run flutter pub get'
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
 target 'Runner' do
-  # Flutter Pod
-
-  copied_flutter_dir = File.join(__dir__, 'Flutter')
-  copied_framework_path = File.join(copied_flutter_dir, 'Flutter.framework')
-  copied_podspec_path = File.join(copied_flutter_dir, 'Flutter.podspec')
-  unless File.exist?(copied_framework_path) && File.exist?(copied_podspec_path)
-    # Copy Flutter.framework and Flutter.podspec to Flutter/ to have something to link against if the xcode backend script has not run yet.
-    # That script will copy the correct debug/profile/release version of the framework based on the currently selected Xcode configuration.
-    # CocoaPods will not embed the framework on pod install (before any build phases can generate) if the dylib does not exist.
-
-    generated_xcode_build_settings_path = File.join(copied_flutter_dir, 'Generated.xcconfig')
-    unless File.exist?(generated_xcode_build_settings_path)
-      raise "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first"
-    end
-    generated_xcode_build_settings = parse_KV_file(generated_xcode_build_settings_path)
-    cached_framework_dir = generated_xcode_build_settings['FLUTTER_FRAMEWORK_DIR'];
-
-    unless File.exist?(copied_framework_path)
-      FileUtils.cp_r(File.join(cached_framework_dir, 'Flutter.framework'), copied_flutter_dir)
-    end
-    unless File.exist?(copied_podspec_path)
-      FileUtils.cp(File.join(cached_framework_dir, 'Flutter.podspec'), copied_flutter_dir)
-    end
-  end
-
-  # Keep pod path relative so it can be checked into Podfile.lock.
-  pod 'Flutter', :path => 'Flutter'
-
-  # Plugin Pods
-
-  # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
-  # referring to absolute paths on developers' machines.
-  system('rm -rf .symlinks')
-  system('mkdir -p .symlinks/plugins')
-  plugin_pods = parse_KV_file('../.flutter-plugins')
-  plugin_pods.each do |name, path|
-    symlink = File.join('.symlinks', 'plugins', name)
-    File.symlink(path, symlink)
-    pod name, :path => File.join(symlink, 'ios')
-  end
+  flutter_install_all_ios_pods ios_application_path
 end
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     target.build_configurations.each do |config|
       config.build_settings['PROVISIONING_PROFILE_SPECIFIER'] = ''
-      config.build_settings['ENABLE_BITCODE'] = 'NO'
+      flutter_additional_ios_build_settings(config)
     end
   end
 end

--- a/dev/integration_tests/flutter_gallery/ios/Podfile
+++ b/dev/integration_tests/flutter_gallery/ios/Podfile
@@ -33,9 +33,9 @@ end
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
     target.build_configurations.each do |config|
       config.build_settings['PROVISIONING_PROFILE_SPECIFIER'] = ''
-      flutter_additional_ios_build_settings(config)
     end
   end
 end

--- a/dev/integration_tests/flutter_gallery/ios/Podfile
+++ b/dev/integration_tests/flutter_gallery/ios/Podfile
@@ -11,7 +11,7 @@ project 'Runner', {
 }
 
 def flutter_root
-  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__))
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
   unless File.exist?(generated_xcode_build_settings_path)
     raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
   end

--- a/dev/integration_tests/flutter_gallery/ios/Podfile
+++ b/dev/integration_tests/flutter_gallery/ios/Podfile
@@ -10,29 +10,25 @@ project 'Runner', {
   'Release' => :release,
 }
 
-def ios_application_path
-  ios_application_path = File.dirname(defined_in_file.realpath) if self.respond_to?(:defined_in_file)
-  ios_application_path ||= File.dirname(File.realpath(__FILE__))
-  ios_application_path
-end
-
 def flutter_root
-  generated_xcode_build_settings_path = File.expand_path(File.join('Flutter', 'Generated.xcconfig'), ios_application_path)
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__))
   unless File.exist?(generated_xcode_build_settings_path)
-    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first."
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
   end
 
   File.foreach(generated_xcode_build_settings_path) do |line|
     matches = line.match(/FLUTTER_ROOT\=(.*)/)
     return matches[1].strip if matches
   end
-  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get."
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
 end
 
 require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
 
+flutter_ios_podfile_setup
+
 target 'Runner' do
-  flutter_install_all_ios_pods ios_application_path
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end
 
 post_install do |installer|

--- a/dev/integration_tests/release_smoke_test/ios/Podfile
+++ b/dev/integration_tests/release_smoke_test/ios/Podfile
@@ -19,14 +19,14 @@ end
 def flutter_root
   generated_xcode_build_settings_path = File.expand_path(File.join('Flutter', 'Generated.xcconfig'), ios_application_path)
   unless File.exist?(generated_xcode_build_settings_path)
-    raise "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first."
   end
 
   File.foreach(generated_xcode_build_settings_path) do |line|
     matches = line.match(/FLUTTER_ROOT\=(.*)/)
     return matches[1].strip if matches
   end
-  raise 'FLUTTER_ROOT not found in Generated.xcconfig. Try deleting Generated.xcconfig, then run flutter pub get'
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get."
 end
 
 require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)

--- a/dev/integration_tests/release_smoke_test/ios/Podfile
+++ b/dev/integration_tests/release_smoke_test/ios/Podfile
@@ -24,7 +24,7 @@ def flutter_root
 
   File.foreach(generated_xcode_build_settings_path) do |line|
     matches = line.match(/FLUTTER_ROOT\=(.*)/)
-    return matches[1] if matches
+    return matches[1].strip if matches
   end
   raise 'FLUTTER_ROOT not found in Generated.xcconfig. Try deleting Generated.xcconfig, then run flutter pub get'
 end

--- a/dev/integration_tests/release_smoke_test/ios/Podfile
+++ b/dev/integration_tests/release_smoke_test/ios/Podfile
@@ -10,75 +10,35 @@ project 'Runner', {
   'Release' => :release,
 }
 
-def parse_KV_file(file, separator='=')
-  file_abs_path = File.expand_path(file)
-  if !File.exists? file_abs_path
-    return [];
-  end
-  generated_key_values = {}
-  skip_line_start_symbols = ["#", "/"]
-  File.foreach(file_abs_path) do |line|
-    next if skip_line_start_symbols.any? { |symbol| line =~ /^\s*#{symbol}/ }
-    plugin = line.split(pattern=separator)
-    if plugin.length == 2
-      podname = plugin[0].strip()
-      path = plugin[1].strip()
-      podpath = File.expand_path("#{path}", file_abs_path)
-      generated_key_values[podname] = podpath
-    else
-      puts "Invalid plugin specification: #{line}"
-    end
-  end
-  generated_key_values
+def ios_application_path
+  ios_application_path = File.dirname(defined_in_file.realpath) if self.respond_to?(:defined_in_file)
+  ios_application_path ||= File.dirname(File.realpath(__FILE__))
+  ios_application_path
 end
 
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('Flutter', 'Generated.xcconfig'), ios_application_path)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1] if matches
+  end
+  raise 'FLUTTER_ROOT not found in Generated.xcconfig. Try deleting Generated.xcconfig, then run flutter pub get'
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
 target 'Runner' do
-  # Flutter Pod
-
-  copied_flutter_dir = File.join(__dir__, 'Flutter')
-  copied_framework_path = File.join(copied_flutter_dir, 'Flutter.framework')
-  copied_podspec_path = File.join(copied_flutter_dir, 'Flutter.podspec')
-  unless File.exist?(copied_framework_path) && File.exist?(copied_podspec_path)
-    # Copy Flutter.framework and Flutter.podspec to Flutter/ to have something to link against if the xcode backend script has not run yet.
-    # That script will copy the correct debug/profile/release version of the framework based on the currently selected Xcode configuration.
-    # CocoaPods will not embed the framework on pod install (before any build phases can generate) if the dylib does not exist.
-
-    generated_xcode_build_settings_path = File.join(copied_flutter_dir, 'Generated.xcconfig')
-    unless File.exist?(generated_xcode_build_settings_path)
-      raise "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first"
-    end
-    generated_xcode_build_settings = parse_KV_file(generated_xcode_build_settings_path)
-    cached_framework_dir = generated_xcode_build_settings['FLUTTER_FRAMEWORK_DIR'];
-
-    unless File.exist?(copied_framework_path)
-      FileUtils.cp_r(File.join(cached_framework_dir, 'Flutter.framework'), copied_flutter_dir)
-    end
-    unless File.exist?(copied_podspec_path)
-      FileUtils.cp(File.join(cached_framework_dir, 'Flutter.podspec'), copied_flutter_dir)
-    end
-  end
-
-  # Keep pod path relative so it can be checked into Podfile.lock.
-  pod 'Flutter', :path => 'Flutter'
-
-  # Plugin Pods
-
-  # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
-  # referring to absolute paths on developers' machines.
-  system('rm -rf .symlinks')
-  system('mkdir -p .symlinks/plugins')
-  plugin_pods = parse_KV_file('../.flutter-plugins')
-  plugin_pods.each do |name, path|
-    symlink = File.join('.symlinks', 'plugins', name)
-    File.symlink(path, symlink)
-    pod name, :path => File.join(symlink, 'ios')
-  end
+  flutter_install_all_ios_pods ios_application_path
 end
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     target.build_configurations.each do |config|
-      config.build_settings['ENABLE_BITCODE'] = 'NO'
+      flutter_additional_ios_build_settings(config)
     end
   end
 end

--- a/dev/integration_tests/release_smoke_test/ios/Podfile
+++ b/dev/integration_tests/release_smoke_test/ios/Podfile
@@ -33,8 +33,6 @@ end
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|
-    target.build_configurations.each do |config|
-      flutter_additional_ios_build_settings(config)
-    end
+    flutter_additional_ios_build_settings(target)
   end
 end

--- a/dev/integration_tests/release_smoke_test/ios/Podfile
+++ b/dev/integration_tests/release_smoke_test/ios/Podfile
@@ -11,7 +11,7 @@ project 'Runner', {
 }
 
 def flutter_root
-  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__))
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
   unless File.exist?(generated_xcode_build_settings_path)
     raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
   end

--- a/dev/integration_tests/release_smoke_test/ios/Podfile
+++ b/dev/integration_tests/release_smoke_test/ios/Podfile
@@ -10,29 +10,25 @@ project 'Runner', {
   'Release' => :release,
 }
 
-def ios_application_path
-  ios_application_path = File.dirname(defined_in_file.realpath) if self.respond_to?(:defined_in_file)
-  ios_application_path ||= File.dirname(File.realpath(__FILE__))
-  ios_application_path
-end
-
 def flutter_root
-  generated_xcode_build_settings_path = File.expand_path(File.join('Flutter', 'Generated.xcconfig'), ios_application_path)
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__))
   unless File.exist?(generated_xcode_build_settings_path)
-    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first."
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
   end
 
   File.foreach(generated_xcode_build_settings_path) do |line|
     matches = line.match(/FLUTTER_ROOT\=(.*)/)
     return matches[1].strip if matches
   end
-  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get."
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
 end
 
 require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
 
+flutter_ios_podfile_setup
+
 target 'Runner' do
-  flutter_install_all_ios_pods ios_application_path
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end
 
 post_install do |installer|

--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -20,14 +20,14 @@ end
 # @example
 # post_install do |installer|
 #   installer.pods_project.targets.each do |target|
-#     target.build_configurations.each do |config|
-#       flutter_additional_ios_build_settings(config)
-#     end
+#     flutter_additional_ios_build_settings(target)
 #   end
 # end
-# @param [XCBuildConfiguration] build_configuration Build configuration for Pod target.
-def flutter_additional_ios_build_settings(build_configuration)
-  build_configuration.build_settings['ENABLE_BITCODE'] = 'NO'
+# @param [PBXAggregateTarget] target Pod target.
+def flutter_additional_ios_build_settings(target)
+  target.build_configurations.each do |build_configuration|
+     build_configuration.build_settings['ENABLE_BITCODE'] = 'NO'
+  end
 end
 
 # Install pods needed to embed Flutter iOS engine and plugins.

--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -2,6 +2,16 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+# Hook for Podfile setup, installation settings.
+#
+# @example
+# flutter_ios_podfile_setup
+# target 'Runner' do
+# ...
+# end
+def flutter_ios_podfile_setup
+end
+
 # Add iOS build settings to pod targets.
 #
 # @example
@@ -41,7 +51,7 @@ end
 def flutter_install_ios_engine_pod(ios_application_path = nil)
   # defined_in_file is set by CocoaPods and is a Pathname to the Podfile.
   ios_application_path ||= File.dirname(defined_in_file.realpath) if self.respond_to?(:defined_in_file)
-  raise 'Could not find iOS application path.' unless ios_application_path
+  raise 'Could not find iOS application path' unless ios_application_path
 
   copied_flutter_dir = File.join(ios_application_path, 'Flutter')
   copied_framework_path = File.join(copied_flutter_dir, 'Flutter.framework')
@@ -81,7 +91,7 @@ end
 def flutter_install_ios_plugin_pods(ios_application_path = nil)
   # defined_in_file is set by CocoaPods and is a Pathname to the Podfile.
   ios_application_path ||= File.dirname(defined_in_file.realpath) if self.respond_to?(:defined_in_file)
-  raise 'Could not find iOS application path.' unless ios_application_path
+  raise 'Could not find iOS application path' unless ios_application_path
 
   # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
   # referring to absolute paths on developers' machines.

--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -103,7 +103,7 @@ def flutter_install_ios_plugin_pods(ios_application_path = nil)
   end
 end
 
-def flutter_parse_plugins_file(file, separator='=')
+def flutter_parse_plugins_file(file)
   file_path = File.expand_path(file)
   unless File.exists? file_path
     return [];
@@ -112,10 +112,10 @@ def flutter_parse_plugins_file(file, separator='=')
   skip_line_start_symbols = ["#", "/"]
   File.foreach(file_path) do |line|
     next if skip_line_start_symbols.any? { |symbol| line =~ /^\s*#{symbol}/ }
-    plugin = line.split(pattern=separator)
+    plugin = line.split('=')
     if plugin.length == 2
-      podname = plugin[0].strip()
-      path = plugin[1].strip()
+      podname = plugin[0].strip
+      path = plugin[1].strip
       podpath = File.expand_path(path, file_path)
       generated_key_values[podname] = File.expand_path(path, file_path)
     else

--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -1,0 +1,126 @@
+# Copyright 2014 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Add iOS build settings to pod targets.
+#
+# @example
+# post_install do |installer|
+#   installer.pods_project.targets.each do |target|
+#     target.build_configurations.each do |config|
+#       flutter_additional_ios_build_settings(config)
+#     end
+#   end
+# end
+# @param [XCBuildConfiguration] build_configuration Build configuration for Pod target.
+def flutter_additional_ios_build_settings(build_configuration)
+  build_configuration.build_settings['ENABLE_BITCODE'] = 'NO'
+end
+
+# Install pods needed to embed Flutter iOS engine and plugins.
+#
+# @example
+#   target 'Runner' do
+#     flutter_install_all_ios_pods
+#   end
+# @param [String] ios_application_path Path of the iOS directory of the Flutter app.
+#                                      Optional, defaults to the Podfile directory.
+def flutter_install_all_ios_pods(ios_application_path = nil)
+  flutter_install_ios_engine_pod(ios_application_path)
+  flutter_install_ios_plugin_pods(ios_application_path)
+end
+
+# Install iOS Flutter engine pod.
+#
+# @example
+#   target 'Runner' do
+#     flutter_install_ios_engine_pod
+#   end
+# @param [String] ios_application_path Path of the iOS directory of the Flutter app.
+#                                      Optional, defaults to the Podfile directory.
+def flutter_install_ios_engine_pod(ios_application_path = nil)
+  # defined_in_file is set by CocoaPods and is a Pathname to the Podfile.
+  ios_application_path ||= File.dirname(defined_in_file.realpath) if self.respond_to?(:defined_in_file)
+  raise 'Could not find iOS application path.' unless ios_application_path
+
+  copied_flutter_dir = File.join(ios_application_path, 'Flutter')
+  copied_framework_path = File.join(copied_flutter_dir, 'Flutter.framework')
+  copied_podspec_path = File.join(copied_flutter_dir, 'Flutter.podspec')
+
+  unless File.exist?(copied_framework_path) && File.exist?(copied_podspec_path)
+    # Copy Flutter.framework and Flutter.podspec to Flutter/ to have something to link against if the xcode backend script has not run yet.
+    # That script will copy the correct debug/profile/release version of the framework based on the currently selected Xcode configuration,
+    # which can handle a local engine.
+    # CocoaPods will not embed the framework on pod install (before any build phases can generate) if the dylib does not exist.
+
+    # This podhelper script is at $FLUTTER_ROOT/packages/flutter_tools/bin.
+    # Copy frameworks from $FLUTTER_ROOT/bin/cache/artifacts/engine/ios (Debug).
+    debug_framework_dir = File.expand_path(File.join('..', '..', '..', '..', 'bin', 'cache', 'artifacts', 'engine', 'ios'), __FILE__)
+
+    unless File.exist?(copied_framework_path)
+      # Avoid the complication of dependencies like FileUtils.
+      system('cp', '-r', File.expand_path('Flutter.framework', debug_framework_dir), copied_flutter_dir)
+    end
+    unless File.exist?(copied_podspec_path)
+      system('cp', File.expand_path('Flutter.podspec', debug_framework_dir), copied_flutter_dir)
+    end
+  end
+
+  # Keep pod path relative so it can be checked into Podfile.lock.
+  pod 'Flutter', :path => 'Flutter'
+end
+
+# Install iOS Flutter plugin pods.
+#
+# @example
+#   target 'Runner' do
+#     flutter_install_ios_plugin_pods
+#   end
+# @param [String] ios_application_path Path of the iOS directory of the Flutter app.
+#                                      Optional, defaults to the Podfile directory.
+def flutter_install_ios_plugin_pods(ios_application_path = nil)
+  # defined_in_file is set by CocoaPods and is a Pathname to the Podfile.
+  ios_application_path ||= File.dirname(defined_in_file.realpath) if self.respond_to?(:defined_in_file)
+  raise 'Could not find iOS application path.' unless ios_application_path
+
+  # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
+  # referring to absolute paths on developers' machines.
+
+  symlink_dir = File.expand_path('.symlinks', ios_application_path)
+  system('rm', '-rf', symlink_dir) # Avoid the complication of dependencies like FileUtils.
+
+  symlink_plugins_dir = File.expand_path('plugins', symlink_dir)
+  system('mkdir', '-p', symlink_plugins_dir)
+
+  plugins_file = File.join(ios_application_path, '..', '.flutter-plugins')
+  plugin_pods = flutter_parse_plugins_file(plugins_file)
+  plugin_pods.each do |name, path|
+    symlink = File.join(symlink_plugins_dir, name)
+    File.symlink(path, symlink)
+
+    # Keep pod path relative so it can be checked into Podfile.lock.
+    pod name, :path => File.join('.symlinks', 'plugins', name, 'ios')
+  end
+end
+
+def flutter_parse_plugins_file(file, separator='=')
+  file_path = File.expand_path(file)
+  unless File.exists? file_path
+    return [];
+  end
+  generated_key_values = {}
+  skip_line_start_symbols = ["#", "/"]
+  File.foreach(file_path) do |line|
+    next if skip_line_start_symbols.any? { |symbol| line =~ /^\s*#{symbol}/ }
+    plugin = line.split(pattern=separator)
+    if plugin.length == 2
+      podname = plugin[0].strip()
+      path = plugin[1].strip()
+      podpath = File.expand_path(path, file_path)
+      generated_key_values[podname] = File.expand_path(path, file_path)
+    else
+      puts "Invalid plugin specification: #{line}"
+    end
+  end
+  generated_key_values
+end

--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -2,6 +2,9 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+# Minimum CocoaPods Ruby version is 2.0.
+# Don't depend on features newer than that.
+
 # Hook for Podfile setup, installation settings.
 #
 # @example
@@ -116,7 +119,7 @@ end
 def flutter_parse_plugins_file(file)
   file_path = File.expand_path(file)
   unless File.exists? file_path
-    return [];
+    return {};
   end
   generated_key_values = {}
   skip_line_start_symbols = ["#", "/"]

--- a/packages/flutter_tools/templates/cocoapods/Podfile-ios-objc
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-ios-objc
@@ -19,14 +19,14 @@ end
 def flutter_root
   generated_xcode_build_settings_path = File.expand_path(File.join('Flutter', 'Generated.xcconfig'), ios_application_path)
   unless File.exist?(generated_xcode_build_settings_path)
-    raise "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first."
   end
 
   File.foreach(generated_xcode_build_settings_path) do |line|
     matches = line.match(/FLUTTER_ROOT\=(.*)/)
     return matches[1].strip if matches
   end
-  raise 'FLUTTER_ROOT not found in Generated.xcconfig. Try deleting Generated.xcconfig, then run flutter pub get'
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get."
 end
 
 require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)

--- a/packages/flutter_tools/templates/cocoapods/Podfile-ios-objc
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-ios-objc
@@ -24,7 +24,7 @@ def flutter_root
 
   File.foreach(generated_xcode_build_settings_path) do |line|
     matches = line.match(/FLUTTER_ROOT\=(.*)/)
-    return matches[1] if matches
+    return matches[1].strip if matches
   end
   raise 'FLUTTER_ROOT not found in Generated.xcconfig. Try deleting Generated.xcconfig, then run flutter pub get'
 end

--- a/packages/flutter_tools/templates/cocoapods/Podfile-ios-objc
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-ios-objc
@@ -10,75 +10,35 @@ project 'Runner', {
   'Release' => :release,
 }
 
-def parse_KV_file(file, separator='=')
-  file_abs_path = File.expand_path(file)
-  if !File.exists? file_abs_path
-    return [];
-  end
-  generated_key_values = {}
-  skip_line_start_symbols = ["#", "/"]
-  File.foreach(file_abs_path) do |line|
-    next if skip_line_start_symbols.any? { |symbol| line =~ /^\s*#{symbol}/ }
-    plugin = line.split(pattern=separator)
-    if plugin.length == 2
-      podname = plugin[0].strip()
-      path = plugin[1].strip()
-      podpath = File.expand_path("#{path}", file_abs_path)
-      generated_key_values[podname] = podpath
-    else
-      puts "Invalid plugin specification: #{line}"
-    end
-  end
-  generated_key_values
+def ios_application_path
+  ios_application_path = File.dirname(defined_in_file.realpath) if self.respond_to?(:defined_in_file)
+  ios_application_path ||= File.dirname(File.realpath(__FILE__))
+  ios_application_path
 end
 
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('Flutter', 'Generated.xcconfig'), ios_application_path)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1] if matches
+  end
+  raise 'FLUTTER_ROOT not found in Generated.xcconfig. Try deleting Generated.xcconfig, then run flutter pub get'
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
 target 'Runner' do
-  # Flutter Pod
-
-  copied_flutter_dir = File.join(__dir__, 'Flutter')
-  copied_framework_path = File.join(copied_flutter_dir, 'Flutter.framework')
-  copied_podspec_path = File.join(copied_flutter_dir, 'Flutter.podspec')
-  unless File.exist?(copied_framework_path) && File.exist?(copied_podspec_path)
-    # Copy Flutter.framework and Flutter.podspec to Flutter/ to have something to link against if the xcode backend script has not run yet.
-    # That script will copy the correct debug/profile/release version of the framework based on the currently selected Xcode configuration.
-    # CocoaPods will not embed the framework on pod install (before any build phases can generate) if the dylib does not exist.
-
-    generated_xcode_build_settings_path = File.join(copied_flutter_dir, 'Generated.xcconfig')
-    unless File.exist?(generated_xcode_build_settings_path)
-      raise "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first"
-    end
-    generated_xcode_build_settings = parse_KV_file(generated_xcode_build_settings_path)
-    cached_framework_dir = generated_xcode_build_settings['FLUTTER_FRAMEWORK_DIR'];
-
-    unless File.exist?(copied_framework_path)
-      FileUtils.cp_r(File.join(cached_framework_dir, 'Flutter.framework'), copied_flutter_dir)
-    end
-    unless File.exist?(copied_podspec_path)
-      FileUtils.cp(File.join(cached_framework_dir, 'Flutter.podspec'), copied_flutter_dir)
-    end
-  end
-
-  # Keep pod path relative so it can be checked into Podfile.lock.
-  pod 'Flutter', :path => 'Flutter'
-
-  # Plugin Pods
-
-  # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
-  # referring to absolute paths on developers' machines.
-  system('rm -rf .symlinks')
-  system('mkdir -p .symlinks/plugins')
-  plugin_pods = parse_KV_file('../.flutter-plugins')
-  plugin_pods.each do |name, path|
-    symlink = File.join('.symlinks', 'plugins', name)
-    File.symlink(path, symlink)
-    pod name, :path => File.join(symlink, 'ios')
-  end
+  flutter_install_all_ios_pods ios_application_path
 end
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     target.build_configurations.each do |config|
-      config.build_settings['ENABLE_BITCODE'] = 'NO'
+      flutter_additional_ios_build_settings(config)
     end
   end
 end

--- a/packages/flutter_tools/templates/cocoapods/Podfile-ios-objc
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-ios-objc
@@ -33,8 +33,6 @@ end
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|
-    target.build_configurations.each do |config|
-      flutter_additional_ios_build_settings(config)
-    end
+    flutter_additional_ios_build_settings(target)
   end
 end

--- a/packages/flutter_tools/templates/cocoapods/Podfile-ios-objc
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-ios-objc
@@ -11,7 +11,7 @@ project 'Runner', {
 }
 
 def flutter_root
-  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__))
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
   unless File.exist?(generated_xcode_build_settings_path)
     raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
   end

--- a/packages/flutter_tools/templates/cocoapods/Podfile-ios-objc
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-ios-objc
@@ -10,29 +10,25 @@ project 'Runner', {
   'Release' => :release,
 }
 
-def ios_application_path
-  ios_application_path = File.dirname(defined_in_file.realpath) if self.respond_to?(:defined_in_file)
-  ios_application_path ||= File.dirname(File.realpath(__FILE__))
-  ios_application_path
-end
-
 def flutter_root
-  generated_xcode_build_settings_path = File.expand_path(File.join('Flutter', 'Generated.xcconfig'), ios_application_path)
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__))
   unless File.exist?(generated_xcode_build_settings_path)
-    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first."
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
   end
 
   File.foreach(generated_xcode_build_settings_path) do |line|
     matches = line.match(/FLUTTER_ROOT\=(.*)/)
     return matches[1].strip if matches
   end
-  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get."
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
 end
 
 require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
 
+flutter_ios_podfile_setup
+
 target 'Runner' do
-  flutter_install_all_ios_pods ios_application_path
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end
 
 post_install do |installer|

--- a/packages/flutter_tools/templates/cocoapods/Podfile-ios-swift
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-ios-swift
@@ -10,14 +10,8 @@ project 'Runner', {
   'Release' => :release,
 }
 
-def ios_application_path
-  ios_application_path = File.dirname(defined_in_file.realpath) if self.respond_to?(:defined_in_file)
-  ios_application_path ||= File.dirname(File.realpath(__FILE__))
-  ios_application_path
-end
-
 def flutter_root
-  generated_xcode_build_settings_path = File.expand_path(File.join('Flutter', 'Generated.xcconfig'), ios_application_path)
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__))
   unless File.exist?(generated_xcode_build_settings_path)
     raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
   end
@@ -31,11 +25,13 @@ end
 
 require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
 
+flutter_ios_podfile_setup
+
 target 'Runner' do
   use_frameworks!
   use_modular_headers!
 
-  flutter_install_all_ios_pods ios_application_path
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end
 
 post_install do |installer|

--- a/packages/flutter_tools/templates/cocoapods/Podfile-ios-swift
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-ios-swift
@@ -36,8 +36,6 @@ end
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|
-    target.build_configurations.each do |config|
-      flutter_additional_ios_build_settings(config)
-    end
+    flutter_additional_ios_build_settings(target)
   end
 end

--- a/packages/flutter_tools/templates/cocoapods/Podfile-ios-swift
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-ios-swift
@@ -24,7 +24,7 @@ def flutter_root
 
   File.foreach(generated_xcode_build_settings_path) do |line|
     matches = line.match(/FLUTTER_ROOT\=(.*)/)
-    return matches[1] if matches
+    return matches[1].strip if matches
   end
   raise 'FLUTTER_ROOT not found in Generated.xcconfig. Try deleting Generated.xcconfig, then run flutter pub get'
 end

--- a/packages/flutter_tools/templates/cocoapods/Podfile-ios-swift
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-ios-swift
@@ -10,78 +10,38 @@ project 'Runner', {
   'Release' => :release,
 }
 
-def parse_KV_file(file, separator='=')
-  file_abs_path = File.expand_path(file)
-  if !File.exists? file_abs_path
-    return [];
-  end
-  generated_key_values = {}
-  skip_line_start_symbols = ["#", "/"]
-  File.foreach(file_abs_path) do |line|
-    next if skip_line_start_symbols.any? { |symbol| line =~ /^\s*#{symbol}/ }
-    plugin = line.split(pattern=separator)
-    if plugin.length == 2
-      podname = plugin[0].strip()
-      path = plugin[1].strip()
-      podpath = File.expand_path("#{path}", file_abs_path)
-      generated_key_values[podname] = podpath
-    else
-      puts "Invalid plugin specification: #{line}"
-    end
-  end
-  generated_key_values
+def ios_application_path
+  ios_application_path = File.dirname(defined_in_file.realpath) if self.respond_to?(:defined_in_file)
+  ios_application_path ||= File.dirname(File.realpath(__FILE__))
+  ios_application_path
 end
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('Flutter', 'Generated.xcconfig'), ios_application_path)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1] if matches
+  end
+  raise 'FLUTTER_ROOT not found in Generated.xcconfig. Try deleting Generated.xcconfig, then run flutter pub get'
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
 
 target 'Runner' do
   use_frameworks!
   use_modular_headers!
 
-  # Flutter Pod
-
-  copied_flutter_dir = File.join(__dir__, 'Flutter')
-  copied_framework_path = File.join(copied_flutter_dir, 'Flutter.framework')
-  copied_podspec_path = File.join(copied_flutter_dir, 'Flutter.podspec')
-  unless File.exist?(copied_framework_path) && File.exist?(copied_podspec_path)
-    # Copy Flutter.framework and Flutter.podspec to Flutter/ to have something to link against if the xcode backend script has not run yet.
-    # That script will copy the correct debug/profile/release version of the framework based on the currently selected Xcode configuration.
-    # CocoaPods will not embed the framework on pod install (before any build phases can generate) if the dylib does not exist.
-
-    generated_xcode_build_settings_path = File.join(copied_flutter_dir, 'Generated.xcconfig')
-    unless File.exist?(generated_xcode_build_settings_path)
-      raise "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first"
-    end
-    generated_xcode_build_settings = parse_KV_file(generated_xcode_build_settings_path)
-    cached_framework_dir = generated_xcode_build_settings['FLUTTER_FRAMEWORK_DIR'];
-
-    unless File.exist?(copied_framework_path)
-      FileUtils.cp_r(File.join(cached_framework_dir, 'Flutter.framework'), copied_flutter_dir)
-    end
-    unless File.exist?(copied_podspec_path)
-      FileUtils.cp(File.join(cached_framework_dir, 'Flutter.podspec'), copied_flutter_dir)
-    end
-  end
-
-  # Keep pod path relative so it can be checked into Podfile.lock.
-  pod 'Flutter', :path => 'Flutter'
-
-  # Plugin Pods
-
-  # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
-  # referring to absolute paths on developers' machines.
-  system('rm -rf .symlinks')
-  system('mkdir -p .symlinks/plugins')
-  plugin_pods = parse_KV_file('../.flutter-plugins')
-  plugin_pods.each do |name, path|
-    symlink = File.join('.symlinks', 'plugins', name)
-    File.symlink(path, symlink)
-    pod name, :path => File.join(symlink, 'ios')
-  end
+  flutter_install_all_ios_pods ios_application_path
 end
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     target.build_configurations.each do |config|
-      config.build_settings['ENABLE_BITCODE'] = 'NO'
+      flutter_additional_ios_build_settings(config)
     end
   end
 end

--- a/packages/flutter_tools/templates/cocoapods/Podfile-ios-swift
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-ios-swift
@@ -19,14 +19,14 @@ end
 def flutter_root
   generated_xcode_build_settings_path = File.expand_path(File.join('Flutter', 'Generated.xcconfig'), ios_application_path)
   unless File.exist?(generated_xcode_build_settings_path)
-    raise "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
   end
 
   File.foreach(generated_xcode_build_settings_path) do |line|
     matches = line.match(/FLUTTER_ROOT\=(.*)/)
     return matches[1].strip if matches
   end
-  raise 'FLUTTER_ROOT not found in Generated.xcconfig. Try deleting Generated.xcconfig, then run flutter pub get'
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
 end
 
 require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)

--- a/packages/flutter_tools/templates/cocoapods/Podfile-ios-swift
+++ b/packages/flutter_tools/templates/cocoapods/Podfile-ios-swift
@@ -11,7 +11,7 @@ project 'Runner', {
 }
 
 def flutter_root
-  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__))
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
   unless File.exist?(generated_xcode_build_settings_path)
     raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
   end


### PR DESCRIPTION
## Description

Move Podfile logic into the tool so changes can be easily made without the user needing to migrate or regenerate their Podfile.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/45197
Will make https://github.com/flutter/flutter/issues/39659 easier

## Tests

Add checks to plugin_lint_mac.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*