### PR TITLE
Add null safety options to build ios-framework

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -28,6 +28,7 @@ class BuildCommand extends FlutterCommand {
     addSubcommand(BuildIOSCommand(verboseHelp: verboseHelp));
     addSubcommand(BuildIOSFrameworkCommand(
       buildSystem: globals.buildSystem,
+      verboseHelp: verboseHelp,
     ));
     addSubcommand(BuildBundleCommand(verboseHelp: verboseHelp));
     addSubcommand(BuildWebCommand(verboseHelp: verboseHelp));

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -37,6 +37,7 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
   BuildIOSFrameworkCommand({
     FlutterVersion flutterVersion, // Instantiating FlutterVersion kicks off networking, so delay until it's needed, but allow test injection.
     @required BuildSystem buildSystem,
+    @required bool verboseHelp,
     Cache cache,
     Platform platform
   }) : _flutterVersion = flutterVersion,
@@ -51,6 +52,9 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
     addSplitDebugInfoOption();
     addDartObfuscationOption();
     usesExtraFrontendOptions();
+    addNullSafetyModeOptions(hide: !verboseHelp);
+    addEnableExperimentation(hide: !verboseHelp);
+
     argParser
       ..addFlag('debug',
         negatable: true,

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
@@ -66,7 +66,8 @@ void main() {
           buildSystem: MockBuildSystem(),
           platform: fakePlatform,
           flutterVersion: mockFlutterVersion,
-          cache: mockCache
+          cache: mockCache,
+          verboseHelp: false,
         );
 
         expect(() => command.produceFlutterPodspec(BuildMode.debug, outputDirectory),
@@ -90,7 +91,8 @@ void main() {
           buildSystem: MockBuildSystem(),
           platform: fakePlatform,
           flutterVersion: mockFlutterVersion,
-          cache: mockCache
+          cache: mockCache,
+          verboseHelp: false,
         );
 
         expect(() => command.produceFlutterPodspec(BuildMode.debug, outputDirectory),
@@ -111,7 +113,8 @@ void main() {
           buildSystem: MockBuildSystem(),
           platform: fakePlatform,
           flutterVersion: mockFlutterVersion,
-          cache: mockCache
+          cache: mockCache,
+          verboseHelp: false,
         );
 
         expect(() => command.produceFlutterPodspec(BuildMode.debug, outputDirectory),
@@ -149,6 +152,7 @@ void main() {
               platform: fakePlatform,
               flutterVersion: mockFlutterVersion,
               cache: mockCache,
+              verboseHelp: false,
             );
             command.produceFlutterPodspec(BuildMode.debug, outputDirectory, force: true);
 
@@ -171,6 +175,7 @@ void main() {
               platform: fakePlatform,
               flutterVersion: mockFlutterVersion,
               cache: mockCache,
+              verboseHelp: false,
             );
             command.produceFlutterPodspec(BuildMode.debug, outputDirectory);
 
@@ -190,6 +195,7 @@ void main() {
               platform: fakePlatform,
               flutterVersion: mockFlutterVersion,
               cache: mockCache,
+              verboseHelp: false,
             );
             command.produceFlutterPodspec(BuildMode.debug, outputDirectory);
 
@@ -207,6 +213,7 @@ void main() {
               platform: fakePlatform,
               flutterVersion: mockFlutterVersion,
               cache: mockCache,
+              verboseHelp: false,
             );
             command.produceFlutterPodspec(BuildMode.profile, outputDirectory);
 
@@ -224,6 +231,7 @@ void main() {
               platform: fakePlatform,
               flutterVersion: mockFlutterVersion,
               cache: mockCache,
+              verboseHelp: false,
             );
             command.produceFlutterPodspec(BuildMode.release, outputDirectory);
 

--- a/packages/flutter_tools/test/general.shard/commands/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_test.dart
@@ -9,10 +9,12 @@ import 'package:flutter_tools/src/commands/build_apk.dart';
 import 'package:flutter_tools/src/commands/build_appbundle.dart';
 import 'package:flutter_tools/src/commands/build_fuchsia.dart';
 import 'package:flutter_tools/src/commands/build_ios.dart';
+import 'package:flutter_tools/src/commands/build_ios_framework.dart';
 import 'package:flutter_tools/src/commands/build_linux.dart';
 import 'package:flutter_tools/src/commands/build_macos.dart';
 import 'package:flutter_tools/src/commands/build_web.dart';
 import 'package:flutter_tools/src/commands/build_windows.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
 
 import '../../src/common.dart';
 import '../../src/context.dart';
@@ -29,6 +31,7 @@ void main() {
       BuildAppBundleCommand(verboseHelp: false),
       BuildFuchsiaCommand(verboseHelp: false),
       BuildAarCommand(verboseHelp: false),
+      BuildIOSFrameworkCommand(verboseHelp: false, buildSystem: globals.buildSystem),
     ];
 
     for (final BuildSubCommand command in commands) {


### PR DESCRIPTION
## Description
Now that `BuildIOSFrameworkCommand` is parsing build mode params, add the null safety options.

## Related Issues

https://github.com/flutter/flutter/pull/59773#discussion_r442366309
https://github.com/flutter/flutter/pull/59874

## Tests

Added to build_test.
BuildIOSFrameworkCommand is pretty untestable right now, so it would be nice to add something to build_ios_framework_module_test to verify, but there's probably no way to check if null safety was used in the product binaries?
Tested this manually, the flags are passed into dart (I can see with `-v`)

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*