### PR TITLE
Add support in WidgetTester for an array of inputs

### DIFF
--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1216,7 +1216,6 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
     _timeoutStopwatch = null;
     _timeout = null;
   }
-
 }
 
 /// Available policies for how a [LiveTestWidgetsFlutterBinding] should paint

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -256,6 +256,13 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   // See AutomatedTestWidgetsFlutterBinding.addTime for an actual implementation.
   void addTime(Duration duration);
 
+  /// Execute a callback in a later time for the binding.
+  ///
+  /// If the binding comes with a fake clock, this will increase the clock by
+  /// `duration` and then execute the `body`, otherwise it will wait `duration`
+  /// and then execute the `body`.
+  Future<T> executeLater<T>(Duration duration, FutureOr<T> body());
+
   /// The value to set [debugCheckIntrinsicSizes] to while tests are running.
   ///
   /// This can be used to enable additional checks. For example,
@@ -1110,6 +1117,14 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   }
 
   @override
+  Future<T> executeLater<T>(Duration duration, FutureOr<T> body()) async {
+    assert(_currentFakeAsync != null);
+    addTime(duration);
+    _currentFakeAsync.elapse(duration);
+    return await body();
+  }
+
+  @override
   Future<void> runTest(
     Future<void> testBody(),
     VoidCallback invariantTester, {
@@ -1352,6 +1367,11 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   void addTime(Duration duration) {
     // We don't support timeouts on the LiveTestWidgetsFlutterBinding.
     // See runTest().
+  }
+
+  @override
+  Future<T> executeLater<T>(Duration duration, FutureOr<T> body()) {
+    return Future<T>.delayed(duration, body);
   }
 
   @override

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -256,12 +256,16 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   // See AutomatedTestWidgetsFlutterBinding.addTime for an actual implementation.
   void addTime(Duration duration);
 
-  /// Execute a callback in a later time for the binding.
+  /// Delay for `duration` of time.
   ///
-  /// If the binding comes with a fake clock, this will increase the clock by
-  /// `duration` and then execute the `body`, otherwise it will wait `duration`
-  /// and then execute the `body`.
-  Future<T> executeLater<T>(Duration duration, FutureOr<T> body());
+  /// In the automated test environment ([AutomatedTestWidgetsFlutterBinding],
+  /// typically used in `flutter test`), this advances the fake [clock] for the
+  /// period and also increases timeout (see [addTime]).
+  ///
+  /// In the live test environemnt ([LiveTestWidgetsFlutterBinding], typically
+  /// used for `flutter run` and for [e2e](https://pub.dev/packages/e2e)), it is
+  /// equivalent as [Future.delayed].
+  Future<void> delayed(Duration duration);
 
   /// The value to set [debugCheckIntrinsicSizes] to while tests are running.
   ///
@@ -1117,11 +1121,11 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   }
 
   @override
-  Future<T> executeLater<T>(Duration duration, FutureOr<T> body()) async {
+  Future<void> delayed(Duration duration) {
     assert(_currentFakeAsync != null);
     addTime(duration);
     _currentFakeAsync.elapse(duration);
-    return await body();
+    return Future<void>.value();
   }
 
   @override
@@ -1369,8 +1373,8 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   }
 
   @override
-  Future<T> executeLater<T>(Duration duration, FutureOr<T> body()) {
-    return Future<T>.delayed(duration, body);
+  Future<void> delayed(Duration duration) {
+    return Future<void>.delayed(duration);
   }
 
   @override

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1686,7 +1686,6 @@ class _LiveTestRenderView extends RenderView {
 
   final VoidCallback onNeedPaint;
 
-  // The class record pointers to draw positions of touch.
   final Map<int, _LiveTestPointerRecord> _pointers = <int, _LiveTestPointerRecord>{};
 
   TextPainter _label;

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1666,6 +1666,7 @@ class _LiveTestRenderView extends RenderView {
 
   final VoidCallback onNeedPaint;
 
+  // The class record pointers to draw positions of touch.
   final Map<int, _LiveTestPointerRecord> _pointers = <int, _LiveTestPointerRecord>{};
 
   TextPainter _label;

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -400,6 +400,12 @@ abstract class WidgetController {
     });
   }
 
+  /// A simulator of how the framework handles a serials of [PointerEvent]s
+  /// received from the flutter engine.
+  ///
+  /// See [PointerEventPack].
+  Future<void> handlePointerEventPack(List<PointerEventPack> records);
+
   /// Called to indicate that time should advance.
   ///
   /// This is invoked by [flingFrom], for instance, so that the sequence of
@@ -678,5 +684,10 @@ class LiveWidgetController extends WidgetController {
       await Future<void>.delayed(duration);
     binding.scheduleFrame();
     await binding.endOfFrame;
+  }
+
+  @override
+  Future<void> handlePointerEventPack(List<PointerEventPack> records) {
+    throw UnimplementedError;
   }
 }

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -400,10 +400,10 @@ abstract class WidgetController {
     });
   }
 
