### PR TITLE
Specify encoding for vswhere output

### DIFF
--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -236,6 +236,7 @@ abstract class ProcessUtils {
     String workingDirectory,
     Map<String, String> environment,
     bool allowReentrantFlutter = false,
+    Encoding encoding = systemEncoding,
   });
 
   /// This runs the command in the background from the specified working
@@ -412,12 +413,15 @@ class _DefaultProcessUtils implements ProcessUtils {
     String workingDirectory,
     Map<String, String> environment,
     bool allowReentrantFlutter = false,
+    Encoding encoding = systemEncoding,
   }) {
     _traceCommand(cmd, workingDirectory: workingDirectory);
     final ProcessResult results = _processManager.runSync(
       cmd,
       workingDirectory: workingDirectory,
       environment: _environment(allowReentrantFlutter, environment),
+      stderrEncoding: encoding,
+      stdoutEncoding: encoding,
     );
     final RunResult runResult = RunResult(results, cmd);
 

--- a/packages/flutter_tools/lib/src/windows/visual_studio.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio.dart
@@ -283,7 +283,7 @@ class VisualStudio {
         ...defaultArguments,
         ...?additionalArguments,
         ...?requirementArguments,
-      ]);
+      ], encoding: utf8);
       if (whereResult.exitCode == 0) {
         final List<Map<String, dynamic>> installations =
             (json.decode(whereResult.stdout) as List<dynamic>).cast<Map<String, dynamic>>();

--- a/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
@@ -236,6 +236,8 @@ void main() {
         any,
         workingDirectory: anyNamed('workingDirectory'),
         environment: anyNamed('environment'),
+        stdoutEncoding: utf8,
+        stderrEncoding: utf8,
       )).thenThrow(const ProcessException('vswhere', <String>[]));
       final VisualStudio visualStudio = VisualStudio(
         logger: BufferLogger.test(),
@@ -253,6 +255,8 @@ void main() {
         any,
         workingDirectory: anyNamed('workingDirectory'),
         environment: anyNamed('environment'),
+        stdoutEncoding: utf8,
+        stderrEncoding: utf8,
       )).thenThrow(const ProcessException('vswhere', <String>[]));
       final VisualStudio visualStudio = VisualStudio(
         logger: BufferLogger.test(),
@@ -271,6 +275,8 @@ void main() {
         any,
         workingDirectory: anyNamed('workingDirectory'),
         environment: anyNamed('environment'),
+        stdoutEncoding: utf8,
+        stderrEncoding: utf8,
       )).thenAnswer((Invocation invocation) {
         return FakeProcessResult(exitCode: 1, stderr: '', stdout: '');
       });

