### PR TITLE
Skip codecov upload

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -190,6 +190,7 @@ task:
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: tool_coverage-linux # linux-only
+      skip: true # Skip while moving between Cirrus and LUCI
       only_if: "$CIRRUS_BRANCH == 'master'"
       environment:
         # As of February 2020, the tool_coverage-linux shard needed at least 24G of RAM to run without


### PR DESCRIPTION
## Description

This will need to be moved, so we can skip for now to avoid issues around double uploading or changing the token config. The tool coverage is fairly steady and we're not losing any historical data.