### PR TITLE
Do not call Picture.toImage on web during shader warm-up

### DIFF
--- a/packages/flutter/lib/src/painting/shader_warm_up.dart
+++ b/packages/flutter/lib/src/painting/shader_warm_up.dart
@@ -91,7 +91,10 @@ abstract class ShaderWarmUp {
     final ui.Picture picture = recorder.endRecording();
     final TimelineTask shaderWarmUpTask = TimelineTask();
     shaderWarmUpTask.start('Warm-up shader');
-    await picture.toImage(size.width.ceil(), size.height.ceil());
+    // Picture.toImage is not yet implemented on the web.
+    if (!kIsWeb) {
+      await picture.toImage(size.width.ceil(), size.height.ceil());
+    }
     shaderWarmUpTask.finish();
   }
 }


### PR DESCRIPTION
## Description

Do not call `toImage` when running on the Web. It's not implemented. `toImage` is changing to return a non-null value, so when not implemented it will throw instead of returning null.

## Related Issues

https://github.com/flutter/flutter/issues/58811

## Tests

This is already covered by web benchmarks. They currently don't fail because we are still returning null, but they will start failing when https://github.com/flutter/engine/pull/19172 rolls in.