--- a/packages/flutter_tools/test/src/fake_process_manager.dart
+++ b/packages/flutter_tools/test/src/fake_process_manager.dart
@@ -22,6 +22,7 @@ class FakeCommand {
     @required this.command,
     this.workingDirectory,
     this.environment,
+    this.encoding,
     this.duration = const Duration(),
     this.onRun,
     this.exitCode = 0,
@@ -50,6 +51,12 @@ class FakeCommand {
   /// Otherwise, each key in this environment must be present and must have a
   /// value that matches the one given here for the [FakeCommand] to match.
   final Map<String, String> environment;
+
+  /// The stdout and stderr encoding that must be matched for this [FakeCommand]
+  /// to be considered correct.
+  ///
+  /// If this is null, then the encodings are ignored.
+  final Encoding encoding;
 
   /// The time to allow to elapse before returning the [exitCode], if this command
   /// is "executed".
@@ -87,13 +94,21 @@ class FakeCommand {
   /// [FakeProcess].
   final IOSink stdin;
 
-  void _matches(List<String> command, String workingDirectory, Map<String, String> environment) {
+  void _matches(
+    List<String> command,
+    String workingDirectory,
+    Map<String, String> environment,
+    Encoding encoding,
+  ) {
     expect(command, equals(this.command));
     if (this.workingDirectory != null) {
       expect(this.workingDirectory, workingDirectory);
     }
     if (this.environment != null) {
       expect(this.environment, environment);
+    }
+    if (this.encoding != null) {
+      expect(this.encoding, encoding);
     }
   }
 }
@@ -190,13 +205,23 @@ abstract class FakeProcessManager implements ProcessManager {
   bool get hasRemainingExpectations;
 
   @protected
-  FakeCommand findCommand(List<String> command, String workingDirectory, Map<String, String> environment);
+  FakeCommand findCommand(
+    List<String> command,
+    String workingDirectory,
+    Map<String, String> environment,
+    Encoding encoding,
+  );
 
   int _pid = 9999;
 
-  _FakeProcess _runCommand(List<String> command, String workingDirectory, Map<String, String> environment) {
+  _FakeProcess _runCommand(
+    List<String> command,
+    String workingDirectory,
+    Map<String, String> environment,
+    Encoding encoding,
+  ) {
     _pid += 1;
-    final FakeCommand fakeCommand = findCommand(command, workingDirectory, environment);
+    final FakeCommand fakeCommand = findCommand(command, workingDirectory, environment, encoding);
     return _FakeProcess(
       fakeCommand.exitCode,
       fakeCommand.duration,
@@ -217,7 +242,7 @@ abstract class FakeProcessManager implements ProcessManager {
     bool includeParentEnvironment = true, // ignored
     bool runInShell = false, // ignored
     ProcessStartMode mode = ProcessStartMode.normal, // ignored
-  }) async => _runCommand(command.cast<String>(), workingDirectory, environment);
+  }) async => _runCommand(command.cast<String>(), workingDirectory, environment, systemEncoding);
 
   @override
   Future<ProcessResult> run(
@@ -229,7 +254,7 @@ abstract class FakeProcessManager implements ProcessManager {
     Encoding stdoutEncoding = systemEncoding,
     Encoding stderrEncoding = systemEncoding,
   }) async {
-    final _FakeProcess process = _runCommand(command.cast<String>(), workingDirectory, environment);
+    final _FakeProcess process = _runCommand(command.cast<String>(), workingDirectory, environment, stdoutEncoding);
     await process.exitCode;
     return ProcessResult(
       process.pid,
@@ -249,7 +274,7 @@ abstract class FakeProcessManager implements ProcessManager {
     Encoding stdoutEncoding = systemEncoding, // actual encoder is ignored
     Encoding stderrEncoding = systemEncoding, // actual encoder is ignored
   }) {
-    final _FakeProcess process = _runCommand(command.cast<String>(), workingDirectory, environment);
+    final _FakeProcess process = _runCommand(command.cast<String>(), workingDirectory, environment, stdoutEncoding);
     return ProcessResult(
       process.pid,
       process._exitCode,
@@ -272,11 +297,17 @@ class _FakeAnyProcessManager extends FakeProcessManager {
   _FakeAnyProcessManager() : super._();
 
   @override
-  FakeCommand findCommand(List<String> command, String workingDirectory, Map<String, String> environment) {
+  FakeCommand findCommand(
+    List<String> command,
+    String workingDirectory,
+    Map<String, String> environment,
+    Encoding encoding,
+  ) {
     return FakeCommand(
       command: command,
       workingDirectory: workingDirectory,
       environment: environment,
+      encoding: encoding,
       duration: const Duration(),
       exitCode: 0,
       stdout: '',
@@ -297,12 +328,17 @@ class _SequenceProcessManager extends FakeProcessManager {
   final List<FakeCommand> _commands;
 
   @override
-  FakeCommand findCommand(List<String> command, String workingDirectory, Map<String, String> environment) {
+  FakeCommand findCommand(
+    List<String> command,
+    String workingDirectory,
+    Map<String, String> environment,
+    Encoding encoding,
+  ) {
     expect(_commands, isNotEmpty,
       reason: 'ProcessManager was told to execute $command (in $workingDirectory) '
               'but the FakeProcessManager.list expected no more processes.'
     );
-    _commands.first._matches(command, workingDirectory, environment);
+    _commands.first._matches(command, workingDirectory, environment, encoding);
     return _commands.removeAt(0);
   }
 


### PR DESCRIPTION
## Description

On Windows, Process.run assumes the output uses the system codepage by default. This allows specifying it in our wrapper, and sets the encoding for `vswhere` to UTF-8 since we're passing a flag that forces it to use UTF-8 output.

## Related Issues

Fixes #53515

## Tests

I added the following tests: Ensure vswhere is called with the correct output encoding.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
