### PR TITLE
Revert "flutter.gradle: collect list of Android plugins from .flutter-plugins-dependencies"

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -372,27 +372,17 @@ class FlutterPlugin implements Plugin<Project> {
     }
 
     private Properties getPluginList() {
+        File pluginsFile = new File(project.projectDir.parentFile.parentFile, '.flutter-plugins')
+        Properties allPlugins = readPropertiesIfExist(pluginsFile)
         Properties androidPlugins = new Properties()
-
-        def flutterProjectRoot = project.projectDir.parentFile.parentFile
-        def pluginsFile = new File(flutterProjectRoot, '.flutter-plugins-dependencies')
-        if (!pluginsFile.exists()) {
-            return androidPlugins
+        allPlugins.each { name, path ->
+            if (doesSupportAndroidPlatform(path)) {
+                androidPlugins.setProperty(name, path)
+            }
+            // TODO(amirh): log an error if this plugin was specified to be an Android
+            // plugin according to the new schema, and was missing a build.gradle file.
+            // https://github.com/flutter/flutter/issues/40784
         }
-
-        def object = new JsonSlurper().parseText(pluginsFile.text)
-        assert object instanceof Map
-        assert object.plugins instanceof Map
-        assert object.plugins.android instanceof List
-        // Includes the Flutter plugins that support the Android platform.
-        object.plugins.android.each { androidPlugin ->
-            assert androidPlugin.name instanceof String
-            assert androidPlugin.path instanceof String
-            def pluginDirectory = new File(androidPlugin.path, 'android')
-            assert pluginDirectory.exists()
-            androidPlugins.setProperty(androidPlugin.name, androidPlugin.path)
-        }
-
         return androidPlugins
     }
 


### PR DESCRIPTION
Reverts flutter/flutter#59294

This is breaking the new gallery tests:

```
2020-06-18T14:35:19.920439: stdout: [   +1 ms] --------- beginning of main
stdout:            06-18 14:34:03.141 D/QtiTetherService/IpaWrapper( 4418): getStats(false)
2020-06-18T14:35:19.924970: stdout: [   +4 ms] executing: /usr/local/share/android-sdk/platform-tools/adb -s ZY22458D8C shell -x logcat -v time -t 1
2020-06-18T14:35:20.015160: stdout: [  +88 ms] Exit code 0 from: /usr/local/share/android-sdk/platform-tools/adb -s ZY22458D8C shell -x logcat -v time -t 1
2020-06-18T14:35:20.015442: stdout: [   +1 ms] --------- beginning of main
2020-06-18T14:35:20.015649: stdout:            06-18 14:34:03.251 I/Finsky  (13274): [317332] nib.run(2): Cleaning dev-triggered-update data on package uninstall for io.flutter.demo.gallery.
2020-06-18T14:35:20.035047: stdout: [  +19 ms] executing: /usr/local/share/android-sdk/platform-tools/adb version
2020-06-18T14:35:20.043001: stdout: [   +8 ms] Android Debug Bridge version 1.0.41
stdout:            Version 29.0.4-5871666
stdout:            Installed as /usr/local/share/android-sdk/platform-tools/adb
2020-06-18T14:35:20.043858: stdout: [   +1 ms] executing: /usr/local/share/android-sdk/platform-tools/adb start-server
2020-06-18T14:35:20.052822: stdout: [   +8 ms] Building APK
2020-06-18T14:35:20.081660: stdout: [  +29 ms] Invalid build-number: 020400 for Android, overridden by 20400.
stdout:            See versionCode at https://developer.android.com/studio/publish/versioning
2020-06-18T14:35:20.084858: stdout: [   +3 ms] Running Gradle task 'assembleProfile'...
2020-06-18T14:35:20.087209: stdout: [   +2 ms] gradle.properties already sets `android.enableR8`
2020-06-18T14:35:20.123624: stdout: [  +36 ms] /Users/flutter/.cocoon/flutter/bin/cache/artifacts/gradle_wrapper/gradle/wrapper/gradle-wrapper.jar mode: 33188 rw-r--r--.
2020-06-18T14:35:20.124717: stdout: [   +1 ms] /Users/flutter/.cocoon/flutter/bin/cache/artifacts/gradle_wrapper/gradlew mode: 33261 rwxr-xr-x.
2020-06-18T14:35:20.129609: stdout: [   +4 ms] /private/var/folders/fj/4p233sqd1z52wg04dxx6q79m0000gn/T/new_gallery_testCVcxMn/gallery/android/gradlew mode: 33188 rw-r--r--.
2020-06-18T14:35:20.129838: stdout: [        ] Trying to give execute permission to /private/var/folders/fj/4p233sqd1z52wg04dxx6q79m0000gn/T/new_gallery_testCVcxMn/gallery/android/gradlew.
2020-06-18T14:35:20.139127: stdout: [   +8 ms] /Users/flutter/.cocoon/flutter/bin/cache/artifacts/gradle_wrapper/gradlew.bat mode: 33188 rw-r--r--.
2020-06-18T14:35:20.139905: stdout: [   +1 ms] Using gradle from /private/var/folders/fj/4p233sqd1z52wg04dxx6q79m0000gn/T/new_gallery_testCVcxMn/gallery/android/gradlew.
2020-06-18T14:35:20.140041: stdout: [        ] /private/var/folders/fj/4p233sqd1z52wg04dxx6q79m0000gn/T/new_gallery_testCVcxMn/gallery/android/gradlew mode: 33261 rwxr-xr-x.
2020-06-18T14:35:20.149222: stdout: [   +8 ms] executing: [/private/var/folders/fj/4p233sqd1z52wg04dxx6q79m0000gn/T/new_gallery_testCVcxMn/gallery/android/] /private/var/folders/fj/4p233sqd1z52wg04dxx6q79m0000gn/T/new_gallery_testCVcxMn/gallery/android/gradlew -Pverbose=true -Ptarget-platform=android-arm -Ptarget=/private/var/folders/fj/4p233sqd1z52wg04dxx6q79m0000gn/T/new_gallery_testCVcxMn/gallery/test_driver/transitions_perf.dart -Ptrack-widget-creation=true assembleProfile
2020-06-18T14:35:23.725330: stdout: [+3575 ms] > Configure project :app
2020-06-18T14:35:23.725961: stdout: [        ] WARNING: The option setting 'android.enableR8=true' is experimental and unsupported.
2020-06-18T14:35:23.726381: stdout: [        ] The current default is 'false'
2020-06-18T14:35:23.727044: stdout: [        ] Consider disabling R8 by removing 'android.enableR8=true' from your gradle.properties before publishing your app.
2020-06-18T14:35:24.505231: stdout: [ +777 ms] > Configure project :package_info
stdout: [        ] WARNING: The option setting 'android.enableR8=true' is experimental and unsupported.
2020-06-18T14:35:24.505997: stdout: [        ] The current default is 'false'
2020-06-18T14:35:24.506753: stdout: [        ] Consider disabling R8 by removing 'android.enableR8=true' from your gradle.properties before publishing your app.
stdout: [        ] > Configure project :path_provider
stdout: [        ] WARNING: The option setting 'android.enableR8=true' is experimental and unsupported.
2020-06-18T14:35:24.506954: stdout: [        ] The current default is 'false'
2020-06-18T14:35:24.507411: stdout: [        ] Consider disabling R8 by removing 'android.enableR8=true' from your gradle.properties before publishing your app.
2020-06-18T14:35:24.707712: stdout: [ +200 ms] > Configure project :path_provider_macos
2020-06-18T14:35:24.707866: stdout: [        ] WARNING: The option setting 'android.enableR8=true' is experimental and unsupported.
2020-06-18T14:35:24.708304: stdout: [        ] The current default is 'false'
2020-06-18T14:35:24.708707: stdout: [        ] Consider disabling R8 by removing 'android.enableR8=true' from your gradle.properties before publishing your app.
2020-06-18T14:35:24.804052: stdout: [  +95 ms] > Configure project :shared_preferences
2020-06-18T14:35:24.804202: stdout: [        ] WARNING: The option setting 'android.enableR8=true' is experimental and unsupported.
2020-06-18T14:35:24.804731: stdout: [        ] The current default is 'false'
2020-06-18T14:35:24.805096: stdout: [        ] Consider disabling R8 by removing 'android.enableR8=true' from your gradle.properties before publishing your app.
2020-06-18T14:35:24.805586: stdout: [        ] > Configure project :shared_preferences_macos
2020-06-18T14:35:24.805906: stdout: [        ] WARNING: The option setting 'android.enableR8=true' is experimental and unsupported.
2020-06-18T14:35:24.806280: stdout: [        ] The current default is 'false'
2020-06-18T14:35:24.806565: stdout: [        ] Consider disabling R8 by removing 'android.enableR8=true' from your gradle.properties before publishing your app.
2020-06-18T14:35:24.903397: stdout: [  +96 ms] > Configure project :shared_preferences_web
2020-06-18T14:35:24.903786: stdout: [        ] WARNING: The option setting 'android.enableR8=true' is experimental and unsupported.
2020-06-18T14:35:24.904117: stdout: [        ] The current default is 'false'
2020-06-18T14:35:24.904507: stdout: [        ] Consider disabling R8 by removing 'android.enableR8=true' from your gradle.properties before publishing your app.
2020-06-18T14:35:25.104916: stdout: [ +200 ms] > Configure project :url_launcher
2020-06-18T14:35:25.105198: stdout: [        ] WARNING: The option setting 'android.enableR8=true' is experimental and unsupported.
2020-06-18T14:35:25.105489: stdout: [        ] The current default is 'false'
2020-06-18T14:35:25.105871: stdout: [        ] Consider disabling R8 by removing 'android.enableR8=true' from your gradle.properties before publishing your app.
2020-06-18T14:35:25.106226: stdout: [        ] > Configure project :url_launcher_macos
2020-06-18T14:35:25.106547: stdout: [        ] WARNING: The option setting 'android.enableR8=true' is experimental and unsupported.
2020-06-18T14:35:25.106887: stdout: [        ] The current default is 'false'
2020-06-18T14:35:25.107278: stdout: [        ] Consider disabling R8 by removing 'android.enableR8=true' from your gradle.properties before publishing your app.
2020-06-18T14:35:25.204094: stdout: [  +96 ms] > Configure project :url_launcher_web
2020-06-18T14:35:25.204281: stdout: [        ] WARNING: The option setting 'android.enableR8=true' is experimental and unsupported.
2020-06-18T14:35:25.204665: stdout: [        ] The current default is 'false'
2020-06-18T14:35:25.204980: stdout: [        ] Consider disabling R8 by removing 'android.enableR8=true' from your gradle.properties before publishing your app.
2020-06-18T14:35:25.501366: stderr: [ +295 ms] FAILURE: Build failed with an exception.
2020-06-18T14:35:25.501873: stderr: [        ] * What went wrong:
2020-06-18T14:35:25.502150: stderr: [        ] Could not determine the dependencies of task ':path_provider:compileProfileAidl'.
2020-06-18T14:35:25.502460: stderr: [        ] > Could not resolve all task dependencies for configuration ':path_provider:profileCompileClasspath'.
2020-06-18T14:35:25.502873: stderr: [        ]    > Could not resolve project :path_provider_macos.
2020-06-18T14:35:25.503083: stderr: [        ]      Required by:
2020-06-18T14:35:25.503562: stderr: [        ]          project :path_provider
2020-06-18T14:35:25.503875: stderr: [        ]       > Unable to find a matching variant of project :path_provider_macos:
2020-06-18T14:35:25.504224: stderr: [        ]           - Variant 'debugApiElements':
2020-06-18T14:35:25.504588: stderr: [        ]               - Required com.android.build.api.attributes.BuildTypeAttr 'profile' and found incompatible value 'debug'.
2020-06-18T14:35:25.504941: stderr: [        ]               - Found com.android.build.api.attributes.VariantAttr 'debug' but wasn't required.
2020-06-18T14:35:25.505309: stderr: [        ]               - Required com.android.build.gradle.internal.dependency.AndroidTypeAttr 'Aar' and found compatible value 'Aar'.
2020-06-18T14:35:25.505658: stderr: [        ]               - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
2020-06-18T14:35:25.506017: stderr: [        ]           - Variant 'debugRuntimeElements':
2020-06-18T14:35:25.506369: stderr: [        ]               - Required com.android.build.api.attributes.BuildTypeAttr 'profile' and found incompatible value 'debug'.
2020-06-18T14:35:25.506658: stderr: [        ]               - Found com.android.build.api.attributes.VariantAttr 'debug' but wasn't required.
2020-06-18T14:35:25.507430: stderr: [        ]               - Required com.android.build.gradle.internal.dependency.AndroidTypeAttr 'Aar' and found compatible value 'Aar'.
2020-06-18T14:35:25.507725: stderr: [        ]               - Required org.gradle.usage 'java-api' and found incompatible value 'java-runtime'.
2020-06-18T14:35:25.508075: stderr: [        ]           - Variant 'releaseApiElements':
2020-06-18T14:35:25.508373: stderr: [        ]               - Required com.android.build.api.attributes.BuildTypeAttr 'profile' and found incompatible value 'release'.
2020-06-18T14:35:25.508690: stderr: [        ]               - Found com.android.build.api.attributes.VariantAttr 'release' but wasn't required.
2020-06-18T14:35:25.509115: stderr: [        ]               - Required com.android.build.gradle.internal.dependency.AndroidTypeAttr 'Aar' and found compatible value 'Aar'.
2020-06-18T14:35:25.509756: stderr: [        ]               - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
stderr: [        ]           - Variant 'releaseRuntimeElements':
2020-06-18T14:35:25.510569: stderr: [        ]               - Required com.android.build.api.attributes.BuildTypeAttr 'profile' and found incompatible value 'release'.
2020-06-18T14:35:25.510824: stderr: [        ]               - Found com.android.build.api.attributes.VariantAttr 'release' but wasn't required.
2020-06-18T14:35:25.511087: stderr: [        ]               - Required com.android.build.gradle.internal.dependency.AndroidTypeAttr 'Aar' and found compatible value 'Aar'.
2020-06-18T14:35:25.511452: stderr: [        ]               - Required org.gradle.usage 'java-api' and found incompatible value 'java-runtime'.
2020-06-18T14:35:25.511802: stderr: [        ] * Try:
2020-06-18T14:35:25.512142: stderr: [        ] Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
2020-06-18T14:35:25.512639: stderr: [        ] * Get more help at https://help.gradle.org
2020-06-18T14:35:25.512988: stderr: [        ] BUILD FAILED in 5s
2020-06-18T14:35:25.973472: stdout: [ +460 ms] Running Gradle task 'assembleProfile'... (completed in 5.9s)
2020-06-18T14:35:25.988499: stdout: [  +14 ms] "flutter drive" took 9,679ms.
2020-06-18T14:35:25.997907: stderr: [   +9 ms] Gradle task assembleProfile failed with exit code 1
2020-06-18T14:35:25.999803: stderr: [   +1 ms] 
stderr:            #0      throwToolExit (package:flutter_tools/src/base/common.dart:14:3)
stderr:            #1      buildGradleApp (package:flutter_tools/src/android/gradle.dart:411:7)
stderr:            #2      _rootRunUnary (dart:async/zone.dart:1198:47)
stderr:            #3      _CustomZone.runUnary (dart:async/zone.dart:1100:19)
stderr:            #4      _FutureListener.handleValue (dart:async/future_impl.dart:143:18)
stderr:            #5      Future._propagateToListeners.handleValueCallback (dart:async/future_impl.dart:696:45)
stderr:            #6      Future._propagateToListeners (dart:async/future_impl.dart:725:32)
stderr:            #7      Future._completeWithValue (dart:async/future_impl.dart:529:5)
stderr:            #8      _AsyncAwaitCompleter.complete (dart:async-patch/async_patch.dart:40:15)
stderr:            #9      _completeOnAsyncReturn (dart:async-patch/async_patch.dart:311:13)
stderr:            #10     _DefaultProcessUtils.stream (package:flutter_tools/src/base/process.dart)
stderr:            #11     _rootRunUnary (dart:async/zone.dart:1198:47)
stderr:            #12     _CustomZone.runUnary (dart:async/zone.dart:1100:19)
stderr:            #13     _FutureListener.handleValue (dart:async/future_impl.dart:143:18)
stderr:            #14     Future._propagateToListeners.handleValueCallback (dart:async/future_impl.dart:696:45)
stderr:            #15     Future._propagateToListeners (dart:async/future_impl.dart:725:32)
stderr:            #16     Future._completeWithValue (dart:async/future_impl.dart:529:5)
stderr:            #17     Future._asyncCompleteWithValue.<anonymous closure> (dart:async/future_impl.dart:567:7)
stderr:            #18     _rootRun (dart:async/zone.dart:1190:13)
stderr:            #19     _CustomZone.run (dart:async/zone.dart:1093:19)
stderr:            #20     _CustomZone.runGuarded (dart:async/zone.dart:997:7)
stderr:            #21     _CustomZone.bindCallbackGuarded.<anonymous closure> (dart:async/zone.dart:1037:23)
stderr:            #22     _microtaskLoop (dart:async/schedule_microtask.dart:41:21)
stderr:            #23     _startMicrotaskLoop (dart:async/schedule_microtask.dart:50:5)
stderr:            #24     _runPendingImmediateCallback (dart:isolate-patch/isolate_patch.dart:118:13)
stderr:            #25     _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:169:5)
stderr: 
stderr: 
2020-06-18T14:35:26.004484: stdout: [   +5 ms] ensureAnalyticsSent: 1ms
2020-06-18T14:35:26.006996: stdout: [   +2 ms] Running shutdown hooks
2020-06-18T14:35:26.007255: stdout: [        ] Shutdown hooks complete
2020-06-18T14:35:26.008133: stdout: [        ] exiting with code 1
2020-06-18T14:35:26.023978: "/Users/flutter/.cocoon/flutter/bin/flutter" exit code: 1
2020-06-18T14:35:26.038484: Task failed: Executable "/Users/flutter/.cocoon/flutter/bin/flutter" failed with exit code 1.2020-06-18T14:35:26.038643: 

Stack trace:
2020-06-18T14:35:26.067927: package:flutter_devicelab/framework/utils.dart 98:3        fail
package:flutter_devicelab/framework/utils.dart 363:5       _execute
===== asynchronous gap ===========================
dart:async                                                 _asyncErrorWrapperHelper
package:flutter_devicelab/framework/framework.dart         _TaskRunner._performTask.<fn>
package:stack_trace                                        Chain.capture
package:flutter_devicelab/framework/framework.dart 169:11  _TaskRunner._performTask
package:flutter_devicelab/framework/framework.dart 101:41  _TaskRunner.run

2020-06-18T14:35:26.069399: 

═══════════╡ ••• Checking running Dart processes after task... ••• ╞════════════

2020-06-18T14:35:26.103480: Cleaning up after task...
2020-06-18T14:35:26.320137: Task execution finished

Task failed with the following reason:
Task failed: Executable "/Users/flutter/.cocoon/flutter/bin/flutter" failed with exit code 1.
```