### PR TITLE
Remove unused physicalDepth code

### DIFF
--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -97,7 +97,6 @@ class MediaQueryData {
     this.viewInsets = EdgeInsets.zero,
     this.systemGestureInsets = EdgeInsets.zero,
     this.viewPadding = EdgeInsets.zero,
-    this.physicalDepth = double.maxFinite,
     this.alwaysUse24HourFormat = false,
     this.accessibleNavigation = false,
     this.invertColors = false,
@@ -113,7 +112,6 @@ class MediaQueryData {
        assert(viewInsets != null),
        assert(systemGestureInsets != null),
        assert(viewPadding != null),
-       assert(physicalDepth != null),
        assert(alwaysUse24HourFormat != null),
        assert(accessibleNavigation != null),
        assert(invertColors != null),
@@ -137,7 +135,6 @@ class MediaQueryData {
       viewPadding = EdgeInsets.fromWindowPadding(window.viewPadding, window.devicePixelRatio),
       viewInsets = EdgeInsets.fromWindowPadding(window.viewInsets, window.devicePixelRatio),
       systemGestureInsets = EdgeInsets.fromWindowPadding(window.systemGestureInsets, window.devicePixelRatio),
-      physicalDepth = window.physicalDepth,
       accessibleNavigation = window.accessibilityFeatures.accessibleNavigation,
       invertColors = window.accessibilityFeatures.invertColors,
       disableAnimations = window.accessibilityFeatures.disableAnimations,
@@ -291,19 +288,6 @@ class MediaQueryData {
   /// {@end-tool}
   final EdgeInsets systemGestureInsets;
 
-  /// The physical depth is the maximum elevation that the Window allows.
-  ///
-  /// Physical layers drawn at or above this elevation will have their elevation
-  /// clamped to this value. This can happen if the physical layer itself has
-  /// an elevation larger than the available depth, or if some ancestor of the
-  /// layer causes it to have a cumulative elevation that is larger than the
-  /// available depth.
-  ///
-  /// The default value is [double.maxFinite], which is used for platforms that
-  /// do not specify a maximum elevation. This property is currently only
-  /// expected to be set to a non-default value on Fuchsia.
-  final double physicalDepth;
-
   /// Whether to use 24-hour format when formatting time.
   ///
   /// The behavior of this flag is different across platforms:
@@ -394,7 +378,6 @@ class MediaQueryData {
     EdgeInsets viewPadding,
     EdgeInsets viewInsets,
     EdgeInsets systemGestureInsets,
-    double physicalDepth,
     bool alwaysUse24HourFormat,
     bool highContrast,
     bool disableAnimations,
@@ -412,7 +395,6 @@ class MediaQueryData {
       viewPadding: viewPadding ?? this.viewPadding,
       viewInsets: viewInsets ?? this.viewInsets,
       systemGestureInsets: systemGestureInsets ?? this.systemGestureInsets,
-      physicalDepth: physicalDepth ?? this.physicalDepth,
       alwaysUse24HourFormat: alwaysUse24HourFormat ?? this.alwaysUse24HourFormat,
       invertColors: invertColors ?? this.invertColors,
       highContrast: highContrast ?? this.highContrast,
@@ -581,7 +563,6 @@ class MediaQueryData {
         && other.padding == padding
         && other.viewPadding == viewPadding
         && other.viewInsets == viewInsets
-        && other.physicalDepth == physicalDepth
         && other.alwaysUse24HourFormat == alwaysUse24HourFormat
         && other.highContrast == highContrast
         && other.disableAnimations == disableAnimations
@@ -601,7 +582,6 @@ class MediaQueryData {
       padding,
       viewPadding,
       viewInsets,
-      physicalDepth,
       alwaysUse24HourFormat,
       highContrast,
       disableAnimations,
@@ -622,7 +602,6 @@ class MediaQueryData {
       'padding: $padding',
       'viewPadding: $viewPadding',
       'viewInsets: $viewInsets',
-      'physicalDepth: $physicalDepth',
       'alwaysUse24HourFormat: $alwaysUse24HourFormat',
       'accessibleNavigation: $accessibleNavigation',
       'highContrast: $highContrast',

--- a/packages/flutter/test/widgets/media_query_test.dart
+++ b/packages/flutter/test/widgets/media_query_test.dart
@@ -71,7 +71,6 @@ void main() {
     expect(data.boldText, false);
     expect(data.highContrast, false);
     expect(data.platformBrightness, Brightness.light);
-    expect(data.physicalDepth, equals(WidgetsBinding.instance.window.physicalDepth));
   });
 
   testWidgets('MediaQueryData.copyWith defaults to source', (WidgetTester tester) async {
@@ -84,7 +83,6 @@ void main() {
     expect(copied.viewPadding, data.viewPadding);
     expect(copied.viewInsets, data.viewInsets);
     expect(copied.systemGestureInsets, data.systemGestureInsets);
-    expect(copied.physicalDepth, data.physicalDepth);
     expect(copied.alwaysUse24HourFormat, data.alwaysUse24HourFormat);
     expect(copied.accessibleNavigation, data.accessibleNavigation);
     expect(copied.invertColors, data.invertColors);
@@ -104,7 +102,6 @@ void main() {
     const EdgeInsets customViewPadding = EdgeInsets.all(11.24031);
     const EdgeInsets customViewInsets = EdgeInsets.all(1.67262);
     const EdgeInsets customSystemGestureInsets = EdgeInsets.all(1.5556);
-    const double customPhysicalDepth = 120.0;
 
     final MediaQueryData data = MediaQueryData.fromWindow(WidgetsBinding.instance.window);
     final MediaQueryData copied = data.copyWith(
@@ -115,7 +112,6 @@ void main() {
       viewPadding: customViewPadding,
       viewInsets: customViewInsets,
       systemGestureInsets: customSystemGestureInsets,
-      physicalDepth: customPhysicalDepth,
       alwaysUse24HourFormat: true,
       accessibleNavigation: true,
       invertColors: true,
@@ -131,7 +127,6 @@ void main() {
     expect(copied.viewPadding, customViewPadding);
     expect(copied.viewInsets, customViewInsets);
     expect(copied.systemGestureInsets, customSystemGestureInsets);
-    expect(copied.physicalDepth, customPhysicalDepth);
     expect(copied.alwaysUse24HourFormat, true);
     expect(copied.accessibleNavigation, true);
     expect(copied.invertColors, true);
@@ -649,17 +644,6 @@ void main() {
       MediaQueryData(viewPadding: null);
     } on AssertionError catch (error) {
       expect(error.toString(), contains('viewPadding != null'));
-      expect(error.toString(), contains('is not true'));
-      return;
-    }
-    fail('The assert was never called when it should have been');
-  });
-
-  test('physicalDepth parameter in MediaQueryData cannot be null', () {
-    try {
-      MediaQueryData(physicalDepth: null);
-    } on AssertionError catch (error) {
-      expect(error.toString(), contains('physicalDepth != null'));
       expect(error.toString(), contains('is not true'));
       return;
     }

--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -87,22 +87,6 @@ class TestWindow implements Window {
   }
 
   @override
-  double get physicalDepth => _physicalDepthTestValue ?? _window.physicalDepth;
-  double _physicalDepthTestValue;
-  /// Hides the real physical depth and reports the given
-  /// [physicalDepthTestValue] instead.
-  set physicalDepthTestValue (double physicalDepthTestValue) {
-    _physicalDepthTestValue = physicalDepthTestValue;
-    onMetricsChanged();
-  }
-  /// Deletes any existing test physical depth and returns to using the real
-  /// physical depth.
-  void clearPhysicalDepthTestValue() {
-    _physicalDepthTestValue = null;
-    onMetricsChanged();
-  }
-
-  @override
   WindowPadding get viewInsets => _viewInsetsTestValue ??  _window.viewInsets;
   WindowPadding _viewInsetsTestValue;
   /// Hides the real view insets and reports the given [viewInsetsTestValue]
@@ -418,7 +402,6 @@ class TestWindow implements Window {
     clearLocalesTestValue();
     clearPaddingTestValue();
     clearPhysicalSizeTestValue();
-    clearPhysicalDepthTestValue();
     clearSemanticsEnabledTestValue();
     clearTextScaleFactorTestValue();
     clearViewInsetsTestValue();

--- a/packages/flutter_test/test/window_test.dart
+++ b/packages/flutter_test/test/window_test.dart
@@ -43,20 +43,6 @@ void main() {
     );
   });
 
-  testWidgets('TestWindow can fake physical depth', (WidgetTester tester) async {
-    verifyThatTestWindowCanFakeProperty<double>(
-      tester: tester,
-      realValue: ui.window.physicalDepth,
-      fakeValue: 120.0,
-      propertyRetriever: () {
-        return WidgetsBinding.instance.window.physicalDepth;
-      },
-      propertyFaker: (TestWidgetsFlutterBinding binding, double fakeValue) {
-        binding.window.physicalDepthTestValue = fakeValue;
-      },
-    );
-  });
-
   testWidgets('TestWindow can fake view insets', (WidgetTester tester) async {
     verifyThatTestWindowCanFakeProperty<WindowPadding>(
       tester: tester,


### PR DESCRIPTION
Fuchsia no longer wants to expose physicalDepth as part of
Fixes https://github.com/flutter/flutter/issues/60151

Fuchsia intended to use this, but no longer.  There aren't any clients
that use this, so it should be safe to just delete.

BUG: 54947