### PR TITLE
Dismiss modal routes with a keyboard shortcut

### DIFF
--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -1154,21 +1154,20 @@ class SelectIntent extends Intent {}
 /// select something. It is not bound to any key by default.
 abstract class SelectAction extends Action<SelectIntent> {}
 
-/// An [Intent] that cancels or dismisses the currently focused widget.
+/// An [Intent] that dismisses the currently focused widget.
 ///
-/// By default, this intent is bound to [LogicalKeyboardKey.escape],
-/// and [LogicalKeyboardKey.gameButtonB] in the
-/// default keyboard shortcuts in [WidgetsApp].
+/// The [WidgetsApp.defaultShortcuts] binds this intent to the
+/// [LogicalKeyboardKey.escape] and [LogicalKeyboardKey.gameButtonB] keys.
 ///
 /// See also:
 ///  - [ModalRoute] which listens for this intent to dismiss modal routes
 ///    (dialogs, pop-up menus, drawers, etc).
-class CancelIntent extends Intent {
-  /// Creates a const [CancelIntent].
-  const CancelIntent();
+class DismissIntent extends Intent {
+  /// Creates a const [DismissIntent].
+  const DismissIntent();
 }
 
-/// An action that cancels or dismisses the focused widget.
+/// An action that dismisses the focused widget.
 ///
-/// This is an abstract class that serves as a base class for cancel actions.
-abstract class CancelAction extends Action<CancelIntent> {}
+/// This is an abstract class that serves as a base class for dismiss actions.
+abstract class DismissAction extends Action<DismissIntent> {}

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -1153,3 +1153,22 @@ class SelectIntent extends Intent {}
 /// This is an abstract class that serves as a base class for actions that
 /// select something. It is not bound to any key by default.
 abstract class SelectAction extends Action<SelectIntent> {}
+
+/// An [Intent] that cancels or dismisses the currently focused widget.
+///
+/// By default, this intent is bound to [LogicalKeyboardKey.escape],
+/// and [LogicalKeyboardKey.gameButtonB] in the
+/// default keyboard shortcuts in [WidgetsApp].
+///
+/// See also:
+///  - [ModalRoute] which listens for this intent to dismiss modal routes
+///    (dialogs, pop-up menus, drawers, etc).
+class CancelIntent extends Intent {
+  /// Creates a const [CancelIntent].
+  const CancelIntent();
+}
+
+/// An action that cancels or dismisses the focused widget.
+///
+/// This is an abstract class that serves as a base class for cancel actions.
+abstract class CancelAction extends Action<CancelIntent> {}

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -853,6 +853,10 @@ class WidgetsApp extends StatefulWidget {
     LogicalKeySet(LogicalKeyboardKey.space): const ActivateIntent(),
     LogicalKeySet(LogicalKeyboardKey.gameButtonA): const ActivateIntent(),
 
+    // Dismissal
+    LogicalKeySet(LogicalKeyboardKey.escape): const DismissIntent(),
+    LogicalKeySet(LogicalKeyboardKey.gameButtonB): const ActivateIntent(),
+
     // Keyboard traversal.
     LogicalKeySet(LogicalKeyboardKey.tab): const NextFocusIntent(),
     LogicalKeySet(LogicalKeyboardKey.shift, LogicalKeyboardKey.tab): const PreviousFocusIntent(),
@@ -874,6 +878,9 @@ class WidgetsApp extends StatefulWidget {
   static final Map<LogicalKeySet, Intent> _defaultWebShortcuts = <LogicalKeySet, Intent>{
     // Activation
     LogicalKeySet(LogicalKeyboardKey.space): const ActivateIntent(),
+
+    // Dismissal
+    LogicalKeySet(LogicalKeyboardKey.escape): const DismissIntent(),
 
     // Keyboard traversal.
     LogicalKeySet(LogicalKeyboardKey.tab): const NextFocusIntent(),

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -852,8 +852,8 @@ class WidgetsApp extends StatefulWidget {
     LogicalKeySet(LogicalKeyboardKey.space): const ActivateIntent(),
     LogicalKeySet(LogicalKeyboardKey.gameButtonA): const ActivateIntent(),
 
-    // Cancel
-    LogicalKeySet(LogicalKeyboardKey.escape): const CancelIntent(),
+    // Dismissal
+    LogicalKeySet(LogicalKeyboardKey.escape): const DismissIntent(),
     LogicalKeySet(LogicalKeyboardKey.gameButtonB): const ActivateIntent(),
 
     // Keyboard traversal.
@@ -878,8 +878,8 @@ class WidgetsApp extends StatefulWidget {
     // Activation
     LogicalKeySet(LogicalKeyboardKey.space): const ActivateIntent(),
 
-    // Cancel
-    LogicalKeySet(LogicalKeyboardKey.escape): const CancelIntent(),
+    // Dismissal
+    LogicalKeySet(LogicalKeyboardKey.escape): const DismissIntent(),
 
     // Keyboard traversal.
     LogicalKeySet(LogicalKeyboardKey.tab): const NextFocusIntent(),
@@ -900,8 +900,8 @@ class WidgetsApp extends StatefulWidget {
     LogicalKeySet(LogicalKeyboardKey.enter): const ActivateIntent(),
     LogicalKeySet(LogicalKeyboardKey.space): const ActivateIntent(),
 
-    // Cancel
-    LogicalKeySet(LogicalKeyboardKey.escape): const CancelIntent(),
+    // Dismissal
+    LogicalKeySet(LogicalKeyboardKey.escape): const DismissIntent(),
 
     // Keyboard traversal
     LogicalKeySet(LogicalKeyboardKey.tab): const NextFocusIntent(),

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -22,6 +22,7 @@ import 'media_query.dart';
 import 'navigator.dart';
 import 'pages.dart';
 import 'performance_overlay.dart';
+import 'routes.dart';
 import 'scrollable.dart';
 import 'semantics_debugger.dart';
 import 'shortcuts.dart';
@@ -892,6 +893,9 @@ class WidgetsApp extends StatefulWidget {
     // Activation
     LogicalKeySet(LogicalKeyboardKey.enter): const ActivateIntent(),
     LogicalKeySet(LogicalKeyboardKey.space): const ActivateIntent(),
+
+    // Dismissal
+    LogicalKeySet(LogicalKeyboardKey.escape): const DismissIntent(),
 
     // Keyboard traversal
     LogicalKeySet(LogicalKeyboardKey.tab): const NextFocusIntent(),

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -22,7 +22,6 @@ import 'media_query.dart';
 import 'navigator.dart';
 import 'pages.dart';
 import 'performance_overlay.dart';
-import 'routes.dart';
 import 'scrollable.dart';
 import 'semantics_debugger.dart';
 import 'shortcuts.dart';
@@ -853,8 +852,8 @@ class WidgetsApp extends StatefulWidget {
     LogicalKeySet(LogicalKeyboardKey.space): const ActivateIntent(),
     LogicalKeySet(LogicalKeyboardKey.gameButtonA): const ActivateIntent(),
 
-    // Dismissal
-    LogicalKeySet(LogicalKeyboardKey.escape): const DismissIntent(),
+    // Cancel
+    LogicalKeySet(LogicalKeyboardKey.escape): const CancelIntent(),
     LogicalKeySet(LogicalKeyboardKey.gameButtonB): const ActivateIntent(),
 
     // Keyboard traversal.
@@ -879,8 +878,8 @@ class WidgetsApp extends StatefulWidget {
     // Activation
     LogicalKeySet(LogicalKeyboardKey.space): const ActivateIntent(),
 
-    // Dismissal
-    LogicalKeySet(LogicalKeyboardKey.escape): const DismissIntent(),
+    // Cancel
+    LogicalKeySet(LogicalKeyboardKey.escape): const CancelIntent(),
 
     // Keyboard traversal.
     LogicalKeySet(LogicalKeyboardKey.tab): const NextFocusIntent(),
@@ -901,8 +900,8 @@ class WidgetsApp extends StatefulWidget {
     LogicalKeySet(LogicalKeyboardKey.enter): const ActivateIntent(),
     LogicalKeySet(LogicalKeyboardKey.space): const ActivateIntent(),
 
-    // Dismissal
-    LogicalKeySet(LogicalKeyboardKey.escape): const DismissIntent(),
+    // Cancel
+    LogicalKeySet(LogicalKeyboardKey.escape): const CancelIntent(),
 
     // Keyboard traversal
     LogicalKeySet(LogicalKeyboardKey.tab): const NextFocusIntent(),

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -652,9 +652,9 @@ mixin LocalHistoryRoute<T> on Route<T> {
   }
 }
 
-class _DismissModalAction extends CancelAction {
+class _DismissModalAction extends DismissAction {
   @override
-  Object invoke(CancelIntent intent) {
+  Object invoke(DismissIntent intent) {
     return Navigator.of(primaryFocus.context).maybePop();
   }
 }
@@ -771,7 +771,7 @@ class _ModalScopeState<T> extends State<_ModalScope<T>> {
   }
 
   static final Map<Type, Action<Intent>> _actionMap = <Type, Action<Intent>>{
-    CancelIntent: _DismissModalAction(),
+    DismissIntent: _DismissModalAction(),
   };
 
   @override

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -652,10 +652,19 @@ mixin LocalHistoryRoute<T> on Route<T> {
   }
 }
 
+/// An [Intent] that requests dismissing the modal route containing the
+/// focused widget.
 class DismissIntent extends Intent {
+  /// Creates a const [DismissIntent].
   const DismissIntent();
 }
 
+/// An action that dismisses the modal route containing the
+/// focused widget.
+///
+/// By default, this action is bound to [LogicalKeyboardKey.escape],
+/// and [LogicalKeyboardKey.gameButtonB] in the
+/// default keyboard map in [WidgetsApp].
 class DismissAction extends Action<DismissIntent> {
   @override
   Object invoke(DismissIntent intent) {

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -652,22 +652,9 @@ mixin LocalHistoryRoute<T> on Route<T> {
   }
 }
 
-/// An [Intent] that requests dismissing the modal route containing the
-/// focused widget.
-class DismissIntent extends Intent {
-  /// Creates a const [DismissIntent].
-  const DismissIntent();
-}
-
-/// An action that dismisses the modal route containing the
-/// focused widget.
-///
-/// By default, this action is bound to [LogicalKeyboardKey.escape],
-/// and [LogicalKeyboardKey.gameButtonB] in the
-/// default keyboard map in [WidgetsApp].
-class DismissAction extends Action<DismissIntent> {
+class _DismissModalAction extends CancelAction {
   @override
-  Object invoke(DismissIntent intent) {
+  Object invoke(CancelIntent intent) {
     return Navigator.of(primaryFocus.context).maybePop();
   }
 }
@@ -784,7 +771,7 @@ class _ModalScopeState<T> extends State<_ModalScope<T>> {
   }
 
   static final Map<Type, Action<Intent>> _actionMap = <Type, Action<Intent>>{
-    DismissIntent: DismissAction(),
+    CancelIntent: _DismissModalAction(),
   };
 
   @override

--- a/packages/flutter/test/material/debug_test.dart
+++ b/packages/flutter/test/material/debug_test.dart
@@ -137,6 +137,8 @@ void main() {
       '     _FocusMarker\n'
       '     Semantics\n'
       '     FocusScope\n'
+      '     _ActionsMarker\n'
+      '     Actions\n'
       '     PageStorage\n'
       '     Offstage\n'
       '     _ModalScopeStatus\n'

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -8,6 +8,7 @@ import 'dart:collection';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
@@ -1318,6 +1319,28 @@ void main() {
       await tester.pump();
       expect(tester.takeException(), null);
     });
+  });
+
+  testWidgets('can be dismissed with escape keyboard shortcut', (WidgetTester tester) async {
+    final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+    await tester.pumpWidget(MaterialApp(
+      navigatorKey: navigatorKey,
+      home: const Text('dummy1'),
+    ));
+    final Element textOnPageOne = tester.element(find.text('dummy1'));
+
+    // Show a simple dialog
+    showDialog<void>(
+      context: textOnPageOne,
+      builder: (BuildContext context) => const Text('dialog1'),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('dialog1'), findsOneWidget);
+
+    // Try to dismiss the dialog with the shortcut key
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pumpAndSettle();
+    expect(find.text('dialog1'), findsNothing);
   });
 }
 


### PR DESCRIPTION
## Description

Currently there is no support for dismissing modal routes with the keyboard (usually with the 'escape' shortcut key). This PR adds a new general `DismissIntent` and corresponding `DismissAction`. The intent is mapped to the `escape` key in the default shortcut map, and modal routes (dialogs, popups, drawers, etc) will now look for this and dismiss themselves when it is triggered.

## Related Issues

#49809

## Tests

I added a simple test to verify that a modal dialog can be dismissed with the 'escape' key.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them?

- [x] No, no existing tests failed, so this is *not* a breaking change.
