### PR TITLE
[WIP] ScaffoldMessenger

### DIFF
--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -16,6 +16,7 @@ import 'floating_action_button.dart';
 import 'icons.dart';
 import 'material_localizations.dart';
 import 'page.dart';
+import 'scaffold.dart';
 import 'theme.dart';
 
 /// [MaterialApp] uses this [TextStyle] as its [DefaultTextStyle] to encourage
@@ -607,7 +608,7 @@ class _MaterialAppState extends State<MaterialApp> {
   Widget build(BuildContext context) {
     Widget result = HeroControllerScope(
       controller: _heroController,
-      child: WidgetsApp(
+      child: ScaffoldMessenger(child: WidgetsApp(
         key: GlobalObjectKey(this),
         navigatorKey: widget.navigatorKey,
         navigatorObservers: widget.navigatorObservers,
@@ -687,6 +688,7 @@ class _MaterialAppState extends State<MaterialApp> {
         shortcuts: widget.shortcuts,
         actions: widget.actions,
       ),
+      )
     );
 
     assert(() {

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -99,7 +99,6 @@ class ScaffoldMessenger extends StatefulWidget {
 class ScaffoldMessengerState extends State<ScaffoldMessenger> {
   final Set<ScaffoldState> _scaffolds = <ScaffoldState>{};
   final Queue<ScaffoldFeatureController<SnackBar, SnackBarClosedReason>> _snackBars = Queue<ScaffoldFeatureController<SnackBar, SnackBarClosedReason>>();
-  // const String snackHeroTag = '<ScaffoldMessenger.snackBarHeroTag>';
 
   void _register(ScaffoldState scaffold) {
     // Are we in the middle of showing a SnackBar elsewhere?
@@ -1806,7 +1805,6 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
     _snackBarController ??= SnackBar.createAnimationController(vsync: this)
       ..addStatusListener(_handleSnackBarStatusChange);
     if (listener != null) {
-      print('Adding Listener');
       _snackBarController.addStatusListener(listener);
     }
     if (_snackBars.isEmpty) {
@@ -2302,7 +2300,6 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin {
 
   @override
   void didChangeDependencies() {
-
     final MediaQueryData mediaQuery = MediaQuery.of(context);
     // If we transition from accessible navigation to non-accessible navigation
     // and there is a SnackBar that would have timed out that has already

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -117,8 +117,11 @@ class ScaffoldMessengerState extends State<ScaffoldMessenger> {
   void _handleSnackBarStatusChange(AnimationStatus status) {
     switch (status) {
       case AnimationStatus.dismissed:
-        assert(_snackBars.isNotEmpty);
+        if (_snackBars.isNotEmpty)
           _snackBars.removeFirst();
+        // If there is another Scaffold in the stack presenting a SnackBar, we
+        // want to make sure it has been dismissed too.
+        hideCurrentSnackBar();
         break;
       case AnimationStatus.completed:
       case AnimationStatus.forward:

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -29,6 +29,7 @@ const Duration _snackBarDisplayDuration = Duration(milliseconds: 4000);
 const Curve _snackBarHeightCurve = Curves.fastOutSlowIn;
 const Curve _snackBarFadeInCurve = Interval(0.45, 1.0, curve: Curves.fastOutSlowIn);
 const Curve _snackBarFadeOutCurve = Interval(0.72, 1.0, curve: Curves.fastOutSlowIn);
+const String _snackBarHeroTag = '<SnackBar Hero Tag>';
 
 /// Specify how a [SnackBar] was closed.
 ///
@@ -375,7 +376,7 @@ class _SnackBarState extends State<SnackBar> {
       reverseCurve: const Threshold(0.0),
     );
 
-    Widget snackBar = SafeArea(
+    Widget snackBar = Hero(tag: _snackBarHeroTag, child: SafeArea(
       top: false,
       bottom: !isFloatingSnackBar,
       child: Row(
@@ -402,7 +403,7 @@ class _SnackBarState extends State<SnackBar> {
             SizedBox(width: snackBarPadding),
         ],
       ),
-    );
+    ));
 
     final double elevation = widget.elevation ?? snackBarTheme.elevation ?? 6.0;
     final Color backgroundColor = widget.backgroundColor ?? snackBarTheme.backgroundColor ?? inverseTheme.backgroundColor;


### PR DESCRIPTION
## Description

WIP

Sample API Usage:

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(new MaterialApp(
    routes: <String, WidgetBuilder>{
      '/': (BuildContext context) => HomePage(),
      '/second': (BuildContext context) => SecondPage(),
    },
  ));
}

class HomePage extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(title: Text('Home')),
      body: HomeBody(),
      floatingActionButton: FloatingActionButton(
        onPressed: () async {
          // --------------------------------------------------------------------------------
          ScaffoldMessengerState scaffoldMessenger = ScaffoldMessenger.of(context);
          // Invoke ScaffoldMessenger to show SnackBar across other Scaffolds.
          await Future.delayed(Duration(seconds: 5));
          scaffoldMessenger.showSnackBar(
            const SnackBar(content: Text('Snack-tastic')),
          );
          // Eventually, should also be able to:
          //  - showDialog [Alert, Simple, Pickers]
          //  - push routes
          // --------------------------------------------------------------------------------
        },
        // Press GO on HomePage before navigating to another route
        child: const Text('GO!'),
      ),
    );
  }
}

class HomeBody extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return Center(
      child: Column(
        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
        children: [
          Expanded(child: Container()),
          Text('Press GO before proceeding to Page 2'),
          Container(height: 100),
          RaisedButton(
            child: Text('push Page 2'),
            onPressed: () {
              Navigator.of(context).pushNamed('/second');
            },
          ),
          Container(height: 50),
          RaisedButton(
            child: Text('popAndPush Page 2'),
            onPressed: () {
              Navigator.of(context).popAndPushNamed('/second');
            },
          ),
          Container(height: 50),
          RaisedButton(
            child: Text('pushReplacement Page 2'),
            onPressed: () {
              Navigator.of(context).pushReplacementNamed('/second');
            },
          ),
          Expanded(child: Container(), flex: 2),
        ],
      ),
    );
  }
}

class SecondPage extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    bool canPop = ModalRoute.of(context)?.canPop ?? false;
    return Scaffold(
      appBar: AppBar(title: Text('Second')),
      body: Center(child: Column(
        mainAxisAlignment: MainAxisAlignment.center,
        children: [
          Text('Second Page'),
          if (!canPop) RaisedButton(
            child: Text('Start Over'),
            onPressed: () {
              Navigator.of(context).pushReplacementNamed('/');
            },
          )
        ],
      ))
    );
  }
}
```

## Related Issues

WIP

## Tests

WIP

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
