### PR TITLE
[flutter_tools] Add support for web in plugin template.

### DIFF
--- a/packages/flutter_tools/templates/plugin/lib/projectName_web.dart.tmpl
+++ b/packages/flutter_tools/templates/plugin/lib/projectName_web.dart.tmpl
@@ -1,0 +1,45 @@
+import 'dart:async';
+// In order to *not* need this ignore, consider extracting the "web" version
+// of your plugin as a separate package, instead of inlining it in the same
+// package as the core of your plugin.
+// ignore: avoid_web_libraries_in_flutter
+import 'dart:html' as html show window;
+
+import 'package:flutter/services.dart';
+import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+
+/// A web implementation of the {{pluginDartClass}} plugin.
+class {{pluginDartClass}}Web {
+  static void registerWith(Registrar registrar) {
+    final MethodChannel channel = MethodChannel(
+      '{{projectName}}',
+      const StandardMethodCodec(),
+      registrar.messenger,
+    );
+
+    final pluginInstance = {{pluginDartClass}}Web();
+    channel.setMethodCallHandler(pluginInstance.handleMethodCall);
+  }
+
+  /// Handles method calls over the MethodChannel of this plugin.
+  /// Note: Check the "federated" architecture for a new way of doing this:
+  /// https://flutter.dev/go/federated-plugins
+  Future<dynamic> handleMethodCall(MethodCall call) async {
+    switch (call.method) {
+      case 'getPlatformVersion':
+        return getPlatformVersion();
+        break;
+      default:
+        throw PlatformException(
+          code: 'Unimplemented',
+          details: '{{projectName}} for web doesn\'t implement \'${call.method}\'',
+        );
+    }
+  }
+
+  /// Returns a [String] containing the version of the platform.
+  Future<String> getPlatformVersion() {
+    final version = html.window.navigator.userAgent;
+    return Future.value(version);
+  }
+}

--- a/packages/flutter_tools/templates/plugin/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/plugin/pubspec.yaml.tmpl
@@ -11,6 +11,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+{{#web}}
+  flutter_web_plugins:
+    sdk: flutter
+{{/web}}
 
 dev_dependencies:
   flutter_test:
@@ -40,6 +44,11 @@ flutter:
       macos:
         pluginClass: {{pluginClass}}
 {{/macos}}
+{{#web}}
+      web:
+        pluginClass: {{pluginDartClass}}Web
+        fileName: {{projectName}}_web.dart
+{{/web}}
 
   # To add assets to your plugin package, add an assets section, like this:
   # assets:


### PR DESCRIPTION
## Description

This PR adds support for the web platform with the plugin template in a backwards-compatible way (using MethodChannels).

This PR addresses comments on #59700 (which maybe should be re-done as a new `federated-plugin` template, if needed.)

## Related Issues

* #59562

## Tests

I added the following tests:

In `flutter_tools/test/commands.shard/permeable/create_test.dart`:

* `plugin project supports web`
* Asserted `lib/flutter_project_web.dart` is not created by default.

```
dit@dit:~/github/flutter/packages/flutter_tools$ pub run test test/commands.shard/permeable/create_test.dart
Precompiling executable... (8.9s)
Precompiled test:test.
03:02 +59: All tests passed!

dit@dit:~/github/flutter/packages/flutter_tools$ pub run test test/commands.shard/permeable/create_test.dart -n web
00:21 +1: All tests passed!
```


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
