### PR TITLE
Don't move to word edge when tapping with a mouse

### DIFF
--- a/packages/flutter/lib/src/gestures/multitap.dart
+++ b/packages/flutter/lib/src/gestures/multitap.dart
@@ -478,9 +478,9 @@ class MultiTapGestureRecognizer extends GestureRecognizer {
     if (onTapUp != null)
       invokeCallback<void>('onTapUp', () {
         onTapUp!(pointer, TapUpDetails(
+          kind: getKindForPointer(pointer),
           localPosition: position.local,
           globalPosition: position.global,
-          kind: getKindForPointer(pointer),
         ));
       });
     if (onTap != null)

--- a/packages/flutter/lib/src/gestures/multitap.dart
+++ b/packages/flutter/lib/src/gestures/multitap.dart
@@ -480,6 +480,7 @@ class MultiTapGestureRecognizer extends GestureRecognizer {
         onTapUp!(pointer, TapUpDetails(
           localPosition: position.local,
           globalPosition: position.global,
+          kind: getKindForPointer(pointer),
         ));
       });
     if (onTap != null)

--- a/packages/flutter/lib/src/gestures/tap.dart
+++ b/packages/flutter/lib/src/gestures/tap.dart
@@ -516,9 +516,9 @@ class TapGestureRecognizer extends BaseTapGestureRecognizer {
   @override
   void handleTapUp({ required PointerDownEvent down, required PointerUpEvent up}) {
     final TapUpDetails details = TapUpDetails(
+      kind: up.kind,
       globalPosition: up.position,
       localPosition: up.localPosition,
-      kind: up.kind,
     );
     switch (down.buttons) {
       case kPrimaryButton:

--- a/packages/flutter/lib/src/gestures/tap.dart
+++ b/packages/flutter/lib/src/gestures/tap.dart
@@ -59,6 +59,7 @@ typedef GestureTapDownCallback = void Function(TapDownDetails details);
 class TapUpDetails {
   /// The [globalPosition] argument must not be null.
   TapUpDetails({
+    required this.kind,
     this.globalPosition = Offset.zero,
     Offset? localPosition,
   }) : assert(globalPosition != null),
@@ -69,6 +70,9 @@ class TapUpDetails {
 
   /// The local position at which the pointer contacted the screen.
   final Offset localPosition;
+
+  /// The kind of the device that initiated the event.
+  final PointerDeviceKind kind;
 }
 
 /// Signature for when a pointer that will trigger a tap has stopped contacting
@@ -514,6 +518,7 @@ class TapGestureRecognizer extends BaseTapGestureRecognizer {
     final TapUpDetails details = TapUpDetails(
       globalPosition: up.position,
       localPosition: up.localPosition,
+      kind: up.kind,
     );
     switch (down.buttons) {
       case kPrimaryButton:

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -93,10 +93,19 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
       switch (Theme.of(_state.context).platform) {
         case TargetPlatform.iOS:
         case TargetPlatform.macOS:
-          if (details.kind == PointerDeviceKind.mouse) {
-            renderEditable.selectPosition(cause: SelectionChangedCause.tap);
-          } else {
-            renderEditable.selectWordEdge(cause: SelectionChangedCause.tap);
+          switch (details.kind) {
+            case PointerDeviceKind.mouse:
+            case PointerDeviceKind.stylus:
+            case PointerDeviceKind.invertedStylus:
+              // Precise devices should place the cursor at a precise position.
+              renderEditable.selectPosition(cause: SelectionChangedCause.tap);
+              break;
+            case PointerDeviceKind.touch:
+            case PointerDeviceKind.unknown:
+              // On macOS/iOS/iPadOS a touch tap places the cursor at the edge
+              // of the word.
+              renderEditable.selectWordEdge(cause: SelectionChangedCause.tap);
+              break;
           }
           break;
         case TargetPlatform.android:

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -93,7 +93,11 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
       switch (Theme.of(_state.context).platform) {
         case TargetPlatform.iOS:
         case TargetPlatform.macOS:
-          renderEditable.selectWordEdge(cause: SelectionChangedCause.tap);
+          if (details.kind == PointerDeviceKind.mouse) {
+            renderEditable.selectPosition(cause: SelectionChangedCause.tap);
+          } else {
+            renderEditable.selectWordEdge(cause: SelectionChangedCause.tap);
+          }
           break;
         case TargetPlatform.android:
         case TargetPlatform.fuchsia:

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -1260,7 +1260,7 @@ class _DefaultSemanticsGestureDelegate extends SemanticsGestureDelegate {
       if (tap.onTapDown != null)
         tap.onTapDown(TapDownDetails());
       if (tap.onTapUp != null)
-        tap.onTapUp(TapUpDetails());
+        tap.onTapUp(TapUpDetails(kind: PointerDeviceKind.unknown));
       if (tap.onTap != null)
         tap.onTap();
     };

--- a/packages/flutter/test/gestures/tap_test.dart
+++ b/packages/flutter/test/gestures/tap_test.dart
@@ -109,6 +109,35 @@ void main() {
     tap.dispose();
   });
 
+  testGesture('Details contain the correct device kind', (GestureTester tester) {
+    final TapGestureRecognizer tap = TapGestureRecognizer();
+
+    TapDownDetails lastDownDetails;
+    TapUpDetails lastUpDetails;
+
+    tap.onTapDown = (TapDownDetails details) {
+      lastDownDetails = details;
+    };
+    tap.onTapUp = (TapUpDetails details) {
+      lastUpDetails = details;
+    };
+
+    const PointerDownEvent mouseDown =
+        PointerDownEvent(pointer: 1, kind: PointerDeviceKind.mouse);
+    const PointerUpEvent mouseUp =
+        PointerUpEvent(pointer: 1, kind: PointerDeviceKind.mouse);
+
+    tap.addPointer(mouseDown);
+    tester.closeArena(1);
+    tester.route(mouseDown);
+    expect(lastDownDetails.kind, PointerDeviceKind.mouse);
+
+    tester.route(mouseUp);
+    expect(lastUpDetails.kind, PointerDeviceKind.mouse);
+
+    tap.dispose();
+  });
+
   testGesture('No duplicate tap events', (GestureTester tester) {
     final TapGestureRecognizer tap = TapGestureRecognizer();
 

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -6138,7 +6138,6 @@ void main() {
       addTearDown(gesture.removePointer);
       await tester.pump();
       await gesture.up();
-      await tester.pump();
 
       // Cursor at tap position, not at word edge.
       expect(

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -6110,6 +6110,43 @@ void main() {
       expect(find.byType(CupertinoButton), findsNothing);
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
+  testWidgets(
+    'tap with a mouse does not move cursor to the edge of the word',
+    (WidgetTester tester) async {
+      final TextEditingController controller = TextEditingController(
+        text: 'Atwater Peel Sherbrooke Bonaventure',
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Center(
+              child: TextField(
+                controller: controller,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
+
+      final TestGesture gesture = await tester.startGesture(
+        textfieldStart + const Offset(50.0, 9.0),
+        pointer: 1,
+        kind: PointerDeviceKind.mouse,
+      );
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      // Cursor at tap position, not at word edge.
+      expect(
+        controller.selection,
+        const TextSelection.collapsed(offset: 3, affinity: TextAffinity.downstream),
+      );
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
+
   testWidgets('tap moves cursor to the position tapped', (WidgetTester tester) async {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -6136,7 +6136,6 @@ void main() {
         kind: PointerDeviceKind.mouse,
       );
       addTearDown(gesture.removePointer);
-      await tester.pump();
       await gesture.up();
 
       // Cursor at tap position, not at word edge.


### PR DESCRIPTION
## Description

When the user taps a text field with a mouse, don't move the cursor to the word edge.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/37969

## Tests

I added the following tests:

- `test/gestures/tap_test.dart`
- `test/material/text_field_test.dart`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
