### PR TITLE
flutter.gradle: collect list of Android plugins from .flutter-plugins-dependencies

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -372,17 +372,27 @@ class FlutterPlugin implements Plugin<Project> {
     }
 
     private Properties getPluginList() {
-        File pluginsFile = new File(project.projectDir.parentFile.parentFile, '.flutter-plugins')
-        Properties allPlugins = readPropertiesIfExist(pluginsFile)
         Properties androidPlugins = new Properties()
-        allPlugins.each { name, path ->
-            if (doesSupportAndroidPlatform(path)) {
-                androidPlugins.setProperty(name, path)
-            }
-            // TODO(amirh): log an error if this plugin was specified to be an Android
-            // plugin according to the new schema, and was missing a build.gradle file.
-            // https://github.com/flutter/flutter/issues/40784
+
+        def flutterProjectRoot = project.projectDir.parentFile.parentFile
+        def pluginsFile = new File(flutterProjectRoot, '.flutter-plugins-dependencies')
+        if (!pluginsFile.exists()) {
+            return androidPlugins
         }
+
+        def object = new JsonSlurper().parseText(pluginsFile.text)
+        assert object instanceof Map
+        assert object.plugins instanceof Map
+        assert object.plugins.android instanceof List
+        // Includes the Flutter plugins that support the Android platform.
+        object.plugins.android.each { androidPlugin ->
+            assert androidPlugin.name instanceof String
+            assert androidPlugin.path instanceof String
+            def pluginDirectory = new File(androidPlugin.path, 'android')
+            assert pluginDirectory.exists()
+            androidPlugins.setProperty(androidPlugin.name, androidPlugin.path)
+        }
+
         return androidPlugins
     }
 


### PR DESCRIPTION
## Description

*Note: This is a clone of PR #57907, which got merged and later rolled back.*

Some packages include transitive dependencies to their web version, e.g.
- *location* -> *location_web*
- *firebase_core* -> *firebase_core_web*

PR #54407 introduced a change to the default `settings.gradle` file. The required plugins are now loaded through `app_plugin_loader.gradle`, which retrieves the list from `.flutter-plugins-dependencies`. Instead, the current logic in `flutter.gradle` still relies on `.flutter-plugins`, which lists transitive non-Android plugins.

This leads to a warning in the build:
```
Plugin project :location_web not found. Please update settings.gradle.
```

The pull request now uses the same logic as in `app_plugin_loader.gradle` to retrieve the list of Android plugins.

*Note:* The same logic now exists in 3 different locations and should be extracted to a separate file. The 3 locations are:
- *app_plugin_loader.gradle*
- *module_plugin_loader.gradle*
- *flutter.gradle*

## Related Issues

#57907 (original PR)

#55827
#57863  
#59732

## Tests

Please help me understand if / where to add tests for the changes. Thank you!

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
