### PR TITLE
Use ephemeral ports for iOS port forwarding

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -14,6 +14,7 @@ import '../artifacts.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
+import '../base/os.dart';
 import '../base/platform.dart';
 import '../base/process.dart';
 import '../base/utils.dart';
@@ -493,6 +494,7 @@ class IOSDevice extends Device {
     dyLdLibEntry: globals.cache.dyLdLibEntry,
     id: id,
     iproxyPath: _iproxyPath,
+    operatingSystemUtils: globals.os,
   );
 
   @visibleForTesting
@@ -763,11 +765,13 @@ class IOSDevicePortForwarder extends DevicePortForwarder {
     @required MapEntry<String, String> dyLdLibEntry,
     @required String id,
     @required String iproxyPath,
+    @required OperatingSystemUtils operatingSystemUtils,
   }) : _logger = logger,
        _dyLdLibEntry = dyLdLibEntry,
        _id = id,
        _iproxyPath = iproxyPath,
-       _processUtils = ProcessUtils(processManager: processManager, logger: logger);
+       _processUtils = ProcessUtils(processManager: processManager, logger: logger),
+       _operatingSystemUtils = operatingSystemUtils;
 
   /// Create a [IOSDevicePortForwarder] for testing.
   ///
@@ -779,6 +783,7 @@ class IOSDevicePortForwarder extends DevicePortForwarder {
     @required ProcessManager processManager,
     @required Logger logger,
     String id,
+    OperatingSystemUtils operatingSystemUtils,
   }) {
     return IOSDevicePortForwarder(
       processManager: processManager,
@@ -788,6 +793,7 @@ class IOSDevicePortForwarder extends DevicePortForwarder {
       dyLdLibEntry: const MapEntry<String, String>(
         'DYLD_LIBRARY_PATH', '/path/to/libs',
       ),
+      operatingSystemUtils: operatingSystemUtils,
     );
   }
 
@@ -796,6 +802,7 @@ class IOSDevicePortForwarder extends DevicePortForwarder {
   final MapEntry<String, String> _dyLdLibEntry;
   final String _id;
   final String _iproxyPath;
+  final OperatingSystemUtils _operatingSystemUtils;
 
   @override
   List<ForwardedPort> forwardedPorts = <ForwardedPort>[];
@@ -811,7 +818,9 @@ class IOSDevicePortForwarder extends DevicePortForwarder {
   Future<int> forward(int devicePort, { int hostPort }) async {
     final bool autoselect = hostPort == null || hostPort == 0;
     if (autoselect) {
-      hostPort = 1024;
+      final int freePort = await _operatingSystemUtils?.findFreePort();
+      // Dynamic port range 49152 - 65535.
+      hostPort = freePort == null || freePort == 0 ? 49152 : freePort;
     }
 
     Process process;

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
@@ -226,6 +227,12 @@ void main() {
           iproxyPath: mockArtifacts.getArtifactPath(Artifact.iproxy, platform: TargetPlatform.ios),
           logger: logger,
           processManager: FakeProcessManager.any(),
+          operatingSystemUtils: OperatingSystemUtils(
+            fileSystem: mockFileSystem,
+            logger: logger,
+            platform: FakePlatform(operatingSystem: 'macos'),
+            processManager: FakeProcessManager.any(),
+          ),
         );
         portForwarder.addForwardedPorts(<ForwardedPort>[forwardedPort]);
         return portForwarder;


### PR DESCRIPTION
## Description

Get an available socket, only try again in the ephemeral port range.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/59333

## Tests

Updated ios_device_port_forwarder_test.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*