### PR TITLE
[flutter_tools] include dart-defines in cached kernel name

### DIFF
--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -4,6 +4,8 @@
 
 import 'dart:async';
 
+import 'package:convert/convert.dart';
+import 'package:crypto/crypto.dart';
 import 'package:meta/meta.dart';
 import 'package:pool/pool.dart';
 
@@ -17,6 +19,7 @@ import 'build_system/depfile.dart';
 import 'build_system/targets/common.dart';
 import 'build_system/targets/icon_tree_shaker.dart';
 import 'cache.dart';
+import 'convert.dart';
 import 'dart/package_map.dart';
 import 'devfs.dart';
 import 'globals.dart' as globals;
@@ -34,9 +37,20 @@ String getDefaultApplicationKernelPath({ @required bool trackWidgetCreation }) {
   );
 }
 
-String getDefaultCachedKernelPath({ @required bool trackWidgetCreation }) {
+String getDefaultCachedKernelPath({
+  @required bool trackWidgetCreation,
+  @required List<String> dartDefines,
+}) {
+  final StringBuffer buffer = StringBuffer();
+  buffer.writeAll(dartDefines);
+  String buildPrefix = '';
+  if (buffer.isNotEmpty) {
+    final String output = buffer.toString();
+    final Digest digest = md5.convert(utf8.encode(output));
+    buildPrefix = hex.encode(digest.bytes);
+  }
   return getKernelPathForTransformerOptions(
-    globals.fs.path.join(getBuildDirectory(), 'cache.dill'),
+    globals.fs.path.join(getBuildDirectory(), '$buildPrefix.cache.dill'),
     trackWidgetCreation: trackWidgetCreation,
   );
 }

--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -47,10 +47,10 @@ String getDefaultCachedKernelPath({
   if (buffer.isNotEmpty) {
     final String output = buffer.toString();
     final Digest digest = md5.convert(utf8.encode(output));
-    buildPrefix = hex.encode(digest.bytes);
+    buildPrefix = '${hex.encode(digest.bytes)}.';
   }
   return getKernelPathForTransformerOptions(
-    globals.fs.path.join(getBuildDirectory(), '$buildPrefix.cache.dill'),
+    globals.fs.path.join(getBuildDirectory(), '${buildPrefix}cache.dill'),
     trackWidgetCreation: trackWidgetCreation,
   );
 }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -104,6 +104,7 @@ class FlutterDevice {
             globals.printTrace(message),
         initializeFromDill: getDefaultCachedKernelPath(
           trackWidgetCreation: buildInfo.trackWidgetCreation,
+          dartDefines: buildInfo.dartDefines,
         ),
         targetModel: TargetModel.dartdevc,
         extraFrontEndOptions: buildInfo.extraFrontEndOptions,
@@ -131,6 +132,7 @@ class FlutterDevice {
         extraFrontEndOptions: buildInfo.extraFrontEndOptions,
         initializeFromDill: getDefaultCachedKernelPath(
           trackWidgetCreation: buildInfo.trackWidgetCreation,
+          dartDefines: buildInfo.dartDefines,
         ),
         packagesPath: globalPackagesPath,
       );
@@ -1060,6 +1062,7 @@ abstract class ResidentRunner {
     if (outputDill.existsSync()) {
       final String copyPath = getDefaultCachedKernelPath(
         trackWidgetCreation: trackWidgetCreation,
+        dartDefines: debuggingOptions.buildInfo.dartDefines,
       );
       globals.fs.file(copyPath).parent.createSync(recursive: true);
       outputDill.copySync(copyPath);


### PR DESCRIPTION
## Description

This prevents using a cached kernel file with different defines, since --initialize-from-dill does not handle this correctly.

Fixes https://github.com/flutter/flutter/issues/58976