### PR TITLE
ReorderableListView should not reorder if there is only a single item present

### DIFF
--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -382,9 +382,6 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
 
     // Places the value from startIndex one space before the element at endIndex.
     void reorder(int startIndex, int endIndex) {
-      if (widget.children.length <= 1) {
-        return;
-      }
       setState(() {
         if (startIndex != endIndex)
           widget.onReorder(startIndex, endIndex);
@@ -577,6 +574,11 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
           );
           break;
       }
+
+      // If the reorderable list only has one child element, reordering
+      // should not be allowed.
+      final bool hasMoreThanOneChildElement = widget.children.length > 1;
+
       return SingleChildScrollView(
         scrollDirection: widget.scrollDirection,
         padding: widget.padding,
@@ -584,10 +586,10 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
         reverse: widget.reverse,
         child: _buildContainerForScrollDirection(
           children: <Widget>[
-            if (widget.reverse) _wrap(finalDropArea, widget.children.length, constraints),
+            if (widget.reverse && hasMoreThanOneChildElement) _wrap(finalDropArea, widget.children.length, constraints),
             if (widget.header != null) widget.header,
             for (int i = 0; i < widget.children.length; i += 1) _wrap(widget.children[i], i, constraints),
-            if (!widget.reverse) _wrap(finalDropArea, widget.children.length, constraints),
+            if (!widget.reverse && hasMoreThanOneChildElement) _wrap(finalDropArea, widget.children.length, constraints),
           ],
         ),
       );

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -382,6 +382,9 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
 
     // Places the value from startIndex one space before the element at endIndex.
     void reorder(int startIndex, int endIndex) {
+      if (widget.children.length <= 1) {
+        return;
+      }
       setState(() {
         if (startIndex != endIndex)
           widget.onReorder(startIndex, endIndex);

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -56,6 +56,33 @@ void main() {
     });
 
     group('in vertical mode', () {
+      testWidgets('reorder is not triggered when children length is less or equals to 1', (WidgetTester tester) async {
+        bool onReorderWasCalled = false;
+        final List<String> currentListItems = listItems.take(1).toList();
+        final ReorderableListView reorderableListView = ReorderableListView(
+          header: const Text('Header'),
+          children: currentListItems.map<Widget>(listItemToWidget).toList(),
+          scrollDirection: Axis.vertical,
+          onReorder: (_, __) => onReorderWasCalled = true,
+        );
+        final List<String> currentOriginalListItems = originalListItems.take(1).toList();
+        await tester.pumpWidget(MaterialApp(
+          home: SizedBox(
+            height: itemHeight * 10,
+            child: reorderableListView,
+          ),
+        ));
+        expect(currentListItems, orderedEquals(currentOriginalListItems));
+        final TestGesture drag = await tester.startGesture(tester.getCenter(find.text('Item 1')));
+        await tester.pump(kLongPressTimeout + kPressTimeout);
+        expect(currentListItems, orderedEquals(currentOriginalListItems));
+        await drag.moveTo(tester.getBottomLeft(find.text('Item 1')) * 2);
+        expect(currentListItems, orderedEquals(currentOriginalListItems));
+        await drag.up();
+        expect(onReorderWasCalled, false);
+        expect(currentListItems, orderedEquals(<String>['Item 1']));
+      });
+
       testWidgets('reorders its contents only when a drag finishes', (WidgetTester tester) async {
         await tester.pumpWidget(build());
         expect(listItems, orderedEquals(originalListItems));
@@ -547,6 +574,33 @@ void main() {
     });
 
     group('in horizontal mode', () {
+      testWidgets('reorder is not triggered when children length is less or equals to 1', (WidgetTester tester) async {
+        bool onReorderWasCalled = false;
+        final List<String> currentListItems = listItems.take(1).toList();
+        final ReorderableListView reorderableListView = ReorderableListView(
+          header: const Text('Header'),
+          children: currentListItems.map<Widget>(listItemToWidget).toList(),
+          scrollDirection: Axis.horizontal,
+          onReorder: (_, __) => onReorderWasCalled = true,
+        );
+        final List<String> currentOriginalListItems = originalListItems.take(1).toList();
+        await tester.pumpWidget(MaterialApp(
+          home: SizedBox(
+            height: itemHeight * 10,
+            child: reorderableListView,
+          ),
+        ));
+        expect(currentListItems, orderedEquals(currentOriginalListItems));
+        final TestGesture drag = await tester.startGesture(tester.getCenter(find.text('Item 1')));
+        await tester.pump(kLongPressTimeout + kPressTimeout);
+        expect(currentListItems, orderedEquals(currentOriginalListItems));
+        await drag.moveTo(tester.getBottomLeft(find.text('Item 1')) * 2);
+        expect(currentListItems, orderedEquals(currentOriginalListItems));
+        await drag.up();
+        expect(onReorderWasCalled, false);
+        expect(currentListItems, orderedEquals(<String>['Item 1']));
+      });
+
       testWidgets('allows reordering from the very top to the very bottom', (WidgetTester tester) async {
         await tester.pumpWidget(build(scrollDirection: Axis.horizontal));
         expect(listItems, orderedEquals(originalListItems));


### PR DESCRIPTION
## Description

When ReorderableListView just contains a single item and the drawing movement to reorder does not trigger [onReorder](https://github.com/flutter/flutter/blob/e0ed12c73a3df00b72af6e5657d35035a76c90db/packages/flutter/lib/src/material/reorderable_list.dart#L384-L393), since there is nothing to reorder.

## Related Issues

Fixes #59599

## Tests

I added the following tests:

- on **packages/flutter/test/material/reorderable_list_test.dart**
  - vertical mode
    - reorder is not triggered when children length is less or equals to 1
  - horizontal mode
    - reorder is not triggered when children length is less or equals to 1

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.