### PR TITLE
In layers_test create a canvas to start recording on the PictureRecorder

### DIFF
--- a/packages/flutter/test/rendering/layers_test.dart
+++ b/packages/flutter/test/rendering/layers_test.dart
@@ -277,6 +277,7 @@ void main() {
     final PictureLayer pictureLayer = PictureLayer(Rect.zero);
     checkNeedsAddToScene(pictureLayer, () {
       final PictureRecorder recorder = PictureRecorder();
+      Canvas(recorder);
       pictureLayer.picture = recorder.endRecording();
     });
 


### PR DESCRIPTION
A PictureRecorder does not start recording until it is used to construct
a Canvas.  The engine API will soon change to throw an exception if
endRecording is called on a PictureRecorder that is not recording.