### PR TITLE
Typo fixing sweep through packages/flutter.

### DIFF
--- a/packages/flutter/lib/src/cupertino/colors.dart
+++ b/packages/flutter/lib/src/cupertino/colors.dart
@@ -18,7 +18,7 @@ import 'theme.dart';
 /// A palette of [Color] constants that describe colors commonly used when
 /// matching the iOS platform aesthetics.
 class CupertinoColors {
-  // This class is not meant to be instatiated or extended; this constructor
+  // This class is not meant to be instantiated or extended; this constructor
   // prevents instantiation and extension.
   // ignore: unused_element
   CupertinoColors._();
@@ -572,7 +572,7 @@ class CupertinoColors {
   );
 }
 
-/// A [Color] subclass that represents a family of colors, and the currect effective
+/// A [Color] subclass that represents a family of colors, and the correct effective
 /// color in the color family.
 ///
 /// When used as a regular color, [CupertinoDynamicColor] is equivalent to the
@@ -772,7 +772,7 @@ class CupertinoDynamicColor extends Color with Diagnosticable {
       assert(_effectiveColor != null),
       // The super constructor has to be called with a dummy value in order to mark
       // this constructor const.
-      // The field `value` is overriden in the class implementation.
+      // The field `value` is overridden in the class implementation.
       super(0);
 
   /// The current effective color.

--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -1091,7 +1091,7 @@ class _ContextMenuRouteStaticState extends State<_ContextMenuRouteStatic> with T
     );
   }
 
