### PR TITLE
[flutter_tools] make expando on vm service null safe to handle web stuff

### DIFF
--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1136,11 +1136,13 @@ abstract class ResidentRunner {
       _devtoolsServer ??= await devtools_server.serveDevTools(
         enableStdinCommands: false,
       );
+      final Uri vmServiceAddress = flutterDevices.first.vmService.httpAddress ??
+        flutterDevices.first.vmService.wsAddress;
       await devtools_server.launchDevTools(
         <String, dynamic>{
           'reuseWindows': true,
         },
-        flutterDevices.first.vmService.httpAddress,
+        vmServiceAddress,
         'http://${_devtoolsServer.address.host}:${_devtoolsServer.port}',
         false,  // headless mode,
         false,  // machine mode

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1136,13 +1136,11 @@ abstract class ResidentRunner {
       _devtoolsServer ??= await devtools_server.serveDevTools(
         enableStdinCommands: false,
       );
-      final Uri vmServiceAddress = flutterDevices.first.vmService.httpAddress ??
-        flutterDevices.first.vmService.wsAddress;
       await devtools_server.launchDevTools(
         <String, dynamic>{
           'reuseWindows': true,
         },
-        vmServiceAddress,
+        flutterDevices.first.vmService.httpAddress,
         'http://${_devtoolsServer.address.host}:${_devtoolsServer.port}',
         false,  // headless mode,
         false,  // machine mode

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -444,9 +444,9 @@ class FlutterView {
 
 /// Flutter specific VM Service functionality.
 extension FlutterVmService on vm_service.VmService {
-  Uri get wsAddress => _wsAddressExpando[this];
+  Uri get wsAddress => this != null ? _wsAddressExpando[this] : null;
 
-  Uri get httpAddress => _httpAddressExpando[this];
+  Uri get httpAddress => this != null ? _httpAddressExpando[this] : null;
 
   /// Set the asset directory for the an attached Flutter view.
   Future<void> setAssetDirectory({

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -395,6 +395,13 @@ void main() {
     );
     expect(fakeVmServiceHost.hasRemainingExpectations, false);
   });
+
+  testWithoutContext('expandos are null safe', () {
+    vm_service.VmService vmService;
+
+    expect(vmService.httpAddress, null);
+    expect(vmService.wsAddress, null);
+  });
 }
 
 class MockDevice extends Mock implements Device {}


### PR DESCRIPTION
## Description

Fixes https://github.com/flutter/flutter/issues/59606

null check on the extension method (because its a static method, so `this` can be null - NNBD when). The vm service will be null when running on the web - the devtools logic needs to be slightly tweaked here, but that fix is potentially riskier so easier to stop the crash for now