### PR TITLE
Fix tooltip position using correct overlay to calculate render box position.

### DIFF
--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -284,8 +284,16 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
   }
 
   void _createNewEntry() {
+    final OverlayState overlayState = Overlay.of(
+      context,
+      debugRequiredFor: widget,
+    );
+
     final RenderBox box = context.findRenderObject() as RenderBox;
-    final Offset target = box.localToGlobal(box.size.center(Offset.zero));
+    final Offset target = box.localToGlobal(
+      box.size.center(Offset.zero),
+      ancestor: overlayState.context.findRenderObject(),
+    );
 
     // We create this widget outside of the overlay entry's builder to prevent
     // updated values from happening to leak into the overlay when the overlay
@@ -309,7 +317,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
       ),
     );
     _entry = OverlayEntry(builder: (BuildContext context) => overlay);
-    Overlay.of(context, debugRequiredFor: widget).insert(_entry);
+    overlayState.insert(_entry);
     SemanticsService.tooltip(widget.message);
   }
 

--- a/packages/flutter/test/material/tooltip_test.dart
+++ b/packages/flutter/test/material/tooltip_test.dart
@@ -99,6 +99,68 @@ void main() {
     expect(tipInGlobal.dy, 20.0);
   });
 
+  testWidgets('Does tooltip end up in the right place - center with padding outside overlay', (WidgetTester tester) async {
+    final GlobalKey key = GlobalKey();
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Overlay(
+            initialEntries: <OverlayEntry>[
+              OverlayEntry(
+                builder: (BuildContext context) {
+                  return Stack(
+                    children: <Widget>[
+                      Positioned(
+                        left: 300.0,
+                        top: 0.0,
+                        child: Tooltip(
+                          key: key,
+                          message: tooltipText,
+                          height: 20.0,
+                          padding: const EdgeInsets.all(5.0),
+                          verticalOffset: 20.0,
+                          preferBelow: false,
+                          child: const SizedBox(
+                            width: 0.0,
+                            height: 0.0,
+                          ),
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    (key.currentState as dynamic).ensureTooltipVisible(); // Before using "as dynamic" in your code, see note at the top of the file.
+    await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
+
+    /************************ 800x600 screen
+     *   ________________   * }- 20.0 padding outside overlay
+     *  |    o           |  * y=0
+     *  |    |           |  * }- 20.0 vertical offset, of which 10.0 is in the screen edge margin
+     *  | +----+         |  * \- (5.0 padding in height)
+     *  | |    |         |  * |- 20 height
+     *  | +----+         |  * /- (5.0 padding in height)
+     *  |________________|  *
+     *                      * } - 20.0 padding outside overlay
+     ************************/
+
+    final RenderBox tip = tester.renderObject(
+      _findTooltipContainer(tooltipText),
+    );
+    final Offset tipInGlobal = tip.localToGlobal(tip.size.topCenter(Offset.zero));
+    // The exact position of the left side depends on the font the test framework
+    // happens to pick, so we don't test that.
+    expect(tipInGlobal.dx, 320.0);
+    expect(tipInGlobal.dy, 40.0);
+  });
+
   testWidgets('Does tooltip end up in the right place - top left', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
     await tester.pumpWidget(


### PR DESCRIPTION
Use correct overlay ancestor when calculating the box position.

## Description

Tooltip position is not correct when the overlay is not "fullscreen". 

For example, if you wrap a `MaterialApp` with a `Padding` the position calculation will be relative to root `RenderBox` but applied to first `Overlay`. But as the `Overlay` is not at (0,0) in the root `RenderBox`, tooltip position is wrong.

In my example I am building a macOS app which wraps a `MaterialApp` to add custom actions on top of the app. You can see the difference before and after the fix int the images below.

| Before | After |
| -- | -- |
| <img width="349" alt="Screenshot 2020-06-28 at 20 52 36" src="https://user-images.githubusercontent.com/4008513/85955935-5fa8b380-b982-11ea-9c6a-2d5bc8369c8d.png"> | <img width="349" alt="Screenshot 2020-06-28 at 20 45 14" src="https://user-images.githubusercontent.com/4008513/85955951-6a634880-b982-11ea-9245-c62c992dca2d.png"> |

## Related Issues

Fixes #50400 
Fixes #52571.

## Tests

I added the following tests:

- A tooltip test with the overlay wrapped with a padding to simulate this behavior.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing. **(The tooltip tests passed. But some test already failed on master on my machine.)**
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR. **(Already fails on master on my machine)**
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change. **(The tooltip tests passed. But some test already failed on master on my machine.)**

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
