### PR TITLE
Make module run script names unique

### DIFF
--- a/dev/integration_tests/ios_add2app/ios_add2app.xcodeproj/project.pbxproj
+++ b/dev/integration_tests/ios_add2app/ios_add2app.xcodeproj/project.pbxproj
@@ -213,7 +213,7 @@
 			buildConfigurationList = 24E221CB21A28A0C008ADF09 /* Build configuration list for PBXNativeTarget "ios_add2app" */;
 			buildPhases = (
 				4375EE880A727341E9C9A57D /* [CP] Check Pods Manifest.lock */,
-				CE6831C2A33C6C5C84521FDE /* [CP-User] Run Flutter Build Script */,
+				52B3E7E8995E582399C42407 /* [CP-User] Run Flutter Build ios_add2app_flutter Script */,
 				24E221B121A28A0B008ADF09 /* Sources */,
 				24E221B221A28A0B008ADF09 /* Frameworks */,
 				24E221B321A28A0B008ADF09 /* Resources */,
@@ -307,6 +307,22 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		52B3E7E8995E582399C42407 /* [CP-User] Run Flutter Build ios_add2app_flutter Script */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/flutterapp/.metadata",
+				"${SRCROOT}/flutterapp/.ios/Flutter/App.framework/App",
+				"${SRCROOT}/flutterapp/.ios/Flutter/engine/Flutter.framework/Flutter",
+				"${SRCROOT}/flutterapp/.ios/Flutter/flutter_export_environment.sh",
+			);
+			name = "[CP-User] Run Flutter Build ios_add2app_flutter Script";
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -e\nset -u\nsource \"${SRCROOT}/flutterapp/.ios/Flutter/flutter_export_environment.sh\"\n\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/xcode_backend.sh build";
+		};
 		7FADF19EC61F97E525982780 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -323,22 +339,6 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ios_add2app/Pods-ios_add2app-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
-		};
-		CE6831C2A33C6C5C84521FDE /* [CP-User] Run Flutter Build Script */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${SRCROOT}/flutterapp/.metadata",
-				"${SRCROOT}/flutterapp/.ios/Flutter/App.framework/App",
-				"${SRCROOT}/flutterapp/.ios/Flutter/engine/Flutter.framework/Flutter",
-				"${SRCROOT}/flutterapp/.ios/Flutter/flutter_export_environment.sh",
-			);
-			name = "[CP-User] Run Flutter Build Script";
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -e\nset -u\nsource \"${SRCROOT}/flutterapp/.ios/Flutter/flutter_export_environment.sh\"\n\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/xcode_backend.sh build";
 		};
 		DE5CDCD8B3565EAB9F38F455 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/dev/integration_tests/ios_add2app_life_cycle/ios_add2app.xcodeproj/project.pbxproj
+++ b/dev/integration_tests/ios_add2app_life_cycle/ios_add2app.xcodeproj/project.pbxproj
@@ -195,7 +195,7 @@
 			buildConfigurationList = 24E221CB21A28A0C008ADF09 /* Build configuration list for PBXNativeTarget "ios_add2app" */;
 			buildPhases = (
 				4375EE880A727341E9C9A57D /* [CP] Check Pods Manifest.lock */,
-				CE6831C2A33C6C5C84521FDE /* [CP-User] Run Flutter Build Script */,
+				76B7AB396D25C19F6CCF750F /* [CP-User] Run Flutter Build ios_add2app_life_cycle_flutter Script */,
 				24E221B121A28A0B008ADF09 /* Sources */,
 				24E221B221A28A0B008ADF09 /* Frameworks */,
 				24E221B321A28A0B008ADF09 /* Resources */,
@@ -289,6 +289,22 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		76B7AB396D25C19F6CCF750F /* [CP-User] Run Flutter Build ios_add2app_life_cycle_flutter Script */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/flutterapp/.metadata",
+				"${SRCROOT}/flutterapp/.ios/Flutter/App.framework/App",
+				"${SRCROOT}/flutterapp/.ios/Flutter/engine/Flutter.framework/Flutter",
+				"${SRCROOT}/flutterapp/.ios/Flutter/flutter_export_environment.sh",
+			);
+			name = "[CP-User] Run Flutter Build ios_add2app_life_cycle_flutter Script";
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -e\nset -u\nsource \"${SRCROOT}/flutterapp/.ios/Flutter/flutter_export_environment.sh\"\n\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/xcode_backend.sh build";
+		};
 		7FADF19EC61F97E525982780 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -305,22 +321,6 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ios_add2app/Pods-ios_add2app-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
