### PR TITLE
Fix docs for Focus.onKey event propagation

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -16,7 +16,7 @@ import 'inherited_notifier.dart';
 ///
 /// For keyboard events, [onKey] is called if [FocusNode.hasFocus] is true for
 /// this widget's [focusNode], unless a focused descendant's [onKey] callback
-/// returns false when called.
+/// returns true when called.
 ///
 /// This widget does not provide any visual indication that the focus has
 /// changed. Any desired visual changes should be made when [onFocusChanged] is


### PR DESCRIPTION
## Description
As I understand it event propagation of key events stops when a callback returns true. To me, the docs for `Focus` state that event propagation stops when a callback returns false.