### PR TITLE
Add hot reload test

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -946,18 +946,22 @@ Future<void> _runWebHotReloadTest(String target, {
           final String newContents = oldContents
             .split('\n')
             .map((String line) {
-              if (line.endsWith('// HOT RELOAD MARKER')) {
+              if (line.endsWith('HOT RELOAD MARKER')) {
                 return "final String message = 'GOODBYE'; // HOT RELOAD MARKER";
               }
               return line;
             }).join('\n');
             file.writeAsStringSync(newContents, flush: true);
-            await Future<void>.delayed(const Duration(milliseconds: 50));
+            await Future<void>.delayed(const Duration(milliseconds: 250));
             started = true;
             process.stdin.add('R'.codeUnits);
         }
-        if (started || line.contains('GOODBYE')) {
+        if (started && line.contains('GOODBYE')) {
           success = true;
+          process.stdin.add('q'.codeUnits);
+        }
+        if (start && line.contains('HELLO')) {
+          success = false;
           process.stdin.add('q'.codeUnits);
         }
       },

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -766,7 +766,7 @@ Future<void> _runWebIntegrationTests() async {
       '--dart-define=test.valueB=Value',
     ]
   );
-  await _runWebHotReloadTest('lib/hot_reload_test.dart');
+  await _runWebHotReloadTest('lib/hot_restart_test.dart');
 }
 
 Future<void> _runWebStackTraceTest(String buildMode) async {

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -960,7 +960,7 @@ Future<void> _runWebHotReloadTest(String target, {
           success = true;
           process.stdin.add('q'.codeUnits);
         }
-        if (start && line.contains('HELLO')) {
+        if (started && line.contains('HELLO')) {
           success = false;
           process.stdin.add('q'.codeUnits);
         }

--- a/dev/integration_tests/web/lib/hot_restart_test.dart
+++ b/dev/integration_tests/web/lib/hot_restart_test.dart
@@ -1,0 +1,12 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+final String message = 'HELLO'; // HOT RELOAD MARKER
+
+void main() {
+  print(message);
+  runApp(Center(child: Text(message, textDirection: TextDirection.ltr)));
+}


### PR DESCRIPTION
## Description

Creates a basic web hot reload/restart test that validates it can complete without error. Instead of the devicelab, uses the existing web integration presubmit shard. This would allow engine roll PRs that contain regressions in hot reload/restart to be caught before landing, and also reduces the risk that a bug in the test leaves hundreds of chrome instances open.

This **will not** catch regressions like https://github.com/flutter/flutter/issues/60286 , because those require interaction with the application for the error state to become obvious.

