### PR TITLE
First pass at keyboard navigation for the Material Date Picker

### DIFF
--- a/packages/flutter/lib/src/material/pickers/date_picker_header.dart
+++ b/packages/flutter/lib/src/material/pickers/date_picker_header.dart
@@ -8,6 +8,7 @@ import 'package:flutter/widgets.dart';
 
 import '../color_scheme.dart';
 import '../icon_button.dart';
+import '../material.dart';
 import '../text_theme.dart';
 import '../theme.dart';
 
@@ -127,66 +128,69 @@ class DatePickerHeader extends StatelessWidget {
 
     switch (orientation) {
       case Orientation.portrait:
-         return Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Container(
-              height: _datePickerHeaderPortraitHeight,
-              color: primarySurfaceColor,
-              padding: const EdgeInsetsDirectional.only(
-                start: 24,
-                end: 12,
-              ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  const SizedBox(height: 16),
-                  Flexible(child: help),
-                  const SizedBox(height: 38),
-                  Row(
-                    children: <Widget>[
-                      Expanded(child: title),
-                      icon,
-                    ],
-                  ),
-                ],
-              ),
-            ),
-          ],
-        );
+         return SizedBox(
+           height: _datePickerHeaderPortraitHeight,
+           child: Material(
+             color: primarySurfaceColor,
+             child: Padding(
+               padding: const EdgeInsetsDirectional.only(
+                 start: 24,
+                 end: 12,
+               ),
+               child: Column(
+                 crossAxisAlignment: CrossAxisAlignment.start,
+                 children: <Widget>[
+                   const SizedBox(height: 16),
+                   Flexible(child: help),
+                   const SizedBox(height: 38),
+                   Row(
+                     children: <Widget>[
+                       Expanded(child: title),
+                       icon,
+                     ],
+                   ),
+                 ],
+               ),
+             ),
+           ),
+         );
       case Orientation.landscape:
         return Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            Container(
-              width: _datePickerHeaderLandscapeWidth,
-              color: primarySurfaceColor,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  const SizedBox(height: 16),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: _headerPaddingLandscape,
-                    ),
-                    child: help,
-                  ),
-                  SizedBox(height: isShort ? 16 : 56),
-                  Expanded(
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: _headerPaddingLandscape,
+            Material(
+              child: SizedBox(
+                width: _datePickerHeaderLandscapeWidth,
+                child: Material(
+                  color: primarySurfaceColor,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      const SizedBox(height: 16),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: _headerPaddingLandscape,
+                        ),
+                        child: help,
                       ),
-                      child: title,
-                    ),
+                      SizedBox(height: isShort ? 16 : 56),
+                      Expanded(
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: _headerPaddingLandscape,
+                          ),
+                          child: title,
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 4,
+                        ),
+                        child: icon,
+                      ),
+                    ],
                   ),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 4,
-                    ),
-                    child: icon,
-                  ),
-                ],
+                ),
               ),
             ),
           ],

--- a/packages/flutter/lib/src/material/pickers/date_picker_header.dart
+++ b/packages/flutter/lib/src/material/pickers/date_picker_header.dart
@@ -155,45 +155,38 @@ class DatePickerHeader extends StatelessWidget {
            ),
          );
       case Orientation.landscape:
-        return Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Material(
-              child: SizedBox(
-                width: _datePickerHeaderLandscapeWidth,
-                child: Material(
-                  color: primarySurfaceColor,
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: <Widget>[
-                      const SizedBox(height: 16),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: _headerPaddingLandscape,
-                        ),
-                        child: help,
-                      ),
-                      SizedBox(height: isShort ? 16 : 56),
-                      Expanded(
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: _headerPaddingLandscape,
-                          ),
-                          child: title,
-                        ),
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 4,
-                        ),
-                        child: icon,
-                      ),
-                    ],
+        return SizedBox(
+          width: _datePickerHeaderLandscapeWidth,
+          child: Material(
+            color: primarySurfaceColor,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                const SizedBox(height: 16),
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: _headerPaddingLandscape,
+                  ),
+                  child: help,
+                ),
+                SizedBox(height: isShort ? 16 : 56),
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: _headerPaddingLandscape,
+                    ),
+                    child: title,
                   ),
                 ),
-              ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 4,
+                  ),
+                  child: icon,
+                ),
+              ],
             ),
-          ],
+          ),
         );
     }
     return null;

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -1159,35 +1159,6 @@ void main() {
         expect(find.text('March 2016'), findsOneWidget);
       });
     });
