### PR TITLE
Turn on iOS wireless debugging, connect to remote observatory

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -134,7 +134,7 @@ class IOSDevices extends PollingDeviceDiscovery {
   }
 }
 
-enum IOSDeviceInterface {
+enum IOSDeviceConnectionInterface {
   none,
   usb,
   network,
@@ -197,7 +197,7 @@ class IOSDevice extends Device {
 
   final DarwinArch cpuArchitecture;
 
-  final IOSDeviceInterface interfaceType;
+  final IOSDeviceConnectionInterface interfaceType;
 
   Map<IOSApp, DeviceLogReader> _logReaders;
 
@@ -355,7 +355,8 @@ class IOSDevice extends Device {
       '--enable-service-port-fallback',
       '--disable-service-auth-codes',
       '--observatory-port=$assumedObservatoryPort',
-      if (interfaceType == IOSDeviceInterface.network)
+      if (interfaceType == IOSDeviceConnectionInterface.network)
+        // Tell the observatory to listen on all interfaces, don't restrict to the loopback.
         '--observatory-host=${ipv6 ? '::/0' : '0.0.0.0'}',
       if (debuggingOptions.startPaused) '--start-paused',
       if (dartVmFlags.isNotEmpty) '--dart-flags="$dartVmFlags"',
@@ -756,7 +757,7 @@ class IOSDevicePortForwarder extends DevicePortForwarder {
     @required String id,
     @required IProxy iproxy,
     @required OperatingSystemUtils operatingSystemUtils,
-    @required IOSDeviceInterface interfaceType,
+    @required IOSDeviceConnectionInterface interfaceType,
   }) : _logger = logger,
        _id = id,
        _iproxy = iproxy,
@@ -783,7 +784,7 @@ class IOSDevicePortForwarder extends DevicePortForwarder {
       ),
       id: id ?? '1234',
       operatingSystemUtils: operatingSystemUtils,
-      interfaceType: IOSDeviceInterface.usb,
+      interfaceType: IOSDeviceConnectionInterface.usb,
     );
   }
 
@@ -791,7 +792,7 @@ class IOSDevicePortForwarder extends DevicePortForwarder {
   final String _id;
   final IProxy _iproxy;
   final OperatingSystemUtils _operatingSystemUtils;
-  final IOSDeviceInterface _interfaceType;
+  final IOSDeviceConnectionInterface _interfaceType;
 
   @override
   List<ForwardedPort> forwardedPorts = <ForwardedPort>[];

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -190,15 +190,6 @@ class IOSDevice extends Device {
   }
 
   @override
-  bool get supportsHotReload => interfaceType == IOSDeviceInterface.usb;
-
-  @override
-  bool get supportsHotRestart => interfaceType == IOSDeviceInterface.usb;
-
-  @override
-  bool get supportsFlutterExit => interfaceType == IOSDeviceInterface.usb;
-
-  @override
   final String name;
 
   @override
@@ -493,6 +484,7 @@ class IOSDevice extends Device {
     iproxy: _iproxy,
     id: id,
     operatingSystemUtils: globals.os,
+    interfaceType: interfaceType,
   );
 
   @visibleForTesting
@@ -762,10 +754,12 @@ class IOSDevicePortForwarder extends DevicePortForwarder {
     @required String id,
     @required IProxy iproxy,
     @required OperatingSystemUtils operatingSystemUtils,
+    @required IOSDeviceInterface interfaceType,
   }) : _logger = logger,
        _id = id,
        _iproxy = iproxy,
-       _operatingSystemUtils = operatingSystemUtils;
+       _operatingSystemUtils = operatingSystemUtils,
+       _interfaceType = interfaceType;
 
   /// Create a [IOSDevicePortForwarder] for testing.
   ///
@@ -787,6 +781,7 @@ class IOSDevicePortForwarder extends DevicePortForwarder {
       ),
       id: id ?? '1234',
       operatingSystemUtils: operatingSystemUtils,
+      interfaceType: IOSDeviceInterface.usb,
     );
   }
 