-  /// A simulator of how the framework handles a serials of [PointerEvent]s
-  /// received from the flutter engine.
+  /// A simulator of how the framework handles a series of [PointerEvent]s
+  /// received from the Flutter engine.
   ///
-  /// The [PointerEventPacket.timeStamp] is used for time delay of an event
+  /// The [PointerEventPacket.timeStamp] is used as the time delay of an event
   /// packet relative to the starting point of the method call.
   ///
   /// Returns a list of the difference between [PointerEventPacket.timeStamp]

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -403,15 +403,15 @@ abstract class WidgetController {
   /// A simulator of how the framework handles a series of [PointerEvent]s
   /// received from the Flutter engine.
   ///
-  /// The [PointerEventPacket.timeStamp] is used as the time delay of an event
-  /// packet relative to the starting point of the method call.
+  /// The [PointerEventRecord.timeStamp] is used as the time delay of the events
+  /// injection relative to the starting point of the method call.
   ///
-  /// Returns a list of the difference between [PointerEventPacket.timeStamp]
-  /// and the real timestamp when the event packet is processed. The closer
+  /// Returns a list of the difference between [PointerEventRecord.timeStamp]
+  /// and the real timestamp when the event record is processed. The closer
   /// these values are to zero the more faithful it is to the `records`.
   ///
-  /// See [PointerEventPacket].
-  Future<List<Duration>> handlePointerEventPacket(List<PointerEventPacket> packets);
+  /// See [PointerEventRecord].
+  Future<List<Duration>> handlePointerEventRecord(List<PointerEventRecord> records);
 
   /// Called to indicate that time should advance.
   ///
@@ -694,7 +694,7 @@ class LiveWidgetController extends WidgetController {
   }
 
   @override
-  Future<List<Duration>> handlePointerEventPacket(List<PointerEventPacket> packets) {
+  Future<List<Duration>> handlePointerEventRecord(List<PointerEventRecord> records) {
     // TODO(CareF): This will be implemented after we decide what should be the
     // correct pumping strategy.
     throw UnimplementedError;

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -411,7 +411,7 @@ abstract class WidgetController {
   /// these values are to zero the more faithful it is to the `records`.
   ///
   /// See [PointerEventPacket].
-  Future<List<Duration>> handlePointerEventPack(List<PointerEventPacket> records);
+  Future<List<Duration>> handlePointerEventPacket(List<PointerEventPacket> packet);
 
   /// Called to indicate that time should advance.
   ///
@@ -694,7 +694,7 @@ class LiveWidgetController extends WidgetController {
   }
 
   @override
-  Future<List<Duration>> handlePointerEventPack(List<PointerEventPacket> records) {
+  Future<List<Duration>> handlePointerEventPacket(List<PointerEventPacket> packet) {
     throw UnimplementedError;
   }
 }

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -403,12 +403,13 @@ abstract class WidgetController {
   /// A simulator of how the framework handles a series of [PointerEvent]s
   /// received from the Flutter engine.
   ///
-  /// The [PointerEventRecord.timeStamp] is used as the time delay of the events
+  /// The [PointerEventRecord.timeDelay] is used as the time delay of the events
   /// injection relative to the starting point of the method call.
   ///
-  /// Returns a list of the difference between [PointerEventRecord.timeStamp]
-  /// and the real timestamp when the event record is processed. The closer
-  /// these values are to zero the more faithful it is to the `records`.
+  /// Returns a list of the difference between [PointerEventRecord.timeDelay]
+  /// and the real delay time when the [PointerEventRecord.events] are processed.
+  /// The closer these values are to zero the more faithful it is to the
+  /// `records`.
   ///
   /// See [PointerEventRecord].
   Future<List<Duration>> handlePointerEventRecord(List<PointerEventRecord> records);

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -411,7 +411,7 @@ abstract class WidgetController {
   /// these values are to zero the more faithful it is to the `records`.
   ///
   /// See [PointerEventPacket].
-  Future<List<Duration>> handlePointerEventPacket(List<PointerEventPacket> packet);
+  Future<List<Duration>> handlePointerEventPacket(List<PointerEventPacket> packets);
 
   /// Called to indicate that time should advance.
   ///
@@ -694,7 +694,9 @@ class LiveWidgetController extends WidgetController {
   }
 
   @override
-  Future<List<Duration>> handlePointerEventPacket(List<PointerEventPacket> packet) {
+  Future<List<Duration>> handlePointerEventPacket(List<PointerEventPacket> packets) {
+    // TODO(CareF): This will be implemented after we decide what should be the
+    // correct pumping strategy.
     throw UnimplementedError;
   }
 }

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -403,8 +403,15 @@ abstract class WidgetController {
   /// A simulator of how the framework handles a serials of [PointerEvent]s
   /// received from the flutter engine.
   ///
-  /// See [PointerEventPack].
-  Future<void> handlePointerEventPack(List<PointerEventPack> records);
+  /// The [PointerEventPacket.timeStamp] is used for time delay of an event
+  /// packet relative to the starting point of the method call.
+  ///
+  /// Returns a list of the difference between [PointerEventPacket.timeStamp]
+  /// and the real timestamp when the event packet is processed. The closer
+  /// these values are to zero the more faithful it is to the `records`.
+  ///
+  /// See [PointerEventPacket].
+  Future<List<Duration>> handlePointerEventPack(List<PointerEventPacket> records);
 
   /// Called to indicate that time should advance.
   ///
@@ -687,7 +694,7 @@ class LiveWidgetController extends WidgetController {
   }
 
   @override
-  Future<void> handlePointerEventPack(List<PointerEventPack> records) {
+  Future<List<Duration>> handlePointerEventPack(List<PointerEventPacket> records) {
     throw UnimplementedError;
   }
 }

--- a/packages/flutter_test/lib/src/test_pointer.dart
+++ b/packages/flutter_test/lib/src/test_pointer.dart
@@ -438,7 +438,7 @@ class TestGesture {
   }
 }
 
-/// A pack of input PointerEvent queue.
+/// A packet of input PointerEvent queue.
 ///
 /// [timeStamp] is used to indicate the time when the pack is received.
 ///
@@ -451,7 +451,7 @@ class PointerEventPacket {
   /// The time stamp of when the event packet is received.
   ///
   /// This value is used as the time delay relative to the start of
-  /// [WidgeTester.handlePointerEventPack] call.
+  /// [WidgetTester.handlePointerEventPacket] call.
   final Duration timeStamp;
 
   /// The event.

--- a/packages/flutter_test/lib/src/test_pointer.dart
+++ b/packages/flutter_test/lib/src/test_pointer.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -436,4 +437,21 @@ class TestGesture {
       _result = null;
     });
   }
+}
+
+/// A pack of input PointerEvent queue.
+///
+/// [timeStamp] is used to indicate the time when the pack is received.
+///
+/// This is a simulation of how the framework is receiving input events from
+/// the engine. See [GestureBinding] and [PointerDataPacket].
+class PointerEventPack {
+  /// Creates a pack of PointerEvents.
+  PointerEventPack(this.timeStamp, this.events);
+
+  /// The time stamp of when the event happens
+  final Duration timeStamp;
+
+  /// The event.
+  final List<PointerEvent> events;
 }

--- a/packages/flutter_test/lib/src/test_pointer.dart
+++ b/packages/flutter_test/lib/src/test_pointer.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';

--- a/packages/flutter_test/lib/src/test_pointer.dart
+++ b/packages/flutter_test/lib/src/test_pointer.dart
@@ -441,19 +441,20 @@ class TestGesture {
 /// A record of input [PointerEvent] list with the timeStamp of when it is
 /// injected.
 ///
-/// The [timeStamp] is used to indicate the time when the pack is received.
+/// The [timeDelay] is used to indicate the time when the event packet should
+/// be sent.
 ///
 /// This is a simulation of how the framework is receiving input events from
 /// the engine. See [GestureBinding] and [PointerDataPacket].
 class PointerEventRecord {
   /// Creates a pack of [PointerEvent]s.
-  PointerEventRecord(this.timeStamp, this.events);
+  PointerEventRecord(this.timeDelay, this.events);
 
-  /// The time stamp of when the event record is received.
+  /// The time delay of when the event record should be sent.
   ///
   /// This value is used as the time delay relative to the start of
   /// [WidgetTester.handlePointerEventRecord] call.
-  final Duration timeStamp;
+  final Duration timeDelay;
 
   /// The event list of the record.
   ///

--- a/packages/flutter_test/lib/src/test_pointer.dart
+++ b/packages/flutter_test/lib/src/test_pointer.dart
@@ -444,11 +444,14 @@ class TestGesture {
 ///
 /// This is a simulation of how the framework is receiving input events from
 /// the engine. See [GestureBinding] and [PointerDataPacket].
-class PointerEventPack {
+class PointerEventPacket {
   /// Creates a pack of PointerEvents.
-  PointerEventPack(this.timeStamp, this.events);
+  PointerEventPacket(this.timeStamp, this.events);
 
-  /// The time stamp of when the event happens
+  /// The time stamp of when the event packet is received.
+  ///
+  /// This value is used as the time delay relative to the start of
+  /// [WidgeTester.handlePointerEventPack] call.
   final Duration timeStamp;
 
   /// The event.

--- a/packages/flutter_test/lib/src/test_pointer.dart
+++ b/packages/flutter_test/lib/src/test_pointer.dart
@@ -438,14 +438,14 @@ class TestGesture {
   }
 }
 
-/// A packet of input PointerEvent queue.
+/// A packet of input [PointerEvent] queue.
 ///
-/// [timeStamp] is used to indicate the time when the pack is received.
+/// The [timeStamp] is used to indicate the time when the pack is received.
 ///
 /// This is a simulation of how the framework is receiving input events from
 /// the engine. See [GestureBinding] and [PointerDataPacket].
 class PointerEventPacket {
-  /// Creates a pack of PointerEvents.
+  /// Creates a pack of [PointerEvent]s.
   PointerEventPacket(this.timeStamp, this.events);
 
   /// The time stamp of when the event packet is received.
@@ -454,6 +454,8 @@ class PointerEventPacket {
   /// [WidgetTester.handlePointerEventPacket] call.
   final Duration timeStamp;
 
-  /// The event.
+  /// The event list that expanded from the [PointerDataPacket].
+  ///
+  /// See [PointerEventConverter.expand].
   final List<PointerEvent> events;
 }

--- a/packages/flutter_test/lib/src/test_pointer.dart
+++ b/packages/flutter_test/lib/src/test_pointer.dart
@@ -438,23 +438,27 @@ class TestGesture {
   }
 }
 
-/// A packet of input [PointerEvent] queue.
+/// A record of input [PointerEvent] list with the timeStamp of when it is
+/// injected.
 ///
 /// The [timeStamp] is used to indicate the time when the pack is received.
 ///
 /// This is a simulation of how the framework is receiving input events from
 /// the engine. See [GestureBinding] and [PointerDataPacket].
-class PointerEventPacket {
+class PointerEventRecord {
   /// Creates a pack of [PointerEvent]s.
-  PointerEventPacket(this.timeStamp, this.events);
+  PointerEventRecord(this.timeStamp, this.events);
 
-  /// The time stamp of when the event packet is received.
+  /// The time stamp of when the event record is received.
   ///
   /// This value is used as the time delay relative to the start of
-  /// [WidgetTester.handlePointerEventPacket] call.
+  /// [WidgetTester.handlePointerEventRecord] call.
   final Duration timeStamp;
 
-  /// The event list that expanded from the [PointerDataPacket].
+  /// The event list of the record.
+  ///
+  /// This can be considered as a simulation of the events expanded from the
+  /// [PointerDataPacket].
   ///
   /// See [PointerEventConverter.expand].
   final List<PointerEvent> events;

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -505,7 +505,7 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
     });
   }
 
-  // This is a parallele implementation of [GestureBinding._handlePointerEvent]
+  // This is a parallel implementation of [GestureBinding._handlePointerEvent]
   // to make compatible with test bindings.
   void _handlePointerEvent(
     PointerEvent event,

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -500,7 +500,7 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
   }
 
   // This is a parallele implementation of [GestureBinding._handlePointerEvent]
-  // to make compativle with test bindings.
+  // to make compatible with test bindings.
   void _handlePointerEvent(
     PointerEvent event,
     Map<int, HitTestResult> _hitTests

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -477,7 +477,7 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
         final DateTime now = binding.clock.now();
         startTime ??= now;
         // So that the first event is promised to receive a zero timeDiff
-        final Duration timeDiff = record.timeStamp - now.difference(startTime);
+        final Duration timeDiff = record.timeDelay - now.difference(startTime);
         if (timeDiff.isNegative) {
           // Flush all past events
           handleTimeStampDiff.add(timeDiff);
@@ -490,7 +490,7 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
           await binding.pump();
           await binding.delayed(timeDiff);
           handleTimeStampDiff.add(
-            record.timeStamp - binding.clock.now().difference(startTime),
+            record.timeDelay - binding.clock.now().difference(startTime),
           );
           for (final PointerEvent event in record.events) {
             _handlePointerEvent(event, hitTestHistory);

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -465,22 +465,22 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
   }
 
   @override
-  Future<List<Duration>> handlePointerEventPack(List<PointerEventPacket> records) {
-    assert(records != null);
-    assert(records.isNotEmpty);
+  Future<List<Duration>> handlePointerEventPacket(
+    List<PointerEventPacket> packet) {
+    assert(packet != null);
+    assert(packet.isNotEmpty);
     return TestAsyncUtils.guard<List<Duration>>(() async {
       // hitTestHistory is an equivalence of _hitTests in [GestureBinding]
       final Map<int, HitTestResult> hitTestHistory = <int, HitTestResult>{};
       final List<Duration> handleTimeStampDiff = <Duration>[];
       DateTime startTime;
-      for(final PointerEventPacket packet in records) {
+      for(final PointerEventPacket packet in packet) {
         final DateTime now = binding.clock.now();
         startTime ??= now;
         // So that the first event is promised to received a zero timeDiff
         final Duration timeDiff = packet.timeStamp - now.difference(startTime);
         if (timeDiff.isNegative) {
           // Flush all past events
-          // maybe trigger a warning
           handleTimeStampDiff.add(timeDiff);
           for (final PointerEvent event in packet.events) {
             _handlePointerEvent(event, hitTestHistory);

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -482,21 +482,17 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
           }
         }
         else {
+          // TODO(CareF): reconsider the pumping strategy after
+          // https://github.com/flutter/flutter/issues/60739 is fixed
+          await binding.pump();
           await binding.executeLater(timeDiff, () async {
             for (final PointerEvent event in pack.events) {
               _handlePointerEvent(event, hitTestHistory);
             }
           });
-          // TODO(CareF): delete the if sentence when
-          // https://github.com/flutter/flutter/issues/60739 is fixed
-          if (binding is LiveTestWidgetsFlutterBinding &&
-              (binding as LiveTestWidgetsFlutterBinding).framePolicy ==
-              LiveTestWidgetsFlutterBindingFramePolicy.fullyLive) {
-            continue;
-          }
-          await binding.pump();
         }
       }
+      await binding.pump();
       // This make sure that a gesture is completed, with no more pointers
       // active.
       assert(hitTestHistory.isEmpty);

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -465,8 +465,7 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
   }
 
   @override
-  Future<List<Duration>> handlePointerEventPacket(
-    List<PointerEventPacket> packet) {
+  Future<List<Duration>> handlePointerEventPacket(List<PointerEventPacket> packet) {
     assert(packet != null);
     assert(packet.isNotEmpty);
     return TestAsyncUtils.guard<List<Duration>>(() async {
@@ -474,7 +473,7 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
       final Map<int, HitTestResult> hitTestHistory = <int, HitTestResult>{};
       final List<Duration> handleTimeStampDiff = <Duration>[];
       DateTime startTime;
-      for(final PointerEventPacket packet in packet) {
+      for (final PointerEventPacket packet in packet) {
         final DateTime now = binding.clock.now();
         startTime ??= now;
         // So that the first event is promised to received a zero timeDiff
@@ -485,14 +484,14 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
           for (final PointerEvent event in packet.events) {
             _handlePointerEvent(event, hitTestHistory);
           }
-        }
-        else {
+        } else {
           // TODO(CareF): reconsider the pumping strategy after
           // https://github.com/flutter/flutter/issues/60739 is fixed
           await binding.pump();
           await binding.executeLater(timeDiff, () async {
             handleTimeStampDiff.add(
-              packet.timeStamp - binding.clock.now().difference(startTime));
+              packet.timeStamp - binding.clock.now().difference(startTime),
+            );
             for (final PointerEvent event in packet.events) {
               _handlePointerEvent(event, hitTestHistory);
             }
@@ -545,8 +544,7 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
         event is PointerHoverEvent ||
         event is PointerAddedEvent ||
         event is PointerRemovedEvent) {
-      binding.dispatchEvent(
-        event, hitTestResult, source: TestBindingEventSource.test);
+      binding.dispatchEvent(event, hitTestResult, source: TestBindingEventSource.test);
     }
   }
 

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -466,6 +466,8 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
 
   @override
   Future<void> handlePointerEventPack(List<PointerEventPack> records) {
+    assert(records != null);
+    assert(records.isNotEmpty);
     // hitTestHistory is an equivalence of _hitTests in [GestureBinding]
     final Map<int, HitTestResult> hitTestHistory = <int, HitTestResult>{};
     return TestAsyncUtils.guard<void>(() async {

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -465,23 +465,23 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
   }
 
   @override
-  Future<List<Duration>> handlePointerEventPacket(List<PointerEventPacket> packets) {
-    assert(packets != null);
-    assert(packets.isNotEmpty);
+  Future<List<Duration>> handlePointerEventRecord(List<PointerEventRecord> records) {
+    assert(records != null);
+    assert(records.isNotEmpty);
     return TestAsyncUtils.guard<List<Duration>>(() async {
       // hitTestHistory is an equivalence of _hitTests in [GestureBinding]
       final Map<int, HitTestResult> hitTestHistory = <int, HitTestResult>{};
       final List<Duration> handleTimeStampDiff = <Duration>[];
       DateTime startTime;
-      for (final PointerEventPacket packet in packets) {
+      for (final PointerEventRecord record in records) {
         final DateTime now = binding.clock.now();
         startTime ??= now;
         // So that the first event is promised to receive a zero timeDiff
-        final Duration timeDiff = packet.timeStamp - now.difference(startTime);
+        final Duration timeDiff = record.timeStamp - now.difference(startTime);
         if (timeDiff.isNegative) {
           // Flush all past events
           handleTimeStampDiff.add(timeDiff);
-          for (final PointerEvent event in packet.events) {
+          for (final PointerEvent event in record.events) {
             _handlePointerEvent(event, hitTestHistory);
           }
         } else {
@@ -490,9 +490,9 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
           await binding.pump();
           await binding.delayed(timeDiff);
           handleTimeStampDiff.add(
-            packet.timeStamp - binding.clock.now().difference(startTime),
+            record.timeStamp - binding.clock.now().difference(startTime),
           );
-          for (final PointerEvent event in packet.events) {
+          for (final PointerEvent event in record.events) {
             _handlePointerEvent(event, hitTestHistory);
           }
         }

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -481,16 +481,19 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
           }
         }
         else {
-          await Future<void>.delayed(timeDiff, () async {
+          await binding.executeLater(timeDiff, () async {
             for (final PointerEvent event in pack.events) {
               await _handlePointerEvent(event, hitTestHistory);
-          }
+            }
           });
-          if (!(binding is LiveTestWidgetsFlutterBinding && (
-            binding as LiveTestWidgetsFlutterBinding).framePolicy
-              == LiveTestWidgetsFlutterBindingFramePolicy.fullyLive)) {
-            await binding.pump();
+          // TODO(CareF): delete the if sentence when
+          // https://github.com/flutter/flutter/issues/60739 is fixed
+          if (binding is LiveTestWidgetsFlutterBinding &&
+              (binding as LiveTestWidgetsFlutterBinding).framePolicy ==
+              LiveTestWidgetsFlutterBindingFramePolicy.fullyLive) {
+            continue;
           }
+          await binding.pump();
         }
       }
       assert(hitTestHistory.isEmpty);

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -476,13 +476,13 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
           // Flush all past events
           // maybe trigger a warning
           for (final PointerEvent event in pack.events) {
-            await _handlePointerEvent(event, hitTestHistory);
+            _handlePointerEvent(event, hitTestHistory);
           }
         }
         else {
           await binding.executeLater(timeDiff, () async {
             for (final PointerEvent event in pack.events) {
-              await _handlePointerEvent(event, hitTestHistory);
+              _handlePointerEvent(event, hitTestHistory);
             }
           });
           // TODO(CareF): delete the if sentence when
@@ -501,10 +501,10 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
 
   // This is a parallele implementation of [GestureBinding._handlePointerEvent]
   // to make compativle with test bindings.
-  Future<void> _handlePointerEvent(
+  void _handlePointerEvent(
     PointerEvent event,
     Map<int, HitTestResult> _hitTests
-  ) async {
+  ) {
     HitTestResult hitTestResult;
     if (event is PointerDownEvent || event is PointerSignalEvent) {
       assert(!_hitTests.containsKey(event.pointer));
@@ -537,7 +537,8 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
         event is PointerHoverEvent ||
         event is PointerAddedEvent ||
         event is PointerRemovedEvent) {
-      await sendEventToBinding(event, hitTestResult);
+      binding.dispatchEvent(
+        event, hitTestResult, source: TestBindingEventSource.test);
     }
   }
 

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -497,6 +497,8 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
           await binding.pump();
         }
       }
+      // This make sure that a gesture is completed, with no more pointers
+      // active.
       assert(hitTestHistory.isEmpty);
     });
   }

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -468,7 +468,6 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
   Future<void> handlePointerEventPack(List<PointerEventPack> records) {
     // hitTestHistory is an equivalence of _hitTests in [GestureBinding]
     final Map<int, HitTestResult> hitTestHistory = <int, HitTestResult>{};
-    assert(hitTestHistory.isEmpty);
     return TestAsyncUtils.guard<void>(() async {
       final DateTime startTime = binding.clock.now();
       for(final PointerEventPack pack in records) {

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -657,7 +657,7 @@ void main() {
       );
 
       final Offset location = tester.getCenter(find.text('test'));
-      final List<PointerEventPacket> records = <PointerEventPacket>[
+      final List<PointerEventPacket> packets = <PointerEventPacket>[
         PointerEventPacket(Duration.zero, <PointerEvent>[
           // Typically PointerAddedEvent is not used in testers, but for records
           // captured on a device it is usually what start a gesture.
@@ -694,7 +694,11 @@ void main() {
           )
         ])
       ];
-      await tester.handlePointerEventPacket(records);
+      final List<Duration> timeDiffs = await tester.handlePointerEventPacket(packets);
+      expect(timeDiffs.length, packets.length);
+      for(final Duration diff in timeDiffs) {
+        expect(diff, Duration.zero);
+      }
 
       const String b = '$kSecondaryMouseButton';
       for(int i = 0; i < logs.length; i++) {

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -696,19 +696,16 @@ void main() {
       ];
       final List<Duration> timeDiffs = await tester.handlePointerEventRecord(records);
       expect(timeDiffs.length, records.length);
-      for(final Duration diff in timeDiffs) {
+      for (final Duration diff in timeDiffs) {
         expect(diff, Duration.zero);
       }
 
       const String b = '$kSecondaryMouseButton';
-      for(int i = 0; i < logs.length; i++) {
-        if (i == 0)
-          expect(logs[i], 'down $b');
-        else if (i != logs.length - 1)
-          expect(logs[i], 'move $b');
-        else
-          expect(logs[i], 'up $b');
+      expect(logs.first, 'down $b');
+      for (int i = 1; i < logs.length - 1; i++) {
+        expect(logs[i], 'move $b');
       }
+      expect(logs.last, 'up $b');
   });
 
   group('runAsync', () {

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -8,6 +8,7 @@ import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
@@ -638,6 +639,72 @@ void main() {
     controller.duration = const Duration(seconds: 1);
     controller.forward();
     expect(await tester.pumpAndSettle(const Duration(milliseconds: 300)), 5); // 0, 300, 600, 900, 1200ms
+  });
+
+  testWidgets('Input event array', (WidgetTester tester) async {
+      final List<String> logs = <String>[];
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Listener(
+            onPointerDown: (PointerDownEvent event) => logs.add('down ${event.buttons}'),
+            onPointerMove: (PointerMoveEvent event) => logs.add('move ${event.buttons}'),
+            onPointerUp: (PointerUpEvent event) => logs.add('up ${event.buttons}'),
+            child: const Text('test'),
+          ),
+        ),
+      );
+
+      final Offset location = tester.getCenter(find.text('test'));
+      final List<PointerEventPack> records = <PointerEventPack>[
+        PointerEventPack(Duration.zero, <PointerEvent>[
+          // Typically PointerAddedEvent is not used in testers, but on for
+          // records captured on a device it is usually what start a gesture.
+          PointerAddedEvent(
+            timeStamp: Duration.zero,
+            position: location,
+          ),
+          PointerDownEvent(
+            timeStamp: Duration.zero,
+            position: location,
+            buttons: kSecondaryMouseButton,
+            pointer: 1,
+          ),
+        ]),
+        ...<PointerEventPack>[
+          for (Duration t = const Duration(milliseconds: 5);
+               t < const Duration(milliseconds: 80);
+               t += const Duration(milliseconds: 16))
+            PointerEventPack(t, <PointerEvent>[
+              PointerMoveEvent(
+                timeStamp: t - const Duration(milliseconds: 1),
+                position: location,
+                buttons: kSecondaryMouseButton,
+                pointer: 1,
+              )
+            ])
+        ],
+        PointerEventPack(const Duration(milliseconds: 80), <PointerEvent>[
+          PointerUpEvent(
+            timeStamp: const Duration(milliseconds: 79),
+            position: location,
+            buttons: kSecondaryMouseButton,
+            pointer: 1,
+          )
+        ])
+      ];
+      await tester.handlePointerEventPack(records);
+
+      const String b = '$kSecondaryMouseButton';
+      for(int i = 0; i < logs.length; i++) {
+        if (i == 0)
+          expect(logs[i], 'down $b');
+        else if (i != logs.length - 1)
+          expect(logs[i], 'move $b');
+        else
+          expect(logs[i], 'up $b');
+      }
   });
 
   group('runAsync', () {

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -659,8 +659,8 @@ void main() {
       final Offset location = tester.getCenter(find.text('test'));
       final List<PointerEventPack> records = <PointerEventPack>[
         PointerEventPack(Duration.zero, <PointerEvent>[
-          // Typically PointerAddedEvent is not used in testers, but on for
-          // records captured on a device it is usually what start a gesture.
+          // Typically PointerAddedEvent is not used in testers, but for records
+          // captured on a device it is usually what start a gesture.
           PointerAddedEvent(
             timeStamp: Duration.zero,
             position: location,

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -657,8 +657,8 @@ void main() {
       );
 
       final Offset location = tester.getCenter(find.text('test'));
-      final List<PointerEventPacket> packets = <PointerEventPacket>[
-        PointerEventPacket(Duration.zero, <PointerEvent>[
+      final List<PointerEventRecord> records = <PointerEventRecord>[
+        PointerEventRecord(Duration.zero, <PointerEvent>[
           // Typically PointerAddedEvent is not used in testers, but for records
           // captured on a device it is usually what start a gesture.
           PointerAddedEvent(
@@ -672,11 +672,11 @@ void main() {
             pointer: 1,
           ),
         ]),
-        ...<PointerEventPacket>[
+        ...<PointerEventRecord>[
           for (Duration t = const Duration(milliseconds: 5);
                t < const Duration(milliseconds: 80);
                t += const Duration(milliseconds: 16))
-            PointerEventPacket(t, <PointerEvent>[
+            PointerEventRecord(t, <PointerEvent>[
               PointerMoveEvent(
                 timeStamp: t - const Duration(milliseconds: 1),
                 position: location,
@@ -685,7 +685,7 @@ void main() {
               )
             ])
         ],
-        PointerEventPacket(const Duration(milliseconds: 80), <PointerEvent>[
+        PointerEventRecord(const Duration(milliseconds: 80), <PointerEvent>[
           PointerUpEvent(
             timeStamp: const Duration(milliseconds: 79),
             position: location,
@@ -694,8 +694,8 @@ void main() {
           )
         ])
       ];
-      final List<Duration> timeDiffs = await tester.handlePointerEventPacket(packets);
-      expect(timeDiffs.length, packets.length);
+      final List<Duration> timeDiffs = await tester.handlePointerEventRecord(records);
+      expect(timeDiffs.length, records.length);
       for(final Duration diff in timeDiffs) {
         expect(diff, Duration.zero);
       }

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -657,8 +657,8 @@ void main() {
       );
 
       final Offset location = tester.getCenter(find.text('test'));
-      final List<PointerEventPack> records = <PointerEventPack>[
-        PointerEventPack(Duration.zero, <PointerEvent>[
+      final List<PointerEventPacket> records = <PointerEventPacket>[
+        PointerEventPacket(Duration.zero, <PointerEvent>[
           // Typically PointerAddedEvent is not used in testers, but for records
           // captured on a device it is usually what start a gesture.
           PointerAddedEvent(
@@ -672,11 +672,11 @@ void main() {
             pointer: 1,
           ),
         ]),
-        ...<PointerEventPack>[
+        ...<PointerEventPacket>[
           for (Duration t = const Duration(milliseconds: 5);
                t < const Duration(milliseconds: 80);
                t += const Duration(milliseconds: 16))
-            PointerEventPack(t, <PointerEvent>[
+            PointerEventPacket(t, <PointerEvent>[
               PointerMoveEvent(
                 timeStamp: t - const Duration(milliseconds: 1),
                 position: location,
@@ -685,7 +685,7 @@ void main() {
               )
             ])
         ],
-        PointerEventPack(const Duration(milliseconds: 80), <PointerEvent>[
+        PointerEventPacket(const Duration(milliseconds: 80), <PointerEvent>[
           PointerUpEvent(
             timeStamp: const Duration(milliseconds: 79),
             position: location,

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -694,7 +694,7 @@ void main() {
           )
         ])
       ];
-      await tester.handlePointerEventPack(records);
+      await tester.handlePointerEventPacket(records);
 
       const String b = '$kSecondaryMouseButton';
       for(int i = 0; i < logs.length; i++) {


### PR DESCRIPTION
## Description

Add support to use a stream of input `PointerEvent`s to drive a test.

The motivation of this is to enable the use of `WidgetTester` as a tool to drive a live integration test app on a device, with [e2e](https://pub.dev/packages/e2e) or simple `flutter run`, for performance purposes. With this feature the long term goal is to provide a solution of host-independent test and migrating current `flutter_driver` based test to such solution, so that we can perform test on Firebase test lab and use the solution for shader warm up test runs. The short term goal is to have an e2e based scrolling test to catch #41118. For such purposes we need an API to drive the test app by a stream of inputs with some time duration. 

Use cases would be for example drive the app similar to [`Scroll`](https://api.flutter.dev/flutter/flutter_driver/Scroll/Scroll.html) in `flutter_driver` which has a `duration` as parameter. Using device driven solution will do better than `flutter_driver` because on the device time control is more accurate than `flutter_driver`, and therefore input time can be controlled at sub-frame-interval level. Another demo of the use case is https://github.com/CareF/scroll_test/tree/external where I implement recording physical user inputs in one test app (by running `flutter drive -t test/using_record.dart --driver test_driver/scrolling_test_e2e_test.dart -d moto --trace-startup`) to generate data for another test app replaying the recorded input (by `flutter drive -t test/using_record.dart --driver test_driver/scrolling_test_e2e_test.dart -d moto --trace-startup  --profile`). The recording part of this demo will be published as a separate package. 

This was part of #60649 and #60741.

However currently our APIs in `WidgetTester` have very limited design for inputs that's time stamped. This is needed for the above motivation, and implementing it is the main goal of this PR. Apart from that, this also enables us to customize the input `PointerEvents` that can be as faithful as the real world. 

To achieve this, we need: 
1. A mechanism in the test binding to advance the clock of the `TestWidgetsFlutterBinding`, which means for `AutomatedTestWidgetsFlutterBinding` to advance the clock and for `LiveTestWidgetsFlutterBinding` to wait a period of time. The situations when an app binds to which of these two bindings, together with `E2EWidgetsFlutterBinding` which is a subclass of `LiveTestWidgetsFlutterBinding` and `_DriverBinding` of `flutter_driver` are listed below: 

  | command         | start point         | Binding                                                         |
  |----------------|----------------|------------------------------------------|
  |`flutter test`      | `testWidgets(...)`  | `AutomatedTestWidgetsFlutterBinding`   |
  |FLUTTER_TEST=[..] `flutter test`    | `testWidgets(...)`  | `LiveTestWidgetsFlutterBinding`   |
  |`flutter test`      | `LiveTestWidgetsFlutterBinding();` <br> `testWidgets(...)`  | `LiveTestWidgetsFlutterBinding`   |
  |`flutter run`       | `testWidgets(...)`  | `LiveTestWidgetsFlutterBinding`               |
  |`flutter drive`    | `enableFlutterDriverExtension()`  | `_DriverBinding`   |
  |`flutter drive`    |  `E2EWidgetsFlutterBinding.ensureInitialized();` <br> `testWidgets(...)` | `E2EWidgetsFlutterBinding`|

FLUTTER_TEST=[..] means the environment variable `FLUTTER_TEST` being anything but `false` or empty. 

2. A method in `WidgetTester` that accepts an array of inputs with timestamp. Note that this timestamp is not necessarily the timestamp tagged within the event, but the timestamp for when the packet of the event is received. 

These two corresponds to `TestWidgetsFlutterBinding.delayed` and `WidgetTester.handlePointerEventPacket` in this PR. 

## Related Issues

Resolves #60650

## Tests

I added the following tests:

- `'Input event array'` in `packages/flutter_test/test/widget_tester_test.dart`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
