### PR TITLE
[flutter_tool] fix ide-config crash because of no android key

### DIFF
--- a/packages/flutter_tools/lib/src/commands/ide_config.dart
+++ b/packages/flutter_tools/lib/src/commands/ide_config.dart
@@ -236,6 +236,7 @@ class IdeConfigCommand extends FlutterCommand {
     int generatedCount = 0;
     generatedCount += _renderTemplate(_ideName, dirPath, <String, dynamic>{
       'withRootModule': boolArg('with-root-module'),
+      'android': true,
     });
 
     globals.printStatus('Wrote $generatedCount files.');

--- a/packages/flutter_tools/test/commands.shard/hermetic/ide_config_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/ide_config_test.dart
@@ -20,6 +20,7 @@ void main() {
     Directory templateDir;
     Directory intellijDir;
     Directory toolsDir;
+    Directory exampleDir;
 
     Map<String, String> _getFilesystemContents([ Directory root ]) {
       final String tempPath = tempDir.absolute.path;
@@ -52,6 +53,7 @@ void main() {
         globals.fs.path.join(basePath, '.idea', 'runConfigurations', 'hello_world.xml$suffix'): 'hello_world $marker',
         globals.fs.path.join(basePath, 'flutter.iml$suffix'): 'flutter $marker',
         globals.fs.path.join(basePath, 'packages', 'new', 'deep.iml$suffix'): 'deep $marker',
+        globals.fs.path.join(basePath, 'example', 'gallery', 'android.iml$suffix'): 'android $marker',
       };
     }
 
@@ -114,6 +116,7 @@ void main() {
       toolsDir = packagesDir.childDirectory('flutter_tools')..createSync();
       templateDir = toolsDir.childDirectory('ide_templates')..createSync();
       intellijDir = templateDir.childDirectory('intellij')..createSync();
+      exampleDir = templateDir.childDirectory('examples')..createSync();
     });
 
     tearDown(() {
@@ -318,6 +321,5 @@ void main() {
         expectedContents: expectedContents,
       );
     });
-
   });
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/ide_config_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/ide_config_test.dart
@@ -20,7 +20,6 @@ void main() {
     Directory templateDir;
     Directory intellijDir;
     Directory toolsDir;
-    Directory exampleDir;
 
     Map<String, String> _getFilesystemContents([ Directory root ]) {
       final String tempPath = tempDir.absolute.path;
@@ -116,7 +115,6 @@ void main() {
       toolsDir = packagesDir.childDirectory('flutter_tools')..createSync();
       templateDir = toolsDir.childDirectory('ide_templates')..createSync();
       intellijDir = templateDir.childDirectory('intellij')..createSync();
-      exampleDir = templateDir.childDirectory('examples')..createSync();
     });
 
     tearDown(() {
@@ -321,5 +319,6 @@ void main() {
         expectedContents: expectedContents,
       );
     });
+
   });
 }


### PR DESCRIPTION
## Description

After https://github.com/flutter/flutter/pull/59507, the context template requires explicitly setting platform keys include "android". The `ide-config` has a template file whose name started with "android". It caused a crash. This PR adds the "android" key to the `ide-config` command's template context to fix the issue.

Note: Another solution I can think of is to add a command type key in the template context, and only enforce the platform key check if the command type is "create". I think this alternative solution is better assuming that only the "create" command requires  the platforms key check here https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/template.dart#L127-L152

## Related Issues

https://github.com/flutter/flutter/issues/60561

## Tests

I updated the ide_config_test to contain an android file in the testing template to catch the bug.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
