### PR TITLE
[flutter_driver] Fix tracing of startup events

### DIFF
--- a/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
@@ -464,9 +464,19 @@ class VMServiceFlutterDriver extends FlutterDriver {
         List<TimelineStream> streams = const <TimelineStream>[TimelineStream.all],
         bool retainPriorEvents = false,
       }) async {
-    if (!retainPriorEvents) {
-      await clearTimeline();
+    if (retainPriorEvents) {
+      await startTracing(streams: streams);
+      await action();
+
+      if (!(await _isPrecompiledMode())) {
+        _log(_kDebugWarning);
+      }
+
+      return stopTracingAndDownloadTimeline();
     }
+
+    await clearTimeline();
+
     final Map<String, Object> startTimestamp = await _getVMTimelineMicros();
     await startTracing(streams: streams);
     await action();

--- a/packages/flutter_driver/test/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/flutter_driver_test.dart
@@ -574,10 +574,8 @@ void main() {
         }, retainPriorEvents: true);
 
         expect(log, const <String>[
-          'getVMTimelineMicros',
           'startTracing',
           'action',
-          'getVMTimelineMicros',
           'stopTracing',
           'download',
         ]);


### PR DESCRIPTION
## Description

When `retainPriorEvents` is passed as true, the current behavior still limits timeline events to the timestamp after `traceEvents` is called. This can cause startup events to be missing.

This fixes it by passing null to `stopTracingAndDownloadTimeline` for the start and end time.

## Related Issues

#58430
b/158233207