### PR TITLE
[flutter_tools] cleanup iOS test

### DIFF
--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -47,7 +47,7 @@ void main() {
       environment: <String, String>{},
       operatingSystem: 'macos',
     );
-    fileSystem = MemoryFileSystem();
+    fileSystem = MemoryFileSystem.test();
     fsUtils = FileSystemUtils(fileSystem: fileSystem, platform: osx);
   });
 
@@ -458,6 +458,12 @@ void main() {
     overrides: <Type, Generator>{
       ProcessManager: () => mockProcessManager,
       FileSystem: () => fileSystem,
+      Platform: () => FakePlatform(
+        operatingSystem: 'macos',
+        environment: <String, String>{
+          'HOME': '/'
+        },
+      ),
     });
 
     testUsingContext('unified logging with app name', () async {


### PR DESCRIPTION
## Description

The test needs to look up HOME, but one wasn't provided. This would end up using the real home directory, crashing on windows