-  // Build the animation for the overall draggable dismissable content.
+  // Build the animation for the overall draggable dismissible content.
   Widget _buildAnimation(BuildContext context, Widget child) {
     return Transform.translate(
       offset: _moveAnimation.value,

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -36,7 +36,7 @@ const double _kTimerPickerHalfColumnPadding = 2;
 const double _kTimerPickerLabelPadSize = 4.5;
 const double _kTimerPickerLabelFontSize = 17.0;
 
-// The width of each colmn of the countdown time picker.
+// The width of each column of the countdown time picker.
 const double _kTimerPickerColumnIntrinsicWidth = 106;
 // Unfortunately turning on magnification for the timer picker messes up the label
 // alignment. So we'll have to hard code the font size and turn magnification off
@@ -265,7 +265,7 @@ class CupertinoDatePicker extends StatefulWidget {
     );
     assert(
       mode != CupertinoDatePickerMode.date || (minimumYear >= 1 && this.initialDateTime.year >= minimumYear),
-      'initial year is not greater than minimum year, or mininum year is not positive',
+      'initial year is not greater than minimum year, or minimum year is not positive',
     );
     assert(
       mode != CupertinoDatePickerMode.date || maximumYear == null || this.initialDateTime.year <= maximumYear,
@@ -713,7 +713,7 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
     );
   }
 
-  // With the meridem picker set to `meridiemIndex`, and the hour picker set to
+  // With the meridiem picker set to `meridiemIndex`, and the hour picker set to
   // `hourIndex`, is it possible to change the value of the minute picker, so
   // that the resulting date stays in the valid range.
   bool _isValidHour(int meridiemIndex, int hourIndex) {

--- a/packages/flutter/lib/src/cupertino/icons.dart
+++ b/packages/flutter/lib/src/cupertino/icons.dart
@@ -26,7 +26,7 @@ import 'package:flutter/widgets.dart';
 ///  * [Icon], used to show these icons.
 ///  * <https://github.com/flutter/cupertino_icons/blob/master/map.png>, a map of the icons in this icons font.
 class CupertinoIcons {
-  // This class is not meant to be instatiated or extended; this constructor
+  // This class is not meant to be instantiated or extended; this constructor
   // prevents instantiation and extension.
   // ignore: unused_element
   CupertinoIcons._();

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -49,7 +49,7 @@ const double _kSegmentMinPadding = 9.25;
 
 // The threshold value used in hasDraggedTooFar, for checking against the square
 // L2 distance from the location of the current drag pointer, to the closest
-// vertice of the CupertinoSlidingSegmentedControl's Rect.
+// vertex of the CupertinoSlidingSegmentedControl's Rect.
 //
 // Both the mechanism and the value are speculated.
 const double _kTouchYDistanceThreshold = 50.0 * 50.0;
@@ -64,7 +64,7 @@ final SpringSimulation _kThumbSpringAnimationSimulation = SpringSimulation(
   const SpringDescription(mass: 1, stiffness: 503.551, damping: 44.8799),
   0,
   1,
-  0, // Everytime a new spring animation starts the previous animation stops.
+  0, // Every time a new spring animation starts the previous animation stops.
 );
 
 const Duration _kSpringAnimationDuration = Duration(milliseconds: 412);

--- a/packages/flutter/lib/src/cupertino/text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection.dart
@@ -478,7 +478,7 @@ class _CupertinoTextSelectionControls extends TextSelectionControls {
       mediaQuery.size.width - mediaQuery.padding.right - _kArrowScreenPadding,
     ) as double;
 
-    // The y-coordinate has to be calculated instead of directly quoting postion.dy,
+    // The y-coordinate has to be calculated instead of directly quoting position.dy,
     // since the caller (TextSelectionOverlay._buildToolbar) does not know whether
     // the toolbar is going to be facing up or down.
     final double localBarTopY = isArrowPointingDown

--- a/packages/flutter/lib/src/foundation/_platform_web.dart
+++ b/packages/flutter/lib/src/foundation/_platform_web.dart
@@ -8,7 +8,7 @@ import 'platform.dart' as platform;
 /// The dart:html implementation of [platform.defaultTargetPlatform].
 platform.TargetPlatform get defaultTargetPlatform {
   // To getter a better guess at the targetPlatform we need to be able to
-  // reference the window, but that won't be availible until we fix the
+  // reference the window, but that won't be available until we fix the
   // platforms configuration for Flutter.
   platform.TargetPlatform result = _browserPlatform();
   if (platform.debugDefaultTargetPlatformOverride != null)

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -88,7 +88,7 @@ abstract class StackFilter {
   /// A const constructor to allow subclasses to be const.
   const StackFilter();
 
-  /// Filters the list of [StackFrame]s by updating corrresponding indices in
+  /// Filters the list of [StackFrame]s by updating corresponding indices in
   /// `reasons`.
   ///
   /// To elide a frame or number of frames, set the string
@@ -115,7 +115,7 @@ class RepetitiveStackFrameFilter extends StackFilter {
   }) : assert(frames != null),
        assert(replacement != null);
 
-  /// The shape of this repetative stack pattern.
+  /// The shape of this repetitive stack pattern.
   final List<PartialStackFrame> frames;
 
   /// The number of frames in this pattern.

--- a/packages/flutter/lib/src/foundation/licenses.dart
+++ b/packages/flutter/lib/src/foundation/licenses.dart
@@ -288,7 +288,7 @@ class LicenseEntryWithLineBreaks extends LicenseEntry {
 ///  * [AboutListTile], which is a widget that can be added to a [Drawer]. When
 ///    tapped it calls [showAboutDialog].
 class LicenseRegistry {
-  // This class is not meant to be instatiated or extended; this constructor
+  // This class is not meant to be instantiated or extended; this constructor
   // prevents instantiation and extension.
   // ignore: unused_element
   LicenseRegistry._();

--- a/packages/flutter/lib/src/foundation/unicode.dart
+++ b/packages/flutter/lib/src/foundation/unicode.dart
@@ -11,7 +11,7 @@
 ///  * <http://unicode.org/reports/tr9/>, which describes the Unicode
 ///    bidirectional text algorithm.
 class Unicode {
-  // This class is not meant to be instatiated or extended; this constructor
+  // This class is not meant to be instantiated or extended; this constructor
   // prevents instantiation and extension.
   // ignore: unused_element
   Unicode._();

--- a/packages/flutter/lib/src/gestures/converter.dart
+++ b/packages/flutter/lib/src/gestures/converter.dart
@@ -32,7 +32,7 @@ int _synthesiseDownButtons(int buttons, PointerDeviceKind kind) {
 /// [dart:ui.Window.onPointerDataPacket], and converts them to [PointerEvent]
 /// objects.
 class PointerEventConverter {
-  // This class is not meant to be instatiated or extended; this constructor
+  // This class is not meant to be instantiated or extended; this constructor
   // prevents instantiation and extension.
   // ignore: unused_element
   PointerEventConverter._();

--- a/packages/flutter/lib/src/material/back_button.dart
+++ b/packages/flutter/lib/src/material/back_button.dart
@@ -88,7 +88,7 @@ class BackButton extends StatelessWidget {
   /// to pop the [Navigator].
   ///
   /// It can, for instance, be used to pop the platform's navigation stack
-  /// via [SytemNavigator] instead of Flutter's [Navigator] in add-to-app
+  /// via [SystemNavigator] instead of Flutter's [Navigator] in add-to-app
   /// situations.
   ///
   /// Defaults to null.
@@ -142,7 +142,7 @@ class CloseButton extends StatelessWidget {
   /// to pop the [Navigator].
   ///
   /// It can, for instance, be used to pop the platform's navigation stack
-  /// via [SytemNavigator] instead of Flutter's [Navigator] in add-to-app
+  /// via [SystemNavigator] instead of Flutter's [Navigator] in add-to-app
   /// situations.
   ///
   /// Defaults to null.

--- a/packages/flutter/lib/src/material/button_bar.dart
+++ b/packages/flutter/lib/src/material/button_bar.dart
@@ -231,7 +231,7 @@ class ButtonBar extends StatelessWidget {
 /// the widget, it then aligns its buttons in a column. The key difference here
 /// is that the [MainAxisAlignment] will then be treated as a
 /// cross-axis/horizontal alignment. For example, if the buttons overflow and
-/// [ButtonBar.alignment] was set to [MainAxisAligment.start], the column of
+/// [ButtonBar.alignment] was set to [MainAxisAlignment.start], the column of
 /// buttons would align to the horizontal start of the button bar.
 class _ButtonBarRow extends Flex {
   /// Creates a button bar that attempts to display in a row, but displays in
@@ -299,7 +299,7 @@ class _ButtonBarRow extends Flex {
 /// the widget, it then aligns its buttons in a column. The key difference here
 /// is that the [MainAxisAlignment] will then be treated as a
 /// cross-axis/horizontal alignment. For example, if the buttons overflow and
-/// [ButtonBar.alignment] was set to [MainAxisAligment.start], the buttons would
+/// [ButtonBar.alignment] was set to [MainAxisAlignment.start], the buttons would
 /// align to the horizontal start of the button bar.
 class _RenderButtonBarRow extends RenderFlex {
   /// Creates a button bar that attempts to display in a row, but displays in
@@ -376,9 +376,9 @@ class _RenderButtonBarRow extends RenderFlex {
         child.layout(childConstraints, parentUsesSize: true);
 
         // Set the cross axis alignment for the column to match the main axis
-        // alignment for a row. For [MainAxisAligment.spaceAround],
-        // [MainAxisAligment.spaceBetween] and [MainAxisAlignment.spaceEvenly]
-        // cases, use [MainAxisAligmnent.start].
+        // alignment for a row. For [MainAxisAlignment.spaceAround],
+        // [MainAxisAlignment.spaceBetween] and [MainAxisAlignment.spaceEvenly]
+        // cases, use [MainAxisAlignment.start].
         switch (textDirection) {
           case TextDirection.ltr:
             switch (mainAxisAlignment) {

--- a/packages/flutter/lib/src/material/colors.dart
+++ b/packages/flutter/lib/src/material/colors.dart
@@ -192,7 +192,7 @@ class MaterialAccentColor extends ColorSwatch<int> {
 /// The [Colors.transparent] color isn't shown here because it is entirely
 /// invisible!
 class Colors {
-  // This class is not meant to be instatiated or extended; this constructor
+  // This class is not meant to be instantiated or extended; this constructor
   // prevents instantiation and extension.
   // ignore: unused_element
   Colors._();

--- a/packages/flutter/lib/src/material/feedback.dart
+++ b/packages/flutter/lib/src/material/feedback.dart
@@ -80,7 +80,7 @@ import 'theme.dart';
 /// ```
 /// {@end-tool}
 class Feedback {
-  // This class is not meant to be instatiated or extended; this constructor
+  // This class is not meant to be instantiated or extended; this constructor
   // prevents instantiation and extension.
   // ignore: unused_element
   Feedback._();

--- a/packages/flutter/lib/src/material/icons.dart
+++ b/packages/flutter/lib/src/material/icons.dart
@@ -59,7 +59,7 @@ import 'package:flutter/widgets.dart';
 ///  * [IconButton]
 ///  * <https://design.google.com/icons/>
 class Icons {
-  // This class is not meant to be instatiated or extended; this constructor
+  // This class is not meant to be instantiated or extended; this constructor
   // prevents instantiation and extension.
   // ignore: unused_element
   Icons._();

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2784,7 +2784,7 @@ class InputDecoration {
   /// `contentPadding` is `EdgeInsets.fromLTRB(0, 8, 0, 8)` when [isDense] is
   /// true and `EdgeInsets.fromLTRB(0, 12, 0, 12)` when [isDense] is false`.
   ///
-  /// If `isOutline` property of [border] is true then `contentPaddding` is
+  /// If `isOutline` property of [border] is true then `contentPadding` is
   /// `EdgeInsets.fromLTRB(12, 20, 12, 12)` when [isDense] is true
   /// and `EdgeInsets.fromLTRB(12, 24, 12, 16)` when [isDense] is false.
   final EdgeInsetsGeometry contentPadding;

--- a/packages/flutter/lib/src/material/mergeable_material.dart
+++ b/packages/flutter/lib/src/material/mergeable_material.dart
@@ -436,7 +436,7 @@ class _MergeableMaterialState extends State<MergeableMaterial> with TickerProvid
         }
       } else {
         // Check whether the items are the same type. If they are, it means that
-        // their places have been swaped.
+        // their places have been swapped.
         if ((_children[j] is MaterialGap) == (newChildren[i] is MaterialGap)) {
           _children[j] = newChildren[i];
 

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -201,7 +201,7 @@ class __ZoomPageTransitionState extends State<_ZoomPageTransition> {
   }
 
   // This check ensures that the animation reverses the original animation if
-  // the transition were interruped midway. This prevents a disjointed
+  // the transition were interrupted midway. This prevents a disjointed
   // experience since the reverse animation uses different fade and scaling
   // curves.
   bool get _transitionWasInterrupted {

--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -329,7 +329,7 @@ class _SearchPageRoute<T> extends PageRoute<T> {
       delegate._route == null,
       'The ${delegate.runtimeType} instance is currently used by another active '
       'search. Please close that search by calling close() on the SearchDelegate '
-      'before openening another search with the same delegate instance.',
+      'before opening another search with the same delegate instance.',
     );
     delegate._route = this;
   }

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -2290,7 +2290,7 @@ class _EmptySliderTickMarkShape extends SliderTickMarkShape {
 /// that will not paint any component shape. A static reference is stored in
 /// [SliderTickMarkShape.noThumb] and [SliderTickMarkShape.noOverlay]. When this value
 /// is specified for [SliderThemeData.thumbShape], the thumb painting is
-/// skipped.  When this value is specified for [SliderThemeData.overlaySHape],
+/// skipped.  When this value is specified for [SliderThemeData.overlayShape],
 /// the overlay painting is skipped.
 class _EmptySliderComponentShape extends SliderComponentShape {
   @override

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -416,7 +416,7 @@ abstract class ImageStreamCompleter with Diagnosticable {
     _onLastListenerRemovedCallbacks.add(callback);
   }
 
-  /// Removes a callback previously suppplied to
+  /// Removes a callback previously supplied to
   /// [addOnLastListenerRemovedCallback].
   void removeOnLastListenerRemovedCallback(VoidCallback callback) {
     assert(callback != null);

--- a/packages/flutter/lib/src/painting/inline_span.dart
+++ b/packages/flutter/lib/src/painting/inline_span.dart
@@ -104,7 +104,7 @@ class InlineSpanSemanticsInformation {
 ///  * The subclass [TextSpan] specifies text and may contain child [InlineSpan]s.
 ///  * The subclass [PlaceholderSpan] represents a placeholder that may be
 ///    filled with non-text content. [PlaceholderSpan] itself defines a
-///    [ui.PlaceholderAlignemnt] and a [TextBaseline]. To be useful,
+///    [ui.PlaceholderAlignment] and a [TextBaseline]. To be useful,
 ///    [PlaceholderSpan] must be extended to define content. An instance of
 ///    this is the [WidgetSpan] class in the widgets library.
 ///  * The subclass [WidgetSpan] specifies embedded inline widgets.

--- a/packages/flutter/lib/src/painting/matrix_utils.dart
+++ b/packages/flutter/lib/src/painting/matrix_utils.dart
@@ -11,7 +11,7 @@ import 'basic_types.dart';
 
 /// Utility functions for working with matrices.
 class MatrixUtils {
-  // This class is not meant to be instatiated or extended; this constructor
+  // This class is not meant to be instantiated or extended; this constructor
   // prevents instantiation and extension.
   // ignore: unused_element
   MatrixUtils._();

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -1086,7 +1086,7 @@ class TextStyle with Diagnosticable {
     return ui.ParagraphStyle(
       textAlign: textAlign,
       textDirection: textDirection,
-      // Here, we stablish the contents of this TextStyle as the paragraph's default font
+      // Here, we establish the contents of this TextStyle as the paragraph's default font
       // unless an override is passed in.
       fontWeight: fontWeight ?? this.fontWeight,
       fontStyle: fontStyle ?? this.fontStyle,

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -794,7 +794,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     _textLayoutLastMinWidth = null;
   }
 
-  // Retuns a cached plain text version of the text in the painter.
+  // Returns a cached plain text version of the text in the painter.
   String _cachedPlainText;
   String get _plainText {
     _cachedPlainText ??= _textPainter.text.toPlainText();

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -37,7 +37,7 @@ class AnnotationEntry<T> {
 
   @override
   String toString() {
-    return '${objectRuntimeType(this, 'AnnotationEntry')}(annotation: $annotation, localPostion: $localPosition)';
+    return '${objectRuntimeType(this, 'AnnotationEntry')}(annotation: $annotation, localPosition: $localPosition)';
   }
 }
 

--- a/packages/flutter/lib/src/rendering/mouse_cursor.dart
+++ b/packages/flutter/lib/src/rendering/mouse_cursor.dart
@@ -141,7 +141,7 @@ abstract class MouseCursorSession {
 /// I-beam.
 ///
 /// During the painting phase, [MouseCursor] objects are assigned to regions on
-/// the screen via annotaions. Later during a device update (e.g. when a mouse
+/// the screen via annotations. Later during a device update (e.g. when a mouse
 /// moves), [MouseTracker] finds the _active cursor_ of each mouse device, which
 /// is the front-most region associated with the position of each mouse cursor,
 /// or defaults to [SystemMouseCursors.basic] if no cursors are associated with
@@ -218,7 +218,7 @@ abstract class MouseCursor with Diagnosticable {
 
   /// A very short description of the mouse cursor.
   ///
-  /// The [debugDescription] shoule be a few words that can describe this cursor
+  /// The [debugDescription] should be a few words that can describe this cursor
   /// to make debug information more readable. It is returned as the [toString]
   /// when the diagnostic level is at or above [DiagnosticLevel.info].
   ///
@@ -431,7 +431,7 @@ class SystemMouseCursors {
 
   /// A cursor that indicates a forbidden action.
   ///
-  /// Typically the shape of a circle with a diagnal line.
+  /// Typically the shape of a circle with a diagonal line.
   static const SystemMouseCursor forbidden = SystemMouseCursor._(kind: 'forbidden');
 
   /// A cursor that indicates something that can be dragged.

--- a/packages/flutter/lib/src/rendering/mouse_tracking.dart
+++ b/packages/flutter/lib/src/rendering/mouse_tracking.dart
@@ -93,7 +93,7 @@ class MouseTrackerAnnotation with Diagnosticable {
   ///
   ///  * [onEnter], which is triggered when a mouse pointer enters the region.
   ///  * [MouseRegion.onExit], which uses this callback, but is not triggered in
-  ///    certain cases and does not always match its earier [MouseRegion.onEnter].
+  ///    certain cases and does not always match its earlier [MouseRegion.onEnter].
   final PointerExitEventListener onExit;
 
   /// The mouse cursor for mouse pointers that are hovering over the region.
@@ -103,7 +103,7 @@ class MouseTrackerAnnotation with Diagnosticable {
   /// found at the new location.
   ///
   /// Defaults to [MouseCursor.defer], deferring the choice of cursor to the next
-  /// region behing it in hit-test order.
+  /// region behind it in hit-test order.
   ///
   /// See also:
   ///
@@ -582,10 +582,10 @@ mixin _MouseTrackerEventMixin on BaseMouseTracker {
   }
 }
 
-/// Trackes the relationship between mouse devices and annotations, and
+/// Tracks the relationship between mouse devices and annotations, and
 /// triggers mouse events and cursor changes accordingly.
 ///
-/// The [MouseTracker] trackes the relationship between mouse devices and
+/// The [MouseTracker] tracks the relationship between mouse devices and
 /// [MouseTrackerAnnotation]s, and when such relationship changes, triggers
 /// the following changes if applicable:
 ///

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -927,7 +927,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   ///
   /// The `parentMainAxisPosition` is a distance from the top edge (for vertical
   /// viewports) or left edge (for horizontal viewports) of the viewport bounds.
-  /// This describes a line, perpendicular to the viewport's main axis, heretofor
+  /// This describes a line, perpendicular to the viewport's main axis, heretofore
   /// known as the target line.
   ///
   /// The child's coordinate system's origin in the main axis is at the leading

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -4060,7 +4060,7 @@ abstract class SemanticsSortKey with Diagnosticable implements Comparable<Semant
 ///
 /// [OrdinalSortKey]s are sorted by the optional [name], then by their [order].
 /// If [SemanticsProperties.sortKey] is a [OrdinalSortKey], then all the other
-/// speficied sort keys in the same semantics group must also be
+/// specified sort keys in the same semantics group must also be
 /// [OrdinalSortKey]s.
 ///
 /// Keys with no [name] are compared to other keys with no [name], and will

--- a/packages/flutter/lib/src/semantics/semantics_service.dart
+++ b/packages/flutter/lib/src/semantics/semantics_service.dart
@@ -18,7 +18,7 @@ import 'semantics_event.dart' show AnnounceSemanticsEvent, TooltipSemanticsEvent
 /// When possible, prefer using mechanisms like [Semantics] to implicitly
 /// trigger announcements over using this event.
 class SemanticsService {
-  // This class is not meant to be instatiated or extended; this constructor
+  // This class is not meant to be instantiated or extended; this constructor
   // prevents instantiation and extension.
   // ignore: unused_element
   SemanticsService._();

--- a/packages/flutter/lib/src/services/binary_messenger.dart
+++ b/packages/flutter/lib/src/services/binary_messenger.dart
@@ -47,7 +47,7 @@ abstract class BinaryMessenger {
   /// passed to [setMessageHandler].
   ///
   /// This method is useful for tests or test harnesses that want to assert the
-  /// handler for the vspecified channel has not been altered by a previous test.
+  /// handler for the specified channel has not been altered by a previous test.
   bool checkMessageHandler(String channel, MessageHandler handler);
 
   /// Set a mock callback for intercepting messages from the [send] method on

--- a/packages/flutter/lib/src/services/clipboard.dart
+++ b/packages/flutter/lib/src/services/clipboard.dart
@@ -23,7 +23,7 @@ class ClipboardData {
 
 /// Utility methods for interacting with the system's clipboard.
 class Clipboard {
-  // This class is not meant to be instatiated or extended; this constructor
+  // This class is not meant to be instantiated or extended; this constructor
   // prevents instantiation and extension.
   // ignore: unused_element
   Clipboard._();

--- a/packages/flutter/lib/src/services/haptic_feedback.dart
+++ b/packages/flutter/lib/src/services/haptic_feedback.dart
@@ -11,7 +11,7 @@ import 'system_channels.dart';
 /// This API is intentionally terse since it calls default platform behavior. It
 /// is not suitable for precise control of the system's haptic feedback module.
 class HapticFeedback {
-  // This class is not meant to be instatiated or extended; this constructor
+  // This class is not meant to be instantiated or extended; this constructor
   // prevents instantiation and extension.
   // ignore: unused_element
   HapticFeedback._();

--- a/packages/flutter/lib/src/services/platform_messages.dart
+++ b/packages/flutter/lib/src/services/platform_messages.dart
@@ -31,7 +31,7 @@ import 'platform_channel.dart';
   'This feature was deprecated after v1.6.5.'
 )
 class BinaryMessages {
-  // This class is not meant to be instatiated or extended; this constructor
+  // This class is not meant to be instantiated or extended; this constructor
   // prevents instantiation and extension.
   // ignore: unused_element
   BinaryMessages._();

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -99,7 +99,7 @@ class PlatformViewsService {
   /// first time.
   ///
   /// The `id, `viewType, and `layoutDirection` parameters must not be null.
-  /// If `creationParams` is non null then `cretaionParamsCodec` must not be null.
+  /// If `creationParams` is non null then `creationParamsCodec` must not be null.
   static AndroidViewController initAndroidView({
     @required int id,
     @required String viewType,

--- a/packages/flutter/lib/src/services/system_channels.dart
+++ b/packages/flutter/lib/src/services/system_channels.dart
@@ -9,7 +9,7 @@ import 'platform_channel.dart';
 
 /// Platform channels used by the Flutter system.
 class SystemChannels {
-  // This class is not meant to be instatiated or extended; this constructor
+  // This class is not meant to be instantiated or extended; this constructor
   // prevents instantiation and extension.
   // ignore: unused_element
   SystemChannels._();

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -214,7 +214,7 @@ List<String> _stringify(List<dynamic> list) => <String>[
 /// Controls specific aspects of the operating system's graphical interface and
 /// how it interacts with the application.
 class SystemChrome {
-  // This class is not meant to be instatiated or extended; this constructor
+  // This class is not meant to be instantiated or extended; this constructor
   // prevents instantiation and extension.
   // ignore: unused_element
   SystemChrome._();

--- a/packages/flutter/lib/src/services/system_navigator.dart
+++ b/packages/flutter/lib/src/services/system_navigator.dart
@@ -8,7 +8,7 @@ import 'system_channels.dart';
 
 /// Controls specific aspects of the system navigation stack.
 class SystemNavigator {
-  // This class is not meant to be instatiated or extended; this constructor
+  // This class is not meant to be instantiated or extended; this constructor
   // prevents instantiation and extension.
   // ignore: unused_element
   SystemNavigator._();

--- a/packages/flutter/lib/src/services/system_sound.dart
+++ b/packages/flutter/lib/src/services/system_sound.dart
@@ -15,7 +15,7 @@ enum SystemSoundType {
 /// Provides access to the library of short system specific sounds for common
 /// tasks.
 class SystemSound {
-  // This class is not meant to be instatiated or extended; this constructor
+  // This class is not meant to be instantiated or extended; this constructor
   // prevents instantiation and extension.
   // ignore: unused_element
   SystemSound._();

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -947,7 +947,7 @@ TextInputAction _toTextInputAction(String action) {
       return TextInputAction.send;
     case 'TextInputAction.next':
       return TextInputAction.next;
-    case 'TextInputAction.previuos':
+    case 'TextInputAction.previous':
       return TextInputAction.previous;
     case 'TextInputAction.continue_action':
       return TextInputAction.continueAction;

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -930,7 +930,7 @@ class FocusableActionDetector extends StatefulWidget {
   /// widget.
   ///
   /// The [cursor] defaults to [MouseCursor.defer], deferring the choice of
-  /// cursor to the next region behing it in hit-test order.
+  /// cursor to the next region behind it in hit-test order.
   final MouseCursor mouseCursor;
 
   /// The child widget for this [FocusableActionDetector] widget.

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -200,7 +200,7 @@ class WidgetsApp extends StatefulWidget {
        assert(
          home == null ||
          onGenerateInitialRoutes == null,
-         'If onGenerateInitialRoutes is specifiied, the home argument will be '
+         'If onGenerateInitialRoutes is specified, the home argument will be '
          'redundant.'
        ),
        assert(
@@ -1190,7 +1190,7 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
         }
       }
       // countryCode-only match. When all else except default supported locale fails,
-      // attempt to match by country only, as a user is likely to be familar with a
+      // attempt to match by country only, as a user is likely to be familiar with a
       // language from their listed country.
       if (matchesCountryCode == null && userLocale.countryCode != null) {
         match = countryLocales[userLocale.countryCode];
@@ -1201,7 +1201,7 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
     }
     // When there is no languageCode-only match. Fallback to matching countryCode only. Country
     // fallback only applies on iOS. When there is no countryCode-only match, we return first
-    // suported locale.
+    // supported locale.
     final Locale resolvedLocale = matchesLanguageCode ?? matchesCountryCode ?? supportedLocales.first;
     return resolvedLocale;
   }

--- a/packages/flutter/lib/src/widgets/autofill.dart
+++ b/packages/flutter/lib/src/widgets/autofill.dart
@@ -125,7 +125,7 @@ class AutofillGroup extends StatefulWidget {
   ///
   /// See also:
   ///
-  /// * [EditableTextState], where this method is used to retrive the closest
+  /// * [EditableTextState], where this method is used to retrieve the closest
   ///   [AutofillGroupState].
   static AutofillGroupState of(BuildContext context) {
     final _AutofillScope scope = context.dependOnInheritedWidgetOfExactType<_AutofillScope>();

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -6003,7 +6003,7 @@ class MouseRegion extends StatefulWidget {
   ///
   /// {@tool dartpad --template=stateful_widget_scaffold_center}
   /// The following example shows a widget that hides its content one second
-  /// after behing hovered, and also exposes the enter and exit callbacks.
+  /// after being hovered, and also exposes the enter and exit callbacks.
   /// Because the widget conditionally creates the `MouseRegion`, and leaks the
   /// hover state, it needs to take the restriction into consideration. In this
   /// case, since it has access to the event that triggers the disappearance of
@@ -6109,7 +6109,7 @@ class MouseRegion extends StatefulWidget {
   /// found at the new location.
   ///
   /// The [cursor] defaults to [MouseCursor.defer], deferring the choice of
-  /// cursor to the next region behing it in hit-test order.
+  /// cursor to the next region behind it in hit-test order.
   final MouseCursor cursor;
 
   /// Whether this widget should prevent other [MouseRegion]s visually behind it

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -162,7 +162,7 @@ class DraggableScrollableSheet extends StatefulWidget {
 /// this notification bubbles up through the tree, which means a given
 /// [NotificationListener] will receive notifications for all descendant
 /// [DraggableScrollableSheet] widgets. To focus on notifications from the
-/// nearest [DraggableScorllableSheet] descendant, check that the [depth]
+/// nearest [DraggableScrollableSheet] descendant, check that the [depth]
 /// property of the notification is zero.
 ///
 /// When an extent notification is received by a [NotificationListener], the
@@ -556,7 +556,7 @@ class DraggableScrollableActuator extends StatelessWidget {
   }
 }
 
-/// A [ChangeNotifier] to use with [InheritedResetNotifer] to notify
+/// A [ChangeNotifier] to use with [InheritedResetNotifier] to notify
 /// descendants that they should reset to initial state.
 class _ResetNotifier extends ChangeNotifier {
   /// Whether someone called [sendReset] or not.

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2486,7 +2486,7 @@ class _Editable extends LeafRenderObjectWidget {
 //
 // When typing in a direction that opposes the base direction
 // of the paragraph, un-enclosed whitespace gets the directionality
-// of the paragraph. This is often at odds with what is immeditely
+// of the paragraph. This is often at odds with what is immediately
 // being typed causing the caret to jump to the wrong side of the text.
 // This formatter makes use of the RLM and LRM to cause the text
 // shaper to inherently treat the whitespace as being surrounded
@@ -2604,7 +2604,7 @@ class _WhitespaceDirectionalityFormatter extends TextInputFormatter {
           previousWasDirectionalityMarker = true;
         } else {
           // If the whitespace was already enclosed by the same directionality,
-          // we can remove the artifically added marker.
+          // we can remove the artificially added marker.
           if (!previousWasDirectionalityMarker &&
               previousWasWhitespace &&
               getDirection(codepoint) == _previousNonWhitespaceDirection) {

--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -474,7 +474,7 @@ class _AnimatedFadeOutFadeInState extends ImplicitlyAnimatedWidgetState<_Animate
       ),
     ]))..addStatusListener((AnimationStatus status) {
       if (_placeholderOpacityAnimation.isCompleted) {
-        // Need to rebuild to remove placeholder now that it is invisibile.
+        // Need to rebuild to remove placeholder now that it is invisible.
         setState(() {});
       }
     });

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -187,11 +187,11 @@ abstract class GlobalKey<T extends State<StatefulWidget>> extends Key {
   static void _debugVerifyGlobalKeyReservation() {
     assert(() {
       final Map<GlobalKey, Element> keyToParent = <GlobalKey, Element>{};
-      _debugReservations.forEach((Element parent, Map<Element, GlobalKey> chidToKey) {
+      _debugReservations.forEach((Element parent, Map<Element, GlobalKey> childToKey) {
         // We ignore parent that are detached.
         if (parent.renderObject?.attached == false)
           return;
-        chidToKey.forEach((Element child, GlobalKey key) {
+        childToKey.forEach((Element child, GlobalKey key) {
           // If parent = null, the node is deactivated by its parent and is
           // not re-attached to other part of the tree. We should ignore this
           // node.

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -338,7 +338,7 @@ class _HeroState extends State<Hero> {
   // needs to be built to replace the original hero widget. When
   // `shouldIncludeChildInPlaceholder` is set to true and `widget.placeholderBuilder`
   // is null, the placeholder widget will include the original hero's child
-  // widget as a descendant, allowing the orignal element tree to be preserved.
+  // widget as a descendant, allowing the original element tree to be preserved.
   //
   // It is typically set to true for the *from* hero in a push transition,
   // and false otherwise.

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -87,7 +87,7 @@ ImageConfiguration createLocalImageConfiguration(BuildContext context, { Size si
 ///
 /// Callers should be cautious about pinning large images or a large number of
 /// images in memory, as this can result in running out of memory and being
-/// killed by the operating system. The lower the avilable physical memory, the
+/// killed by the operating system. The lower the available physical memory, the
 /// more susceptible callers will be to running into OOM issues. These issues
 /// manifest as immediate process death, sometimes with no other error messages.
 ///

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -24,7 +24,7 @@ typedef LayoutWidgetBuilder = Widget Function(BuildContext context, BoxConstrain
 /// * The first time the widget is laid out.
 /// * When the parent widget passes different layout constraints.
 /// * When the parent widget updates this widget.
-/// * When the depedencies that the [builder] function subscribes to change.
+/// * When the dependencies that the [builder] function subscribes to change.
 ///
 /// The [builder] function is _not_ called during layout if the parent passes
 /// the same constraints repeatedly.

--- a/packages/flutter/lib/src/widgets/page_storage.dart
+++ b/packages/flutter/lib/src/widgets/page_storage.dart
@@ -177,7 +177,7 @@ class PageStorageBucket {
 ///   Widget build(BuildContext context) {
 ///     return Scaffold(
 ///       appBar: AppBar(
-///         title: Text("Persistance Example"),
+///         title: Text("Persistence Example"),
 ///       ),
 ///       body: PageStorage(
 ///         child: pages[currentTab],

--- a/packages/flutter/lib/src/widgets/scroll_aware_image_provider.dart
+++ b/packages/flutter/lib/src/widgets/scroll_aware_image_provider.dart
@@ -101,7 +101,7 @@ class ScrollAwareImageProvider<T> extends ImageProvider<T> {
         });
         return;
     }
-    // We are in the tree, we're not scrolling too fast, the cache doens't
+    // We are in the tree, we're not scrolling too fast, the cache doesn't
     // have our image, and no one has otherwise completed the stream.  Go.
     imageProvider.resolveStreamForKey(configuration, stream, key, handleError);
   }

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -309,7 +309,7 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
   void correctBy(double correction) {
     assert(
       _pixels != null,
-      'An initial pixels value must exist by caling correctPixels on the ScrollPosition',
+      'An initial pixels value must exist by calling correctPixels on the ScrollPosition',
     );
     _pixels += correction;
     _didChangeViewportDimensionOrReceiveCorrection = true;

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -27,7 +27,7 @@ import 'viewport.dart';
 /// A representation of how a [ScrollView] should dismiss the on-screen
 /// keyboard.
 enum ScrollViewKeyboardDismissBehavior {
-  /// `manual` means there is no automatic dimissal of the on-screen keyboard.
+  /// `manual` means there is no automatic dismissal of the on-screen keyboard.
   /// It is up to the client to dismiss the keyboard.
   manual,
   /// `onDrag` means that the [ScrollView] will dismiss an on-screen keyboard

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -55,7 +55,7 @@ class DefaultTextStyle extends InheritedTheme {
        assert(textWidthBasis != null),
        super(key: key, child: child);
 
-  /// A const-constructible default text style that provides fallback values.
+  /// A const-constructable default text style that provides fallback values.
   ///
   /// Returned from [of] when the given [BuildContext] doesn't have an enclosing default text style.
   ///

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -869,7 +869,7 @@ abstract class TextSelectionGestureDetectorBuilderDelegate {
 ///
 /// The class implements sensible defaults for many user interactions
 /// with an [EditableText] (see the documentation of the various gesture handler
-/// methods, e.g. [onTapDown], [onFrocePress], etc.). Subclasses of
+/// methods, e.g. [onTapDown], [onForcePress], etc.). Subclasses of
 /// [EditableTextSelectionHandlesProvider] can change the behavior performed in
 /// responds to these gesture events by overriding the corresponding handler
 /// methods of this class.

--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -819,7 +819,7 @@ void main() {
       debugSemanticsDisableAnimations = null;
     });
 
-    test('AnimationBehavior.normal runs "faster" whan AnimationBehavior.preserve', () {
+    test('AnimationBehavior.normal runs "faster" than AnimationBehavior.preserve', () {
       debugSemanticsDisableAnimations = true;
       final AnimationController controller = AnimationController(
         vsync: const TestVSync(),

--- a/packages/flutter/test/animation/curves_test.dart
+++ b/packages/flutter/test/animation/curves_test.dart
@@ -125,7 +125,7 @@ void main() {
     ];
   }
 
-  test('Ellastic overshoots its bounds', () {
+  test('Elastic overshoots its bounds', () {
     expect(Curves.elasticIn, hasOneLineDescription);
     expect(Curves.elasticOut, hasOneLineDescription);
     expect(Curves.elasticInOut, hasOneLineDescription);

--- a/packages/flutter/test/cupertino/colors_test.dart
+++ b/packages/flutter/test/cupertino/colors_test.dart
@@ -238,7 +238,7 @@ void main() {
       expect(find.byType(DependentWidget), paints..rect(color: color0));
       expect(find.byType(DependentWidget), isNot(paints..rect(color: color1)));
 
-      // CupertinoTheme should take percedence over MediaQuery.
+      // CupertinoTheme should take precedence over MediaQuery.
       await tester.pumpWidget(
         const CupertinoTheme(
           data: CupertinoThemeData(brightness: Brightness.light),
@@ -318,7 +318,7 @@ void main() {
       expect(tester.takeException()?.toString(), contains('does not contain a CupertinoUserInterfaceLevel'));
   });
 
-  testWidgets('Dynamic color with all 3 depedencies works', (WidgetTester tester) async {
+  testWidgets('Dynamic color with all 3 dependencies works', (WidgetTester tester) async {
     const Color dynamicRainbowColor1 = CupertinoDynamicColor(
       color: color0,
       darkColor: color1,

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -275,7 +275,7 @@ void main() {
     expect(count, 0x010101);
   });
 
-  testWidgets('Theme active color can be overriden', (WidgetTester tester) async {
+  testWidgets('Theme active color can be overridden', (WidgetTester tester) async {
     count = 0x000000;
     await tester.pumpWidget(
       CupertinoApp(

--- a/packages/flutter/test/cupertino/refresh_test.dart
+++ b/packages/flutter/test/cupertino/refresh_test.dart
@@ -1410,7 +1410,7 @@ void main() {
       );
 
       // Drag the content down far enough so that
-      // geometry.paintExent > constraints.maxPaintExtent
+      // geometry.paintExtent > constraints.maxPaintExtent
       await tester.dragFrom(const Offset(10, 10), const Offset(0, 500));
       await tester.pump();
 

--- a/packages/flutter/test/cupertino/scaffold_test.dart
+++ b/packages/flutter/test/cupertino/scaffold_test.dart
@@ -159,7 +159,7 @@ void main() {
     expect(tester.getSize(find.byType(Container)).height, 600.0);
   });
 
-  testWidgets('Contents bottom padding are not consumed by viewInsets when resizeToAvoidBottomInset overriden', (WidgetTester tester) async {
+  testWidgets('Contents bottom padding are not consumed by viewInsets when resizeToAvoidBottomInset overridden', (WidgetTester tester) async {
     const Widget child = CupertinoPageScaffold(
       resizeToAvoidBottomInset: false,
       navigationBar: CupertinoNavigationBar(

--- a/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
@@ -432,7 +432,7 @@ void main() {
       4: Text('Child 5'),
     };
 
-    // Child 3 is intially selected.
+    // Child 3 is initially selected.
     groupValue = 2;
 
     await tester.pumpWidget(

--- a/packages/flutter/test/cupertino/tab_scaffold_test.dart
+++ b/packages/flutter/test/cupertino/tab_scaffold_test.dart
@@ -407,7 +407,7 @@ void main() {
     expect(MediaQuery.of(innerContext).padding.bottom, 0);
   });
 
-  testWidgets('Tab contents are not inset when resizeToAvoidBottomInset overriden', (WidgetTester tester) async {
+  testWidgets('Tab contents are not inset when resizeToAvoidBottomInset overridden', (WidgetTester tester) async {
     BuildContext innerContext;
 
     await tester.pumpWidget(
@@ -434,7 +434,7 @@ void main() {
     expect(MediaQuery.of(innerContext).padding.bottom, 50);
   });
 
-  testWidgets('Tab contents bottom padding are not consumed by viewInsets when resizeToAvoidBottomInset overriden', (WidgetTester tester) async {
+  testWidgets('Tab contents bottom padding are not consumed by viewInsets when resizeToAvoidBottomInset overridden', (WidgetTester tester) async {
     final Widget child = Localizations(
       locale: const Locale('en', 'US'),
       delegates: const <LocalizationsDelegate<dynamic>>[

--- a/packages/flutter/test/cupertino/text_selection_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_test.dart
@@ -193,7 +193,7 @@ void main() {
     // Make sure the clipboard is empty to start.
     await Clipboard.setData(const ClipboardData(text: ''));
 
-    // Double tap to selet the first word.
+    // Double tap to select the first word.
     const int index = 4;
     await tester.tapAt(textOffsetToPosition(tester, index));
     await tester.pump(const Duration(milliseconds: 50));

--- a/packages/flutter/test/foundation/diagnostics_json_test.dart
+++ b/packages/flutter/test/foundation/diagnostics_json_test.dart
@@ -16,7 +16,7 @@ void main() {
     expect(json['stateful'], isFalse);
   });
 
-  test('StatefulElement diganostics are stateful', () {
+  test('StatefulElement diagnostics are stateful', () {
     final Element element = StatefulElement(const Tooltip(message: 'foo'));
 
     final Map<String, Object> json = element.toDiagnosticsNode().toJsonMap(const DiagnosticsSerializationDelegate());

--- a/packages/flutter/test/gestures/hit_test_test.dart
+++ b/packages/flutter/test/gestures/hit_test_test.dart
@@ -8,7 +8,7 @@ import 'package:vector_math/vector_math_64.dart';
 import '../flutter_test_alternative.dart';
 
 void main() {
-  test('wrpped HitTestResult gets HitTestEntry added to wrapping HitTestResult', () async {
+  test('wrapped HitTestResult gets HitTestEntry added to wrapping HitTestResult', () async {
     final HitTestEntry entry1 = HitTestEntry(_DummyHitTestTarget());
     final HitTestEntry entry2 = HitTestEntry(_DummyHitTestTarget());
     final HitTestEntry entry3 = HitTestEntry(_DummyHitTestTarget());

--- a/packages/flutter/test/gestures/transformed_long_press_test.dart
+++ b/packages/flutter/test/gestures/transformed_long_press_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/gestures.dart';
 
 void main() {
-  testWidgets('gets local corrdinates', (WidgetTester tester) async {
+  testWidgets('gets local coordinates', (WidgetTester tester) async {
     int longPressCount = 0;
     int longPressUpCount = 0;
     final List<LongPressEndDetails> endDetails = <LongPressEndDetails>[];

--- a/packages/flutter/test/gestures/transformed_monodrag_test.dart
+++ b/packages/flutter/test/gestures/transformed_monodrag_test.dart
@@ -11,7 +11,7 @@ import 'package:flutter/gestures.dart';
 
 void main() {
   group('Horizontal', () {
-    testWidgets('gets local corrdinates', (WidgetTester tester) async {
+    testWidgets('gets local coordinates', (WidgetTester tester) async {
       int dragCancelCount = 0;
       final List<DragDownDetails> downDetails = <DragDownDetails>[];
       final List<DragEndDetails> endDetails = <DragEndDetails>[];
@@ -262,7 +262,7 @@ void main() {
       updateDetails.clear();
     });
 
-    testWidgets('kTouchSlop is evaluated in the global coordinate space when roateted 45 degrees', (WidgetTester tester) async {
+    testWidgets('kTouchSlop is evaluated in the global coordinate space when rotated 45 degrees', (WidgetTester tester) async {
       int dragCancelCount = 0;
       final List<DragDownDetails> downDetails = <DragDownDetails>[];
       final List<DragEndDetails> endDetails = <DragEndDetails>[];
@@ -339,7 +339,7 @@ void main() {
   });
 
   group('Vertical', () {
-    testWidgets('gets local corrdinates', (WidgetTester tester) async {
+    testWidgets('gets local coordinates', (WidgetTester tester) async {
       int dragCancelCount = 0;
       final List<DragDownDetails> downDetails = <DragDownDetails>[];
       final List<DragEndDetails> endDetails = <DragEndDetails>[];
@@ -590,7 +590,7 @@ void main() {
       updateDetails.clear();
     });
 
-    testWidgets('kTouchSlop is evaluated in the global coordinate space when roateted 45 degrees', (WidgetTester tester) async {
+    testWidgets('kTouchSlop is evaluated in the global coordinate space when rotated 45 degrees', (WidgetTester tester) async {
       int dragCancelCount = 0;
       final List<DragDownDetails> downDetails = <DragDownDetails>[];
       final List<DragEndDetails> endDetails = <DragEndDetails>[];

--- a/packages/flutter/test/gestures/transformed_scale_test.dart
+++ b/packages/flutter/test/gestures/transformed_scale_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/gestures.dart';
 
 void main() {
-  testWidgets('gets local corrdinates', (WidgetTester tester) async {
+  testWidgets('gets local coordinates', (WidgetTester tester) async {
     final List<ScaleStartDetails> startDetails = <ScaleStartDetails>[];
     final List<ScaleUpdateDetails> updateDetails = <ScaleUpdateDetails>[];
 

--- a/packages/flutter/test/gestures/transformed_tap_test.dart
+++ b/packages/flutter/test/gestures/transformed_tap_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/gestures.dart';
 
 void main() {
-  testWidgets('gets local corrdinates', (WidgetTester tester) async {
+  testWidgets('gets local coordinates', (WidgetTester tester) async {
     int tapCount = 0;
     int tapCancelCount = 0;
     final List<TapDownDetails> downDetails = <TapDownDetails>[];

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -376,7 +376,7 @@ void main() {
 
     // Centering a title with width 700 within the 800 pixel wide test widget
     // would mean that its start edge would have to be 50. The material spec says
-    // that the start edge of the title must be atleast 72.
+    // that the start edge of the title must be at least 72.
     await tester.pumpWidget(buildApp());
 
     final Finder title = find.byKey(titleKey);
@@ -431,7 +431,7 @@ void main() {
 
     // Centering a title with width 700 within the 800 pixel wide test widget
     // would mean that its start edge would have to be 50. The material spec says
-    // that the start edge of the title must be atleast 72.
+    // that the start edge of the title must be at least 72.
     await tester.pumpWidget(buildApp());
 
     final Finder title = find.byKey(titleKey);
@@ -1257,7 +1257,7 @@ void main() {
     expect(tester.getTopLeft(find.byKey(trailingKey)), const Offset(0.0, 100));
 
     // Because the topPadding eliminates the vertical space for the
-    // NavigtationToolbar within the AppBar, the toolbar is constrained
+    // NavigationToolbar within the AppBar, the toolbar is constrained
     // with minHeight=maxHeight=0. The _AppBarTitle widget vertically centers
     // the title, so its Y coordinate relative to the toolbar is -kToolbarHeight / 2
     // (-28). The top of the toolbar is at (screen coordinates) y=100, so the

--- a/packages/flutter/test/material/bottom_navigation_bar_theme_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_theme_test.dart
@@ -93,7 +93,7 @@ void main() {
     expect(description[10], 'type: BottomNavigationBarType.fixed');
   });
 
-  testWidgets('BottomNavigationBar is themable', (WidgetTester tester) async {
+  testWidgets('BottomNavigationBar is themeable', (WidgetTester tester) async {
     const Color backgroundColor = Color(0xFF000001);
     const Color selectedItemColor = Color(0xFF000002);
     const Color unselectedItemColor = Color(0xFF000003);

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -376,7 +376,7 @@ void main() {
 
     // The fling below must be such that the velocity estimation examines an
     // offset greater than the kTouchSlop. Too slow or too short a distance, and
-    // it won't trigger. Also, it musn't be so much that it drags the bottom
+    // it won't trigger. Also, it must not be so much that it drags the bottom
     // sheet off the screen, or we won't see it after we pump!
     await tester.fling(find.text('BottomSheet'), const Offset(0.0, 50.0), 2000.0);
     await tester.pump(); // drain the microtask queue (Future completion callback)

--- a/packages/flutter/test/material/bottom_sheet_theme_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_theme_test.dart
@@ -168,7 +168,7 @@ void main() {
     expect(material.color, modalBackgroundColor);
   });
 
-  testWidgets('General bottom sheet parameters take priority over modal bottom sheet-specific parameters for peristent bottom sheets', (WidgetTester tester) async {
+  testWidgets('General bottom sheet parameters take priority over modal bottom sheet-specific parameters for persistent bottom sheets', (WidgetTester tester) async {
     const double modalElevation = 5.0;
     const double persistentElevation = 7.0;
     const Color modalBackgroundColor = Colors.yellow;

--- a/packages/flutter/test/material/button_bar_test.dart
+++ b/packages/flutter/test/material/button_bar_test.dart
@@ -111,7 +111,7 @@ void main() {
       expect(buttonBarRect.size.width, equals(800.0));
       expect(buttonBarRect.size.height, equals(100.0));
 
-      // The children of [ButtonBar] are aligned by [MainAxisAligment.end] by
+      // The children of [ButtonBar] are aligned by [MainAxisAlignment.end] by
       // default.
       Rect childRect;
       childRect = tester.getRect(find.byKey(child0Key));
@@ -218,7 +218,7 @@ void main() {
       expect(buttonBarRect.size.width, equals(800.0));
       expect(buttonBarRect.size.height, equals(100.0));
 
-      // The children of [ButtonBar] are aligned by [MainAxisAligment.end] by
+      // The children of [ButtonBar] are aligned by [MainAxisAlignment.end] by
       // default.
       Rect childRect;
       childRect = tester.getRect(find.byKey(child0Key));
@@ -238,7 +238,7 @@ void main() {
     });
   });
 
-  group('button properies override ButtonTheme', () {
+  group('button properties override ButtonTheme', () {
 
     testWidgets('default button properties override ButtonTheme properties', (WidgetTester tester) async {
       BuildContext capturedContext;

--- a/packages/flutter/test/material/button_theme_test.dart
+++ b/packages/flutter/test/material/button_theme_test.dart
@@ -314,7 +314,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(menu, findsNothing);
 
-    // Same test as above execpt RTL
+    // Same test as above except RTL
     await tester.pumpWidget(
       buildFrame(
         alignedDropdown: true,

--- a/packages/flutter/test/material/checkbox_list_tile_test.dart
+++ b/packages/flutter/test/material/checkbox_list_tile_test.dart
@@ -115,7 +115,7 @@ void main() {
     expect(Focus.of(childKey.currentContext, nullOk: true).hasPrimaryFocus, isFalse);
   });
 
-  testWidgets('CheckoxListTile contentPadding test', (WidgetTester tester) async {
+  testWidgets('CheckboxListTile contentPadding test', (WidgetTester tester) async {
     await tester.pumpWidget(
       wrap(
         child: const Center(

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -922,7 +922,7 @@ void main() {
     semantics.dispose();
   });
 
-  testWidgets('Dismissable.confirmDismiss defers to an AlertDialog', (WidgetTester tester) async {
+  testWidgets('Dismissible.confirmDismiss defers to an AlertDialog', (WidgetTester tester) async {
     final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
     final List<int> dismissedItems = <int>[];
 

--- a/packages/flutter/test/material/expansion_panel_test.dart
+++ b/packages/flutter/test/material/expansion_panel_test.dart
@@ -936,7 +936,7 @@ void main() {
       ),
     );
 
-    // Check the semantics of [ExpanIcon] for expanded panel.
+    // Check the semantics of [ExpandIcon] for expanded panel.
     final Finder expandedIcon = find.descendant(
       of: find.ancestor(
         of: find.byKey(expandedKey),
@@ -960,7 +960,7 @@ void main() {
       label: 'Expanded',
     ));
 
-    // Check the semantics of [ExpanIcon] for collapsed panel.
+    // Check the semantics of [ExpandIcon] for collapsed panel.
     final Finder collapsedIcon = find.descendant(
       of: find.ancestor(
         of: find.byKey(collapsedKey),

--- a/packages/flutter/test/material/floating_action_button_location_test.dart
+++ b/packages/flutter/test/material/floating_action_button_location_test.dart
@@ -110,14 +110,14 @@ void main() {
               lessThanOrEqualTo(maxDeltaWidth),
               reason: "The Floating Action Button's width should not change "
                   'faster than $maxDeltaWidth per animation step.\n'
-                  'Prevous rect: $previousRect, current rect: $currentRect',
+                  'Previous rect: $previousRect, current rect: $currentRect',
             );
             expect(
               deltaHeight.abs(),
               lessThanOrEqualTo(maxDeltaHeight),
               reason: "The Floating Action Button's width should not change "
                   'faster than $maxDeltaHeight per animation step.\n'
-                  'Prevous rect: $previousRect, current rect: $currentRect',
+                  'Previous rect: $previousRect, current rect: $currentRect',
             );
           }
           previousRect = currentRect;
@@ -152,7 +152,7 @@ void main() {
                   'faster than $maxDeltaRotation per animation step.\n'
                   'Detected deltas were: $deltas\n'
                   'Previous values: $previousRotations, current values: $currentRotations\n'
-                  'Prevous rect: $previousRect, current rect: $currentRect',);
+                  'Previous rect: $previousRect, current rect: $currentRect',);
             }
           }
           previousRotations = currentRotations;

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -4049,7 +4049,7 @@ void main() {
 
     await tester.pumpAndSettle();
 
-    // floatingLabelGeight = 12 (ahem font size 16dps * 0.75 = 12)
+    // floatingLabelHeight = 12 (ahem font size 16dps * 0.75 = 12)
     // labelY = -floatingLabelHeight/2 + borderWidth/2
     expect(tester.getTopLeft(find.text('label')).dy, -4.0);
   });

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -1378,7 +1378,7 @@ void main() {
     );
   });
 
-  testWidgets('ListTile can be triggerd by keyboard shortcuts', (WidgetTester tester) async {
+  testWidgets('ListTile can be triggered by keyboard shortcuts', (WidgetTester tester) async {
     tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
     const Key tileKey = Key('ListTile');
     bool tapped = false;

--- a/packages/flutter/test/material/page_transitions_theme_test.dart
+++ b/packages/flutter/test/material/page_transitions_theme_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('Default PageTranstionsTheme platform', (WidgetTester tester) async {
+  testWidgets('Default PageTransitionsTheme platform', (WidgetTester tester) async {
     await tester.pumpWidget(const MaterialApp(home: Text('home')));
     final PageTransitionsTheme theme = Theme.of(tester.element(find.text('home'))).pageTransitionsTheme;
     expect(theme.builders, isNotNull);
@@ -21,7 +21,7 @@ void main() {
     }
   });
 
-  testWidgets('Default PageTranstionsTheme builds a CupertionPageTransition', (WidgetTester tester) async {
+  testWidgets('Default PageTransitionsTheme builds a CupertionPageTransition', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
       '/': (BuildContext context) => Material(
         child: FlatButton(
@@ -80,7 +80,7 @@ void main() {
     expect(findFadeUpwardsPageTransition(), findsOneWidget);
   }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 
-  testWidgets('pageTranstionsTheme override builds a _OpenUpwardsPageTransition', (WidgetTester tester) async {
+  testWidgets('PageTransitionsTheme override builds a _OpenUpwardsPageTransition', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
       '/': (BuildContext context) => Material(
         child: FlatButton(
@@ -120,7 +120,7 @@ void main() {
     expect(findOpenUpwardsPageTransition(), findsOneWidget);
   }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 
-  testWidgets('pageTranstionsTheme override builds a _ZoomPageTransition', (WidgetTester tester) async {
+  testWidgets('PageTransitionsTheme override builds a _ZoomPageTransition', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
       '/': (BuildContext context) => Material(
         child: FlatButton(

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -913,7 +913,7 @@ void main() {
                     value: '0',
                     child: Text('Item 0'),
                   ),
-                  // This menu item's height parameter specifies its minium height. The
+                  // This menu item's height parameter specifies its minimum height. The
                   // overall height of the menu item will be 50 because the child's
                   // height 40, is less than 50.
                   const PopupMenuItem<String>(
@@ -924,7 +924,7 @@ void main() {
                       child: Text('Item 1'),
                     ),
                   ),
-                  // This menu item's height parameter specifies its minium height, so the
+                  // This menu item's height parameter specifies its minimum height, so the
                   // overall height of the menu item will be 75.
                   const PopupMenuItem<String>(
                     height: 75,

--- a/packages/flutter/test/material/progress_indicator_test.dart
+++ b/packages/flutter/test/material/progress_indicator_test.dart
@@ -344,7 +344,7 @@ void main() {
     expect(tester.binding.transientCallbackCount, 0);
   });
 
-  testWidgets('LinearProgressIndicator with a height less than the minumum', (WidgetTester tester) async {
+  testWidgets('LinearProgressIndicator with a height less than the minimum', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -251,7 +251,7 @@ void main() {
     expect(values.end.round(), equals(90));
   });
 
-  testWidgets('Range Slider thumbs can be dragged to the min and max (continous LTR)', (WidgetTester tester) async {
+  testWidgets('Range Slider thumbs can be dragged to the min and max (continuous LTR)', (WidgetTester tester) async {
     RangeValues values = const RangeValues(0.3, 0.7);
 
     await tester.pumpWidget(
@@ -298,7 +298,7 @@ void main() {
     expect(values.end, equals(1));
   });
 
-  testWidgets('Range Slider thumbs can be dragged to the min and max (continous RTL)', (WidgetTester tester) async {
+  testWidgets('Range Slider thumbs can be dragged to the min and max (continuous RTL)', (WidgetTester tester) async {
     RangeValues values = const RangeValues(0.3, 0.7);
 
     await tester.pumpWidget(
@@ -445,7 +445,7 @@ void main() {
     expect(values.start, equals(0));
   });
 
-  testWidgets('Range Slider thumbs can be dragged together and the start thumb can be dragged apart (continous LTR)', (WidgetTester tester) async {
+  testWidgets('Range Slider thumbs can be dragged together and the start thumb can be dragged apart (continuous LTR)', (WidgetTester tester) async {
     RangeValues values = const RangeValues(0.3, 0.7);
 
     await tester.pumpWidget(
@@ -498,7 +498,7 @@ void main() {
     expect(values.start, closeTo(0.2, 0.05));
   });
 
-  testWidgets('Range Slider thumbs can be dragged together and the start thumb can be dragged apart (continous RTL)', (WidgetTester tester) async {
+  testWidgets('Range Slider thumbs can be dragged together and the start thumb can be dragged apart (continuous RTL)', (WidgetTester tester) async {
     RangeValues values = const RangeValues(0.3, 0.7);
 
     await tester.pumpWidget(
@@ -663,7 +663,7 @@ void main() {
     expect(values.start, closeTo(20, 0.01));
   });
 
-  testWidgets('Range Slider thumbs can be dragged together and the end thumb can be dragged apart (continous LTR)', (WidgetTester tester) async {
+  testWidgets('Range Slider thumbs can be dragged together and the end thumb can be dragged apart (continuous LTR)', (WidgetTester tester) async {
     RangeValues values = const RangeValues(0.3, 0.7);
 
     await tester.pumpWidget(
@@ -716,7 +716,7 @@ void main() {
     expect(values.end, closeTo(0.8, 0.05));
   });
 
-  testWidgets('Range Slider thumbs can be dragged together and the end thumb can be dragged apart (continous RTL)', (WidgetTester tester) async {
+  testWidgets('Range Slider thumbs can be dragged together and the end thumb can be dragged apart (continuous RTL)', (WidgetTester tester) async {
     RangeValues values = const RangeValues(0.3, 0.7);
 
     await tester.pumpWidget(

--- a/packages/flutter/test/material/scrollbar_paint_test.dart
+++ b/packages/flutter/test/material/scrollbar_paint_test.dart
@@ -43,7 +43,7 @@ void main() {
     expect(find.byType(Scrollbar), paints..rect(rect: const Rect.fromLTRB(0.0, 1.5, 6.0, 91.5)));
   });
 
-  testWidgets('workds with MaterialApp and Scaffold', (WidgetTester tester) async {
+  testWidgets('works with MaterialApp and Scaffold', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
       home: MediaQuery(
         data: const MediaQueryData(

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -270,7 +270,7 @@ void main() {
     expect(textField.focusNode.hasFocus, isFalse);
   });
 
-  testWidgets('Fresh search allways starts with empty query', (WidgetTester tester) async {
+  testWidgets('Fresh search always starts with empty query', (WidgetTester tester) async {
     final _TestSearchDelegate delegate = _TestSearchDelegate();
 
     await tester.pumpWidget(TestHomePage(

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -859,7 +859,7 @@ void main() {
   //
   // The value indicator can be skipped by passing the appropriate
   // [ShowValueIndicator].
-  testWidgets('The slider can skip all of its comoponent painting', (WidgetTester tester) async {
+  testWidgets('The slider can skip all of its component painting', (WidgetTester tester) async {
     // Pump a slider with all shapes skipped.
     await tester.pumpWidget(_buildApp(
       ThemeData().sliderTheme.copyWith(

--- a/packages/flutter/test/material/text_selection_test.dart
+++ b/packages/flutter/test/material/text_selection_test.dart
@@ -603,7 +603,7 @@ void main() {
     // Make sure the clipboard is empty to start.
     await Clipboard.setData(const ClipboardData(text: ''));
 
-    // Double tap to selet the first word.
+    // Double tap to select the first word.
     const int index = 4;
     await tester.tapAt(textOffsetToPosition(tester, index));
     await tester.pump(const Duration(milliseconds: 50));

--- a/packages/flutter/test/material/theme_defaults_test.dart
+++ b/packages/flutter/test/material/theme_defaults_test.dart
@@ -155,7 +155,7 @@ void main() {
       expect(raw.disabledElevation, 0.0);
       expect(raw.constraints, defaultButtonConstraints);
       expect(raw.padding, defaultButtonPadding);
-      // animationDuration can't be configed by the theme/constructor
+      // animationDuration can't be configured by the theme/constructor
       expect(raw.materialTapTargetSize, MaterialTapTargetSize.padded);
     });
 
@@ -182,7 +182,7 @@ void main() {
       expect(raw.disabledElevation, 0.0);
       expect(raw.constraints, defaultButtonConstraints);
       expect(raw.padding, defaultButtonPadding);
-      // animationDuration can't be configed by the theme/constructor
+      // animationDuration can't be configured by the theme/constructor
       expect(raw.materialTapTargetSize, MaterialTapTargetSize.padded);
     });
 
@@ -209,7 +209,7 @@ void main() {
       expect(raw.disabledElevation, 0.0);
       expect(raw.constraints, defaultButtonConstraints);
       expect(raw.padding, defaultButtonPadding);
-      // animationDuration can't be configed by the theme/constructor
+      // animationDuration can't be configured by the theme/constructor
       expect(raw.materialTapTargetSize, MaterialTapTargetSize.padded);
     });
   });

--- a/packages/flutter/test/painting/decoration_test.dart
+++ b/packages/flutter/test/painting/decoration_test.dart
@@ -534,7 +534,7 @@ void main() {
     // sourceRect should contain all pixels of the source image
     expect(call.positionalArguments[1], Offset.zero & imageSize);
 
-    // Image should be scaled down to fit in hejght
+    // Image should be scaled down to fit in height
     // and be positioned in the bottom right of the outputRect
     const Size expectedTileSize = Size(20.0, 20.0);
     final Rect expectedTileRect = Rect.fromPoints(

--- a/packages/flutter/test/painting/flutter_logo_test.dart
+++ b/packages/flutter/test/painting/flutter_logo_test.dart
@@ -54,7 +54,7 @@ void main() {
     expect(logo.margin, EdgeInsets.lerp(start.margin, end.margin, 0.5));
   });
 
-  test('FlutterLogoDecorationl.lerpFrom and FlutterLogoDecorationl.lerpTo', () {
+  test('FlutterLogoDecoration.lerpFrom and FlutterLogoDecoration.lerpTo', () {
     expect(Decoration.lerp(start, const BoxDecoration(), 0.0), start);
     expect(Decoration.lerp(start, const BoxDecoration(), 1.0), const BoxDecoration());
     expect(Decoration.lerp(const BoxDecoration(), end, 0.0), const BoxDecoration());

--- a/packages/flutter/test/painting/image_cache_test.dart
+++ b/packages/flutter/test/painting/image_cache_test.dart
@@ -212,8 +212,8 @@ void main() {
         .addListener(ImageStreamListener(
           (ImageInfo image, bool synchronousCall) { },
           onError: (dynamic exception, StackTrace stackTrace) {
-            final bool evicationResult = imageCache.evict(1);
-            expect(evicationResult, isTrue);
+            final bool evictionResult = imageCache.evict(1);
+            expect(evictionResult, isTrue);
           },
         ));
   });

--- a/packages/flutter/test/rendering/annotated_region_test.dart
+++ b/packages/flutter/test/rendering/annotated_region_test.dart
@@ -124,7 +124,7 @@ void main() {
       expect(layer.find<int>(const Offset(100.0, 100.0)), 1);
     });
 
-    test('handles non-invertable transforms', () {
+    test('handles non-invertible transforms', () {
       final AnnotatedRegionLayer<int> child = AnnotatedRegionLayer<int>(1);
       final TransformLayer parent = TransformLayer(transform: Matrix4.diagonal3Values(0.0, 1.0, 1.0));
       parent.append(child);
@@ -274,7 +274,7 @@ void main() {
       expect(layer.findAllAnnotations<int>(const Offset(100.0, 100.0)).annotations.toList(), equals(<int>[1]));
     });
 
-    test('handles non-invertable transforms', () {
+    test('handles non-invertible transforms', () {
       final AnnotatedRegionLayer<int> child = AnnotatedRegionLayer<int>(1);
       final TransformLayer parent = TransformLayer(transform: Matrix4.diagonal3Values(0.0, 1.0, 1.0));
       parent.append(child);

--- a/packages/flutter/test/rendering/box_test.dart
+++ b/packages/flutter/test/rendering/box_test.dart
@@ -378,7 +378,7 @@ void main() {
     expect(unconstrained.getMaxIntrinsicWidth(100.0), equals(200.0));
   });
 
-  test ('getMinInstrinsicWidth error handling', () {
+  test ('getMinIntrinsicWidth error handling', () {
     final RenderUnconstrainedBox unconstrained = RenderUnconstrainedBox(
       textDirection: TextDirection.ltr,
       child: RenderConstrainedBox(

--- a/packages/flutter/test/rendering/mouse_tracking_cursor_test.dart
+++ b/packages/flutter/test/rendering/mouse_tracking_cursor_test.dart
@@ -496,7 +496,7 @@ class _TestGestureFlutterBinding extends BindingBase
   @override
   SchedulerPhase get schedulerPhase => _overridePhase ?? super.schedulerPhase;
 
-  // Mannually schedule a postframe check.
+  // Manually schedule a post-frame check.
   //
   // In real apps this is done by the renderer binding, but in tests we have to
   // bypass the phase assertion of [MouseTracker.schedulePostFrameCheck].

--- a/packages/flutter/test/rendering/mouse_tracking_test.dart
+++ b/packages/flutter/test/rendering/mouse_tracking_test.dart
@@ -28,7 +28,7 @@ class _TestGestureFlutterBinding extends BindingBase
   @override
   SchedulerPhase get schedulerPhase => _overridePhase ?? super.schedulerPhase;
 
-  // Mannually schedule a postframe check.
+  // Manually schedule a post-frame check.
   //
   // In real apps this is done by the renderer binding, but in tests we have to
   // bypass the phase assertion of [MouseTracker.schedulePostFrameCheck].
@@ -480,7 +480,7 @@ void main() {
     ]));
   });
 
-  test('should not schedule postframe callbacks when no mouse is connected', () {
+  test('should not schedule post-frame callbacks when no mouse is connected', () {
     _setUpMouseAnnotationFinder((Offset position) sync* {
     });
 

--- a/packages/flutter/test/services/lifecycle_test.dart
+++ b/packages/flutter/test/services/lifecycle_test.dart
@@ -14,7 +14,7 @@ void main() {
     final TestWidgetsFlutterBinding binding = tester.binding;
     // Use paused as the initial state.
     binding.window.initialLifecycleStateTestValue = 'AppLifecycleState.paused';
-    binding.readTestInitialLifecycleStateFromNativeWindow(); // Re-attempt the initializaiton.
+    binding.readTestInitialLifecycleStateFromNativeWindow(); // Re-attempt the initialization.
 
     // The lifecycleState should now be the state we passed above,
     // even though no lifecycle event was fired from the platform.

--- a/packages/flutter/test/services/text_formatter_test.dart
+++ b/packages/flutter/test/services/text_formatter_test.dart
@@ -98,7 +98,7 @@ void main() {
       // The new value is always the oldValue plus a non-digit character (user press @)
       expect(newValue.text, equals('12345@'));
       // we expect that the formatted value returns the oldValue only since the newValue does not
-      // satisfy the formatter condition (wich is, in this case digitsOnly)
+      // satisfy the formatter condition (which is, in this case digitsOnly)
       expect(formatted.text, equals('12345'));
     });
 

--- a/packages/flutter/test/widgets/editable_text_show_on_screen_test.dart
+++ b/packages/flutter/test/widgets/editable_text_show_on_screen_test.dart
@@ -195,7 +195,7 @@ void main() {
     expect(find.byType(EditableText), findsNothing);
   });
 
-  testWidgets('entering text does not scroll a sourrounding PageView', (WidgetTester tester) async {
+  testWidgets('entering text does not scroll a surrounding PageView', (WidgetTester tester) async {
     // regression test for https://github.com/flutter/flutter/issues/19523
 
     final TextEditingController textController = TextEditingController();

--- a/packages/flutter/test/widgets/fitted_box_test.dart
+++ b/packages/flutter/test/widgets/fitted_box_test.dart
@@ -77,7 +77,7 @@ void main() {
     expect(insidePoint, equals(outsidePoint));
   });
 
-  testWidgets('Child can conver', (WidgetTester tester) async {
+  testWidgets('Child can cover', (WidgetTester tester) async {
     final Key outside = UniqueKey();
     final Key inside = UniqueKey();
 

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -1024,7 +1024,7 @@ void main() {
     );
   });
 
-  testWidgets('GlobalKey - dettach and re-attach child to different parents', (WidgetTester tester) async {
+  testWidgets('GlobalKey - detach and re-attach child to different parents', (WidgetTester tester) async {
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
       child: Center(
@@ -1345,10 +1345,10 @@ void main() {
             onBuild: (BuildContext context) {
               debugDoingBuildOnBuild = context.debugDoingBuild;
             },
-            onDispose: (BuildContext contex) {
+            onDispose: (BuildContext context) {
               debugDoingBuildOnDispose = context.debugDoingBuild;
             },
-            onDeactivate: (BuildContext contex) {
+            onDeactivate: (BuildContext context) {
               debugDoingBuildOnDeactivate = context.debugDoingBuild;
             },
           ),
@@ -1383,7 +1383,7 @@ void main() {
             return Inherited(value, child: child);
           },
           child: RenderObjectWidgetSpy(
-            onCreateRenderObjet: (BuildContext context) {
+            onCreateRenderObject: (BuildContext context) {
               spyContext = context;
               context.dependOnInheritedWidgetOfExactType<Inherited>();
               debugDoingBuildOnCreateRenderObject = context.debugDoingBuild;
@@ -1391,7 +1391,7 @@ void main() {
             onUpdateRenderObject: (BuildContext context) {
               debugDoingBuildOnUpdateRenderObject = context.debugDoingBuild;
             },
-            onDidUmountRenderObject: () {
+            onDidUnmountRenderObject: () {
               debugDoingBuildOnDidUnmountRenderObject = spyContext.debugDoingBuild;
             },
           ),
@@ -1771,18 +1771,18 @@ class _StatefulWidgetSpyState extends State<StatefulWidgetSpy> {
 class RenderObjectWidgetSpy extends LeafRenderObjectWidget {
   const RenderObjectWidgetSpy({
     Key key,
-    this.onCreateRenderObjet,
+    this.onCreateRenderObject,
     this.onUpdateRenderObject,
-    this.onDidUmountRenderObject,
+    this.onDidUnmountRenderObject,
   })  : super(key: key);
 
-  final void Function(BuildContext) onCreateRenderObjet;
+  final void Function(BuildContext) onCreateRenderObject;
   final void Function(BuildContext) onUpdateRenderObject;
-  final void Function() onDidUmountRenderObject;
+  final void Function() onDidUnmountRenderObject;
 
   @override
   RenderObject createRenderObject(BuildContext context) {
-    onCreateRenderObjet?.call(context);
+    onCreateRenderObject?.call(context);
     return FakeLeafRenderObject();
   }
 
@@ -1794,7 +1794,7 @@ class RenderObjectWidgetSpy extends LeafRenderObjectWidget {
   @override
   void didUnmountRenderObject(RenderObject renderObject) {
     super.didUnmountRenderObject(renderObject);
-    onDidUmountRenderObject?.call();
+    onDidUnmountRenderObject?.call();
   }
 }
 

--- a/packages/flutter/test/widgets/gesture_detector_test.dart
+++ b/packages/flutter/test/widgets/gesture_detector_test.dart
@@ -665,7 +665,7 @@ void main() {
         }
       });
 
-      test('constructur duplicate drag recognizer', () {
+      test('constructor duplicate drag recognizer', () {
         FlutterError error;
         try {
           GestureDetector(

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -1553,7 +1553,7 @@ void main() {
     expect(provider.loadCallCount, 1);
   });
 
-  testWidgets('precacheImage allows time to take over weak refernce', (WidgetTester tester) async {
+  testWidgets('precacheImage allows time to take over weak reference', (WidgetTester tester) async {
     final TestImageProvider provider = TestImageProvider();
     Future<void> precache;
     await tester.pumpWidget(

--- a/packages/flutter/test/widgets/inherited_model_test.dart
+++ b/packages/flutter/test/widgets/inherited_model_test.dart
@@ -190,7 +190,7 @@ void main() {
     expect(find.text('a: 2 b: 2 c: 3'), findsOneWidget);
   });
 
-  testWidgets('Looking up an non existent InherintedModel ancestor returns null', (WidgetTester tester) async {
+  testWidgets('Looking up an non existent InheritedModel ancestor returns null', (WidgetTester tester) async {
     ABCModel inheritedModel;
 
     await tester.pumpWidget(

--- a/packages/flutter/test/widgets/interactive_viewer_test.dart
+++ b/packages/flutter/test/widgets/interactive_viewer_test.dart
@@ -154,7 +154,7 @@ void main() {
       await tester.pumpAndSettle();
       expect(transformationController.value, equals(Matrix4.identity()));
 
-      // Attempting to pinch to zoom doens't work because it's disabled.
+      // Attempting to pinch to zoom doesn't work because it's disabled.
       final Offset scaleStart1 = childInterior;
       final Offset scaleStart2 = Offset(childInterior.dx + 10.0, childInterior.dy);
       final Offset scaleEnd1 = Offset(childInterior.dx - 10.0, childInterior.dy);

--- a/packages/flutter/test/widgets/layout_builder_test.dart
+++ b/packages/flutter/test/widgets/layout_builder_test.dart
@@ -618,7 +618,7 @@ void main() {
     // builder invocation.
     expect(builderInvocationCount, 1);
 
-    // Invalidate the layout without chaning the constraints.
+    // Invalidate the layout without changing the constraints.
     tester.renderObject(find.byType(LayoutBuilder)).markNeedsLayout();
 
     // The second pump will not go through the `performRebuild` or `update`, and

--- a/packages/flutter/test/widgets/localizations_test.dart
+++ b/packages/flutter/test/widgets/localizations_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter/widgets.dart';
 void main() {
   final TestAutomatedTestWidgetsFlutterBinding binding = TestAutomatedTestWidgetsFlutterBinding();
 
-  testWidgets('Locale is available when Localizations widget stops defering frames', (WidgetTester tester) async {
+  testWidgets('Locale is available when Localizations widget stops deferring frames', (WidgetTester tester) async {
     final FakeLocalizationsDelegate delegate = FakeLocalizationsDelegate();
     await tester.pumpWidget(Localizations(
       locale: const Locale('fo'),

--- a/packages/flutter/test/widgets/modal_barrier_test.dart
+++ b/packages/flutter/test/widgets/modal_barrier_test.dart
@@ -163,7 +163,7 @@ void main() {
     hovered = false;
   });
 
-  testWidgets('ModalBarrier pops the Navigator when dismissed by primay tap', (WidgetTester tester) async {
+  testWidgets('ModalBarrier pops the Navigator when dismissed by primary tap', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
       '/': (BuildContext context) => const FirstWidget(),
       '/modal': (BuildContext context) => const SecondWidget(),

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -572,7 +572,7 @@ void main() {
     expect(routes['/A'].secondaryAnimation.value, equals(routes['/C'].animation.value));
   });
 
-  testWidgets('new route removed from navigator history druing pushReplacement transition', (WidgetTester tester) async {
+  testWidgets('new route removed from navigator history during pushReplacement transition', (WidgetTester tester) async {
     final Map<String, SlideInOutPageRoute<dynamic>> routes = <String, SlideInOutPageRoute<dynamic>>{};
     final Map<String, WidgetBuilder> builders = <String, WidgetBuilder>{
       '/' : (BuildContext context) => OnTapPage(
@@ -1914,7 +1914,7 @@ void main() {
     expect(tickCount, 4);
   });
 
-  testWidgets('Route annouce correctly for first route and last route', (WidgetTester tester) async {
+  testWidgets('Route announce correctly for first route and last route', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/57133.
     Route<void> previousOfFirst = NotAnnounced();
     Route<void> nextOfFirst = NotAnnounced();

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -1197,7 +1197,7 @@ void main() {
       expect(modalBarrierAnimation.value, Colors.black);
     });
 
-    testWidgets('focus traverse correct when pop mutiple page simultaneously', (WidgetTester tester) async {
+    testWidgets('focus traverse correct when pop multiple page simultaneously', (WidgetTester tester) async {
       // Regression test: https://github.com/flutter/flutter/issues/48903
       final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
       await tester.pumpWidget(MaterialApp(
@@ -1243,7 +1243,7 @@ void main() {
       expect(focusNodeOnPageOne.hasFocus, isTrue);
     });
 
-    testWidgets('focus traversal is correct when popping mutiple pages simultaneously - with focused children', (WidgetTester tester) async {
+    testWidgets('focus traversal is correct when popping multiple pages simultaneously - with focused children', (WidgetTester tester) async {
       // Regression test: https://github.com/flutter/flutter/issues/48903
       final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
       await tester.pumpWidget(MaterialApp(

--- a/packages/flutter/test/widgets/scroll_aware_image_provider_test.dart
+++ b/packages/flutter/test/widgets/scroll_aware_image_provider_test.dart
@@ -315,7 +315,7 @@ void main() {
     expect(imageCache.containsKey(testImageProvider), false);
     expect(imageCache.currentSize, 0);
 
-    // Simulate a case where somone else has managed to complete this stream -
+    // Simulate a case where someone else has managed to complete this stream -
     // so it can land in the cache right before we stop scrolling fast.
     // If we miss the early return, we will fail.
     testImageProvider.complete();
@@ -378,7 +378,7 @@ void main() {
     testImageProvider.complete();
     stream.setCompleter(testImageProvider.load(testImageProvider, PaintingBinding.instance.instantiateImageCodec));
 
-    // Verify that this hasn't chagned the cache state yet
+    // Verify that this hasn't changed the cache state yet
     expect(imageCache.containsKey(testImageProvider), false);
     expect(imageCache.containsKey(testImageProvider2), true);
     expect(imageCache.currentSize, 1);

--- a/packages/flutter/test/widgets/scrollable_dispose_test.dart
+++ b/packages/flutter/test/widgets/scrollable_dispose_test.dart
@@ -32,13 +32,13 @@ void main() {
     // Regression test for https://github.com/flutter/flutter/issues/27707.
 
     final ScrollController controller = ScrollController();
-    final Key outterContainer = GlobalKey();
+    final Key outerContainer = GlobalKey();
 
     await tester.pumpWidget(
       MaterialApp(
         home: Center(
           child: Container(
-            key: outterContainer,
+            key: outerContainer,
             color: Colors.purple,
             width: 400.0,
             child: SingleChildScrollView(
@@ -75,7 +75,7 @@ void main() {
     final double currentOffset = controller.offset;
 
     // Start a hold activity by putting one pointer down.
-    await tester.startGesture(tester.getTopLeft(find.byKey(outterContainer)) + const Offset(50.0, 50.0));
+    await tester.startGesture(tester.getTopLeft(find.byKey(outerContainer)) + const Offset(50.0, 50.0));
     await tester.pumpAndSettle(); // This shouldn't change the scroll offset because of the down event above.
     expect(controller.offset, currentOffset);
 

--- a/packages/flutter/test/widgets/sliver_appbar_opacity_test.dart
+++ b/packages/flutter/test/widgets/sliver_appbar_opacity_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 
 void main() {
-  testWidgets('!pinned && !floating && !bottom ==> fade opactiy', (WidgetTester tester) async {
+  testWidgets('!pinned && !floating && !bottom ==> fade opacity', (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     await tester.pumpWidget(
         _TestWidget(
@@ -26,7 +26,7 @@ void main() {
     expect(render.text.style.color.opacity, 0.0);
   });
 
-  testWidgets('!pinned && !floating && bottom ==> fade opactiy', (WidgetTester tester) async {
+  testWidgets('!pinned && !floating && bottom ==> fade opacity', (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     await tester.pumpWidget(
         _TestWidget(
@@ -45,7 +45,7 @@ void main() {
     expect(render.text.style.color.opacity, 0.0);
   });
 
-  testWidgets('!pinned && floating && !bottom ==> fade opactiy', (WidgetTester tester) async {
+  testWidgets('!pinned && floating && !bottom ==> fade opacity', (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     await tester.pumpWidget(
         _TestWidget(
@@ -64,7 +64,7 @@ void main() {
     expect(render.text.style.color.opacity, 0.0);
   });
 
-  testWidgets('!pinned && floating && bottom ==> fade opactiy', (WidgetTester tester) async {
+  testWidgets('!pinned && floating && bottom ==> fade opacity', (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     await tester.pumpWidget(
         _TestWidget(
@@ -142,7 +142,7 @@ void main() {
     expect(render.text.style.color.opacity, 1.0);
   });
 
-  testWidgets('pinned && floating && bottom && extraToolbarHeight == 0.0 ==> fade opactiy', (WidgetTester tester) async {
+  testWidgets('pinned && floating && bottom && extraToolbarHeight == 0.0 ==> fade opacity', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/25993.
 
     final ScrollController controller = ScrollController();

--- a/packages/flutter/test/widgets/sliver_fill_remaining_test.dart
+++ b/packages/flutter/test/widgets/sliver_fill_remaining_test.dart
@@ -639,7 +639,7 @@ void main() {
         }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
       });
 
-      group('fillOverscroll: true, is ignored on irrevelant platforms', () {
+      group('fillOverscroll: true, is ignored on irrelevant platforms', () {
         // Android/Other scroll physics when hasScrollBody: false, ignores fillOverscroll: true
         testWidgets('child without size is sized by extent', (WidgetTester tester) async {
           final List<Widget> slivers = <Widget>[

--- a/packages/flutter/test/widgets/slivers_keepalive_test.dart
+++ b/packages/flutter/test/widgets/slivers_keepalive_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter/rendering.dart';
 
 void main() {
-  testWidgets('Sliver with keep alive without key - should dispose after reodering', (WidgetTester tester) async {
+  testWidgets('Sliver with keep alive without key - should dispose after reordering', (WidgetTester tester) async {
     List<Widget> childList= <Widget>[
       const WidgetTest0(text: 'child 0', keepAlive: true),
       const WidgetTest1(text: 'child 1', keepAlive: true),
@@ -30,7 +30,7 @@ void main() {
     expect(state2.hasBeenDisposed, false);
   });
 
-  testWidgets('Sliver without keep alive without key - should dispose after reodering', (WidgetTester tester) async {
+  testWidgets('Sliver without keep alive without key - should dispose after reordering', (WidgetTester tester) async {
     List<Widget> childList= <Widget>[
       const WidgetTest0(text: 'child 0'),
       const WidgetTest1(text: 'child 1'),
@@ -53,7 +53,7 @@ void main() {
     expect(state2.hasBeenDisposed, false);
   });
 
-  testWidgets('Sliver without keep alive with key - should dispose after reodering', (WidgetTester tester) async {
+  testWidgets('Sliver without keep alive with key - should dispose after reordering', (WidgetTester tester) async {
     List<Widget> childList= <Widget>[
       WidgetTest0(text: 'child 0', key: GlobalKey()),
       WidgetTest1(text: 'child 1', key: GlobalKey()),
@@ -76,7 +76,7 @@ void main() {
     expect(state2.hasBeenDisposed, false);
   });
 
-  testWidgets('Sliver with keep alive with key - should not dispose after reodering', (WidgetTester tester) async {
+  testWidgets('Sliver with keep alive with key - should not dispose after reordering', (WidgetTester tester) async {
     List<Widget> childList= <Widget>[
       WidgetTest0(text: 'child 0', key: GlobalKey(), keepAlive: true),
       WidgetTest1(text: 'child 1', key: GlobalKey(), keepAlive: true),
@@ -98,7 +98,7 @@ void main() {
     expect(state2.hasBeenDisposed, false);
   });
 
-  testWidgets('Sliver with keep alive with Unique key - should not dispose after reodering', (WidgetTester tester) async {
+  testWidgets('Sliver with keep alive with Unique key - should not dispose after reordering', (WidgetTester tester) async {
     List<Widget> childList= <Widget>[
       WidgetTest0(text: 'child 0', key: UniqueKey(), keepAlive: true),
       WidgetTest1(text: 'child 1', key: UniqueKey(), keepAlive: true),
@@ -120,7 +120,7 @@ void main() {
     expect(state2.hasBeenDisposed, false);
   });
 
-  testWidgets('Sliver with keep alive with Value key - should not dispose after reodering', (WidgetTester tester) async {
+  testWidgets('Sliver with keep alive with Value key - should not dispose after reordering', (WidgetTester tester) async {
     List<Widget> childList= <Widget>[
       const WidgetTest0(text: 'child 0', key: ValueKey<int>(0), keepAlive: true),
       const WidgetTest1(text: 'child 1', key: ValueKey<int>(1), keepAlive: true),

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -193,7 +193,7 @@ void main() {
     expect(singleLongTapStartCount, 0);
   });
 
-  testWidgets('a force press intiates a force press', (WidgetTester tester) async {
+  testWidgets('a force press initiates a force press', (WidgetTester tester) async {
     await pumpGestureDetector(tester);
 
     const int pointerValue = 1;
@@ -259,7 +259,7 @@ void main() {
     expect(forcePressStartCount, 4);
   });
 
-  testWidgets('a tap and then force press intiates a force press and not a double tap', (WidgetTester tester) async {
+  testWidgets('a tap and then force press initiates a force press and not a double tap', (WidgetTester tester) async {
     await pumpGestureDetector(tester);
 
     const int pointerValue = 1;

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -1882,7 +1882,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
       state.updateTime(); // Triggers a rebuild.
       await tester.pump();
-      // Verify that rapint events are not fired once the extension is disabled.
+      // Verify that repaint events are not fired once the extension is disabled.
       expect(repaintEvents, isEmpty);
     }, skip: !WidgetInspectorService.instance.isWidgetCreationTracked()); // Test requires --track-widget-creation flag.
 


### PR DESCRIPTION
## Description

Fixes a bunch of small typos throughout the `packages/flutter` directory, including several dartdoc link problems.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them?

- [x] No, no existing tests failed, so this is *not* a breaking change.
