### PR TITLE
Fix issue with stack traces getting mangled

### DIFF
--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -379,9 +379,7 @@ class FlutterErrorDetails with Diagnosticable {
   /// The [exception] must not be null; other arguments can be left to
   /// their default values. (`throw null` results in a
   /// [NullThrownError] exception.)
-  // If you add a property to this class, do not forget to update _runTest in
-  // packages/flutter_test/lib/src/binding.dart, where we copy this class
-  // and unmangle the stack property.
+  // If you add a property to this class, do not forget to update [copyWith].
   const FlutterErrorDetails({
     this.exception,
     this.stack,
@@ -391,6 +389,28 @@ class FlutterErrorDetails with Diagnosticable {
     this.informationCollector,
     this.silent = false,
   });
+
+  /// Creates a copy of the error details but with the given fields replaced
+  /// with new values.
+  FlutterErrorDetails copyWith({
+    DiagnosticsNode context,
+    dynamic exception,
+    InformationCollector informationCollector,
+    String library,
+    bool silent,
+    StackTrace stack,
+    IterableFilter<String> stackFilter,
+  }) {
+    return FlutterErrorDetails(
+      context: context ?? this.context,
+      exception: exception ?? this.exception,
+      informationCollector: informationCollector ?? this.informationCollector,
+      library: library ?? this.library,
+      silent: silent ?? this.silent,
+      stack: stack ?? this.stack,
+      stackFilter: stackFilter ?? this.stackFilter,
+    );
+  }
 
   /// Transformers to transform [DiagnosticsNode] in [DiagnosticPropertiesBuilder]
   /// into a more descriptive form.

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -379,7 +379,6 @@ class FlutterErrorDetails with Diagnosticable {
   /// The [exception] must not be null; other arguments can be left to
   /// their default values. (`throw null` results in a
   /// [NullThrownError] exception.)
-  // If you add a property to this class, do not forget to update [copyWith].
   const FlutterErrorDetails({
     this.exception,
     this.stack,

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -379,6 +379,9 @@ class FlutterErrorDetails with Diagnosticable {
   /// The [exception] must not be null; other arguments can be left to
   /// their default values. (`throw null` results in a
   /// [NullThrownError] exception.)
+  // If you add a property to this class, do not forget to update _runTest in
+  // packages/flutter_test/lib/src/binding.dart, where we copy this class
+  // and unmangle the stack property.
   const FlutterErrorDetails({
     this.exception,
     this.stack,

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -579,6 +579,10 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
       // our main future completing.
       assert(Zone.current == _parentZone);
       if (_pendingExceptionDetails != null) {
+        assert(
+          _unmangle(_pendingExceptionDetails.stack) == _pendingExceptionDetails.stack,
+          'The test binding presented an unmangled a test stack trace to the framework.',
+        );
         debugPrint = debugPrintOverride; // just in case the test overrides it -- otherwise we won't see the error!
         reportTestException(_pendingExceptionDetails, testDescription);
         _pendingExceptionDetails = null;
@@ -611,6 +615,15 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     _oldExceptionHandler = FlutterError.onError;
     int _exceptionCount = 0; // number of un-taken exceptions
     FlutterError.onError = (FlutterErrorDetails details) {
+      details = FlutterErrorDetails(
+        context: details.context,
+        exception: details.exception,
+        informationCollector: details.informationCollector,
+        library: details.library,
+        silent: details.silent,
+        stack: _unmangle(details.stack),
+        stackFilter: details.stackFilter,
+      );
       if (_pendingExceptionDetails != null) {
         debugPrint = debugPrintOverride; // just in case the test overrides it -- otherwise we won't see the errors!
         if (_exceptionCount == 0) {

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -581,7 +581,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
       if (_pendingExceptionDetails != null) {
         assert(
           _unmangle(_pendingExceptionDetails.stack) == _pendingExceptionDetails.stack,
-          'The test binding presented an unmangled a test stack trace to the framework.',
+          'The test binding presented an unmangled stack trace to the framework.',
         );
         debugPrint = debugPrintOverride; // just in case the test overrides it -- otherwise we won't see the error!
         reportTestException(_pendingExceptionDetails, testDescription);
@@ -615,15 +615,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     _oldExceptionHandler = FlutterError.onError;
     int _exceptionCount = 0; // number of un-taken exceptions
     FlutterError.onError = (FlutterErrorDetails details) {
-      details = FlutterErrorDetails(
-        context: details.context,
-        exception: details.exception,
-        informationCollector: details.informationCollector,
-        library: details.library,
-        silent: details.silent,
-        stack: _unmangle(details.stack),
-        stackFilter: details.stackFilter,
-      );
+      details = details.copyWith(stack: _unmangle(details.stack));
       if (_pendingExceptionDetails != null) {
         debugPrint = debugPrintOverride; // just in case the test overrides it -- otherwise we won't see the errors!
         if (_exceptionCount == 0) {

--- a/packages/flutter_test/test/bindings_async_gap_test.dart
+++ b/packages/flutter_test/test/bindings_async_gap_test.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
-
+import 'package:stack_trace/stack_trace.dart' as stack_trace;
 
 Future<void> main() async {
   test('demangles stacks', () async {
@@ -29,6 +29,7 @@ Future<void> main() async {
       completer.future.then(
         (String value) {},
         onError: (dynamic error, StackTrace stack) {
+          assert(stack is stack_trace.Chain);
           FlutterError.reportError(FlutterErrorDetails(
             exception: error,
             stack: stack,

--- a/packages/flutter_test/test/bindings_async_gap_test.dart
+++ b/packages/flutter_test/test/bindings_async_gap_test.dart
@@ -1,0 +1,51 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+
+Future<void> main() async {
+  test('demangles stacks', () async {
+    // Test that the tester bindings unmangle stacks that come in as
+    // package:stack_trace types.
+    // Uses runTest directly so that the test does not get hung up waiting for
+    // the error reporter to be reset to the original one.
+
+    final Completer<FlutterErrorDetails> errorCompleter = Completer<FlutterErrorDetails>();
+    final TestExceptionReporter oldReporter = reportTestException;
+    reportTestException = (FlutterErrorDetails details, String testDescription) {
+      errorCompleter.complete(details);
+      reportTestException = oldReporter;
+    };
+
+    final AutomatedTestWidgetsFlutterBinding binding = AutomatedTestWidgetsFlutterBinding();
+    await binding.runTest(() async {
+      final Completer<String> completer = Completer<String>();
+
+      completer.future.then(
+        (String value) {},
+        onError: (dynamic error, StackTrace stack) {
+          FlutterError.reportError(FlutterErrorDetails(
+            exception: error,
+            stack: stack,
+          ));
+        }
+      );
+
+      completer.completeError(const CustomException());
+    }, null);
+
+    final FlutterErrorDetails details = await errorCompleter.future;
+    expect(details, isNotNull);
+    expect(details.exception, isA<CustomException>());
+    reportTestException = oldReporter;
+  });
+}
+
+class CustomException implements Exception {
+  const CustomException();
+}


### PR DESCRIPTION
## Description

Certain types of async errors can get through with a mangled stack trace today, which causes a failure noted in the linked bug - the stack frame parser does not want stack traces as they come from package:stack_trace, we want the raw ones.

## Related Issues

Fixes #59893

## Tests

I added the following tests:

Test that throws that kind of error and then that we don't run into issues trying to parse it. Also adds an assertion that we don't get an unmangled trace.

/cc @PixelToast 

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
