### PR TITLE
Take screenshots of wirelessly paired iOS devices

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -509,11 +509,11 @@ class IOSDevice extends Device {
   void clearLogs() { }
 
   @override
-  bool get supportsScreenshot => _iMobileDevice.isInstalled && interfaceType == IOSDeviceInterface.usb;
+  bool get supportsScreenshot => _iMobileDevice.isInstalled;
 
   @override
   Future<void> takeScreenshot(File outputFile) async {
-    await _iMobileDevice.takeScreenshot(outputFile, id);
+    await _iMobileDevice.takeScreenshot(outputFile, id, interfaceType);
   }
 
   @override

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -24,6 +24,7 @@ import '../macos/xcode.dart';
 import '../project.dart';
 import '../reporting/reporting.dart';
 import 'code_signing.dart';
+import 'devices.dart';
 import 'migrations/ios_migrator.dart';
 import 'migrations/project_base_configuration_migration.dart';
 import 'migrations/remove_framework_link_and_embedding_migration.dart';
@@ -66,13 +67,19 @@ class IMobileDevice {
   }
 
   /// Captures a screenshot to the specified outputFile.
-  Future<void> takeScreenshot(File outputFile, String deviceID) {
+  Future<void> takeScreenshot(
+    File outputFile,
+    String deviceID,
+    IOSDeviceInterface interfaceType,
+  ) {
     return _processUtils.run(
       <String>[
         _idevicescreenshotPath,
         outputFile.path,
         '--udid',
         deviceID,
+        if (interfaceType == IOSDeviceInterface.network)
+          '--network',
       ],
       throwOnError: true,
       environment: Map<String, String>.fromEntries(

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -14,6 +14,7 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/ios/devices.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/project.dart';
@@ -85,10 +86,14 @@ void main() {
           logger: logger,
         );
 
-        expect(() async => await iMobileDevice.takeScreenshot(mockOutputFile, '1234'), throwsA(anything));
+        expect(() async => await iMobileDevice.takeScreenshot(
+          mockOutputFile,
+          '1234',
+          IOSDeviceInterface.usb,
+        ), throwsA(anything));
       });
 
-      testWithoutContext('idevicescreenshot captures and returns screenshot', () async {
+      testWithoutContext('idevicescreenshot captures and returns USB screenshot', () async {
         when(mockOutputFile.path).thenReturn(outputPath);
         when(mockProcessManager.run(any, environment: anyNamed('environment'), workingDirectory: null)).thenAnswer(
             (Invocation invocation) => Future<ProcessResult>.value(ProcessResult(4, 0, '', '')));
@@ -100,10 +105,37 @@ void main() {
           logger: logger,
         );
 
-        await iMobileDevice.takeScreenshot(mockOutputFile, '1234');
+        await iMobileDevice.takeScreenshot(
+          mockOutputFile,
+          '1234',
+          IOSDeviceInterface.usb,
+        );
         verify(mockProcessManager.run(<String>[idevicescreenshotPath, outputPath, '--udid', '1234'],
             environment: <String, String>{'DYLD_LIBRARY_PATH': libimobiledevicePath},
             workingDirectory: null,
+        ));
+      });
+
+      testWithoutContext('idevicescreenshot captures and returns network screenshot', () async {
+        when(mockOutputFile.path).thenReturn(outputPath);
+        when(mockProcessManager.run(any, environment: anyNamed('environment'), workingDirectory: null)).thenAnswer(
+            (Invocation invocation) => Future<ProcessResult>.value(ProcessResult(4, 0, '', '')));
+
+        final IMobileDevice iMobileDevice = IMobileDevice(
+          artifacts: mockArtifacts,
+          cache: mockCache,
+          processManager: mockProcessManager,
+          logger: logger,
+        );
+
+        await iMobileDevice.takeScreenshot(
+          mockOutputFile,
+          '1234',
+          IOSDeviceInterface.network,
+        );
+        verify(mockProcessManager.run(<String>[idevicescreenshotPath, outputPath, '--udid', '1234', '--network'],
+          environment: <String, String>{'DYLD_LIBRARY_PATH': libimobiledevicePath},
+          workingDirectory: null,
         ));
       });
     });


### PR DESCRIPTION
## Description

[idevicescreenshot 1.3.0](https://github.com/flutter/flutter/pull/59512) supports the `--network` flag to take screenshots of wirelessly paired iOS devices.  Pipe the flag through based on the detected device interface.

## Related Issues

Next part of #15072.

## Tests

`idevicescreenshot captures and returns network screenshot`

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*