### PR TITLE
[flutter_tools] deprecate build aot

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -52,7 +52,10 @@ class BuildAotCommand extends BuildSubCommand with TargetPlatformBasedDevelopmen
   final String name = 'aot';
 
   @override
-  final String description = "Build an ahead-of-time compiled snapshot of your app's Dart code.";
+  bool get deprecated => true;
+
+  @override
+  final String description = "(deprecated) Build an ahead-of-time compiled snapshot of your app's Dart code.";
 
   @override
   Future<FlutterCommandResult> runCommand() async {

--- a/packages/flutter_tools/lib/src/commands/build_aot.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aot.dart
@@ -51,6 +51,7 @@ class BuildAotCommand extends BuildSubCommand with TargetPlatformBasedDevelopmen
   @override
   final String name = 'aot';
 
+  // TODO(jonahwilliams): remove after https://github.com/flutter/flutter/issues/49562 is resolved.
   @override
   bool get deprecated => true;
 

--- a/packages/flutter_tools/test/integration.shard/command_output_test.dart
+++ b/packages/flutter_tools/test/integration.shard/command_output_test.dart
@@ -62,4 +62,20 @@ void main() {
 
     expect(result.stdout, isEmpty);
   });
+
+  test('flutter build aot is deprecated', () async {
+    final String flutterBin = globals.fs.path.join(getFlutterRoot(), 'bin', 'flutter');
+    final ProcessResult result = await const LocalProcessManager().run(<String>[
+      flutterBin,
+      'build',
+      '-h',
+      '-v',
+    ]);
+
+    // Deprecated.
+    expect(result.stdout, isNot(contains('aot')));
+
+    // Only printed by verbose tool.
+    expect(result.stdout, isNot(contains('exiting with code 0')));
+  });
 }


### PR DESCRIPTION
## Description

This command was previously used by the re-entrant build scripts in xcode_backend.sh and build.gradle. These have since been refactored to use flutter assemble.

Deprecation the command in preparation for removal in a future release of flutter. The only current use is a test on HHH

https://github.com/flutter/flutter/issues/49562