### PR TITLE
reland "fix the widget span layout when text scale factor != 1" and h…

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -83,7 +83,7 @@ class RenderParagraph extends RenderBox
       'This parameter is a temporary flag to migrate the internal tests and '
       'should not be used in other context. For more details, please check '
       'https://github.com/flutter/flutter/issues/59316.'
-      'This feature was deprecated after v1.19.0'
+      'This feature was deprecated after v1.19.0.'
     )
     bool applyTextScaleFactorToWidgetSpan = false,
     List<RenderBox> children,

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -81,7 +81,7 @@ class RenderParagraph extends RenderBox
     ui.TextHeightBehavior textHeightBehavior,
     @Deprecated(
       'This parameter is a temporary flag to migrate the internal tests and '
-      'should not be used in other context. For more details, please check '
+      'should not be used in other contexts. For more details, please check '
       'https://github.com/flutter/flutter/issues/59316. '
       'This feature was deprecated after v1.19.0.'
     )

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -82,7 +82,7 @@ class RenderParagraph extends RenderBox
     @Deprecated(
       'This parameter is a temporary flag to migrate the internal tests and '
       'should not be used in other context. For more details, please check '
-      'https://github.com/flutter/flutter/issues/59316.'
+      'https://github.com/flutter/flutter/issues/59316. '
       'This feature was deprecated after v1.19.0.'
     )
     bool applyTextScaleFactorToWidgetSpan = false,

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -79,6 +79,13 @@ class RenderParagraph extends RenderBox
     StrutStyle strutStyle,
     TextWidthBasis textWidthBasis = TextWidthBasis.parent,
     ui.TextHeightBehavior textHeightBehavior,
+    @Deprecated(
+      'This parameter is a temporary flag to migrate the internal tests and '
+      'should not be used in other context. For more details, please check '
+      'https://github.com/flutter/flutter/issues/59316.'
+      'This feature was deprecated after v1.19.0'
+    )
+    bool applyTextScaleFactorToWidgetSpan = false,
     List<RenderBox> children,
   }) : assert(text != null),
        assert(text.debugAssertIsValid()),
@@ -91,6 +98,7 @@ class RenderParagraph extends RenderBox
        assert(textWidthBasis != null),
        _softWrap = softWrap,
        _overflow = overflow,
+       _applyTextScaleFactorToWidgetSpan = applyTextScaleFactorToWidgetSpan,
        _textPainter = TextPainter(
          text: text,
          textAlign: textAlign,
@@ -289,6 +297,8 @@ class RenderParagraph extends RenderBox
     _overflowShader = null;
     markNeedsLayout();
   }
