### PR TITLE
Add integration tests for structured error

### DIFF
--- a/packages/flutter_tools/test/integration.shard/flutter_run_with_error_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_run_with_error_test.dart
@@ -1,0 +1,69 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+
+import '../src/common.dart';
+import 'test_data/project_with_early_error.dart';
+import 'test_driver.dart';
+import 'test_utils.dart';
+
+void main() {
+  Directory tempDir;
+  final ProjectWithEarlyError _project = ProjectWithEarlyError();
+  const String _exceptionStart = '══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞══════════════════';
+  FlutterRunTestDriver _flutter;
+
+  setUp(() async {
+    tempDir = createResolvedTempDirectorySync('run_test.');
+    await _project.setUpIn(tempDir);
+    _flutter = FlutterRunTestDriver(tempDir);
+  });
+
+  tearDown(() async {
+    await _flutter.stop();
+    tryToDelete(tempDir);
+  });
+
+  test('flutter run reports an early error in an application', () async {
+    final StringBuffer stdout = StringBuffer();
+    _flutter.stdout.listen(stdout.writeln);
+
+    await _flutter.run(startPaused: true, withDebugger: true, structuredErrors: true);
+    await _flutter.resume();
+    await _flutter.stop();
+
+    expect(stdout.toString(), contains(_exceptionStart));
+  });
+
+  test('flutter run for web reports an early error in an application', () async {
+    final StringBuffer stdout = StringBuffer();
+
+    await _flutter.run(startPaused: true, withDebugger: true, structuredErrors: true, chrome: true);
+    await _flutter.resume();
+
+    final Completer<void> completer = Completer<void>();
+    bool lineFound = false;
+
+    await Future<void>(() async {
+      _flutter.stdout.listen((String line) {
+        stdout.writeln(line);
+        if (line.startsWith('Another exception was thrown') && !lineFound) {
+          lineFound = true;
+          completer.complete();
+        }
+      });
+      await completer.future;
+    }).timeout(const Duration(seconds: 15), onTimeout: () {
+      // Complete anyway in case we don't see the 'Another exception' line.
+      completer.complete();
+    });
+
+    expect(stdout.toString(), contains(_exceptionStart));
+    await _flutter.stop();
+  });
+}

--- a/packages/flutter_tools/test/integration.shard/flutter_run_with_error_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_run_with_error_test.dart
@@ -65,5 +65,5 @@ void main() {
 
     expect(stdout.toString(), contains(_exceptionStart));
     await _flutter.stop();
-  });
+  }, skip: 'Running in cirrus environment causes premature exit');
 }

--- a/packages/flutter_tools/test/integration.shard/test_data/project_with_early_error.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/project_with_early_error.dart
@@ -1,0 +1,41 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'project.dart';
+
+class ProjectWithEarlyError extends Project {
+
+  @override
+  final String pubspec = '''
+  name: test
+  environment:
+    sdk: ">=2.0.0-dev.68.0 <3.0.0"
+
+  dependencies:
+    flutter:
+      sdk: flutter
+  ''';
+
+  @override
+  final String main = r'''
+  import 'dart:async';
+
+  import 'package:flutter/material.dart';
+
+  Future<void> main() async {
+    while (true) {
+      runApp(new MyApp());
+      await Future.delayed(const Duration(milliseconds: 50));
+    }
+  }
+
+  class MyApp extends StatelessWidget {
+    @override
+    Widget build(BuildContext context) {
+      throw FormatException();
+    }
+  }
+  ''';
+
+}

--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -437,6 +437,7 @@ class FlutterRunTestDriver extends FlutterTestDriver {
     bool startPaused = false,
     bool pauseOnExceptions = false,
     bool chrome = false,
+    bool structuredErrors = false,
     File pidFile,
     String script,
   }) async {
@@ -451,6 +452,8 @@ class FlutterRunTestDriver extends FlutterTestDriver {
           ...<String>['chrome', '--web-run-headless', '--web-enable-expression-evaluation']
         else
           'flutter-tester',
+        if (structuredErrors)
+          '--dart-define=flutter.inspector.structuredErrors=true',
       ],
       withDebugger: withDebugger,
       startPaused: startPaused,


### PR DESCRIPTION
## Description

Adds integration tests to verify that structured errors can be printed out while running mobile and web applications.

## Related Issues

Follow up to https://github.com/flutter/flutter/pull/59018

## Tests

I added the following tests:
- Test that flutter run with structured errors enabled will display structured errors to stdout
- Test that flutter run for web with structured errors enabled will display structured errors to stdout

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
