### PR TITLE
Don't crash when pubspec isn't a map

### DIFF
--- a/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
@@ -32,6 +32,16 @@ void main() {
     expect(flutterManifest.assets, isEmpty);
   });
 
+  testWithoutContext('FlutterManifest is null when the pubspec.yaml file is not a map', () async {
+    final BufferLogger logger = BufferLogger.test();
+    expect(FlutterManifest.createFromString(
+      'Not a map',
+      logger: logger,
+    ), isNull);
+
+    expect(logger.errorText, contains('Expected YAML map'));
+  });
+
   testWithoutContext('FlutterManifest has no fonts or assets when the "flutter" section is empty', () async {
     const String manifest = '''
 name: test


### PR DESCRIPTION
## Description

Validation error when the pubspec is valid YAML, but not a map.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/59610

## Tests

flutter_manifest_test

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*