### PR TITLE
Expose the ElevationOverlay functions so applications can use the directly.

### DIFF
--- a/packages/flutter/lib/material.dart
+++ b/packages/flutter/lib/material.dart
@@ -57,6 +57,7 @@ export 'src/material/divider_theme.dart';
 export 'src/material/drawer.dart';
 export 'src/material/drawer_header.dart';
 export 'src/material/dropdown.dart';
+export 'src/material/elevation_overlay.dart';
 export 'src/material/expand_icon.dart';
 export 'src/material/expansion_panel.dart';
 export 'src/material/expansion_tile.dart';

--- a/packages/flutter/lib/src/material/elevation_overlay.dart
+++ b/packages/flutter/lib/src/material/elevation_overlay.dart
@@ -19,7 +19,7 @@ class ElevationOverlay {
   ElevationOverlay._();
 
   /// Applies an overlay color to a surface color to indicate
-  /// the level of surface elevation in a dark theme.
+  /// the level of its elevation in a dark theme.
   ///
   /// Material drop shadows can be difficult to see in a dark theme, so the
   /// elevation of a surface should be portrayed with an "overlay" in addition

--- a/packages/flutter/lib/src/material/elevation_overlay.dart
+++ b/packages/flutter/lib/src/material/elevation_overlay.dart
@@ -10,25 +10,29 @@ import 'package:flutter/widgets.dart';
 
 import 'theme.dart';
 
-/// A simple utility class for dealing with the overlay color needed
-/// to indicate elevation for dark theme widgets.
-///
-/// This is an internal implementation class and should not be exported by
-/// the material package.
+/// A utility class for dealing with the overlay color needed
+/// to indicate elevation of surfaces in a dark theme.
 class ElevationOverlay {
   // This class is not meant to be instantiated or extended; this constructor
   // prevents instantiation and extension.
   // ignore: unused_element
   ElevationOverlay._();
 
-  /// Applies an elevation overlay color to a given color to indicate
-  /// the level of elevation in a dark theme.
+  /// Applies an overlay color to a surface color to indicate
+  /// the level of surface elevation in a dark theme.
   ///
-  /// If the ambient [ThemeData.applyElevationOverlayColor] is true,
-  /// and [ThemeData.brightness] is [Brightness.dark] then this will return
-  /// a version of the given color with a semi-transparent
-  /// [ThemeData.colorScheme.onSurface] overlaid on top of it. The opacity
-  /// of the overlay is computed based on the [elevation].
+  /// Material drop shadows can be difficult to see in a dark theme, so the
+  /// elevation of a surface should be portrayed with an "overlay" in addition
+  /// to the shadow. As the elevation of the component increases, the
+  /// overlay increases in opacity. This function computes and applies this
+  /// overlay to a given color as needed.
+  ///
+  /// If the ambient theme is dark ([ThemeData.brightness] is [Brightness.dark]),
+  /// and [ThemeData.applyElevationOverlayColor] is true, and the given
+  /// [color] is [ColorScheme.surface] then this will return a version of
+  /// the [color] with a semi-transparent [ColorScheme.onSurface] overlaid
+  /// on top of it. The opacity of the overlay is computed based on the
+  /// [elevation].
   ///
   /// Otherwise it will just return the [color] unmodified.
   ///
@@ -37,12 +41,15 @@ class ElevationOverlay {
   ///  * [ThemeData.applyElevationOverlayColor] which controls the whether
   ///    an overlay color will be applied to indicate elevation.
   ///  * [overlayColor] which computes the needed overlay color.
+  ///  * [Material] which uses this to apply an elevation overlay to its surface.
+  ///  * <https://material.io/design/color/dark-theme.html>, which specifies how
+  ///    the overlay should be applied.
   static Color applyOverlay(BuildContext context, Color color, double elevation) {
     final ThemeData theme = Theme.of(context);
     if (elevation > 0.0 &&
         theme.applyElevationOverlayColor &&
-        theme.brightness == Brightness.dark) {
-
+        theme.brightness == Brightness.dark &&
+        color == theme.colorScheme.surface) {
       return Color.alphaBlend(overlayColor(context, elevation), color);
     }
     return color;

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -945,15 +945,13 @@ class ThemeData with Diagnosticable {
   ///
   /// If [true] and [brightness] is [Brightness.dark], a
   /// semi-transparent version of [colorScheme.onSurface] will be
-  /// applied on top of the color of [Material] widgets. The level of
-  /// transparency is based on [Material.elevation] as per the
-  /// Material Dark theme specification.
+  /// applied on top of [Material] widgets that have a [colorScheme.surface]
+  /// color. The level of transparency is based on [Material.elevation] as
+  /// per the Material Dark theme specification.
   ///
   /// If [false] the surface color will be used unmodified.
   ///
-  /// Defaults to [false].
-  ///
-  /// Note: this setting is here to maintain backwards compatibility with
+  /// Defaults to [false] in order to maintain backwards compatibility with
   /// apps that were built before the Material Dark theme specification
   /// was published. New apps should set this to [true] for any themes
   /// where [brightness] is [Brightness.dark].
@@ -962,7 +960,8 @@ class ThemeData with Diagnosticable {
   ///
   ///  * [Material.elevation], which effects the level of transparency of the
   ///    overlay color.
-  ///  * [Material.color], the elevation overlay will be applied to this color.
+  ///  * [ElevationOverlay.applyOverlay], which is used by [Material] to apply
+  ///    the overlay color to its surface color.
   ///  * <https://material.io/design/color/dark-theme.html>, which specifies how
   ///    the overlay should be applied.
   final bool applyElevationOverlayColor;

--- a/packages/flutter/test/material/material_test.dart
+++ b/packages/flutter/test/material/material_test.dart
@@ -275,6 +275,24 @@ void main() {
       }
     });
 
+    testWidgets('overlay will not apply to materials using a non-surface color', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Theme(
+          data: ThemeData(
+            applyElevationOverlayColor: true,
+            colorScheme: const ColorScheme.dark(),
+          ),
+          child: buildMaterial(
+            color: Colors.cyan,
+            elevation: 8.0,
+          ),
+        ),
+      );
+      final RenderPhysicalShape model = getModel(tester);
+      // Shouldn't change, as it is not using a ColorScheme.surface color
+      expect(model.color, equals(Colors.cyan));
+    });
+
     testWidgets('overlay will not apply to materials using a light theme', (WidgetTester tester) async {
       await tester.pumpWidget(
           Theme(


### PR DESCRIPTION
## Description

As Material drop shadows can be difficult to see in a dark theme, we add a semi-transparent overlay color on top of surface colors of `Material` widgets to indicate their elevation. Currently the computation of this overlay color is not available for applications to use directly. The PR exposes two functions `ElevationOverlay.applyOverlay` and `ElevationOverlay.overlayColor` that were previously internal to the library.  Applications that need an overlay for custom widgets or special use cases can use these to match the overlay colors used by `Material` widgets.

In addition, this PR also re-introduces a restriction to only apply this elevation overlay colors to `Material` widgets that are using the ambient `ColorScheme.surface` color. The reason for this is that the specification indicates that this should only apply to surfaces, and some widgets like `FloatingActionButton` should have an elevation, but not an overlay.

### Example usage

Using #59359 as an example, it needs an AppBar above a TabBar, but doesn't want the AppBar to have an elevation, as it will put a drop shadow over the top fo the TabBar. Here is how you could achieve that for a dark theme:

```dart
AppBar(
  backgroundColor: Color.alphaBlend(ElevationOverlay.overlayColor(context, elevation), color);
  ...,
)
```

Where `elevation` is the elevation that you would normally put on the `AppBar` if it wasn't above the `TabBar` and `color` is what ever color you were using for the surface of the `AppBar`.

## Related Issues

Fixes: https://github.com/flutter/flutter/issues/59359

## Tests

Added a new test that ensures it only applies the overlay to `Material` widgets with a surface color.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them?

- [x] No, no existing tests failed, so this is *not* a breaking change.
