### PR TITLE
Add a flag to toggle navigator route update reporting

### DIFF
--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1308,6 +1308,7 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
           },
         onUnknownRoute: _onUnknownRoute,
         observers: widget.navigatorObservers,
+        reportsRouteUpdateToEngine: true,
       );
     }
 

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -1397,11 +1397,13 @@ class Navigator extends StatefulWidget {
     this.onGenerateRoute,
     this.onUnknownRoute,
     this.transitionDelegate = const DefaultTransitionDelegate<dynamic>(),
+    this.reportsRouteUpdateToEngine = false,
     this.observers = const <NavigatorObserver>[],
   }) : assert(pages != null),
        assert(onGenerateInitialRoutes != null),
        assert(transitionDelegate != null),
        assert(observers != null),
+       assert(reportsRouteUpdateToEngine != null),
        super(key: key);
 
   /// The list of pages with which to populate the history.
@@ -1496,6 +1498,15 @@ class Navigator extends StatefulWidget {
   /// The callback must return a list of [Route] objects with which the history
   /// will be primed.
   final RouteListFactory onGenerateInitialRoutes;
+
+  /// Whether this navigator should report route update message back to the
+  /// engine when the top-most route changes.
+  ///
+  /// If the property is set to true, this navigator automatically sends the
+  /// route update message to the engine when it detects top-most route changes.
+  ///
+  /// Defaults to false.
+  final bool reportsRouteUpdateToEngine;
 
   /// Push a named route onto the navigator that most tightly encloses the given
   /// context.
@@ -3240,11 +3251,15 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin {
     _flushRouteAnnouncement();
 
     // Announces route name changes.
-    final _RouteEntry lastEntry = _history.lastWhere(_RouteEntry.isPresentPredicate, orElse: () => null);
-    final String routeName = lastEntry?.route?.settings?.name;
-    if (routeName != _lastAnnouncedRouteName) {
-      RouteNotificationMessages.maybeNotifyRouteChange(routeName, _lastAnnouncedRouteName);
-      _lastAnnouncedRouteName = routeName;
+    if (widget.reportsRouteUpdateToEngine) {
+      final _RouteEntry lastEntry = _history.lastWhere(
+        _RouteEntry.isPresentPredicate, orElse: () => null);
+      final String routeName = lastEntry?.route?.settings?.name;
+      if (routeName != _lastAnnouncedRouteName) {
+        RouteNotificationMessages.maybeNotifyRouteChange(
+          routeName, _lastAnnouncedRouteName);
+        _lastAnnouncedRouteName = routeName;
+      }
     }
 
     // Lastly, removes the overlay entries of all marked entries and disposes

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -1504,6 +1504,13 @@ class Navigator extends StatefulWidget {
   ///
   /// If the property is set to true, this navigator automatically sends the
   /// route update message to the engine when it detects top-most route changes.
+  /// The messages are used by the web engine to update the browser URL bar.
+  ///
+  /// If there are multiple navigators in the widget tree, at most one of them
+  /// can set this property to true (typically, the top-most one created from
+  /// the [WidgetsApp]). Otherwise, the web engine may receive multiple route
+  /// update messages from different navigators and fail to update the URL
+  /// bar.
   ///
   /// Defaults to false.
   final bool reportsRouteUpdateToEngine;

--- a/packages/flutter/test/widgets/route_notification_messages_test.dart
+++ b/packages/flutter/test/widgets/route_notification_messages_test.dart
@@ -103,6 +103,48 @@ void main() {
         ));
   });
 
+  testWidgets('Navigator does not report route name by default', (WidgetTester tester) async {
+    final List<MethodCall> log = <MethodCall>[];
+    SystemChannels.navigation.setMockMethodCallHandler((MethodCall methodCall) async {
+      log.add(methodCall);
+    });
+
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: Navigator(
+        pages: <Page<void>>[
+          TransitionBuilderPage<void>(
+            name: '/',
+            pageBuilder: (BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) => const Placeholder(),
+          ),
+        ],
+        onPopPage: (Route<void> route, void result) => false,
+      )
+    ));
+
+    expect(log, hasLength(0));
+
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: Navigator(
+        pages: <Page<void>>[
+          TransitionBuilderPage<void>(
+            name: '/',
+            pageBuilder: (BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) => const Placeholder(),
+          ),
+          TransitionBuilderPage<void>(
+            name: '/abc',
+            pageBuilder: (BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) => const Placeholder(),
+          ),
+        ],
+        onPopPage: (Route<void> route, void result) => false,
+      )
+    ));
+
+    await tester.pumpAndSettle();
+    expect(log, hasLength(0));
+  });
+
   testWidgets('Replace should send platform messages', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
       '/': (BuildContext context) => OnTapPage(


### PR DESCRIPTION
## Description

The navigator reports route update back to engine when the top most route changes. This may become a problem when there are multiple navigators in the app, and it will also conflicting with the route widget.

## Related Issues

https://github.com/flutter/flutter/issues/45938

## Tests

I added the following tests:
see files

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
