### PR TITLE
Make the InkResponse's focus highlight honor the radius parameter

### DIFF
--- a/packages/flutter/lib/src/material/ink_highlight.dart
+++ b/packages/flutter/lib/src/material/ink_highlight.dart
@@ -41,6 +41,7 @@ class InkHighlight extends InteractiveInkFeature {
     @required Color color,
     @required TextDirection textDirection,
     BoxShape shape = BoxShape.rectangle,
+    double radius,
     BorderRadius borderRadius,
     ShapeBorder customBorder,
     RectCallback rectCallback,
@@ -51,6 +52,7 @@ class InkHighlight extends InteractiveInkFeature {
        assert(textDirection != null),
        assert(fadeDuration != null),
        _shape = shape,
+       _radius = radius,
        _borderRadius = borderRadius ?? BorderRadius.zero,
        _customBorder = customBorder,
        _textDirection = textDirection,
@@ -69,6 +71,7 @@ class InkHighlight extends InteractiveInkFeature {
   }
 
   final BoxShape _shape;
+  final double _radius;
   final BorderRadius _borderRadius;
   final ShapeBorder _customBorder;
   final RectCallback _rectCallback;
@@ -112,7 +115,7 @@ class InkHighlight extends InteractiveInkFeature {
     }
     switch (_shape) {
       case BoxShape.circle:
-        canvas.drawCircle(rect.center, Material.defaultSplashRadius, paint);
+        canvas.drawCircle(rect.center, _radius ?? Material.defaultSplashRadius, paint);
         break;
       case BoxShape.rectangle:
         if (_borderRadius != BorderRadius.zero) {

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -840,6 +840,7 @@ class _InkResponseState extends State<_InkResponseStateWidget>
           referenceBox: referenceBox,
           color: getHighlightColorForType(type),
           shape: widget.highlightShape,
+          radius: widget.radius,
           borderRadius: widget.borderRadius,
           customBorder: widget.customBorder,
           rectCallback: widget.getRectCallback(referenceBox),

--- a/packages/flutter/test/material/ink_well_test.dart
+++ b/packages/flutter/test/material/ink_well_test.dart
@@ -327,13 +327,8 @@ void main() {
               child: InkResponse(
                 focusNode: focusNode,
                 radius: 20,
-                hoverColor: const Color(0xff00ff00),
-                splashColor: const Color(0xffff0000),
                 focusColor: const Color(0xff0000ff),
-                highlightColor: const Color(0xf00fffff),
                 onTap: () { },
-                onLongPress: () { },
-                onHover: (bool hover) { },
               ),
             ),
           ),
@@ -345,9 +340,7 @@ void main() {
     expect(inkFeatures, paintsExactlyCountTimes(#drawCircle, 0));
     focusNode.requestFocus();
     await tester.pumpAndSettle();
-    expect(inkFeatures, paintsExactlyCountTimes(#drawCircle, 1));
-    expect(inkFeatures, paints
-      ..circle(radius: 20, color: const Color(0xff0000ff)));
+    expect(inkFeatures, paints..circle(radius: 20, color: const Color(0xff0000ff)));
   });
 
   testWidgets("ink response doesn't change color on focus when on touch device", (WidgetTester tester) async {

--- a/packages/flutter/test/material/ink_well_test.dart
+++ b/packages/flutter/test/material/ink_well_test.dart
@@ -313,6 +313,43 @@ void main() {
     await gesture.up();
   });
 
+  testWidgets('ink response uses radius for focus highlight', (WidgetTester tester) async {
+    FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+    final FocusNode focusNode = FocusNode(debugLabel: 'Ink Focus');
+    await tester.pumpWidget(
+      Material(
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: Container(
+              width: 100,
+              height: 100,
+              child: InkResponse(
+                focusNode: focusNode,
+                radius: 20,
+                hoverColor: const Color(0xff00ff00),
+                splashColor: const Color(0xffff0000),
+                focusColor: const Color(0xff0000ff),
+                highlightColor: const Color(0xf00fffff),
+                onTap: () { },
+                onLongPress: () { },
+                onHover: (bool hover) { },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
+    expect(inkFeatures, paintsExactlyCountTimes(#drawCircle, 0));
+    focusNode.requestFocus();
+    await tester.pumpAndSettle();
+    expect(inkFeatures, paintsExactlyCountTimes(#drawCircle, 1));
+    expect(inkFeatures, paints
+      ..circle(radius: 20, color: const Color(0xff0000ff)));
+  });
+
   testWidgets("ink response doesn't change color on focus when on touch device", (WidgetTester tester) async {
     FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTouch;
     final FocusNode focusNode = FocusNode(debugLabel: 'Ink Focus');


### PR DESCRIPTION
## Description

Currently, the highlight used on an `InkResponse` when it is focused is a circle with a hard coded radius of 35 (`Material.defaultSplashRadius`). While a good default, it may not be appropriate for all use cases. This PR has the response use the `radius` parameter for this if it is given. If not it reverts to `Material.defaultSplashRadius` as normal.

## Tests

I added a test 'ink response uses radius for focus highlight' to `ink_well_test.dart`.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them?

- [x] No, no existing tests failed, so this is *not* a breaking change.