-		};
-		CE6831C2A33C6C5C84521FDE /* [CP-User] Run Flutter Build Script */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${SRCROOT}/flutterapp/.metadata",
-				"${SRCROOT}/flutterapp/.ios/Flutter/App.framework/App",
-				"${SRCROOT}/flutterapp/.ios/Flutter/engine/Flutter.framework/Flutter",
-				"${SRCROOT}/flutterapp/.ios/Flutter/flutter_export_environment.sh",
-			);
-			name = "[CP-User] Run Flutter Build Script";
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -e\nset -u\nsource \"${SRCROOT}/flutterapp/.ios/Flutter/flutter_export_environment.sh\"\n\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/xcode_backend.sh build";
 		};
 		DE5CDCD8B3565EAB9F38F455 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/dev/integration_tests/ios_host_app_swift/Host.xcodeproj/project.pbxproj
+++ b/dev/integration_tests/ios_host_app_swift/Host.xcodeproj/project.pbxproj
@@ -100,11 +100,12 @@
 			buildConfigurationList = F724F2D22329B8CD0012DB29 /* Build configuration list for PBXNativeTarget "Host" */;
 			buildPhases = (
 				057F850E20C20171224A8BD8 /* [CP] Check Pods Manifest.lock */,
-				EEED2F2AE8060ACBF2210C77 /* [CP-User] Run Flutter Build Script */,
+				5D4384B6DD186AC159B9ACB3 /* [CP-User] Run Flutter Build hello Script */,
 				F724F2BA2329B8CC0012DB29 /* Sources */,
 				F724F2BB2329B8CC0012DB29 /* Frameworks */,
 				F724F2BC2329B8CC0012DB29 /* Resources */,
 				D7D46336FAE5656C7ADAAD08 /* [CP] Embed Pods Frameworks */,
+				96286B727046BA8457A788D0 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -185,6 +186,39 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		5D4384B6DD186AC159B9ACB3 /* [CP-User] Run Flutter Build hello Script */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/../hello/.metadata",
+				"${SRCROOT}/../hello/.ios/Flutter/App.framework/App",
+				"${SRCROOT}/../hello/.ios/Flutter/engine/Flutter.framework/Flutter",
+				"${SRCROOT}/../hello/.ios/Flutter/flutter_export_environment.sh",
+			);
+			name = "[CP-User] Run Flutter Build hello Script";
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -e\nset -u\nsource \"${SRCROOT}/../hello/.ios/Flutter/flutter_export_environment.sh\"\n\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/xcode_backend.sh build";
+		};
+		96286B727046BA8457A788D0 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Host/Pods-Host-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Host/Pods-Host-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Host/Pods-Host-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		D7D46336FAE5656C7ADAAD08 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -201,22 +235,6 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Host/Pods-Host-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
-		};
-		EEED2F2AE8060ACBF2210C77 /* [CP-User] Run Flutter Build Script */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${SRCROOT}/Users/magder/Projects/hello/.metadata",
-				"${SRCROOT}/../../../../hello/.ios/Flutter/App.framework/App",
-				"${SRCROOT}/../../../../hello/.ios/Flutter/engine/Flutter.framework/Flutter",
-				"${SRCROOT}/../../../../hello/.ios/Flutter/flutter_export_environment.sh",
-			);
-			name = "[CP-User] Run Flutter Build Script";
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -e\nset -u\nsource \"${SRCROOT}/../../../../hello/.ios/Flutter/flutter_export_environment.sh\"\n\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/xcode_backend.sh build";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
+++ b/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
@@ -99,7 +99,7 @@ def install_flutter_application_pod(flutter_application_path)
   pod '{{projectName}}', :path => relative.to_s, :inhibit_warnings => true
 
   flutter_export_environment_path = File.join('${SRCROOT}', relative, 'flutter_export_environment.sh');
-  script_phase :name => 'Run Flutter Build Script',
+  script_phase :name => 'Run Flutter Build {{projectName}} Script',
     :script => "set -e\nset -u\nsource \"#{flutter_export_environment_path}\"\n\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/xcode_backend.sh build",
     :input_files => [
       File.join('${SRCROOT}', flutter_application_path, '.metadata'),


### PR DESCRIPTION
## Description

Make the script phase name unique per module so multiple modules can be embedded into a host app.  Ran the integration tests, and you can see the updated script names there.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/60223

## Tests

Integration tests already test that these scripts are embedded and run.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*