### PR TITLE
[flutter_tools] Update roll_dev.dart

### DIFF
--- a/dev/tools/lib/roll_dev.dart
+++ b/dev/tools/lib/roll_dev.dart
@@ -241,6 +241,7 @@ String getVersionFromParts(List<int> parts) {
   return buf.toString();
 }
 
+/// A wrapper around git process calls that can be mocked for unit testing.
 class Git {
   const Git();
 

--- a/dev/tools/lib/roll_dev.dart
+++ b/dev/tools/lib/roll_dev.dart
@@ -109,17 +109,25 @@ bool run({
     throw Exception('Commit $commit is already on the dev branch as $lastVersion.');
   }
 
-  if (!force) {
-    git.run(
-      'merge-base --is-ancestor $lastVersion $commit',
-      'verify $lastVersion is a direct ancestor of $commit. The flag `--force` '
-      'is required to force push a new release past a cherry-pick',
-    );
-  }
-
   if (justPrint) {
     print(version);
     return false;
+  }
+
+  if (skipTagging) {
+    git.run(
+      'describe --exact-match --tags $commit',
+      'verify $commit is already tagged. You can only use the flag '
+      '`$kSkipTagging` if the commit has already been tagged.'
+    );
+  }
+
+  if (!force) {
+    git.run(
+      'merge-base --is-ancestor $lastVersion $commit',
+      'verify $lastVersion is a direct ancestor of $commit. The flag `$kForce`'
+      'is required to force push a new release past a cherry-pick',
+    );
   }
 
   git.run('reset $commit --hard', 'reset to the release commit');

--- a/dev/tools/lib/roll_dev.dart
+++ b/dev/tools/lib/roll_dev.dart
@@ -133,10 +133,7 @@ bool run({
     }
   }
 
-  if (skipTagging) {
-    // ensure tag already exist
-    // TODO
-  } else {
+  if (!skipTagging) {
     git.run('tag $version', 'tag the commit with the version label');
     git.run('push $origin $version', 'publish the version');
   }

--- a/dev/tools/lib/roll_dev.dart
+++ b/dev/tools/lib/roll_dev.dart
@@ -92,18 +92,21 @@ bool run({
     );
   }
 
-  // TODO(fujino): move this after `justPrint`
   git.run('fetch $origin', 'fetch $origin');
-  git.run('reset $commit --hard', 'reset to the release commit');
 
   String version = getFullTag(git, origin);
 
   version = incrementLevel(version, level);
 
+  // Do force check
+  throw Exception('Oops!');
+
   if (justPrint) {
     print(version);
     return false;
   }
+
+  git.run('reset $commit --hard', 'reset to the release commit');
 
   final String hash = git.getOutput('rev-parse HEAD', 'Get git hash for $commit');
 

--- a/dev/tools/lib/roll_dev.dart
+++ b/dev/tools/lib/roll_dev.dart
@@ -102,6 +102,13 @@ bool run({
     ? lastVersion
     : incrementLevel(lastVersion, level);
 
+  if (git.getOutput(
+    'rev-parse $lastVersion',
+    'check if commit is already on dev',
+  ).contains(commit.trim())) {
+    throw Exception('Commit $commit is already on the dev branch as $lastVersion.');
+  }
+
   if (!force) {
     git.run(
       'merge-base --is-ancestor $lastVersion $commit',

--- a/dev/tools/test/roll_dev_test.dart
+++ b/dev/tools/test/roll_dev_test.dart
@@ -78,7 +78,7 @@ void main() {
         commit: commit,
         origin: origin,
       );
-      final String errorMessage = 'The remote named $origin is set to $remote, when $kUpstreamRemote was expected.';
+      const String errorMessage = 'The remote named $origin is set to $remote, when $kUpstreamRemote was expected.';
       expect(
         () => run(
           usage: usage,

--- a/packages/flutter_tools/test/general.shard/base/process_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/process_test.dart
@@ -247,7 +247,6 @@ void main() {
           timeout: timeout,
           timeoutRetries: 0,
         ), throwsA(isA<ProcessException>()));
-
         time.elapse(timeout);
       });
     });


### PR DESCRIPTION
## Description

By default, the `roll_dev.dart` script will publish a dev release by creating a local tag, pushing it to the upstream, and then doing a `git push upstream HEAD:dev`, or pushing the current HEAD commit to the upstream dev branch. It also has a `--force` flag, which will do a force push, necessary if the current dev release has cherry-picks. However, if a force push is required and the `--force` flag is not provided, the tool will push the tag successfully, then fail to update the branch (the push can also fail if `--force` is provided but the remote branch is protected). If the tool is re-run with the `--force` flag, it will fail while tagging because the tag already exists. This PR contains the following changes:

1. Adds a check before the tagging step if the `--force` flag is not provided to verify if a regular git push will succeed.
2. Adds a flag `--skip-tagging` specifically for re-runs in cases where the tagging was successful but the push failed. If the flag is provided, the script will check that commit is already tagged before proceeding.
3. Moves `git reset --hard $commit` to after the `--just-print` exit point, so that running the script with `--just-print` doesn't move HEAD.
4. Moves tagging the commit to after the user verification prompt. Before, the script would tag, check for confirmation, and if the user declined, the tag would be deleted.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/59112.

## Tests

I updated and added a lot of unit tests.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*