### PR TITLE
re-enable codesign test

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -657,7 +657,6 @@ task:
         - ./dev/bots/deploy_gallery.sh
 
     - name: verify_binaries_codesigned-macos # macos-only
-      skip: true # TODO(fujino): restore once https://github.com/flutter/flutter/issues/60296 resolved
       # TODO(fujino): remove this `only_if` after https://github.com/flutter/flutter/issues/44372
       # Only run pre/post submit for release branches
       only_if: "$CIRRUS_BASE_BRANCH == 'dev' || $CIRRUS_BRANCH == 'dev' || $CIRRUS_BASE_BRANCH == 'beta' || $CIRRUS_BRANCH == 'beta' || $CIRRUS_BASE_BRANCH == 'stable' || $CIRRUS_BRANCH == 'stable'"


### PR DESCRIPTION
## Description

Re-enable codesign test because https://github.com/flutter/flutter/issues/60296 looks like it was caused by a one-off malformed webhook from GitHub. The test was originally disabled in https://github.com/flutter/flutter/pull/60302.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/60296

## Tests

This re-enables a skipped test