### PR TITLE
Fix the layout calculation in sliver list where the scroll offset cor…

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_list.dart
@@ -120,7 +120,6 @@ class RenderSliverList extends RenderSliverMultiBoxAdaptor {
         earliestScrollOffset = childScrollOffset(earliestUsefulChild)) {
       // We have to add children before the earliestUsefulChild.
       earliestUsefulChild = insertAndLayoutLeadingChild(childConstraints, parentUsesSize: true);
-
       if (earliestUsefulChild == null) {
         final SliverMultiBoxAdaptorParentData childParentData = firstChild.parentData as SliverMultiBoxAdaptorParentData;
         childParentData.layoutOffset = 0.0;
@@ -148,29 +147,14 @@ class RenderSliverList extends RenderSliverMultiBoxAdaptor {
       final double firstChildScrollOffset = earliestScrollOffset - paintExtentOf(firstChild);
       // firstChildScrollOffset may contain double precision error
       if (firstChildScrollOffset < -precisionErrorTolerance) {
-        // The first child doesn't fit within the viewport (underflow) and
-        // there may be additional children above it. Find the real first child
-        // and then correct the scroll position so that there's room for all and
-        // so that the trailing edge of the original firstChild appears where it
-        // was before the scroll offset correction.
-        // TODO(hansmuller): do this work incrementally, instead of all at once,
-        // i.e. find a way to avoid visiting ALL of the children whose offset
-        // is < 0 before returning for the scroll correction.
-        double correction = 0.0;
-        while (earliestUsefulChild != null) {
-          assert(firstChild == earliestUsefulChild);
-          correction += paintExtentOf(firstChild);
-          earliestUsefulChild = insertAndLayoutLeadingChild(childConstraints, parentUsesSize: true);
-        }
-        earliestUsefulChild = firstChild;
-        if ((correction - earliestScrollOffset).abs() > precisionErrorTolerance) {
-          geometry = SliverGeometry(
-            scrollOffsetCorrection: correction - earliestScrollOffset,
-          );
-          final SliverMultiBoxAdaptorParentData childParentData = firstChild.parentData as SliverMultiBoxAdaptorParentData;
-          childParentData.layoutOffset = 0.0;
-          return;
-        }
+        // Let's assume there is no child before the first child. We will
+        // correct it on the next layout if it is not.
+        geometry = SliverGeometry(
+          scrollOffsetCorrection: -firstChildScrollOffset,
+        );
+        final SliverMultiBoxAdaptorParentData childParentData = firstChild.parentData as SliverMultiBoxAdaptorParentData;
+        childParentData.layoutOffset = 0.0;
+        return;
       }
 
       final SliverMultiBoxAdaptorParentData childParentData = earliestUsefulChild.parentData as SliverMultiBoxAdaptorParentData;
@@ -178,6 +162,28 @@ class RenderSliverList extends RenderSliverMultiBoxAdaptor {
       assert(earliestUsefulChild == firstChild);
       leadingChildWithLayout = earliestUsefulChild;
       trailingChildWithLayout ??= earliestUsefulChild;
+    }
+
+    assert(childScrollOffset(firstChild) > -precisionErrorTolerance);
+
+    // If the scroll offset is at the zero, we should make sure we are
+    // actually at the beginning of the list
+    if (scrollOffset < precisionErrorTolerance) {
+      if (indexOf(firstChild) > 0) {
+        final double earliestScrollOffset = childScrollOffset(firstChild);
+        // We correct one child at a time. If there are more children before
+        // the earliestUsefulChild, we will correct it once the scroll offset
+        // reach zero again.
+        earliestUsefulChild = insertAndLayoutLeadingChild(childConstraints, parentUsesSize: true);
+        assert(earliestUsefulChild != null);
+        final double firstChildScrollOffset = earliestScrollOffset - paintExtentOf(firstChild);
+        geometry = SliverGeometry(
+          scrollOffsetCorrection: -firstChildScrollOffset,
+        );
+        final SliverMultiBoxAdaptorParentData childParentData = firstChild.parentData as SliverMultiBoxAdaptorParentData;
+        childParentData.layoutOffset = 0.0;
+        return;
+      }
     }
 
     // At this point, earliestUsefulChild is the first child, and is a child

--- a/packages/flutter/lib/src/rendering/sliver_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_list.dart
@@ -166,8 +166,8 @@ class RenderSliverList extends RenderSliverMultiBoxAdaptor {
 
     assert(childScrollOffset(firstChild) > -precisionErrorTolerance);
 
-    // If the scroll offset is at the zero, we should make sure we are
-    // actually at the beginning of the list
+    // If the scroll offset is at zero, we should make sure we are
+    // actually at the beginning of the list.
     if (scrollOffset < precisionErrorTolerance) {
       if (indexOf(firstChild) > 0) {
         final double earliestScrollOffset = childScrollOffset(firstChild);

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -309,6 +309,107 @@ void main() {
   );
 
   testWidgets(
+    'SliverList can handle inaccurate scroll offset due to changes in children list',
+      (WidgetTester tester) async {
+      bool skip = true;
+      Widget _buildItem(BuildContext context, int index) {
+        return !skip || index.isEven
+          ? Card(
+          child: ListTile(
+            title: Text(
+              'item$index',
+              style: const TextStyle(fontSize: 80),
+            ),
+          ),
+        )
+          : Container();
+      }
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CustomScrollView(
+              slivers: <Widget> [
+                SliverList(
+                  delegate: SliverChildBuilderDelegate(
+                    _buildItem,
+                    childCount: 30,
+                  ),
+                ),
+              ],
+            )
+          ),
+        ),
+      );
+      // Only even items 0~12 are on the screen.
+      expect(find.text('item0'), findsOneWidget);
+      expect(find.text('item12'), findsOneWidget);
+      expect(find.text('item14'), findsNothing);
+
+      await tester.drag(find.byType(CustomScrollView), const Offset(0.0, -750.0));
+      await tester.pump();
+      // Only even items 16~28 are on the screen.
+      expect(find.text('item15'), findsNothing);
+      expect(find.text('item16'), findsOneWidget);
+      expect(find.text('item28'), findsOneWidget);
+
+      skip = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CustomScrollView(
+              slivers: <Widget> [
+                SliverList(
+                  delegate: SliverChildBuilderDelegate(
+                    _buildItem,
+                    childCount: 30,
+                  ),
+                ),
+              ],
+            )
+          ),
+        ),
+      );
+
+      // Only items 12~19 are on the screen.
+      expect(find.text('item11'), findsNothing);
+      expect(find.text('item12'), findsOneWidget);
+      expect(find.text('item19'), findsOneWidget);
+      expect(find.text('item20'), findsNothing);
+
+      await tester.drag(find.byType(CustomScrollView), const Offset(0.0, 250.0));
+      await tester.pump();
+
+      // Only items 10~16 are on the screen.
+      expect(find.text('item9'), findsNothing);
+      expect(find.text('item10'), findsOneWidget);
+      expect(find.text('item16'), findsOneWidget);
+      expect(find.text('item17'), findsNothing);
+
+      // The inaccurate scroll offset should reach zero at this point
+      await tester.drag(find.byType(CustomScrollView), const Offset(0.0, 250.0));
+      await tester.pump();
+
+      // Only items 7~13 are on the screen.
+      expect(find.text('item6'), findsNothing);
+      expect(find.text('item7'), findsOneWidget);
+      expect(find.text('item13'), findsOneWidget);
+      expect(find.text('item14'), findsNothing);
+
+      // It need to be correct as we scroll, so we have to drag multiple times.
+      await tester.drag(find.byType(CustomScrollView), const Offset(0.0, 250.0));
+      await tester.pump();
+      await tester.drag(find.byType(CustomScrollView), const Offset(0.0, 250.0));
+      await tester.pump();
+      await tester.drag(find.byType(CustomScrollView), const Offset(0.0, 250.0));
+      await tester.pump();
+
+      expect(find.text('item0'), findsOneWidget);
+      expect(find.text('item6'), findsOneWidget);
+      expect(find.text('item7'), findsNothing);
+    },
+  );
+
+  testWidgets(
     'SliverFixedExtentList Correctly layout children after rearranging',
     (WidgetTester tester) async {
       await tester.pumpWidget(const TestSliverFixedExtentList(

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -311,6 +311,7 @@ void main() {
   testWidgets(
     'SliverList can handle inaccurate scroll offset due to changes in children list',
       (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/pull/59888.
       bool skip = true;
       Widget _buildItem(BuildContext context, int index) {
         return !skip || index.isEven
@@ -395,7 +396,7 @@ void main() {
       expect(find.text('item13'), findsOneWidget);
       expect(find.text('item14'), findsNothing);
 
-      // It need to be correct as we scroll, so we have to drag multiple times.
+      // It need to be corrected as we scroll, so we have to drag multiple times.
       await tester.drag(find.byType(CustomScrollView), const Offset(0.0, 250.0));
       await tester.pump();
       await tester.drag(find.byType(CustomScrollView), const Offset(0.0, 250.0));
@@ -403,6 +404,7 @@ void main() {
       await tester.drag(find.byType(CustomScrollView), const Offset(0.0, 250.0));
       await tester.pump();
 
+      // Only items 0~6 are on the screen.
       expect(find.text('item0'), findsOneWidget);
       expect(find.text('item6'), findsOneWidget);
       expect(find.text('item7'), findsNothing);

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -396,7 +396,7 @@ void main() {
       expect(find.text('item13'), findsOneWidget);
       expect(find.text('item14'), findsNothing);
 
-      // It need to be corrected as we scroll, so we have to drag multiple times.
+      // It will be corrected as we scroll, so we have to drag multiple times.
       await tester.drag(find.byType(CustomScrollView), const Offset(0.0, 250.0));
       await tester.pump();
       await tester.drag(find.byType(CustomScrollView), const Offset(0.0, 250.0));


### PR DESCRIPTION
…rection accidently set the child with layout offset of zero

## Description

consider following example:
we have sliver list with items where each item has 10 paint extent. the screen is at item 10

-------start of screen----------
item 10 -- layout offset 100
item 11 -- layout offset 110
item 12 -- layout offset 120
item 13 -- layout offset 130
-------end of screen-----------


now, the sliver list children updated, and the each item has 20 paint extent. The RenderSliverList is smart to update the children scroll offset **after** the first child. So it become like this

-------start of screen----------
item 10 -- layout offset 100
item 11 -- layout offset 120
-------end of screen-----------

item 12 and 13 are not in the screen so it will be destroy.

Now, start scrolling back

-------start of screen----------
item 9 -- layout offset 80
item 11 -- layout offset 100
-------end of screen-----------

...keep scrolling

-------start of screen----------
item 5 -- layout offset 0
item 11 -- layout offset 20
-------end of screen-----------
oops, the sliver list think item 5 is the start of the list, so you cannot scroll any further.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/59819

## Tests

I added the following tests:

see files

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
