### PR TITLE
[devicelab] fix concurrent hot reload test: stderr != failure

### DIFF
--- a/dev/devicelab/bin/tasks/run_machine_concurrent_hot_reload.dart
+++ b/dev/devicelab/bin/tasks/run_machine_concurrent_hot_reload.dart
@@ -47,7 +47,6 @@ void main() {
         <String>[
           'run',
           '--machine',
-          '--verbose',
           '--no-fast-start',
           '-d',
           device.deviceId,
@@ -73,10 +72,6 @@ void main() {
           ready.complete();
           ok ??= true;
         }
-      });
-      transformToLines(run.stderr).listen((String line) {
-        stderr.writeln('run:stderr: $line');
-        ok = false;
       });
       run.exitCode.then<void>((int exitCode) {
         ok = false;


### PR DESCRIPTION
## Description

The tool needs to start outputing trace text to stderr to avoid breaking machine mode. This test is bogus, and should use the exit code.