### PR TITLE
skip verify-codesigned-binaries test until cirrus logic is fixed

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -657,6 +657,7 @@ task:
         - ./dev/bots/deploy_gallery.sh
 
     - name: verify_binaries_codesigned-macos # macos-only
+      skip: true # TODO(fujino): restore once https://github.com/flutter/flutter/issues/60296 resolved
       # TODO(fujino): remove this `only_if` after https://github.com/flutter/flutter/issues/44372
       # Only run pre/post submit for release branches
       only_if: "$CIRRUS_BASE_BRANCH == 'dev' || $CIRRUS_BRANCH == 'dev' || $CIRRUS_BASE_BRANCH == 'beta' || $CIRRUS_BRANCH == 'beta' || $CIRRUS_BASE_BRANCH == 'stable' || $CIRRUS_BRANCH == 'stable'"


### PR DESCRIPTION
To open tree until https://github.com/flutter/flutter/issues/60296 is fixed.