+
+  final bool _applyTextScaleFactorToWidgetSpan;
 
   @override
   double computeMinIntrinsicWidth(double height) {
@@ -526,13 +536,17 @@ class RenderParagraph extends RenderBox
     RenderBox child = firstChild;
     _placeholderDimensions = List<PlaceholderDimensions>(childCount);
     int childIndex = 0;
+    BoxConstraints boxConstraints = BoxConstraints(maxWidth: constraints.maxWidth);
+    // The content will be enlarged by textScaleFactor during painting phase.
+    // We reduce constraint by textScaleFactor so that the content will fit
+    // into the box once it is enlarged.
+    if (_applyTextScaleFactorToWidgetSpan)
+      boxConstraints = boxConstraints / textScaleFactor;
     while (child != null) {
       // Only constrain the width to the maximum width of the paragraph.
       // Leave height unconstrained, which will overflow if expanded past.
       child.layout(
-        BoxConstraints(
-          maxWidth: constraints.maxWidth,
-        ),
+        boxConstraints,
         parentUsesSize: true,
       );
       double baselineOffset;

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -5147,7 +5147,7 @@ class RichText extends MultiChildRenderObjectWidget {
     @Deprecated(
       'This parameter is a temporary flag to migrate the internal tests and '
       'should not be used in other context. For more details, see '
-      'https://github.com/flutter/flutter/issues/59316.'
+      'https://github.com/flutter/flutter/issues/59316. '
       'This feature was deprecated after v1.19.0.'
     )
     bool applyTextScaleFactorToWidgetSpan = false,

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -5144,6 +5144,13 @@ class RichText extends MultiChildRenderObjectWidget {
     this.strutStyle,
     this.textWidthBasis = TextWidthBasis.parent,
     this.textHeightBehavior,
+    @Deprecated(
+      'This parameter is a temporary flag to migrate the internal tests and '
+      'should not be used in other context. For more details, please check '
+      'https://github.com/flutter/flutter/issues/59316.'
+      'This feature was deprecated after v1.19.0'
+    )
+    bool applyTextScaleFactorToWidgetSpan = false,
   }) : assert(text != null),
        assert(textAlign != null),
        assert(softWrap != null),
@@ -5151,6 +5158,7 @@ class RichText extends MultiChildRenderObjectWidget {
        assert(textScaleFactor != null),
        assert(maxLines == null || maxLines > 0),
        assert(textWidthBasis != null),
+       _applyTextScaleFactorToWidgetSpan = applyTextScaleFactorToWidgetSpan,
        super(key: key, children: _extractChildren(text));
 
   // Traverses the InlineSpan tree and depth-first collects the list of
@@ -5228,6 +5236,8 @@ class RichText extends MultiChildRenderObjectWidget {
   /// {@macro flutter.dart:ui.textHeightBehavior}
   final ui.TextHeightBehavior textHeightBehavior;
 
+  final bool _applyTextScaleFactorToWidgetSpan;
+
   @override
   RenderParagraph createRenderObject(BuildContext context) {
     assert(textDirection != null || debugCheckHasDirectionality(context));
@@ -5241,6 +5251,7 @@ class RichText extends MultiChildRenderObjectWidget {
       strutStyle: strutStyle,
       textWidthBasis: textWidthBasis,
       textHeightBehavior: textHeightBehavior,
+      applyTextScaleFactorToWidgetSpan: _applyTextScaleFactorToWidgetSpan,
       locale: locale ?? Localizations.localeOf(context, nullOk: true),
     );
   }

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -5146,9 +5146,9 @@ class RichText extends MultiChildRenderObjectWidget {
     this.textHeightBehavior,
     @Deprecated(
       'This parameter is a temporary flag to migrate the internal tests and '
-      'should not be used in other context. For more details, please check '
+      'should not be used in other context. For more details, see '
       'https://github.com/flutter/flutter/issues/59316.'
-      'This feature was deprecated after v1.19.0'
+      'This feature was deprecated after v1.19.0.'
     )
     bool applyTextScaleFactorToWidgetSpan = false,
   }) : assert(text != null),

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -5146,7 +5146,7 @@ class RichText extends MultiChildRenderObjectWidget {
     this.textHeightBehavior,
     @Deprecated(
       'This parameter is a temporary flag to migrate the internal tests and '
-      'should not be used in other context. For more details, see '
+      'should not be used in other contexts. For more details, see '
       'https://github.com/flutter/flutter/issues/59316. '
       'This feature was deprecated after v1.19.0.'
     )

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -392,7 +392,7 @@ class Text extends StatelessWidget {
     @Deprecated(
       'This parameter is a temporary flag to migrate the internal tests and '
       'should not be used in other context. For more details, please check '
-      'https://github.com/flutter/flutter/issues/59316.'
+      'https://github.com/flutter/flutter/issues/59316. '
       'This feature was deprecated after v1.19.0.'
     )
     bool applyTextScaleFactorToWidgetSpan = false,

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -361,6 +361,7 @@ class Text extends StatelessWidget {
          'A non-null String must be provided to a Text widget.',
        ),
        textSpan = null,
+       _applyTextScaleFactorToWidgetSpan = true,
        super(key: key);
 
   /// Creates a text widget with a [InlineSpan].
@@ -388,11 +389,19 @@ class Text extends StatelessWidget {
     this.semanticsLabel,
     this.textWidthBasis,
     this.textHeightBehavior,
+    @Deprecated(
+      'This parameter is a temporary flag to migrate the internal tests and '
+      'should not be used in other context. For more details, please check '
+      'https://github.com/flutter/flutter/issues/59316.'
+      'This feature was deprecated after v1.19.0'
+    )
+    bool applyTextScaleFactorToWidgetSpan = false,
   }) : assert(
          textSpan != null,
          'A non-null TextSpan must be provided to a Text.rich widget.',
        ),
        data = null,
+       _applyTextScaleFactorToWidgetSpan = applyTextScaleFactorToWidgetSpan,
        super(key: key);
 
   /// The text to display.
@@ -493,6 +502,8 @@ class Text extends StatelessWidget {
   /// {@macro flutter.dart:ui.textHeightBehavior}
   final ui.TextHeightBehavior textHeightBehavior;
 
+  final bool _applyTextScaleFactorToWidgetSpan;
+
   @override
   Widget build(BuildContext context) {
     final DefaultTextStyle defaultTextStyle = DefaultTextStyle.of(context);
@@ -512,6 +523,7 @@ class Text extends StatelessWidget {
       strutStyle: strutStyle,
       textWidthBasis: textWidthBasis ?? defaultTextStyle.textWidthBasis,
       textHeightBehavior: textHeightBehavior ?? defaultTextStyle.textHeightBehavior ?? DefaultTextHeightBehavior.of(context),
+      applyTextScaleFactorToWidgetSpan: _applyTextScaleFactorToWidgetSpan,
       text: TextSpan(
         style: effectiveTextStyle,
         text: data,

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -393,7 +393,7 @@ class Text extends StatelessWidget {
       'This parameter is a temporary flag to migrate the internal tests and '
       'should not be used in other context. For more details, please check '
       'https://github.com/flutter/flutter/issues/59316.'
-      'This feature was deprecated after v1.19.0'
+      'This feature was deprecated after v1.19.0.'
     )
     bool applyTextScaleFactorToWidgetSpan = false,
   }) : assert(

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -391,7 +391,7 @@ class Text extends StatelessWidget {
     this.textHeightBehavior,
     @Deprecated(
       'This parameter is a temporary flag to migrate the internal tests and '
-      'should not be used in other context. For more details, please check '
+      'should not be used in other contexts. For more details, please check '
       'https://github.com/flutter/flutter/issues/59316. '
       'This feature was deprecated after v1.19.0.'
     )

--- a/packages/flutter/test/widgets/text_test.dart
+++ b/packages/flutter/test/widgets/text_test.dart
@@ -163,6 +163,70 @@ void main() {
     expect(tester.takeException(), null);
   }, skip: isBrowser); // TODO(yjbanov): https://github.com/flutter/flutter/issues/42086
 
+  testWidgets('inline widgets works with textScaleFactor', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/59316
+    final UniqueKey key = UniqueKey();
+    double textScaleFactor = 1.0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(title: const Text('title')),
+          body: Center(
+            child: Text.rich(
+              TextSpan(
+                children: <InlineSpan>[
+                  WidgetSpan(
+                    child: RichText(
+                      text: const TextSpan(text: 'widget should be truncated'),
+                      textDirection: TextDirection.ltr,
+                    ),
+                  ),
+                ],
+              ),
+              key: key,
+              textDirection: TextDirection.ltr,
+              textScaleFactor: textScaleFactor,
+              applyTextScaleFactorToWidgetSpan: true,
+            ),
+          ),
+        ),
+      ),
+    );
+    RenderBox renderText = tester.renderObject(find.byKey(key));
+    final double singleLineHeight = renderText.size.height;
+    // Now, increases the text scale factor by 5 times.
+    textScaleFactor = textScaleFactor * 5;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(title: const Text('title')),
+          body: Center(
+            child: Text.rich(
+              TextSpan(
+                children: <InlineSpan>[
+                  WidgetSpan(
+                    child: RichText(
+                      text: const TextSpan(text: 'widget should be truncated'),
+                      textDirection: TextDirection.ltr,
+                    ),
+                  ),
+                ],
+              ),
+              key: key,
+              textDirection: TextDirection.ltr,
+              textScaleFactor: textScaleFactor,
+              applyTextScaleFactorToWidgetSpan: true,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    renderText = tester.renderObject(find.byKey(key));
+    // The RichText in the widget span should wrap into three lines.
+    expect(renderText.size.height, singleLineHeight * textScaleFactor * 3);
+  }, skip: isBrowser); // TODO(yjbanov): https://github.com/flutter/flutter/issues/42086
+
   testWidgets('semanticsLabel can override text label', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
     await tester.pumpWidget(


### PR DESCRIPTION
…ide it behind a flag

## Description

This PR relands https://github.com/flutter/flutter/pull/59711 and hide the entire fix behind a flag so that i can do soft transition in our internal tests.

## Related Issues

https://github.com/flutter/flutter/issues/59316

## Tests

I added the following tests:

see files

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
