### PR TITLE
Keyboard navigation for the Material Date Picker grid

### DIFF
--- a/packages/flutter/lib/src/material/pickers/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/pickers/calendar_date_picker.dart
@@ -615,15 +615,13 @@ class _MonthPickerState extends State<_MonthPicker> {
   /// Handler for when the overall day grid obtains or loses focus.
   void _handleGridFocusChange(bool focused) {
     setState(() {
-      if (focused) {
-        if (_focusedDay == null) {
-          if (utils.isSameMonth(widget.selectedDate, _currentMonth)) {
-            _focusedDay = widget.selectedDate;
-          } else if (utils.isSameMonth(widget.currentDate, _currentMonth)) {
-            _focusedDay = _focusableDayForMonth(_currentMonth, widget.currentDate.day);
-          } else {
-            _focusedDay = _focusableDayForMonth(_currentMonth, 1);
-          }
+      if (focused && _focusedDay == null) {
+        if (utils.isSameMonth(widget.selectedDate, _currentMonth)) {
+          _focusedDay = widget.selectedDate;
+        } else if (utils.isSameMonth(widget.currentDate, _currentMonth)) {
+          _focusedDay = _focusableDayForMonth(_currentMonth, widget.currentDate.day);
+        } else {
+          _focusedDay = _focusableDayForMonth(_currentMonth, 1);
         }
       }
     });
@@ -784,14 +782,13 @@ class _FocusedDate extends InheritedWidget {
   final DateTime date;
 
   @override
-  bool updateShouldNotify(InheritedWidget oldWidget) {
-    return !(oldWidget is _FocusedDate
-      && (date == oldWidget.date || utils.isSameDay(date, oldWidget.date)));
+  bool updateShouldNotify(_FocusedDate oldWidget) {
+    return date != oldWidget.date && !utils.isSameDay(date, oldWidget.date);
   }
 
   static DateTime of(BuildContext context) {
-    final _FocusedDate focusWidget = context.dependOnInheritedWidgetOfExactType<_FocusedDate>();
-    return focusWidget?.date;
+    final _FocusedDate focusedDate = context.dependOnInheritedWidgetOfExactType<_FocusedDate>();
+    return focusedDate?.date;
   }
 }
 
@@ -859,22 +856,22 @@ class _DayPickerState extends State<_DayPicker> {
 
   @override
   void initState() {
+    super.initState();
     final int daysInMonth = utils.getDaysInMonth(widget.displayedMonth.year, widget.displayedMonth.month);
     _dayFocusNodes = List<FocusNode>.generate(
       daysInMonth,
       (int index) => FocusNode(skipTraversal: true, debugLabel: 'Day ${index + 1}')
     );
-    super.initState();
   }
 
   @override
   void didChangeDependencies() {
+    super.didChangeDependencies();
     // Check to see if the focused date is in this month, if so focus it.
     final DateTime focusedDate = _FocusedDate.of(context);
     if (focusedDate != null && utils.isSameMonth(widget.displayedMonth, focusedDate)) {
       _dayFocusNodes[focusedDate.day - 1].requestFocus();
     }
-    super.didChangeDependencies();
   }
 
   @override

--- a/packages/flutter/lib/src/material/pickers/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/pickers/calendar_date_picker.dart
@@ -552,7 +552,7 @@ class _MonthPickerState extends State<_MonthPicker> {
   DateTime _focusableDayForMonth(DateTime month, int preferredDay) {
     final int daysInMonth = utils.getDaysInMonth(month.year, month.month);
 
-    // Can we ues the preferred day in this month?
+    // Can we use the preferred day in this month?
     if (preferredDay <= daysInMonth) {
       final DateTime newFocus = DateTime(month.year, month.month, preferredDay);
       if (_isSelectable(newFocus))
@@ -776,8 +776,8 @@ class _MonthPickerState extends State<_MonthPicker> {
 
 /// InheritedWidget indicating what the current focused date is for its children.
 ///
-/// This is used by the [_MonthPicker] to let its children [_DayPicker]s what
-/// the currently focused date (if any) should be.
+/// This is used by the [_MonthPicker] to let its children [_DayPicker]s know
+/// what the currently focused date (if any) should be.
 class _FocusedDate extends InheritedWidget {
   const _FocusedDate({
     Key key,
@@ -789,7 +789,7 @@ class _FocusedDate extends InheritedWidget {
 
   @override
   bool updateShouldNotify(_FocusedDate oldWidget) {
-    return date != oldWidget.date && !utils.isSameDay(date, oldWidget.date);
+    return !utils.isSameDay(date, oldWidget.date);
   }
 
   static DateTime of(BuildContext context) {

--- a/packages/flutter/lib/src/material/pickers/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/pickers/calendar_date_picker.dart
@@ -481,6 +481,7 @@ class _MonthPickerState extends State<_MonthPicker> {
   PageController _pageController;
   MaterialLocalizations _localizations;
   TextDirection _textDirection;
+  Map<LogicalKeySet, Intent> _shortcutMap;
   Map<Type, Action<Intent>> _actionMap;
   FocusNode _dayGridFocus;
   DateTime _focusedDay;
@@ -492,6 +493,12 @@ class _MonthPickerState extends State<_MonthPicker> {
     _previousMonthDate = utils.addMonthsToMonthDate(_currentMonth, -1);
     _nextMonthDate = utils.addMonthsToMonthDate(_currentMonth, 1);
     _pageController = PageController(initialPage: utils.monthDelta(widget.firstDate, _currentMonth));
+    _shortcutMap = <LogicalKeySet, Intent>{
+      LogicalKeySet(LogicalKeyboardKey.arrowLeft): const DirectionalFocusIntent(TraversalDirection.left),
+      LogicalKeySet(LogicalKeyboardKey.arrowRight): const DirectionalFocusIntent(TraversalDirection.right),
+      LogicalKeySet(LogicalKeyboardKey.arrowDown): const DirectionalFocusIntent(TraversalDirection.down),
+      LogicalKeySet(LogicalKeyboardKey.arrowUp): const DirectionalFocusIntent(TraversalDirection.up),
+    };
     _actionMap = <Type, Action<Intent>>{
       NextFocusIntent: CallbackAction<NextFocusIntent>(onInvoke: _handleGridNextFocus),
       PreviousFocusIntent: CallbackAction<PreviousFocusIntent>(onInvoke: _handleGridPreviousFocus),
@@ -740,23 +747,22 @@ class _MonthPickerState extends State<_MonthPicker> {
             ),
           ),
           Expanded(
-            child: Actions(
+            child: FocusableActionDetector(
+              shortcuts: _shortcutMap,
               actions: _actionMap,
-              child: Focus(
-                focusNode: _dayGridFocus,
-                onFocusChange: _handleGridFocusChange,
-                child: _FocusedDate(
-                  date: _dayGridFocus.hasFocus ? _focusedDay : null,
-                  child: Container(
-                    color: _dayGridFocus.hasFocus ? Theme.of(context).focusColor : null,
-                    child: PageView.builder(
-                      key: _pageViewKey,
-                      controller: _pageController,
-                      itemBuilder: _buildItems,
-                      itemCount: utils.monthDelta(widget.firstDate, widget.lastDate) + 1,
-                      scrollDirection: Axis.horizontal,
-                      onPageChanged: _handleMonthPageChanged,
-                    ),
+              focusNode: _dayGridFocus,
+              onFocusChange: _handleGridFocusChange,
+              child: _FocusedDate(
+                date: _dayGridFocus.hasFocus ? _focusedDay : null,
+                child: Container(
+                  color: _dayGridFocus.hasFocus ? Theme.of(context).focusColor : null,
+                  child: PageView.builder(
+                    key: _pageViewKey,
+                    controller: _pageController,
+                    itemBuilder: _buildItems,
+                    itemCount: utils.monthDelta(widget.firstDate, widget.lastDate) + 1,
+                    scrollDirection: Axis.horizontal,
+                    onPageChanged: _handleMonthPageChanged,
                   ),
                 ),
               ),

--- a/packages/flutter/lib/src/material/pickers/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/pickers/calendar_date_picker.dart
@@ -283,11 +283,9 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
   Widget build(BuildContext context) {
     return Stack(
       children: <Widget>[
-        SingleChildScrollView(
-          child: SizedBox(
-            height: _maxDayPickerHeight,
-            child: _buildPicker(),
-          ),
+        SizedBox(
+          height: _subHeaderHeight + _maxDayPickerHeight,
+          child: _buildPicker(),
         ),
         // Put the mode toggle button on top so that it won't be covered up by the _MonthPicker
         _DatePickerModeToggleButton(
@@ -599,7 +597,6 @@ class _MonthPickerState extends State<_MonthPicker> {
               ],
             ),
           ),
-          _DayHeaders(),
           Expanded(
             child: PageView.builder(
               controller: _pageController,
@@ -668,11 +665,45 @@ class _DayPicker extends StatelessWidget {
   /// Optional user supplied predicate function to customize selectable days.
   final SelectableDayPredicate selectableDayPredicate;
 
+  /// Builds widgets showing abbreviated days of week. The first widget in the
+  /// returned list corresponds to the first day of week for the current locale.
+  ///
+  /// Examples:
+  ///
+  /// ```
+  /// ┌ Sunday is the first day of week in the US (en_US)
+  /// |
+  /// S M T W T F S  <-- the returned list contains these widgets
+  /// _ _ _ _ _ 1 2
+  /// 3 4 5 6 7 8 9
+  ///
+  /// ┌ But it's Monday in the UK (en_GB)
+  /// |
+  /// M T W T F S S  <-- the returned list contains these widgets
+  /// _ _ _ _ 1 2 3
+  /// 4 5 6 7 8 9 10
+  /// ```
+  List<Widget> _getDayHeaders(TextStyle headerStyle, MaterialLocalizations localizations) {
+    final List<Widget> result = <Widget>[];
+    for (int i = localizations.firstDayOfWeekIndex; true; i = (i + 1) % 7) {
+      final String weekday = localizations.narrowWeekdays[i];
+      result.add(ExcludeSemantics(
+        child: Center(child: Text(weekday, style: headerStyle)),
+      ));
+      if (i == (localizations.firstDayOfWeekIndex - 1) % 7)
+        break;
+    }
+    return result;
+  }
+
   @override
   Widget build(BuildContext context) {
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
     final TextTheme textTheme = Theme.of(context).textTheme;
+    final TextStyle headerStyle = textTheme.caption?.apply(
+      color: colorScheme.onSurface.withOpacity(0.60),
+    );
     final TextStyle dayStyle = textTheme.caption;
     final Color enabledDayColor = colorScheme.onSurface.withOpacity(0.87);
     final Color disabledDayColor = colorScheme.onSurface.withOpacity(0.38);
@@ -686,7 +717,7 @@ class _DayPicker extends StatelessWidget {
     final int daysInMonth = utils.getDaysInMonth(year, month);
     final int dayOffset = utils.firstDayOffset(year, month, localizations);
 
-    final List<Widget> dayItems = <Widget>[];
+    final List<Widget> dayItems = _getDayHeaders(headerStyle, localizations);
     // 1-based day of month, e.g. 1-31 for January, and 1-29 for February on
     // a leap year.
     int day = -dayOffset;
@@ -781,7 +812,7 @@ class _DayPickerGridDelegate extends SliverGridDelegate {
     const int columnCount = DateTime.daysPerWeek;
     final double tileWidth = constraints.crossAxisExtent / columnCount;
     final double tileHeight = math.min(_dayPickerRowHeight,
-      constraints.viewportMainAxisExtent / _maxDayPickerRowCount);
+      constraints.viewportMainAxisExtent / (_maxDayPickerRowCount + 1));
     return SliverGridRegularTileLayout(
       childCrossAxisExtent: tileWidth,
       childMainAxisExtent: tileHeight,
@@ -797,64 +828,6 @@ class _DayPickerGridDelegate extends SliverGridDelegate {
 }
 
 const _DayPickerGridDelegate _dayPickerGridDelegate = _DayPickerGridDelegate();
-
-class _DayHeaders extends StatelessWidget {
-  /// Builds widgets showing abbreviated days of week. The first widget in the
-  /// returned list corresponds to the first day of week for the current locale.
-  ///
-  /// Examples:
-  ///
-  /// ```
-  /// ┌ Sunday is the first day of week in the US (en_US)
-  /// |
-  /// S M T W T F S  <-- the returned list contains these widgets
-  /// _ _ _ _ _ 1 2
-  /// 3 4 5 6 7 8 9
-  ///
-  /// ┌ But it's Monday in the UK (en_GB)
-  /// |
-  /// M T W T F S S  <-- the returned list contains these widgets
-  /// _ _ _ _ 1 2 3
-  /// 4 5 6 7 8 9 10
-  /// ```
-  List<Widget> _getDayHeaders(TextStyle headerStyle, MaterialLocalizations localizations) {
-    final List<Widget> result = <Widget>[];
-    for (int i = localizations.firstDayOfWeekIndex; true; i = (i + 1) % 7) {
-      final String weekday = localizations.narrowWeekdays[i];
-      result.add(ExcludeSemantics(
-        child: Center(child: Text(weekday, style: headerStyle)),
-      ));
-      if (i == (localizations.firstDayOfWeekIndex - 1) % 7)
-        break;
-    }
-    return result;
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
-    final ColorScheme colorScheme = theme.colorScheme;
-    final TextStyle dayHeaderStyle = theme.textTheme.caption?.apply(
-      color: colorScheme.onSurface.withOpacity(0.60),
-    );
-    final MaterialLocalizations localizations = MaterialLocalizations.of(context);
-    final List<Widget> labels = _getDayHeaders(dayHeaderStyle, localizations);
-
-    return Padding(
-      padding: const EdgeInsets.symmetric(
-        horizontal: _monthPickerHorizontalPadding,
-      ),
-      child: GridView.custom(
-        shrinkWrap: true,
-        gridDelegate: _dayPickerGridDelegate,
-        childrenDelegate: SliverChildListDelegate(
-          labels,
-          addRepaintBoundaries: false,
-        ),
-      ),
-    );
-  }
-}
 
 /// A scrollable list of years to allow picking a year.
 class _YearPicker extends StatefulWidget {

--- a/packages/flutter/lib/src/material/pickers/date_picker_dialog.dart
+++ b/packages/flutter/lib/src/material/pickers/date_picker_dialog.dart
@@ -6,7 +6,7 @@
 
 import 'dart:math' as math;
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 import '../button_bar.dart';
@@ -357,6 +357,11 @@ class _DatePickerDialogState extends State<_DatePickerDialog> {
     return null;
   }
 
+  static final Map<LogicalKeySet, Intent> _formShortcutMap = <LogicalKeySet, Intent>{
+    // Pressing enter on the field will move focus to the next field or control.
+    LogicalKeySet(LogicalKeyboardKey.enter): const NextFocusIntent(),
+  };
+
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
@@ -419,24 +424,27 @@ class _DatePickerDialogState extends State<_DatePickerDialog> {
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 24),
             height: orientation == Orientation.portrait ? _inputFormPortraitHeight : _inputFormLandscapeHeight,
-            child: Column(
-              children: <Widget>[
-                const Spacer(),
-                InputDatePickerFormField(
-                  initialDate: _selectedDate,
-                  firstDate: widget.firstDate,
-                  lastDate: widget.lastDate,
-                  onDateSubmitted: _handleDateChanged,
-                  onDateSaved: _handleDateChanged,
-                  selectableDayPredicate: widget.selectableDayPredicate,
-                  errorFormatText: widget.errorFormatText,
-                  errorInvalidText: widget.errorInvalidText,
-                  fieldHintText: widget.fieldHintText,
-                  fieldLabelText: widget.fieldLabelText,
-                  autofocus: true,
-                ),
-                const Spacer(),
-              ],
+            child: Shortcuts(
+              shortcuts: _formShortcutMap,
+              child: Column(
+                children: <Widget>[
+                  const Spacer(),
+                  InputDatePickerFormField(
+                    initialDate: _selectedDate,
+                    firstDate: widget.firstDate,
+                    lastDate: widget.lastDate,
+                    onDateSubmitted: _handleDateChanged,
+                    onDateSaved: _handleDateChanged,
+                    selectableDayPredicate: widget.selectableDayPredicate,
+                    errorFormatText: widget.errorFormatText,
+                    errorInvalidText: widget.errorInvalidText,
+                    fieldHintText: widget.fieldHintText,
+                    fieldLabelText: widget.fieldLabelText,
+                    autofocus: true,
+                  ),
+                  const Spacer(),
+                ],
+              ),
             ),
           ),
         );

--- a/packages/flutter/lib/src/material/pickers/date_utils.dart
+++ b/packages/flutter/lib/src/material/pickers/date_utils.dart
@@ -29,9 +29,21 @@ DateTimeRange datesOnly(DateTimeRange range) {
 /// year.
 bool isSameDay(DateTime dateA, DateTime dateB) {
   return
+    dateA != null &&
+    dateB != null &&
     dateA.year == dateB.year &&
     dateA.month == dateB.month &&
     dateA.day == dateB.day;
+}
+
+/// Returns true if the two [DateTime] objects have the same month, and
+/// year.
+bool isSameMonth(DateTime dateA, DateTime dateB) {
+  return
+    dateA != null &&
+    dateB != null &&
+    dateA.year == dateB.year &&
+    dateA.month == dateB.month;
 }
 
 /// Determines the number of months between two [DateTime] objects.

--- a/packages/flutter/lib/src/material/pickers/date_utils.dart
+++ b/packages/flutter/lib/src/material/pickers/date_utils.dart
@@ -26,24 +26,20 @@ DateTimeRange datesOnly(DateTimeRange range) {
 }
 
 /// Returns true if the two [DateTime] objects have the same day, month, and
-/// year.
+/// year, or are both null.
 bool isSameDay(DateTime dateA, DateTime dateB) {
   return
-    dateA != null &&
-    dateB != null &&
-    dateA.year == dateB.year &&
-    dateA.month == dateB.month &&
-    dateA.day == dateB.day;
+    dateA?.year == dateB?.year &&
+    dateA?.month == dateB?.month &&
+    dateA?.day == dateB?.day;
 }
 
 /// Returns true if the two [DateTime] objects have the same month, and
-/// year.
+/// year, or are both null.
 bool isSameMonth(DateTime dateA, DateTime dateB) {
   return
-    dateA != null &&
-    dateB != null &&
-    dateA.year == dateB.year &&
-    dateA.month == dateB.month;
+    dateA?.year == dateB?.year &&
+    dateA?.month == dateB?.month;
 }
 
 /// Determines the number of months between two [DateTime] objects.

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -83,7 +83,11 @@ void main() {
     SystemChannels.platform.setMockMethodCallHandler(null);
   });
 
-  Future<void> prepareDatePicker(WidgetTester tester, Future<void> callback(Future<DateTime> date)) async {
+  Future<void> prepareDatePicker(
+    WidgetTester tester,
+    Future<void> callback(Future<DateTime> date),
+    {TextDirection textDirection = TextDirection.ltr}
+  ) async {
     BuildContext buttonContext;
     await tester.pumpWidget(MaterialApp(
       home: Material(
@@ -119,6 +123,12 @@ void main() {
       fieldHintText: fieldHintText,
       fieldLabelText: fieldLabelText,
       helpText: helpText,
+      builder: (BuildContext context, Widget child) {
+        return Directionality(
+          textDirection: textDirection,
+          child: child,
+        );
+      },
     );
 
     await tester.pumpAndSettle(const Duration(seconds: 1));
@@ -845,123 +855,153 @@ void main() {
         expect(tester.getSemantics(find.text('1')), matchesSemantics(
           label: '1, Friday, January 1, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('2')), matchesSemantics(
           label: '2, Saturday, January 2, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('3')), matchesSemantics(
           label: '3, Sunday, January 3, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('4')), matchesSemantics(
           label: '4, Monday, January 4, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('5')), matchesSemantics(
           label: '5, Tuesday, January 5, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('6')), matchesSemantics(
           label: '6, Wednesday, January 6, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('7')), matchesSemantics(
           label: '7, Thursday, January 7, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('8')), matchesSemantics(
           label: '8, Friday, January 8, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('9')), matchesSemantics(
           label: '9, Saturday, January 9, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('10')), matchesSemantics(
           label: '10, Sunday, January 10, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('11')), matchesSemantics(
           label: '11, Monday, January 11, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('12')), matchesSemantics(
           label: '12, Tuesday, January 12, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('13')), matchesSemantics(
           label: '13, Wednesday, January 13, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('14')), matchesSemantics(
           label: '14, Thursday, January 14, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('15')), matchesSemantics(
           label: '15, Friday, January 15, 2016',
           hasTapAction: true,
           isSelected: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('16')), matchesSemantics(
           label: '16, Saturday, January 16, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('17')), matchesSemantics(
           label: '17, Sunday, January 17, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('18')), matchesSemantics(
           label: '18, Monday, January 18, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('19')), matchesSemantics(
           label: '19, Tuesday, January 19, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('20')), matchesSemantics(
           label: '20, Wednesday, January 20, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('21')), matchesSemantics(
           label: '21, Thursday, January 21, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('22')), matchesSemantics(
           label: '22, Friday, January 22, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('23')), matchesSemantics(
           label: '23, Saturday, January 23, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('24')), matchesSemantics(
           label: '24, Sunday, January 24, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('25')), matchesSemantics(
           label: '25, Monday, January 25, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('26')), matchesSemantics(
           label: '26, Tuesday, January 26, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('27')), matchesSemantics(
           label: '27, Wednesday, January 27, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('28')), matchesSemantics(
           label: '28, Thursday, January 28, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('29')), matchesSemantics(
           label: '29, Friday, January 29, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
         expect(tester.getSemantics(find.text('30')), matchesSemantics(
           label: '30, Saturday, January 30, 2016',
           hasTapAction: true,
+          isFocusable: true,
         ));
 
         // Ok/Cancel buttons
@@ -1204,6 +1244,7 @@ void main() {
         await tester.sendKeyEvent(LogicalKeyboardKey.tab);
         await tester.sendKeyEvent(LogicalKeyboardKey.tab);
         await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pumpAndSettle();
 
         // Navigate from Jan 15 to Dec 31 with arrow keys
         await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
@@ -1233,6 +1274,7 @@ void main() {
         await tester.sendKeyEvent(LogicalKeyboardKey.tab);
         await tester.sendKeyEvent(LogicalKeyboardKey.tab);
         await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pumpAndSettle();
 
         // Activate OK
         await tester.sendKeyEvent(LogicalKeyboardKey.space);
@@ -1241,6 +1283,44 @@ void main() {
         // Should have selected Jan 18
         expect(await date, DateTime(2015, DateTime.november, 26));
       });
+    });
+
+    testWidgets('RTL text direction reverses the horizontal arrow key navigation', (WidgetTester tester) async {
+      await prepareDatePicker(tester, (Future<DateTime> date) async {
+        // Navigate to the grid
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pumpAndSettle();
+
+        // Navigate from Jan 15 to 19 with arrow keys
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+        await tester.pumpAndSettle();
+
+        // Activate it
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pumpAndSettle();
+
+        // Navigate out of the grid and to the OK button
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pumpAndSettle();
+
+        // Activate OK
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pumpAndSettle();
+
+        // Should have selected Jan 18
+        expect(await date, DateTime(2016, DateTime.january, 19));
+      },
+      textDirection: TextDirection.rtl);
     });
   });
 

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -1113,6 +1113,7 @@ void main() {
         await tester.sendKeyEvent(LogicalKeyboardKey.tab);
         await tester.sendKeyEvent(LogicalKeyboardKey.tab);
         await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
         await tester.sendKeyEvent(LogicalKeyboardKey.space);
         await tester.pumpAndSettle();
         // Should be in the input mode
@@ -1157,6 +1158,88 @@ void main() {
         await tester.pumpAndSettle();
         // Should be on Mar 2016
         expect(find.text('March 2016'), findsOneWidget);
+      });
+    });
+
+    testWidgets('Can navigate date grid with arrow keys', (WidgetTester tester) async {
+      await prepareDatePicker(tester, (Future<DateTime> date) async {
+        // Navigate to the grid
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+
+        // Navigate from Jan 15 to Jan 18 with arrow keys
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+        await tester.pumpAndSettle();
+
+        // Activate it
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pumpAndSettle();
+
+        // Navigate out of the grid and to the OK button
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+
+        // Activate OK
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pumpAndSettle();
+
+        // Should have selected Jan 18
+        expect(await date, DateTime(2016, DateTime.january, 18));
+      });
+    });
+
+    testWidgets('Navigating with arrow keys scrolls months', (WidgetTester tester) async {
+      await prepareDatePicker(tester, (Future<DateTime> date) async {
+        // Navigate to the grid
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+
+        // Navigate from Jan 15 to Dec 31 with arrow keys
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+        await tester.pumpAndSettle();
+
+        // Should have scrolled to Dec 2015
+        expect(find.text('December 2015'), findsOneWidget);
+
+        // Navigate from Dec 31 to Nov 26 with arrow keys
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+        await tester.pumpAndSettle();
+
+        // Should have scrolled to Nov 2015
+        expect(find.text('November 2015'), findsOneWidget);
+
+        // Activate it
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pumpAndSettle();
+
+        // Navigate out of the grid and to the OK button
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+
+        // Activate OK
+        await tester.sendKeyEvent(LogicalKeyboardKey.space);
+        await tester.pumpAndSettle();
+
+        // Should have selected Jan 18
+        expect(await date, DateTime(2015, DateTime.november, 26));
       });
     });
   });

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -86,7 +86,7 @@ void main() {
   Future<void> prepareDatePicker(
     WidgetTester tester,
     Future<void> callback(Future<DateTime> date),
-    {TextDirection textDirection = TextDirection.ltr}
+    { TextDirection textDirection = TextDirection.ltr }
   ) async {
     BuildContext buttonContext;
     await tester.pumpWidget(MaterialApp(


### PR DESCRIPTION
## Description

Added support for navigating the day grid in the Material Date Picker with just the keyboard. Normal Tab/Shift-Tab navigation can be used to bring focus to the date grid. Once inside the grid, the following keyboard shortcuts are supported:

Key | Action
------------ | -------------
Tab | move focus to next element outside grid
Shift-Tab | move focus to previous element outside grid
Left Arrow | move focus to previous day
Right Arrow | move focus to next day
Up Arrow | move focus to previous week
Down Arrow | move focus to next week
Enter / Space | select the currently focused day

Focus is only allowed on selectable days, and if the focus moves to a date not in the currently displayed month, the view will be scrolled to show the newly focused day.

![DayGridKeyboard](https://user-images.githubusercontent.com/19588/84815242-9a483e80-afc7-11ea-882a-e60d5a543be9.gif)

## Related Issues

#49809

## Tests

I added two tests that verify selecting a date with just keyboard actions.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them?

- [x] No, no existing tests failed, so this is *not* a breaking change.
