### PR TITLE
[flutter_tools] add enable-experiment support to pub

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/build_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/build_runner.dart
@@ -104,6 +104,7 @@ class BuildRunner extends CodeGenerator {
         directory: generatedDirectory.path,
         upgrade: false,
         checkLastModified: false,
+        enabledExperiments: <String>[],
       );
       if (!scriptIdFile.existsSync()) {
         scriptIdFile.createSync(recursive: true);

--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -408,7 +408,8 @@ class _ResidentWebRunner extends ResidentWebRunner {
         // This will result in a NoSuchMethodError thrown by injected_handler.darts
         await pub.get(
           context: PubContext.pubGet,
-          directory: globals.fs.path.join(Cache.flutterRoot, 'packages', 'flutter_tools')
+          directory: globals.fs.path.join(Cache.flutterRoot, 'packages', 'flutter_tools'),
+          enabledExperiments: <String>[],
         );
 
         final ExpressionCompiler expressionCompiler =

--- a/packages/flutter_tools/lib/src/build_runner/web_compilation_delegate.dart
+++ b/packages/flutter_tools/lib/src/build_runner/web_compilation_delegate.dart
@@ -211,6 +211,7 @@ class BuildDaemonCreator {
       await pub.get(
         context: PubContext.pubGet,
         directory: globals.fs.file(buildScriptPackages).parent.path,
+        enabledExperiments: <String>[],
       );
     }
     final String flutterWebSdk = globals.artifacts.getArtifactPath(Artifact.flutterWebSdk);

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -29,6 +29,7 @@ import '../template.dart';
 
 class CreateCommand extends FlutterCommand {
   CreateCommand() {
+    addEnableExperimentation();
     argParser.addFlag('pub',
       defaultsTo: true,
       help: 'Whether to run "flutter pub get" after the project has been created.',
@@ -479,6 +480,7 @@ To edit platform code in an IDE see https://flutter.dev/developing-packages/#edi
         context: PubContext.create,
         directory: directory.path,
         offline: boolArg('offline'),
+        enabledExperiments: stringsArg(FlutterOptions.kEnableExperiment),
       );
       final FlutterProject project = FlutterProject.fromDirectory(directory);
       await project.ensureReadyForPlatformSpecificTooling(checkProjects: false);
@@ -498,6 +500,7 @@ To edit platform code in an IDE see https://flutter.dev/developing-packages/#edi
         context: PubContext.createPackage,
         directory: directory.path,
         offline: boolArg('offline'),
+        enabledExperiments: stringsArg(FlutterOptions.kEnableExperiment),
       );
     }
     return generatedCount;
@@ -515,6 +518,7 @@ To edit platform code in an IDE see https://flutter.dev/developing-packages/#edi
         context: PubContext.createPlugin,
         directory: directory.path,
         offline: boolArg('offline'),
+        enabledExperiments: stringsArg(FlutterOptions.kEnableExperiment),
       );
     }
     final FlutterProject project = FlutterProject.fromDirectory(directory);
