### PR TITLE
[flutter_tools] fix crash if grouped doctor validator crashes

### DIFF
--- a/packages/flutter_tools/lib/src/reporting/events.dart
+++ b/packages/flutter_tools/lib/src/reporting/events.dart
@@ -103,11 +103,12 @@ class DoctorResultEvent extends UsageEvent {
   DoctorResultEvent({
     @required this.validator,
     @required this.result,
+    Usage flutterUsage,
   }) : super(
     'doctor-result',
     '${validator.runtimeType}',
     label: result.typeStr,
-    flutterUsage: globals.flutterUsage,
+    flutterUsage: flutterUsage ?? globals.flutterUsage,
   );
 
   final DoctorValidator validator;
@@ -121,9 +122,12 @@ class DoctorResultEvent extends UsageEvent {
     }
     final GroupedValidator group = validator as GroupedValidator;
     for (int i = 0; i < group.subValidators.length; i++) {
+      if (group.subResults == null) {
+        continue;
+      }
       final DoctorValidator v = group.subValidators[i];
       final ValidationResult r = group.subResults[i];
-      DoctorResultEvent(validator: v, result: r).send();
+      DoctorResultEvent(validator: v, result: r, flutterUsage: flutterUsage).send();
     }
   }
 }

--- a/packages/flutter_tools/lib/src/reporting/events.dart
+++ b/packages/flutter_tools/lib/src/reporting/events.dart
@@ -121,10 +121,12 @@ class DoctorResultEvent extends UsageEvent {
       return;
     }
     final GroupedValidator group = validator as GroupedValidator;
+    // The validator crashed.
+    if (group.subResults == null) {
+      flutterUsage.sendEvent(category, parameter, label: label);
+      return;
+    }
     for (int i = 0; i < group.subValidators.length; i++) {
-      if (group.subResults == null) {
-        continue;
-      }
       final DoctorValidator v = group.subValidators[i];
       final ValidationResult r = group.subResults[i];
       DoctorResultEvent(validator: v, result: r, flutterUsage: flutterUsage).send();

--- a/packages/flutter_tools/test/general.shard/reporting/events_test.dart
+++ b/packages/flutter_tools/test/general.shard/reporting/events_test.dart
@@ -48,7 +48,7 @@ void main() {
 
     expect(() => doctorResultEvent.send(), returnsNormally);
 
-    verifyNever(usage.sendEvent('doctor-result', any, label: anyNamed('label')));
+    verify(usage.sendEvent('doctor-result', any, label: anyNamed('label'))).called(1);
   });
 }
 

--- a/packages/flutter_tools/test/general.shard/reporting/events_test.dart
+++ b/packages/flutter_tools/test/general.shard/reporting/events_test.dart
@@ -1,0 +1,68 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tools/src/doctor.dart';
+import 'package:flutter_tools/src/reporting/reporting.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../src/common.dart';
+
+void main() {
+  testWithoutContext('DoctorResultEvent sends usage event for each sub validator', () async {
+    final Usage usage = MockUsage();
+    final GroupedValidator groupedValidator = FakeGroupedValidator(<DoctorValidator>[
+      FakeDoctorValidator('a'),
+      FakeDoctorValidator('b'),
+      FakeDoctorValidator('c'),
+    ]);
+    final ValidationResult result = await groupedValidator.validate();
+
+    final DoctorResultEvent doctorResultEvent = DoctorResultEvent(
+      validator: groupedValidator,
+      result: result,
+      flutterUsage: usage,
+    );
+
+    expect(() => doctorResultEvent.send(), returnsNormally);
+
+    verify(usage.sendEvent('doctor-result', any, label: anyNamed('label'))).called(3);
+  });
+
+  testWithoutContext('DoctorResultEvent does not crash if a synthetic crash result was used instead'
+    ' of validation. This happens when a grouped validator throws an exception, causing subResults to never '
+    ' be instantiated.', () async {
+    final Usage usage = MockUsage();
+    final GroupedValidator groupedValidator = FakeGroupedValidator(<DoctorValidator>[
+      FakeDoctorValidator('a'),
+      FakeDoctorValidator('b'),
+      FakeDoctorValidator('c'),
+    ]);
+    final ValidationResult result = ValidationResult.crash(Object());
+
+    final DoctorResultEvent doctorResultEvent = DoctorResultEvent(
+      validator: groupedValidator,
+      result: result,
+      flutterUsage: usage,
+    );
+
+    expect(() => doctorResultEvent.send(), returnsNormally);
+
+    verifyNever(usage.sendEvent('doctor-result', any, label: anyNamed('label')));
+  });
+}
+
+class FakeGroupedValidator extends GroupedValidator {
+  FakeGroupedValidator(List<DoctorValidator> subValidators) : super(subValidators);
+}
+
+class FakeDoctorValidator extends DoctorValidator {
+  FakeDoctorValidator(String title) : super(title);
+
+  @override
+  Future<ValidationResult> validate() async {
+    return ValidationResult.crash(Object());
+  }
+}
+
+class MockUsage extends Mock implements Usage {}


### PR DESCRIPTION
## Description

Crash report:

```
Thread 0 main thread CRASHEDNoSuchMethodError: NoSuchMethodError: The method '[]' was called on null.Receiver: nullTried calling: [](0)
at Object.noSuchMethod(object_patch.dart:51)
at DoctorResultEvent.send(events.dart:121)
at Doctor.diagnose(doctor.dart:317)
at <asynchronous gap>(async)
at DoctorCommand.runCommand(doctor.dart:59)
at FlutterCommand.verifyThenRunCommand(flutter_command.dart:844)
at _rootRunUnary(zone.dart:1198)
at _CustomZone.runUnary(zone.dart:1100)
at _FutureListener.handleValue(future_impl.dart:143)
at Future._propagateToListeners.handleValueCallback(future_impl.dart:696)
at Future._propagateToListeners(future_impl.dart:725)
at Future._completeWithValue(future_impl.dart:529)
at Future._asyncCompleteWithValue.<anonymous closure>(future_impl.dart:567)
at _rootRun(zone.dart:1190)
at _CustomZone.run(zone.dart:1093)
at _CustomZone.runGuarded(zone.dart:997)
at _CustomZone.bindCallbackGuarded.<anonymous closure>(zone.dart:1037)
at _microtaskLoop(schedule_microtask.dart:41)
at _startMicrotaskLoop(schedule_microtask.dart:50)
at _runPendingImmediateCallback(isolate_patch.dart:118)
at _RawReceivePortImpl._handleMessage(isolate_patch.dart:169)
```

Consider: https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/doctor.dart#L211

If a doctor validator crashes, the tool generates a synthetic crashed result and uses that to send analytics. Now reference https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/reporting/events.dart#L122

If analytics reporting is sent for a grouped validator we attempt to send events for each of the subvalidators. This relies on the  subResults field being populated, however this is null until all of the validators have finished - leading to and NPE when in this case.

Update the DoctorUsageEvent to check for this case and ensure a crash response is sent.