### PR TITLE
[flutter_tools] skip deferred loading test for l10n generation

### DIFF
--- a/packages/flutter_tools/test/integration.shard/gen_l10n_test.dart
+++ b/packages/flutter_tools/test/integration.shard/gen_l10n_test.dart
@@ -163,5 +163,5 @@ void main() {
     flutter = FlutterRunTestDriver(tempDir);
     final StringBuffer stdout = await runApp();
     expectOutput(stdout);
-  });
+  }, skip: true); // deferred loading support is a WIP for the VM/Flutter.
 }

--- a/packages/flutter_tools/test/integration.shard/gen_l10n_test.dart
+++ b/packages/flutter_tools/test/integration.shard/gen_l10n_test.dart
@@ -163,5 +163,5 @@ void main() {
     flutter = FlutterRunTestDriver(tempDir);
     final StringBuffer stdout = await runApp();
     expectOutput(stdout);
-  }, skip: true); // deferred loading support is a WIP for the VM/Flutter.
+  }, skip: true); // https://github.com/flutter/flutter/issues/59509 deferred loading support is a WIP for the VM/Flutter.
 }


### PR DESCRIPTION
## Description

this test is generating code without a loadLibrary call, which is invalid if deferred loading support is added.

https://github.com/dart-lang/sdk/issues/42350
https://github.com/dart-lang/sdk/issues/41974