### PR TITLE
port devicelab from idevice_id -> xcdevices

### DIFF
--- a/dev/bots/codesign.dart
+++ b/dev/bots/codesign.dart
@@ -62,7 +62,6 @@ bool checkCacheIsCurrent() {
 }
 
 List<String> get binariesWithEntitlements => List<String>.unmodifiable(<String>[
-  'idevice_id',
   'ideviceinfo',
   'idevicename',
   'idevicescreenshot',

--- a/dev/devicelab/lib/framework/adb.dart
+++ b/dev/devicelab/lib/framework/adb.dart
@@ -582,7 +582,9 @@ class IosDeviceDiscovery implements DeviceDiscovery {
 
     for (final dynamic result in results) {
       final Map<String, dynamic> device = result as Map<String, dynamic>;
-      if (device['targetPlatform'] == 'ios' && device['id'] != null) {
+      if (device['targetPlatform'] == 'ios' &&
+          device['id'] != null &&
+          device['emulator'] != true) {
         deviceIds.add(device['id'] as String);
       }
     }

--- a/dev/devicelab/lib/framework/adb.dart
+++ b/dev/devicelab/lib/framework/adb.dart
@@ -551,19 +551,6 @@ class IosDeviceDiscovery implements DeviceDiscovery {
     print('Device chosen: $_workingDevice');
   }
 
-  // Returns a colon-separated environment variable that contains the paths
-  // of linked libraries for idevice_id
-  Map<String, String> get _ideviceIdEnvironment {
-    final String libPath = const <String>[
-      'libimobiledevice',
-      'usbmuxd',
-      'libplist',
-      'openssl',
-      'ios-deploy',
-    ].map((String packageName) => path.join(getArtifactPath(), packageName)).join(':');
-    return <String, String>{'DYLD_LIBRARY_PATH': libPath};
-  }
-
   @override
   Future<List<String>> discoverDevices() async {
     final List<dynamic> results = json.decode(await eval(

--- a/dev/devicelab/lib/framework/adb.dart
+++ b/dev/devicelab/lib/framework/adb.dart
@@ -560,7 +560,7 @@ class IosDeviceDiscovery implements DeviceDiscovery {
 
     // [
     //   {
-    //     "name": "Christopher’s iPhone",
+    //     "name": "Flutter's iPhone",
     //     "id": "00008020-00017DA80CC1002E",
     //     "isSupported": true,
     //     "targetPlatform": "ios",

--- a/dev/devicelab/lib/framework/adb.dart
+++ b/dev/devicelab/lib/framework/adb.dart
@@ -584,7 +584,8 @@ class IosDeviceDiscovery implements DeviceDiscovery {
       final Map<String, dynamic> device = result as Map<String, dynamic>;
       if (device['targetPlatform'] == 'ios' &&
           device['id'] != null &&
-          device['emulator'] != true) {
+          device['emulator'] != true &&
+          device['isSupported'] == true) {
         deviceIds.add(device['id'] as String);
       }
     }

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -811,7 +811,7 @@ abstract class FlutterCommand extends Command<void> {
     // sky_engine package is available in the flutter cache for pub to find.
     if (shouldUpdateCache) {
       // First always update universal artifacts, as some of these (e.g.
-      // idevice_id on macOS) are required to determine `requiredArtifacts`.
+      // ios-deploy on macOS) are required to determine `requiredArtifacts`.
       await globals.cache.updateAll(<DevelopmentArtifact>{DevelopmentArtifact.universal});
 
       await globals.cache.updateAll(await requiredArtifacts);


### PR DESCRIPTION
## Description

The use of idevice_id from the tool has already be deprecated. However, the devicelab is still using `idevice_id` for device discovery. This PR instead calls `flutter devices --machine` to get the list devices, leveraging the existing tool code.

## Related Issues

Unblocks https://github.com/flutter/flutter/issues/50299.

## Tests

I manually ran iOS devicelab tests locally. Ultimately, post-submit will be the integration test for this change.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*