### PR TITLE
Make flutter and dart scripts invoke their batch file equivalents on Windows

### DIFF
--- a/bin/dart
+++ b/bin/dart
@@ -43,8 +43,14 @@ function follow_links() (
   echo "$file"
 )
 
-PROG_NAME="$(follow_links "$BASH_SOURCE")"
+PROG_NAME="$(follow_links "${BASH_SOURCE[0]}")"
 BIN_DIR="$(cd "${PROG_NAME%/*}" ; pwd -P)"
+OS="$(uname -s)"
+
+if [[ $OS =~ MINGW.* ]]; then
+  # If we're on Windows, invoke the batch script instead, to get proper locking.
+  exec "${BIN_DIR}/dart.bat" "$@"
+fi
 
 # To define `shared::execute()` function
 source "$BIN_DIR/internal/shared.sh"

--- a/bin/flutter
+++ b/bin/flutter
@@ -43,8 +43,14 @@ function follow_links() (
   echo "$file"
 )
 
-PROG_NAME="$(follow_links "$BASH_SOURCE")"
+PROG_NAME="$(follow_links "${BASH_SOURCE[0]}")"
 BIN_DIR="$(cd "${PROG_NAME%/*}" ; pwd -P)"
+OS="$(uname -s)"
+
+if [[ $OS =~ MINGW.* ]]; then
+  # If we're on Windows, invoke the batch script instead, to get proper locking.
+  exec "${BIN_DIR}/flutter.bat" "$@"
+fi
 
 # To define `shared::execute()` function
 source "$BIN_DIR/internal/shared.sh"

--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -170,7 +170,7 @@ function shared::execute() {
   # If running over git-bash, overrides the default UNIX executables with win32
   # executables
   case "$(uname -s)" in
-    MINGW32*)
+    MINGW*)
       DART="$DART.exe"
       PUB="$PUB.bat"
       ;;

--- a/bin/internal/update_dart_sdk.sh
+++ b/bin/internal/update_dart_sdk.sh
@@ -67,7 +67,7 @@ if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != `cat "$ENGINE_STAMP"` ]; t
       DART_ZIP_NAME="dart-sdk-linux-x64.zip"
       IS_USER_EXECUTABLE="-perm /u+x"
       ;;
-    MINGW32*)
+    MINGW*)
       DART_ZIP_NAME="dart-sdk-windows-x64.zip"
       IS_USER_EXECUTABLE="-perm /u+x"
       ;;


### PR DESCRIPTION
## Description

This makes the `flutter` and `dart` scripts invoke their batch file equivalents if running under MINGW (i.e. git-bash) on Windows.

This allows for proper locking, and makes sure that people aren't using two different (and non-mutally-aware) locking systems when running flutter on Windows.

I also fixed a couple of places where we look for MINGW32, which fails under MINGW64. It just looks for MINGW now.

## Related Issues

 - https://github.com/flutter/flutter/issues/58993
