### PR TITLE
Check for Xcode 11 and Xcode 12 directory names in build_ios_framework_module_test

### DIFF
--- a/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
@@ -109,14 +109,36 @@ Future<void> main() async {
       }
       await _checkFrameworkArchs(debugAppFrameworkPath, 'Debug');
 
-      checkFileExists(path.join(
+      // Xcode changed the name of this generated directory in Xcode 12.
+      const String xcode11ArmDirectoryName = 'ios-armv7_arm64';
+      const String xcode12ArmDirectoryName = 'ios-arm64_armv7';
+
+      final String xcode11AppFrameworkDirectory = path.join(
         outputPath,
         'Debug',
         'App.xcframework',
-        'ios-armv7_arm64',
+        xcode11ArmDirectoryName,
         'App.framework',
         'App',
-      ));
+      );
+      final String xcode12AppFrameworkDirectory = path.join(
+        outputPath,
+        'Debug',
+        'App.xcframework',
+        xcode12ArmDirectoryName,
+        'App.framework',
+        'App',
+      );
+
+      // This seemed easier than an explicit Xcode version check.
+      String xcodeArmDirectoryName;
+      if (exists(File(xcode11AppFrameworkDirectory))) {
+        xcodeArmDirectoryName = xcode11ArmDirectoryName;
+      } else if (exists(File(xcode12AppFrameworkDirectory))) {
+        xcodeArmDirectoryName = xcode12ArmDirectoryName;
+      } else {
+        throw const FileSystemException('Expected App.framework binary to exist.');
+      }
 
       checkFileExists(path.join(
         outputPath,
@@ -158,7 +180,7 @@ Future<void> main() async {
           outputPath,
           mode,
           'App.xcframework',
-          'ios-armv7_arm64',
+          xcodeArmDirectoryName,
           'App.framework',
           'App',
         ));
@@ -190,7 +212,7 @@ Future<void> main() async {
           outputPath,
           mode,
           'Flutter.xcframework',
-          'ios-armv7_arm64',
+          xcodeArmDirectoryName,
           'Flutter.framework',
           'Flutter',
         ));
@@ -234,7 +256,7 @@ Future<void> main() async {
           outputPath,
           mode,
           'device_info.xcframework',
-          'ios-armv7_arm64',
+          xcodeArmDirectoryName,
           'device_info.framework',
           'device_info',
         ));
@@ -243,7 +265,7 @@ Future<void> main() async {
           outputPath,
           mode,
           'device_info.xcframework',
-          'ios-armv7_arm64',
+          xcodeArmDirectoryName,
           'device_info.framework',
           'Headers',
           'DeviceInfoPlugin.h',
@@ -301,7 +323,7 @@ Future<void> main() async {
           outputPath,
           mode,
           'FlutterPluginRegistrant.xcframework',
-          'ios-armv7_arm64',
+          xcodeArmDirectoryName,
           'FlutterPluginRegistrant.framework',
           'Headers',
           'GeneratedPluginRegistrant.h',


### PR DESCRIPTION
## Description

Xcode 12 changed a generated XCFramework directory from `ios-armv7_arm64`->`ios-arm64_armv7`.  Check for the existence of both instead of an explicit Xcode version check.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/60043.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*