### PR TITLE
restore imagefiltered_transform_animation_perf__timeline_summary benchmark

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/main.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/main.dart
@@ -138,6 +138,13 @@ class HomePage extends StatelessWidget {
             },
           ),
           RaisedButton(
+            key: const Key(kImageFilteredTransformAnimationRouteName),
+            child: const Text('ImageFiltered Transform Animation'),
+            onPressed: () {
+              Navigator.pushNamed(context, kImageFilteredTransformAnimationRouteName);
+            },
+          ),
+          RaisedButton(
             key: const Key(kMultiWidgetConstructionRouteName),
             child: const Text('Widget Construction and Destruction'),
             onPressed: () {


### PR DESCRIPTION
When the Heavey Widget Construction and Destruction benchmark was added, the button to run the ImageFiltered Transform Animation benchmark was accidentally deleted. This PR will restore the button so the benchmark can run.