### PR TITLE
Label unnecessarily ellided

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -986,9 +986,15 @@ class _RenderDecoration extends RenderBox {
       + contentPadding.right));
     // Increase the available width for the label when it is scaled down.
     final double invertedLabelScale = lerpDouble(1.00, 1 / _kFinalLabelScale, decoration.floatingLabelProgress);
+    final double labelWidth = math.max(0.0, constraints.maxWidth - (
+      _boxSize(icon).width
+      + contentPadding.left
+      + _boxSize(prefixIcon).width
+      + _boxSize(suffixIcon).width
+      + contentPadding.right));
     boxToBaseline[label] = _layoutLineBox(
       label,
-      boxConstraints.copyWith(maxWidth: inputWidth * invertedLabelScale),
+      boxConstraints.copyWith(maxWidth: labelWidth * invertedLabelScale),
     );
     boxToBaseline[hint] = _layoutLineBox(
       hint,

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -4162,7 +4162,7 @@ void main() {
     expect(tester.getTopLeft(find.text(hintText)).dy, topPosition);
   });
 
-  testWidgets('InputDecorator label width isn\'t affected by prefix or suffix', (WidgetTester tester) async {
+  testWidgets("InputDecorator label width isn't affected by prefix or suffix", (WidgetTester tester) async {
     const String labelText = 'My Label';
     const String prefixText = 'The five boxing wizards jump quickly.';
     const String suffixText = 'Suffix';

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -4161,4 +4161,59 @@ void main() {
 
     expect(tester.getTopLeft(find.text(hintText)).dy, topPosition);
   });
+
+  testWidgets('InputDecorator label width isn\'t affected by prefix or suffix', (WidgetTester tester) async {
+    const String labelText = 'My Label';
+    const String prefixText = 'The five boxing wizards jump quickly.';
+
+    Widget getLabeledInputDecorator(bool showPrefix) {
+      return MaterialApp(
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return Theme(
+                data: Theme.of(context),
+                child: Align(
+                  alignment: Alignment.topLeft,
+                  child: TextField(
+                    decoration: InputDecoration(
+                      icon: const Icon(Icons.assistant),
+                      prefixText: showPrefix ? prefixText : null,
+                      suffixIcon: const Icon(Icons.threesixty),
+                      labelText: labelText,
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+    }
+
+    // Build with no prefix.
+    await tester.pumpWidget(getLabeledInputDecorator(false));
+
+    // Get the width of the label when there is no prefix.
+    expect(find.text(prefixText), findsNothing);
+    final double labelWidth = tester.getSize(find.text(labelText)).width;
+
+    // Build with a prefix.
+    await tester.pumpWidget(getLabeledInputDecorator(true));
+
+    // The prefix exists but isn't visible. It has not affected the width of the
+    // label.
+    expect(find.text(prefixText), findsOneWidget);
+    expect(getOpacity(tester, prefixText), 0.0);
+    expect(tester.getSize(find.text(labelText)).width, labelWidth);
+
+    // Tap to focus.
+    await tester.tap(find.byType(TextField));
+    await tester.pumpAndSettle();
+
+    // The prefix is visible, and the label is floating and still hasn't had its
+    // width affected.
+    expect(tester.getSize(find.text(labelText)).width, labelWidth);
+    expect(getOpacity(tester, prefixText), 1.0);
+  });
 }

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -4165,8 +4165,9 @@ void main() {
   testWidgets('InputDecorator label width isn\'t affected by prefix or suffix', (WidgetTester tester) async {
     const String labelText = 'My Label';
     const String prefixText = 'The five boxing wizards jump quickly.';
+    const String suffixText = 'Suffix';
 
-    Widget getLabeledInputDecorator(bool showPrefix) {
+    Widget getLabeledInputDecorator(bool showFix) {
       return MaterialApp(
         home: Material(
           child: Builder(
@@ -4178,7 +4179,8 @@ void main() {
                   child: TextField(
                     decoration: InputDecoration(
                       icon: const Icon(Icons.assistant),
-                      prefixText: showPrefix ? prefixText : null,
+                      prefixText: showFix ? prefixText : null,
+                      suffixText: showFix ? suffixText : null,
                       suffixIcon: const Icon(Icons.threesixty),
                       labelText: labelText,
                     ),
@@ -4191,28 +4193,31 @@ void main() {
       );
     }
 
-    // Build with no prefix.
+    // Build with no prefix or suffix.
     await tester.pumpWidget(getLabeledInputDecorator(false));
 
-    // Get the width of the label when there is no prefix.
+    // Get the width of the label when there is no prefix/suffix.
     expect(find.text(prefixText), findsNothing);
+    expect(find.text(suffixText), findsNothing);
     final double labelWidth = tester.getSize(find.text(labelText)).width;
 
-    // Build with a prefix.
+    // Build with a prefix and suffix.
     await tester.pumpWidget(getLabeledInputDecorator(true));
 
-    // The prefix exists but isn't visible. It has not affected the width of the
-    // label.
+    // The prefix and suffix exist but aren't visible. They have not affected
+    // the width of the label.
     expect(find.text(prefixText), findsOneWidget);
     expect(getOpacity(tester, prefixText), 0.0);
+    expect(find.text(suffixText), findsOneWidget);
+    expect(getOpacity(tester, suffixText), 0.0);
     expect(tester.getSize(find.text(labelText)).width, labelWidth);
 
     // Tap to focus.
     await tester.tap(find.byType(TextField));
     await tester.pumpAndSettle();
 
-    // The prefix is visible, and the label is floating and still hasn't had its
-    // width affected.
+    // The prefix and suffix are visible, and the label is floating and still
+    // hasn't had its width affected.
     expect(tester.getSize(find.text(labelText)).width, labelWidth);
     expect(getOpacity(tester, prefixText), 1.0);
   });


### PR DESCRIPTION
## Description

The label in input decoration was making room for prefix and suffix when calculating its width. However, when label is displayed in the input, prefix and suffix are not, so label was being ellided when it didn't need to be.  This removes them from the width calculation and allows label to take up all the available space.

## Related Issues

Closes https://github.com/flutter/flutter/issues/56008

## Tests

I added the following tests:

Test that the label's width stays the same despite adding a prefix and suffix.

## Breaking Change

None.