### PR TITLE
Allow SingleChildScrollView to have overflowArea which will render de…

### DIFF
--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -256,7 +256,7 @@ class SingleChildScrollView extends StatelessWidget {
   final EdgeInsetsGeometry padding;
 
   /// The amount of space inset that cannot be interacted with
-  /// 
+  ///
   /// For example, it can be used for an area that is blocked by a
   /// semi-transparent component on top, and the content under it still
   /// needs to be visible but cannot be interacted with.

--- a/packages/flutter/test/widgets/single_child_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/single_child_scroll_view_test.dart
@@ -69,7 +69,6 @@ void main() {
       textDirection: TextDirection.ltr,
       child: SingleChildScrollView(
         controller: controller,
-        overflowArea: EdgeInsets.zero,
         child: Column(
           children: children = List<Widget>.generate(5, (int i) {
             return Container(
@@ -81,9 +80,9 @@ void main() {
       )
     ));
 
-    // 1st, check that the render object has received the default overflow area.
-    final dynamic renderObject = tester.allRenderObjects.where((RenderObject o) => o.runtimeType.toString() == '_RenderSingleChildViewport').first;
-    expect(renderObject.overflowArea, equals(EdgeInsets.zero));
+    // 1st, check that the render object has received the default visible overflow.
+    dynamic renderObject = tester.allRenderObjects.where((RenderObject o) => o.runtimeType.toString() == '_RenderSingleChildViewport').first;
+    expect(renderObject.visibleOverflow, equals(EdgeInsets.zero));
     tester.renderObject(find.byWidget(children[4])).showOnScreen();
     await tester.pumpAndSettle();
     expect(controller.offset, equals(400.0));
@@ -93,7 +92,7 @@ void main() {
       textDirection: TextDirection.ltr,
       child: SingleChildScrollView(
         controller: controller,
-        overflowArea: const EdgeInsets.only(top: 200, bottom: 200),
+        scrollPadding: const EdgeInsets.only(top: 200, bottom: 200),
         child: Column(
           children: children = List<Widget>.generate(5, (int i) {
             return Container(
@@ -104,14 +103,15 @@ void main() {
         )
       )
     ));
-    expect(renderObject.overflowArea, equals(const EdgeInsets.only(top: 200, bottom: 200)));
+    renderObject = tester.allRenderObjects.where((RenderObject o) => o.runtimeType.toString() == '_RenderSingleChildViewport').first;
+    expect(renderObject.visibleOverflow, equals(const EdgeInsets.only(top: 200, bottom: 200)));
 
-    // 3rd, check if the overflow area didn't affect the viewport
+    // 3rd, check if the 4th tile is focus pass scroll padding
     tester.renderObject(find.byWidget(children[4])).showOnScreen();
     await tester.pumpAndSettle();
-    expect(controller.offset, equals(400.0));
+    expect(controller.offset, equals(800.0));
 
-    // 4th, check if the 2nd tile is shown due to the top overflow area
+    // 4th, check if the 3rd tile is shown due to the top scroll padding
     expect(semantics, hasSemantics(
       TestSemantics(
         children: <TestSemantics>[
@@ -127,14 +127,6 @@ void main() {
                 flags: <SemanticsFlag>[
                   SemanticsFlag.isHidden,
                 ],
-                label: r'Tile 0',
-                textDirection: TextDirection.ltr,
-              ),
-              TestSemantics(
-                label: r'Tile 1',
-                textDirection: TextDirection.ltr,
-              ),
-              TestSemantics(
                 label: r'Tile 2',
                 textDirection: TextDirection.ltr,
               ),


### PR DESCRIPTION
## Description

This will allow user specified overflow area to render in single child scroll view.

## Related Issues

Close #60203 

## Tests

I added the following tests:
`packages/flutter/test/widgets/single_child_scroll_view_test.dart`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
