### PR TITLE
fix the widget span layout when text scale factor != 1

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -530,9 +530,10 @@ class RenderParagraph extends RenderBox
       // Only constrain the width to the maximum width of the paragraph.
       // Leave height unconstrained, which will overflow if expanded past.
       child.layout(
-        BoxConstraints(
-          maxWidth: constraints.maxWidth,
-        ),
+        // The content will be enlarged by textScaleFactor during painting phase.
+        // We reduce contraint by textScaleFactor so that the content will fit
+        // into the box once it is enlarged.
+        BoxConstraints(maxWidth: constraints.maxWidth) / textScaleFactor,
         parentUsesSize: true,
       );
       double baselineOffset;

--- a/packages/flutter/test/widgets/text_test.dart
+++ b/packages/flutter/test/widgets/text_test.dart
@@ -178,7 +178,7 @@ void main() {
                   WidgetSpan(
                     child: RichText(
                       text: const TextSpan(text: 'widget should be truncated'),
-                      textDirection: TextDirection.rtl,
+                      textDirection: TextDirection.ltr,
                     ),
                   ),
                 ],
@@ -206,7 +206,7 @@ void main() {
                   WidgetSpan(
                     child: RichText(
                       text: const TextSpan(text: 'widget should be truncated'),
-                      textDirection: TextDirection.rtl,
+                      textDirection: TextDirection.ltr,
                     ),
                   ),
                 ],
@@ -223,7 +223,7 @@ void main() {
     renderText = tester.renderObject(find.byKey(key));
     // The RichText in the widget span should wrap into three lines.
     expect(renderText.size.height, singleLineHeight * textScaleFactor * 3);
-  });
+  }, skip: isBrowser); // TODO(yjbanov): https://github.com/flutter/flutter/issues/42086
 
   testWidgets('semanticsLabel can override text label', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);

--- a/packages/flutter/test/widgets/text_test.dart
+++ b/packages/flutter/test/widgets/text_test.dart
@@ -163,6 +163,68 @@ void main() {
     expect(tester.takeException(), null);
   }, skip: isBrowser); // TODO(yjbanov): https://github.com/flutter/flutter/issues/42086
 
+  testWidgets('inline widgets works with textScaleFactor', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/59316
+    final UniqueKey key = UniqueKey();
+    double textScaleFactor = 1.0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(title: const Text('title')),
+          body: Center(
+            child: Text.rich(
+              TextSpan(
+                children: <InlineSpan>[
+                  WidgetSpan(
+                    child: RichText(
+                      text: const TextSpan(text: 'widget should be truncated'),
+                      textDirection: TextDirection.rtl,
+                    ),
+                  ),
+                ],
+              ),
+              key: key,
+              textDirection: TextDirection.ltr,
+              textScaleFactor: textScaleFactor,
+            ),
+          ),
+        ),
+      ),
+    );
+    RenderBox renderText = tester.renderObject(find.byKey(key));
+    final double singleLineHeight = renderText.size.height;
+    // Now, increases the text scale factor by 5 times.
+    textScaleFactor = textScaleFactor * 5;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(title: const Text('title')),
+          body: Center(
+            child: Text.rich(
+              TextSpan(
+                children: <InlineSpan>[
+                  WidgetSpan(
+                    child: RichText(
+                      text: const TextSpan(text: 'widget should be truncated'),
+                      textDirection: TextDirection.rtl,
+                    ),
+                  ),
+                ],
+              ),
+              key: key,
+              textDirection: TextDirection.ltr,
+              textScaleFactor: textScaleFactor,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    renderText = tester.renderObject(find.byKey(key));
+    // The RichText in the widget span should wrap into three lines.
+    expect(renderText.size.height, singleLineHeight * textScaleFactor * 3);
+  });
+
   testWidgets('semanticsLabel can override text label', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
     await tester.pumpWidget(


### PR DESCRIPTION
## Description

The widget span is laid out with original size but enlarged after paint. This cause the content to flow out of the box.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/59316

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behaviour with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
