### PR TITLE
Adding ColorFiltered "Widget of the week" video to docs.

### DIFF
--- a/packages/flutter/lib/src/widgets/color_filter.dart
+++ b/packages/flutter/lib/src/widgets/color_filter.dart
@@ -12,6 +12,8 @@ import 'package:flutter/rendering.dart';
 import 'framework.dart';
 
 /// Applies a [ColorFilter] to its child.
+///
+/// {@youtube 560 315 https://www.youtube.com/watch?v=F7Cll22Dno8}
 @immutable
 class ColorFiltered extends SingleChildRenderObjectWidget {
   /// Creates a widget that applies a [ColorFilter] to its child.


### PR DESCRIPTION
## Description

Adding ColorFiltered "Widget of the week" video to docs. Most other widgets have it already as part of their docs.

## Related Issues

-

## Tests

I added the following tests:

-

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*