### PR TITLE
Expose height and width factor in AnimatedAlign 

### DIFF
--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -937,14 +937,14 @@ class AnimatedAlign extends ImplicitlyAnimatedWidget {
 
 class _AnimatedAlignState extends AnimatedWidgetBaseState<AnimatedAlign> {
   AlignmentGeometryTween _alignment;
-  Tween _heightFactorTween;
-  Tween _widthFactorTween;
+  Tween<double> _heightFactorTween;
+  Tween<double> _widthFactorTween;
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
     _alignment = visitor(_alignment, widget.alignment, (dynamic value) => AlignmentGeometryTween(begin: value as AlignmentGeometry)) as AlignmentGeometryTween;
-    _heightFactorTween = visitor(_heightFactorTween, widget.heightFactor, (dynamic value) => Tween(begin: value as double));
-    _widthFactorTween = visitor(_widthFactorTween, widget.widthFactor, (dynamic value) => Tween(begin: value as double));
+    _heightFactorTween = visitor(_heightFactorTween, widget.heightFactor, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>;
+    _widthFactorTween = visitor(_widthFactorTween, widget.widthFactor, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>;
 
   }
 

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -882,10 +882,14 @@ class AnimatedAlign extends ImplicitlyAnimatedWidget {
     Key key,
     @required this.alignment,
     this.child,
+    this.heightFactor = 1.0,
+    this.widthFactor = 1.0,
     Curve curve = Curves.linear,
     @required Duration duration,
     VoidCallback onEnd,
   }) : assert(alignment != null),
+        assert(widthFactor == null || widthFactor >= 0.0),
+        assert(heightFactor == null || heightFactor >= 0.0),
        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// How to align the child.
@@ -911,6 +915,16 @@ class AnimatedAlign extends ImplicitlyAnimatedWidget {
   /// {@macro flutter.widgets.child}
   final Widget child;
 
+  /// If non-null, sets its height to the child's height multiplied by this factor.
+  ///
+  /// Can be both greater and less than 1.0 but must be positive.
+  final double heightFactor;
+
+  /// If non-null, sets its width to the child's width multiplied by this factor.
+  ///
+  /// Can be both greater and less than 1.0 but must be positive.
+  final double widthFactor;
+
   @override
   _AnimatedAlignState createState() => _AnimatedAlignState();
 
@@ -923,16 +937,23 @@ class AnimatedAlign extends ImplicitlyAnimatedWidget {
 
 class _AnimatedAlignState extends AnimatedWidgetBaseState<AnimatedAlign> {
   AlignmentGeometryTween _alignment;
+  Tween _heightFactorTween;
+  Tween _widthFactorTween;
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
     _alignment = visitor(_alignment, widget.alignment, (dynamic value) => AlignmentGeometryTween(begin: value as AlignmentGeometry)) as AlignmentGeometryTween;
+    _heightFactorTween = visitor(_heightFactorTween, widget.heightFactor, (dynamic value) => Tween(begin: value as double));
+    _widthFactorTween = visitor(_widthFactorTween, widget.widthFactor, (dynamic value) => Tween(begin: value as double));
+
   }
 
   @override
   Widget build(BuildContext context) {
     return Align(
       alignment: _alignment.evaluate(animation),
+      heightFactor: _heightFactorTween.evaluate(animation),
+      widthFactor: _widthFactorTween.evaluate(animation),
       child: widget.child,
     );
   }
@@ -941,6 +962,8 @@ class _AnimatedAlignState extends AnimatedWidgetBaseState<AnimatedAlign> {
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
     description.add(DiagnosticsProperty<AlignmentGeometryTween>('alignment', _alignment, defaultValue: null));
+    description.add(DiagnosticsProperty<Tween>('width factor', _widthFactorTween, defaultValue: null));
+    description.add(DiagnosticsProperty<Tween>('height factor', _heightFactorTween, defaultValue: null));
   }
 }
 

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -888,8 +888,8 @@ class AnimatedAlign extends ImplicitlyAnimatedWidget {
     @required Duration duration,
     VoidCallback onEnd,
   }) : assert(alignment != null),
-        assert(widthFactor == null || widthFactor >= 0.0),
-        assert(heightFactor == null || heightFactor >= 0.0),
+       assert(widthFactor == null || widthFactor >= 0.0),
+       assert(heightFactor == null || heightFactor >= 0.0),
        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// How to align the child.

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -917,12 +917,12 @@ class AnimatedAlign extends ImplicitlyAnimatedWidget {
 
   /// If non-null, sets its height to the child's height multiplied by this factor.
   ///
-  /// Must be within the range 0.0 - 1.0. Defaults to 1.0.
+  /// Can be both greater and less than 1.0 but must be positive. Defaults to 1.0.
   final double heightFactor;
 
   /// If non-null, sets its width to the child's width multiplied by this factor.
   ///
-  /// Must be within the range 0.0 - 1.0. Defaults to 1.0.
+  /// Can be both greater and less than 1.0 but must be positive. Defaults to 1.0.
   final double widthFactor;
 
   @override

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -917,12 +917,12 @@ class AnimatedAlign extends ImplicitlyAnimatedWidget {
 
   /// If non-null, sets its height to the child's height multiplied by this factor.
   ///
-  /// Can be both greater and less than 1.0 but must be positive.
+  /// Must be within the range 0.0 - 1.0. Defaults to 1.0.
   final double heightFactor;
 
   /// If non-null, sets its width to the child's width multiplied by this factor.
   ///
-  /// Can be both greater and less than 1.0 but must be positive.
+  /// Must be within the range 0.0 - 1.0. Defaults to 1.0.
   final double widthFactor;
 
   @override
@@ -962,8 +962,8 @@ class _AnimatedAlignState extends AnimatedWidgetBaseState<AnimatedAlign> {
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
     description.add(DiagnosticsProperty<AlignmentGeometryTween>('alignment', _alignment, defaultValue: null));
-    description.add(DiagnosticsProperty<Tween>('width factor', _widthFactorTween, defaultValue: null));
-    description.add(DiagnosticsProperty<Tween>('height factor', _heightFactorTween, defaultValue: null));
+    description.add(DiagnosticsProperty<Tween<double>>('widthFactor', _widthFactorTween, defaultValue: null));
+    description.add(DiagnosticsProperty<Tween<double>>('heightFactor', _heightFactorTween, defaultValue: null));
   }
 }
 

--- a/packages/flutter/test/widgets/align_test.dart
+++ b/packages/flutter/test/widgets/align_test.dart
@@ -112,4 +112,70 @@ void main() {
     expect(size.width, equals(800.0));
     expect(size.height, equals(10.0));
   });
+
+  testWidgets('Align widthFactor', (WidgetTester tester) async {
+    final GlobalKey inner = GlobalKey();
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Align(
+              widthFactor: 0.5,
+              child: Container(
+                height: 100.0,
+                width: 100.0,
+              ),
+            ),
+            Align(
+              key: inner,
+              widthFactor: 0.5,
+              child: Container(
+                height: 100.0,
+                width: 100.0,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+    final RenderBox box = inner.currentContext.findRenderObject() as RenderBox;
+    expect(box.size.width, equals(50.0));
+  });
+
+  testWidgets('Align heightFactor', (WidgetTester tester) async {
+    final GlobalKey inner = GlobalKey();
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Align(
+              alignment: Alignment.center,
+              heightFactor: 0.5,
+              child: Container(
+                height: 100.0,
+                width: 100.0,
+              ),
+            ),
+            Align(
+              key: inner,
+              alignment: Alignment.center,
+              heightFactor: 0.5,
+              child: Container(
+                height: 100.0,
+                width: 100.0,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+    final RenderBox box = inner.currentContext.findRenderObject() as RenderBox;
+    expect(box.size.height, equals(50.0));
+  });
 }

--- a/packages/flutter/test/widgets/animated_align_test.dart
+++ b/packages/flutter/test/widgets/animated_align_test.dart
@@ -59,4 +59,78 @@ void main() {
     expect(tester.getSize(find.byKey(target)), const Size(100.0, 200.0));
     expect(tester.getTopRight(find.byKey(target)), const Offset(800.0, 400.0));
   });
+
+  testWidgets('AnimatedAlign widthFactor', (WidgetTester tester) async {
+    final GlobalKey inner = GlobalKey();
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            AnimatedAlign(
+              alignment: Alignment.center,
+              curve: Curves.ease,
+              widthFactor: 0.5,
+              duration: const Duration(milliseconds: 200),
+              child: Container(
+                height: 100.0,
+                width: 100.0,
+              ),
+            ),
+            AnimatedAlign(
+              key: inner,
+              alignment: Alignment.center,
+              curve: Curves.ease,
+              widthFactor: 0.5,
+              duration: const Duration(milliseconds: 200),
+              child: Container(
+                height: 100.0,
+                width: 100.0,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+    final RenderBox box = inner.currentContext.findRenderObject() as RenderBox;
+    expect(box.size, equals(const Size(50.0, 100)));
+  });
+
+  testWidgets('AnimatedAlign heightFactor', (WidgetTester tester) async {
+    final GlobalKey inner = GlobalKey();
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            AnimatedAlign(
+              alignment: Alignment.center,
+              curve: Curves.ease,
+              heightFactor: 0.5,
+              duration: const Duration(milliseconds: 200),
+              child: Container(
+                height: 100.0,
+                width: 100.0,
+              ),
+            ),
+            AnimatedAlign(
+              key: inner,
+              alignment: Alignment.center,
+              curve: Curves.ease,
+              heightFactor: 0.5,
+              duration: const Duration(milliseconds: 200),
+              child: Container(
+                height: 100.0,
+                width: 100.0,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+    final RenderBox box = inner.currentContext.findRenderObject() as RenderBox;
+    expect(box.size, equals(const Size(100.0, 50)));
+  });
 }


### PR DESCRIPTION
## Description
`Align` allows developers to customize the width and height factor, however `AnimatedAlign` does not expose these properties. This PR exposes `widthFactor` and `heightFactor` for AnimatedAlign and adds the necessary Tween visitors and documentation for both properties.

## Tests
No test added. I looked at the existing implementation of `Align` and saw that there was no test covering the height and width factors so none was added to the Animated widget. 

## Checklist

- [ x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x ] I signed the [CLA].
- [ x ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ x ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ x ] I updated/added relevant documentation (doc comments with `///`).
- [ x ] All existing and new tests are passing.
- [ x ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ x ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ x ] No, no existing tests failed, so this is *not* a breaking change.

