### PR TITLE
[flutter_tools] add missing null-safety flags

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -22,7 +22,7 @@ import 'build_web.dart';
 
 class BuildCommand extends FlutterCommand {
   BuildCommand({ bool verboseHelp = false }) {
-    addSubcommand(BuildAarCommand());
+    addSubcommand(BuildAarCommand(verboseHelp: verboseHelp));
     addSubcommand(BuildApkCommand(verboseHelp: verboseHelp));
     addSubcommand(BuildAppBundleCommand(verboseHelp: verboseHelp));
     addSubcommand(BuildAotCommand());

--- a/packages/flutter_tools/lib/src/commands/build_aar.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aar.dart
@@ -4,6 +4,8 @@
 
 import 'dart:async';
 
+import 'package:meta/meta.dart';
+
 import '../android/android_builder.dart';
 import '../android/gradle_utils.dart';
 import '../base/common.dart';
@@ -17,7 +19,7 @@ import '../runner/flutter_command.dart' show FlutterCommandResult;
 import 'build.dart';
 
 class BuildAarCommand extends BuildSubCommand {
-  BuildAarCommand() {
+  BuildAarCommand({ @required bool verboseHelp }) {
     argParser
       ..addFlag(
         'debug',
@@ -41,7 +43,8 @@ class BuildAarCommand extends BuildSubCommand {
     addSplitDebugInfoOption();
     addDartObfuscationOption();
     usesTrackWidgetCreation(verboseHelp: false);
-    addNullSafetyModeOptions();
+    addNullSafetyModeOptions(hide: !verboseHelp);
+    addEnableExperimentation(hide: !verboseHelp);
     argParser
       ..addMultiOption(
         'target-platform',

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -33,7 +33,7 @@ class BuildApkCommand extends BuildSubCommand {
     addBundleSkSLPathOption(hide: !verboseHelp);
     addEnableExperimentation(hide: !verboseHelp);
     addBuildPerformanceFile(hide: !verboseHelp);
-    addNullSafetyModeOptions();
+    addNullSafetyModeOptions(hide: !verboseHelp);
     argParser
       ..addFlag('split-per-abi',
         negatable: false,

--- a/packages/flutter_tools/lib/src/commands/build_appbundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_appbundle.dart
@@ -32,6 +32,8 @@ class BuildAppBundleCommand extends BuildSubCommand {
     addBundleSkSLPathOption(hide: !verboseHelp);
     addBuildPerformanceFile(hide: !verboseHelp);
     usesTrackWidgetCreation(verboseHelp: verboseHelp);
+    addNullSafetyModeOptions();
+    addEnableExperimentation();
     argParser.addMultiOption('target-platform',
         splitCommas: true,
         defaultsTo: <String>['android-arm', 'android-arm64', 'android-x64'],

--- a/packages/flutter_tools/lib/src/commands/build_appbundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_appbundle.dart
@@ -32,8 +32,8 @@ class BuildAppBundleCommand extends BuildSubCommand {
     addBundleSkSLPathOption(hide: !verboseHelp);
     addBuildPerformanceFile(hide: !verboseHelp);
     usesTrackWidgetCreation(verboseHelp: verboseHelp);
-    addNullSafetyModeOptions();
-    addEnableExperimentation();
+    addNullSafetyModeOptions(hide: !verboseHelp);
+    addEnableExperimentation(hide: !verboseHelp);
     argParser.addMultiOption('target-platform',
         splitCommas: true,
         defaultsTo: <String>['android-arm', 'android-arm64', 'android-x64'],

--- a/packages/flutter_tools/lib/src/commands/build_fuchsia.dart
+++ b/packages/flutter_tools/lib/src/commands/build_fuchsia.dart
@@ -4,6 +4,8 @@
 
 import 'dart:async';
 
+import 'package:meta/meta.dart';
+
 import '../base/common.dart';
 import '../build_info.dart';
 import '../cache.dart';
@@ -16,13 +18,13 @@ import 'build.dart';
 
 /// A command to build a Fuchsia target.
 class BuildFuchsiaCommand extends BuildSubCommand {
-  BuildFuchsiaCommand({bool verboseHelp = false}) {
+  BuildFuchsiaCommand({ @required bool verboseHelp }) {
     addTreeShakeIconsFlag();
     usesTargetOption();
     usesDartDefineOption();
     addBuildModeFlags(verboseHelp: verboseHelp);
-    addNullSafetyModeOptions();
-    addEnableExperimentation();
+    addNullSafetyModeOptions(hide: !verboseHelp);
+    addEnableExperimentation(hide: !verboseHelp);
     argParser.addOption(
       'runner-source',
       help: 'The package source to use for the flutter_runner. '

--- a/packages/flutter_tools/lib/src/commands/build_fuchsia.dart
+++ b/packages/flutter_tools/lib/src/commands/build_fuchsia.dart
@@ -22,6 +22,7 @@ class BuildFuchsiaCommand extends BuildSubCommand {
     usesDartDefineOption();
     addBuildModeFlags(verboseHelp: verboseHelp);
     addNullSafetyModeOptions();
+    addEnableExperimentation();
     argParser.addOption(
       'runner-source',
       help: 'The package source to use for the flutter_runner. '

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -34,7 +34,7 @@ class BuildIOSCommand extends BuildSubCommand {
     addEnableExperimentation(hide: !verboseHelp);
     addBuildPerformanceFile(hide: !verboseHelp);
     addBundleSkSLPathOption(hide: !verboseHelp);
-    addNullSafetyModeOptions();
+    addNullSafetyModeOptions(hide: !verboseHelp);
     argParser
       ..addFlag('simulator',
         help: 'Build for the iOS simulator instead of the device. This changes '

--- a/packages/flutter_tools/lib/src/commands/build_linux.dart
+++ b/packages/flutter_tools/lib/src/commands/build_linux.dart
@@ -29,7 +29,7 @@ class BuildLinuxCommand extends BuildSubCommand {
     usesTrackWidgetCreation(verboseHelp: verboseHelp);
     addBuildPerformanceFile(hide: !verboseHelp);
     addBundleSkSLPathOption(hide: !verboseHelp);
-    addNullSafetyModeOptions();
+    addNullSafetyModeOptions(hide: !verboseHelp);
   }
 
   @override

--- a/packages/flutter_tools/lib/src/commands/build_macos.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos.dart
@@ -30,7 +30,7 @@ class BuildMacosCommand extends BuildSubCommand {
     addEnableExperimentation(hide: !verboseHelp);
     addBuildPerformanceFile(hide: !verboseHelp);
     addBundleSkSLPathOption(hide: !verboseHelp);
-    addNullSafetyModeOptions();
+    addNullSafetyModeOptions(hide: !verboseHelp);
   }
 
   @override

--- a/packages/flutter_tools/lib/src/commands/build_web.dart
+++ b/packages/flutter_tools/lib/src/commands/build_web.dart
@@ -25,7 +25,7 @@ class BuildWebCommand extends BuildSubCommand {
     addBuildModeFlags(excludeDebug: true);
     usesDartDefineOption();
     addEnableExperimentation(hide: !verboseHelp);
-    addNullSafetyModeOptions();
+    addNullSafetyModeOptions(hide: !verboseHelp);
     argParser.addFlag('web-initialize-platform',
         defaultsTo: true,
         negatable: true,

--- a/packages/flutter_tools/lib/src/commands/build_windows.dart
+++ b/packages/flutter_tools/lib/src/commands/build_windows.dart
@@ -32,6 +32,7 @@ class BuildWindowsCommand extends BuildSubCommand {
     usesTrackWidgetCreation(verboseHelp: verboseHelp);
     addBuildPerformanceFile(hide: !verboseHelp);
     addBundleSkSLPathOption(hide: !verboseHelp);
+    addNullSafetyModeOptions();
   }
 
   @override

--- a/packages/flutter_tools/lib/src/commands/build_windows.dart
+++ b/packages/flutter_tools/lib/src/commands/build_windows.dart
@@ -32,7 +32,7 @@ class BuildWindowsCommand extends BuildSubCommand {
     usesTrackWidgetCreation(verboseHelp: verboseHelp);
     addBuildPerformanceFile(hide: !verboseHelp);
     addBundleSkSLPathOption(hide: !verboseHelp);
-    addNullSafetyModeOptions();
+    addNullSafetyModeOptions(hide: !verboseHelp);
   }
 
   @override

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -66,7 +66,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
     usesPubOption();
     usesTrackWidgetCreation(verboseHelp: verboseHelp);
     usesIsolateFilterOption(hide: !verboseHelp);
-    addNullSafetyModeOptions();
+    addNullSafetyModeOptions(hide: !verboseHelp);
     usesDeviceUserOption();
   }
 

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -31,7 +31,7 @@ class TestCommand extends FlutterCommand {
   }) : assert(testWrapper != null) {
     requiresPubspecYaml();
     usesPubOption();
-    addNullSafetyModeOptions();
+    addNullSafetyModeOptions(hide: !verboseHelp);
     usesTrackWidgetCreation(verboseHelp: verboseHelp);
     addEnableExperimentation(hide: !verboseHelp);
     argParser

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -474,11 +474,14 @@ abstract class FlutterCommand extends Command<void> {
       );
   }
 
-  void addNullSafetyModeOptions() {
+  void addNullSafetyModeOptions({ @required bool hide }) {
     argParser.addFlag(FlutterOptions.kNullSafety,
-      help: 'Whether to override the default null safety setting.',
+      help:
+        'Whether to override the inferred null safety mode to support out of '
+        'order migrations. By default, Flutter applications will attempt to '
+        'run at the null safety level of their entrypoint library.',
       defaultsTo: null,
-      hide: true,
+      hide: hide,
     );
   }
 
@@ -506,7 +509,7 @@ abstract class FlutterCommand extends Command<void> {
     );
   }
 
-  void addEnableExperimentation({ bool hide = false }) {
+  void addEnableExperimentation({ @required bool hide }) {
     argParser.addMultiOption(
       FlutterOptions.kEnableExperiment,
       help:

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -477,9 +477,10 @@ abstract class FlutterCommand extends Command<void> {
   void addNullSafetyModeOptions({ @required bool hide }) {
     argParser.addFlag(FlutterOptions.kNullSafety,
       help:
-        'Whether to override the inferred null safety mode to support out of '
-        'order migrations. By default, Flutter applications will attempt to '
-        'run at the null safety level of their entrypoint library.',
+        'Whether to override the inferred null safety mode. This allows null-safe '
+        'libraries to depend on un-migrated (non-null safe) libraries. By default, '
+        'Flutter applications will attempt to run at the null safety level of their '
+        'entrypoint library (usually lib/main.dart).',
       defaultsTo: null,
       hide: hide,
     );

--- a/packages/flutter_tools/test/commands.shard/permeable/build_aar_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_aar_test.dart
@@ -26,7 +26,7 @@ void main() {
   Cache.disableLocking();
 
   Future<BuildAarCommand> runCommandIn(String target, { List<String> arguments }) async {
-    final BuildAarCommand command = BuildAarCommand();
+    final BuildAarCommand command = BuildAarCommand(verboseHelp: false);
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>[
       'aar',
@@ -282,7 +282,7 @@ Future<BuildAarCommand> runBuildAarCommand(
   String target, {
   List<String> arguments,
 }) async {
-  final BuildAarCommand command = BuildAarCommand();
+  final BuildAarCommand command = BuildAarCommand(verboseHelp: false);
   final CommandRunner<void> runner = createTestCommandRunner(command);
   await runner.run(<String>[
     'aar',

--- a/packages/flutter_tools/test/general.shard/commands/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_test.dart
@@ -1,0 +1,44 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:args/args.dart';
+import 'package:flutter_tools/src/commands/build.dart';
+import 'package:flutter_tools/src/commands/build_aar.dart';
+import 'package:flutter_tools/src/commands/build_apk.dart';
+import 'package:flutter_tools/src/commands/build_appbundle.dart';
+import 'package:flutter_tools/src/commands/build_fuchsia.dart';
+import 'package:flutter_tools/src/commands/build_ios.dart';
+import 'package:flutter_tools/src/commands/build_linux.dart';
+import 'package:flutter_tools/src/commands/build_macos.dart';
+import 'package:flutter_tools/src/commands/build_web.dart';
+import 'package:flutter_tools/src/commands/build_windows.dart';
+
+import '../../src/common.dart';
+import '../../src/context.dart';
+
+void main() {
+  testUsingContext('All build commands support null safety options', () {
+    final List<BuildSubCommand> commands = <BuildSubCommand>[
+      BuildWindowsCommand(verboseHelp: false),
+      BuildLinuxCommand(verboseHelp: false),
+      BuildMacosCommand(verboseHelp: false),
+      BuildWebCommand(verboseHelp: false),
+      BuildApkCommand(verboseHelp: false),
+      BuildIOSCommand(verboseHelp: false),
+      BuildAppBundleCommand(verboseHelp: false),
+      BuildFuchsiaCommand(verboseHelp: false),
+      BuildAarCommand(verboseHelp: false),
+    ];
+
+    for (final BuildSubCommand command in commands) {
+      final ArgResults results = command.argParser.parse(<String>[
+        '--sound-null-safety',
+        '--enable-experiment=non-nullable',
+      ]);
+
+      expect(results.wasParsed('sound-null-safety'), true);
+      expect(results.wasParsed('enable-experiment'), true);
+    }
+  });
+}


### PR DESCRIPTION
## Description

Some of the null-safety commands were missing - plumb them through. Ensure that verbose mode shows their output, and clean up the messaging around sound-null-safety.

Fixes https://github.com/flutter/flutter/issues/59769

Adds a test that validate each of the null safety supporting build commands has everything plumbed through.