### PR TITLE
skip fuchsia_precache-linux on release branches

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -121,7 +121,8 @@ task:
         - dart --enable-asserts ./dev/bots/analyze.dart
 
     - name: fuchsia_precache-linux # linux-only
-      only_if: "changesInclude('.cirrus.yml', 'bin/internal/engine.version')"
+      # Skip on release branches
+      only_if: "changesInclude('.cirrus.yml', 'bin/internal/engine.version') && ($CIRRUS_BASE_BRANCH == 'master' || $CIRRUS_BRANCH == 'master')"
       script:
         - flutter precache --fuchsia --no-android --no-ios
         - flutter precache --flutter_runner --no-android --no-ios


### PR DESCRIPTION
Fuchsia is not currently supported on releases anyway, and this would fail because a CIPD package wasn't generated if the engine had a cherry pick (see linked issue).

Fixes https://github.com/flutter/flutter/issues/59704