### PR TITLE
Removed an unused static local key from ScrollAction.

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -909,9 +909,6 @@ class ScrollIntent extends Intent {
 /// size of the scroll window, and for [ScrollIncrementType.line], 50 logical
 /// pixels.
 class ScrollAction extends Action<ScrollIntent> {
-  /// The [LocalKey] that uniquely connects this action to a [ScrollIntent].
-  static const LocalKey key = ValueKey<Type>(ScrollAction);
-
   @override
   bool isEnabled(ScrollIntent intent) {
     final FocusNode focus = primaryFocus;


### PR DESCRIPTION
## Description

Simple cleanup of an unused static local key in `ScrollAction`.

## Tests

No tests were added for this, as it was an unused constant.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them?

- [x] No, no existing tests failed, so this is *not* a breaking change.
