### PR TITLE
[flutter_tools] fix tests that depend on correct cache existance

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/devices_test.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_tools/src/android/android_sdk.dart';
+import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/devices.dart';
 import 'package:flutter_tools/src/device.dart';
@@ -23,9 +24,19 @@ void main() {
       Cache.disableLocking();
     });
 
+    MockCache cache;
+
+    setUp(() {
+      cache = MockCache();
+      when(cache.dyLdLibEntry).thenReturn(const MapEntry<String, String>('foo', 'bar'));
+    });
+
     testUsingContext('returns 0 when called', () async {
       final DevicesCommand command = DevicesCommand();
       await createTestCommandRunner(command).run(<String>['devices']);
+    }, overrides: <Type, Generator>{
+      Cache: () => cache,
+      Artifacts: () => Artifacts.test(),
     });
 
     testUsingContext('no error when no connected devices', () async {
@@ -36,6 +47,8 @@ void main() {
       AndroidSdk: () => null,
       DeviceManager: () => NoDevicesManager(),
       ProcessManager: () => MockProcessManager(),
+      Cache: () => cache,
+      Artifacts: () => Artifacts.test(),
     });
 
     testUsingContext('get devices\' platform types', () async {
@@ -46,6 +59,8 @@ void main() {
     }, overrides: <Type, Generator>{
       DeviceManager: () => _FakeDeviceManager(),
       ProcessManager: () => MockProcessManager(),
+      Cache: () => cache,
+      Artifacts: () => Artifacts.test(),
     });
 
     testUsingContext('Outputs parsable JSON with --machine flag', () async {
@@ -93,6 +108,8 @@ void main() {
     }, overrides: <Type, Generator>{
       DeviceManager: () => _FakeDeviceManager(),
       ProcessManager: () => MockProcessManager(),
+      Cache: () => cache,
+      Artifacts: () => Artifacts.test(),
     });
 
     testUsingContext('available devices and diagnostics', () async {
@@ -169,3 +186,5 @@ class NoDevicesManager extends DeviceManager {
   Future<List<Device>> refreshAllConnectedDevices({Duration timeout}) =>
     getAllConnectedDevices();
 }
+
+class MockCache extends Mock implements Cache {}

--- a/packages/flutter_tools/test/general.shard/device_test.dart
+++ b/packages/flutter_tools/test/general.shard/device_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/project.dart';
@@ -18,6 +19,13 @@ import '../src/fake_devices.dart';
 import '../src/mocks.dart';
 
 void main() {
+  MockCache cache;
+
+  setUp(() {
+    cache = MockCache();
+    when(cache.dyLdLibEntry).thenReturn(const MapEntry<String, String>('foo', 'bar'));
+  });
+
   group('DeviceManager', () {
     testUsingContext('getDevices', () async {
       final FakeDevice device1 = FakeDevice('Nexus 5', '0553790d0a4e726f');
@@ -28,6 +36,7 @@ void main() {
       expect(await deviceManager.getDevices(), devices);
     }, overrides: <Type, Generator>{
       Artifacts: () => Artifacts.test(),
+      Cache: () => cache,
     });
 
     testUsingContext('getDeviceById', () async {
@@ -48,6 +57,7 @@ void main() {
       await expectDevice('Nexus', <Device>[device1, device2]);
     }, overrides: <Type, Generator>{
       Artifacts: () => Artifacts.test(),
+      Cache: () => cache,
     });
 
     testUsingContext('getAllConnectedDevices caches', () async {
@@ -60,6 +70,7 @@ void main() {
       expect(await deviceManager.getAllConnectedDevices(), <Device>[device1]);
     }, overrides: <Type, Generator>{
       Artifacts: () => Artifacts.test(),
+      Cache: () => cache,
     });
 
     testUsingContext('refreshAllConnectedDevices does not cache', () async {
@@ -72,6 +83,7 @@ void main() {
       expect(await deviceManager.refreshAllConnectedDevices(), <Device>[device2]);
     }, overrides: <Type, Generator>{
       Artifacts: () => Artifacts.test(),
+      Cache: () => cache,
     });
   });
 
@@ -94,6 +106,7 @@ void main() {
       });
     }, overrides: <Type, Generator>{
       Artifacts: () => Artifacts.test(),
+      Cache: () => cache,
     });
   });
 
@@ -130,6 +143,7 @@ void main() {
       expect(filtered.single, ephemeral);
     }, overrides: <Type, Generator>{
       Artifacts: () => Artifacts.test(),
+      Cache: () => cache,
     });
 
     testUsingContext('does not remove all non-ephemeral', () async {
@@ -147,6 +161,7 @@ void main() {
       ]);
     }, overrides: <Type, Generator>{
       Artifacts: () => Artifacts.test(),
+      Cache: () => cache,
     });
 
     testUsingContext('Removes a single unsupported device', () async {
@@ -160,6 +175,7 @@ void main() {
       expect(filtered, <Device>[]);
     }, overrides: <Type, Generator>{
       Artifacts: () => Artifacts.test(),
+      Cache: () => cache,
     });
 
     testUsingContext('Removes web and fuchsia from --all', () async {
@@ -175,6 +191,7 @@ void main() {
       expect(filtered, <Device>[]);
     }, overrides: <Type, Generator>{
       Artifacts: () => Artifacts.test(),
+      Cache: () => cache,
     });
 
     testUsingContext('Removes unsupported devices from --all', () async {
@@ -194,6 +211,7 @@ void main() {
       ]);
     }, overrides: <Type, Generator>{
       Artifacts: () => Artifacts.test(),
+      Cache: () => cache,
     });
 
     testUsingContext('uses DeviceManager.isDeviceSupportedForProject instead of device.isSupportedForProject', () async {
@@ -210,6 +228,7 @@ void main() {
       ]);
     }, overrides: <Type, Generator>{
       Artifacts: () => Artifacts.test(),
+      Cache: () => cache,
     });
   });
   group('ForwardedPort', () {
@@ -267,3 +286,4 @@ class TestDeviceManager extends DeviceManager {
 }
 
 class MockProcess extends Mock implements Process {}
+class MockCache extends Mock implements Cache {}

--- a/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:flutter_tools/src/vmservice.dart';
@@ -27,6 +28,7 @@ void main() {
             trackWidgetCreation: false,
             treeShakeIcons: false,
           ),
+          generator: MockResidentCompiler(),
         ),
       ],
     );
@@ -413,12 +415,12 @@ class MockDevice extends Mock implements Device {
 }
 
 class MockResidentRunner extends Mock implements ResidentRunner {}
-
 class MockFlutterDevice extends Mock implements FlutterDevice {}
+class MockResidentCompiler extends Mock implements ResidentCompiler {}
 
 class TestRunner extends ResidentRunner {
   TestRunner(List<FlutterDevice> devices)
-    : super(devices);
+    : super(devices, debuggingOptions: DebuggingOptions.disabled(BuildInfo.debug));
 
   bool hasHelpBeenPrinted = false;
   String receivedCommand;


### PR DESCRIPTION
## Description

These tests will hit the real Cache, failing if the flutter root has been modified
