### PR TITLE
Remove last references to ideviceinstaller

### DIFF
--- a/dev/bots/codesign.dart
+++ b/dev/bots/codesign.dart
@@ -68,7 +68,6 @@ List<String> get binariesWithEntitlements => List<String>.unmodifiable(<String>[
   'idevicescreenshot',
   'idevicesyslog',
   'libimobiledevice.6.dylib',
-  'ideviceinstaller',
   'libplist.3.dylib',
   'iproxy',
   'libusbmuxd.4.dylib',

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -45,7 +45,6 @@ enum Artifact {
   iosDeploy,
   idevicesyslog,
   idevicescreenshot,
-  ideviceinstaller,
   iproxy,
   /// The root of the Linux desktop sources.
   linuxDesktopPath,
@@ -116,8 +115,6 @@ String _artifactToFileName(Artifact artifact, [ TargetPlatform platform, BuildMo
       return 'idevicesyslog';
     case Artifact.idevicescreenshot:
       return 'idevicescreenshot';
-    case Artifact.ideviceinstaller:
-      return 'ideviceinstaller';
     case Artifact.iproxy:
       return 'iproxy';
     case Artifact.linuxDesktopPath:
@@ -272,9 +269,6 @@ class CachedArtifacts extends Artifacts {
       case Artifact.iosDeploy:
         final String artifactFileName = _artifactToFileName(artifact);
         return _cache.getArtifactDirectory('ios-deploy').childFile(artifactFileName).path;
-      case Artifact.ideviceinstaller:
-        final String artifactFileName = _artifactToFileName(artifact);
-        return _cache.getArtifactDirectory('ideviceinstaller').childFile(artifactFileName).path;
       case Artifact.iproxy:
         final String artifactFileName = _artifactToFileName(artifact);
         return _cache.getArtifactDirectory('usbmuxd').childFile(artifactFileName).path;
@@ -533,8 +527,6 @@ class LocalEngineArtifacts extends Artifacts {
       case Artifact.idevicescreenshot:
       case Artifact.idevicesyslog:
         return _cache.getArtifactDirectory('libimobiledevice').childFile(artifactFileName).path;
-      case Artifact.ideviceinstaller:
-        return _cache.getArtifactDirectory('ideviceinstaller').childFile(artifactFileName).path;
       case Artifact.iosDeploy:
         return _cache.getArtifactDirectory('ios-deploy').childFile(artifactFileName).path;
       case Artifact.iproxy:

--- a/packages/flutter_tools/lib/src/ios/ios_workflow.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_workflow.dart
@@ -15,7 +15,7 @@ class IOSWorkflow implements Workflow {
   @override
   bool get canListDevices => globals.xcode.isInstalledAndMeetsVersionCheck && globals.xcode.isSimctlInstalled;
 
-  // We need xcode to launch simulator devices, and ideviceinstaller and ios-deploy
+  // We need xcode to launch simulator devices, and ios-deploy
   // for real devices.
   @override
   bool get canLaunchDevices => globals.xcode.isInstalledAndMeetsVersionCheck;


### PR DESCRIPTION
## Description

Remove artifacts and any remaining references to ideviceinstaller.

## Related Issues

Usage was removed in #50772
See https://github.com/flutter/flutter/issues/59506

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*