### PR TITLE
Fixes HitTest for Align 

### DIFF
--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -403,7 +403,6 @@ class RenderPositionedBox extends RenderAligningShiftedBox {
     }
   }
 
-
   @override
   bool hitTest(BoxHitTestResult result, {@required Offset position}) {
     if(child != null){

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -403,6 +403,21 @@ class RenderPositionedBox extends RenderAligningShiftedBox {
     }
   }
 
+
+  @override
+  bool hitTest(BoxHitTestResult result, {@required Offset position}) {
+    if(child != null){
+      final BoxParentData childParentData = child.parentData as BoxParentData;
+      if ((childParentData.offset & child.size).contains(position)) {
+        if (hitTestChildren(result, position: position) || hitTestSelf(position)) {
+          result.add(BoxHitTestEntry(this, position));
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
   @override
   void debugPaintSize(PaintingContext context, Offset offset) {
     super.debugPaintSize(context, offset);

--- a/packages/flutter/test/widgets/align_test.dart
+++ b/packages/flutter/test/widgets/align_test.dart
@@ -4,6 +4,9 @@
 
 // @dart = 2.8
 
+import 'dart:async';
+
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -111,5 +114,54 @@ void main() {
     final Size size = alignKey.currentContext.size;
     expect(size.width, equals(800.0));
     expect(size.height, equals(10.0));
+  });
+
+  testWidgets('Hit test w/ width and height factor',
+      (WidgetTester tester) async {
+    int value = -1;
+    Widget _widget() => MaterialApp(
+          home: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: List<Widget>.generate(
+              3,
+              (int index) => Align(
+                widthFactor: 0.5,
+                child: Material(
+                  key: ValueKey<int>(index),
+                  type: MaterialType.circle,
+                  clipBehavior: Clip.antiAlias,
+                  color: Colors.blue,
+                  child: InkWell(
+                    onTap: () => value = index,
+                    customBorder: const CircleBorder(),
+                    child: const SizedBox(
+                      width: 100.0,
+                      height: 100.0,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+    await tester.pumpWidget(_widget());
+
+    final Finder boxOneFinder = find.byKey(const ValueKey<int>(0));
+    final Finder boxTwoFinder = find.byKey(const ValueKey<int>(1));
+    final Finder boxThreeFinder = find.byKey(const ValueKey<int>(2));
+
+    final Offset itemOneEdge = tester.getCenter(boxOneFinder);
+    final Offset itemTwoEdge = tester.getCenter(boxTwoFinder);
+    final Offset itemThreeEdge = tester.getCenter(boxThreeFinder);
+
+    await tester.tapAt(Offset(itemOneEdge.dx - 50, itemOneEdge.dy));
+    expect(value, equals(0));
+
+    await tester.tapAt(Offset(itemTwoEdge.dx - 10, itemTwoEdge.dy));
+    expect(value, equals(1));
+
+    await tester.tapAt(Offset(itemThreeEdge.dx - 10, itemThreeEdge.dy));
+    expect(value, equals(2));
   });
 }

--- a/packages/flutter/test/widgets/align_test.dart
+++ b/packages/flutter/test/widgets/align_test.dart
@@ -4,8 +4,6 @@
 
 // @dart = 2.8
 
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/rendering.dart';


### PR DESCRIPTION
## Description
This PR solves the problem of foreground widgets not receiving pointer events when used in an Align with a width factor overlap. 

## Related Issue
- Fixes https://github.com/flutter/flutter/issues/60844

### Pre-patch:
![pre align patch](https://user-images.githubusercontent.com/25674767/86523886-320bb080-be41-11ea-8bad-cfbb3b249d89.gif)

### Post-Patch
![post align patch](https://user-images.githubusercontent.com/25674767/86523895-451e8080-be41-11ea-9c3e-0eba2c0fa283.gif)


## Tests

- Hit test on Align 

## Checklist

- [ x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x ] I signed the [CLA].
- [ x ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ x ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ x ] I updated/added relevant documentation (doc comments with `///`).
- [ x ] All existing and new tests are passing.
- [ x ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ x ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ x ] No, no existing tests failed, so this is *not* a breaking change.

