### PR TITLE
Assert valid composing TextRange

### DIFF
--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -714,6 +714,13 @@ class TextEditingValue {
     );
   }
 
+  /// Whether the [composing] range is a valid range within [text].
+  ///
+  /// Returns if and only if the [composing] range is normalized, its start is
+  /// greater than or equal to 0, and its end is less than or equal to [text]'s
+  /// length.
+  bool get isComposingRangeValid => composing.isValid && composing.isNormalized && composing.end <= text.length;
+
   @override
   String toString() => '${objectRuntimeType(this, 'TextEditingValue')}(text: \u2524$text\u251C, selection: $selection, composing: $composing)';
 

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -716,12 +716,13 @@ class TextEditingValue {
 
   /// Whether the [composing] range is a valid range within [text].
   ///
-  /// Returns if and only if the [composing] range is normalized, its start is
-  /// greater than or equal to 0, and its end is less than or equal to [text]'s
-  /// length.
+  /// Returns true if and only if the [composing] range is normalized, its start
+  /// is greater than or equal to 0, and its end is less than or equal to
+  /// [text]'s length.
   ///
-  /// If the [composing] range's `isValid` is true, this property being false
-  /// usually indicates a programming error.
+  /// If this property is false while the [composing] range's `isValid` is true,
+  /// it usually indicates the current [composing] range is invalid because of a
+  /// programming error.
   bool get isComposingRangeValid => composing.isValid && composing.isNormalized && composing.end <= text.length;
 
   @override

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -719,6 +719,9 @@ class TextEditingValue {
   /// Returns if and only if the [composing] range is normalized, its start is
   /// greater than or equal to 0, and its end is less than or equal to [text]'s
   /// length.
+  ///
+  /// If the [composing] range's `isValid` is true, this property being false
+  /// usually indicates a programming error.
   bool get isComposingRangeValid => composing.isValid && composing.isNormalized && composing.end <= text.length;
 
   @override

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -164,7 +164,7 @@ class TextEditingController extends ValueNotifier<TextEditingValue> {
     // preserve the tree integrity, otherwise in release mode a RangeError will
     // be thrown instead of the asserts, as a result this EditableText will be
     // built with a broken subtree.
-    assert((value.composing.isValid && withComposing) && value.isComposingRangeValid);
+    assert(!(value.composing.isValid && withComposing) || value.isComposingRangeValid, '${value.composing}');
     if (!value.isComposingRangeValid || !withComposing) {
       return TextSpan(style: style, text: text);
     }
@@ -1425,6 +1425,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   void didUpdateWidget(EditableText oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.controller != oldWidget.controller) {
+      _debugAssertInvalidComposingRange(widget.controller.value);
       oldWidget.controller.removeListener(_didChangeTextEditingValue);
       widget.controller.addListener(_didChangeTextEditingValue);
       _updateRemoteEditingValueIfNeeded();
@@ -1655,13 +1656,17 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
 
   TextEditingValue get _value => widget.controller.value;
   set _value(TextEditingValue value) {
+    _debugAssertInvalidComposingRange(value);
+    widget.controller.value = value;
+  }
+
+  void _debugAssertInvalidComposingRange(TextEditingValue value) {
     assert(
       !value.composing.isValid || value.isComposingRangeValid,
       'New TextEditingValue $value has an invalid non-empty composing range '
       '${value.composing}. It is recommended to use a valid composing range, '
       'even for readonly text fields',
     );
-    widget.controller.value = value;
   }
 
   bool get _hasFocus => widget.focusNode.hasFocus;

--- a/packages/flutter/test/services/text_input_test.dart
+++ b/packages/flutter/test/services/text_input_test.dart
@@ -192,6 +192,40 @@ void main() {
       expect(client.latestMethodCall, 'showAutocorrectionPromptRect');
     });
   });
+
+  test('TextEditingValue.isComposingRangeValid', () async {
+    // isValue == false.
+    expect(const TextEditingValue(text: '').isComposingRangeValid, isFalse);
+
+    // isNormalized == false.
+    expect(
+      const TextEditingValue(text: 'test', composing: TextRange(start: 1, end: 0)).isComposingRangeValid,
+      isFalse,
+    );
+
+    // isNormalized == false.
+    expect(
+      const TextEditingValue(text: 'test', composing: TextRange(start: 1, end: 0)).isComposingRangeValid,
+      isFalse,
+    );
+
+    // out of range.
+    expect(
+      const TextEditingValue(text: 'test', composing: TextRange(start: 1, end: 5)).isComposingRangeValid,
+      isFalse,
+    );
+
+    // out of range.
+    expect(
+      const TextEditingValue(text: 'test', composing: TextRange(start: -1, end: 4)).isComposingRangeValid,
+      isFalse,
+    );
+
+    expect(
+      const TextEditingValue(text: 'test', composing: TextRange(start: 1, end: 4)).isComposingRangeValid,
+      isTrue,
+    );
+  });
 }
 
 class FakeTextInputClient implements TextInputClient {

--- a/packages/flutter/test/services/text_input_test.dart
+++ b/packages/flutter/test/services/text_input_test.dart
@@ -194,28 +194,21 @@ void main() {
   });
 
   test('TextEditingValue.isComposingRangeValid', () async {
-    // isValue == false.
+    // The composing range is empty.
     expect(const TextEditingValue(text: '').isComposingRangeValid, isFalse);
 
-    // isNormalized == false.
     expect(
       const TextEditingValue(text: 'test', composing: TextRange(start: 1, end: 0)).isComposingRangeValid,
       isFalse,
     );
 
-    // isNormalized == false.
-    expect(
-      const TextEditingValue(text: 'test', composing: TextRange(start: 1, end: 0)).isComposingRangeValid,
-      isFalse,
-    );
-
-    // out of range.
+    // The composing range is out of range for the text.
     expect(
       const TextEditingValue(text: 'test', composing: TextRange(start: 1, end: 5)).isComposingRangeValid,
       isFalse,
     );
 
-    // out of range.
+    // The composing range is out of range for the text.
     expect(
       const TextEditingValue(text: 'test', composing: TextRange(start: -1, end: 4)).isComposingRangeValid,
       isFalse,

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4700,20 +4700,20 @@ void main() {
 
     await tester.tap(find.byType(EditableText));
     await tester.showKeyboard(find.byType(EditableText));
-    controller.text = '';
+    controller.text = 'test';
     await tester.idle();
 
     final EditableTextState state =
         tester.state<EditableTextState>(find.byType(EditableText));
-    expect(tester.testTextInput.editingState['text'], equals(''));
+    expect(tester.testTextInput.editingState['text'], equals('test'));
     expect(state.wantKeepAlive, true);
 
     expect(formatter.formatCallCount, 0);
-    state.updateEditingValue(const TextEditingValue(text: ''));
-    state.updateEditingValue(const TextEditingValue(text: '', composing: TextRange(start: 1, end: 2)));
+    state.updateEditingValue(const TextEditingValue(text: 'test'));
+    state.updateEditingValue(const TextEditingValue(text: 'test', composing: TextRange(start: 1, end: 2)));
     state.updateEditingValue(const TextEditingValue(text: '0')); // pass to formatter once to check the values.
     expect(formatter.lastOldValue.composing, const TextRange(start: 1, end: 2));
-    expect(formatter.lastOldValue.text, '');
+    expect(formatter.lastOldValue.text, 'test');
   });
 
   testWidgets('Whitespace directionality formatter input Arabic', (WidgetTester tester) async {
@@ -5169,6 +5169,42 @@ void main() {
     final RenderEditable renderObject = tester.allRenderObjects.whereType<RenderEditable>().first;
     expect(renderObject.textHeightBehavior, isNot(equals(inheritedTextHeightBehavior)));
     expect(renderObject.textHeightBehavior, equals(customTextHeightBehavior));
+  });
+
+  testWidgets('Asserts if composing text is not valid', (WidgetTester tester) async {
+    await tester.pumpWidget(MediaQuery(
+      data: const MediaQueryData(),
+      child: Directionality(
+        textDirection: TextDirection.ltr,
+        child: FocusScope(
+          node: focusScopeNode,
+          child: EditableText(
+            backgroundCursorColor: Colors.grey,
+            controller: controller,
+            focusNode: focusNode,
+            style: textStyle,
+            cursorColor: cursorColor,
+          ),
+        ),
+      ),
+    ));
+
+    final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
+
+    void expectToAssert(TextEditingValue value, bool shouldAssert) {
+      dynamic exception;
+      try {
+        state.updateEditingValue(value);
+      } catch (e) {
+        exception = e;
+      }
+      expect(exception?.toString(), shouldAssert ? contains('composing range'): isNull);
+    }
+
+    expectToAssert(const TextEditingValue(text: ''), false);
+    expectToAssert(const TextEditingValue(text: 'test', composing: TextRange(start: 1, end: 0)), true);
+    expectToAssert(const TextEditingValue(text: 'test', composing: TextRange(start: 1, end: 9)), true);
+    expectToAssert(const TextEditingValue(text: 'test', composing: TextRange(start: -1, end: 9)), false);
   });
 }
 

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -5171,34 +5171,26 @@ void main() {
     expect(renderObject.textHeightBehavior, equals(customTextHeightBehavior));
   });
 
-  testWidgets('Asserts if composing text is not valid', (WidgetTester tester) async {
-    await tester.pumpWidget(MediaQuery(
-      data: const MediaQueryData(),
-      child: Directionality(
-        textDirection: TextDirection.ltr,
-        child: FocusScope(
-          node: focusScopeNode,
-          child: EditableText(
-            backgroundCursorColor: Colors.grey,
-            controller: controller,
-            focusNode: focusNode,
-            style: textStyle,
-            cursorColor: cursorColor,
-          ),
-        ),
-      ),
-    ));
-
-    final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
-
+  test('Asserts if composing text is not valid', () async {
     void expectToAssert(TextEditingValue value, bool shouldAssert) {
-      dynamic exception;
+      dynamic initException;
+      dynamic updateException;
+      controller = TextEditingController();
       try {
-        state.updateEditingValue(value);
+        controller = TextEditingController.fromValue(value);
       } catch (e) {
-        exception = e;
+        initException = e;
       }
-      expect(exception?.toString(), shouldAssert ? contains('composing range'): isNull);
+
+      controller = TextEditingController();
+      try {
+        controller.value = value;
+      } catch (e) {
+        updateException = e;
+      }
+
+      expect(initException?.toString(), shouldAssert ? contains('composing range'): isNull);
+      expect(updateException?.toString(), shouldAssert ? contains('composing range'): isNull);
     }
 
     expectToAssert(const TextEditingValue(text: ''), false);


### PR DESCRIPTION
## Description

- Try to catch invalid composing ranges early in `TextEditingController`s, rather than during build time.
- Ignore the composing range if it's invalid during build.

## Related Issues

fixes https://github.com/flutter/flutter/issues/49989
related: https://github.com/flutter/flutter/issues/33730

## Tests

I added the following tests:

- TextEditingValue.isComposingRangeValid
- Asserts if composing text is not valid

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
