### PR TITLE
Parse build ios framework build mode from params

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -126,19 +126,19 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
   FlutterProject _project;
 
   List<BuildInfo> get buildInfos {
-    final List<BuildInfo> buildModes = <BuildInfo>[];
+    final List<BuildInfo> buildInfos = <BuildInfo>[];
 
     if (boolArg('debug')) {
-      buildModes.add(BuildInfo.debug);
+      buildInfos.add(getBuildInfo(forcedBuildMode: BuildMode.debug));
     }
     if (boolArg('profile')) {
-      buildModes.add(BuildInfo.profile);
+      buildInfos.add(getBuildInfo(forcedBuildMode: BuildMode.profile));
     }
     if (boolArg('release')) {
-      buildModes.add(BuildInfo.release);
+      buildInfos.add(getBuildInfo(forcedBuildMode: BuildMode.release));
     }
 
-    return buildModes;
+    return buildInfos;
   }
 
   @override
@@ -377,7 +377,7 @@ end
           mainPath: globals.fs.path.absolute(targetFile),
           assetDirPath: destinationAppFrameworkDirectory.childDirectory('flutter_assets').path,
           precompiledSnapshot: buildInfo.mode != BuildMode.debug,
-          treeShakeIcons: boolArg('tree-shake-icons')
+          treeShakeIcons: buildInfo.treeShakeIcons,
         );
       }
     } finally {


### PR DESCRIPTION
## Description

Use `getBuildInfo` to parse all the extra options.

## Related Issues
`getBuildInfo` will allow us to add null-safety options easier (PR forthcoming) https://github.com/flutter/flutter/pull/59773

## Tests

`BuildIOSFrameworkCommand` remains pretty unit-untestable at the moment.  Will work on that soon.

The build_ios_framework_module_test integration validates every expected output file for this command, but that doesn't really help validating these flags...

I tested it manually and it's passing the flag to dart.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*