### PR TITLE
Use assemble build system directly for build ios-framework

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import '../bundle.dart';
 import '../commands/build_linux.dart';
 import '../commands/build_macos.dart';
 import '../commands/build_windows.dart';
@@ -29,7 +28,6 @@ class BuildCommand extends FlutterCommand {
     addSubcommand(BuildIOSCommand(verboseHelp: verboseHelp));
     addSubcommand(BuildIOSFrameworkCommand(
       buildSystem: globals.buildSystem,
-      bundleBuilder: BundleBuilder(),
     ));
     addSubcommand(BuildBundleCommand(verboseHelp: verboseHelp));
     addSubcommand(BuildWebCommand(verboseHelp: verboseHelp));

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
@@ -65,7 +65,6 @@ void main() {
 
         final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
           buildSystem: MockBuildSystem(),
-          bundleBuilder: MockBundleBuilder(),
           platform: fakePlatform,
           flutterVersion: mockFlutterVersion,
           cache: mockCache
@@ -90,7 +89,6 @@ void main() {
 
         final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
           buildSystem: MockBuildSystem(),
-          bundleBuilder: MockBundleBuilder(),
           platform: fakePlatform,
           flutterVersion: mockFlutterVersion,
           cache: mockCache
@@ -112,7 +110,6 @@ void main() {
 
         final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
           buildSystem: MockBuildSystem(),
-          bundleBuilder: MockBundleBuilder(),
           platform: fakePlatform,
           flutterVersion: mockFlutterVersion,
           cache: mockCache
@@ -149,11 +146,10 @@ void main() {
 
           testUsingContext('created when forced', () async {
             final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
-                buildSystem: MockBuildSystem(),
-                bundleBuilder: MockBundleBuilder(),
-                platform: fakePlatform,
-                flutterVersion: mockFlutterVersion,
-                cache: mockCache
+              buildSystem: MockBuildSystem(),
+              platform: fakePlatform,
+              flutterVersion: mockFlutterVersion,
+              cache: mockCache,
             );
             command.produceFlutterPodspec(BuildMode.debug, outputDirectory, force: true);
 
@@ -172,11 +168,10 @@ void main() {
 
           testUsingContext('contains license and version', () async {
             final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
-                buildSystem: MockBuildSystem(),
-                bundleBuilder: MockBundleBuilder(),
-                platform: fakePlatform,
-                flutterVersion: mockFlutterVersion,
-                cache: mockCache
+              buildSystem: MockBuildSystem(),
+              platform: fakePlatform,
+              flutterVersion: mockFlutterVersion,
+              cache: mockCache,
             );
             command.produceFlutterPodspec(BuildMode.debug, outputDirectory);
 
@@ -192,11 +187,10 @@ void main() {
 
           testUsingContext('debug URL', () async {
             final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
-                buildSystem: MockBuildSystem(),
-                bundleBuilder: MockBundleBuilder(),
-                platform: fakePlatform,
-                flutterVersion: mockFlutterVersion,
-                cache: mockCache
+              buildSystem: MockBuildSystem(),
+              platform: fakePlatform,
+              flutterVersion: mockFlutterVersion,
+              cache: mockCache,
             );
             command.produceFlutterPodspec(BuildMode.debug, outputDirectory);
 
@@ -210,11 +204,10 @@ void main() {
 
           testUsingContext('profile URL', () async {
             final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
-                buildSystem: MockBuildSystem(),
-                bundleBuilder: MockBundleBuilder(),
-                platform: fakePlatform,
-                flutterVersion: mockFlutterVersion,
-                cache: mockCache
+              buildSystem: MockBuildSystem(),
+              platform: fakePlatform,
+              flutterVersion: mockFlutterVersion,
+              cache: mockCache,
             );
             command.produceFlutterPodspec(BuildMode.profile, outputDirectory);
 
@@ -228,11 +221,10 @@ void main() {
 
           testUsingContext('release URL', () async {
             final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
-                buildSystem: MockBuildSystem(),
-                bundleBuilder: MockBundleBuilder(),
-                platform: fakePlatform,
-                flutterVersion: mockFlutterVersion,
-                cache: mockCache
+              buildSystem: MockBuildSystem(),
+              platform: fakePlatform,
+              flutterVersion: mockFlutterVersion,
+              cache: mockCache,
             );
             command.produceFlutterPodspec(BuildMode.release, outputDirectory);
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
-import 'package:flutter_tools/src/bundle.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build_ios_framework.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
@@ -245,4 +244,3 @@ class MockFlutterVersion extends Mock implements FlutterVersion {}
 class MockGitTagVersion extends Mock implements GitTagVersion {}
 class MockCache extends Mock implements Cache {}
 class MockBuildSystem extends Mock implements BuildSystem {}
-class MockBundleBuilder extends Mock implements BundleBuilder {}


### PR DESCRIPTION
## Description

Migrate off BundleBuilder and use the build system for all App.framework modes.

## Tests

The build_ios_framework_module_test integration already validates every expected output file for this command.  It passes on this PR.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*