@@ -547,7 +551,12 @@ To edit platform code in an IDE see https://flutter.dev/developing-packages/#edi
     }
 
     if (boolArg('pub')) {
-      await pub.get(context: PubContext.create, directory: directory.path, offline: boolArg('offline'));
+      await pub.get(
+        context: PubContext.create,
+        directory: directory.path,
+        offline: boolArg('offline'),
+        enabledExperiments: stringsArg(FlutterOptions.kEnableExperiment),
+      );
       await project.ensureReadyForPlatformSpecificTooling(checkProjects: false);
     }
 

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -45,6 +45,7 @@ class PackagesCommand extends FlutterCommand {
 class PackagesGetCommand extends FlutterCommand {
   PackagesGetCommand(this.name, this.upgrade) {
     requiresPubspecYaml();
+    addEnableExperimentation();
     argParser.addFlag('offline',
       negatable: false,
       help: 'Use cached packages instead of accessing the network.',
@@ -96,6 +97,7 @@ class PackagesGetCommand extends FlutterCommand {
         upgrade: upgrade ,
         offline: boolArg('offline'),
         checkLastModified: false,
+        enabledExperiments: stringsArg(FlutterOptions.kEnableExperiment),
       );
       pubGetTimer.stop();
       globals.flutterUsage.sendTiming('pub', 'get', pubGetTimer.elapsed, label: 'success');
@@ -139,6 +141,7 @@ class PackagesGetCommand extends FlutterCommand {
 
 class PackagesTestCommand extends FlutterCommand {
   PackagesTestCommand() {
+    addEnableExperimentation();
     requiresPubspecYaml();
   }
 
@@ -162,13 +165,19 @@ class PackagesTestCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
-    await pub.batch(<String>['run', 'test', ...argResults.rest], context: PubContext.runTest, retry: false);
+    await pub.batch(
+      <String>['run', 'test', ...argResults.rest],
+      context: PubContext.runTest,
+      retry: false,
+      enabledExperiments: stringsArg(FlutterOptions.kEnableExperiment),
+    );
     return FlutterCommandResult.success();
   }
 }
 
 class PackagesPublishCommand extends FlutterCommand {
   PackagesPublishCommand() {
+    addEnableExperimentation();
     requiresPubspecYaml();
     argParser.addFlag('dry-run',
       abbr: 'n',
@@ -202,14 +211,17 @@ class PackagesPublishCommand extends FlutterCommand {
       if (boolArg('dry-run')) '--dry-run',
       if (boolArg('force')) '--force',
     ];
-    await pub.interactively(<String>['publish', ...args], stdio: globals.stdio);
+    await pub.interactively(
+      <String>['publish', ...args],
+      stdio: globals.stdio,
+    );
     return FlutterCommandResult.success();
   }
 }
 
 class PackagesForwardCommand extends FlutterCommand {
   PackagesForwardCommand(this._commandName, this._description, {bool requiresPubspec = false}) {
-    if (requiresPubspec) {
+   if (requiresPubspec) {
       requiresPubspecYaml();
     }
   }
@@ -232,7 +244,10 @@ class PackagesForwardCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
-    await pub.interactively(<String>[_commandName, ...argResults.rest], stdio: globals.stdio);
+    await pub.interactively(
+      <String>[_commandName, ...argResults.rest],
+      stdio: globals.stdio,
+    );
     return FlutterCommandResult.success();
   }
 
@@ -259,7 +274,10 @@ class PackagesPassthroughCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
-    await pub.interactively(argResults.rest, stdio: globals.stdio);
+    await pub.interactively(
+      argResults.rest,
+      stdio: globals.stdio,
+    );
     return FlutterCommandResult.success();
   }
 }

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -164,7 +164,11 @@ class TestCommand extends FlutterCommand {
         'directory (or one of its subdirectories).');
     }
     if (shouldRunPub) {
-      await pub.get(context: PubContext.getVerifyContext(name), skipPubspecYamlCheck: true);
+      await pub.get(
+        context: PubContext.getVerifyContext(name),
+        skipPubspecYamlCheck: true,
+        enabledExperiments: stringsArg(FlutterOptions.kEnableExperiment),
+      );
     }
     final bool buildTestAssets = boolArg('test-assets');
     final List<String> names = stringsArg('name');

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -298,6 +298,7 @@ class UpdatePackagesCommand extends FlutterCommand {
           upgrade: true,
           checkLastModified: false,
           offline: offline,
+          enabledExperiments: <String>[],
           flutterRootOverride: upgrade
             ? temporaryFlutterSdk.path
             : null,
@@ -319,6 +320,7 @@ class UpdatePackagesCommand extends FlutterCommand {
           context: PubContext.updatePackages,
           directory: tempDir.path,
           filter: tree.fill,
+          enabledExperiments: <String>[],
           retry: false, // errors here are usually fatal since we're not hitting the network
         );
       } finally {
@@ -380,6 +382,7 @@ class UpdatePackagesCommand extends FlutterCommand {
         directory: dir.path,
         checkLastModified: false,
         offline: offline,
+        enabledExperiments: <String>[],
       );
       count += 1;
     }

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -294,7 +294,12 @@ class UpgradeCommandRunner {
     final String projectRoot = findProjectRoot();
     if (projectRoot != null) {
       globals.printStatus('');
-      await pub.get(context: PubContext.pubUpgrade, directory: projectRoot, upgrade: true, checkLastModified: false);
+      await pub.get(
+        context: PubContext.pubUpgrade,
+        directory: projectRoot,
+        upgrade: true, checkLastModified: false,
+        enabledExperiments: <String>[],
+      );
     }
   }
 

--- a/packages/flutter_tools/lib/src/commands/version.dart
+++ b/packages/flutter_tools/lib/src/commands/version.dart
@@ -151,6 +151,7 @@ class VersionCommand extends FlutterCommand {
         directory: projectRoot,
         upgrade: true,
         checkLastModified: false,
+        enabledExperiments: <String>[],
       );
     }
 

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -88,6 +88,7 @@ abstract class Pub {
   /// understand usage.
   Future<void> get({
     @required PubContext context,
+    List<String> enabledExperiments = const <String>[],
     String directory,
     bool skipIfAbsent = false,
     bool upgrade = false,
@@ -111,6 +112,7 @@ abstract class Pub {
   /// understand usage.
   Future<void> batch(
     List<String> arguments, {
+    List<String> enabledExperiments = const <String>[],
     @required PubContext context,
     String directory,
     MessageFilter filter,
@@ -159,6 +161,7 @@ class _DefaultPub implements Pub {
   @override
   Future<void> get({
     @required PubContext context,
+    List<String> enabledExperiments = const <String>[],
     String directory,
     bool skipIfAbsent = false,
     bool upgrade = false,
@@ -208,6 +211,7 @@ class _DefaultPub implements Pub {
       try {
         await batch(
           args,
+          enabledExperiments: enabledExperiments,
           context: context,
           directory: directory,
           failureMessage: 'pub $command failed',
@@ -247,6 +251,7 @@ class _DefaultPub implements Pub {
   @override
   Future<void> batch(
     List<String> arguments, {
+    List<String> enabledExperiments = const <String>[],
     @required PubContext context,
     String directory,
     MessageFilter filter,
@@ -279,7 +284,7 @@ class _DefaultPub implements Pub {
     loop: while (true) {
       attempts += 1;
       code = await _processUtils.stream(
-        _pubCommand(arguments),
+        _pubCommand(<String>[...arguments, ...enabledExperiments]),
         workingDirectory: directory,
         mapFunction: filterWrapper, // may set versionSolvingFailed, lastPubMessage
         environment: await _createPubEnvironment(context, flutterRootOverride),

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -805,7 +805,12 @@ abstract class FlutterCommand extends Command<void> {
     await validateCommand();
 
     if (shouldRunPub) {
-      await pub.get(context: PubContext.getVerifyContext(name));
+      await pub.get(
+        context: PubContext.getVerifyContext(name),
+        enabledExperiments: argResults.wasParsed(FlutterOptions.kEnableExperiment)
+          ? stringsArg(FlutterOptions.kEnableExperiment)
+          : <String>[],
+      );
       // All done updating dependencies. Release the cache lock.
       Cache.releaseLock();
       final FlutterProject project = FlutterProject.current();

--- a/packages/flutter_tools/lib/src/template.dart
+++ b/packages/flutter_tools/lib/src/template.dart
@@ -275,5 +275,6 @@ Future<void> _ensurePackageDependencies(String packagePath) async {
   await pub.get(
     context: PubContext.pubGet,
     directory: packagePath,
+    enabledExperiments: <String>[],
   );
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/analyze_continuously_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/analyze_continuously_test.dart
@@ -77,7 +77,11 @@ void main() {
         botDetector: globals.botDetector,
         usage: globals.flutterUsage,
       );
-      await pub.get(context: PubContext.flutterTests, directory: tempDir.path);
+      await pub.get(
+        context: PubContext.flutterTests,
+        directory: tempDir.path,
+        enabledExperiments: <String>[],
+      );
 
       server = AnalysisServer(
         globals.artifacts.getArtifactPath(Artifact.engineDartSdkPath),
@@ -112,7 +116,11 @@ void main() {
       usage: globals.flutterUsage,
       botDetector: globals.botDetector,
     );
-    await pub.get(context: PubContext.flutterTests, directory: tempDir.path);
+    await pub.get(
+      context: PubContext.flutterTests,
+      directory: tempDir.path,
+      enabledExperiments: <String>[],
+    );
 
       server = AnalysisServer(
         globals.artifacts.getArtifactPath(Artifact.engineDartSdkPath),

--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -205,6 +205,28 @@ void main() {
       ),
     });
 
+    testUsingContext('get fetches packages with --enable-experiment', () async {
+      final String projectPath = await createProject(tempDir,
+        arguments: <String>['--no-pub', '--template=module']);
+      removeGeneratedFiles(projectPath);
+
+      await runCommandIn(projectPath, 'get', args: <String>[
+        '--enable-experiment=non-nullable',
+      ]);
+
+      expectDependenciesResolved(projectPath);
+      expectZeroPluginsInjected(projectPath);
+    }, overrides: <Type, Generator>{
+      Pub: () => Pub(
+        fileSystem: globals.fs,
+        logger: globals.logger,
+        processManager: globals.processManager,
+        usage: globals.flutterUsage,
+        botDetector: globals.botDetector,
+        platform: globals.platform,
+      ),
+    });
+
     testUsingContext('get --offline fetches packages', () async {
       final String projectPath = await createProject(tempDir,
         arguments: <String>['--no-pub', '--template=module']);

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -258,7 +258,8 @@ void main() {
     verify(status.stop()).called(1);
     verify(pub.get(
       context: PubContext.pubGet,
-      directory: globals.fs.path.join('packages', 'flutter_tools')
+      directory: globals.fs.path.join('packages', 'flutter_tools'),
+      enabledExperiments: anyNamed('enabledExperiments'),
     )).called(1);
 
     expect(bufferLogger.statusText, contains('Debug service listening on ws://127.0.0.1/abcd/'));

--- a/packages/flutter_tools/test/src/throwing_pub.dart
+++ b/packages/flutter_tools/test/src/throwing_pub.dart
@@ -11,6 +11,7 @@ import 'package:meta/meta.dart';
 class ThrowingPub implements Pub {
   @override
   Future<void> batch(List<String> arguments, {
+    @required List<String> enabledExperiments,
     PubContext context,
     String directory,
     MessageFilter filter,
@@ -23,6 +24,7 @@ class ThrowingPub implements Pub {
 
   @override
   Future<void> get({
+    @required List<String> enabledExperiments,
     PubContext context,
     String directory,
     bool skipIfAbsent = false,
@@ -36,7 +38,11 @@ class ThrowingPub implements Pub {
   }
 
   @override
-  Future<void> interactively(List<String> arguments, {String directory, @required Stdio stdio,}) {
+  Future<void> interactively(List<String> arguments, {
+     @required List<String> enabledExperiments,
+    String directory,
+    @required Stdio stdio,
+  }) {
     throw UnsupportedError('Attempted to invoke pub during test.');
   }
 }

--- a/packages/flutter_tools/test/template_test.dart
+++ b/packages/flutter_tools/test/template_test.dart
@@ -83,6 +83,7 @@ void main() {
     when(pub.get(
       context: PubContext.pubGet,
       directory: anyNamed('directory'),
+      enabledExperiments: anyNamed('enabledExperiments'),
     )).thenAnswer((Invocation invocation) async {
       // Create valid package entry.
       packagesFile.writeAsStringSync('flutter_template_images:file:///flutter_template_images');


### PR DESCRIPTION
## Description

For commands that flutter surfaces from pub, ensure --enable-experiment can be passed through. Note that some commands are already full pass throughs, so nothing needs to be explicitly added.

Fixes https://github.com/flutter/flutter/issues/52819