### PR TITLE
[flutter_tools] attempt to work around null interoplate

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -88,7 +88,8 @@ class BuildIOSCommand extends BuildSubCommand {
 
     final String logTarget = forSimulator ? 'simulator' : 'device';
 
-    final String typeName = globals.artifacts.getEngineType(TargetPlatform.ios, buildInfo.mode);
+    final String typeName = globals.artifacts.getEngineType(TargetPlatform.ios, buildInfo.mode)
+      ?? 'ios-release';
     globals.printStatus('Building $app for $logTarget ($typeName)...');
     final XcodeBuildResult result = await buildXcodeProject(
       app: app,


### PR DESCRIPTION
## Description

No idea what is causing this. Possibly the tool is in a bad state and would crash later, but it is impossible to tell. The line that is crashing is:

`    globals.printStatus('Building $app for $logTarget ($typeName)...');`

Both app and logTarget are null checked/initialized the line below. TypeName is a lookup from the cache artifacts which asks for a path basename. doesn't seem like that could be null either. NNBD SOON

Crash:


```
Thread 0 main thread CRASHEDArgumentError: Invalid argument(s)
at _StringBase._interpolate(string_patch.dart:854)
at BuildIOSCommand.runCommand(build_ios.dart:92)
at <asynchronous gap>(async)
at FlutterCommand.verifyThenRunCommand(flutter_command.dart:860)
at _rootRunUnary(zone.dart:1198)
at _CustomZone.runUnary(zone.dart:1100)
at _FutureListener.handleValue(future_impl.dart:143)
at Future._propagateToListeners.handleValueCallback(future_impl.dart:696)
at Future._propagateToListeners(future_impl.dart:725)
at Future._completeWithValue(future_impl.dart:529)
at Future._asyncCompleteWithValue.<anonymous closure>(future_impl.dart:567)
at _rootRun(zone.dart:1190)
at _CustomZone.run(zone.dart:1093)
at _CustomZone.runGuarded(zone.dart:997)
at _CustomZone.bindCallbackGuarded.<anonymous closure>(zone.dart:1037)
at _microtaskLoop(schedule_microtask.dart:41)
at _startMicrotaskLoop(schedule_microtask.dart:50)
at _runPendingImmediateCallback(isolate_patch.dart:118)
at _RawReceivePortImpl._handleMessage(isolate_patch.dart:169)
```