### PR TITLE
Deprecate flutter build bundle

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
@@ -71,12 +71,10 @@ class BuildBundleCommand extends BuildSubCommand {
   final String name = 'bundle';
 
   @override
-  final String description = 'Build the Flutter assets directory from your app.';
+  bool get deprecated => true;
 
   @override
-  final String usageFooter = 'The Flutter assets directory contains your '
-      'application code and resources; they are used by some Flutter Android and'
-      ' iOS runtimes.';
+  final String description = 'Replaced by "flutter assemble".';
 
   @override
   Future<Map<CustomDimensions, String>> get usageValues async {

--- a/packages/flutter_tools/test/commands.shard/permeable/build_bundle_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_bundle_test.dart
@@ -69,6 +69,12 @@ void main() {
     return command;
   }
 
+  testUsingContext('bundle is deprecated', () async {
+    final BuildBundleCommand command = BuildBundleCommand(bundleBuilder: mockBundleBuilder);
+    expect(command.deprecated, isTrue);
+    expect(command.hidden, isTrue);
+  });
+
   testUsingContext('bundle getUsage indicate that project is a module', () async {
     final String projectPath = await createProject(tempDir,
         arguments: <String>['--no-pub', '--template=module']);


### PR DESCRIPTION
## Description
bundle no longer in build subcommands help:
```
$ flutter build -h 
Flutter build commands.
...

Available subcommands:
  aar             Build a repository containing an AAR and a POM file.
  apk             Build an Android APK file from your app.
  appbundle       Build an Android App Bundle file from your app.
  ios             Build an iOS application bundle (Mac OS X host only).
  ios-framework   Produces a .framework directory for a Flutter module and its plugins for integration into existing, plain Xcode projects.
  macos           Build a macOS desktop application.
  web             Build a web application bundle.

Run "flutter help" to see global options.
```
`flutter build bundle -h` shows deprecation message.
<img width="642" alt="Screen Shot 2020-06-22 at 6 30 04 PM" src="https://user-images.githubusercontent.com/682784/85350609-692fa880-b4b6-11ea-8dfe-15ecf5e687f1.png">

## Tests

Added deprecation test.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*