### PR TITLE
InteractiveViewer mouse scale bug

### DIFF
--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -659,16 +659,17 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
 
   // Returns true iff the given _GestureType is enabled.
   bool _gestureIsSupported(_GestureType gestureType) {
-    if (gestureType == _GestureType.pan && !widget.panEnabled) {
-      return false;
+    switch (gestureType) {
+      case _GestureType.rotate:
+        return _rotateEnabled;
+
+      case _GestureType.scale:
+        return widget.scaleEnabled;
+
+      case _GestureType.pan:
+      default:
+        return widget.panEnabled;
     }
-    if (gestureType == _GestureType.scale && !widget.scaleEnabled) {
-      return false;
-    }
-    if (gestureType == _GestureType.rotate && !_rotateEnabled) {
-      return false;
-    }
-    return true;
   }
 
   // Handle the start of a gesture. All of pan, scale, and rotate are handled

--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -659,13 +659,13 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
 
   // Returns true iff the given _GestureType is enabled.
   bool _gestureIsSupported(_GestureType gestureType) {
-    if (_gestureType == _GestureType.pan && !widget.panEnabled) {
+    if (gestureType == _GestureType.pan && !widget.panEnabled) {
       return false;
     }
-    if (_gestureType == _GestureType.scale && !widget.scaleEnabled) {
+    if (gestureType == _GestureType.scale && !widget.scaleEnabled) {
       return false;
     }
-    if (_gestureType == _GestureType.rotate && !_rotateEnabled) {
+    if (gestureType == _GestureType.rotate && !_rotateEnabled) {
       return false;
     }
     return true;
@@ -841,6 +841,9 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
 
   // Handle mousewheel scroll events.
   void _receivedPointerSignal(PointerSignalEvent event) {
+    if (!_gestureIsSupported(_GestureType.scale)) {
+      return;
+    }
     if (event is PointerScrollEvent) {
       final RenderBox childRenderBox = _childKey.currentContext.findRenderObject() as RenderBox;
       final Size childSize = childRenderBox.size;

--- a/packages/flutter/test/widgets/gesture_utils.dart
+++ b/packages/flutter/test/widgets/gesture_utils.dart
@@ -1,0 +1,16 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Future<void> scrollAt(Offset position, WidgetTester tester) {
+  final TestPointer testPointer = TestPointer(1, PointerDeviceKind.mouse);
+  // Create a hover event so that |testPointer| has a location when generating the scroll.
+  testPointer.hover(position);
+  final HitTestResult result = tester.hitTestOnBinding(position);
+  return tester.sendEventToBinding(testPointer.scroll(const Offset(0.0, 20.0)), result);
+}

--- a/packages/flutter/test/widgets/interactive_viewer_test.dart
+++ b/packages/flutter/test/widgets/interactive_viewer_test.dart
@@ -4,10 +4,13 @@
 
 // @dart = 2.8
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math_64.dart' show Quad, Vector3, Matrix4;
+
+import 'gesture_utils.dart';
 
 void main() {
   group('InteractiveViewer', () {
@@ -401,6 +404,51 @@ void main() {
       final Offset newSceneFocalPoint = transformationController.toScene(viewportFocalPoint);
       expect(newSceneFocalPoint.dx, closeTo(sceneFocalPoint.dx, 1.0));
       expect(newSceneFocalPoint.dy, closeTo(sceneFocalPoint.dy, 1.0));
+    });
+
+    testWidgets('Can scale with mouse', (WidgetTester tester) async {
+      final TransformationController transformationController = TransformationController();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: InteractiveViewer(
+                transformationController: transformationController,
+                child: Container(width: 200.0, height: 200.0),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final Offset center = tester.getCenter(find.byType(InteractiveViewer));
+      await scrollAt(center, tester);
+      await tester.pumpAndSettle();
+
+      expect(transformationController.value.getMaxScaleOnAxis(), greaterThan(1.0));
+    });
+
+    testWidgets('Cannot scale with mouse when scale is disabled', (WidgetTester tester) async {
+      final TransformationController transformationController = TransformationController();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: InteractiveViewer(
+                transformationController: transformationController,
+                scaleEnabled: false,
+                child: Container(width: 200.0, height: 200.0),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final Offset center = tester.getCenter(find.byType(InteractiveViewer));
+      await scrollAt(center, tester);
+      await tester.pumpAndSettle();
+
+      expect(transformationController.value.getMaxScaleOnAxis(), equals(1.0));
     });
   });
 

--- a/packages/flutter/test/widgets/listener_test.dart
+++ b/packages/flutter/test/widgets/listener_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/gestures.dart';
 
+import 'gesture_utils.dart';
 
 void main() {
   testWidgets('Events bubble up the tree', (WidgetTester tester) async {
@@ -399,12 +400,4 @@ void main() {
       'listeners: down, move, up, cancel, signal',
     ]);
   });
-}
-
-Future<void> scrollAt(Offset position, WidgetTester tester) {
-  final TestPointer testPointer = TestPointer(1, PointerDeviceKind.mouse);
-  // Create a hover event so that |testPointer| has a location when generating the scroll.
-  testPointer.hover(position);
-  final HitTestResult result = tester.hitTestOnBinding(position);
-  return tester.sendEventToBinding(testPointer.scroll(const Offset(0.0, 20.0)), result);
 }


### PR DESCRIPTION
## Description

InteractiveViewer wasn't respecting the `scaleEnabled` parameter when scaling was done with a mouse.

## Related Issues

Closes https://github.com/flutter/flutter/issues/59411

## Tests

I added the following tests:

  * Test that scaling with the mouse works normally, and test that it doesn't work when `scaleEnabled` is false.

## Breaking Change

None