### PR TITLE
Make Scrollable's free scroll initial velocity matches that of iOS

### DIFF
--- a/dev/benchmarks/microbenchmarks/README.md
+++ b/dev/benchmarks/microbenchmarks/README.md
@@ -5,7 +5,7 @@ window to see the device logs, then, in a different window, run any of
 these:
 
 ```
-flutter run --release lib/gestures/velocity_tracker_data.dart
+flutter run --release lib/gestures/velocity_tracker_bench.dart
 flutter run --release lib/gestures/gesture_detector_bench.dart
 flutter run --release lib/stocks/animation_bench.dart
 flutter run --release lib/stocks/build_bench.dart

--- a/dev/benchmarks/microbenchmarks/lib/gestures/velocity_tracker_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/gestures/velocity_tracker_bench.dart
@@ -11,26 +11,31 @@ const int _kNumIters = 10000;
 
 void main() {
   assert(false, "Don't run benchmarks in checked mode! Use 'flutter run --release'.");
-  final VelocityTracker tracker = VelocityTracker();
-  final Stopwatch watch = Stopwatch();
-  print('Velocity tracker benchmark...');
-  watch.start();
-  for (int i = 0; i < _kNumIters; i += 1) {
-    for (final PointerEvent event in velocityEventData) {
-      if (event is PointerDownEvent || event is PointerMoveEvent)
-        tracker.addPosition(event.timeStamp, event.position);
-      if (event is PointerUpEvent)
-        tracker.getVelocity();
-    }
-  }
-  watch.stop();
-
   final BenchmarkResultPrinter printer = BenchmarkResultPrinter();
-  printer.addResult(
-    description: 'Velocity tracker',
-    value: watch.elapsedMicroseconds / _kNumIters,
-    unit: 'µs per iteration',
-    name: 'velocity_tracker_iteration',
-  );
+  final List<VelocityTracker> trackers = <VelocityTracker>[VelocityTracker(), IOSScrollViewFlingVelocityTracker()];
+  final Stopwatch watch = Stopwatch();
+
+  for (final VelocityTracker tracker in trackers) {
+    final String trackerType = tracker.runtimeType.toString();
+    print('$trackerType benchmark...');
+    watch.reset();
+    watch.start();
+    for (int i = 0; i < _kNumIters; i += 1) {
+      for (final PointerEvent event in velocityEventData) {
+        if (event is PointerDownEvent || event is PointerMoveEvent)
+          tracker.addPosition(event.timeStamp, event.position);
+        if (event is PointerUpEvent)
+          tracker.getVelocity();
+      }
+    }
+    watch.stop();
+    printer.addResult(
+      description: 'Velocity tracker: $trackerType',
+      value: watch.elapsedMicroseconds / _kNumIters,
+      unit: 'µs per iteration',
+      name: 'velocity_tracker_iteration_$trackerType',
+    );
+  }
+
   printer.printToStdout();
 }

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -173,26 +173,28 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   /// If null then [kMaxFlingVelocity] is used.
   double? maxFlingVelocity;
 
-  /// Determines the type of velocity estimation method should be used for a
-  /// potential drag gesture, when a new pointer is added to this gesture
-  /// recognizer.
+  /// Determines the type of velocity estimation method to use for a potential
+  /// drag gesture, when a new pointer is added.
   ///
-  /// To provide a velocity estimate of the gesture, [DragGestureRecognizer]
-  /// creates a [VelocityTracker] (or a subclass of it) using the builder
-  /// specified by [velocityTrackerBuilder], when it starts to track a pointer
-  /// in [addAllowedPointer]. Subsequent updates on the pointer will be sent to
-  /// that velocity tracker, until the gesture recognizer stops tracking the
-  /// pointer. Common velocity tracker classes includes:
-  ///
-  /// * [VelocityTracker], a least squares estimation that uses the 20 most
-  ///   recent pointer data to estimate the velocity of the drag gesture. It's a
-  ///   well-rounded velocity tracker and is used by default.
-  /// * [IOSScrollViewFlingVelocityTracker], a specialized velocity tracker for
-  ///   determining the initial fling velocity of a [Scrollable] on iOS, to
-  ///   match the native behavior on that platform.
+  /// To estimate the velocity of a gesture, [DragGestureRecognizer] calls
+  /// [velocityTrackerBuilder] when it starts to track a new pointer in
+  /// [addAllowedPointer], and add subsequent updates on the pointer to the
+  /// resulting velocity tracker, until the gesture recognizer stops tracking the
+  /// pointer. This allows you to specify a different velocity estimation strategy
+  /// for each allowed pointer added, by changing the type of velocity tracker
+  /// this builder returns.
   ///
   /// The default value is null, in which case [addAllowedPointer] creates a new
-  /// instance of [VelocityTracker] for every pointer added.
+  /// [VelocityTracker] for every pointer added.
+  ///
+  /// See also:
+  ///
+  ///  * [VelocityTracker], a velocity tracker that uses least squares estimation
+  ///    on the 20 most recent pointer data samples. It's a well-rounded velocity
+  ///    tracker and is used by default.
+  ///  * [IOSScrollViewFlingVelocityTracker], a specialized velocity tracker for
+  ///    determining the initial fling velocity for a [Scrollable] on iOS, to
+  ///    match the native behavior on that platform.
   GestureVelocityTrackerBuilder? velocityTrackerBuilder;
 
   _DragState _state = _DragState.ready;

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -66,10 +66,12 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
     Object? debugOwner,
     PointerDeviceKind? kind,
     this.dragStartBehavior = DragStartBehavior.start,
-    this.velocityTrackerBuilder,
+    this.velocityTrackerBuilder = _defaultBuilder,
   }) : assert(dragStartBehavior != null),
+       //this.velocityTrackerBuilder = velocityTrackerBuilder
        super(debugOwner: debugOwner, kind: kind);
 
+  static VelocityTracker _defaultBuilder(PointerEvent ev) => VelocityTracker();
   /// Configure the behavior of offsets sent to [onStart].
   ///
   /// If set to [DragStartBehavior.start], the [onStart] callback will be called
@@ -179,12 +181,12 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   /// To estimate the velocity of a gesture, [DragGestureRecognizer] calls
   /// [velocityTrackerBuilder] when it starts to track a new pointer in
   /// [addAllowedPointer], and add subsequent updates on the pointer to the
-  /// resulting velocity tracker, until the gesture recognizer stops tracking the
-  /// pointer. This allows you to specify a different velocity estimation strategy
-  /// for each allowed pointer added, by changing the type of velocity tracker
-  /// this builder returns.
+  /// resulting velocity tracker, until the gesture recognizer stops tracking
+  /// the pointer. This allows you to specify a different velocity estimation
+  /// strategy for each allowed pointer added, by changing the type of velocity
+  /// tracker this [GestureVelocityTrackerBuilder] returns.
   ///
-  /// The default value is null, in which case [addAllowedPointer] creates a new
+  /// If left unspecified the default [velocityTrackerBuilder] creates a new
   /// [VelocityTracker] for every pointer added.
   ///
   /// See also:
@@ -195,7 +197,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   ///  * [IOSScrollViewFlingVelocityTracker], a specialized velocity tracker for
   ///    determining the initial fling velocity for a [Scrollable] on iOS, to
   ///    match the native behavior on that platform.
-  GestureVelocityTrackerBuilder? velocityTrackerBuilder;
+  GestureVelocityTrackerBuilder velocityTrackerBuilder;
 
   _DragState _state = _DragState.ready;
   late OffsetPair _initialPosition;
@@ -252,7 +254,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   @override
   void addAllowedPointer(PointerEvent event) {
     startTrackingPointer(event.pointer, event.transform);
-    _velocityTrackers[event.pointer] = velocityTrackerBuilder?.call(event) ?? VelocityTracker();
+    _velocityTrackers[event.pointer] = velocityTrackerBuilder(event);
     if (_state == _DragState.ready) {
       _state = _DragState.possible;
       _initialPosition = OffsetPair(global: event.position, local: event.localPosition);

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -68,7 +68,6 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
     this.dragStartBehavior = DragStartBehavior.start,
     this.velocityTrackerBuilder = _defaultBuilder,
   }) : assert(dragStartBehavior != null),
-       //this.velocityTrackerBuilder = velocityTrackerBuilder
        super(debugOwner: debugOwner, kind: kind);
 
   static VelocityTracker _defaultBuilder(PointerEvent ev) => VelocityTracker();

--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -80,7 +80,8 @@ class ScrollBehavior {
       case TargetPlatform.windows:
         return (PointerEvent ev) => VelocityTracker();
     }
-    return null;
+    assert(false);
+    return (PointerEvent ev) => VelocityTracker();
   }
 
   static const ScrollPhysics _bouncingPhysics = BouncingScrollPhysics(parent: RangeMaintainingScrollPhysics());

--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -5,6 +5,7 @@
 // @dart = 2.8
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 
 import 'framework.dart';
@@ -48,6 +49,36 @@ class ScrollBehavior {
           axisDirection: axisDirection,
           color: _kDefaultGlowColor,
         );
+    }
+    return null;
+  }
+
+  /// Specifies the type of velocity tracker to use in the descendant
+  /// [Scrollable]s' drag gesture recognizers, for estimating the velocity of a
+  /// drag gesture.
+  ///
+  /// This can be used to, for example, apply different fling velocity
+  /// estimation methods on different platforms, in order to match the
+  /// platform's native behavior.
+  ///
+  /// Typically, the provided [GestureVelocityTrackerBuilder] should return a
+  /// fresh velocity tracker. If null is returned, [Scrollable] creates a new
+  /// [VelocityTracker] to track the newly added pointer that may develop into
+  /// a drag gesture.
+  ///
+  /// The default implementation provides a new
+  /// [IOSScrollViewFlingVelocityTracker] on iOS and macOS for each new pointer,
+  /// and a new [VelocityTracker] on other platforms for each new pointer.
+  GestureVelocityTrackerBuilder velocityTrackerBuilder(BuildContext context) {
+    switch (getPlatform(context)) {
+      case TargetPlatform.iOS:
+      case TargetPlatform.macOS:
+        return (PointerEvent ev) => IOSScrollViewFlingVelocityTracker();
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.linux:
+      case TargetPlatform.windows:
+        return (PointerEvent ev) => VelocityTracker();
     }
     return null;
   }

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -533,7 +533,7 @@ class BouncingScrollPhysics extends ScrollPhysics {
       return BouncingScrollSimulation(
         spring: spring,
         position: position.pixels,
-        velocity: velocity * 0.91, // TODO(abarth): We should move this constant closer to the drag end.
+        velocity: velocity,
         leadingExtent: position.minScrollExtent,
         trailingExtent: position.maxScrollExtent,
         tolerance: tolerance,

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -465,6 +465,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin
                   ..minFlingDistance = _physics?.minFlingDistance
                   ..minFlingVelocity = _physics?.minFlingVelocity
                   ..maxFlingVelocity = _physics?.maxFlingVelocity
+                  ..velocityTrackerBuilder = _configuration.velocityTrackerBuilder(context)
                   ..dragStartBehavior = widget.dragStartBehavior;
               },
             ),
@@ -484,6 +485,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin
                   ..minFlingDistance = _physics?.minFlingDistance
                   ..minFlingVelocity = _physics?.minFlingVelocity
                   ..maxFlingVelocity = _physics?.maxFlingVelocity
+                  ..velocityTrackerBuilder = _configuration.velocityTrackerBuilder(context)
                   ..dragStartBehavior = widget.dragStartBehavior;
               },
             ),

--- a/packages/flutter/test/gestures/velocity_tracker_test.dart
+++ b/packages/flutter/test/gestures/velocity_tracker_test.dart
@@ -78,4 +78,71 @@ void main() {
     final VelocityTracker tracker = VelocityTracker();
     expect(tracker.getVelocity(), Velocity.zero);
   });
+
+  test('FreeScrollStartVelocityTracker.getVelocity throws when no points', () {
+    final IOSScrollViewFlingVelocityTracker tracker = IOSScrollViewFlingVelocityTracker();
+    AssertionError exception;
+    try {
+      tracker.getVelocity();
+    } on AssertionError catch (e) {
+      exception = e;
+    }
+
+    expect(exception?.toString(), contains('at least 1 point'));
+  });
+
+  test('FreeScrollStartVelocityTracker.getVelocity throws when the new point precedes the previous point', () {
+    final IOSScrollViewFlingVelocityTracker tracker = IOSScrollViewFlingVelocityTracker();
+    AssertionError exception;
+
+    tracker.addPosition(const Duration(hours: 1), Offset.zero);
+    try {
+      tracker.getVelocity();
+      tracker.addPosition(const Duration(seconds: 1), Offset.zero);
+    } on AssertionError catch (e) {
+      exception = e;
+    }
+
+    expect(exception?.toString(), contains('has a smaller timestamp'));
+  });
+
+  test('Estimate does not throw when there are more than 1 point', () {
+    final IOSScrollViewFlingVelocityTracker tracker = IOSScrollViewFlingVelocityTracker();
+    Offset position = Offset.zero;
+    Duration time = Duration.zero;
+    const Offset positionDelta = Offset(0, -1);
+    const Duration durationDelta = Duration(seconds: 1);
+    AssertionError exception;
+
+    for (int i = 0; i < 5; i+=1) {
+      position += positionDelta;
+      time += durationDelta;
+      tracker.addPosition(time, position);
+
+      try {
+        tracker.getVelocity();
+      } on AssertionError catch (e) {
+        exception = e;
+      }
+      expect(exception, isNull);
+    }
+  });
+
+  test('Makes consistent velocity estimation with consistent velocity', () {
+    final IOSScrollViewFlingVelocityTracker tracker = IOSScrollViewFlingVelocityTracker();
+    Offset position = Offset.zero;
+    Duration time = Duration.zero;
+    const Offset positionDelta = Offset(0, -1);
+    const Duration durationDelta = Duration(seconds: 1);
+
+    for (int i = 0; i < 10; i+=1) {
+      position += positionDelta;
+      time += durationDelta;
+      tracker.addPosition(time, position);
+
+      if (i >= 3) {
+        expect(tracker.getVelocity().pixelsPerSecond, positionDelta);
+      }
+    }
+  });
 }

--- a/packages/flutter/test/gestures/velocity_tracker_test.dart
+++ b/packages/flutter/test/gestures/velocity_tracker_test.dart
@@ -128,7 +128,7 @@ void main() {
     }
   });
 
-  test('Makes consistent velocity estimation with consistent velocity', () {
+  test('Makes consistent velocity estimates with consistent velocity', () {
     final IOSScrollViewFlingVelocityTracker tracker = IOSScrollViewFlingVelocityTracker();
     Offset position = Offset.zero;
     Duration time = Duration.zero;

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -182,8 +182,7 @@ void main() {
     await tester.pump();
     // The only applied velocity to the scrollable is the second fling that was in the
     // opposite direction.
-    expect(getScrollVelocity(tester), greaterThan(-1000.0));
-    expect(getScrollVelocity(tester), lessThan(0.0));
+    expect(getScrollVelocity(tester), -1000.0);
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
   testWidgets('No iOS/macOS momentum kept on hold gestures', (WidgetTester tester) async {
@@ -269,7 +268,7 @@ void main() {
     expect(getScrollOffset(tester), 30.0);
     await gesture.moveBy(const Offset(0.0, -0.5), timeStamp: const Duration(milliseconds: 20));
     expect(getScrollOffset(tester), 30.5);
-    await gesture.moveBy(Offset.zero);
+    await gesture.moveBy(Offset.zero, timeStamp: const Duration(milliseconds: 21));
     // Stationary too long, threshold reset.
     await gesture.moveBy(Offset.zero, timeStamp: const Duration(milliseconds: 120));
     await gesture.moveBy(const Offset(0.0, -1.0), timeStamp: const Duration(milliseconds: 140));

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -381,25 +381,25 @@ abstract class WidgetController {
       final TestPointer testPointer = TestPointer(pointer ?? _getNextPointer(), PointerDeviceKind.touch, null, buttons);
       final HitTestResult result = hitTestOnBinding(startLocation);
       const int kMoveCount = 50; // Needs to be >= kHistorySize, see _LeastSquaresVelocityTrackerStrategy
-      final double timeStampDelta = 1000.0 * offset.distance / (kMoveCount * speed);
+      final double timeStampDelta = 1000000.0 * offset.distance / (kMoveCount * speed);
       double timeStamp = 0.0;
       double lastTimeStamp = timeStamp;
-      await sendEventToBinding(testPointer.down(startLocation, timeStamp: Duration(milliseconds: timeStamp.round())), result);
+      await sendEventToBinding(testPointer.down(startLocation, timeStamp: Duration(microseconds: timeStamp.round())), result);
       if (initialOffset.distance > 0.0) {
-        await sendEventToBinding(testPointer.move(startLocation + initialOffset, timeStamp: Duration(milliseconds: timeStamp.round())), result);
-        timeStamp += initialOffsetDelay.inMilliseconds;
+        await sendEventToBinding(testPointer.move(startLocation + initialOffset, timeStamp: Duration(microseconds: timeStamp.round())), result);
+        timeStamp += initialOffsetDelay.inMicroseconds;
         await pump(initialOffsetDelay);
       }
       for (int i = 0; i <= kMoveCount; i += 1) {
         final Offset location = startLocation + initialOffset + Offset.lerp(Offset.zero, offset, i / kMoveCount);
-        await sendEventToBinding(testPointer.move(location, timeStamp: Duration(milliseconds: timeStamp.round())), result);
+        await sendEventToBinding(testPointer.move(location, timeStamp: Duration(microseconds: timeStamp.round())), result);
         timeStamp += timeStampDelta;
-        if (timeStamp - lastTimeStamp > frameInterval.inMilliseconds) {
-          await pump(Duration(milliseconds: (timeStamp - lastTimeStamp).truncate()));
+        if (timeStamp - lastTimeStamp > frameInterval.inMicroseconds) {
+          await pump(Duration(microseconds: (timeStamp - lastTimeStamp).truncate()));
           lastTimeStamp = timeStamp;
         }
       }
-      await sendEventToBinding(testPointer.up(timeStamp: Duration(milliseconds: timeStamp.round())), result);
+      await sendEventToBinding(testPointer.up(timeStamp: Duration(microseconds: timeStamp.round())), result);
     });
   }
 

--- a/packages/flutter_test/test/controller_test.dart
+++ b/packages/flutter_test/test/controller_test.dart
@@ -551,6 +551,33 @@ void main() {
   );
 
   testWidgets(
+    'WidgetTester.fling produces strictly monotonically increasing timestamps, '
+    'when given a large velocity',
+    (WidgetTester tester) async {
+      // Velocity trackers may misbehave if the `PointerMoveEvent`s' have the
+      // same timestamp. This is more likely to happen when the velocity tracker
+      // has a small sample size.
+      final List<Duration> logs = <Duration>[];
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Listener(
+            onPointerMove: (PointerMoveEvent event) => logs.add(event.timeStamp),
+            child: const Text('test'),
+          ),
+        ),
+      );
+
+      await tester.fling(find.text('test'), const Offset(0.0, -50.0), 10000.0);
+      await tester.pumpAndSettle();
+
+      for (int i = 0; i + 1 < logs.length; i += 1) {
+        expect(logs[i + 1],  greaterThan(logs[i]));
+      }
+  });
+
+  testWidgets(
     'ensureVisible: scrolls to make widget visible',
     (WidgetTester tester) async {
       await tester.pumpWidget(


### PR DESCRIPTION
## Description

This PR makes flinging velocity platform-dependent. We can't reliably correct the flinging velocity on iOS in the friction simulation because the velocity estimation is done differently on iOS. This change brings the initial scroll velocity very close to what `scrollViewWillEndDragging(_:withVelocity:targetContentOffset:)` reports in the [scroll_overlay](https://github.com/flutter/platform_tests/tree/master/scroll_overlay) app, also since the final scroll distance (the delta) of a free scroll solely depends on the initial velocity, this in theory should also make the amount the scrollable scrolls during free scrolling match iOS (it's still not as close as it could be because of pixel snapping on iOS and another minor difference in friction simulation, but from the results below it seems this should be good enough).

### Test results (using a modified version of the scroll_overlay app):
test run 1 
```
trigger velocity: 4030.787700, target offset: 2135.000000, scrollOffset delta: 2008.500000
2020-06-29 00:50:58.828681-0700 Runner[5062:3670119] flutter: goBallistic with initial velocity: 4030.6899249427292
2020-06-29 00:50:58.828743-0700 Runner[5062:3670119] flutter: start pixel: 258.6666666666667
2020-06-29 00:51:01.815903-0700 Runner[5062:3669876] velocityY: 0.000000
2020-06-29 00:51:01.849800-0700 Runner[5062:3670119] flutter: becomes Idle. Pixels: 2266.561898725746
```
In this run `scrollViewWillEndDragging(_:withVelocity:targetContentOffset:)` reported an initial velocity of 4030.787700 and a scroll distance of 2008.500000, while flutter reported 4030.6899249427292 and 2266.561898725746-258.6666666666667= 2007.89523206 respectively.

test run 2
```
2020-06-29 01:02:29.504894-0700 Runner[5116:3673262] trigger velocity: 6895.866228, target offset: 3816.500000, scrollOffset delta: 3439.500000
2020-06-29 01:02:29.531646-0700 Runner[5116:3673481] flutter: goBallistic with initial velocity: 6895.867438846153
2020-06-29 01:02:29.531713-0700 Runner[5116:3673481] flutter: start pixel: 455.0
2020-06-29 01:02:32.778637-0700 Runner[5116:3673262] velocityY: 0.000000
2020-06-29 01:02:32.812310-0700 Runner[5116:3673481] flutter: becomes Idle. Pixels: 3893.693637211801
```
this time it's 6895.866228 vs 6895.867438846153 and 3439.500000 vs 3438.69363721.

## Related Issues
Fixes https://github.com/flutter/flutter/issues/11772

## Related PR
adopted some changes from https://github.com/flutter/flutter/pull/59623 for better results.

## Tests

I added the following tests:

FreeScrollStartVelocityTracker.getVelocity throws when no points, etc.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
