### PR TITLE
1.19 CP: [flutter_tools] move mingit path addition back to flutter.bat (#59369)

### DIFF
--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -15,6 +15,21 @@ SETLOCAL ENABLEDELAYEDEXPANSION
 
 FOR %%i IN ("%~dp0..") DO SET FLUTTER_ROOT=%%~fi
 
+REM If available, add location of bundled mingit to PATH
+SET mingit_path=%FLUTTER_ROOT%\bin\mingit\cmd
+IF EXIST "%mingit_path%" SET PATH=%PATH%;%mingit_path%
+
+REM Test if Git is available on the Host
+where /q git || ECHO Error: Unable to find git in your PATH. && EXIT /B 1
+REM  Test if the flutter directory is a git clone, otherwise git rev-parse HEAD would fail
+IF NOT EXIST "%flutter_root%\.git" (
+  ECHO Error: The Flutter directory is not a clone of the GitHub project.
+  ECHO        The flutter tool requires Git in order to operate properly;
+  ECHO        to set up Flutter, run the following command:
+  ECHO        git clone -b stable https://github.com/flutter/flutter.git
+  EXIT /B 1
+)
+
 REM Include shared scripts in shared.bat
 SET shared_bin=%FLUTTER_ROOT%/bin/internal/shared.bat
 CALL "%shared_bin%"

--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -26,21 +26,6 @@ SET pub_cache_path=%FLUTTER_ROOT%\.pub-cache
 SET dart=%dart_sdk_path%\bin\dart.exe
 SET pub=%dart_sdk_path%\bin\pub.bat
 
-REM If available, add location of bundled mingit to PATH
-SET mingit_path=%FLUTTER_ROOT%\bin\mingit\cmd
-IF EXIST "%mingit_path%" SET PATH=%PATH%;%mingit_path%
-
-REM Test if Git is available on the Host
-where /q git || ECHO Error: Unable to find git in your PATH. && EXIT /B 1
-REM  Test if the flutter directory is a git clone, otherwise git rev-parse HEAD would fail
-IF NOT EXIST "%flutter_root%\.git" (
-  ECHO Error: The Flutter directory is not a clone of the GitHub project.
-  ECHO        The flutter tool requires Git in order to operate properly;
-  ECHO        to set up Flutter, run the following command:
-  ECHO        git clone -b stable https://github.com/flutter/flutter.git
-  EXIT /B 1
-)
-
 REM Detect which PowerShell executable is available on the Host
 REM PowerShell version <= 5: PowerShell.exe
 REM PowerShell version >= 6: pwsh.exe


### PR DESCRIPTION
fixes #57802

For users without git installed, flutter on windows bundles mingit. This needs to be added to the PATH in the main script, not the executed script, so that it is available to the tool

## Description

*Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change. If you're changing visual properties, consider including before/after screenshots (and runnable code snippets to reproduce them).*

## Related Issues

*Replace this paragraph with a list of issues related to this PR from our [issue database]. Indicate, which of these issues are resolved or fixed by this PR. There should be at least one issue listed here.*

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behaviour with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
