### PR TITLE
Fix theme for cursors and the inside check on checkboxes.

### DIFF
--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -135,7 +135,7 @@ class Checkbox extends StatefulWidget {
 
   /// The color to use for the check icon when this checkbox is checked.
   ///
-  /// Defaults to Color(0xFFFFFFFF)
+  /// Defaults to [ThemeData.canvasColor].
   final Color checkColor;
 
   /// If true the checkbox's [value] can be true, false, or null.
@@ -271,7 +271,7 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin {
             value: widget.value,
             tristate: widget.tristate,
             activeColor: widget.activeColor ?? themeData.toggleableActiveColor,
-            checkColor: widget.checkColor ?? const Color(0xFFFFFFFF),
+            checkColor: widget.checkColor ?? themeData.canvasColor,
             inactiveColor: enabled ? themeData.unselectedWidgetColor : themeData.disabledColor,
             focusColor: widget.focusColor ?? themeData.focusColor,
             hoverColor: widget.hoverColor ?? themeData.hoverColor,

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -320,8 +320,8 @@ class ThemeData with Diagnosticable {
     secondaryHeaderColor ??= isDark ? Colors.grey[700] : primarySwatch[50];
     textSelectionColor ??= isDark ? accentColor : primarySwatch[200];
     // TODO(hansmuller): We need a TextFieldTheme to handle this instead, https://github.com/flutter/flutter/issues/56082
-    cursorColor = cursorColor ?? const Color.fromRGBO(66, 133, 244, 1.0);
-    textSelectionHandleColor ??= isDark ? Colors.tealAccent[400] : primarySwatch[300];
+    cursorColor ??= isDark ? Colors.tealAccent[200] : primarySwatch;
+    textSelectionHandleColor ??= isDark ? Colors.tealAccent[200] : primarySwatch[300];
     backgroundColor ??= isDark ? Colors.grey[700] : primarySwatch[200];
     dialogBackgroundColor ??= isDark ? Colors.grey[800] : Colors.white;
     indicatorColor ??= accentColor == primaryColor ? Colors.white : accentColor;

--- a/packages/flutter/test/material/checkbox_list_tile_test.dart
+++ b/packages/flutter/test/material/checkbox_list_tile_test.dart
@@ -52,7 +52,7 @@ void main() {
 
     await tester.pumpWidget(buildFrame(null));
     await tester.pumpAndSettle();
-    expect(getCheckboxListTileRenderer(), paints..path(color: const Color(0xFFFFFFFF))); // paints's color is 0xFFFFFFFF (default color)
+    expect(getCheckboxListTileRenderer(), paints..path(color: const Color(0xFFFAFAFA))); // paints's color is 0xFFFAFAFA (light theme default)
 
     await tester.pumpWidget(buildFrame(const Color(0xFF000000)));
     await tester.pumpAndSettle();
@@ -80,9 +80,9 @@ void main() {
     await tester.pumpAndSettle();
     expect(getCheckboxListTileRenderer(), paints..rrect(color: const Color(0xFF000000))); // paints's color is 0xFF000000 (theme)
 
-    await tester.pumpWidget(buildFrame(const Color(0xFF000000), const Color(0xFFFFFFFF)));
+    await tester.pumpWidget(buildFrame(const Color(0xFF000000), const Color(0xFFFAFAFA)));
     await tester.pumpAndSettle();
-    expect(getCheckboxListTileRenderer(), paints..rrect(color: const Color(0xFFFFFFFF))); // paints's color is 0xFFFFFFFF (params)
+    expect(getCheckboxListTileRenderer(), paints..rrect(color: const Color(0xFFFAFAFA))); // paints's color is 0xFFFAFAFA (params)
   });
 
   testWidgets('CheckboxListTile can autofocus unless disabled.', (WidgetTester tester) async {

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -372,9 +372,9 @@ void main() {
       }));
     }
 
-    await tester.pumpWidget(buildFrame(checkColor: const Color(0xFFFFFFFF)));
+    await tester.pumpWidget(buildFrame(checkColor: const Color(0xFFFAFAFA)));
     await tester.pumpAndSettle();
-    expect(getCheckboxRenderer(), paints..path(color: const Color(0xFFFFFFFF))); // paints's color is 0xFFFFFFFF (default color)
+    expect(getCheckboxRenderer(), paints..path(color: const Color(0xFFFAFAFA))); // paints's color is 0xFFFAFAFA (light theme default)
 
     await tester.pumpWidget(buildFrame(checkColor: const Color(0xFF000000)));
     await tester.pumpAndSettle();
@@ -426,7 +426,7 @@ void main() {
             color: const Color(0xff1e88e5),
             rrect: RRect.fromLTRBR(
                 391.0, 291.0, 409.0, 309.0, const Radius.circular(1.0)))
-        ..path(color: Colors.white),
+        ..path(color: Colors.grey[50]),
     );
 
     // Check the false value.
@@ -494,7 +494,7 @@ void main() {
             color: const Color(0xff1e88e5),
             rrect: RRect.fromLTRBR(
                 391.0, 291.0, 409.0, 309.0, const Radius.circular(1.0)))
-        ..path(color: const Color(0xffffffff), style: PaintingStyle.stroke, strokeWidth: 2.0),
+        ..path(color: const Color(0xfffafafa), style: PaintingStyle.stroke, strokeWidth: 2.0),
     );
 
     // Start hovering
