### PR TITLE
Turn back on macOS shard Cirrus caching

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -522,8 +522,6 @@ task:
         - dart --enable-asserts dev\customer_testing\run_tests.dart --skip-on-fetch-failure --skip-template bin/cache/pkg/tests/registry/*.test
 
 # MACOS SHARDS
-# Mac doesn't use caches because they apparently take longer to populate and save
-# than just fetching the data in the first place.
 task:
   osx_instance:
     image: catalina-xcode-11.3.1-flutter # see https://cirrus-ci.org/guide/macOS/ for list of images (we should update regularly)
@@ -536,6 +534,21 @@ task:
     COCOAPODS_DISABLE_STATS: true
     CPU: 2
     MEMORY: 8G
+  all_flutter_cache:
+    folder: bin/cache/
+    fingerprint_script: echo $OS; cat bin/internal/*.version
+    populate_script:
+      - git fetch origin
+      - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
+      - flutter precache
+      - flutter doctor -v
+  pub_cache:
+    folder: $HOME/.pub-cache
+    fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"
+    populate_script:
+      - git fetch origin
+      - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
+      - flutter update-packages
   setup_script:
     - date
     - which flutter
@@ -547,7 +560,7 @@ task:
     - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
     - flutter config --no-analytics
     - flutter doctor -v
-    - flutter update-packages
+    - flutter update-packages --offline
     - date
     - which flutter
   on_failure:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -542,6 +542,7 @@ task:
       - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
       - flutter precache
       - flutter doctor -v
+    reupload_on_changes: false
   pub_cache:
     folder: $HOME/.pub-cache
     fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"
@@ -549,6 +550,7 @@ task:
       - git fetch origin
       - git fetch origin master # To set FETCH_HEAD, so that "git merge-base" works.
       - flutter update-packages
+    reupload_on_changes: false
   setup_script:
     - date
     - which flutter


### PR DESCRIPTION
## Description

This was previously attempted in https://github.com/flutter/flutter/pull/50496 and #51516 and reverted or closed due to longer cache miss times/network issues.

Maybe cache misses will be less frequent with `reupload_on_changes` off? https://github.com/flutter/flutter/pull/51524

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*