### PR TITLE
[flutter_tools] fix crash if the platform section was a list

### DIFF
--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -214,7 +214,7 @@ class Plugin {
     }
 
     if (usesNewPluginFormat) {
-      if (yaml['platforms'] is! YamlMap) {
+      if (yaml['platforms'] != null && yaml['platforms'] is! YamlMap) {
         const String errorMessage = 'flutter.plugin.platforms should be a map with the platform name as the key';
         return <String>[errorMessage];
       }

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -214,6 +214,10 @@ class Plugin {
     }
 
     if (usesNewPluginFormat) {
+      if (yaml['platforms'] is! YamlMap) {
+        const String errorMessage = 'flutter.plugin.platforms should be a map with the platform name as the key';
+        return <String>[errorMessage];
+      }
       return _validateMultiPlatformYaml(yaml['platforms'] as YamlMap);
     } else {
       return _validateLegacyYaml(yaml);

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
@@ -943,6 +943,26 @@ flutter:
                               <String, dynamic>{'pluginClass': 'SomeClass',
                                                 'package': 'com.example'});
   });
+
+  testWithoutContext('FlutterManifest validates a platform section that is a list '
+    'instead of a map', () {
+    const String manifest = '''
+name: test
+flutter:
+    plugin:
+      platforms:
+        - android
+''';
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+      manifest,
+      logger: logger,
+    );
+
+    expect(flutterManifest, null);
+    expect(logger.errorText,
+      contains('flutter.plugin.platforms should be a map with the platform name as the key'));
+  });
 }
 
 Matcher matchesManifest({


### PR DESCRIPTION
## Description

Missed validation to go with cast. Added test case to reproduce.

Crash:

```

Thread 0 main thread CRASHED_CastError: type 'YamlList' is not a subtype of type 'YamlMap' in type cast
at Plugin.validatePluginYaml(plugins.dart:218)
at _validateFlutter(flutter_manifest.dart:438)
at _validate(flutter_manifest.dart:371)
at FlutterManifest._createFromYaml(flutter_manifest.dart:47)
at FlutterManifest.createFromString(flutter_manifest.dart:43)
at FlutterManifest.createFromPath(flutter_manifest.dart:37)
at FlutterProject._readManifest(project.dart:211)
at FlutterProjectFactory.fromDirectory.<anonymous closure>(project.dart:46)
at _LinkedHashMapMixin.putIfAbsent(compact_hash.dart:291)
at FlutterProjectFactory.fromDirectory(project.dart:45)
at FlutterProject.fromDirectory(project.dart:81)
at FlutterProject.fromPath(project.dart:89)
at PackagesGetCommand.usageValues(packages.dart:77)
at FlutterCommand.verifyThenRunCommand(flutter_command.dart:853)
at <asynchronous gap>(async)
at FlutterCommand.run.<anonymous closure>(flutter_command.dart:741)
at <asynchronous gap>(async)
at FlutterCommand.run.<anonymous closure>(flutter_command.dart)
at AppContext.run.<anonymous closure>(context.dart:150)
at _rootRun(zone.dart:1190)
at _CustomZone.run(zone.dart:1093)
at _runZoned(zone.dart:1630)
at runZoned(zone.dart:1550)
at AppContext.run(context.dart:149)
at FlutterCommand.run(flutter_command.dart:730)
at CommandRunner.runCommand(command_runner.dart:197)
at FlutterCommandRunner.runCommand.<anonymous closure>(flutter_command_runner.dart:332)
at <asynchronous gap>(async)
at FlutterCommandRunner.runCommand.<anonymous closure>(flutter_command_runner.dart)
at AppContext.run.<anonymous closure>(context.dart:150)
at _rootRun(zone.dart:1190)
at _CustomZone.run(zone.dart:1093)
at _runZoned(zone.dart:1630)
at runZoned(zone.dart:1550)
at AppContext.run(context.dart:149)
at FlutterCommandRunner.runCommand(flutter_command_runner.dart:282)
at <asynchronous gap>(async)
at CommandRunner.run.<anonymous closure>(command_runner.dart:112)
at new Future.sync(future.dart:223)
at CommandRunner.run(command_runner.dart:112)
at FlutterCommandRunner.run(flutter_command_runner.dart:231)
at run.<anonymous closure>.<anonymous closure>(runner.dart:69)
at _rootRun(zone.dart:1190)
at _CustomZone.run(zone.dart:1093)
at _runZoned(zone.dart:1630)
at runZonedGuarded(zone.dart:1618)
at runZoned(zone.dart:1547)
at run.<anonymous closure>(runner.dart:67)
at <asynchronous gap>(async)
at run.<anonymous closure>(runner.dart)
at runInContext.runnerWrapper(context_runner.dart:62)
at <asynchronous gap>(async)
at runInContext.runnerWrapper(context_runner.dart)
at AppContext.run.<anonymous closure>(context.dart:150)
at _rootRun(zone.dart:1190)
at _CustomZone.run(zone.dart:1093)
at _runZoned(zone.dart:1630)
at runZoned(zone.dart:1550)
at AppContext.run(context.dart:149)
at runInContext(context_runner.dart:65)
at run(runner.dart:52)
at main(executable.dart:72)
at main(flutter_tools.dart:8)
at _startIsolate.<anonymous closure>(isolate_patch.dart:299)
at _RawReceivePortImpl._handleMessage(isolate_patch.dart:168)
```