### PR TITLE
Issues/58665 reland and prevent the material widget from absorbing gesture

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -681,7 +681,12 @@ class _AppBarState extends State<AppBar> {
         fit: StackFit.passthrough,
         children: <Widget>[
           widget.flexibleSpace,
-          appBar,
+          // Creates a material widget to prevent the flexibleSpace from swallow
+          // the ink splash effect.
+          Material(
+            type: MaterialType.transparency,
+            child: appBar,
+          ),
         ],
       );
     }

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -681,8 +681,8 @@ class _AppBarState extends State<AppBar> {
         fit: StackFit.passthrough,
         children: <Widget>[
           widget.flexibleSpace,
-          // Creates a material widget to prevent the flexibleSpace from swallow
-          // the ink splash effect.
+          // Creates a material widget to prevent the flexibleSpace from
+          // obscuring the ink splashes produced by appBar children.
           Material(
             type: MaterialType.transparency,
             child: appBar,

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -366,6 +366,7 @@ class _MaterialState extends State<Material> with TickerProviderStateMixin {
       },
       child: _InkFeatures(
         key: _inkFeatureRenderer,
+        absorbHitTest: widget.type != MaterialType.transparency,
         color: backgroundColor,
         child: contents,
         vsync: this,
@@ -477,6 +478,7 @@ class _RenderInkFeatures extends RenderProxyBox implements MaterialInkController
   _RenderInkFeatures({
     RenderBox child,
     @required this.vsync,
+    this.absorbHitTest,
     this.color,
   }) : assert(vsync != null),
        super(child);
@@ -492,6 +494,8 @@ class _RenderInkFeatures extends RenderProxyBox implements MaterialInkController
   // MaterialState build method.
   @override
   Color color;
+
+  bool absorbHitTest;
 
   List<InkFeature> _inkFeatures;
 
@@ -517,6 +521,9 @@ class _RenderInkFeatures extends RenderProxyBox implements MaterialInkController
   }
 
   @override
+  bool hitTestSelf(Offset position) => absorbHitTest;
+
+  @override
   void paint(PaintingContext context, Offset offset) {
     if (_inkFeatures != null && _inkFeatures.isNotEmpty) {
       final Canvas canvas = context.canvas;
@@ -536,6 +543,7 @@ class _InkFeatures extends SingleChildRenderObjectWidget {
     Key key,
     this.color,
     @required this.vsync,
+    @required this.absorbHitTest,
     Widget child,
   }) : super(key: key, child: child);
 
@@ -546,17 +554,21 @@ class _InkFeatures extends SingleChildRenderObjectWidget {
 
   final TickerProvider vsync;
 
+  final bool absorbHitTest;
+
   @override
   _RenderInkFeatures createRenderObject(BuildContext context) {
     return _RenderInkFeatures(
       color: color,
+      absorbHitTest: absorbHitTest,
       vsync: vsync,
     );
   }
 
   @override
   void updateRenderObject(BuildContext context, _RenderInkFeatures renderObject) {
-    renderObject.color = color;
+    renderObject..color = color
+                ..absorbHitTest = absorbHitTest;
     assert(vsync == renderObject.vsync);
   }
 }

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -517,9 +517,6 @@ class _RenderInkFeatures extends RenderProxyBox implements MaterialInkController
   }
 
   @override
-  bool hitTestSelf(Offset position) => true;
-
-  @override
   void paint(PaintingContext context, Offset offset) {
     if (_inkFeatures != null && _inkFeatures.isNotEmpty) {
       final Canvas canvas = context.canvas;

--- a/packages/flutter/test/material/material_test.dart
+++ b/packages/flutter/test/material/material_test.dart
@@ -220,6 +220,7 @@ void main() {
   });
 
   testWidgets('Transparent material widget does not absorb hit test', (WidgetTester tester) async {
+    // This is a regression test for https://github.com/flutter/flutter/issues/58665.
     bool pressed = false;
     await tester.pumpWidget(
       MaterialApp(

--- a/packages/flutter/test/material/material_test.dart
+++ b/packages/flutter/test/material/material_test.dart
@@ -219,6 +219,34 @@ void main() {
     expect(modelE.shadowColor, equals(const Color(0xFFFF0000)));
   });
 
+  testWidgets('Transparent material widget does not absorb hit test', (WidgetTester tester) async {
+    bool pressed = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Stack(
+            children: <Widget>[
+              RaisedButton(
+                onPressed: () {
+                  pressed = true;
+                },
+              ),
+              Material(
+                type: MaterialType.transparency,
+                child: Container(
+                  width: 400.0,
+                  height: 500.0,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.byType(RaisedButton));
+    expect(pressed, isTrue);
+  });
+
   group('Elevation Overlay', () {
 
     testWidgets('applyElevationOverlayColor set to false does not change surface color', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

Internal test has a button in the flexiblespace. The previous pr adds a layer of material in the appbar which will paint on top of the flexiblespace. The material will always absorb the hittest regardless whether it has hittestable child in it. This pr reland the change and make the material won't absorb the hittest when there is no hittestable child in it.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/58665

## Tests

I added the following tests:

see files

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
