### PR TITLE
Add iOS Podfile migration warning to support federated plugins

### DIFF
--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -324,9 +324,6 @@ abstract class XcodeBasedProject {
 
   /// The CocoaPods 'Manifest.lock'.
   File get podManifestLock;
-
-  /// Directory containing symlinks to pub cache plugins source generated on `pod install`.
-  Directory get symlinks;
 }
 
 /// Represents the iOS sub-project of a Flutter project.
@@ -389,7 +386,6 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
   /// The default 'Info.plist' file of the host app. The developer can change this location in Xcode.
   File get defaultHostInfoPlist => hostAppRoot.childDirectory(_hostAppProjectName).childFile('Info.plist');
 
-  @override
   Directory get symlinks => _flutterLibRoot.childDirectory('.symlinks');
 
   @override
@@ -969,9 +965,6 @@ class MacOSProject extends FlutterProjectPlatform implements XcodeBasedProject {
 
   @override
   Directory get xcodeWorkspace => _macOSDirectory.childDirectory('$_hostAppProjectName.xcworkspace');
-
-  @override
-  Directory get symlinks => ephemeralDirectory.childDirectory('.symlinks');
 
   /// The file where the Xcode build will write the name of the built app.
   ///

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -355,7 +355,7 @@ void main() {
       ));
     });
 
-    testWithoutContext('prints warning, if Podfile is out of date', () async {
+    testWithoutContext('prints warning, if Podfile creates the Flutter engine symlink', () async {
       pretendPodIsInstalled();
 
       fs.file(fs.path.join('project', 'ios', 'Podfile'))
@@ -365,6 +365,20 @@ void main() {
       final Directory symlinks = projectUnderTest.ios.symlinks
         ..createSync(recursive: true);
       symlinks.childLink('flutter').createSync('cache');
+
+      await cocoaPodsUnderTest.processPods(
+        xcodeProject: projectUnderTest.ios,
+        engineDir: 'engine/path',
+      );
+      expect(logger.errorText, contains('Warning: Podfile is out of date'));
+    });
+
+    testWithoutContext('prints warning, if Podfile parses .flutter-plugins', () async {
+      pretendPodIsInstalled();
+
+      fs.file(fs.path.join('project', 'ios', 'Podfile'))
+        ..createSync()
+        ..writeAsStringSync('plugin_pods = parse_KV_file(\'../.flutter-plugins\')');
 
       await cocoaPodsUnderTest.processPods(
         xcodeProject: projectUnderTest.ios,


### PR DESCRIPTION
## Description

https://github.com/flutter/flutter/pull/59044 moved as much logic as possible from the app Podfile into a ruby script in the tool.  The Podfile needs to be regenerated to import and use the new script.  Now that the logic is in the tool, app developers won't need to regenerate it when the plugin logic changes.

## Related Issues

Part 2 of https://github.com/flutter/flutter/pull/59044.
First part of https://github.com/flutter/flutter/issues/39659

## Tests

cocoapods_test

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*