### PR TITLE
[flutter_tools] ensure flutter daemon can exit correctly

### DIFF
--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -487,13 +487,20 @@ class _ResidentWebRunner extends ResidentWebRunner {
         );
       });
     } on WebSocketException {
+      appFailedToStart();
       throwToolExit(kExitMessage);
     } on ChromeDebugException {
+      appFailedToStart();
       throwToolExit(kExitMessage);
     } on AppConnectionException {
+      appFailedToStart();
       throwToolExit(kExitMessage);
     } on SocketException {
+      appFailedToStart();
       throwToolExit(kExitMessage);
+    } on Exception {
+      appFailedToStart();
+      rethrow;
     }
     return 0;
   }

--- a/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/build_runner/resident_web_runner.dart
@@ -410,6 +410,7 @@ class _ResidentWebRunner extends ResidentWebRunner {
             '\nConsider using the -t option to specify the Dart file to start.';
       }
       globals.printError(message);
+      appFailedToStart();
       return 1;
     }
     final String modeName = debuggingOptions.buildInfo.friendlyModeName;
@@ -458,6 +459,7 @@ class _ResidentWebRunner extends ResidentWebRunner {
           final UpdateFSReport report = await _updateDevFS(fullRestart: true);
           if (!report.success) {
             globals.printError('Failed to compile application.');
+            appFailedToStart();
             return 1;
           }
           device.generator.accept();

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -409,7 +409,7 @@ class DaemonDomain extends Domain {
   }
 }
 
-typedef _RunOrAttach = Future<int> Function({
+typedef _RunOrAttach = Future<void> Function({
   Completer<DebugConnectionInfo> connectionInfoCompleter,
   Completer<void> appStartedCompleter,
 });

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -409,7 +409,7 @@ class DaemonDomain extends Domain {
   }
 }
 
-typedef _RunOrAttach = Future<void> Function({
+typedef _RunOrAttach = Future<int> Function({
   Completer<DebugConnectionInfo> connectionInfoCompleter,
   Completer<void> appStartedCompleter,
 });

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1226,6 +1226,10 @@ abstract class ResidentRunner {
     _finished.complete(0);
   }
 
+  void appFailedToStart() {
+    _finished.complete(1);
+  }
+
   Future<int> waitForAppToFinish() async {
     final int exitCode = await _finished.future;
     assert(exitCode != null);

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1227,7 +1227,9 @@ abstract class ResidentRunner {
   }
 
   void appFailedToStart() {
-    _finished.complete(1);
+    if (!_finished.isCompleted) {
+      _finished.complete(1);
+    }
   }
 
   Future<int> waitForAppToFinish() async {

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -59,14 +59,21 @@ class ColdRunner extends ResidentRunner {
       }
     }
 
-    for (final FlutterDevice device in flutterDevices) {
-      final int result = await device.runCold(
-        coldRunner: this,
-        route: route,
-      );
-      if (result != 0) {
-        return result;
+    try {
+      for (final FlutterDevice device in flutterDevices) {
+        final int result = await device.runCold(
+          coldRunner: this,
+          route: route,
+        );
+        if (result != 0) {
+          appFailedToStart();
+          return result;
+        }
       }
+    } on Exception catch (err) {
+      globals.printError(err.toString());
+      appFailedToStart();
+      return 1;
     }
 
     // Connect to observatory.
@@ -75,6 +82,7 @@ class ColdRunner extends ResidentRunner {
         await connectToServiceProtocol();
       } on String catch (message) {
         globals.printError(message);
+        appFailedToStart();
         return 2;
       }
     }

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -373,11 +373,13 @@ class HotRunner extends ResidentRunner {
     try {
       final List<bool> results = await Future.wait(startupTasks);
       if (!results.every((bool passed) => passed)) {
+        appFailedToStart();
         return 1;
       }
       cacheInitialDillCompilation();
     } on Exception catch (err) {
       globals.printError(err.toString());
+      appFailedToStart();
       return 1;
     }
 

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
@@ -92,6 +92,32 @@ void main() {
     )),
   }));
 
+  // Regression test for https://github.com/flutter/flutter/issues/60613
+  test('ResidentWebRunner calls appFailedToStart if initial compilation fails', () => testbed.run(() async {
+    _setupMocks();
+    when(mockBuildSystem.build(any, any)).thenAnswer((Invocation invocation) async {
+      return BuildResult(success: false);
+    });
+    expect(() async => await residentWebRunner.run(), throwsToolExit());
+    expect(await residentWebRunner.waitForAppToFinish(), 1);
+
+  }, overrides: <Type, Generator>{
+    BuildSystem: () => mockBuildSystem,
+  }));
+
+  // Regression test for https://github.com/flutter/flutter/issues/60613
+  test('ResidentWebRunner calls appFailedToStart if error is thrown during startup', () => testbed.run(() async {
+    _setupMocks();
+    when(mockBuildSystem.build(any, any)).thenAnswer((Invocation invocation) async {
+      throw Exception('foo');
+    });
+    expect(() async => await residentWebRunner.run(), throwsA(isA<Exception>()));
+    expect(await residentWebRunner.waitForAppToFinish(), 1);
+
+  }, overrides: <Type, Generator>{
+    BuildSystem: () => mockBuildSystem,
+  }));
+
   test('Can full restart after attaching', () => testbed.run(() async {
     _setupMocks();
     final Completer<DebugConnectionInfo> connectionInfoCompleter = Completer<DebugConnectionInfo>();


### PR DESCRIPTION
## Description

The flutter daemon unconditionally waits for the appFinished signal, even if startup failed. Ensure this future is correctly completed if there is a failure in ResidentRunner.run and not just ResidentRunner.attach. Adds regression tests for run release, debug, debug web, and release web. Adds missing try catch in cold runner startup.


Manually tested with release/debug on Android and release/debug on web.

Fixes https://github.com/flutter/flutter/issues/60613