@@ -511,7 +511,7 @@ void main() {
             color: const Color(0xff1e88e5),
             rrect: RRect.fromLTRBR(
                 391.0, 291.0, 409.0, 309.0, const Radius.circular(1.0)))
-        ..path(color: const Color(0xffffffff), style: PaintingStyle.stroke, strokeWidth: 2.0),
+        ..path(color: const Color(0xfffafafa), style: PaintingStyle.stroke, strokeWidth: 2.0),
     );
 
     // Check what happens when disabled.
@@ -524,7 +524,7 @@ void main() {
             color: const Color(0x61000000),
             rrect: RRect.fromLTRBR(
                 391.0, 291.0, 409.0, 309.0, const Radius.circular(1.0)))
-        ..path(color: const Color(0xffffffff), style: PaintingStyle.stroke, strokeWidth: 2.0),
+        ..path(color: const Color(0xfffafafa), style: PaintingStyle.stroke, strokeWidth: 2.0),
     );
   });
 

--- a/packages/flutter/test/widgets/editable_text_cursor_test.dart
+++ b/packages/flutter/test/widgets/editable_text_cursor_test.dart
@@ -226,12 +226,12 @@ void main() {
 
     await tester.pump();
     expect(renderEditable.cursorColor.alpha, 255);
-    expect(renderEditable, paints..rect(color: const Color(0xff4285f4)));
+    expect(renderEditable, paints..rect(color: const Color(0xff2196f3)));
 
     // Android cursor goes from exactly on to exactly off on the 500ms dot.
     await tester.pump(const Duration(milliseconds: 499));
     expect(renderEditable.cursorColor.alpha, 255);
-    expect(renderEditable, paints..rect(color: const Color(0xff4285f4)));
+    expect(renderEditable, paints..rect(color: const Color(0xff2196f3)));
 
     await tester.pump(const Duration(milliseconds: 1));
     expect(renderEditable.cursorColor.alpha, 0);
@@ -240,7 +240,7 @@ void main() {
 
     await tester.pump(const Duration(milliseconds: 500));
     expect(renderEditable.cursorColor.alpha, 255);
-    expect(renderEditable, paints..rect(color: const Color(0xff4285f4)));
+    expect(renderEditable, paints..rect(color: const Color(0xff2196f3)));
 
     await tester.pump(const Duration(milliseconds: 500));
     expect(renderEditable.cursorColor.alpha, 0);
@@ -304,21 +304,21 @@ void main() {
 
     await tester.pump();
     expect(renderEditable.cursorColor.alpha, 255);
-    expect(renderEditable, paints..rect(color: const Color(0xff4285f4)));
+    expect(renderEditable, paints..rect(color: const Color(0xff2196f3)));
 
     await tester.pump(const Duration(milliseconds: 500));
     expect(renderEditable.cursorColor.alpha, 255);
-    expect(renderEditable, paints..rect(color: const Color(0xff4285f4)));
+    expect(renderEditable, paints..rect(color: const Color(0xff2196f3)));
 
     // Cursor draw never changes.
     await tester.pump(const Duration(milliseconds: 500));
     expect(renderEditable.cursorColor.alpha, 255);
-    expect(renderEditable, paints..rect(color: const Color(0xff4285f4)));
+    expect(renderEditable, paints..rect(color: const Color(0xff2196f3)));
 
     // No more transient calls.
     await tester.pumpAndSettle();
     expect(renderEditable.cursorColor.alpha, 255);
-    expect(renderEditable, paints..rect(color: const Color(0xff4285f4)));
+    expect(renderEditable, paints..rect(color: const Color(0xff2196f3)));
 
     EditableText.debugDeterministicCursor = false;
   });


### PR DESCRIPTION
## Description

This pull relates to temporary fixes removing some hard-coded default values which make theming more difficult. The changes comprise: text cursor (caret) and selection handle are both set to the primary color per the images and implementations in the material design specs, and the drawn check in checkboxes now default to the background color, as generally an icon with a transparent hole should be used there instead.

## Related Issues

#17635, #56082, #32023
