### PR TITLE
[ExpansionPanelList] adds dividerColor property

### DIFF
--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -4,6 +4,7 @@
 
 // @dart = 2.8
 
+import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
@@ -230,6 +231,7 @@ class ExpansionPanelList extends StatefulWidget {
     this.expansionCallback,
     this.animationDuration = kThemeAnimationDuration,
     this.expandedHeaderPadding = _kPanelHeaderExpandedDefaultPadding,
+    this.dividerColor,
   }) : assert(children != null),
        assert(animationDuration != null),
        _allowOnlyOnePanelOpen = false,
@@ -319,6 +321,7 @@ class ExpansionPanelList extends StatefulWidget {
     this.animationDuration = kThemeAnimationDuration,
     this.initialOpenPanelValue,
     this.expandedHeaderPadding = _kPanelHeaderExpandedDefaultPadding,
+    this.dividerColor,
   }) : assert(children != null),
        assert(animationDuration != null),
        _allowOnlyOnePanelOpen = true,
@@ -362,6 +365,12 @@ class ExpansionPanelList extends StatefulWidget {
   /// By default, 16px of space is added to the header vertically (above and below)
   /// during expansion.
   final EdgeInsets expandedHeaderPadding;
+
+  /// Defines Color for the divider when [ExpansionPanel.isExpanded] is false.
+  ///
+  /// If `dividerColor` is null, then [DividerThemeData.color] is used. If that
+  /// is null, then [ThemeData.dividerColor] is used.
+  final Color dividerColor;
 
   @override
   State<StatefulWidget> createState() => _ExpansionPanelListState();
@@ -528,6 +537,7 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
 
     return MergeableMaterial(
       hasDividers: true,
+      dividerColor: widget.dividerColor,
       children: items,
     );
   }

--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -4,7 +4,6 @@
 
 // @dart = 2.8
 
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
@@ -366,7 +365,7 @@ class ExpansionPanelList extends StatefulWidget {
   /// during expansion.
   final EdgeInsets expandedHeaderPadding;
 
-  /// Defines Color for the divider when [ExpansionPanel.isExpanded] is false.
+  /// Defines color for the divider when [ExpansionPanel.isExpanded] is false.
   ///
   /// If `dividerColor` is null, then [DividerThemeData.color] is used. If that
   /// is null, then [ThemeData.dividerColor] is used.

--- a/packages/flutter/test/material/expansion_panel_test.dart
+++ b/packages/flutter/test/material/expansion_panel_test.dart
@@ -1347,7 +1347,7 @@ void main() {
     expect(box.size.width, equals(736.0));
   });
 
-  testWidgets('ExpansionPanelList respect dividerColor', (WidgetTester tester) async {
+  testWidgets('ExpansionPanelList respects dividerColor', (WidgetTester tester) async {
     const Color dividerColor = Colors.red;
     await tester.pumpWidget(const MaterialApp(
       home: SingleChildScrollView(
@@ -1360,11 +1360,11 @@ void main() {
     final DecoratedBox decoratedBox = tester.widget(find.byType(DecoratedBox).last);
     final BoxDecoration decoration = decoratedBox.decoration as BoxDecoration;
 
-    // For the last DecoratedBox, we will have a Border.top.
+    // For the last DecoratedBox, we will have a Border.top with the provided dividerColor.
     expect(decoration.border.top.color, dividerColor);
   });
 
-  testWidgets('ExpansionPanelList.Radio respects DividerColor', (WidgetTester tester) async {
+  testWidgets('ExpansionPanelList.radio respects DividerColor', (WidgetTester tester) async {
     const Color dividerColor = Colors.red;
     await tester.pumpWidget(MaterialApp(
       home: SingleChildScrollView(
@@ -1387,13 +1387,13 @@ void main() {
             ),
           ],
         ),
-      )
+      ),
     ));
 
     final DecoratedBox decoratedBox = tester.widget(find.byType(DecoratedBox).last);
     final BoxDecoration boxDecoration = decoratedBox.decoration as BoxDecoration;
 
-    // For the last DecoratedBox, we will have a Border.top.
+    // For the last DecoratedBox, we will have a Border.top with the provided dividerColor.
     expect(boxDecoration.border.top.color, dividerColor);
   });
 }

--- a/packages/flutter/test/material/expansion_panel_test.dart
+++ b/packages/flutter/test/material/expansion_panel_test.dart
@@ -13,12 +13,14 @@ class SimpleExpansionPanelListTestWidget extends StatefulWidget {
     this.firstPanelKey,
     this.secondPanelKey,
     this.canTapOnHeader = false,
-    this.expandedHeaderPadding
+    this.expandedHeaderPadding,
+    this.dividerColor,
   }) : super(key: key);
 
   final Key firstPanelKey;
   final Key secondPanelKey;
   final bool canTapOnHeader;
+  final Color dividerColor;
 
   /// If null, the default [ExpansionPanelList]'s expanded header padding value is applied via [defaultExpandedHeaderPadding]
   final EdgeInsets expandedHeaderPadding;
@@ -45,6 +47,7 @@ class _SimpleExpansionPanelListTestWidgetState extends State<SimpleExpansionPane
           extendedState[_index] = !extendedState[_index];
         });
       },
