### PR TITLE
await TimelineSummary.write***ToFile

### DIFF
--- a/dev/benchmarks/complex_layout/test_driver/scroll_perf_test.dart
+++ b/dev/benchmarks/complex_layout/test_driver/scroll_perf_test.dart
@@ -50,8 +50,8 @@ void main() {
       });
 
       final TimelineSummary summary = TimelineSummary.summarize(timeline);
-      summary.writeSummaryToFile(summaryName, pretty: true);
-      summary.writeTimelineToFile(summaryName, pretty: true);
+      await summary.writeSummaryToFile(summaryName, pretty: true);
+      await summary.writeTimelineToFile(summaryName, pretty: true);
     }
 
     test('complex_layout_scroll_perf', () async {

--- a/dev/benchmarks/macrobenchmarks/test_driver/util.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/util.dart
@@ -53,10 +53,10 @@ void macroPerfTest(
       await durationFuture;
     });
 
-    final TimelineSummary summary = TimelineSummary.summarize(timeline);
-    summary.writeSummaryToFile(testName, pretty: true);
-    summary.writeTimelineToFile(testName, pretty: true);
-
     driver.close();
+
+    final TimelineSummary summary = TimelineSummary.summarize(timeline);
+    await summary.writeSummaryToFile(testName, pretty: true);
+    await summary.writeTimelineToFile(testName, pretty: true);
   }, timeout: Timeout(timeout));
 }

--- a/dev/benchmarks/platform_views_layout/test_driver/scroll_perf_test.dart
+++ b/dev/benchmarks/platform_views_layout/test_driver/scroll_perf_test.dart
@@ -50,8 +50,8 @@ void main() {
       });
 
       final TimelineSummary summary = TimelineSummary.summarize(timeline);
-      summary.writeSummaryToFile(summaryName, pretty: true);
-      summary.writeTimelineToFile(summaryName, pretty: true);
+      await summary.writeSummaryToFile(summaryName, pretty: true);
+      await summary.writeTimelineToFile(summaryName, pretty: true);
     }
 
     test('platform_views_scroll_perf', () async {

--- a/dev/benchmarks/test_apps/stocks/test_driver/scroll_perf_test.dart
+++ b/dev/benchmarks/test_apps/stocks/test_driver/scroll_perf_test.dart
@@ -40,8 +40,8 @@ void main() {
       });
 
       final TimelineSummary summary = TimelineSummary.summarize(timeline);
-      summary.writeSummaryToFile('stocks_scroll_perf', pretty: true);
-      summary.writeTimelineToFile('stocks_scroll_perf', pretty: true);
+      await summary.writeSummaryToFile('stocks_scroll_perf', pretty: true);
+      await summary.writeTimelineToFile('stocks_scroll_perf', pretty: true);
     });
   });
 }

--- a/dev/integration_tests/flutter_gallery/test_driver/scroll_perf_test.dart
+++ b/dev/integration_tests/flutter_gallery/test_driver/scroll_perf_test.dart
@@ -43,9 +43,9 @@ void main() {
         }
       });
 
-      TimelineSummary.summarize(timeline)
-        ..writeSummaryToFile('home_scroll_perf', pretty: true)
-        ..writeTimelineToFile('home_scroll_perf', pretty: true);
+      final TimelineSummary summary = TimelineSummary.summarize(timeline);
+      await summary.writeSummaryToFile('home_scroll_perf', pretty: true);
+      await summary.writeTimelineToFile('home_scroll_perf', pretty: true);
     });
   });
 }


### PR DESCRIPTION
## Description

`TimelineSummary.writeSummaryToFile` and `TimelineSummary.writeTimelineToFile` are async IO method, but in many of our use cases they are not awaited, but rely on zone to await when exit. This PR await them explicitly. 

In the unit test case of `TimelineSummary` they are awaited, so this most likely happened when we switched from sync IO to async IO. 

## Related Issues

N/A

## Tests

N/A

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
