### PR TITLE
Support .flutter-plugins-dependencies

### DIFF
--- a/dev/devicelab/bin/tasks/plugin_lint_mac.dart
+++ b/dev/devicelab/bin/tasks/plugin_lint_mac.dart
@@ -204,6 +204,8 @@ Future<void> main() async {
 
       section('Remove iOS support from plugin');
 
+      Directory(path.join(objcPluginPath, 'ios')).deleteSync(recursive: true);
+
       const String iosPlatformMap = '''
       ios:
         pluginClass: TestPluginObjcPlugin''';

--- a/dev/devicelab/bin/tasks/plugin_lint_mac.dart
+++ b/dev/devicelab/bin/tasks/plugin_lint_mac.dart
@@ -106,12 +106,12 @@ Future<void> main() async {
 
       final String swiftPluginPath = path.join(tempDir.path, swiftPluginName);
       final File objcPubspec = File(path.join(objcAppPath, 'pubspec.yaml'));
-      String podspecContent = objcPubspec.readAsStringSync();
-      podspecContent = podspecContent.replaceFirst(
+      String pubspecContent = objcPubspec.readAsStringSync();
+      pubspecContent = pubspecContent.replaceFirst(
         '\ndependencies:\n',
         '\ndependencies:\n  $objcPluginName:\n    path: $objcPluginPath\n  $swiftPluginName:\n    path: $swiftPluginPath\n  device_info:\n',
       );
-      objcPubspec.writeAsStringSync(podspecContent, flush: true);
+      objcPubspec.writeAsStringSync(pubspecContent, flush: true);
 
       await inDirectory(objcAppPath, () async {
         await flutter(
@@ -167,7 +167,7 @@ Future<void> main() async {
       final String swiftAppPath = path.join(tempDir.path, swiftAppName);
 
       final File swiftPubspec = File(path.join(swiftAppPath, 'pubspec.yaml'));
-      swiftPubspec.writeAsStringSync(podspecContent, flush: true);
+      swiftPubspec.writeAsStringSync(pubspecContent, flush: true);
 
       await inDirectory(swiftAppPath, () async {
         await flutter(
@@ -201,6 +201,69 @@ Future<void> main() async {
       });
 
       _validatePodfile(swiftAppPath);
+
+      section('Remove iOS support from plugin');
+
+      const String iosPlatformMap = '''
+      ios:
+        pluginClass: TestPluginObjcPlugin''';
+
+      final File pluginPubspec = File(path.join(objcPluginPath, 'pubspec.yaml'));
+      String pluginPubspecContent = pluginPubspec.readAsStringSync();
+      if (!pluginPubspecContent.contains(iosPlatformMap)) {
+        return TaskResult.failure('Plugin pubspec.yaml missing iOS platform map');
+      }
+
+      pluginPubspecContent = pluginPubspecContent.replaceFirst(iosPlatformMap, '');
+      pluginPubspec.writeAsStringSync(pluginPubspecContent, flush: true);
+
+      await inDirectory(swiftAppPath, () async {
+        await flutter('clean');
+        await flutter(
+          'build',
+          options: <String>[
+            'ios',
+            '--no-codesign'
+          ],
+        );
+      });
+
+      section('Validate plugin without iOS platform');
+
+      final File podfileLockFile = File(path.join(swiftAppPath, 'ios', 'Podfile.lock'));
+      final String podfileLockOutput = podfileLockFile.readAsStringSync();
+      if (!podfileLockOutput.contains(':path: ".symlinks/plugins/device_info/ios"')
+        || !podfileLockOutput.contains(':path: Flutter')
+          // test_plugin_objc no longer supports iOS, shouldn't be present.
+        || podfileLockOutput.contains(':path: ".symlinks/plugins/test_plugin_objc/ios"')
+        || !podfileLockOutput.contains(':path: ".symlinks/plugins/test_plugin_swift/ios"')) {
+        return TaskResult.failure('Podfile.lock does not contain expected pods');
+      }
+
+      final String pluginSymlinks = path.join(
+        swiftAppPath,
+        'ios',
+        '.symlinks',
+        'plugins',
+      );
+
+      checkDirectoryExists(path.join(
+        pluginSymlinks,
+        'device_info',
+        'ios',
+      ));
+
+      checkDirectoryExists(path.join(
+        pluginSymlinks,
+        'test_plugin_swift',
+        'ios',
+      ));
+
+      // test_plugin_objc no longer supports iOS, shouldn't exist!
+      checkDirectoryNotExists(path.join(
+        pluginSymlinks,
+        'test_plugin_objc',
+      ));
 
       return TaskResult.success(null);
     } catch (e) {

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -664,6 +664,13 @@ void checkDirectoryExists(String directory) {
   }
 }
 
+/// Checks that the directory does not exist, otherwise throws a [FileSystemException].
+void checkDirectoryNotExists(String directory) {
+  if (exists(Directory(directory))) {
+    throw FileSystemException('Expected directory to not exist.', directory);
+  }
+}
+
 /// Check that `collection` contains all entries in `values`.
 void checkCollectionContains<T>(Iterable<T> values, Iterable<T> collection) {
   for (final T value in values) {

--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -2,6 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+require 'json'
+
 # Minimum CocoaPods Ruby version is 2.0.
 # Don't depend on features newer than that.
 
@@ -105,35 +107,30 @@ def flutter_install_ios_plugin_pods(ios_application_path = nil)
   symlink_plugins_dir = File.expand_path('plugins', symlink_dir)
   system('mkdir', '-p', symlink_plugins_dir)
 
-  plugins_file = File.join(ios_application_path, '..', '.flutter-plugins')
+  plugins_file = File.join(ios_application_path, '..', '.flutter-plugins-dependencies')
   plugin_pods = flutter_parse_plugins_file(plugins_file)
-  plugin_pods.each do |name, path|
-    symlink = File.join(symlink_plugins_dir, name)
-    File.symlink(path, symlink)
+  plugin_pods.each do |plugin_hash|
+    plugin_name = plugin_hash['name']
+    plugin_path = plugin_hash['path']
+    if (plugin_name && plugin_path)
+      symlink = File.join(symlink_plugins_dir, plugin_name)
+      File.symlink(plugin_path, symlink)
 
-    # Keep pod path relative so it can be checked into Podfile.lock.
-    pod name, :path => File.join('.symlinks', 'plugins', name, 'ios')
+      # Keep pod path relative so it can be checked into Podfile.lock.
+      pod plugin_name, :path => File.join('.symlinks', 'plugins', plugin_name, 'ios')
+    end
   end
 end
 
 def flutter_parse_plugins_file(file)
   file_path = File.expand_path(file)
-  unless File.exists? file_path
-    return {};
-  end
-  generated_key_values = {}
-  skip_line_start_symbols = ["#", "/"]
-  File.foreach(file_path) do |line|
-    next if skip_line_start_symbols.any? { |symbol| line =~ /^\s*#{symbol}/ }
-    plugin = line.split('=')
-    if plugin.length == 2
-      podname = plugin[0].strip
-      path = plugin[1].strip
-      podpath = File.expand_path(path, file_path)
-      generated_key_values[podname] = File.expand_path(path, file_path)
-    else
-      puts "Invalid plugin specification: #{line}"
-    end
-  end
-  generated_key_values
+  return [] unless File.exists? file_path
+
+  dependencies_file = File.read(file)
+  dependencies_hash = JSON.parse(dependencies_file)
+
+  # dependencies_hash.dig('plugins', 'ios') not available until Ruby 2.3
+  return [] unless dependencies_hash.has_key?('plugins')
+  return [] unless dependencies_hash['plugins'].has_key?('ios')
+  dependencies_hash['plugins']['ios'] || []
 end

--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -122,6 +122,8 @@ def flutter_install_ios_plugin_pods(ios_application_path = nil)
   end
 end
 
+# .flutter-plugins-dependencies format documented at
+# https://flutter.dev/go/plugins-list-migration
 def flutter_parse_plugins_file(file)
   file_path = File.expand_path(file)
   return [] unless File.exists? file_path


### PR DESCRIPTION
## Description

Parse `.flutter-plugins-dependencies` instead of the old ` .flutter-plugins` to only embed the `ios`-enabled plugins via CocoaPods.

`.flutter-plugins` was a flat list of all plugins and their pub cache path, regardless of supported platform:
```
device_info=/Users/m/.pub-cache/hosted/pub.dartlang.org/device_info-0.4.2+4/
```
`.flutter-plugins-dependencies` is json:
```
{
   "info":"This is a generated file; do not edit or check into version control.",
   "plugins":{
      "ios":[
         {
            "name":"device_info",
            "path":"/Users/m/.pub-cache/hosted/pub.dartlang.org/device_info-0.4.2+4/",
            "dependencies":[
            ]
         }
      ],
      "android":[
         {
            "name":"device_info",
            "path":"/Users/m/.pub-cache/hosted/pub.dartlang.org/device_info-0.4.2+4/",
            "dependencies":[
            ]
         }
      ],
      "macos":[
      ],
      "linux":[
      ],
      "windows":[
      ],
      "web":[
      ]
   },
   "dependencyGraph":[
      {
         "name":"device_info",
         "dependencies":[
         ]
      }
   ],
   "date_created":"2020-06-09 13:50:39.352998",
   "version":"1.19.0-6.0.pre.38"
}
```
See https://docs.google.com/document/d/1W_IpXetVIgjHipKnu-zPHnDApdiwXR0RfugY6Sm8NAg/edit

## Related Issues

Fixes https://github.com/flutter/flutter/issues/39659

## Tests

Updated integration test to test a plugin that doesn't support iOS.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*