### PR TITLE
Serialize pointer event

### DIFF
--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -4,7 +4,7 @@
 
 // @dart = 2.8
 
-import 'dart:convert' show JsonUnsupportedObjectError;
+import 'dart:convert' show json, JsonUnsupportedObjectError;
 import 'dart:ui' show Offset, PointerDeviceKind;
 
 import 'package:flutter/foundation.dart';
@@ -234,36 +234,39 @@ abstract class PointerEvent with Diagnosticable {
        localDelta = localDelta ?? delta;
 
   /// Deserialize a PointerEvent from json
-  factory PointerEvent.fromJson(Map<String, dynamic> jsonObject) {
+  factory PointerEvent.fromJson(dynamic value) {
+    assert(value is Map<String, dynamic> || value is String);
+    final Map<String, dynamic> jsonObject = value is String
+      ? json.decode(value) as Map<String, dynamic>
+      : value as Map<String, dynamic>;
     switch (jsonObject['type'] as String) {
       case 'PointerAddedEvent':
-        return PointerAddedEvent._fromJson(jsonObject);
+        return PointerAddedEvent._deserialize(jsonObject);
       case 'PointerCancelEvent':
-        return PointerCancelEvent._fromJson(jsonObject);
+        return PointerCancelEvent._deserialize(jsonObject);
       case 'PointerDownEvent':
-        return PointerDownEvent._fromJson(jsonObject);
+        return PointerDownEvent._deserialize(jsonObject);
       case 'PointerEnterEvent':
-        return PointerEnterEvent._fromJson(jsonObject);
+        return PointerEnterEvent._deserialize(jsonObject);
       case 'PointerExitEvent':
-        return PointerExitEvent._fromJson(jsonObject);
+        return PointerExitEvent._deserialize(jsonObject);
       case 'PointerHoverEvent':
-        return PointerHoverEvent._fromJson(jsonObject);
+        return PointerHoverEvent._deserialize(jsonObject);
       case 'PointerMoveEvent':
-        return PointerMoveEvent._fromJson(jsonObject);
+        return PointerMoveEvent._deserialize(jsonObject);
       case 'PointerRemovedEvent':
-        return PointerRemovedEvent._fromJson(jsonObject);
+        return PointerRemovedEvent._deserialize(jsonObject);
       case 'PointerScrollEvent':
-        return PointerScrollEvent._fromJson(jsonObject);
+        return PointerScrollEvent._deserialize(jsonObject);
       case 'PointerUpEvent':
-        return PointerUpEvent._fromJson(jsonObject);
+        return PointerUpEvent._deserialize(jsonObject);
       default:
         throw JsonUnsupportedObjectError(jsonObject);
     }
   }
 
-  /// Deserialize a PointerEvent from json for internal use
   @protected
-  PointerEvent.serialize(Map<String, dynamic> jsonObject) :
+  PointerEvent._deserialize(Map<String, dynamic> jsonObject) :
     timeStamp = Duration(microseconds: jsonObject['timeStamp'] as int ?? 0),
     pointer = jsonObject['pointer'] as int ?? 0,
     kind = PointerDeviceKind.values[jsonObject['kind'] as int ?? 0],
@@ -296,8 +299,9 @@ abstract class PointerEvent with Diagnosticable {
       : Matrix4.fromList(jsonObject['transform'] as List<double>),
     original = null;
 
-  /// Serialize the event tto a json strong.
+  /// Serialize the event to a json object.
   Map<String, dynamic> toJson () {
+    // TODO(CareF): provide a warning message when original is not null.
     return <String,dynamic>{
       'type': runtimeType.toString(),
       if(timeStamp != Duration.zero) 'timeStamp': timeStamp.inMicroseconds,
@@ -326,7 +330,6 @@ abstract class PointerEvent with Diagnosticable {
       if(platformData != 0.0) 'platformData': platformData,
       if(synthesized != false) 'synthesized': synthesized,
       if(transform != null) 'transform': transform.storage,
-      // TODO(CareF): original may be replaced by an id number.
     };
   }
 
@@ -709,7 +712,8 @@ class PointerAddedEvent extends PointerEvent {
          original: original,
        );
 
-  PointerAddedEvent._fromJson(Map<String, dynamic> jsonObject) : super.serialize(jsonObject);
+  @override
+  PointerAddedEvent._deserialize(Map<String, dynamic> jsonObject) : super._deserialize(jsonObject);
 
   @override
   PointerAddedEvent transformed(Matrix4 transform) {
@@ -776,7 +780,8 @@ class PointerRemovedEvent extends PointerEvent {
          original: original,
        );
 
-  PointerRemovedEvent._fromJson(Map<String, dynamic> jsonObject): super.serialize(jsonObject);
+  @override
+  PointerRemovedEvent._deserialize(Map<String, dynamic> jsonObject): super._deserialize(jsonObject);
 
   @override
   PointerRemovedEvent transformed(Matrix4 transform) {
@@ -867,7 +872,8 @@ class PointerHoverEvent extends PointerEvent {
          original: original,
        );
 
-  PointerHoverEvent._fromJson(Map<String, dynamic> jsonObject): super.serialize(jsonObject);
+  @override
+  PointerHoverEvent._deserialize(Map<String, dynamic> jsonObject): super._deserialize(jsonObject);
 
   @override
   PointerHoverEvent transformed(Matrix4 transform) {
@@ -975,7 +981,8 @@ class PointerEnterEvent extends PointerEvent {
          original: original,
        );
 
-  PointerEnterEvent._fromJson(Map<String, dynamic> jsonObject): super.serialize(jsonObject);
+  @override
+  PointerEnterEvent._deserialize(Map<String, dynamic> jsonObject): super._deserialize(jsonObject);
 
   /// Creates an enter event from a [PointerHoverEvent].
   ///
@@ -1123,7 +1130,8 @@ class PointerExitEvent extends PointerEvent {
          original: original,
        );
 
-  PointerExitEvent._fromJson(Map<String, dynamic> jsonObject): super.serialize(jsonObject);
+  @override
+  PointerExitEvent._deserialize(Map<String, dynamic> jsonObject): super._deserialize(jsonObject);
 
   /// Creates an exit event from a [PointerHoverEvent].
   ///
@@ -1257,7 +1265,8 @@ class PointerDownEvent extends PointerEvent {
          original: original,
        );
 
-  PointerDownEvent._fromJson(Map<String, dynamic> jsonObject): super.serialize(jsonObject);
+  @override
+  PointerDownEvent._deserialize(Map<String, dynamic> jsonObject): super._deserialize(jsonObject);
 
   @override
   PointerDownEvent transformed(Matrix4 transform) {
@@ -1357,7 +1366,8 @@ class PointerMoveEvent extends PointerEvent {
          original: original,
        );
 
-  PointerMoveEvent._fromJson(Map<String, dynamic> jsonObject): super.serialize(jsonObject);
+  @override
+  PointerMoveEvent._deserialize(Map<String, dynamic> jsonObject): super._deserialize(jsonObject);
 
   @override
   PointerMoveEvent transformed(Matrix4 transform) {
@@ -1457,7 +1467,8 @@ class PointerUpEvent extends PointerEvent {
          original: original,
        );
 
-  PointerUpEvent._fromJson(Map<String, dynamic> jsonObject): super.serialize(jsonObject);
+  @override
+  PointerUpEvent._deserialize(Map<String, dynamic> jsonObject): super._deserialize(jsonObject);
 
   @override
   PointerUpEvent transformed(Matrix4 transform) {
@@ -1519,7 +1530,8 @@ abstract class PointerSignalEvent extends PointerEvent {
          original: original,
        );
 
-  PointerSignalEvent._fromJson(Map<String, dynamic> jsonObject): super.serialize(jsonObject);
+  @override
+  PointerSignalEvent._deserialize(Map<String, dynamic> jsonObject): super._deserialize(jsonObject);
 }
 
 /// The pointer issued a scroll event.
@@ -1554,9 +1566,10 @@ class PointerScrollEvent extends PointerSignalEvent {
          original: original,
        );
 
-  PointerScrollEvent._fromJson(Map<String, dynamic> jsonObject):
+  @override
+  PointerScrollEvent._deserialize(Map<String, dynamic> jsonObject):
     scrollDelta = _deserializeOffset(jsonObject['scrollDelta']),
-    super._fromJson(jsonObject);
+    super._deserialize(jsonObject);
 
   @override
   Map<String, dynamic> toJson() {
@@ -1645,7 +1658,8 @@ class PointerCancelEvent extends PointerEvent {
          original: original,
        );
 
-  PointerCancelEvent._fromJson(Map<String, dynamic> jsonObject): super.serialize(jsonObject);
+  @override
+  PointerCancelEvent._deserialize(Map<String, dynamic> jsonObject): super._deserialize(jsonObject);
 
   @override
   PointerCancelEvent transformed(Matrix4 transform) {

--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -4,6 +4,7 @@
 
 // @dart = 2.8
 
+import 'dart:convert' show JsonUnsupportedObjectError;
 import 'dart:ui' show Offset, PointerDeviceKind;
 
 import 'package:flutter/foundation.dart';
@@ -232,6 +233,102 @@ abstract class PointerEvent with Diagnosticable {
   }) : localPosition = localPosition ?? position,
        localDelta = localDelta ?? delta;
 
+  /// Deserialize a PointerEvent from json
+  factory PointerEvent.fromJson(Map<String, dynamic> jsonObject) {
+    switch (jsonObject['type'] as String) {
+      case 'PointerAddedEvent':
+        return PointerAddedEvent._fromJson(jsonObject);
+      case 'PointerCancelEvent':
+        return PointerCancelEvent._fromJson(jsonObject);
+      case 'PointerDownEvent':
+        return PointerDownEvent._fromJson(jsonObject);
+      case 'PointerEnterEvent':
+        return PointerEnterEvent._fromJson(jsonObject);
+      case 'PointerExitEvent':
+        return PointerExitEvent._fromJson(jsonObject);
+      case 'PointerHoverEvent':
+        return PointerHoverEvent._fromJson(jsonObject);
+      case 'PointerMoveEvent':
+        return PointerMoveEvent._fromJson(jsonObject);
+      case 'PointerRemovedEvent':
+        return PointerRemovedEvent._fromJson(jsonObject);
+      case 'PointerScrollEvent':
+        return PointerScrollEvent._fromJson(jsonObject);
+      case 'PointerUpEvent':
+        return PointerUpEvent._fromJson(jsonObject);
+      default:
+        throw JsonUnsupportedObjectError(jsonObject);
+    }
+  }
+
+  /// Deserialize a PointerEvent from json for internal use
+  @protected
+  PointerEvent.serialize(Map<String, dynamic> jsonObject) :
+    timeStamp = Duration(microseconds: jsonObject['timeStamp'] as int ?? 0),
+    pointer = jsonObject['pointer'] as int ?? 0,
+    kind = PointerDeviceKind.values[jsonObject['kind'] as int ?? 0],
+    device = jsonObject['device'] as int ?? 0,
+    position = _deserializeOffset(jsonObject['position']),
+    localPosition = _deserializeOffset(jsonObject['localPosition'],
+      _deserializeOffset(jsonObject['position'])),
+    delta = _deserializeOffset(jsonObject['delta']),
+    localDelta = _deserializeOffset(jsonObject['localDelta'],
+      _deserializeOffset(jsonObject['delta'])),
+    buttons = jsonObject['buttons'] as int ?? 0,
+    down = jsonObject['down'] as bool ?? false,
+    obscured = jsonObject['obscured'] as bool ?? false,
+    pressure = jsonObject['pressure'] as double ?? 0.0,
+    pressureMin = jsonObject['pressureMin'] as double ?? 0.0,
+    pressureMax = jsonObject['pressureMax'] as double ?? 0.0,
+    distance = jsonObject['distance'] as double ?? 0.0,
+    distanceMax = jsonObject['distanceMax'] as double ?? 0.0,
+    size = jsonObject['size'] as double ?? 0.0,
+    radiusMajor = jsonObject['radiusMajor'] as double ?? 0.0,
+    radiusMinor = jsonObject['radiusMinor'] as double ?? 0.0,
+    radiusMin = jsonObject['radiusMin'] as double ?? 0.0,
+    radiusMax = jsonObject['radiusMax'] as double ?? 0.0,
+    orientation = jsonObject['orientation'] as double ?? 0.0,
+    tilt = jsonObject['tilt'] as double ?? 0.0,
+    platformData = jsonObject['platformData'] as int ?? 0,
+    synthesized = jsonObject['synthesized'] as bool ?? false,
+    transform = jsonObject['transform'] == null
+      ? null
+      : Matrix4.fromList(jsonObject['transform'] as List<double>),
+    original = null;
+
+  /// Serialize the event tto a json strong.
+  Map<String, dynamic> toJson () {
+    return <String,dynamic>{
+      'type': runtimeType.toString(),
+      if(timeStamp != Duration.zero) 'timeStamp': timeStamp.inMicroseconds,
+      if(pointer != 0) 'pointer': pointer,
+      if(kind != PointerDeviceKind.touch) 'kind': kind.index,
+      if(device != 0) 'device': device,
+      if(position != Offset.zero) 'position': <double>[position.dx, position.dy],
+      if(localPosition != position) 'localPosition': <double>[localPosition.dx, localPosition.dy],
+      if(delta != Offset.zero) 'delta': <double>[delta.dx, delta.dy],
+      if(localDelta != delta) 'localDelta': <double>[localDelta.dx, localDelta.dy],
+      if(buttons != 0) 'buttons': buttons,
+      if(down != false) 'down': down,
+      if(obscured != false) 'obscured': obscured,
+      if(pressure != 1.0) 'pressure': pressure,
+      if(pressureMin != 1.0) 'pressureMin': pressureMin,
+      if(pressureMax != 1.0) 'pressureMax': pressureMax,
+      if(distance != 0.0) 'distance': distance,
+      if(distanceMax != 0.0) 'distanceMax': distanceMax,
+      if(size != 0.0) 'size': size,
+      if(radiusMajor != 0.0) 'radiusMajor': radiusMajor,
+      if(radiusMinor != 0.0) 'radiusMinor': radiusMinor,
+      if(radiusMin != 0.0) 'radiusMin': radiusMin,
+      if(radiusMax != 0.0) 'radiusMax': radiusMax,
+      if(orientation != 0.0) 'orientation': orientation,
+      if(tilt != 0.0) 'tilt': tilt,
+      if(platformData != 0.0) 'platformData': platformData,
+      if(synthesized != false) 'synthesized': synthesized,
+      if(transform != null) 'transform': transform.storage,
+      // TODO(CareF): original may be replaced by an id number.
+    };
+  }
 
   /// Time of event dispatch, relative to an arbitrary timeline.
   final Duration timeStamp;
@@ -612,6 +709,8 @@ class PointerAddedEvent extends PointerEvent {
          original: original,
        );
 
+  PointerAddedEvent._fromJson(Map<String, dynamic> jsonObject) : super.serialize(jsonObject);
+
   @override
   PointerAddedEvent transformed(Matrix4 transform) {
     if (transform == null || transform == this.transform) {
@@ -676,6 +775,8 @@ class PointerRemovedEvent extends PointerEvent {
          transform: transform,
          original: original,
        );
+
+  PointerRemovedEvent._fromJson(Map<String, dynamic> jsonObject): super.serialize(jsonObject);
 
   @override
   PointerRemovedEvent transformed(Matrix4 transform) {
@@ -765,6 +866,8 @@ class PointerHoverEvent extends PointerEvent {
          transform: transform,
          original: original,
        );
+
+  PointerHoverEvent._fromJson(Map<String, dynamic> jsonObject): super.serialize(jsonObject);
 
   @override
   PointerHoverEvent transformed(Matrix4 transform) {
@@ -871,6 +974,8 @@ class PointerEnterEvent extends PointerEvent {
          transform: transform,
          original: original,
        );
+
+  PointerEnterEvent._fromJson(Map<String, dynamic> jsonObject): super.serialize(jsonObject);
 
   /// Creates an enter event from a [PointerHoverEvent].
   ///
@@ -1018,6 +1123,8 @@ class PointerExitEvent extends PointerEvent {
          original: original,
        );
 
+  PointerExitEvent._fromJson(Map<String, dynamic> jsonObject): super.serialize(jsonObject);
+
   /// Creates an exit event from a [PointerHoverEvent].
   ///
   /// Deprecated. Please use [PointerExitEvent.fromMouseEvent] instead.
@@ -1150,6 +1257,8 @@ class PointerDownEvent extends PointerEvent {
          original: original,
        );
 
+  PointerDownEvent._fromJson(Map<String, dynamic> jsonObject): super.serialize(jsonObject);
+
   @override
   PointerDownEvent transformed(Matrix4 transform) {
     if (transform == null || transform == this.transform) {
@@ -1247,6 +1356,8 @@ class PointerMoveEvent extends PointerEvent {
          transform: transform,
          original: original,
        );
+
+  PointerMoveEvent._fromJson(Map<String, dynamic> jsonObject): super.serialize(jsonObject);
 
   @override
   PointerMoveEvent transformed(Matrix4 transform) {
@@ -1346,6 +1457,8 @@ class PointerUpEvent extends PointerEvent {
          original: original,
        );
 
+  PointerUpEvent._fromJson(Map<String, dynamic> jsonObject): super.serialize(jsonObject);
+
   @override
   PointerUpEvent transformed(Matrix4 transform) {
     if (transform == null || transform == this.transform) {
@@ -1405,6 +1518,8 @@ abstract class PointerSignalEvent extends PointerEvent {
          transform: transform,
          original: original,
        );
+
+  PointerSignalEvent._fromJson(Map<String, dynamic> jsonObject): super.serialize(jsonObject);
 }
 
 /// The pointer issued a scroll event.
@@ -1438,6 +1553,17 @@ class PointerScrollEvent extends PointerSignalEvent {
          transform: transform,
          original: original,
        );
+
+  PointerScrollEvent._fromJson(Map<String, dynamic> jsonObject):
+    scrollDelta = _deserializeOffset(jsonObject['scrollDelta']),
+    super._fromJson(jsonObject);
+
+  @override
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> result = super.toJson();
+    result['scrollDelta'] = <double>[scrollDelta.dx, scrollDelta.dy];
+    return result;
+  }
 
   /// The amount to scroll, in logical pixels.
   final Offset scrollDelta;
@@ -1519,6 +1645,8 @@ class PointerCancelEvent extends PointerEvent {
          original: original,
        );
 
+  PointerCancelEvent._fromJson(Map<String, dynamic> jsonObject): super.serialize(jsonObject);
+
   @override
   PointerCancelEvent transformed(Matrix4 transform) {
     if (transform == null || transform == this.transform) {
@@ -1548,4 +1676,13 @@ class PointerCancelEvent extends PointerEvent {
       original: original as PointerCancelEvent ?? this,
     );
   }
+}
+
+Offset _deserializeOffset(dynamic value, [Offset defaultValue = Offset.zero]) {
+  if (value == null) {
+    return defaultValue;
+  }
+  final List<dynamic> coordinates = value as List<dynamic>;
+  assert(coordinates.length == 2);
+  return Offset(coordinates[0] as double, coordinates[1] as double);
 }

--- a/packages/flutter/test/gestures/events_test.dart
+++ b/packages/flutter/test/gestures/events_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 // @dart = 2.8
+import 'dart:convert';
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -497,6 +498,66 @@ void main() {
       transform: transform,
       localPosition: localPosition,
     );
+  });
+
+  test('Serialize and deserialize PointerEvent to/from json', (){
+    const PointerMoveEvent move = PointerMoveEvent(
+      timeStamp: Duration(seconds: 2),
+      pointer: 45,
+      kind: PointerDeviceKind.mouse,
+      device: 1,
+      position: Offset(20, 30),
+      delta: Offset(5, 5),
+      buttons: 4,
+      obscured: true,
+      pressure: 34,
+      pressureMin: 10,
+      pressureMax: 60,
+      distanceMax: 24,
+      size: 10,
+      radiusMajor: 33,
+      radiusMinor: 44,
+      radiusMin: 10,
+      radiusMax: 50,
+      orientation: 2,
+      tilt: 4,
+      platformData: 10,
+      synthesized: true,
+    );
+    final PointerEvent restoredMove = PointerEvent.fromJson(json.encode(move));
+    expect(restoredMove.runtimeType, PointerMoveEvent);
+    expect(restoredMove.timeStamp,    move.timeStamp);
+    expect(restoredMove.pointer,      move.pointer);
+    expect(restoredMove.kind,         move.kind);
+    expect(restoredMove.device,       move.device);
+    expect(restoredMove.position,     move.position);
+    expect(restoredMove.delta,        move.delta);
+    expect(restoredMove.buttons,      move.buttons);
+    expect(restoredMove.down,         move.down);
+    expect(restoredMove.obscured,     move.obscured);
+    expect(restoredMove.pressure,     move.pressure);
+    expect(restoredMove.pressureMin,  move.pressureMin);
+    expect(restoredMove.pressureMax,  move.pressureMax);
+    expect(restoredMove.distance,     move.distance);
+    expect(restoredMove.distanceMax,  move.distanceMax);
+    expect(restoredMove.size,         move.size);
+    expect(restoredMove.radiusMajor,  move.radiusMajor);
+    expect(restoredMove.radiusMinor,  move.radiusMinor);
+    expect(restoredMove.radiusMin,    move.radiusMin);
+    expect(restoredMove.radiusMax,    move.radiusMax);
+    expect(restoredMove.orientation,  move.orientation);
+    expect(restoredMove.tilt,         move.tilt);
+    expect(restoredMove.platformData, move.platformData);
+    expect(restoredMove.synthesized,  move.synthesized);
+    expect(restoredMove.original, null);
+
+    const PointerScrollEvent scroll = PointerScrollEvent(
+      scrollDelta: Offset(3, 4),
+    );
+    final PointerEvent restoredEvent = PointerEvent.fromJson(json.encode(scroll));
+    expect(restoredEvent.runtimeType, PointerScrollEvent);
+    final PointerScrollEvent restoredScroll = restoredEvent as PointerScrollEvent;
+    expect(restoredScroll.scrollDelta, scroll.scrollDelta);
   });
 }
 


### PR DESCRIPTION
## Description

This PR added serialize to and deserialize from json for `PointerEvent`
This is part of #60741, which provides use case.

## Related Issues

path to #60649 

## Tests

I added the following tests:

- `'Serialize and deserialize PointerEvent to/from json'` in `packages/flutter/test/gestures/events_test.dart `

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
