### PR TITLE
Fixed a problem with date calculations that caused a test to fail in a non-US time zone.

### DIFF
--- a/packages/flutter/lib/src/material/pickers/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/pickers/calendar_date_picker.dart
@@ -668,14 +668,14 @@ class _MonthPickerState extends State<_MonthPicker> {
     });
   }
 
-  static const Map<TraversalDirection, Duration> _directionOffset = <TraversalDirection, Duration>{
-    TraversalDirection.up: Duration(days: -DateTime.daysPerWeek),
-    TraversalDirection.right: Duration(days: 1),
-    TraversalDirection.down: Duration(days: DateTime.daysPerWeek),
-    TraversalDirection.left: Duration(days: -1),
+  static const Map<TraversalDirection, int> _directionOffset = <TraversalDirection, int>{
+    TraversalDirection.up: -DateTime.daysPerWeek,
+    TraversalDirection.right: 1,
+    TraversalDirection.down: DateTime.daysPerWeek,
+    TraversalDirection.left: -1,
   };
 
-  Duration _dayDirectionOffset(TraversalDirection traversalDirection, TextDirection textDirection) {
+  int _dayDirectionOffset(TraversalDirection traversalDirection, TextDirection textDirection) {
     // Swap left and right if the text direction if RTL
     if (textDirection == TextDirection.rtl) {
       if (traversalDirection == TraversalDirection.left)
@@ -688,12 +688,12 @@ class _MonthPickerState extends State<_MonthPicker> {
 
   DateTime _nextDateInDirection(DateTime date, TraversalDirection direction) {
     final TextDirection textDirection = Directionality.of(context);
-    DateTime nextDate = date.toUtc().add(_dayDirectionOffset(direction, textDirection));
+    DateTime nextDate = utils.addDaysToDate(date, _dayDirectionOffset(direction, textDirection));
     while (!nextDate.isBefore(widget.firstDate) && !nextDate.isAfter(widget.lastDate)) {
       if (_isSelectable(nextDate)) {
         return nextDate;
       }
-      nextDate = nextDate.add(_dayDirectionOffset(direction, textDirection));
+      nextDate = utils.addDaysToDate(nextDate, _dayDirectionOffset(direction, textDirection));
     }
     return null;
   }

--- a/packages/flutter/lib/src/material/pickers/date_utils.dart
+++ b/packages/flutter/lib/src/material/pickers/date_utils.dart
@@ -72,8 +72,7 @@ DateTime addMonthsToMonthDate(DateTime monthDate, int monthsToAdd) {
   return DateTime(monthDate.year, monthDate.month + monthsToAdd);
 }
 
-/// Returns a [DateTime] with the added number of days and truncates any day
-/// and time information.
+/// Returns a [DateTime] with the added number of days and no time set.
 DateTime addDaysToDate(DateTime date, int days) {
   return DateTime(date.year, date.month, date.day + days);
 }

--- a/packages/flutter/lib/src/material/pickers/date_utils.dart
+++ b/packages/flutter/lib/src/material/pickers/date_utils.dart
@@ -72,6 +72,12 @@ DateTime addMonthsToMonthDate(DateTime monthDate, int monthsToAdd) {
   return DateTime(monthDate.year, monthDate.month + monthsToAdd);
 }
 
+/// Returns a [DateTime] with the added number of days and truncates any day
+/// and time information.
+DateTime addDaysToDate(DateTime date, int days) {
+  return DateTime(date.year, date.month, date.day + days);
+}
+
 /// Computes the offset from the first day of the week that the first day of
 /// the [month] falls on.
 ///


### PR DESCRIPTION
## Description

In order to navigate the date picker's grid with the keyboard we were computing the next/previous day by using `DateTime.add(Duration(days: -1))`. Unfortunately this uses daylight-saving changes in this computation, sometimes causing the computed day to be off by a day (instead of the time being 12:00 it is now 11:00 the previous day).

The PR addresses this by just calculating the days without using the `DateTime.add` function.

## Related Issues

Fixes: #60370

## Tests

This fixes the existing tests when running in non-US timezones.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them?

- [x] No, no existing tests failed, so this is *not* a breaking change.
