### PR TITLE
Fix hintcolor to use a heavier color

### DIFF
--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -315,7 +315,7 @@ class ThemeData with Diagnosticable {
     backgroundColor ??= isDark ? Colors.grey[700] : primarySwatch[200];
     dialogBackgroundColor ??= isDark ? Colors.grey[800] : Colors.white;
     indicatorColor ??= accentColor == primaryColor ? Colors.white : accentColor;
-    hintColor ??= isDark ? const Color(0x80FFFFFF) : const Color(0x8A000000);
+    hintColor ??= isDark ? const Color(0x99FFFFFF) : const Color(0x99000000);
     errorColor ??= Colors.red[700];
     inputDecorationTheme ??= const InputDecorationTheme();
     pageTransitionsTheme ??= const PageTransitionsTheme();

--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -298,6 +298,29 @@ void main() {
     expect(glyphText.text.style.fontSize, 20.0);
   });
 
+  testWidgets('hint color has correct default', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Text('dummy'),
+      ),
+    );
+    ThemeData data = tester.widget<Theme>(find.byType(Theme)).data;
+    expect(data.hintColor, const Color(0x99000000));
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(),
+        home: const Text('dummy'),
+      ),
+    );
+
+    // Waits for theme transition.
+    await tester.pumpAndSettle();
+
+    data = tester.widget<Theme>(find.byType(Theme)).data;
+    expect(data.hintColor, const Color(0x99FFFFFF));
+  });
+
   testWidgets(
     'Same ThemeData reapplied does not trigger descendants rebuilds',
     (WidgetTester tester) async {

--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -298,28 +298,54 @@ void main() {
     expect(glyphText.text.style.fontSize, 20.0);
   });
 
-  testWidgets('hint color has correct default', (WidgetTester tester) async {
+  testWidgets('default hint color passes contract test - light', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(
-        home: Text('dummy'),
+        home: Scaffold(
+          body: TextField(
+            decoration: InputDecoration(
+              labelText: 'label text',
+            ),
+          ),
+        ),
       ),
     );
-    ThemeData data = tester.widget<Theme>(find.byType(Theme)).data;
-    expect(data.hintColor, const Color(0x99000000));
+    await expectLater(
+      tester,
+      meetsGuideline(
+        CustomMinimumContrastGuideline(
+          finder: find.text('label text'),
+          minimumRatio: 5.5,
+        ),
+      )
+    );
+  });
 
+  testWidgets('default hint color passes contract test - dark', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData.dark(),
-        home: const Text('dummy'),
+        home: const Scaffold(
+          body: TextField(
+            decoration: InputDecoration(
+              labelText: 'label text',
+            ),
+          ),
+        ),
       ),
     );
 
-    // Waits for theme transition.
-    await tester.pumpAndSettle();
-
-    data = tester.widget<Theme>(find.byType(Theme)).data;
-    expect(data.hintColor, const Color(0x99FFFFFF));
+    await expectLater(
+      tester,
+      meetsGuideline(
+        CustomMinimumContrastGuideline(
+          finder: find.text('label text'),
+          minimumRatio: 5.5,
+        ),
+      )
+    );
   });
+
 
   testWidgets(
     'Same ThemeData reapplied does not trigger descendants rebuilds',


### PR DESCRIPTION
## Description
The documentation of labelStyle https://master-api.flutter.dev/flutter/material/InputDecoration/labelStyle.html
mentioned that when labelText  is on top of the input field, it will uses hintStyle. However, the code does not reflect that. This PR fixes it. This also provide the ability to override the text style for labelText and floating labelText separately 

## Related Issues

Fixes https://github.com/flutter/flutter/issues/58941

## Tests

I added the following tests:

See files

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
