### PR TITLE
[flutter_tools] ensure generated entrypoint matches test and web entrypoint language version

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -544,7 +544,7 @@ Future<void> _runAddToAppLifeCycleTests() async {
 
 Future<void> _runFrameworkTests() async {
   final bq.BigqueryApi bigqueryApi = await _getBigqueryApi();
-  final List<String> nullSafetyOptions = <String>['--enable-experiment=non-nullable', '--no-sound-null-safety'];
+  final List<String> nullSafetyOptions = <String>['--enable-experiment=non-nullable'];
   final List<String> trackWidgetCreationAlternatives = <String>['--track-widget-creation', '--no-track-widget-creation'];
 
   Future<void> runWidgets() async {

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -378,7 +378,7 @@ Future<void> _runExampleProjectBuildTests(FileSystemEntity exampleDirectory) asy
   final String examplePath = exampleDirectory.path;
   final bool hasNullSafety = File(path.join(examplePath, 'null_safety')).existsSync();
   final List<String> additionalArgs = hasNullSafety
-    ? <String>['--enable-experiment', 'non-nullable', '--no-sound-null-safety']
+    ? <String>['--enable-experiment', 'non-nullable']
     : <String>[];
   if (Directory(path.join(examplePath, 'android')).existsSync()) {
     await _flutterBuildApk(examplePath, release: false, additionalArgs: additionalArgs, verifyCaching: verifyCaching);

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -378,7 +378,7 @@ Future<void> _runExampleProjectBuildTests(FileSystemEntity exampleDirectory) asy
   final String examplePath = exampleDirectory.path;
   final bool hasNullSafety = File(path.join(examplePath, 'null_safety')).existsSync();
   final List<String> additionalArgs = hasNullSafety
-    ? <String>['--enable-experiment', 'non-nullable']
+    ? <String>['--enable-experiment', 'non-nullable', '--no-sound-null-safety']
     : <String>[];
   if (Directory(path.join(examplePath, 'android')).existsSync()) {
     await _flutterBuildApk(examplePath, release: false, additionalArgs: additionalArgs, verifyCaching: verifyCaching);

--- a/dev/integration_tests/non_nullable/test/test_test.dart
+++ b/dev/integration_tests/non_nullable/test/test_test.dart
@@ -2,10 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
+// @dart=2.8
 import 'package:flutter_test/flutter_test.dart';
-
-String? x;
 
 void main() {
   testWidgets('trivial', (WidgetTester tester) async {

--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -23,6 +23,7 @@ import '../base/utils.dart';
 import '../build_info.dart';
 import '../cache.dart';
 import '../convert.dart';
+import '../dart/language_version.dart';
 import '../dart/pub.dart';
 import '../devfs.dart';
 import '../device.dart';
@@ -581,6 +582,10 @@ class _ResidentWebRunner extends ResidentWebRunner {
       }
 
       final String entrypoint = <String>[
+        determineLanguageVersion(
+          globals.fs.file(mainUri),
+          packageConfig[flutterProject.manifest.appName],
+        ),
         '// Flutter web bootstrap script for $importedEntrypoint.',
         '',
         "import 'dart:ui' as ui;",

--- a/packages/flutter_tools/lib/src/dart/language_version.dart
+++ b/packages/flutter_tools/lib/src/dart/language_version.dart
@@ -5,7 +5,7 @@
 import 'package:file/file.dart';
 import 'package:package_config/package_config.dart';
 
-final RegExp _languageVersion = RegExp('/\/\\s*@dart');
+final RegExp _languageVersion = RegExp(r'\/\/\s*@dart');
 final RegExp _declarationEnd = RegExp('(import)|(library)|(part)');
 const String _blockCommentStart = '/*';
 const String _blockCommentEnd = '*/';

--- a/packages/flutter_tools/lib/src/dart/language_version.dart
+++ b/packages/flutter_tools/lib/src/dart/language_version.dart
@@ -1,0 +1,29 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/file.dart';
+import 'package:package_config/package_config.dart';
+
+final RegExp _languageVersion = RegExp('/\/\\s*@dart');
+
+/// Attempts to read the language version of a dart [file].
+///
+/// If this is not present, falls back to the language version defined in
+/// [package]. If [package] is not provided and there is no
+/// language version header, returns `null`.
+String determineLanguageVersion(File file, Package package) {
+  for (final String line in file.readAsLinesSync()) {
+    final Match match = _languageVersion.matchAsPrefix(line);
+    if (match != null) {
+      return line;
+    }
+    if (line.startsWith('import')) {
+      break;
+    }
+  }
+  if (package != null) {
+    return '// @dart = ${package.languageVersion}';
+  }
+  return null;
+}

--- a/packages/flutter_tools/lib/src/dart/language_version.dart
+++ b/packages/flutter_tools/lib/src/dart/language_version.dart
@@ -10,7 +10,8 @@ final RegExp _declarationEnd = RegExp('(import)|(library)|(part)');
 const String _blockCommentStart = '/*';
 const String _blockCommentEnd = '*/';
 
-/// Attempts to read the language version of a dart [file].
+/// Attempts to read the language version of a dart [file], returning
+/// the entire comment.
 ///
 /// If this is not present, falls back to the language version defined in
 /// [package]. If [package] is not provided and there is no

--- a/packages/flutter_tools/lib/src/dart/language_version.dart
+++ b/packages/flutter_tools/lib/src/dart/language_version.dart
@@ -29,17 +29,21 @@ String determineLanguageVersion(File file, Package package) {
     // Check for the start or end of a block comment. Within a block
     // comment, all language version declarations are ignored. Block
     // comments can be nested, and the start or end may occur on
-    // the same line.
+    // the same line. This does not handle the case of invalid
+    // block comment combinations like `*/ /*` since that will cause
+    // a compilation error anyway.
     bool sawBlockComment = false;
-    if (trimmedLine.startsWith(_blockCommentStart)) {
-      blockCommentDepth += 1;
+    final int startMatches = _blockCommentStart.allMatches(trimmedLine).length;
+    final int endMatches = _blockCommentEnd.allMatches(trimmedLine).length;
+    if (startMatches > 0) {
+      blockCommentDepth += startMatches;
       sawBlockComment = true;
     }
-    if (trimmedLine.endsWith(_blockCommentEnd)) {
-      blockCommentDepth -= 1;
+    if (endMatches > 0) {
+      blockCommentDepth -= endMatches;
       sawBlockComment = true;
     }
-    if (blockCommentDepth > 0 || sawBlockComment) {
+    if (blockCommentDepth != 0 || sawBlockComment) {
       continue;
     }
     // Check for a match with the language version.

--- a/packages/flutter_tools/lib/src/dart/language_version.dart
+++ b/packages/flutter_tools/lib/src/dart/language_version.dart
@@ -6,22 +6,56 @@ import 'package:file/file.dart';
 import 'package:package_config/package_config.dart';
 
 final RegExp _languageVersion = RegExp('/\/\\s*@dart');
+final RegExp _declarationEnd = RegExp('(import)|(library)|(part)');
+const String _blockCommentStart = '/*';
+const String _blockCommentEnd = '*/';
 
 /// Attempts to read the language version of a dart [file].
 ///
 /// If this is not present, falls back to the language version defined in
 /// [package]. If [package] is not provided and there is no
-/// language version header, returns `null`.
+/// language version header, returns `null`. This does not specifically check
+/// for language declarations other than library, part, or import.
+///
+/// The specification for the language version tag is defined at:
+/// https://github.com/dart-lang/language/blob/master/accepted/future-releases/language-versioning/feature-specification.md#individual-library-language-version-override
 String determineLanguageVersion(File file, Package package) {
+  int blockCommentDepth = 0;
   for (final String line in file.readAsLinesSync()) {
-    final Match match = _languageVersion.matchAsPrefix(line);
-    if (match != null) {
-      return line;
+    final String trimmedLine = line.trim();
+    if (trimmedLine.isEmpty) {
+      continue;
     }
-    if (line.startsWith('import')) {
+    // Check for the start or end of a block comment. Within a block
+    // comment, all language version declarations are ignored. Block
+    // comments can be nested, and the start or end may occur on
+    // the same line.
+    bool sawBlockComment = false;
+    if (trimmedLine.startsWith(_blockCommentStart)) {
+      blockCommentDepth += 1;
+      sawBlockComment = true;
+    }
+    if (trimmedLine.endsWith(_blockCommentEnd)) {
+      blockCommentDepth -= 1;
+      sawBlockComment = true;
+    }
+    if (blockCommentDepth > 0 || sawBlockComment) {
+      continue;
+    }
+    // Check for a match with the language version.
+    final Match match = _languageVersion.matchAsPrefix(trimmedLine);
+    if (match != null) {
+      return trimmedLine;
+    }
+
+    // Check for a declaration which ends the search for a language
+    // version.
+    if (_declarationEnd.matchAsPrefix(trimmedLine) != null) {
       break;
     }
   }
+
+  // If the language version cannot be found, use the package version.
   if (package != null) {
     return '// @dart = ${package.languageVersion}';
   }

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -7,13 +7,12 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 import 'package:package_config/package_config.dart';
 import 'package:stream_channel/stream_channel.dart';
-import 'package:vm_service/vm_service.dart' as vm_service;
-
 import 'package:test_api/src/backend/suite_platform.dart'; // ignore: implementation_imports
+import 'package:test_core/src/runner/environment.dart'; // ignore: implementation_imports
+import 'package:test_core/src/runner/plugin/platform_helpers.dart'; // ignore: implementation_imports
 import 'package:test_core/src/runner/runner_suite.dart'; // ignore: implementation_imports
 import 'package:test_core/src/runner/suite.dart'; // ignore: implementation_imports
-import 'package:test_core/src/runner/plugin/platform_helpers.dart'; // ignore: implementation_imports
-import 'package:test_core/src/runner/environment.dart'; // ignore: implementation_imports
+import 'package:vm_service/vm_service.dart' as vm_service;
 
 import '../base/common.dart';
 import '../base/file_system.dart';
@@ -21,6 +20,7 @@ import '../base/io.dart';
 import '../build_info.dart';
 import '../compile.dart';
 import '../convert.dart';
+import '../dart/language_version.dart';
 import '../dart/package_map.dart';
 import '../globals.dart' as globals;
 import '../project.dart';
@@ -756,29 +756,13 @@ class FlutterPlatform extends PlatformPlugin {
       testConfigFile: findTestConfigFile(globals.fs.file(testUrl)),
       host: host,
       updateGoldens: updateGoldens,
-      languageVersionHeader: _findLanguageVersionCommentHeader(file),
+      languageVersionHeader: determineLanguageVersion(
+        file,
+        _packageConfig[flutterProject?.manifest?.appName],
+      ),
     );
   }
 
-  static final RegExp _languageVersion = RegExp('\/\/\s+@dart');
-
-  /// Instead of attempting to extract the exact language header,
-  /// just grab every line that starts with a comment.
-  String _findLanguageVersionCommentHeader(File file) {
-    for (final String line in file.readAsLinesSync()) {
-      if (line.startsWith(_languageVersion)) {
-        return line;
-      }
-      if (line.startsWith('import')) {
-        break;
-      }
-    }
-    final Package package = _packageConfig[flutterProject?.manifest?.appName];
-    if (package != null) {
-      return '// @dart = ${package.languageVersion}';
-    }
-    return '';
-  }
 
   File _cachedFontConfig;
 

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -405,7 +405,7 @@ class FlutterPlatform extends PlatformPlugin {
     StreamChannel<dynamic> controller,
     int ourTestCount,
   ) async {
-    _packageConfig = await loadPackageConfigWithLogging(
+    _packageConfig ??= await loadPackageConfigWithLogging(
       globals.fs.file(globalPackagesPath),
       logger: globals.logger,
     );

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -152,7 +152,7 @@ String generateTestBootstrap({
   @required InternetAddress host,
   File testConfigFile,
   bool updateGoldens = false,
-  @required String languageVersionHeader,
+  String languageVersionHeader = '',
 }) {
   assert(testUrl != null);
   assert(host != null);
@@ -756,16 +756,17 @@ class FlutterPlatform extends PlatformPlugin {
       testConfigFile: findTestConfigFile(globals.fs.file(testUrl)),
       host: host,
       updateGoldens: updateGoldens,
-      // nullSafety: extraFrontEndOptions?.contains('--enable-experiment=non-nullable') ?? false,
       languageVersionHeader: _findLanguageVersionCommentHeader(file),
     );
   }
+
+  static final RegExp _languageVersion = RegExp('\/\/\s+@dart');
 
   /// Instead of attempting to extract the exact language header,
   /// just grab every line that starts with a comment.
   String _findLanguageVersionCommentHeader(File file) {
     for (final String line in file.readAsLinesSync()) {
-      if (line.startsWith('// @dart =')) {
+      if (line.startsWith(_languageVersion)) {
         return line;
       }
       if (line.startsWith('import')) {

--- a/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
@@ -89,7 +89,7 @@ void main() {
 // Some license
 
 /*
-@dart = 2.9
+// @dart = 2.9
 */
 ''');
 
@@ -104,7 +104,7 @@ void main() {
 
 /*
 /*
-@dart = 2.9
+// @dart = 2.9
 */
 */
 ''');
@@ -136,7 +136,7 @@ void main() {
 /*
 /*
 */
-@dart = 2.9
+// @dart = 2.9
 ''');
 
     expect(determineLanguageVersion(file, null), null);
@@ -151,7 +151,7 @@ void main() {
 /*
 */
 */
-@dart = 2.9
+// @dart = 2.9
 ''');
 
     expect(determineLanguageVersion(file, null), null);
@@ -163,7 +163,7 @@ void main() {
       ..writeAsStringSync('''
 // Some license
 
-/* @dart = 2.9 */
+/* // @dart = 2.9 */
 ''');
 
     expect(determineLanguageVersion(file, null), null);

--- a/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
@@ -1,0 +1,88 @@
+
+
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/dart/language_version.dart';
+import 'package:package_config/package_config.dart';
+
+import '../../src/common.dart';
+
+void main() {
+  testWithoutContext('detects language version in comment', () {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final File file = fileSystem.file('example.dart')
+      ..writeAsStringSync('''
+// Some license
+
+// @dart = 2.9
+''');
+
+    expect(determineLanguageVersion(file, null), '// @dart = 2.9');
+  });
+
+  testWithoutContext('detects technically invalid language version', () {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final File file = fileSystem.file('example.dart')
+      ..writeAsStringSync('''
+// Some license
+
+// @dart
+''');
+
+    expect(determineLanguageVersion(file, null), '// @dart');
+  });
+
+  testWithoutContext('detects language version with tons of whitespace', () {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final File file = fileSystem.file('example.dart')
+      ..writeAsStringSync('''
+// Some license
+
+//        @dart       = 23
+''');
+
+    expect(determineLanguageVersion(file, null), '//        @dart       = 23');
+  });
+
+  testWithoutContext('does not detect language version in dartdoc', () {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final File file = fileSystem.file('example.dart')
+      ..writeAsStringSync('''
+// Some license
+
+/// @dart = 2.9
+''');
+
+    expect(determineLanguageVersion(file, null), null);
+  });
+
+
+  testWithoutContext('does not detect language version after import', () {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final File file = fileSystem.file('example.dart')
+      ..writeAsStringSync('''
+// Some license
+
+import 'dart:ui' as ui;
+
+// @dart = 2.9
+''');
+
+    expect(determineLanguageVersion(file, null), null);
+  });
+
+  testWithoutContext('looks up language version from package if not found in file', () {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final File file = fileSystem.file('example.dart')
+      ..writeAsStringSync('''
+// Some license
+''');
+    final Package package = Package(
+      'foo',
+      Uri.parse('file://foo/'),
+      languageVersion: LanguageVersion(2, 7),
+    );
+
+    expect(determineLanguageVersion(file, package), '// @dart = 2.7');
+  });
+}

--- a/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
@@ -34,6 +34,30 @@ void main() {
     expect(determineLanguageVersion(file, null), '// @dart');
   });
 
+  testWithoutContext('detects language version with leading whitespace', () {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final File file = fileSystem.file('example.dart')
+      ..writeAsStringSync('''
+// Some license
+
+    // @dart = 2.9
+''');
+
+    expect(determineLanguageVersion(file, null), '// @dart = 2.9');
+  });
+
+  testWithoutContext('detects language version with tabs', () {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final File file = fileSystem.file('example.dart')
+      ..writeAsStringSync('''
+// Some license
+
+//\t@dart = 2.9
+''');
+
+    expect(determineLanguageVersion(file, null), '//\t@dart = 2.9');
+  });
+
   testWithoutContext('detects language version with tons of whitespace', () {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final File file = fileSystem.file('example.dart')
@@ -58,14 +82,81 @@ void main() {
     expect(determineLanguageVersion(file, null), null);
   });
 
+  testWithoutContext('does not detect language version in block comment', () {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final File file = fileSystem.file('example.dart')
+      ..writeAsStringSync('''
+// Some license
 
-  testWithoutContext('does not detect language version after import', () {
+/*
+@dart = 2.9
+*/
+''');
+
+    expect(determineLanguageVersion(file, null), null);
+  });
+
+  testWithoutContext('does not detect language version in nested block comment', () {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final File file = fileSystem.file('example.dart')
+      ..writeAsStringSync('''
+// Some license
+
+/* /*
+@dart = 2.9
+*/ */
+''');
+
+    expect(determineLanguageVersion(file, null), null);
+  });
+
+  testWithoutContext('does not detect language version in single line block comment', () {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final File file = fileSystem.file('example.dart')
+      ..writeAsStringSync('''
+// Some license
+
+/* @dart = 2.9 */
+''');
+
+    expect(determineLanguageVersion(file, null), null);
+  });
+
+  testWithoutContext('does not detect language version after import declaration', () {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final File file = fileSystem.file('example.dart')
       ..writeAsStringSync('''
 // Some license
 
 import 'dart:ui' as ui;
+
+// @dart = 2.9
+''');
+
+    expect(determineLanguageVersion(file, null), null);
+  });
+
+  testWithoutContext('does not detect language version after part declaration', () {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final File file = fileSystem.file('example.dart')
+      ..writeAsStringSync('''
+// Some license
+
+part of 'foo.dart';
+
+// @dart = 2.9
+''');
+
+    expect(determineLanguageVersion(file, null), null);
+  });
+
+  testWithoutContext('does not detect language version after library declaration', () {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final File file = fileSystem.file('example.dart')
+      ..writeAsStringSync('''
+// Some license
+
+library funstuff;
 
 // @dart = 2.9
 ''');

--- a/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
@@ -102,9 +102,56 @@ void main() {
       ..writeAsStringSync('''
 // Some license
 
-/* /*
+/*
+/*
 @dart = 2.9
-*/ */
+*/
+*/
+''');
+
+    expect(determineLanguageVersion(file, null), null);
+  });
+
+  testWithoutContext('detects language version after nested block comment', () {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final File file = fileSystem.file('example.dart')
+      ..writeAsStringSync('''
+// Some license
+
+/* /*
+*/
+*/
+// @dart = 2.9
+''');
+
+    expect(determineLanguageVersion(file, null), '// @dart = 2.9');
+  });
+
+  testWithoutContext('does not crash with unbalanced opening block comments', () {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final File file = fileSystem.file('example.dart')
+      ..writeAsStringSync('''
+// Some license
+
+/*
+/*
+*/
+@dart = 2.9
+''');
+
+    expect(determineLanguageVersion(file, null), null);
+  });
+
+  testWithoutContext('does not crash with unbalanced closing block comments', () {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final File file = fileSystem.file('example.dart')
+      ..writeAsStringSync('''
+// Some license
+
+/*
+*/
+*/
+@dart = 2.9
 ''');
 
     expect(determineLanguageVersion(file, null), null);

--- a/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
@@ -1,4 +1,6 @@
-
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';


### PR DESCRIPTION
## Description

Fixes https://github.com/flutter/flutter/issues/57592
Fixes https://github.com/flutter/flutter/issues/59295

Ensure that the language version of the test/web generated entrypoint matches the language version of the test file to run, or the overall package language version if no annotation is provided.