### PR TITLE
Don't crash on requests for invalid package URLs

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/build_runner/devfs_web.dart
@@ -517,10 +517,13 @@ class WebAssetServer implements AssetReader {
     // The file might have been a package file which is signaled by a
     // `/packages/<package>/<path>` request.
     if (segments.first == 'packages') {
-      final File packageFile = globals.fs.file(_packages.resolve(Uri(
-        scheme: 'package', pathSegments: segments.skip(1))));
-      if (packageFile.existsSync()) {
-        return packageFile;
+      final Uri filePath = _packages.resolve(Uri(
+        scheme: 'package', pathSegments: segments.skip(1)));
+      if (filePath != null) {
+        final File packageFile = globals.fs.file(filePath);
+        if (packageFile.existsSync()) {
+          return packageFile;
+        }
       }
     }
 

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -41,7 +41,6 @@ import '../dart/package_map.dart';
 import '../globals.dart' as globals;
 import '../project.dart';
 import '../web/chrome.dart';
-
 import 'test_compiler.dart';
 import 'test_config.dart';
 
@@ -222,20 +221,22 @@ class FlutterWebPlatform extends PlatformPlugin {
         scheme: 'package',
         pathSegments: request.requestedUri.pathSegments.skip(1),
       ));
-      final String dirname = p.dirname(fileUri.toFilePath());
-      final String basename = p.basename(fileUri.toFilePath());
-      final shelf.Handler handler = createStaticHandler(dirname);
-      final shelf.Request modifiedRequest = shelf.Request(
-        request.method,
-        request.requestedUri.replace(path: basename),
-        protocolVersion: request.protocolVersion,
-        headers: request.headers,
-        handlerPath: request.handlerPath,
-        url: request.url.replace(path: basename),
-        encoding: request.encoding,
-        context: request.context,
-      );
-      return handler(modifiedRequest);
+      if (fileUri != null) {
+        final String dirname = p.dirname(fileUri.toFilePath());
+        final String basename = p.basename(fileUri.toFilePath());
+        final shelf.Handler handler = createStaticHandler(dirname);
+        final shelf.Request modifiedRequest = shelf.Request(
+          request.method,
+          request.requestedUri.replace(path: basename),
+          protocolVersion: request.protocolVersion,
+          headers: request.headers,
+          handlerPath: request.handlerPath,
+          url: request.url.replace(path: basename),
+          encoding: request.encoding,
+          context: request.context,
+        );
+        return handler(modifiedRequest);
+      }
     }
     return shelf.Response.notFound('Not Found');
   }

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -364,6 +364,13 @@ void main() {
     expect(response.statusCode, HttpStatus.notFound);
   }));
 
+  test('handles serving unresolvable package file', () => testbed.run(() async {
+    final Response response = await webAssetServer
+      .handleRequest(Request('GET', Uri.parse('http://foobar/packages/notpackage/file')));
+
+    expect(response.statusCode, HttpStatus.notFound);
+  }));
+
   test('serves /packages/<package>/<path> files as if they were '
        'package:<package>/<path> uris', () => testbed.run(() async {
     final Uri expectedUri = packages.resolve(


### PR DESCRIPTION
@jonahwilliams I think this is the fix for #54971, however when I try to reproduce it today, it crashes (for basically the same reason) in a completely different place:

```
GET /packages/ui/assets/Roboto-Regular.ttf
Error thrown by handler.
Invalid argument(s): Invalid type for "path": null
package:file/src/interface/file_system.dart 162:7                     FileSystem.getPath
package:file/src/backends/local/local_file_system.dart 28:54          LocalFileSystem.file
package:flutter_tools/src/base/error_handling_file_system.dart 51:24  ErrorHandlingFileSystem.file
package:flutter_tools/src/build_runner/devfs_web.dart 520:43          WebAssetServer._resolveDartFile
package:flutter_tools/src/build_runner/devfs_web.dart 334:17          WebAssetServer.handleRequest
package:dwds/src/handlers/injected_handler.dart 82:30                 createInjectedHandler.<fn>.<fn>
```

So this includes fixes for both of them (however I'm unable to repro the original one to verify it, but the logic seems simple enough).

Both issues are that we get a `null` back when resolving the package, but assume that can never happen. I don't know if it's correct that we're getting `null` here (or if these packages should be resolving), but it seems like it should be a 404 in case where we can't whatever the reason.