### PR TITLE
gitignore generated_plugin_registrant.dart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ version
 .dart_tool/
 .flutter-plugins
 .flutter-plugins-dependencies
+**/generated_plugin_registrant.dart
 .packages
 .pub-cache/
 .pub/


### PR DESCRIPTION
## Description

Add `generated_plugin_registrant.dart` to `.gitignore`. This file is auto-generated and does not need to be checked into the repo.