@@ -794,6 +789,7 @@ class IOSDevicePortForwarder extends DevicePortForwarder {
   final String _id;
   final IProxy _iproxy;
   final OperatingSystemUtils _operatingSystemUtils;
+  final IOSDeviceInterface _interfaceType;
 
   @override
   List<ForwardedPort> forwardedPorts = <ForwardedPort>[];
@@ -819,7 +815,7 @@ class IOSDevicePortForwarder extends DevicePortForwarder {
     bool connected = false;
     while (!connected) {
       _logger.printTrace('Attempting to forward device port $devicePort to host port $hostPort');
-      process = await _iproxy.forward(devicePort, hostPort, _id);
+      process = await _iproxy.forward(devicePort, hostPort, _id, _interfaceType);
       // TODO(ianh): This is a flakey race condition, https://github.com/libimobiledevice/libimobiledevice/issues/674
       connected = !await process.stdout.isEmpty.timeout(_kiProxyPortForwardTimeout, onTimeout: () => false);
       if (!connected) {

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -355,6 +355,8 @@ class IOSDevice extends Device {
       '--enable-service-port-fallback',
       '--disable-service-auth-codes',
       '--observatory-port=$assumedObservatoryPort',
+      if (interfaceType == IOSDeviceInterface.network)
+        '--observatory-host=${ipv6 ? '::/0' : '0.0.0.0'}',
       if (debuggingOptions.startPaused) '--start-paused',
       if (dartVmFlags.isNotEmpty) '--dart-flags="$dartVmFlags"',
       if (debuggingOptions.useTestFonts) '--use-test-fonts',

--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -85,7 +85,7 @@ class IOSDeploy {
     @required String deviceId,
     @required String bundlePath,
     @required List<String>launchArguments,
-    @required IOSDeviceInterface interfaceType,
+    @required IOSDeviceConnectionInterface interfaceType,
   }) async {
     final List<String> launchCommand = <String>[
       _binaryPath,
@@ -93,7 +93,7 @@ class IOSDeploy {
       deviceId,
       '--bundle',
       bundlePath,
-      if (interfaceType != IOSDeviceInterface.network)
+      if (interfaceType != IOSDeviceConnectionInterface.network)
         '--no-wifi',
       if (launchArguments.isNotEmpty) ...<String>[
         '--args',
@@ -116,7 +116,7 @@ class IOSDeploy {
     @required String deviceId,
     @required String bundlePath,
     @required List<String> launchArguments,
-    @required IOSDeviceInterface interfaceType,
+    @required IOSDeviceConnectionInterface interfaceType,
   }) async {
     final List<String> launchCommand = <String>[
       _binaryPath,
@@ -124,7 +124,7 @@ class IOSDeploy {
       deviceId,
       '--bundle',
       bundlePath,
-      if (interfaceType != IOSDeviceInterface.network)
+      if (interfaceType != IOSDeviceConnectionInterface.network)
         '--no-wifi',
       '--justlaunch',
       if (launchArguments.isNotEmpty) ...<String>[

--- a/packages/flutter_tools/lib/src/ios/iproxy.dart
+++ b/packages/flutter_tools/lib/src/ios/iproxy.dart
@@ -10,6 +10,7 @@ import 'package:process/process.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
+import 'devices.dart';
 
 /// Wraps iproxy command line tool port forwarding.
 ///
@@ -21,8 +22,9 @@ class IProxy {
     @required ProcessManager processManager,
     @required MapEntry<String, String> dyLdLibEntry,
   }) : _dyLdLibEntry = dyLdLibEntry,
-        _processUtils = ProcessUtils(processManager: processManager, logger: logger),
-        _iproxyPath = iproxyPath;
+       _processUtils = ProcessUtils(processManager: processManager, logger: logger),
+       _logger = logger,
+       _iproxyPath = iproxyPath;
 
   /// Create a [IProxy] for testing.
   ///
@@ -44,9 +46,10 @@ class IProxy {
 
   final String _iproxyPath;
   final ProcessUtils _processUtils;
+  final Logger _logger;
   final MapEntry<String, String> _dyLdLibEntry;
 
-  Future<Process> forward(int devicePort, int hostPort, String deviceId) {
+  Future<Process> forward(int devicePort, int hostPort, String deviceId, IOSDeviceInterface interfaceType) {
     // Usage: iproxy LOCAL_PORT:DEVICE_PORT --udid UDID
     return _processUtils.start(
       <String>[
@@ -54,6 +57,10 @@ class IProxy {
         '$hostPort:$devicePort',
         '--udid',
         deviceId,
+        if (interfaceType == IOSDeviceInterface.network)
+          '--network',
+        if (_logger.isVerbose)
+          '--debug',
       ],
       environment: Map<String, String>.fromEntries(
         <MapEntry<String, String>>[_dyLdLibEntry],

--- a/packages/flutter_tools/lib/src/ios/iproxy.dart
+++ b/packages/flutter_tools/lib/src/ios/iproxy.dart
@@ -49,7 +49,7 @@ class IProxy {
   final Logger _logger;
   final MapEntry<String, String> _dyLdLibEntry;
 
-  Future<Process> forward(int devicePort, int hostPort, String deviceId, IOSDeviceInterface interfaceType) {
+  Future<Process> forward(int devicePort, int hostPort, String deviceId, IOSDeviceConnectionInterface interfaceType) {
     // Usage: iproxy LOCAL_PORT:DEVICE_PORT --udid UDID
     return _processUtils.start(
       <String>[
@@ -57,7 +57,7 @@ class IProxy {
         '$hostPort:$devicePort',
         '--udid',
         deviceId,
-        if (interfaceType == IOSDeviceInterface.network)
+        if (interfaceType == IOSDeviceConnectionInterface.network)
           '--network',
         if (_logger.isVerbose)
           '--debug',

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -70,7 +70,7 @@ class IMobileDevice {
   Future<void> takeScreenshot(
     File outputFile,
     String deviceID,
-    IOSDeviceInterface interfaceType,
+    IOSDeviceConnectionInterface interfaceType,
   ) {
     return _processUtils.run(
       <String>[
@@ -78,7 +78,7 @@ class IMobileDevice {
         outputFile.path,
         '--udid',
         deviceID,
-        if (interfaceType == IOSDeviceInterface.network)
+        if (interfaceType == IOSDeviceConnectionInterface.network)
           '--network',
       ],
       throwOnError: true,

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -534,18 +534,18 @@ class XCDevice {
     return null;
   }
 
-  static IOSDeviceInterface _interfaceType(Map<String, dynamic> deviceProperties) {
+  static IOSDeviceConnectionInterface _interfaceType(Map<String, dynamic> deviceProperties) {
     // Interface can be "usb", "network", or "none" for simulators
     // and unknown future interfaces.
     if (deviceProperties.containsKey('interface')) {
       if ((deviceProperties['interface'] as String).toLowerCase() == 'network') {
-        return IOSDeviceInterface.network;
+        return IOSDeviceConnectionInterface.network;
       } else {
-        return IOSDeviceInterface.usb;
+        return IOSDeviceConnectionInterface.usb;
       }
     }
 
-    return IOSDeviceInterface.none;
+    return IOSDeviceConnectionInterface.none;
   }
 
   static String _sdkVersion(Map<String, dynamic> deviceProperties) {

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -419,7 +419,7 @@ class XCDevice {
 
   /// [timeout] defaults to 2 seconds.
   Future<List<IOSDevice>> getAvailableIOSDevices({ Duration timeout }) async {
-    final List<dynamic> allAvailableDevices = await _getAllDevices(timeout: timeout ?? const Duration(seconds: 2));
+    final List<dynamic> allAvailableDevices = await _getAllDevices(timeout: timeout ?? const Duration(seconds: 10));
 
     if (allAvailableDevices == null) {
       return const <IOSDevice>[];
@@ -492,19 +492,11 @@ class XCDevice {
         }
       }
 
-      final IOSDeviceInterface interface = _interfaceType(deviceProperties);
-
-      // Only support USB devices, skip "network" interface (Xcode > Window > Devices and Simulators > Connect via network).
-      // TODO(jmagman): Remove this check once wirelessly detected devices can be observed and attached, https://github.com/flutter/flutter/issues/15072.
-      if (interface != IOSDeviceInterface.usb) {
-        continue;
-      }
-
       devices.add(IOSDevice(
         device['identifier'] as String,
         name: device['name'] as String,
         cpuArchitecture: _cpuArchitecture(deviceProperties),
-        interfaceType: interface,
+        interfaceType: _interfaceType(deviceProperties),
         sdkVersion: _sdkVersion(deviceProperties),
         iProxy: _iProxy,
         fileSystem: globals.fs,

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -419,7 +419,7 @@ class XCDevice {
 
   /// [timeout] defaults to 2 seconds.
   Future<List<IOSDevice>> getAvailableIOSDevices({ Duration timeout }) async {
-    final List<dynamic> allAvailableDevices = await _getAllDevices(timeout: timeout ?? const Duration(seconds: 10));
+    final List<dynamic> allAvailableDevices = await _getAllDevices(timeout: timeout ?? const Duration(seconds: 2));
 
     if (allAvailableDevices == null) {
       return const <IOSDevice>[];

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -234,6 +234,7 @@ void main() {
             processManager: FakeProcessManager.any(),
           ),
           iproxy: iproxy,
+          interfaceType: IOSDeviceInterface.usb,
         );
         portForwarder.addForwardedPorts(<ForwardedPort>[forwardedPort]);
         return portForwarder;

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -78,7 +78,7 @@ void main() {
         name: 'iPhone 1',
         sdkVersion: '13.3',
         cpuArchitecture: DarwinArch.arm64,
-        interfaceType: IOSDeviceInterface.usb,
+        interfaceType: IOSDeviceConnectionInterface.usb,
         vmServiceConnectUri: (String string, {Log log}) async => mockVmService,
       );
     });
@@ -95,7 +95,7 @@ void main() {
         name: 'iPhone 1',
         cpuArchitecture: DarwinArch.arm64,
         sdkVersion: '1.0.0',
-        interfaceType: IOSDeviceInterface.usb,
+        interfaceType: IOSDeviceConnectionInterface.usb,
         vmServiceConnectUri: (String string, {Log log}) async => mockVmService,
       ).majorSdkVersion, 1);
       expect(IOSDevice(
@@ -109,7 +109,7 @@ void main() {
         name: 'iPhone 1',
         cpuArchitecture: DarwinArch.arm64,
         sdkVersion: '13.1.1',
-        interfaceType: IOSDeviceInterface.usb,
+        interfaceType: IOSDeviceConnectionInterface.usb,
         vmServiceConnectUri: (String string, {Log log}) async => mockVmService,
       ).majorSdkVersion, 13);
       expect(IOSDevice(
@@ -123,7 +123,7 @@ void main() {
         name: 'iPhone 1',
         cpuArchitecture: DarwinArch.arm64,
         sdkVersion: '10',
-        interfaceType: IOSDeviceInterface.usb,
+        interfaceType: IOSDeviceConnectionInterface.usb,
         vmServiceConnectUri: (String string, {Log log}) async => mockVmService,
       ).majorSdkVersion, 10);
       expect(IOSDevice(
@@ -137,7 +137,7 @@ void main() {
         name: 'iPhone 1',
         cpuArchitecture: DarwinArch.arm64,
         sdkVersion: '0',
-        interfaceType: IOSDeviceInterface.usb,
+        interfaceType: IOSDeviceConnectionInterface.usb,
         vmServiceConnectUri: (String string, {Log log}) async => mockVmService,
       ).majorSdkVersion, 0);
       expect(IOSDevice(
@@ -151,7 +151,7 @@ void main() {
         name: 'iPhone 1',
         cpuArchitecture: DarwinArch.arm64,
         sdkVersion: 'bogus',
-        interfaceType: IOSDeviceInterface.usb,
+        interfaceType: IOSDeviceConnectionInterface.usb,
         vmServiceConnectUri: (String string, {Log log}) async => mockVmService,
       ).majorSdkVersion, 0);
     });
@@ -168,7 +168,7 @@ void main() {
         name: 'iPhone 1',
         sdkVersion: '13.3',
         cpuArchitecture: DarwinArch.arm64,
-        interfaceType: IOSDeviceInterface.usb,
+        interfaceType: IOSDeviceConnectionInterface.usb,
         vmServiceConnectUri: (String string, {Log log}) async => mockVmService,
       );
 
@@ -193,7 +193,7 @@ void main() {
               name: 'iPhone 1',
               sdkVersion: '13.3',
               cpuArchitecture: DarwinArch.arm64,
-              interfaceType: IOSDeviceInterface.usb,
+              interfaceType: IOSDeviceConnectionInterface.usb,
               vmServiceConnectUri: (String string, {Log log}) async => mockVmService,
             );
           },
@@ -234,7 +234,7 @@ void main() {
             processManager: FakeProcessManager.any(),
           ),
           iproxy: iproxy,
-          interfaceType: IOSDeviceInterface.usb,
+          interfaceType: IOSDeviceConnectionInterface.usb,
         );
         portForwarder.addForwardedPorts(<ForwardedPort>[forwardedPort]);
         return portForwarder;
@@ -285,7 +285,7 @@ void main() {
           name: 'iPhone 1',
           sdkVersion: '13.3',
           cpuArchitecture: DarwinArch.arm64,
-          interfaceType: IOSDeviceInterface.usb,
+          interfaceType: IOSDeviceConnectionInterface.usb,
           vmServiceConnectUri: (String string, {Log log}) async => mockVmService,
         );
         logReader1 = createLogReader(device, appPackage1, mockProcess1);
@@ -352,7 +352,7 @@ void main() {
         logger: logger,
         platform: macPlatform,
         fileSystem: MemoryFileSystem.test(),
-        interfaceType: IOSDeviceInterface.usb,
+        interfaceType: IOSDeviceConnectionInterface.usb,
         vmServiceConnectUri: (String string, {Log log}) async => mockVmService1,
       );
 
@@ -367,7 +367,7 @@ void main() {
         logger: logger,
         platform: macPlatform,
         fileSystem: MemoryFileSystem.test(),
-        interfaceType: IOSDeviceInterface.usb,
+        interfaceType: IOSDeviceConnectionInterface.usb,
         vmServiceConnectUri: (String string, {Log log}) async => mockVmService2,
       );
     });

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
@@ -49,7 +49,7 @@ void main() {
     final IOSDevice device = setUpIOSDevice(
       processManager: processManager,
       fileSystem: fileSystem,
-      interfaceType: IOSDeviceInterface.usb,
+      interfaceType: IOSDeviceConnectionInterface.usb,
     );
     final bool wasInstalled = await device.installApp(iosApp);
 
@@ -78,7 +78,7 @@ void main() {
     final IOSDevice device = setUpIOSDevice(
       processManager: processManager,
       fileSystem: fileSystem,
-      interfaceType: IOSDeviceInterface.network,
+      interfaceType: IOSDeviceConnectionInterface.network,
     );
     final bool wasInstalled = await device.installApp(iosApp);
 
@@ -269,7 +269,7 @@ IOSDevice setUpIOSDevice({
   @required ProcessManager processManager,
   FileSystem fileSystem,
   Logger logger,
-  IOSDeviceInterface interfaceType,
+  IOSDeviceConnectionInterface interfaceType,
 }) {
   logger ??= BufferLogger.test();
   final FakePlatform platform = FakePlatform(

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_project_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_project_test.dart
@@ -91,7 +91,7 @@ IOSDevice setUpIOSDevice(FileSystem fileSystem) {
     sdkVersion: '13.3',
     cpuArchitecture: DarwinArch.arm64,
     iProxy: IProxy.test(logger: BufferLogger.test(), processManager: FakeProcessManager.any()),
-    interfaceType: IOSDeviceInterface.usb,
+    interfaceType: IOSDeviceConnectionInterface.usb,
     vmServiceConnectUri: (String string, {Log log}) async => MockVmService(),
   );
 }

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -153,7 +153,7 @@ void main() {
         fileSystem: fileSystem,
         processManager: processManager,
         logger: logger,
-        interface: IOSDeviceInterface.network,
+        interface: IOSDeviceConnectionInterface.network,
       );
       setUpIOSProject(fileSystem);
       final FlutterProject flutterProject = FlutterProject.fromDirectory(fileSystem.currentDirectory);
@@ -356,7 +356,7 @@ IOSDevice setUpIOSDevice({
   FileSystem fileSystem,
   Logger logger,
   ProcessManager processManager,
-  IOSDeviceInterface interface = IOSDeviceInterface.usb,
+  IOSDeviceConnectionInterface interface = IOSDeviceConnectionInterface.usb,
 }) {
   const MapEntry<String, String> dyldLibraryEntry = MapEntry<String, String>(
     'DYLD_LIBRARY_PATH',

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -442,7 +442,7 @@ IOSDevice setUpIOSDevice({
       cache: cache,
     ),
     cpuArchitecture: DarwinArch.arm64,
-    interfaceType: IOSDeviceInterface.usb,
+    interfaceType: IOSDeviceConnectionInterface.usb,
     vmServiceConnectUri: vmServiceConnector,
   );
 }

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -89,7 +89,7 @@ void main() {
         expect(() async => await iMobileDevice.takeScreenshot(
           mockOutputFile,
           '1234',
-          IOSDeviceInterface.usb,
+          IOSDeviceConnectionInterface.usb,
         ), throwsA(anything));
       });
 
@@ -108,7 +108,7 @@ void main() {
         await iMobileDevice.takeScreenshot(
           mockOutputFile,
           '1234',
-          IOSDeviceInterface.usb,
+          IOSDeviceConnectionInterface.usb,
         );
         verify(mockProcessManager.run(<String>[idevicescreenshotPath, outputPath, '--udid', '1234'],
             environment: <String, String>{'DYLD_LIBRARY_PATH': libimobiledevicePath},
@@ -131,7 +131,7 @@ void main() {
         await iMobileDevice.takeScreenshot(
           mockOutputFile,
           '1234',
-          IOSDeviceInterface.network,
+          IOSDeviceConnectionInterface.network,
         );
         verify(mockProcessManager.run(<String>[idevicescreenshotPath, outputPath, '--udid', '1234', '--network'],
           environment: <String, String>{'DYLD_LIBRARY_PATH': libimobiledevicePath},

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -100,8 +100,8 @@ void main() {
         when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
           .thenReturn(ProcessResult(1, 0, '/path/to/xcdevice', ''));
 
-        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '10']))
-          .thenThrow(const ProcessException('xcrun', <String>['xcdevice', 'list', '--timeout', '10']));
+        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '2']))
+          .thenThrow(const ProcessException('xcrun', <String>['xcdevice', 'list', '--timeout', '2']));
 
         expect(await xcdevice.getAvailableIOSDevices(), isEmpty);
       });
@@ -545,7 +545,7 @@ void main() {
 ''';
 
           fakeProcessManager.addCommand(const FakeCommand(
-            command: <String>['xcrun', 'xcdevice', 'list', '--timeout', '10'],
+            command: <String>['xcrun', 'xcdevice', 'list', '--timeout', '2'],
             stdout: devicesOutput,
           ));
           final List<IOSDevice> devices = await xcdevice.getAvailableIOSDevices();
@@ -619,7 +619,7 @@ void main() {
 ''';
 
           fakeProcessManager.addCommand(const FakeCommand(
-            command: <String>['xcrun', 'xcdevice', 'list', '--timeout', '10'],
+            command: <String>['xcrun', 'xcdevice', 'list', '--timeout', '2'],
             stdout: devicesOutput,
           ));
           final List<IOSDevice> devices = await xcdevice.getAvailableIOSDevices();
@@ -668,7 +668,7 @@ void main() {
 ''';
 
           fakeProcessManager.addCommand(const FakeCommand(
-            command: <String>['xcrun', 'xcdevice', 'list', '--timeout', '10'],
+            command: <String>['xcrun', 'xcdevice', 'list', '--timeout', '2'],
             stdout: devicesOutput,
           ));
           final List<IOSDevice> devices = await xcdevice.getAvailableIOSDevices();
@@ -719,7 +719,7 @@ void main() {
 ''';
 
           fakeProcessManager.addCommand(const FakeCommand(
-            command: <String>['xcrun', 'xcdevice', 'list', '--timeout', '10'],
+            command: <String>['xcrun', 'xcdevice', 'list', '--timeout', '2'],
             stdout: devicesOutput,
           ));
 

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -100,8 +100,8 @@ void main() {
         when(processManager.runSync(<String>['xcrun', '--find', 'xcdevice']))
           .thenReturn(ProcessResult(1, 0, '/path/to/xcdevice', ''));
 
-        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '2']))
-          .thenThrow(const ProcessException('xcrun', <String>['xcdevice', 'list', '--timeout', '2']));
+        when(processManager.run(<String>['xcrun', 'xcdevice', 'list', '--timeout', '10']))
+          .thenThrow(const ProcessException('xcrun', <String>['xcdevice', 'list', '--timeout', '10']));
 
         expect(await xcdevice.getAvailableIOSDevices(), isEmpty);
       });
@@ -545,11 +545,11 @@ void main() {
 ''';
 
           fakeProcessManager.addCommand(const FakeCommand(
-            command: <String>['xcrun', 'xcdevice', 'list', '--timeout', '2'],
+            command: <String>['xcrun', 'xcdevice', 'list', '--timeout', '10'],
             stdout: devicesOutput,
           ));
           final List<IOSDevice> devices = await xcdevice.getAvailableIOSDevices();
-          expect(devices, hasLength(3));
+          expect(devices, hasLength(4));
           expect(devices[0].id, '00008027-00192736010F802E');
           expect(devices[0].name, 'An iPhone (Space Gray)');
           expect(await devices[0].sdkNameAndVersion, 'iOS 13.3');
@@ -558,10 +558,14 @@ void main() {
           expect(devices[1].name, 'iPad 1');
           expect(await devices[1].sdkNameAndVersion, 'iOS 10.1');
           expect(devices[1].cpuArchitecture, DarwinArch.armv7);
-          expect(devices[2].id, 'f577a7903cc54959be2e34bc4f7f80b7009efcf4');
-          expect(devices[2].name, 'iPad 2');
+          expect(devices[2].id, '234234234234234234345445687594e089dede3c44');
+          expect(devices[2].name, 'A networked iPad');
           expect(await devices[2].sdkNameAndVersion, 'iOS 10.1');
-          expect(devices[2].cpuArchitecture, DarwinArch.arm64); // Defaults to arm64 for unknown architecture.
+          expect(devices[2].cpuArchitecture, DarwinArch.arm64);
+          expect(devices[3].id, 'f577a7903cc54959be2e34bc4f7f80b7009efcf4');
+          expect(devices[3].name, 'iPad 2');
+          expect(await devices[3].sdkNameAndVersion, 'iOS 10.1');
+          expect(devices[3].cpuArchitecture, DarwinArch.arm64); // Defaults to arm64 for unknown architecture.
           expect(fakeProcessManager.hasRemainingExpectations, isFalse);
         }, overrides: <Type, Generator>{
           Platform: () => macPlatform,
@@ -615,7 +619,7 @@ void main() {
 ''';
 
           fakeProcessManager.addCommand(const FakeCommand(
-            command: <String>['xcrun', 'xcdevice', 'list', '--timeout', '2'],
+            command: <String>['xcrun', 'xcdevice', 'list', '--timeout', '10'],
             stdout: devicesOutput,
           ));
           final List<IOSDevice> devices = await xcdevice.getAvailableIOSDevices();
@@ -664,7 +668,7 @@ void main() {
 ''';
 
           fakeProcessManager.addCommand(const FakeCommand(
-            command: <String>['xcrun', 'xcdevice', 'list', '--timeout', '2'],
+            command: <String>['xcrun', 'xcdevice', 'list', '--timeout', '10'],
             stdout: devicesOutput,
           ));
           final List<IOSDevice> devices = await xcdevice.getAvailableIOSDevices();
@@ -715,7 +719,7 @@ void main() {
 ''';
 
           fakeProcessManager.addCommand(const FakeCommand(
-            command: <String>['xcrun', 'xcdevice', 'list', '--timeout', '2'],
+            command: <String>['xcrun', 'xcdevice', 'list', '--timeout', '10'],
             stdout: devicesOutput,
           ));
 


### PR DESCRIPTION
## Description
Use new `--network` libimobiledevice flags.

`flutter run`, `flutter attach --host-vmservice-port`, `flutter install`, `flutter screenshot` work.

## Related issues
https://github.com/flutter/flutter/issues/15072

## Steps to test
1. Attach a phone to your Mac.  This works best when both are on the same Wi-Fi network (unrelated to Flutter).
1. Make sure the device has a passcode set.
1. Open Xcode > Window > Devices and Simulators > Choose your phone, then check Connect via Network
![Screen Shot 2020-06-26 at 7 40 35 PM](https://user-images.githubusercontent.com/682784/85912899-ff303f80-b7e4-11ea-9786-5262b46321b0.png)
(If you don't get that little network icon next to the device name it probably didn't work, regardless of checkbox state.)
1. Unplug your device from USB.

## Tests
- mac_test.dart
- xcode_test.dart

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*