### PR TITLE
Revert "Modernize selection menu appearance"

### DIFF
--- a/packages/flutter/lib/src/material/material_localizations.dart
+++ b/packages/flutter/lib/src/material/material_localizations.dart
@@ -899,19 +899,19 @@ class DefaultMaterialLocalizations implements MaterialLocalizations {
   String get continueButtonLabel => 'CONTINUE';
 
   @override
-  String get copyButtonLabel => 'Copy';
+  String get copyButtonLabel => 'COPY';
 
   @override
-  String get cutButtonLabel => 'Cut';
+  String get cutButtonLabel => 'CUT';
 
   @override
   String get okButtonLabel => 'OK';
 
   @override
-  String get pasteButtonLabel => 'Paste';
+  String get pasteButtonLabel => 'PASTE';
 
   @override
-  String get selectAllButtonLabel => 'Select all';
+  String get selectAllButtonLabel => 'SELECT ALL';
 
   @override
   String get viewLicensesButtonLabel => 'VIEW LICENSES';

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -175,7 +175,7 @@ void main() {
 
   setUp(() async {
     EditableText.debugDeterministicCursor = false;
-    // Fill the clipboard so that the Paste option is available in the text
+    // Fill the clipboard so that the PASTE option is available in the text
     // selection menu.
     await Clipboard.setData(const ClipboardData(text: 'Clipboard data'));
   });

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -507,7 +507,7 @@ void main() {
     );
 
     // Default US "select all" text.
-    expect(find.text('Select all'), findsOneWidget);
+    expect(find.text('SELECT ALL'), findsOneWidget);
     // Default Cupertino US "select all" text.
     expect(find.text('Select All'), findsOneWidget);
   });

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -73,7 +73,7 @@ void main() {
     fieldLabelText = null;
     helpText = null;
 
-    // Fill the clipboard so that the Paste option is available in the text
+    // Fill the clipboard so that the PASTE option is available in the text
     // selection menu.
     SystemChannels.platform.setMockMethodCallHandler(mockClipboard.handleMethodCall);
     await Clipboard.setData(const ClipboardData(text: 'Clipboard data'));

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -32,7 +32,7 @@ void main() {
   final MockClipboard mockClipboard = MockClipboard();
 
   setUp(() async {
-    // Fill the clipboard so that the Paste option is available in the text
+    // Fill the clipboard so that the PASTE option is available in the text
     // selection menu.
     SystemChannels.platform.setMockMethodCallHandler(mockClipboard.handleMethodCall);
     await Clipboard.setData(const ClipboardData(text: 'Clipboard data'));

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -146,7 +146,7 @@ void main() {
 
   setUp(() async {
     debugResetSemanticsIdCounter();
-    // Fill the clipboard so that the Paste option is available in the text
+    // Fill the clipboard so that the PASTE option is available in the text
     // selection menu.
     await Clipboard.setData(const ClipboardData(text: 'Clipboard data'));
   });
@@ -445,7 +445,7 @@ void main() {
     await tester.pump(const Duration(seconds: 1));
 
     // Sanity check that the toolbar widget exists.
-    expect(find.text('Paste'), findsOneWidget);
+    expect(find.text('PASTE'), findsOneWidget);
 
     await expectLater(
       // The toolbar exists in the Overlay above the MaterialApp.
@@ -627,11 +627,11 @@ void main() {
     await tester.tapAt(textfieldStart + const Offset(150.0, 9.0));
     await tester.pump();
 
-    // Selected text shows 'Copy', and not 'Paste', 'Cut', 'Select all'.
-    expect(find.text('Paste'), findsNothing);
-    expect(find.text('Copy'), findsOneWidget);
-    expect(find.text('Cut'), findsNothing);
-    expect(find.text('Select all'), findsNothing);
+    // Selected text shows 'COPY', and not 'PASTE', 'CUT', 'SELECT ALL'.
+    expect(find.text('PASTE'), findsNothing);
+    expect(find.text('COPY'), findsOneWidget);
+    expect(find.text('CUT'), findsNothing);
+    expect(find.text('SELECT ALL'), findsNothing);
   },
     variant: const TargetPlatformVariant(<TargetPlatform>{
       TargetPlatform.android,
@@ -980,13 +980,13 @@ void main() {
       ),
     ));
 
-    expect(find.text('Paste'), findsNothing);
+    expect(find.text('PASTE'), findsNothing);
 
     final Offset emptyPos = textOffsetToPosition(tester, 0);
     await tester.longPressAt(emptyPos, pointer: 7);
     await tester.pumpAndSettle();
 
-    expect(find.text('Paste'), findsOneWidget);
+    expect(find.text('PASTE'), findsOneWidget);
   });
 
   testWidgets('Entering text hides selection handle caret', (WidgetTester tester) async {
@@ -1092,9 +1092,9 @@ void main() {
     await tester.pumpAndSettle();
 
     // Context menu should not have paste and cut.
-    expect(find.text('Copy'), findsOneWidget);
-    expect(find.text('Paste'), findsNothing);
-    expect(find.text('Cut'), findsNothing);
+    expect(find.text('COPY'), findsOneWidget);
+    expect(find.text('PASTE'), findsNothing);
+    expect(find.text('CUT'), findsNothing);
   });
 
   testWidgets('does not paint toolbar when no options available', (WidgetTester tester) async {
@@ -1630,14 +1630,14 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 200)); // skip past the frame where the opacity is zero
 
-    // Select all should select all the text.
-    await tester.tap(find.text('Select all'));
+    // SELECT ALL should select all the text.
+    await tester.tap(find.text('SELECT ALL'));
     await tester.pump();
     expect(controller.selection.baseOffset, 0);
     expect(controller.selection.extentOffset, testValue.length);
 
-    // Copy should reset the selection.
-    await tester.tap(find.text('Copy'));
+    // COPY should reset the selection.
+    await tester.tap(find.text('COPY'));
     await skipPastScrollingAnimation(tester);
     expect(controller.selection.isCollapsed, true);
 
@@ -1661,8 +1661,8 @@ void main() {
     expect(controller.selection.baseOffset, testValue.indexOf('e'));
     expect(controller.selection.extentOffset, testValue.indexOf('e'));
 
-    // Paste right before the 'e'.
-    await tester.tap(find.text('Paste'));
+    // PASTE right before the 'e'.
+    await tester.tap(find.text('PASTE'));
     await tester.pump();
     expect(controller.text, 'abc d${testValue}ef ghi');
   });
@@ -1673,7 +1673,7 @@ void main() {
     await tester.tapAt(tester.getCenter(find.byType(EditableText)));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 200)); // skip past the frame where the opacity is zero
-    expect(find.text('Select all'), findsNothing);
+    expect(find.text('SELECT ALL'), findsNothing);
 
     // Tap the selection handle to bring up the "paste / select all" menu for
     // the last line of text.
@@ -1719,7 +1719,7 @@ void main() {
       await _showSelectionMenuAt(tester, controller, testValue.indexOf('e'));
 
       // Verify the selection toolbar position is below the text.
-      Offset toolbarTopLeft = tester.getTopLeft(find.text('Select all'));
+      Offset toolbarTopLeft = tester.getTopLeft(find.text('SELECT ALL'));
       Offset textFieldTopLeft = tester.getTopLeft(find.byType(TextField));
       expect(textFieldTopLeft.dy, lessThan(toolbarTopLeft.dy));
 
@@ -1740,7 +1740,7 @@ void main() {
       await _showSelectionMenuAt(tester, controller, testValue.indexOf('e'));
 
       // Verify the selection toolbar position
-      toolbarTopLeft = tester.getTopLeft(find.text('Select all'));
+      toolbarTopLeft = tester.getTopLeft(find.text('SELECT ALL'));
       textFieldTopLeft = tester.getTopLeft(find.byType(TextField));
       expect(toolbarTopLeft.dy, lessThan(textFieldTopLeft.dy));
     },
@@ -1766,7 +1766,7 @@ void main() {
         ),
       ));
 
-      expect(find.text('Select all'), findsNothing);
+      expect(find.text('SELECT ALL'), findsNothing);
       const String testValue = 'abc\ndef\nghi\njkl\nmno\npqr';
       await tester.enterText(find.byType(TextField), testValue);
       await skipPastScrollingAnimation(tester);
@@ -1774,8 +1774,8 @@ void main() {
       // Show the selection menu on the first line and verify the selection
       // toolbar position is below the first line.
       await _showSelectionMenuAt(tester, controller, testValue.indexOf('c'));
-      expect(find.text('Select all'), findsOneWidget);
-      final Offset firstLineToolbarTopLeft = tester.getTopLeft(find.text('Select all'));
+      expect(find.text('SELECT ALL'), findsOneWidget);
+      final Offset firstLineToolbarTopLeft = tester.getTopLeft(find.text('SELECT ALL'));
       final Offset firstLineTopLeft = textOffsetToPosition(tester, testValue.indexOf('a'));
       expect(firstLineTopLeft.dy, lessThan(firstLineToolbarTopLeft.dy));
 
@@ -1783,8 +1783,8 @@ void main() {
       // selection toolbar position is above that line and above the first
       // line's toolbar.
       await _showSelectionMenuAt(tester, controller, testValue.indexOf('o'));
-      expect(find.text('Select all'), findsOneWidget);
-      final Offset penultimateLineToolbarTopLeft = tester.getTopLeft(find.text('Select all'));
+      expect(find.text('SELECT ALL'), findsOneWidget);
+      final Offset penultimateLineToolbarTopLeft = tester.getTopLeft(find.text('SELECT ALL'));
       final Offset penultimateLineTopLeft = textOffsetToPosition(tester, testValue.indexOf('p'));
       expect(penultimateLineToolbarTopLeft.dy, lessThan(penultimateLineTopLeft.dy));
       expect(penultimateLineToolbarTopLeft.dy, lessThan(firstLineToolbarTopLeft.dy));
@@ -1793,8 +1793,8 @@ void main() {
       // toolbar position is above that line and below the position of the
       // second to last line's toolbar.
       await _showSelectionMenuAt(tester, controller, testValue.indexOf('r'));
-      expect(find.text('Select all'), findsOneWidget);
-      final Offset lastLineToolbarTopLeft = tester.getTopLeft(find.text('Select all'));
+      expect(find.text('SELECT ALL'), findsOneWidget);
+      final Offset lastLineToolbarTopLeft = tester.getTopLeft(find.text('SELECT ALL'));
       final Offset lastLineTopLeft = textOffsetToPosition(tester, testValue.indexOf('p'));
       expect(lastLineToolbarTopLeft.dy, lessThan(lastLineTopLeft.dy));
       expect(lastLineToolbarTopLeft.dy, greaterThan(penultimateLineToolbarTopLeft.dy));
@@ -1832,7 +1832,7 @@ void main() {
     await tester.pump();
 
     // Toolbar should fade in. Starting at 0% opacity.
-    final Element target = tester.element(find.text('Select all'));
+    final Element target = tester.element(find.text('SELECT ALL'));
     final FadeTransition opacity = target.findAncestorWidgetOfExactType<FadeTransition>();
     expect(opacity, isNotNull);
     expect(opacity.opacity.value, equals(0.0));
@@ -1942,10 +1942,10 @@ void main() {
     await tester.pumpAndSettle();
 
     // Should only have paste option when whole obscure text is selected.
-    expect(find.text('Paste'), findsOneWidget);
-    expect(find.text('Copy'), findsNothing);
-    expect(find.text('Cut'), findsNothing);
-    expect(find.text('Select all'), findsNothing);
+    expect(find.text('PASTE'), findsOneWidget);
+    expect(find.text('COPY'), findsNothing);
+    expect(find.text('CUT'), findsNothing);
+    expect(find.text('SELECT ALL'), findsNothing);
 
     // Long press at the end
     final Offset iPos = textOffsetToPosition(tester, 10);
@@ -1954,10 +1954,10 @@ void main() {
     await tester.pumpAndSettle();
 
     // Should have paste and select all options when collapse.
-    expect(find.text('Paste'), findsOneWidget);
-    expect(find.text('Select all'), findsOneWidget);
-    expect(find.text('Copy'), findsNothing);
-    expect(find.text('Cut'), findsNothing);
+    expect(find.text('PASTE'), findsOneWidget);
+    expect(find.text('SELECT ALL'), findsOneWidget);
+    expect(find.text('COPY'), findsNothing);
+    expect(find.text('CUT'), findsNothing);
   });
 
   testWidgets('TextField height with minLines unset', (WidgetTester tester) async {
@@ -2436,7 +2436,7 @@ void main() {
     expect(controller.selection.baseOffset, 5);
     expect(controller.selection.extentOffset, 50);
 
-    await tester.tap(find.text('Cut'));
+    await tester.tap(find.text('CUT'));
     await tester.pump();
     expect(controller.selection.isCollapsed, true);
     expect(controller.text, cutValue);
@@ -3234,7 +3234,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 200)); // skip past the frame where the opacity is zero
 
     Clipboard.setData(const ClipboardData(text: '一4二\n5三6'));
-    await tester.tap(find.text('Paste'));
+    await tester.tap(find.text('PASTE'));
     await tester.pump();
     // Puts 456 before the 2 in 123.
     expect(textController.text, '145623');
@@ -6047,14 +6047,14 @@ void main() {
       await tester.pump(const Duration(milliseconds: 50));
       await tester.tapAt(textOffsetToPosition(tester, 0));
       await tester.pumpAndSettle();
-      expect(find.text('Paste'), findsOneWidget);
+      expect(find.text('PASTE'), findsOneWidget);
 
       // Double tap again keeps the selection menu visible.
       await tester.tapAt(textOffsetToPosition(tester, 0));
       await tester.pump(const Duration(milliseconds: 50));
       await tester.tapAt(textOffsetToPosition(tester, 0));
       await tester.pumpAndSettle();
-      expect(find.text('Paste'), findsOneWidget);
+      expect(find.text('PASTE'), findsOneWidget);
     },
   );
 
@@ -6079,12 +6079,12 @@ void main() {
       // Long press shows the selection menu.
       await tester.longPressAt(textOffsetToPosition(tester, 0));
       await tester.pumpAndSettle();
-      expect(find.text('Paste'), findsOneWidget);
+      expect(find.text('PASTE'), findsOneWidget);
 
       // Long press again keeps the selection menu visible.
       await tester.longPressAt(textOffsetToPosition(tester, 0));
       await tester.pump();
-      expect(find.text('Paste'), findsOneWidget);
+      expect(find.text('PASTE'), findsOneWidget);
     },
   );
 
@@ -6109,12 +6109,12 @@ void main() {
       // Long press shows the selection menu.
       await tester.longPress(find.byType(TextField));
       await tester.pumpAndSettle();
-      expect(find.text('Paste'), findsOneWidget);
+      expect(find.text('PASTE'), findsOneWidget);
 
       // Tap hides the selection menu.
       await tester.tap(find.byType(TextField));
       await tester.pump();
-      expect(find.text('Paste'), findsNothing);
+      expect(find.text('PASTE'), findsNothing);
     },
   );
 
@@ -6141,10 +6141,10 @@ void main() {
       await tester.pump();
 
       // Long press shows the selection menu.
-      expect(find.text('Paste'), findsNothing);
+      expect(find.text('PASTE'), findsNothing);
       await tester.longPress(find.byType(TextField));
       await tester.pumpAndSettle();
-      expect(find.text('Paste'), findsOneWidget);
+      expect(find.text('PASTE'), findsOneWidget);
     },
   );
 

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -338,8 +338,8 @@ void main() {
     await tester.pump();
 
     // Context menu should not have paste.
-    expect(find.text('Select all'), findsOneWidget);
-    expect(find.text('Paste'), findsNothing);
+    expect(find.text('SELECT ALL'), findsOneWidget);
+    expect(find.text('PASTE'), findsNothing);
 
     final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
     final RenderEditable renderEditable = editableTextState.renderEditable;

--- a/packages/flutter/test/material/text_selection_test.dart
+++ b/packages/flutter/test/material/text_selection_test.dart
@@ -113,10 +113,10 @@ void main() {
       ));
 
       // Initially, the menu isn't shown at all.
-      expect(find.text('Cut'), findsNothing);
-      expect(find.text('Copy'), findsNothing);
-      expect(find.text('Paste'), findsNothing);
-      expect(find.text('Select all'), findsNothing);
+      expect(find.text('CUT'), findsNothing);
+      expect(find.text('COPY'), findsNothing);
+      expect(find.text('PASTE'), findsNothing);
+      expect(find.text('SELECT ALL'), findsNothing);
       expect(find.byType(IconButton), findsNothing);
 
       // Tap to place the cursor in the field, then tap the handle to show the
@@ -132,10 +132,10 @@ void main() {
       final Offset handlePos = endpoints[0].point + const Offset(0.0, 1.0);
       await tester.tapAt(handlePos, pointer: 7);
       await tester.pumpAndSettle();
-      expect(find.text('Cut'), findsNothing);
-      expect(find.text('Copy'), findsNothing);
-      expect(find.text('Paste'), findsOneWidget);
-      expect(find.text('Select all'), findsOneWidget);
+      expect(find.text('CUT'), findsNothing);
+      expect(find.text('COPY'), findsNothing);
+      expect(find.text('PASTE'), findsOneWidget);
+      expect(find.text('SELECT ALL'), findsOneWidget);
       expect(find.byType(IconButton), findsNothing);
 
       // Long press to select a word and show the full selection menu.
@@ -145,10 +145,10 @@ void main() {
       await tester.pump();
 
       // The full menu is shown without the more button.
-      expect(find.text('Cut'), findsOneWidget);
-      expect(find.text('Copy'), findsOneWidget);
-      expect(find.text('Paste'), findsOneWidget);
-      expect(find.text('Select all'), findsOneWidget);
+      expect(find.text('CUT'), findsOneWidget);
+      expect(find.text('COPY'), findsOneWidget);
+      expect(find.text('PASTE'), findsOneWidget);
+      expect(find.text('SELECT ALL'), findsOneWidget);
       expect(find.byType(IconButton), findsNothing);
     },
       skip: isBrowser, // We do not use Flutter-rendered context menu on the Web
@@ -156,7 +156,7 @@ void main() {
     );
 
     testWidgets('When menu items don\'t fit, an overflow menu is used.', (WidgetTester tester) async {
-      // Set the screen size to more narrow, so that Select all can't fit.
+      // Set the screen size to more narrow, so that SELECT ALL can't fit.
       tester.binding.window.physicalSizeTestValue = const Size(1000, 800);
       addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
 
@@ -179,10 +179,10 @@ void main() {
       ));
 
       // Initially, the menu isn't shown at all.
-      expect(find.text('Cut'), findsNothing);
-      expect(find.text('Copy'), findsNothing);
-      expect(find.text('Paste'), findsNothing);
-      expect(find.text('Select all'), findsNothing);
+      expect(find.text('CUT'), findsNothing);
+      expect(find.text('COPY'), findsNothing);
+      expect(find.text('PASTE'), findsNothing);
+      expect(find.text('SELECT ALL'), findsNothing);
       expect(find.byType(IconButton), findsNothing);
 
       // Long press to show the menu.
@@ -191,24 +191,24 @@ void main() {
       await tester.pumpAndSettle();
 
       // The last button is missing, and a more button is shown.
-      expect(find.text('Cut'), findsOneWidget);
-      expect(find.text('Copy'), findsOneWidget);
-      expect(find.text('Paste'), findsOneWidget);
-      expect(find.text('Select all'), findsNothing);
+      expect(find.text('CUT'), findsOneWidget);
+      expect(find.text('COPY'), findsOneWidget);
+      expect(find.text('PASTE'), findsOneWidget);
+      expect(find.text('SELECT ALL'), findsNothing);
       expect(find.byType(IconButton), findsOneWidget);
-      final Offset cutOffset = tester.getTopLeft(find.text('Cut'));
+      final Offset cutOffset = tester.getTopLeft(find.text('CUT'));
 
       // Tapping the button shows the overflow menu.
       await tester.tap(find.byType(IconButton));
       await tester.pumpAndSettle();
-      expect(find.text('Cut'), findsNothing);
-      expect(find.text('Copy'), findsNothing);
-      expect(find.text('Paste'), findsNothing);
-      expect(find.text('Select all'), findsOneWidget);
+      expect(find.text('CUT'), findsNothing);
+      expect(find.text('COPY'), findsNothing);
+      expect(find.text('PASTE'), findsNothing);
+      expect(find.text('SELECT ALL'), findsOneWidget);
       expect(find.byType(IconButton), findsOneWidget);
 
       // The back button is at the bottom of the overflow menu.
-      final Offset selectAllOffset = tester.getTopLeft(find.text('Select all'));
+      final Offset selectAllOffset = tester.getTopLeft(find.text('SELECT ALL'));
       final Offset moreOffset = tester.getTopLeft(find.byType(IconButton));
       expect(moreOffset.dy, greaterThan(selectAllOffset.dy));
 
@@ -219,10 +219,10 @@ void main() {
       expect(find.byType(IconButton), findsOneWidget);
       await tester.tap(find.byType(IconButton));
       await tester.pumpAndSettle();
-      expect(find.text('Cut'), findsOneWidget);
-      expect(find.text('Copy'), findsOneWidget);
-      expect(find.text('Paste'), findsOneWidget);
-      expect(find.text('Select all'), findsNothing);
+      expect(find.text('CUT'), findsOneWidget);
+      expect(find.text('COPY'), findsOneWidget);
+      expect(find.text('PASTE'), findsOneWidget);
+      expect(find.text('SELECT ALL'), findsNothing);
       expect(find.byType(IconButton), findsOneWidget);
     },
       skip: isBrowser, // We do not use Flutter-rendered context menu on the Web
@@ -230,7 +230,7 @@ void main() {
     );
 
     testWidgets('A smaller menu bumps more items to the overflow menu.', (WidgetTester tester) async {
-      // Set the screen size so narrow that only Cut and Copy can fit.
+      // Set the screen size so narrow that only CUT and COPY can fit.
       tester.binding.window.physicalSizeTestValue = const Size(800, 800);
       addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
 
@@ -253,10 +253,10 @@ void main() {
       ));
 
       // Initially, the menu isn't shown at all.
-      expect(find.text('Cut'), findsNothing);
-      expect(find.text('Copy'), findsNothing);
-      expect(find.text('Paste'), findsNothing);
-      expect(find.text('Select all'), findsNothing);
+      expect(find.text('CUT'), findsNothing);
+      expect(find.text('COPY'), findsNothing);
+      expect(find.text('PASTE'), findsNothing);
+      expect(find.text('SELECT ALL'), findsNothing);
       expect(find.byType(IconButton), findsNothing);
 
       // Long press to show the menu.
@@ -265,29 +265,29 @@ void main() {
       await tester.pumpAndSettle();
 
       // The last two buttons are missing, and a more button is shown.
-      expect(find.text('Cut'), findsOneWidget);
-      expect(find.text('Copy'), findsOneWidget);
-      expect(find.text('Paste'), findsNothing);
-      expect(find.text('Select all'), findsNothing);
+      expect(find.text('CUT'), findsOneWidget);
+      expect(find.text('COPY'), findsOneWidget);
+      expect(find.text('PASTE'), findsNothing);
+      expect(find.text('SELECT ALL'), findsNothing);
       expect(find.byType(IconButton), findsOneWidget);
 
       // Tapping the button shows the overflow menu, which contains both buttons
       // missing from the main menu, and a back button.
       await tester.tap(find.byType(IconButton));
       await tester.pumpAndSettle();
-      expect(find.text('Cut'), findsNothing);
-      expect(find.text('Copy'), findsNothing);
-      expect(find.text('Paste'), findsOneWidget);
-      expect(find.text('Select all'), findsOneWidget);
+      expect(find.text('CUT'), findsNothing);
+      expect(find.text('COPY'), findsNothing);
+      expect(find.text('PASTE'), findsOneWidget);
+      expect(find.text('SELECT ALL'), findsOneWidget);
       expect(find.byType(IconButton), findsOneWidget);
 
       // Tapping the back button shows the selection menu again.
       await tester.tap(find.byType(IconButton));
       await tester.pumpAndSettle();
-      expect(find.text('Cut'), findsOneWidget);
-      expect(find.text('Copy'), findsOneWidget);
-      expect(find.text('Paste'), findsNothing);
-      expect(find.text('Select all'), findsNothing);
+      expect(find.text('CUT'), findsOneWidget);
+      expect(find.text('COPY'), findsOneWidget);
+      expect(find.text('PASTE'), findsNothing);
+      expect(find.text('SELECT ALL'), findsNothing);
       expect(find.byType(IconButton), findsOneWidget);
     },
       skip: isBrowser, // We do not use Flutter-rendered context menu on the Web
@@ -295,7 +295,7 @@ void main() {
     );
 
     testWidgets('When the menu renders below the text, the overflow menu back button is at the top.', (WidgetTester tester) async {
-      // Set the screen size to more narrow, so that Select all can't fit.
+      // Set the screen size to more narrow, so that SELECT ALL can't fit.
       tester.binding.window.physicalSizeTestValue = const Size(1000, 800);
       addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
 
@@ -319,10 +319,10 @@ void main() {
       ));
 
       // Initially, the menu isn't shown at all.
-      expect(find.text('Cut'), findsNothing);
-      expect(find.text('Copy'), findsNothing);
-      expect(find.text('Paste'), findsNothing);
-      expect(find.text('Select all'), findsNothing);
+      expect(find.text('CUT'), findsNothing);
+      expect(find.text('COPY'), findsNothing);
+      expect(find.text('PASTE'), findsNothing);
+      expect(find.text('SELECT ALL'), findsNothing);
       expect(find.byType(IconButton), findsNothing);
 
       // Long press to show the menu.
@@ -331,24 +331,24 @@ void main() {
       await tester.pumpAndSettle();
 
       // The last button is missing, and a more button is shown.
-      expect(find.text('Cut'), findsOneWidget);
-      expect(find.text('Copy'), findsOneWidget);
-      expect(find.text('Paste'), findsOneWidget);
-      expect(find.text('Select all'), findsNothing);
+      expect(find.text('CUT'), findsOneWidget);
+      expect(find.text('COPY'), findsOneWidget);
+      expect(find.text('PASTE'), findsOneWidget);
+      expect(find.text('SELECT ALL'), findsNothing);
       expect(find.byType(IconButton), findsOneWidget);
-      final Offset cutOffset = tester.getTopLeft(find.text('Cut'));
+      final Offset cutOffset = tester.getTopLeft(find.text('CUT'));
 
       // Tapping the button shows the overflow menu.
       await tester.tap(find.byType(IconButton));
       await tester.pumpAndSettle();
-      expect(find.text('Cut'), findsNothing);
-      expect(find.text('Copy'), findsNothing);
-      expect(find.text('Paste'), findsNothing);
-      expect(find.text('Select all'), findsOneWidget);
+      expect(find.text('CUT'), findsNothing);
+      expect(find.text('COPY'), findsNothing);
+      expect(find.text('PASTE'), findsNothing);
+      expect(find.text('SELECT ALL'), findsOneWidget);
       expect(find.byType(IconButton), findsOneWidget);
 
       // The back button is at the top of the overflow menu.
-      final Offset selectAllOffset = tester.getTopLeft(find.text('Select all'));
+      final Offset selectAllOffset = tester.getTopLeft(find.text('SELECT ALL'));
       final Offset moreOffset = tester.getTopLeft(find.byType(IconButton));
       expect(moreOffset.dy, lessThan(selectAllOffset.dy));
 
@@ -358,10 +358,10 @@ void main() {
       // Tapping the back button shows the selection menu again.
       await tester.tap(find.byType(IconButton));
       await tester.pumpAndSettle();
-      expect(find.text('Cut'), findsOneWidget);
-      expect(find.text('Copy'), findsOneWidget);
-      expect(find.text('Paste'), findsOneWidget);
-      expect(find.text('Select all'), findsNothing);
+      expect(find.text('CUT'), findsOneWidget);
+      expect(find.text('COPY'), findsOneWidget);
+      expect(find.text('PASTE'), findsOneWidget);
+      expect(find.text('SELECT ALL'), findsNothing);
       expect(find.byType(IconButton), findsOneWidget);
     },
       skip: isBrowser, // We do not use Flutter-rendered context menu on the Web
@@ -369,7 +369,7 @@ void main() {
     );
 
     testWidgets('When the menu items change, the menu is closed and _closedWidth reset.', (WidgetTester tester) async {
-      // Set the screen size to more narrow, so that Select all can't fit.
+      // Set the screen size to more narrow, so that SELECT ALL can't fit.
       tester.binding.window.physicalSizeTestValue = const Size(1000, 800);
       addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
 
@@ -393,10 +393,10 @@ void main() {
       ));
 
       // Initially, the menu isn't shown at all.
-      expect(find.text('Cut'), findsNothing);
-      expect(find.text('Copy'), findsNothing);
-      expect(find.text('Paste'), findsNothing);
-      expect(find.text('Select all'), findsNothing);
+      expect(find.text('CUT'), findsNothing);
+      expect(find.text('COPY'), findsNothing);
+      expect(find.text('PASTE'), findsNothing);
+      expect(find.text('SELECT ALL'), findsNothing);
       expect(find.byType(IconButton), findsNothing);
 
       // Tap to place the cursor and tap again to show the menu without a
@@ -412,30 +412,30 @@ void main() {
       final Offset handlePos = endpoints[0].point + const Offset(0.0, 1.0);
       await tester.tapAt(handlePos, pointer: 7);
       await tester.pumpAndSettle();
-      expect(find.text('Cut'), findsNothing);
-      expect(find.text('Copy'), findsNothing);
-      expect(find.text('Paste'), findsOneWidget);
-      expect(find.text('Select all'), findsOneWidget);
+      expect(find.text('CUT'), findsNothing);
+      expect(find.text('COPY'), findsNothing);
+      expect(find.text('PASTE'), findsOneWidget);
+      expect(find.text('SELECT ALL'), findsOneWidget);
       expect(find.byType(IconButton), findsNothing);
 
-      // Tap Select all and measure the usual position of Cut, without
+      // Tap SELECT ALL and measure the usual position of CUT, without
       // _closedWidth having been used yet.
-      await tester.tap(find.text('Select all'));
+      await tester.tap(find.text('SELECT ALL'));
       await tester.pumpAndSettle();
-      expect(find.text('Cut'), findsOneWidget);
-      expect(find.text('Copy'), findsOneWidget);
-      expect(find.text('Paste'), findsOneWidget);
-      expect(find.text('Select all'), findsNothing);
+      expect(find.text('CUT'), findsOneWidget);
+      expect(find.text('COPY'), findsOneWidget);
+      expect(find.text('PASTE'), findsOneWidget);
+      expect(find.text('SELECT ALL'), findsNothing);
       expect(find.byType(IconButton), findsNothing);
-      final Offset cutOffset = tester.getTopLeft(find.text('Cut'));
+      final Offset cutOffset = tester.getTopLeft(find.text('CUT'));
 
       // Tap to clear the selection.
       await tester.tapAt(textOffsetToPosition(tester, 0));
       await tester.pumpAndSettle();
-      expect(find.text('Cut'), findsNothing);
-      expect(find.text('Copy'), findsNothing);
-      expect(find.text('Paste'), findsNothing);
-      expect(find.text('Select all'), findsNothing);
+      expect(find.text('CUT'), findsNothing);
+      expect(find.text('COPY'), findsNothing);
+      expect(find.text('PASTE'), findsNothing);
+      expect(find.text('SELECT ALL'), findsNothing);
       expect(find.byType(IconButton), findsNothing);
 
       // Long press to show the menu.
@@ -443,31 +443,31 @@ void main() {
       await tester.pumpAndSettle();
 
       // The last button is missing, and a more button is shown.
-      expect(find.text('Cut'), findsOneWidget);
-      expect(find.text('Copy'), findsOneWidget);
-      expect(find.text('Paste'), findsOneWidget);
-      expect(find.text('Select all'), findsNothing);
+      expect(find.text('CUT'), findsOneWidget);
+      expect(find.text('COPY'), findsOneWidget);
+      expect(find.text('PASTE'), findsOneWidget);
+      expect(find.text('SELECT ALL'), findsNothing);
       expect(find.byType(IconButton), findsOneWidget);
 
       // Tapping the button shows the overflow menu.
       await tester.tap(find.byType(IconButton));
       await tester.pumpAndSettle();
-      expect(find.text('Cut'), findsNothing);
-      expect(find.text('Copy'), findsNothing);
-      expect(find.text('Paste'), findsNothing);
-      expect(find.text('Select all'), findsOneWidget);
+      expect(find.text('CUT'), findsNothing);
+      expect(find.text('COPY'), findsNothing);
+      expect(find.text('PASTE'), findsNothing);
+      expect(find.text('SELECT ALL'), findsOneWidget);
       expect(find.byType(IconButton), findsOneWidget);
 
-      // Tapping Select all changes the menu items so that there is no no longer
+      // Tapping SELECT ALL changes the menu items so that there is no no longer
       // any overflow.
-      await tester.tap(find.text('Select all'));
+      await tester.tap(find.text('SELECT ALL'));
       await tester.pumpAndSettle();
-      expect(find.text('Cut'), findsOneWidget);
-      expect(find.text('Copy'), findsOneWidget);
-      expect(find.text('Paste'), findsOneWidget);
-      expect(find.text('Select all'), findsNothing);
+      expect(find.text('CUT'), findsOneWidget);
+      expect(find.text('COPY'), findsOneWidget);
+      expect(find.text('PASTE'), findsOneWidget);
+      expect(find.text('SELECT ALL'), findsNothing);
       expect(find.byType(IconButton), findsNothing);
-      final Offset newCutOffset = tester.getTopLeft(find.text('Cut'));
+      final Offset newCutOffset = tester.getTopLeft(find.text('CUT'));
       expect(newCutOffset, equals(cutOffset));
     },
       skip: isBrowser, // We do not use Flutter-rendered context menu on the Web
@@ -497,10 +497,10 @@ void main() {
       ));
 
       // Initially, the menu isn't shown at all.
-      expect(find.text('Cut'), findsNothing);
-      expect(find.text('Copy'), findsNothing);
-      expect(find.text('Paste'), findsNothing);
-      expect(find.text('Select all'), findsNothing);
+      expect(find.text('CUT'), findsNothing);
+      expect(find.text('COPY'), findsNothing);
+      expect(find.text('PASTE'), findsNothing);
+      expect(find.text('SELECT ALL'), findsNothing);
       expect(find.byType(IconButton), findsNothing);
 
       // Tap to place the cursor in the field, then tap the handle to show the
@@ -516,21 +516,21 @@ void main() {
       final Offset handlePos = endpoints[0].point + const Offset(0.0, 1.0);
       await tester.tapAt(handlePos, pointer: 7);
       await tester.pumpAndSettle();
-      expect(find.text('Cut'), findsNothing);
-      expect(find.text('Copy'), findsNothing);
-      expect(find.text('Paste'), findsOneWidget);
-      expect(find.text('Select all'), findsOneWidget);
+      expect(find.text('CUT'), findsNothing);
+      expect(find.text('COPY'), findsNothing);
+      expect(find.text('PASTE'), findsOneWidget);
+      expect(find.text('SELECT ALL'), findsOneWidget);
       expect(find.byType(IconButton), findsNothing);
 
       // Tap to select all.
-      await tester.tap(find.text('Select all'));
+      await tester.tap(find.text('SELECT ALL'));
       await tester.pumpAndSettle();
 
-      // Only Cut, Copy, and Paste are shown.
-      expect(find.text('Cut'), findsOneWidget);
-      expect(find.text('Copy'), findsOneWidget);
-      expect(find.text('Paste'), findsOneWidget);
-      expect(find.text('Select all'), findsNothing);
+      // Only CUT, COPY, and PASTE are shown.
+      expect(find.text('CUT'), findsOneWidget);
+      expect(find.text('COPY'), findsOneWidget);
+      expect(find.text('PASTE'), findsOneWidget);
+      expect(find.text('SELECT ALL'), findsNothing);
       expect(find.byType(IconButton), findsNothing);
 
       // The menu appears below the bottom handle.
@@ -541,7 +541,7 @@ void main() {
       );
       expect(endpoints.length, 2);
       final Offset bottomHandlePos = endpoints[1].point;
-      final Offset cutOffset = tester.getTopLeft(find.text('Cut'));
+      final Offset cutOffset = tester.getTopLeft(find.text('CUT'));
       expect(cutOffset.dy, greaterThan(bottomHandlePos.dy));
     },
       skip: isBrowser, // We do not use Flutter-rendered context menu on the Web
@@ -613,17 +613,17 @@ void main() {
     await tester.pumpAndSettle();
 
     // No Paste yet, because nothing has been copied.
-    expect(find.text('Paste'), findsNothing);
-    expect(find.text('Copy'), findsOneWidget);
-    expect(find.text('Cut'), findsOneWidget);
-    expect(find.text('Select all'), findsOneWidget);
+    expect(find.text('PASTE'), findsNothing);
+    expect(find.text('COPY'), findsOneWidget);
+    expect(find.text('CUT'), findsOneWidget);
+    expect(find.text('SELECT ALL'), findsOneWidget);
 
     // Tap copy to add something to the clipboard and close the menu.
-    await tester.tapAt(tester.getCenter(find.text('Copy')));
+    await tester.tapAt(tester.getCenter(find.text('COPY')));
     await tester.pumpAndSettle();
-    expect(find.text('Copy'), findsNothing);
-    expect(find.text('Cut'), findsNothing);
-    expect(find.text('Select all'), findsNothing);
+    expect(find.text('COPY'), findsNothing);
+    expect(find.text('CUT'), findsNothing);
+    expect(find.text('SELECT ALL'), findsNothing);
 
     // Double tap to show the menu again.
     await tester.tapAt(textOffsetToPosition(tester, index));
@@ -632,9 +632,9 @@ void main() {
     await tester.pumpAndSettle();
 
     // Paste now shows.
-    expect(find.text('Copy'), findsOneWidget);
-    expect(find.text('Cut'), findsOneWidget);
-    expect(find.text('Paste'), findsOneWidget);
-    expect(find.text('Select all'), findsOneWidget);
+    expect(find.text('COPY'), findsOneWidget);
+    expect(find.text('CUT'), findsOneWidget);
+    expect(find.text('PASTE'), findsOneWidget);
+    expect(find.text('SELECT ALL'), findsOneWidget);
   }, skip: isBrowser);
 }

--- a/packages/flutter/test/widgets/editable_text_cursor_test.dart
+++ b/packages/flutter/test/widgets/editable_text_cursor_test.dart
@@ -22,7 +22,7 @@ const Color cursorColor = Color.fromARGB(0xFF, 0xFF, 0x00, 0x00);
 
 void main() {
   setUp(() async {
-    // Fill the clipboard so that the Paste option is available in the text
+    // Fill the clipboard so that the PASTE option is available in the text
     // selection menu.
     await Clipboard.setData(const ClipboardData(text: 'Clipboard data'));
   });
@@ -88,7 +88,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 500));
     await tester.pump(const Duration(milliseconds: 500));
 
-    await tester.tap(find.text('Paste'));
+    await tester.tap(find.text('PASTE'));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
     await tester.pump(const Duration(milliseconds: 500));
@@ -141,7 +141,7 @@ void main() {
     tester.state<EditableTextState>(textFinder).showToolbar();
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Paste'));
+    await tester.tap(find.text('PASTE'));
     await tester.pump();
 
     expect(changedValue, clipboardContent);
@@ -779,7 +779,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 500));
     await tester.pump(const Duration(milliseconds: 500));
 
-    await tester.tap(find.text('Paste'));
+    await tester.tap(find.text('PASTE'));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
     await tester.pump(const Duration(milliseconds: 500));

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -54,7 +54,7 @@ void main() {
   setUp(() async {
     debugResetSemanticsIdCounter();
     controller = TextEditingController();
-    // Fill the clipboard so that the Paste option is available in the text
+    // Fill the clipboard so that the PASTE option is available in the text
     // selection menu.
     await Clipboard.setData(const ClipboardData(text: 'Clipboard data'));
   });
@@ -1096,7 +1096,7 @@ void main() {
     // Can't show the toolbar when there's no focus.
     expect(state.showToolbar(), false);
     await tester.pumpAndSettle();
-    expect(find.text('Paste'), findsNothing);
+    expect(find.text('PASTE'), findsNothing);
 
     // Can show the toolbar when focused even though there's no text.
     state.renderEditable.selectWordsInRange(
@@ -1106,19 +1106,19 @@ void main() {
     await tester.pump();
     expect(state.showToolbar(), true);
     await tester.pumpAndSettle();
-    expect(find.text('Paste'), findsOneWidget);
+    expect(find.text('PASTE'), findsOneWidget);
 
     // Hide the menu again.
     state.hideToolbar();
     await tester.pump();
-    expect(find.text('Paste'), findsNothing);
+    expect(find.text('PASTE'), findsNothing);
 
     // Can show the menu with text and a selection.
     controller.text = 'blah';
     await tester.pump();
     expect(state.showToolbar(), true);
     await tester.pumpAndSettle();
-    expect(find.text('Paste'), findsOneWidget);
+    expect(find.text('PASTE'), findsOneWidget);
   }, skip: isBrowser);
 
   testWidgets('can show the toolbar after clearing all text', (WidgetTester tester) async {
@@ -1149,7 +1149,7 @@ void main() {
     await tester.pump();
 
     // Clear the text and selection.
-    expect(find.text('Paste'), findsNothing);
+    expect(find.text('PASTE'), findsNothing);
     state.updateEditingValue(const TextEditingValue(
       text: '',
     ));
@@ -1158,7 +1158,7 @@ void main() {
     // Should be able to show the toolbar.
     expect(state.showToolbar(), true);
     await tester.pumpAndSettle();
-    expect(find.text('Paste'), findsOneWidget);
+    expect(find.text('PASTE'), findsOneWidget);
   });
 
   testWidgets('can dynamically disable options in toolbar', (WidgetTester tester) async {
@@ -1190,10 +1190,10 @@ void main() {
     await tester.pump();
     expect(state.showToolbar(), true);
     await tester.pump();
-    expect(find.text('Select all'), findsOneWidget);
-    expect(find.text('Copy'), findsOneWidget);
-    expect(find.text('Paste'), findsNothing);
-    expect(find.text('Cut'), findsNothing);
+    expect(find.text('SELECT ALL'), findsOneWidget);
+    expect(find.text('COPY'), findsOneWidget);
+    expect(find.text('PASTE'), findsNothing);
+    expect(find.text('CUT'), findsNothing);
   });
 
   testWidgets('can dynamically disable select all option in toolbar - cupertino', (WidgetTester tester) async {
@@ -1256,10 +1256,10 @@ void main() {
     await tester.pump();
     expect(state.showToolbar(), true);
     await tester.pump();
-    expect(find.text('Select all'), findsNothing);
-    expect(find.text('Copy'), findsOneWidget);
-    expect(find.text('Paste'), findsNothing);
-    expect(find.text('Cut'), findsNothing);
+    expect(find.text('SELECT ALL'), findsNothing);
+    expect(find.text('COPY'), findsOneWidget);
+    expect(find.text('PASTE'), findsNothing);
+    expect(find.text('CUT'), findsNothing);
   });
 
   testWidgets('cut and paste are disabled in read only mode even if explicit set', (WidgetTester tester) async {
@@ -1294,10 +1294,10 @@ void main() {
     await tester.pump();
     expect(state.showToolbar(), true);
     await tester.pump();
-    expect(find.text('Select all'), findsOneWidget);
-    expect(find.text('Copy'), findsOneWidget);
-    expect(find.text('Paste'), findsNothing);
-    expect(find.text('Cut'), findsNothing);
+    expect(find.text('SELECT ALL'), findsOneWidget);
+    expect(find.text('COPY'), findsOneWidget);
+    expect(find.text('PASTE'), findsNothing);
+    expect(find.text('CUT'), findsNothing);
   });
 
   testWidgets('Fires onChanged when text changes via TextSelectionOverlay', (WidgetTester tester) async {
@@ -1328,7 +1328,7 @@ void main() {
     tester.state<EditableTextState>(textFinder).showToolbar();
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Paste'));
+    await tester.tap(find.text('PASTE'));
     await tester.pump();
 
     expect(changedValue, clipboardContent);

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -456,7 +456,7 @@ void main() {
     await tester.pumpAndSettle();
     await tester.pump(const Duration(seconds: 1));
 
-    expect(find.text('Select all'), findsOneWidget);
+    expect(find.text('SELECT ALL'), findsOneWidget);
   });
 
   testWidgets('Caret position is updated on tap', (WidgetTester tester) async {
@@ -633,9 +633,9 @@ void main() {
     await tester.pump();
 
     // Context menu should not have paste and cut.
-    expect(find.text('Copy'), findsOneWidget);
-    expect(find.text('Paste'), findsNothing);
-    expect(find.text('Cut'), findsNothing);
+    expect(find.text('COPY'), findsOneWidget);
+    expect(find.text('PASTE'), findsNothing);
+    expect(find.text('CUT'), findsNothing);
   });
 
   testWidgets('selectable text can disable toolbar options', (WidgetTester tester) async {
@@ -655,8 +655,8 @@ void main() {
     await tester.longPressAt(dPos);
     await tester.pump();
     // Context menu should not have copy.
-    expect(find.text('Copy'), findsNothing);
-    expect(find.text('Select all'), findsOneWidget);
+    expect(find.text('COPY'), findsNothing);
+    expect(find.text('SELECT ALL'), findsOneWidget);
   });
 
   testWidgets('Can select text by dragging with a mouse', (WidgetTester tester) async {
@@ -948,14 +948,14 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 200)); // skip past the frame where the opacity is zero
 
-    // Select all should select all the text.
-    await tester.tap(find.text('Select all'));
+    // SELECT ALL should select all the text.
+    await tester.tap(find.text('SELECT ALL'));
     await tester.pump();
     expect(controller.selection.baseOffset, 0);
     expect(controller.selection.extentOffset, testValue.length);
 
-    // Copy should reset the selection.
-    await tester.tap(find.text('Copy'));
+    // COPY should reset the selection.
+    await tester.tap(find.text('COPY'));
     await skipPastScrollingAnimation(tester);
     expect(controller.selection.isCollapsed, true);
   });
@@ -1086,7 +1086,7 @@ void main() {
 
     expect(controller.selection.baseOffset, 5);
     expect(controller.selection.extentOffset, 50);
-    await tester.tap(find.text('Copy'));
+    await tester.tap(find.text('COPY'));
     await tester.pump();
     expect(controller.selection.isCollapsed, true);
   });

--- a/packages/flutter_localizations/lib/src/l10n/generated_material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/generated_material_localizations.dart
@@ -3855,10 +3855,10 @@ class MaterialLocalizationEn extends GlobalMaterialLocalizations {
   String get continueButtonLabel => 'CONTINUE';
 
   @override
-  String get copyButtonLabel => 'Copy';
+  String get copyButtonLabel => 'COPY';
 
   @override
-  String get cutButtonLabel => 'Cut';
+  String get cutButtonLabel => 'CUT';
 
   @override
   String get dateHelpText => 'mm/dd/yyyy';
@@ -3942,7 +3942,7 @@ class MaterialLocalizationEn extends GlobalMaterialLocalizations {
   String get pageRowsInfoTitleApproximateRaw => '\$firstRow–\$lastRow of about \$rowCount';
 
   @override
-  String get pasteButtonLabel => 'Paste';
+  String get pasteButtonLabel => 'PASTE';
 
   @override
   String get popupMenuLabel => 'Popup menu';
@@ -4008,7 +4008,7 @@ class MaterialLocalizationEn extends GlobalMaterialLocalizations {
   String get searchFieldLabel => 'Search';
 
   @override
-  String get selectAllButtonLabel => 'Select all';
+  String get selectAllButtonLabel => 'SELECT ALL';
 
   @override
   String get selectYearSemanticsLabel => 'Select year';
@@ -4095,18 +4095,6 @@ class MaterialLocalizationEnAu extends MaterialLocalizationEn {
   String get licensesPageTitle => 'Licences';
 
   @override
-  String get copyButtonLabel => 'COPY';
-
-  @override
-  String get cutButtonLabel => 'CUT';
-
-  @override
-  String get pasteButtonLabel => 'PASTE';
-
-  @override
-  String get selectAllButtonLabel => 'SELECT ALL';
-
-  @override
   String get viewLicensesButtonLabel => 'VIEW LICENCES';
 
   @override
@@ -4153,18 +4141,6 @@ class MaterialLocalizationEnCa extends MaterialLocalizationEn {
 
   @override
   String get licensesPageTitle => 'Licences';
-
-  @override
-  String get copyButtonLabel => 'COPY';
-
-  @override
-  String get cutButtonLabel => 'CUT';
-
-  @override
-  String get pasteButtonLabel => 'PASTE';
-
-  @override
-  String get selectAllButtonLabel => 'SELECT ALL';
 
   @override
   String get viewLicensesButtonLabel => 'VIEW LICENCES';
@@ -4215,22 +4191,10 @@ class MaterialLocalizationEnGb extends MaterialLocalizationEn {
   TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
 
   @override
-  String get copyButtonLabel => 'COPY';
-
-  @override
-  String get selectAllButtonLabel => 'SELECT ALL';
-
-  @override
   String get viewLicensesButtonLabel => 'VIEW LICENCES';
 
   @override
   String get licensesPageTitle => 'Licences';
-
-  @override
-  String get pasteButtonLabel => 'PASTE';
-
-  @override
-  String get cutButtonLabel => 'CUT';
 
   @override
   String get popupMenuLabel => 'Pop-up menu';
@@ -4278,22 +4242,10 @@ class MaterialLocalizationEnIe extends MaterialLocalizationEn {
   TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
 
   @override
-  String get copyButtonLabel => 'COPY';
-
-  @override
-  String get selectAllButtonLabel => 'SELECT ALL';
-
-  @override
   String get viewLicensesButtonLabel => 'VIEW LICENCES';
 
   @override
   String get licensesPageTitle => 'Licences';
-
-  @override
-  String get pasteButtonLabel => 'PASTE';
-
-  @override
-  String get cutButtonLabel => 'CUT';
 
   @override
   String get popupMenuLabel => 'Pop-up menu';
@@ -4339,18 +4291,6 @@ class MaterialLocalizationEnIn extends MaterialLocalizationEn {
 
   @override
   String get licensesPageTitle => 'Licences';
-
-  @override
-  String get copyButtonLabel => 'COPY';
-
-  @override
-  String get cutButtonLabel => 'CUT';
-
-  @override
-  String get pasteButtonLabel => 'PASTE';
-
-  @override
-  String get selectAllButtonLabel => 'SELECT ALL';
 
   @override
   String get viewLicensesButtonLabel => 'VIEW LICENCES';
@@ -4401,18 +4341,6 @@ class MaterialLocalizationEnNz extends MaterialLocalizationEn {
   String get licensesPageTitle => 'Licences';
 
   @override
-  String get copyButtonLabel => 'COPY';
-
-  @override
-  String get cutButtonLabel => 'CUT';
-
-  @override
-  String get pasteButtonLabel => 'PASTE';
-
-  @override
-  String get selectAllButtonLabel => 'SELECT ALL';
-
-  @override
   String get viewLicensesButtonLabel => 'VIEW LICENCES';
 
   @override
@@ -4459,18 +4387,6 @@ class MaterialLocalizationEnSg extends MaterialLocalizationEn {
 
   @override
   String get licensesPageTitle => 'Licences';
-
-  @override
-  String get copyButtonLabel => 'COPY';
-
-  @override
-  String get cutButtonLabel => 'CUT';
-
-  @override
-  String get pasteButtonLabel => 'PASTE';
-
-  @override
-  String get selectAllButtonLabel => 'SELECT ALL';
 
   @override
   String get viewLicensesButtonLabel => 'VIEW LICENCES';
@@ -4521,22 +4437,10 @@ class MaterialLocalizationEnZa extends MaterialLocalizationEn {
   TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
 
   @override
-  String get copyButtonLabel => 'COPY';
-
-  @override
-  String get selectAllButtonLabel => 'SELECT ALL';
-
-  @override
   String get viewLicensesButtonLabel => 'VIEW LICENCES';
 
   @override
   String get licensesPageTitle => 'Licences';
-
-  @override
-  String get pasteButtonLabel => 'PASTE';
-
-  @override
-  String get cutButtonLabel => 'CUT';
 
   @override
   String get popupMenuLabel => 'Pop-up menu';

--- a/packages/flutter_localizations/lib/src/l10n/material_en.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en.arb
@@ -118,12 +118,12 @@
     "description": "The label for continue buttons and menu items."
   },
 
-  "copyButtonLabel": "Copy",
+  "copyButtonLabel": "COPY",
   "@copyButtonLabel": {
     "description": "The label for copy buttons and menu items."
   },
 
-  "cutButtonLabel": "Cut",
+  "cutButtonLabel": "CUT",
   "@cutButtonLabel": {
     "description": "The label for cut buttons and menu items."
   },
@@ -133,12 +133,12 @@
     "description": "The label for OK buttons and menu items."
   },
 
-  "pasteButtonLabel": "Paste",
+  "pasteButtonLabel": "PASTE",
   "@pasteButtonLabel": {
     "description": "The label for paste buttons and menu items."
   },
 
-  "selectAllButtonLabel": "Select all",
+  "selectAllButtonLabel": "SELECT ALL",
   "@selectAllButtonLabel": {
     "description": "The label for select-all buttons and menu items."
   },


### PR DESCRIPTION
Reverts flutter/flutter#59115

It looks like this change broke `android_semantics_integration_test` in the device lab.