### PR TITLE
[EditableText] Inherit from DefaultTextHeightBehavior 

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -29,6 +29,7 @@ import 'media_query.dart';
 import 'scroll_controller.dart';
 import 'scroll_physics.dart';
 import 'scrollable.dart';
+import 'text.dart';
 import 'text_selection.dart';
 import 'ticker_provider.dart';
 
@@ -2252,7 +2253,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
                 textAlign: widget.textAlign,
                 textDirection: _textDirection,
                 locale: widget.locale,
-                textHeightBehavior: widget.textHeightBehavior,
+                textHeightBehavior: widget.textHeightBehavior ?? DefaultTextHeightBehavior.of(context),
                 textWidthBasis: widget.textWidthBasis,
                 obscuringCharacter: widget.obscuringCharacter,
                 obscureText: widget.obscureText,

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -203,8 +203,8 @@ class DefaultTextStyle extends InheritedTheme {
   }
 }
 
-/// The [TextHeightBehavior] that will apply to descendant [Text] widgets which
-/// have not explicitly set [Text.textHeightBehavior].
+/// The [TextHeightBehavior] that will apply to descendant [Text] and [EditableText]
+/// widgets which have not explicitly set [Text.textHeightBehavior].
 ///
 /// If there is a [DefaultTextStyle] with a non-null [DefaultTextStyle.textHeightBehavior]
 /// below this widget, the [DefaultTextStyle.textHeightBehavior] will be used

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -129,6 +129,7 @@ void main() {
     expect(editableText.enableSuggestions, isTrue);
     expect(editableText.textAlign, TextAlign.start);
     expect(editableText.cursorWidth, 2.0);
+    expect(editableText.textHeightBehavior, isNull);
   });
 
   testWidgets('text keyboard is requested when maxLines is default', (WidgetTester tester) async {
@@ -5061,6 +5062,70 @@ void main() {
       ),
     ));
     expect(renderObject.clipBehavior, equals(Clip.antiAlias));
+  });
+
+  testWidgets('EditableText inherits DefaultTextHeightBehavior', (WidgetTester tester) async {
+    const TextHeightBehavior customTextHeightBehavior = TextHeightBehavior(
+      applyHeightToLastDescent: true,
+      applyHeightToFirstAscent: false,
+    );
+    await tester.pumpWidget(MediaQuery(
+      data: const MediaQueryData(devicePixelRatio: 1.0),
+      child: Directionality(
+        textDirection: TextDirection.ltr,
+        child: FocusScope(
+          node: focusScopeNode,
+          autofocus: true,
+          child: DefaultTextHeightBehavior(
+            textHeightBehavior: customTextHeightBehavior,
+            child: EditableText(
+              backgroundCursorColor: Colors.grey,
+              controller: controller,
+              focusNode: focusNode,
+              style: textStyle,
+              cursorColor: cursorColor,
+            ),
+          ),
+        ),
+      ),
+    ));
+    final RenderEditable renderObject = tester.allRenderObjects.whereType<RenderEditable>().first;
+    expect(renderObject.textHeightBehavior, equals(customTextHeightBehavior));
+  });
+
+  testWidgets('EditableText defaultTextHeightBehavior is used over inherited widget', (WidgetTester tester) async {
+    const TextHeightBehavior inheritedTextHeightBehavior = TextHeightBehavior(
+      applyHeightToLastDescent: true,
+      applyHeightToFirstAscent: false,
+    );
+    const TextHeightBehavior customTextHeightBehavior = TextHeightBehavior(
+      applyHeightToLastDescent: false,
+      applyHeightToFirstAscent: false,
+    );
+    await tester.pumpWidget(MediaQuery(
+      data: const MediaQueryData(devicePixelRatio: 1.0),
+      child: Directionality(
+        textDirection: TextDirection.ltr,
+        child: FocusScope(
+          node: focusScopeNode,
+          autofocus: true,
+          child: DefaultTextHeightBehavior(
+            textHeightBehavior: inheritedTextHeightBehavior,
+            child: EditableText(
+              backgroundCursorColor: Colors.grey,
+              controller: controller,
+              focusNode: focusNode,
+              style: textStyle,
+              cursorColor: cursorColor,
+              textHeightBehavior: customTextHeightBehavior,
+            ),
+          ),
+        ),
+      ),
+    ));
+    final RenderEditable renderObject = tester.allRenderObjects.whereType<RenderEditable>().first;
+    expect(renderObject.textHeightBehavior, isNot(equals(inheritedTextHeightBehavior)));
+    expect(renderObject.textHeightBehavior, equals(customTextHeightBehavior));
   });
 }
 


### PR DESCRIPTION
## Description

This PR adds a call in `EditableText` to `DefaultTextHeightBehavior.of(context)`. This adds support for applying a `DefaultTextHeightBehavior` to more places, such as `TextFields` and `SelectableText`.

## Tests

I added the following tests:

* Test that `EditableText` inherits from `DefaultTextHeightBehavior`.
* Test that the `textHeightBehavior` param takes precedence over the inherited `textHeightBehavior`.
* Check that `EditableText.textHeightBehavior` is `null` in the default case.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
