### PR TITLE
Show hint when label is floating

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2086,12 +2086,14 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
   }
 
   // True if the label will be shown and the hint will not.
-  // If we're not focused, there's no value, labelText was provided, and 
+  // If we're not focused, there's no value, labelText was provided, and
   // floatingLabelBehavior isn't set to always, then the label appears where the
   // hint would.
-  bool get _hasInlineLabel => !widget._labelShouldWithdraw
-      && decoration.labelText != null
-      && decoration.floatingLabelBehavior != FloatingLabelBehavior.always;
+  bool get _hasInlineLabel {
+    return !widget._labelShouldWithdraw
+        && decoration.labelText != null
+        && decoration.floatingLabelBehavior != FloatingLabelBehavior.always;
+  }
 
   // If the label is a floating placeholder, it's always shown.
   bool get _shouldShowLabel => _hasInlineLabel || _floatingLabelEnabled;

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2086,9 +2086,12 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
   }
 
   // True if the label will be shown and the hint will not.
-  // If we're not focused, there's no value, and labelText was provided,
-  // then the label appears where the hint would.
-  bool get _hasInlineLabel => !widget._labelShouldWithdraw && decoration.labelText != null;
+  // If we're not focused, there's no value, labelText was provided, and 
+  // floatingLabelBehavior isn't set to always, then the label appears where the
+  // hint would.
+  bool get _hasInlineLabel => !widget._labelShouldWithdraw
+      && decoration.labelText != null
+      && decoration.floatingLabelBehavior != FloatingLabelBehavior.always;
 
   // If the label is a floating placeholder, it's always shown.
   bool get _shouldShowLabel => _hasInlineLabel || _floatingLabelEnabled;

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -4068,6 +4068,23 @@ void main() {
     expect(tester.getTopLeft(find.text('label')).dy, 20.0);
   });
 
+  testWidgets('InputDecorator hint is displayed when floatingLabelBehavior is always', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      buildInputDecorator(
+        // isEmpty: false (default)
+        // isFocused: false (default)
+        decoration: const InputDecoration(
+          floatingLabelBehavior: FloatingLabelBehavior.always,
+          hintText: 'hint',
+          labelText: 'label',
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(getOpacity(tester, 'hint'), 1.0);
+  });
+
   testWidgets('InputDecorator floating label width scales when focused', (WidgetTester tester) async {
     final String longStringA = String.fromCharCodes(List<int>.generate(200, (_) => 65));
     final String longStringB = String.fromCharCodes(List<int>.generate(200, (_) => 66));

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -4071,8 +4071,8 @@ void main() {
   testWidgets('InputDecorator hint is displayed when floatingLabelBehavior is always', (WidgetTester tester) async {
     await tester.pumpWidget(
       buildInputDecorator(
-        // isEmpty: false (default)
         // isFocused: false (default)
+        isEmpty: true,
         decoration: const InputDecoration(
           floatingLabelBehavior: FloatingLabelBehavior.always,
           hintText: 'hint',


### PR DESCRIPTION
## Description

Previously, hint wasn't showing when floatingLabelBehavior was `always`, even though it had room. It only showed when focused:

![Screen Shot 2020-06-26 at 3 40 00 PM](https://user-images.githubusercontent.com/389558/85906514-6d640a80-b7c3-11ea-8b6b-730702cb7f5e.png)
![Screen Shot 2020-06-26 at 3 40 05 PM](https://user-images.githubusercontent.com/389558/85906516-6d640a80-b7c3-11ea-91fb-b080636fae72.png)

This PR makes it show even when not focused.

## Related Issues

Closes https://github.com/flutter/flutter/issues/60292
Closes https://github.com/flutter/flutter/issues/53753

## Tests

I added the following tests:

Render an InputDecorator with `floatingLabelBehavior: FloatingLabelBehavior.always` and expect the hint to be visible even when it is not focused.