+      dividerColor: widget.dividerColor,
       children: <ExpansionPanel>[
         ExpansionPanel(
           headerBuilder: (BuildContext context, bool isExpanded) {
@@ -1342,5 +1345,55 @@ void main() {
     box = tester.renderObject(find.ancestor(of: find.byKey(firstPanelKey), matching: find.byType(AnimatedContainer)).first);
     expect(box.size.height, equals(128.0)); // _kPanelHeaderCollapsedHeight + 80.0 (double padding)
     expect(box.size.width, equals(736.0));
+  });
+
+  testWidgets('ExpansionPanelList respect dividerColor', (WidgetTester tester) async {
+    const Color dividerColor = Colors.red;
+    await tester.pumpWidget(const MaterialApp(
+      home: SingleChildScrollView(
+        child: SimpleExpansionPanelListTestWidget(
+          dividerColor: dividerColor,
+        ),
+      ),
+    ));
+
+    final DecoratedBox decoratedBox = tester.widget(find.byType(DecoratedBox).last);
+    final BoxDecoration decoration = decoratedBox.decoration as BoxDecoration;
+
+    // For the last DecoratedBox, we will have a Border.top.
+    expect(decoration.border.top.color, dividerColor);
+  });
+
+  testWidgets('ExpansionPanelList.Radio respects DividerColor', (WidgetTester tester) async {
+    const Color dividerColor = Colors.red;
+    await tester.pumpWidget(MaterialApp(
+      home: SingleChildScrollView(
+        child: ExpansionPanelList.radio(
+          dividerColor: dividerColor,
+          children: <ExpansionPanelRadio>[
+            ExpansionPanelRadio(
+              headerBuilder: (BuildContext context, bool isExpanded) {
+                return Text(isExpanded ? 'B' : 'A', key: const Key('firstKey'));
+              },
+              body: const SizedBox(height: 100.0),
+              value: 0,
+            ),
+            ExpansionPanelRadio(
+              headerBuilder: (BuildContext context, bool isExpanded) {
+                return Text(isExpanded ? 'D' : 'C', key: const Key('secondKey'));
+              },
+              body: const SizedBox(height: 100.0),
+              value: 1,
+            ),
+          ],
+        ),
+      )
+    ));
+
+    final DecoratedBox decoratedBox = tester.widget(find.byType(DecoratedBox).last);
+    final BoxDecoration boxDecoration = decoratedBox.decoration as BoxDecoration;
+
+    // For the last DecoratedBox, we will have a Border.top.
+    expect(boxDecoration.border.top.color, dividerColor);
   });
 }


### PR DESCRIPTION
## Description

Exposes the `dividerColor` property of `MergeableMaterial` to change the color of dividers when `ExpansionPanel.isExpanded` is false.

## Related Issues
#51321

## Tests

I added the following tests:
- Added test to check that `dividerColor` is respected by `ExpansionPanelList` and `ExpansionPanelList.radio`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
