### PR TITLE
[Widgets] Add DefaultTextHeightBehavior inherited widget.

### DIFF
--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -237,7 +237,7 @@ class DefaultTextHeightBehavior extends InheritedTheme {
         super(key: key, child: null);
 
   /// {@macro flutter.dart:ui.textHeightBehavior}
-  final ui.TextHeightBehavior textHeightBehavior;
+  final TextHeightBehavior textHeightBehavior;
 
   /// The closest instance of this class that encloses the given context.
   ///

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -205,8 +205,8 @@ class DefaultTextStyle extends InheritedTheme {
 /// have not explicitly set [Text.textHeightBehavior].
 ///
 /// If there is a [DefaultTextStyle] with a non-null [DefaultTextStyle.textHeightBehavior]
-/// in the same tree as this widget, the [DefaultTextStyle.textHeightBehavior]
-/// will be used over this widget's [TextHeightBehavior].
+/// below this widget, the [DefaultTextStyle.textHeightBehavior] will be used
+/// over this widget's [TextHeightBehavior].
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -204,14 +204,16 @@ class DefaultTextStyle extends InheritedTheme {
 /// The [TextHeightBehavior] that will apply to descendant [Text] widgets which
 /// have not explicitly set [Text.textHeightBehavior].
 ///
+/// If there is a [DefaultTextStyle] with a non-null [DefaultTextStyle.textHeightBehavior]
+/// in the same tree as this widget, the [DefaultTextStyle.textHeightBehavior]
+/// will be used over this widget's [TextHeightBehavior].
+///
 /// See also:
 ///
 ///  * [DefaultTextStyle], which defines a [TextStyle] to apply to descendant
 ///    [Text] widgets.
 class DefaultTextHeightBehavior extends InheritedTheme {
   /// Creates a default text height behavior for the given subtree.
-  ///
-  /// This will take precedence over [DefaultTextStyle.textHeightBehavior].
   ///
   /// The [textHeightBehavior] and [child] arguments are required and must not be null.
   const DefaultTextHeightBehavior({
@@ -239,16 +241,15 @@ class DefaultTextHeightBehavior extends InheritedTheme {
 
   /// The closest instance of this class that encloses the given context.
   ///
-  /// If no such instance exists, returns an instance created by
-  /// [DefaultTextHeightBehavior.fallback], which contains fallback values.
+  /// If no such instance exists, this method will return `null`.
   ///
   /// Typical usage is as follows:
   ///
   /// ```dart
   /// DefaultTextHeightBehavior defaultTextHeightBehavior = DefaultTextHeightBehavior.of(context);
   /// ```
-  static DefaultTextHeightBehavior of(BuildContext context) {
-    return context.dependOnInheritedWidgetOfExactType<DefaultTextHeightBehavior>() ?? const DefaultTextHeightBehavior.fallback();
+  static TextHeightBehavior of(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<DefaultTextHeightBehavior>()?.textHeightBehavior;
   }
 
   @override
@@ -505,7 +506,6 @@ class Text extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final DefaultTextStyle defaultTextStyle = DefaultTextStyle.of(context);
-    final DefaultTextHeightBehavior defaultTextHeightBehavior = DefaultTextHeightBehavior.of(context);
     TextStyle effectiveTextStyle = style;
     if (style == null || style.inherit)
       effectiveTextStyle = defaultTextStyle.style.merge(style);
@@ -521,7 +521,7 @@ class Text extends StatelessWidget {
       maxLines: maxLines ?? defaultTextStyle.maxLines,
       strutStyle: strutStyle,
       textWidthBasis: textWidthBasis ?? defaultTextStyle.textWidthBasis,
-      textHeightBehavior: textHeightBehavior ?? defaultTextHeightBehavior.textHeightBehavior ?? defaultTextStyle.textHeightBehavior,
+      textHeightBehavior: textHeightBehavior ?? defaultTextStyle.textHeightBehavior ?? DefaultTextHeightBehavior.of(context),
       text: TextSpan(
         style: effectiveTextStyle,
         text: data,

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -201,6 +201,77 @@ class DefaultTextStyle extends InheritedTheme {
   }
 }
 
+/// The [TextHeightBehavior] that will apply to descendant [Text] widgets which
+/// have not explicitly set [Text.textHeightBehavior].
+///
+/// See also:
+///
+///  * [DefaultTextStyle], which defines a [TextStyle] to apply to descendant
+///    [Text] widgets.
+class DefaultTextHeightBehavior extends InheritedTheme {
+  /// Creates a default text height behavior for the given subtree.
+  ///
+  /// This will take precedence over [DefaultTextStyle.textHeightBehavior].
+  ///
+  /// The [textHeightBehavior] and [child] arguments are required and must not be null.
+  const DefaultTextHeightBehavior({
+    Key key,
+    @required this.textHeightBehavior,
+    @required Widget child,
+  }) :  assert(textHeightBehavior != null),
+        assert(child != null),
+        super(key: key, child: child);
+
+  /// A const-constructible default text height behavior that provides a
+  /// [TextHeightBehavior] of null.
+  ///
+  /// Returned from [of] when the given [BuildContext] doesn't have an enclosing
+  /// [DefaultTextHeightBehavior].
+  ///
+  /// This constructor creates a [DefaultTextStyle] that lacks a [child], which
+  /// means the constructed value cannot be incorporated into the tree.
+  const DefaultTextHeightBehavior.fallback({ Key key })
+      : textHeightBehavior = null,
+        super(key: key, child: null);
+
+  /// {@macro flutter.dart:ui.textHeightBehavior}
+  final ui.TextHeightBehavior textHeightBehavior;
+
+  /// The closest instance of this class that encloses the given context.
+  ///
+  /// If no such instance exists, returns an instance created by
+  /// [DefaultTextHeightBehavior.fallback], which contains fallback values.
+  ///
+  /// Typical usage is as follows:
+  ///
+  /// ```dart
+  /// DefaultTextHeightBehavior defaultTextHeightBehavior = DefaultTextHeightBehavior.of(context);
+  /// ```
+  static DefaultTextHeightBehavior of(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<DefaultTextHeightBehavior>() ?? const DefaultTextHeightBehavior.fallback();
+  }
+
+  @override
+  bool updateShouldNotify(DefaultTextHeightBehavior oldWidget) {
+    return textHeightBehavior != oldWidget.textHeightBehavior;
+  }
+
+  @override
+  Widget wrap(BuildContext context, Widget child) {
+    final DefaultTextHeightBehavior defaultTextHeightBehavior = context.findAncestorWidgetOfExactType<DefaultTextHeightBehavior>();
+    return identical(this, defaultTextHeightBehavior) ? child : DefaultTextHeightBehavior(
+      textHeightBehavior: textHeightBehavior,
+      child: child,
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<ui.TextHeightBehavior>('textHeightBehavior', textHeightBehavior, defaultValue: null));
+  }
+}
+
 /// A run of text with a single style.
 ///
 /// The [Text] widget displays a string of text with single style. The string
@@ -434,6 +505,7 @@ class Text extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final DefaultTextStyle defaultTextStyle = DefaultTextStyle.of(context);
+    final DefaultTextHeightBehavior defaultTextHeightBehavior = DefaultTextHeightBehavior.of(context);
     TextStyle effectiveTextStyle = style;
     if (style == null || style.inherit)
       effectiveTextStyle = defaultTextStyle.style.merge(style);
@@ -449,7 +521,7 @@ class Text extends StatelessWidget {
       maxLines: maxLines ?? defaultTextStyle.maxLines,
       strutStyle: strutStyle,
       textWidthBasis: textWidthBasis ?? defaultTextStyle.textWidthBasis,
-      textHeightBehavior: textHeightBehavior ?? defaultTextStyle.textHeightBehavior,
+      textHeightBehavior: textHeightBehavior ?? defaultTextHeightBehavior.textHeightBehavior ?? defaultTextStyle.textHeightBehavior,
       text: TextSpan(
         style: effectiveTextStyle,
         text: data,

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -224,18 +224,6 @@ class DefaultTextHeightBehavior extends InheritedTheme {
         assert(child != null),
         super(key: key, child: child);
 
-  /// A const-constructible default text height behavior that provides a
-  /// [TextHeightBehavior] of null.
-  ///
-  /// Returned from [of] when the given [BuildContext] doesn't have an enclosing
-  /// [DefaultTextHeightBehavior].
-  ///
-  /// This constructor creates a [DefaultTextStyle] that lacks a [child], which
-  /// means the constructed value cannot be incorporated into the tree.
-  const DefaultTextHeightBehavior.fallback({ Key key })
-      : textHeightBehavior = null,
-        super(key: key, child: null);
-
   /// {@macro flutter.dart:ui.textHeightBehavior}
   final TextHeightBehavior textHeightBehavior;
 

--- a/packages/flutter/test/widgets/default_text_height_behavior_test.dart
+++ b/packages/flutter/test/widgets/default_text_height_behavior_test.dart
@@ -35,7 +35,7 @@ void main() {
     expect(text.textHeightBehavior, behavior1);
   });
 
-  testWidgets('DefaultTextHeightBehavior takes precedence over DefaultTextStyle.textHeightBehavior', (WidgetTester tester) async {
+  testWidgets('DefaultTextStyle.textHeightBehavior takes precedence over DefaultTextHeightBehavior ', (WidgetTester tester) async {
     const TextHeightBehavior behavior1 = TextHeightBehavior(
       applyHeightToLastDescent: false,
       applyHeightToFirstAscent: false,
@@ -61,7 +61,7 @@ void main() {
 
     RichText text = tester.firstWidget(find.byType(RichText));
     expect(text, isNotNull);
-    expect(text.textHeightBehavior, behavior2);
+    expect(text.textHeightBehavior, behavior1);
 
     await tester.pumpWidget(
       const DefaultTextHeightBehavior(
@@ -79,7 +79,7 @@ void main() {
 
     text = tester.firstWidget(find.byType(RichText));
     expect(text, isNotNull);
-    expect(text.textHeightBehavior, behavior2);
+    expect(text.textHeightBehavior, behavior1);
   });
 
   testWidgets('DefaultTextHeightBehavior changes propagate to Text', (WidgetTester tester) async {
@@ -110,5 +110,23 @@ void main() {
     text = tester.firstWidget(find.byType(RichText));
     expect(text, isNotNull);
     expect(text.textHeightBehavior, behavior2);
+  });
+
+  testWidgets('DefaultTextHeightBehavior.of(context) returns null if no '
+      'DefaultTextHeightBehavior widget in tree', (WidgetTester tester) async {
+    const Text textWidget = Text('Hello', textDirection: TextDirection.ltr);
+    TextHeightBehavior textHeightBehavior;
+
+    await tester.pumpWidget(Builder(
+      builder: (BuildContext context) {
+        textHeightBehavior = DefaultTextHeightBehavior.of(context);
+        return textWidget;
+      },
+    ));
+
+    expect(textHeightBehavior, isNull);
+    RichText text = tester.firstWidget(find.byType(RichText));
+    expect(text, isNotNull);
+    expect(text.textHeightBehavior, isNull);
   });
 }

--- a/packages/flutter/test/widgets/default_text_height_behavior_test.dart
+++ b/packages/flutter/test/widgets/default_text_height_behavior_test.dart
@@ -125,7 +125,7 @@ void main() {
     ));
 
     expect(textHeightBehavior, isNull);
-    RichText text = tester.firstWidget(find.byType(RichText));
+    final RichText text = tester.firstWidget(find.byType(RichText));
     expect(text, isNotNull);
     expect(text.textHeightBehavior, isNull);
   });

--- a/packages/flutter/test/widgets/default_text_height_behavior_test.dart
+++ b/packages/flutter/test/widgets/default_text_height_behavior_test.dart
@@ -1,0 +1,114 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' show TextHeightBehavior;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter/painting.dart';
+
+void main() {
+  testWidgets('Text widget parameter takes precedence over DefaultTextHeightBehavior', (WidgetTester tester) async {
+    const TextHeightBehavior behavior1 = TextHeightBehavior(
+      applyHeightToLastDescent: false,
+      applyHeightToFirstAscent: false,
+    );
+    const TextHeightBehavior behavior2 = TextHeightBehavior(
+      applyHeightToLastDescent: true,
+      applyHeightToFirstAscent: false,
+    );
+
+    await tester.pumpWidget(
+      const DefaultTextHeightBehavior(
+        textHeightBehavior: behavior2,
+        child: Text(
+          'Hello',
+          textDirection: TextDirection.ltr,
+          textHeightBehavior: behavior1,
+        ),
+      ),
+    );
+
+    final RichText text = tester.firstWidget(find.byType(RichText));
+    expect(text, isNotNull);
+    expect(text.textHeightBehavior, behavior1);
+  });
+
+  testWidgets('DefaultTextHeightBehavior takes precedence over DefaultTextStyle.textHeightBehavior', (WidgetTester tester) async {
+    const TextHeightBehavior behavior1 = TextHeightBehavior(
+      applyHeightToLastDescent: false,
+      applyHeightToFirstAscent: false,
+    );
+    const TextHeightBehavior behavior2 = TextHeightBehavior(
+      applyHeightToLastDescent: true,
+      applyHeightToFirstAscent: false,
+    );
+
+    await tester.pumpWidget(
+      const DefaultTextStyle(
+        style: TextStyle(),
+        textHeightBehavior: behavior1,
+        child: DefaultTextHeightBehavior(
+          textHeightBehavior: behavior2,
+          child: Text(
+            'Hello',
+            textDirection: TextDirection.ltr,
+          ),
+        ),
+      ),
+    );
+
+    RichText text = tester.firstWidget(find.byType(RichText));
+    expect(text, isNotNull);
+    expect(text.textHeightBehavior, behavior2);
+
+    await tester.pumpWidget(
+      const DefaultTextHeightBehavior(
+        textHeightBehavior: behavior2,
+        child: DefaultTextStyle(
+          style: TextStyle(),
+          textHeightBehavior: behavior1,
+          child: Text(
+            'Hello',
+            textDirection: TextDirection.ltr,
+          ),
+        ),
+      ),
+    );
+
+    text = tester.firstWidget(find.byType(RichText));
+    expect(text, isNotNull);
+    expect(text.textHeightBehavior, behavior2);
+  });
+
+  testWidgets('DefaultTextHeightBehavior changes propagate to Text', (WidgetTester tester) async {
+    const Text textWidget = Text('Hello', textDirection: TextDirection.ltr);
+    const TextHeightBehavior behavior1 = TextHeightBehavior(
+      applyHeightToLastDescent: false,
+      applyHeightToFirstAscent: false,
+    );
+    const TextHeightBehavior behavior2 = TextHeightBehavior(
+      applyHeightToLastDescent: false,
+      applyHeightToFirstAscent: false,
+    );
+
+    await tester.pumpWidget(const DefaultTextHeightBehavior(
+      textHeightBehavior: behavior1,
+      child: textWidget,
+    ));
+
+    RichText text = tester.firstWidget(find.byType(RichText));
+    expect(text, isNotNull);
+    expect(text.textHeightBehavior, behavior1);
+
+    await tester.pumpWidget(const DefaultTextHeightBehavior(
+      textHeightBehavior: behavior2,
+      child: textWidget,
+    ));
+
+    text = tester.firstWidget(find.byType(RichText));
+    expect(text, isNotNull);
+    expect(text.textHeightBehavior, behavior2);
+  });
+}


### PR DESCRIPTION
## Description

The `DefaultTextHeightBehavior` inherited widget will allow users to specify a default `textHeightBehavior` throughout their app. This can already be done in some instances with `DefaultTextStyle.textHeightBehavior`, however it can not be done universally because, for example, in the `material` library, many `DefaultTextStyle` widgets are created which override this setting.

### Usage

```dart
MaterialApp(
  builder: (context, child) {
    return DefaultTextHeightBehavior(
      textHeightBehavior: TextHeightBehavior(
        applyHeightToFirstAscent: false,
        applyHeightToLastDescent: false,
      ),
      child: child,
    );
  },
)
```

## Tests

I added the following tests:

* Test that `DefaultTextHeightBehavior` changes behavior on child widgets.
* Test that `DefaultTextHeightBehavior.textHeightBehavior` takes precedence over `DefaultTextStyle.textHeightBehavior` if both are present in tree.
* Test that `Text.textHeightBehavior` takes the highest precedence.  

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
