### PR TITLE
Fix daemon device discovery crash when Xcode isn't installed

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -64,6 +64,9 @@ class IOSDevices extends PollingDeviceDiscovery {
         'Control of iOS devices or simulators only supported on macOS.'
       );
     }
+    if (!_xcdevice.isInstalled) {
+      return;
+    }
 
     deviceNotifier ??= ItemListNotifier<Device>();
 
@@ -72,7 +75,7 @@ class IOSDevices extends PollingDeviceDiscovery {
 
     // cancel any outstanding subscriptions.
     await _observedDeviceEventsSubscription?.cancel();
-    _observedDeviceEventsSubscription = _xcdevice.observedDeviceEvents().listen(
+    _observedDeviceEventsSubscription = _xcdevice.observedDeviceEvents()?.listen(
       _onDeviceEvent,
       onError: (dynamic error, StackTrace stack) {
         _logger.printTrace('Process exception running xcdevice observe:\n$error\n$stack');

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -370,6 +370,19 @@ void main() {
       );
     });
 
+    testWithoutContext('start polling without Xcode', () async {
+      final IOSDevices iosDevices = IOSDevices(
+        platform: macPlatform,
+        xcdevice: mockXcdevice,
+        iosWorkflow: mockIosWorkflow,
+        logger: logger,
+      );
+      when(mockXcdevice.isInstalled).thenReturn(false);
+
+      await iosDevices.startPolling();
+      verifyNever(mockXcdevice.getAvailableIOSDevices());
+    });
+
     testWithoutContext('start polling', () async {
       final IOSDevices iosDevices = IOSDevices(
         platform: macPlatform,


### PR DESCRIPTION
## Description

When Xcode isn't installed, no Android devices shown in Intellij/Android Studio plugins.  Crash:
```
java.io.IOException: error from device.enable: "NoSuchMethodError: The method 'listen' was called on null.\nReceiver: null\nTried calling: listen(Closure: (Map<XCDeviceEvent, String>) => Future<void> from Function '_onDeviceEvent@132191375':., cancelOnError: true, onDone: Closure: () => Null, onError: Closure: (dynamic, StackTrace) => Null)"
```

## Related Issues

Fallout from #58137, which was [cherry-picked as 1.17.4](https://github.com/flutter/flutter/pull/59695).

https://github.com/flutter/flutter-intellij/issues/4642
https://github.com/flutter/flutter/issues/60473

## Tests
- start polling without Xcode installed
This test crashes on master, passes on this PR.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*