### PR TITLE
1.17.5 CP: Fix daemon device discovery crash when Xcode isn't installed (#60546)

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -69,6 +69,9 @@ class IOSDevices extends PollingDeviceDiscovery {
         'Control of iOS devices or simulators only supported on macOS.'
       );
     }
+    if (!_xcdevice.isInstalled) {
+      return;
+    }
 
     deviceNotifier ??= ItemListNotifier<Device>();
 
@@ -77,7 +80,7 @@ class IOSDevices extends PollingDeviceDiscovery {
 
     // cancel any outstanding subscriptions.
     await _observedDeviceEventsSubscription?.cancel();
-    _observedDeviceEventsSubscription = _xcdevice.observedDeviceEvents().listen(
+    _observedDeviceEventsSubscription = _xcdevice.observedDeviceEvents()?.listen(
       _onDeviceEvent,
       onError: (dynamic error, StackTrace stack) {
         _logger.printTrace('Process exception running xcdevice observe:\n$error\n$stack');

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -328,7 +328,7 @@ void main() {
       when(mockXcdevice.isInstalled).thenReturn(false);
 
       await iosDevices.startPolling();
-      verifyNever(mockXcdevice.getAvailableIOSDevices());
+      verifyNever(mockXcdevice.getAvailableTetheredIOSDevices());
     });
 
     testWithoutContext('start polling', () async {

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -318,6 +318,19 @@ void main() {
       );
     });
 
+    testWithoutContext('start polling without Xcode', () async {
+      final IOSDevices iosDevices = IOSDevices(
+        platform: macPlatform,
+        xcdevice: mockXcdevice,
+        iosWorkflow: mockIosWorkflow,
+        logger: logger,
+      );
+      when(mockXcdevice.isInstalled).thenReturn(false);
+
+      await iosDevices.startPolling();
+      verifyNever(mockXcdevice.getAvailableIOSDevices());
+    });
+
     testWithoutContext('start polling', () async {
       final IOSDevices iosDevices = IOSDevices(
         platform: macPlatform,


### PR DESCRIPTION
1.17.5 CPs
  - https://github.com/flutter/flutter-intellij/issues/4642
    - https://github.com/flutter/flutter/commit/d5225a560dc0ac8f8e4c2d9789b752a8d8fb0ec3