### PR TITLE
[flutter_tools] Federate plugin template, and add web support.

### DIFF
--- a/packages/flutter_tools/templates/app/lib/main.dart.tmpl
+++ b/packages/flutter_tools/templates/app/lib/main.dart.tmpl
@@ -139,6 +139,7 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
   String _platformVersion = 'Unknown';
+  final _plugin = {{pluginDartClass}}();
 
   @override
   void initState() {
@@ -151,7 +152,7 @@ class _MyAppState extends State<MyApp> {
     String platformVersion;
     // Platform messages may fail, so we use a try/catch PlatformException.
     try {
-      platformVersion = await {{pluginDartClass}}.platformVersion;
+      platformVersion = await _plugin.platformVersion;
     } on PlatformException {
       platformVersion = 'Failed to get platform version.';
     }

--- a/packages/flutter_tools/templates/module/common/lib/main.dart.tmpl
+++ b/packages/flutter_tools/templates/module/common/lib/main.dart.tmpl
@@ -137,6 +137,7 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
   String _platformVersion = 'Unknown';
+  final _plugin = {{pluginDartClass}}();
 
   @override
   void initState() {
@@ -149,7 +150,7 @@ class _MyAppState extends State<MyApp> {
     String platformVersion;
     // Platform messages may fail, so we use a try/catch PlatformException.
     try {
-      platformVersion = await {{pluginDartClass}}.platformVersion;
+      platformVersion = await _plugin.platformVersion;
     } on PlatformException {
       platformVersion = 'Failed to get platform version.';
     }

--- a/packages/flutter_tools/templates/plugin/lib/projectName.dart.tmpl
+++ b/packages/flutter_tools/templates/plugin/lib/projectName.dart.tmpl
@@ -1,13 +1,12 @@
 import 'dart:async';
 
-import 'package:flutter/services.dart';
+import 'src/{{projectName}}_platform.dart';
 
 class {{pluginDartClass}} {
-  static const MethodChannel _channel =
-      const MethodChannel('{{projectName}}');
+  final _platform = {{pluginDartClass}}Platform.instance;
 
-  static Future<String> get platformVersion async {
-    final String version = await _channel.invokeMethod('getPlatformVersion');
+  Future<String> get platformVersion async {
+    final String version = await _platform.getPlatformVersion();
     return version;
   }
 }

--- a/packages/flutter_tools/templates/plugin/lib/src/method_channel_projectName.dart.tmpl
+++ b/packages/flutter_tools/templates/plugin/lib/src/method_channel_projectName.dart.tmpl
@@ -1,0 +1,18 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+
+import '{{projectName}}_platform.dart';
+
+/// The interface that implementations of image_picker must implement.
+///
+/// Platform implementations should extend this class rather than implement it.
+class MethodChannel{{pluginDartClass}} extends {{pluginDartClass}}Platform {
+  final _channel = MethodChannel('{{projectName}}');
+
+  /// Returns a [String] containing the version of the platform.
+  Future<String> getPlatformVersion() async {
+    final version = await _channel.invokeMethod('getPlatformVersion');
+    return version.toString();
+  }
+}

--- a/packages/flutter_tools/templates/plugin/lib/src/method_channel_projectName.dart.tmpl
+++ b/packages/flutter_tools/templates/plugin/lib/src/method_channel_projectName.dart.tmpl
@@ -4,9 +4,7 @@ import 'package:flutter/services.dart';
 
 import '{{projectName}}_platform.dart';
 
-/// The interface that implementations of image_picker must implement.
-///
-/// Platform implementations should extend this class rather than implement it.
+/// A MethodChannel-based implementation of the {{pluginDartClass}}Platform class.
 class MethodChannel{{pluginDartClass}} extends {{pluginDartClass}}Platform {
   final _channel = MethodChannel('{{projectName}}');
 

--- a/packages/flutter_tools/templates/plugin/lib/src/projectName_platform.dart.tmpl
+++ b/packages/flutter_tools/templates/plugin/lib/src/projectName_platform.dart.tmpl
@@ -1,0 +1,38 @@
+import 'dart:async';
+
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+import 'method_channel_{{projectName}}.dart';
+
+/// The interface that implementations of image_picker must implement.
+///
+/// Platform implementations should extend this class rather than implement it.
+class {{pluginDartClass}}Platform extends PlatformInterface {
+
+  /// Default constructor.
+  {{pluginDartClass}}Platform() : super(token: _token);
+
+  static final Object _token = Object();
+
+  static {{pluginDartClass}}Platform _instance = MethodChannel{{pluginDartClass}}();
+
+  /// The default instance of [{{pluginDartClass}}Platform] to use.
+  ///
+  /// Defaults to [MethodChannel{{pluginDartClass}}].
+  static {{pluginDartClass}}Platform get instance => _instance;
+
+  /// Platform-specific plugins should set this with their own platform-specific
+  /// class that extends [{{pluginDartClass}}Platform] when they register themselves.
+  static set instance({{pluginDartClass}}Platform instance) {
+    PlatformInterface.verifyToken(instance, _token);
+    _instance = instance;
+  }
+
+  // Below this line are the methods that each platform must implement to provide
+  // functionality from the platform side.
+
+  /// Returns a [String] containing the version of the platform.
+  Future<String> getPlatformVersion() {
+    throw UnimplementedError('getPlatformVersion() is not implemented.');
+  }
+}

--- a/packages/flutter_tools/templates/plugin/lib/src/projectName_platform.dart.tmpl
+++ b/packages/flutter_tools/templates/plugin/lib/src/projectName_platform.dart.tmpl
@@ -9,7 +9,8 @@ import 'method_channel_{{projectName}}.dart';
 /// Platform implementations should extend this class rather than implement it.
 class {{pluginDartClass}}Platform extends PlatformInterface {
 
-  /// Default constructor.
+  /// This constructor registers a unique token for this {{pluginDartClass}}Platform,
+  /// to enforce instances to extend this class, rather than implement it.
   {{pluginDartClass}}Platform() : super(token: _token);
 
   static final Object _token = Object();
@@ -28,8 +29,7 @@ class {{pluginDartClass}}Platform extends PlatformInterface {
     _instance = instance;
   }
 
-  // Below this line are the methods that each platform must implement to provide
-  // functionality from the platform side.
+  // Methods that platforms must implement to provide native functionality follow...
 
   /// Returns a [String] containing the version of the platform.
   Future<String> getPlatformVersion() {

--- a/packages/flutter_tools/templates/plugin/lib/src/projectName_web.dart.tmpl
+++ b/packages/flutter_tools/templates/plugin/lib/src/projectName_web.dart.tmpl
@@ -1,0 +1,26 @@
+import 'dart:async';
+
+import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+
+import '{{projectName}}_platform.dart';
+
+// In order to *not* need this ignore, consider extracting the "web" version
+// of your plugin as a separate package, instead of inlining it in the same
+// package as the core of your plugin.
+// ignore: avoid_web_libraries_in_flutter
+import 'dart:html' as html show window;
+
+/// The interface that implementations of image_picker must implement.
+///
+/// Platform implementations should extend this class rather than implement it.
+class {{pluginDartClass}}Web extends {{pluginDartClass}}Platform {
+  static void registerWith(Registrar registrar) {
+    {{pluginDartClass}}Platform.instance = {{pluginDartClass}}Web();
+  }
+
+  /// Returns a [String] containing the version of the platform.
+  Future<String> getPlatformVersion() {
+    final version = html.window.navigator.userAgent;
+    return Future.value(version);
+  }
+}

--- a/packages/flutter_tools/templates/plugin/lib/src/projectName_web.dart.tmpl
+++ b/packages/flutter_tools/templates/plugin/lib/src/projectName_web.dart.tmpl
@@ -10,9 +10,7 @@ import '{{projectName}}_platform.dart';
 // ignore: avoid_web_libraries_in_flutter
 import 'dart:html' as html show window;
 
-/// The interface that implementations of image_picker must implement.
-///
-/// Platform implementations should extend this class rather than implement it.
+/// A web implementation of the {{pluginDartClass}}Platform class.
 class {{pluginDartClass}}Web extends {{pluginDartClass}}Platform {
   static void registerWith(Registrar registrar) {
     {{pluginDartClass}}Platform.instance = {{pluginDartClass}}Web();

--- a/packages/flutter_tools/templates/plugin/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/plugin/pubspec.yaml.tmpl
@@ -9,8 +9,13 @@ environment:
   flutter: ">=1.10.0"
 
 dependencies:
+  plugin_platform_interface: ^1.0.1
   flutter:
     sdk: flutter
+{{#web}}
+  flutter_web_plugins:
+    sdk: flutter
+{{/web}}
 
 dev_dependencies:
   flutter_test:
@@ -40,6 +45,11 @@ flutter:
       macos:
         pluginClass: {{pluginClass}}
 {{/macos}}
+{{#web}}
+      web:
+        pluginClass: {{pluginDartClass}}Web
+        fileName: src/{{projectName}}_web.dart
+{{/web}}
 
   # To add assets to your plugin package, add an assets section, like this:
   # assets:

--- a/packages/flutter_tools/templates/plugin/test/projectName_test.dart.tmpl
+++ b/packages/flutter_tools/templates/plugin/test/projectName_test.dart.tmpl
@@ -7,6 +7,8 @@ void main() {
 
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  final _plugin = {{pluginDartClass}}();
+
   setUp(() {
     channel.setMockMethodCallHandler((MethodCall methodCall) async {
       return '42';
@@ -18,6 +20,6 @@ void main() {
   });
 
   test('getPlatformVersion', () async {
-    expect(await {{pluginDartClass}}.platformVersion, '42');
+    expect(await _plugin.platformVersion, '42');
   });
 }


### PR DESCRIPTION
## Description

* Migrate the example plugin to be instance-based instead of all static. Update usages.
* Federate the sample plugin so web can be implemented:
  * Separate platform interface from implementations.
  * Core plugin uses *only* platform.
  * Web may override implementation of said platform. 
  * Defaults to MethodChannel version.
* Add web implementation of the plugin (when requested)
* Add test.

## Related Issues

* https://github.com/flutter/flutter/issues/59562

## Tests

I added the following tests:

`flutter_tools/test/commands.shard/permeable/create_test.dart`:
* `plugin project supports web`
* Asserted `lib/src/flutter_project_web.dart` is not created by default. 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
