### PR TITLE
Revert "[flutter_tools] separate target platform, host platform, and architecture"

### DIFF
--- a/packages/flutter_tools/lib/src/aot.dart
+++ b/packages/flutter_tools/lib/src/aot.dart
@@ -38,9 +38,9 @@ class AotBuilder {
     bool expectSo = false;
     switch (platform) {
       case TargetPlatform.android:
-      case TargetPlatform.darwin:
-      case TargetPlatform.linux:
-      case TargetPlatform.windows:
+      case TargetPlatform.darwin_x64:
+      case TargetPlatform.linux_x64:
+      case TargetPlatform.windows_x64:
       case TargetPlatform.fuchsia_arm64:
       case TargetPlatform.tester:
       case TargetPlatform.web_javascript:

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -52,7 +52,7 @@ class ApplicationPackageFactory {
             : IOSApp.fromPrebuiltApp(applicationBinary);
       case TargetPlatform.tester:
         return FlutterTesterApp.fromCurrentDirectory();
-      case TargetPlatform.darwin:
+      case TargetPlatform.darwin_x64:
         return applicationBinary == null
             ? MacOSApp.fromMacOSProject(FlutterProject.current().macos)
             : MacOSApp.fromPrebuiltApp(applicationBinary);
@@ -61,11 +61,11 @@ class ApplicationPackageFactory {
           return null;
         }
         return WebApplicationPackage(FlutterProject.current());
-      case TargetPlatform.linux:
+      case TargetPlatform.linux_x64:
         return applicationBinary == null
             ? LinuxApp.fromLinuxProject(FlutterProject.current().linux)
             : LinuxApp.fromPrebuiltApp(applicationBinary);
-      case TargetPlatform.windows:
+      case TargetPlatform.windows_x64:
         return applicationBinary == null
             ? WindowsApp.fromWindowsProject(FlutterProject.current().windows)
             : WindowsApp.fromPrebuiltApp(applicationBinary);
@@ -436,13 +436,13 @@ class ApplicationPackageStore {
       case TargetPlatform.fuchsia_x64:
         fuchsia ??= FuchsiaApp.fromFuchsiaProject(FlutterProject.current().fuchsia);
         return fuchsia;
-      case TargetPlatform.darwin:
+      case TargetPlatform.darwin_x64:
         macOS ??= MacOSApp.fromMacOSProject(FlutterProject.current().macos);
         return macOS;
-      case TargetPlatform.linux:
+      case TargetPlatform.linux_x64:
         linux ??= LinuxApp.fromLinuxProject(FlutterProject.current().linux);
         return linux;
-      case TargetPlatform.windows:
+      case TargetPlatform.windows_x64:
         windows ??= WindowsApp.fromWindowsProject(FlutterProject.current().windows);
         return windows;
       case TargetPlatform.tester:

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -69,7 +69,7 @@ enum Artifact {
 }
 
 String _artifactToFileName(Artifact artifact, [ TargetPlatform platform, BuildMode mode ]) {
-  final String exe = platform == TargetPlatform.windows ? '.exe' : '';
+  final String exe = platform == TargetPlatform.windows_x64 ? '.exe' : '';
   switch (artifact) {
     case Artifact.genSnapshot:
       return 'gen_snapshot';
@@ -211,9 +211,9 @@ class CachedArtifacts implements Artifacts {
         return _getAndroidArtifactPath(artifact, platform, mode);
       case TargetPlatform.ios:
         return _getIosArtifactPath(artifact, platform, mode);
-      case TargetPlatform.darwin:
-      case TargetPlatform.linux:
-      case TargetPlatform.windows:
+      case TargetPlatform.darwin_x64:
+      case TargetPlatform.linux_x64:
+      case TargetPlatform.windows_x64:
         return _getDesktopArtifactPath(artifact, platform, mode);
       case TargetPlatform.fuchsia_arm64:
       case TargetPlatform.fuchsia_x64:
@@ -390,9 +390,9 @@ class CachedArtifacts implements Artifacts {
     final String engineDir = _cache.getArtifactDirectory('engine').path;
     final String platformName = getNameForTargetPlatform(platform);
     switch (platform) {
-      case TargetPlatform.linux:
-      case TargetPlatform.darwin:
-      case TargetPlatform.windows:
+      case TargetPlatform.linux_x64:
+      case TargetPlatform.darwin_x64:
+      case TargetPlatform.windows_x64:
         // TODO(jonahwilliams): remove once debug desktop artifacts are uploaded
         // under a separate directory from the host artifacts.
         // https://github.com/flutter/flutter/issues/38935
@@ -429,13 +429,13 @@ class CachedArtifacts implements Artifacts {
 
 TargetPlatform _currentHostPlatform(Platform platform) {
   if (platform.isMacOS) {
-    return TargetPlatform.darwin;
+    return TargetPlatform.darwin_x64;
   }
   if (platform.isLinux) {
-    return TargetPlatform.linux;
+    return TargetPlatform.linux_x64;
   }
   if (platform.isWindows) {
-    return TargetPlatform.windows;
+    return TargetPlatform.windows_x64;
   }
   throw UnimplementedError('Host OS not supported.');
 }

--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -143,7 +143,7 @@ class AOTSnapshotter {
     }
 
     final String assembly = _fileSystem.path.join(outputDir.path, 'snapshot_assembly.S');
-    if (platform == TargetPlatform.ios || platform == TargetPlatform.darwin) {
+    if (platform == TargetPlatform.ios || platform == TargetPlatform.darwin_x64) {
       genSnapshotArgs.addAll(<String>[
         '--snapshot_kind=app-aot-assembly',
         '--assembly=$assembly',
@@ -207,7 +207,7 @@ class AOTSnapshotter {
 
     // On iOS and macOS, we use Xcode to compile the snapshot into a dynamic library that the
     // end-developer can link into their app.
-    if (platform == TargetPlatform.ios || platform == TargetPlatform.darwin) {
+    if (platform == TargetPlatform.ios || platform == TargetPlatform.darwin_x64) {
       final RunResult result = await _buildFramework(
         appleArch: darwinArch,
         isIOS: platform == TargetPlatform.ios,
@@ -297,9 +297,9 @@ class AOTSnapshotter {
       TargetPlatform.android_arm64,
       TargetPlatform.android_x64,
       TargetPlatform.ios,
-      TargetPlatform.darwin,
-      TargetPlatform.linux,
-      TargetPlatform.windows,
+      TargetPlatform.darwin_x64,
+      TargetPlatform.linux_x64,
+      TargetPlatform.windows_x64,
     ].contains(platform);
   }
 }

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -273,7 +273,7 @@ String validatedBuildNumberForPlatform(TargetPlatform targetPlatform, String bui
     return null;
   }
   if (targetPlatform == TargetPlatform.ios ||
-      targetPlatform == TargetPlatform.darwin) {
+      targetPlatform == TargetPlatform.darwin_x64) {
     // See CFBundleVersion at https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
     final RegExp disallowed = RegExp(r'[^\d\.]');
     String tmpBuildNumber = buildNumber.replaceAll(disallowed, '');
@@ -320,7 +320,7 @@ String validatedBuildNameForPlatform(TargetPlatform targetPlatform, String build
     return null;
   }
   if (targetPlatform == TargetPlatform.ios ||
-      targetPlatform == TargetPlatform.darwin) {
+      targetPlatform == TargetPlatform.darwin_x64) {
     // See CFBundleShortVersionString at https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
     final RegExp disallowed = RegExp(r'[^\d\.]');
     String tmpBuildName = buildName.replaceAll(disallowed, '');
@@ -370,11 +370,8 @@ bool isEmulatorBuildMode(BuildMode mode) {
 
 enum HostPlatform {
   darwin_x64,
-  darwin_arm64,
   linux_x64,
-  linux_arm64,
   windows_x64,
-  windows_arm64,
 }
 
 String getNameForHostPlatform(HostPlatform platform) {
@@ -385,12 +382,6 @@ String getNameForHostPlatform(HostPlatform platform) {
       return 'linux-x64';
     case HostPlatform.windows_x64:
       return 'windows-x64';
-    case HostPlatform.darwin_arm64:
-      return 'darwin-arm64';
-    case HostPlatform.linux_arm64:
-      return 'linux-arm64';
-    case HostPlatform.windows_arm64:
-      return 'windows-arm64';
   }
   assert(false);
   return null;
@@ -399,9 +390,9 @@ String getNameForHostPlatform(HostPlatform platform) {
 enum TargetPlatform {
   android,
   ios,
-  darwin,
-  linux,
-  windows,
+  darwin_x64,
+  linux_x64,
+  windows_x64,
   fuchsia_arm64,
   fuchsia_x64,
   tester,
@@ -414,16 +405,6 @@ enum TargetPlatform {
   android_arm64,
   android_x64,
   android_x86,
-}
-
-enum WindowsArch {
-  x86_64,
-  arm64,
-}
-
-enum LinuxArch {
-  x86_64,
-  arm64,
 }
 
 /// iOS and macOS target device architecture.
@@ -491,11 +472,11 @@ String getNameForTargetPlatform(TargetPlatform platform, {DarwinArch darwinArch}
         return 'ios-${getNameForDarwinArch(darwinArch)}';
       }
       return 'ios';
-    case TargetPlatform.darwin:
+    case TargetPlatform.darwin_x64:
       return 'darwin-x64';
-    case TargetPlatform.linux:
+    case TargetPlatform.linux_x64:
       return 'linux-x64';
-    case TargetPlatform.windows:
+    case TargetPlatform.windows_x64:
       return 'windows-x64';
     case TargetPlatform.fuchsia_arm64:
       return 'fuchsia-arm64';
@@ -531,11 +512,11 @@ TargetPlatform getTargetPlatformForName(String platform) {
     case 'ios':
       return TargetPlatform.ios;
     case 'darwin-x64':
-      return TargetPlatform.darwin;
+      return TargetPlatform.darwin_x64;
     case 'linux-x64':
-      return TargetPlatform.linux;
+      return TargetPlatform.linux_x64;
     case 'windows-x64':
-      return TargetPlatform.windows;
+      return TargetPlatform.windows_x64;
     case 'web-javascript':
       return TargetPlatform.web_javascript;
   }

--- a/packages/flutter_tools/lib/src/build_system/targets/common.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/common.dart
@@ -223,9 +223,9 @@ class KernelSnapshot extends Target {
     // See https://github.com/flutter/flutter/issues/44724
     bool forceLinkPlatform;
     switch (targetPlatform) {
-      case TargetPlatform.darwin:
-      case TargetPlatform.windows:
-      case TargetPlatform.linux:
+      case TargetPlatform.darwin_x64:
+      case TargetPlatform.windows_x64:
+      case TargetPlatform.linux_x64:
         forceLinkPlatform = true;
         break;
       default:

--- a/packages/flutter_tools/lib/src/build_system/targets/linux.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/linux.dart
@@ -48,13 +48,13 @@ class UnpackLinux extends Target {
       .getArtifactPath(
         Artifact.linuxDesktopPath,
         mode: buildMode,
-        platform: TargetPlatform.linux,
+        platform: TargetPlatform.linux_x64,
       );
     final String headersPath = environment.artifacts
       .getArtifactPath(
         Artifact.linuxHeaders,
         mode: buildMode,
-        platform: TargetPlatform.linux,
+        platform: TargetPlatform.linux_x64,
       );
     final Directory outputDirectory = environment.fileSystem.directory(
       environment.fileSystem.path.join(
@@ -71,7 +71,7 @@ class UnpackLinux extends Target {
       clientSourcePaths: <String>[headersPath],
       icuDataPath: environment.artifacts.getArtifactPath(
         Artifact.icuData,
-        platform: TargetPlatform.linux,
+        platform: TargetPlatform.linux_x64,
       )
     );
     final DepfileService depfileService = DepfileService(
@@ -127,7 +127,7 @@ abstract class BundleLinuxAssets extends Target {
     final Depfile depfile = await copyAssets(
       environment,
       outputDirectory,
-      targetPlatform: TargetPlatform.linux,
+      targetPlatform: TargetPlatform.linux_x64,
     );
     final DepfileService depfileService = DepfileService(
       fileSystem: environment.fileSystem,
@@ -206,7 +206,7 @@ class ProfileBundleLinuxAssets extends BundleLinuxAssets {
   @override
   List<Target> get dependencies => <Target>[
     ...super.dependencies,
-    const LinuxAotBundle(AotElfProfile(TargetPlatform.linux)),
+    const LinuxAotBundle(AotElfProfile(TargetPlatform.linux_x64)),
   ];
 }
 
@@ -222,6 +222,6 @@ class ReleaseBundleLinuxAssets extends BundleLinuxAssets {
   @override
   List<Target> get dependencies => <Target>[
     ...super.dependencies,
-    const LinuxAotBundle(AotElfRelease(TargetPlatform.linux)),
+    const LinuxAotBundle(AotElfRelease(TargetPlatform.linux_x64)),
   ];
 }

--- a/packages/flutter_tools/lib/src/build_system/targets/macos.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/macos.dart
@@ -211,7 +211,7 @@ class CompileMacOSFramework extends Target {
       buildMode: buildMode,
       mainPath: environment.buildDir.childFile('app.dill').path,
       outputPath: environment.buildDir.path,
-      platform: TargetPlatform.darwin,
+      platform: TargetPlatform.darwin_x64,
       darwinArch: DarwinArch.x86_64,
       packagesPath: environment.projectDir.childFile('.packages').path,
       splitDebugInfo: splitDebugInfo,
@@ -232,7 +232,7 @@ class CompileMacOSFramework extends Target {
   List<Source> get inputs => const <Source>[
     Source.pattern('{BUILD_DIR}/app.dill'),
     Source.pattern('{FLUTTER_ROOT}/packages/flutter_tools/lib/src/build_system/targets/macos.dart'),
-    Source.artifact(Artifact.genSnapshot, mode: BuildMode.release, platform: TargetPlatform.darwin),
+    Source.artifact(Artifact.genSnapshot, mode: BuildMode.release, platform: TargetPlatform.darwin_x64),
   ];
 
   @override
@@ -296,7 +296,7 @@ abstract class MacOSBundleFlutterAssets extends Target {
     final Depfile assetDepfile = await copyAssets(
       environment,
       assetDirectory,
-      targetPlatform: TargetPlatform.darwin,
+      targetPlatform: TargetPlatform.darwin_x64,
     );
     final DepfileService depfileService = DepfileService(
       fileSystem: globals.fs,
@@ -346,9 +346,9 @@ abstract class MacOSBundleFlutterAssets extends Target {
       // Copy precompiled runtimes.
       try {
         final String vmSnapshotData = globals.artifacts.getArtifactPath(Artifact.vmSnapshotData,
-            platform: TargetPlatform.darwin, mode: BuildMode.debug);
+            platform: TargetPlatform.darwin_x64, mode: BuildMode.debug);
         final String isolateSnapshotData = globals.artifacts.getArtifactPath(Artifact.isolateSnapshotData,
-            platform: TargetPlatform.darwin, mode: BuildMode.debug);
+            platform: TargetPlatform.darwin_x64, mode: BuildMode.debug);
         globals.fs.file(vmSnapshotData).copySync(
             assetDirectory.childFile('vm_snapshot_data').path);
         globals.fs.file(isolateSnapshotData).copySync(
@@ -409,8 +409,8 @@ class DebugMacOSBundleFlutterAssets extends MacOSBundleFlutterAssets {
   List<Source> get inputs => <Source>[
     ...super.inputs,
     const Source.pattern('{BUILD_DIR}/app.dill'),
-    const Source.artifact(Artifact.isolateSnapshotData, platform: TargetPlatform.darwin, mode: BuildMode.debug),
-    const Source.artifact(Artifact.vmSnapshotData, platform: TargetPlatform.darwin, mode: BuildMode.debug),
+    const Source.artifact(Artifact.isolateSnapshotData, platform: TargetPlatform.darwin_x64, mode: BuildMode.debug),
+    const Source.artifact(Artifact.vmSnapshotData, platform: TargetPlatform.darwin_x64, mode: BuildMode.debug),
   ];
 
   @override

--- a/packages/flutter_tools/lib/src/build_system/targets/windows.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/windows.dart
@@ -54,13 +54,13 @@ class UnpackWindows extends Target {
     final String engineSourcePath = environment.artifacts
       .getArtifactPath(
         Artifact.windowsDesktopPath,
-        platform: TargetPlatform.windows,
+        platform: TargetPlatform.windows_x64,
         mode: buildMode,
       );
     final String clientSourcePath = environment.artifacts
       .getArtifactPath(
         Artifact.windowsCppClientWrapper,
-        platform: TargetPlatform.windows,
+        platform: TargetPlatform.windows_x64,
         mode: buildMode,
       );
     final Directory outputDirectory = environment.fileSystem.directory(
@@ -79,7 +79,7 @@ class UnpackWindows extends Target {
       clientSourcePaths: <String>[clientSourcePath],
       icuDataPath: environment.artifacts.getArtifactPath(
         Artifact.icuData,
-        platform: TargetPlatform.windows
+        platform: TargetPlatform.windows_x64
       )
     );
     final DepfileService depfileService = DepfileService(
@@ -135,7 +135,7 @@ abstract class BundleWindowsAssets extends Target {
     final Depfile depfile = await copyAssets(
       environment,
       outputDirectory,
-      targetPlatform: TargetPlatform.windows,
+      targetPlatform: TargetPlatform.windows_x64,
     );
     final DepfileService depfileService = DepfileService(
       fileSystem: environment.fileSystem,
@@ -197,7 +197,7 @@ class ReleaseBundleWindowsAssets extends BundleWindowsAssets {
   @override
   List<Target> get dependencies => <Target>[
     ...super.dependencies,
-    const WindowsAotBundle(AotElfRelease(TargetPlatform.windows)),
+    const WindowsAotBundle(AotElfRelease(TargetPlatform.windows_x64)),
   ];
 }
 
@@ -213,7 +213,7 @@ class ProfileBundleWindowsAssets extends BundleWindowsAssets {
   @override
   List<Target> get dependencies => <Target>[
     ...super.dependencies,
-    const WindowsAotBundle(AotElfProfile(TargetPlatform.windows)),
+    const WindowsAotBundle(AotElfProfile(TargetPlatform.windows_x64)),
   ];
 }
 

--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
@@ -100,17 +100,17 @@ class BuildBundleCommand extends BuildSubCommand {
     }
     // Check for target platforms that are only allowed via feature flags.
     switch (platform) {
-      case TargetPlatform.darwin:
+      case TargetPlatform.darwin_x64:
         if (!featureFlags.isMacOSEnabled) {
           throwToolExit('macOS is not a supported target platform.');
         }
         break;
-      case TargetPlatform.windows:
+      case TargetPlatform.windows_x64:
         if (!featureFlags.isWindowsEnabled) {
           throwToolExit('Windows is not a supported target platform.');
         }
         break;
-      case TargetPlatform.linux:
+      case TargetPlatform.linux_x64:
         if (!featureFlags.isLinuxEnabled) {
           throwToolExit('Linux is not a supported target platform.');
         }

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -33,7 +33,7 @@ String flutterFrameworkDir(BuildMode mode) {
 
 String flutterMacOSFrameworkDir(BuildMode mode) {
   return globals.fs.path.normalize(globals.fs.path.dirname(globals.artifacts.getArtifactPath(
-      Artifact.flutterMacOSFramework, platform: TargetPlatform.darwin, mode: mode)));
+      Artifact.flutterMacOSFramework, platform: TargetPlatform.darwin_x64, mode: mode)));
 }
 
 /// Writes or rewrites Xcode property files with the specified information.

--- a/packages/flutter_tools/lib/src/linux/linux_device.dart
+++ b/packages/flutter_tools/lib/src/linux/linux_device.dart
@@ -29,7 +29,7 @@ class LinuxDevice extends DesktopDevice {
   String get name => 'Linux desktop';
 
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.linux;
+  Future<TargetPlatform> get targetPlatform async => TargetPlatform.linux_x64;
 
   @override
   bool isSupportedForProject(FlutterProject flutterProject) {

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -27,7 +27,7 @@ class MacOSDevice extends DesktopDevice {
   String get name => 'macOS desktop';
 
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.darwin;
+  Future<TargetPlatform> get targetPlatform async => TargetPlatform.darwin_x64;
 
   @override
   bool isSupportedForProject(FlutterProject flutterProject) {

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1057,17 +1057,17 @@ DevelopmentArtifact _artifactFromTargetPlatform(TargetPlatform targetPlatform) {
       return DevelopmentArtifact.web;
     case TargetPlatform.ios:
       return DevelopmentArtifact.iOS;
-    case TargetPlatform.darwin:
+    case TargetPlatform.darwin_x64:
       if (featureFlags.isMacOSEnabled) {
         return DevelopmentArtifact.macOS;
       }
       return null;
-    case TargetPlatform.windows:
+    case TargetPlatform.windows_x64:
       if (featureFlags.isWindowsEnabled) {
         return DevelopmentArtifact.windows;
       }
       return null;
-    case TargetPlatform.linux:
+    case TargetPlatform.linux_x64:
       if (featureFlags.isLinuxEnabled) {
         return DevelopmentArtifact.linux;
       }

--- a/packages/flutter_tools/lib/src/windows/windows_device.dart
+++ b/packages/flutter_tools/lib/src/windows/windows_device.dart
@@ -30,7 +30,7 @@ class WindowsDevice extends DesktopDevice {
   String get name => 'Windows desktop';
 
   @override
-  Future<TargetPlatform> get targetPlatform async => TargetPlatform.windows;
+  Future<TargetPlatform> get targetPlatform async => TargetPlatform.windows_x64;
 
   @override
   bool isSupportedForProject(FlutterProject flutterProject) {

--- a/packages/flutter_tools/test/general.shard/artifacts_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifacts_test.dart
@@ -62,7 +62,7 @@ void main() {
         'ios-release',
       );
       expect(
-        artifacts.getEngineType(TargetPlatform.darwin),
+        artifacts.getEngineType(TargetPlatform.darwin_x64),
         'darwin-x64',
       );
     });
@@ -121,7 +121,7 @@ void main() {
         'android_debug_unopt',
       );
       expect(
-        artifacts.getEngineType(TargetPlatform.darwin),
+        artifacts.getEngineType(TargetPlatform.darwin_x64),
         'android_debug_unopt',
       );
     });

--- a/packages/flutter_tools/test/general.shard/build_system/source_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/source_test.dart
@@ -91,7 +91,7 @@ void main() {
       'foo',
     );
     globals.fs.file(path).createSync(recursive: true);
-    const Source fizzSource = Source.artifact(Artifact.windowsDesktopPath, platform: TargetPlatform.windows);
+    const Source fizzSource = Source.artifact(Artifact.windowsDesktopPath, platform: TargetPlatform.windows_x64);
     fizzSource.accept(visitor);
 
     expect(visitor.sources.single.resolveSymbolicLinksSync(), globals.fs.path.absolute(path));
@@ -228,7 +228,7 @@ void main() {
     );
     visitor = SourceVisitor(environment);
 
-    const Source fizzSource = Source.artifact(Artifact.windowsDesktopPath, platform: TargetPlatform.windows);
+    const Source fizzSource = Source.artifact(Artifact.windowsDesktopPath, platform: TargetPlatform.windows_x64);
     fizzSource.accept(visitor);
 
     expect(visitor.sources.single.path, contains('engine.version'));

--- a/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/dart_test.dart
@@ -259,7 +259,7 @@ void main() {
     ]);
 
     await const KernelSnapshot().build(androidEnvironment
-      ..defines[kTargetPlatform]  = getNameForTargetPlatform(TargetPlatform.darwin)
+      ..defines[kTargetPlatform]  = getNameForTargetPlatform(TargetPlatform.darwin_x64)
       ..defines[kBuildMode] = getNameForBuildMode(BuildMode.debug)
       ..defines[kTrackWidgetCreation] = 'false'
     );

--- a/packages/flutter_tools/test/general.shard/build_system/targets/linux_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/linux_test.dart
@@ -129,7 +129,7 @@ void main() {
     // Create input files.
     testEnvironment.buildDir.childFile('app.so').createSync();
 
-    await const LinuxAotBundle(AotElfProfile(TargetPlatform.linux)).build(testEnvironment);
+    await const LinuxAotBundle(AotElfProfile(TargetPlatform.linux_x64)).build(testEnvironment);
     await const ProfileBundleLinuxAssets().build(testEnvironment);
     final Directory libDir = testEnvironment.outputDir
       .childDirectory('lib');
@@ -162,7 +162,7 @@ void main() {
     // Create input files.
     testEnvironment.buildDir.childFile('app.so').createSync();
 
-    await const LinuxAotBundle(AotElfRelease(TargetPlatform.linux)).build(testEnvironment);
+    await const LinuxAotBundle(AotElfRelease(TargetPlatform.linux_x64)).build(testEnvironment);
     await const ReleaseBundleLinuxAssets().build(testEnvironment);
     final Directory libDir = testEnvironment.outputDir
       .childDirectory('lib');

--- a/packages/flutter_tools/test/general.shard/build_system/targets/windows_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/windows_test.dart
@@ -197,7 +197,7 @@ void main() {
 
     environment.buildDir.childFile('app.so').createSync(recursive: true);
 
-    await const WindowsAotBundle(AotElfProfile(TargetPlatform.windows)).build(environment);
+    await const WindowsAotBundle(AotElfProfile(TargetPlatform.windows_x64)).build(environment);
     await const ProfileBundleWindowsAssets().build(environment);
 
     // Depfile is created and so is copied.
@@ -224,7 +224,7 @@ void main() {
 
     environment.buildDir.childFile('app.so').createSync(recursive: true);
 
-    await const WindowsAotBundle(AotElfRelease(TargetPlatform.windows)).build(environment);
+    await const WindowsAotBundle(AotElfRelease(TargetPlatform.windows_x64)).build(environment);
     await const ReleaseBundleWindowsAssets().build(environment);
 
     // Depfile is created and so is copied.

--- a/packages/flutter_tools/test/general.shard/bundle_shim_test.dart
+++ b/packages/flutter_tools/test/general.shard/bundle_shim_test.dart
@@ -59,7 +59,7 @@ void main() {
       flutterProject: FlutterProject.current(),
       mainPath: 'lib/main.dart',
       outputDir: 'example',
-      targetPlatform: TargetPlatform.linux,
+      targetPlatform: TargetPlatform.linux_x64,
       depfilePath: 'example.d',
       precompiled: false,
       treeShakeIcons: false,

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -554,7 +554,7 @@ Information about project "Runner":
 
     testUsingOsxContext('do not set OTHER_LDFLAGS for macOS', () async {
       when(mockArtifacts.getArtifactPath(Artifact.flutterMacOSFramework,
-          platform: TargetPlatform.darwin, mode: anyNamed('mode'))).thenReturn(fs.path.join('engine', 'FlutterMacOS.framework'));
+          platform: TargetPlatform.darwin_x64, mode: anyNamed('mode'))).thenReturn(fs.path.join('engine', 'FlutterMacOS.framework'));
       when(mockArtifacts.engineOutPath).thenReturn(fs.path.join('out', 'ios_profile_arm'));
 
       const BuildInfo buildInfo = BuildInfo(BuildMode.debug, null, treeShakeIcons: false);

--- a/packages/flutter_tools/test/general.shard/linux/linux_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/linux/linux_device_test.dart
@@ -27,7 +27,7 @@ void main() {
 
   testWithoutContext('LinuxDevice defaults', () async {
     final PrebuiltLinuxApp linuxApp = PrebuiltLinuxApp(executable: 'foo');
-    expect(await device.targetPlatform, TargetPlatform.linux);
+    expect(await device.targetPlatform, TargetPlatform.linux_x64);
     expect(device.name, 'Linux desktop');
     expect(await device.installApp(linuxApp), true);
     expect(await device.uninstallApp(linuxApp), true);

--- a/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
@@ -39,7 +39,7 @@ void main() {
 
     testUsingContext('defaults', () async {
       final MockMacOSApp mockMacOSApp = MockMacOSApp();
-      expect(await device.targetPlatform, TargetPlatform.darwin);
+      expect(await device.targetPlatform, TargetPlatform.darwin_x64);
       expect(device.name, 'macOS desktop');
       expect(await device.installApp(mockMacOSApp), true);
       expect(await device.uninstallApp(mockMacOSApp), true);

--- a/packages/flutter_tools/test/general.shard/windows/windows_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/windows_device_test.dart
@@ -31,7 +31,7 @@ void main() {
 
     testUsingContext('defaults', () async {
       final PrebuiltWindowsApp windowsApp = PrebuiltWindowsApp(executable: 'foo');
-      expect(await device.targetPlatform, TargetPlatform.windows);
+      expect(await device.targetPlatform, TargetPlatform.windows_x64);
       expect(device.name, 'Windows desktop');
       expect(await device.installApp(windowsApp), true);
       expect(await device.uninstallApp(windowsApp), true);


### PR DESCRIPTION
Reverts flutter/flutter#60119

TargetPlatform.linux_x64 is referenced internally, will recreate with a correct deprecation notice