### PR TITLE
Annotate RawMaterialButton as a Material > Button category.

### DIFF
--- a/packages/flutter/lib/src/material/button.dart
+++ b/packages/flutter/lib/src/material/button.dart
@@ -29,6 +29,7 @@ import 'theme_data.dart';
 ///
 /// [RaisedButton] and [FlatButton] configure a [RawMaterialButton] based
 /// on the current [Theme] and [ButtonTheme].
+@Category(<String>['Material', 'Button'])
 class RawMaterialButton extends StatefulWidget {
   /// Create a button based on [Semantics], [Material], and [InkWell] widgets.
   ///


### PR DESCRIPTION
This will enable aggregation of similar Material > Button symbols.
