### PR TITLE
Assert that RenderImages have gt-zero size on axis of viewport

### DIFF
--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -1731,6 +1731,84 @@ void main() {
     // See https://github.com/flutter/flutter/issues/54292.
     skip: kIsWeb,
   );
+
+  testWidgets('Assert image has size along viewport axis', (WidgetTester tester) async {
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: ListView.builder(
+        itemBuilder: (BuildContext context, int index) {
+          return Image.memory(Uint8List.fromList(kTransparentImage));
+        },
+        itemCount: 1,
+      ),
+    ));
+
+    AssertionError exception = tester.takeException() as AssertionError;
+    expect(
+      exception.message,
+      'A RenderImage was laid out within a vertical Viewport with a zero sized '
+      'height. This will result in the Viewport seeing the image as not taking '
+      'up any space, and build more children than necessary. You can resolve '
+      'this by providing a height on the Image widget or specifying an '
+      'itemExtent on the creator of the Viewport, e.g. the ListView or '
+      'GridView.',
+    );
+    expect(find.byType(Image), findsNothing);
+
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: ListView.builder(
+        scrollDirection: Axis.horizontal,
+        itemBuilder: (BuildContext context, int index) {
+          return Image.memory(Uint8List.fromList(kTransparentImage));
+        },
+        itemCount: 1,
+      ),
+    ));
+
+    exception = tester.takeException() as AssertionError;
+    expect(
+      exception.message,
+      'A RenderImage was laid out within a horizontal Viewport with a zero sized '
+      'width. This will result in the Viewport seeing the image as not taking '
+      'up any space, and build more children than necessary. You can resolve '
+      'this by providing a width on the Image widget or specifying an '
+      'itemExtent on the creator of the Viewport, e.g. the ListView or '
+      'GridView.',
+    );
+    expect(find.byType(Image), findsNothing);
+
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: ListView.builder(
+        scrollDirection: Axis.horizontal,
+        itemBuilder: (BuildContext context, int index) {
+          return Image.memory(Uint8List.fromList(kTransparentImage));
+        },
+        itemCount: 1,
+        itemExtent: 10,
+      ),
+    ));
+
+    exception = tester.takeException() as AssertionError;
+    expect(exception, isNull);
+    expect(find.byType(Image), findsOneWidget);
+
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: ListView.builder(
+        scrollDirection: Axis.horizontal,
+        itemBuilder: (BuildContext context, int index) {
+          return Image.memory(Uint8List.fromList(kTransparentImage), width: 10);
+        },
+        itemCount: 1,
+      ),
+    ));
+
+    exception = tester.takeException() as AssertionError;
+    expect(exception, isNull);
+    expect(find.byType(Image), findsOneWidget);
+  });
 }
 
 class ImagePainter extends CustomPainter {


### PR DESCRIPTION
## Description

By default, a RenderImage takes up 0 height/width until its backing image has been decoded. This is a problem in List/GridViews, particularly lazily built ones, as it can "trick" the viewport into thinking it needs to allocate more children than necessary, particularly if the list is primarily of images.

This adds an assert that if the RenderImage is a child of a ViewportBase, it has a greater-than-zero size on the axis of the viewport.

## Related Issues

See for example https://github.com/flutter/flutter/issues/51046#issuecomment-589395138

## Tests

I added the following tests:

Test the assert is thrown if you put an image in a viewport without a size or itemextent.

## Breaking Change

I'm going to do a FROB run to make sure this doesn't break internal customers before filling this out.

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