-
-    testWidgets('Can confirm dialog with Enter key', (WidgetTester tester) async {
-      await prepareDatePicker(tester, (Future<DateTime> date) async {
-        await tester.tap(find.text('12'));
-        await tester.sendKeyEvent(LogicalKeyboardKey.enter);
-        await tester.pumpAndSettle();
-        expect(await date, equals(DateTime(2016, DateTime.january, 12)));
-      });
-
-      // Same thing should work even if the focus is on a widget that can activate
-      await prepareDatePicker(tester, (Future<DateTime> date) async {
-        await tester.tap(find.text('12'));
-        // Navigate to the year selector
-        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
-        await tester.sendKeyEvent(LogicalKeyboardKey.enter);
-        await tester.pumpAndSettle();
-        expect(await date, equals(DateTime(2016, DateTime.january, 12)));
-      });
-    });
-
-    testWidgets('Can cancel dialog with Escape key', (WidgetTester tester) async {
-      await prepareDatePicker(tester, (Future<DateTime> date) async {
-        await tester.tap(find.text('12'));
-        await tester.sendKeyEvent(LogicalKeyboardKey.escape);
-        await tester.pumpAndSettle();
-        // We shouldn't get a date back
-        expect(await date, isNull);
-      });
-    });
   });
 
   group('Screen configurations', () {

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -803,8 +803,7 @@ void main() {
 
       await prepareDatePicker(tester, (Future<DateTime> date) async {
         // Header
-        expect(
-            tester.getSemantics(find.text('SELECT DATE')), matchesSemantics(
+        expect(tester.getSemantics(find.text('SELECT DATE')), matchesSemantics(
           label: 'SELECT DATE\nFri, Jan 15',
         ));
 
@@ -819,8 +818,7 @@ void main() {
         ));
 
         // Year mode drop down button
-        expect(
-            tester.getSemantics(find.text('January 2016')), matchesSemantics(
+        expect(tester.getSemantics(find.text('January 2016')), matchesSemantics(
           label: 'Select year',
           isButton: true,
         ));
@@ -983,7 +981,6 @@ void main() {
           hasEnabledState: true,
           isFocusable: true,
         ));
-
       });
 
       semantics.dispose();
@@ -1104,6 +1101,92 @@ void main() {
       });
 
       semantics.dispose();
+    });
+  });
+
+  group('Keyboard navigation', () {
+    testWidgets('Can toggle to calendar entry mode', (WidgetTester tester) async {
+      await prepareDatePicker(tester, (Future<DateTime> date) async {
+        expect(find.byType(TextField), findsNothing);
+        // Navigate to the entry toggle button and activate it
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pumpAndSettle();
+        // Should be in the input mode
+        expect(find.byType(TextField), findsOneWidget);
+      });
+    });
+
+    testWidgets('Can toggle to year mode', (WidgetTester tester) async {
+      await prepareDatePicker(tester, (Future<DateTime> date) async {
+        expect(find.text('2016'), findsNothing);
+        // Navigate to the year selector and activate it
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pumpAndSettle();
+        // The years should be visible
+        expect(find.text('2016'), findsOneWidget);
+      });
+    });
+
+    testWidgets('Can navigate next/previous months', (WidgetTester tester) async {
+      await prepareDatePicker(tester, (Future<DateTime> date) async {
+        expect(find.text('January 2016'), findsOneWidget);
+        // Navigate to the previous month button and activate it twice
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pumpAndSettle();
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pumpAndSettle();
+        // Should be showing Nov 2015
+        expect(find.text('November 2015'), findsOneWidget);
+
+        // Navigate to the next month button and activate it four times
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pumpAndSettle();
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pumpAndSettle();
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pumpAndSettle();
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pumpAndSettle();
+        // Should be on Mar 2016
+        expect(find.text('March 2016'), findsOneWidget);
+      });
+    });
+
+    testWidgets('Can confirm dialog with Enter key', (WidgetTester tester) async {
+      await prepareDatePicker(tester, (Future<DateTime> date) async {
+        await tester.tap(find.text('12'));
+        await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+        await tester.pumpAndSettle();
+        expect(await date, equals(DateTime(2016, DateTime.january, 12)));
+      });
+
+      // Same thing should work even if the focus is on a widget that can activate
+      await prepareDatePicker(tester, (Future<DateTime> date) async {
+        await tester.tap(find.text('12'));
+        // Navigate to the year selector
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+        await tester.pumpAndSettle();
+        expect(await date, equals(DateTime(2016, DateTime.january, 12)));
+      });
+    });
+
+    testWidgets('Can cancel dialog with Escape key', (WidgetTester tester) async {
+      await prepareDatePicker(tester, (Future<DateTime> date) async {
+        await tester.tap(find.text('12'));
+        await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+        await tester.pumpAndSettle();
+        // We shouldn't get a date back
+        expect(await date, isNull);
+      });
     });
   });
 


### PR DESCRIPTION
## Description

This PR adds the first steps towards adding full keyboard navigation to the Material Date Picker. Specifically it cleans up the highlight on the entry toggle button so that it is visible and adds some tests exercising the navigation.

Additional PRs will be submitted to handle navigating the calendar date grid, as well as updating the date range picker to the same functionality.

## Related Issues

#49809

## Tests

I added a new group of tests that exercise the keyboard navigation on the date picker .

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them?

- [x] No, no existing tests failed, so this is *not* a breaking change.
