### PR TITLE
Use the correct Transform in the WidgetInspector overlay (#59566)

### DIFF
--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -2293,9 +2293,9 @@ class _WidgetInspectorState extends State<WidgetInspector>
 
   @override
   Widget build(BuildContext context) {
-    // Caution changing this Stack widget. The _InspectorOverlayLayer
+    // Be careful changing this build method. The _InspectorOverlayLayer
     // assumes the root RenderObject for the WidgetInspector will be
-    // a RenderStack with a _RenderInspectorOverlay as last child.
+    // a RenderStack with a _RenderInspectorOverlay as the last child.
     return Stack(children: <Widget>[
       GestureDetector(
         onTap: _handleTap,

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -2293,6 +2293,9 @@ class _WidgetInspectorState extends State<WidgetInspector>
 
   @override
   Widget build(BuildContext context) {
+    // Caution changing this Stack widget. The _InspectorOverlayLayer
+    // assumes the root RenderObject for the WidgetInspector will be
+    // a RenderStack with a _RenderInspectorOverlay as last child.
     return Stack(children: <Widget>[
       GestureDetector(
         onTap: _handleTap,
@@ -2441,7 +2444,7 @@ class _RenderInspectorOverlay extends RenderBox {
     context.addLayer(_InspectorOverlayLayer(
       overlayRect: Rect.fromLTWH(offset.dx, offset.dy, size.width, size.height),
       selection: selection,
-      rootRenderObject: parent as RenderObject,
+      rootRenderObject: parent is RenderObject ? parent as RenderObject : null,
     ));
   }
 }
@@ -2716,9 +2719,8 @@ class _InspectorOverlayLayer extends Layer {
   /// overlays in the same app (i.e. an storyboard), a selected or candidate
   /// render object may not belong to this tree.
   bool _isInInspectorRenderObjectTree(RenderObject child) {
-    RenderObject inspectorRoot;
     RenderObject current = child.parent as RenderObject;
-    while (current != null && inspectorRoot == null) {
+    while (current != null) {
       // We found the widget inspector render object.
       if (current is RenderStack
           && current.lastChild is _RenderInspectorOverlay) {

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -2595,7 +2595,7 @@ class _InspectorOverlayLayer extends Layer {
     final Canvas canvas = Canvas(recorder, state.overlayRect);
     final Size size = state.overlayRect.size;
     // The overlay rect could have an offset if the widget inspector does
-    // not take all the screen
+    // not take all the screen.
     canvas.translate(state.overlayRect.left, state.overlayRect.top);
 
     final Paint fillPaint = Paint()

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -514,26 +514,35 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
     testWidgets('WidgetInspector with Transform above', (WidgetTester tester) async {
       final GlobalKey childKey = GlobalKey();
-      final GlobalKey inspectorKey = GlobalKey();
+      final GlobalKey repaintBoundaryKey = GlobalKey();
 
       final Matrix4 mainTransform = Matrix4.identity()
           ..translate(50.0, 30.0)
-          ..scale(0.5, 0.5);
+          ..scale(0.8, 0.8)
+          ..translate(100.0, 50.0);
 
       await tester.pumpWidget(
-        Transform(
-          transform: mainTransform,
-          child: Directionality(
-            textDirection: TextDirection.ltr,
-            child: WidgetInspector(
-              key: inspectorKey,
-              selectButtonBuilder: null,
-              child: Align(
-                alignment: Alignment.topLeft,
-                child: Container(
-                  key: childKey,
-                  height: 100.0,
-                  width: 50.0,
+        RepaintBoundary(
+          key: repaintBoundaryKey,
+          child: Container(
+            color: Colors.grey,
+            child: Transform(
+              transform: mainTransform,
+              child: Directionality(
+                textDirection: TextDirection.ltr,
+                child: WidgetInspector(
+                  selectButtonBuilder: null,
+                  child: Container(
+                    color: Colors.white,
+                    child: Center(
+                      child: Container(
+                        key: childKey,
+                        height: 100.0,
+                        width: 50.0,
+                        color: Colors.red,
+                      ),
+                    ),
+                  ),
                 ),
               ),
             ),
@@ -541,11 +550,13 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         ),
       );
 
-      final RenderObject childRenderObject = childKey.currentContext.findRenderObject();
+      await tester.tap(find.byKey(childKey));
+      await tester.pump();
 
-      // The tranform of the child with respect to the whole widget should be the same
-      // matrix applied to the widget inspector inspector.
-      expect(childRenderObject.getTransformTo(null), mainTransform);
+      await expectLater(
+        find.byKey(repaintBoundaryKey),
+        matchesGoldenFile('inspector.overlay_positioning_with_transform.png'),
+      );
     });
 
     testWidgets('Multiple widget inspectors', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -606,7 +606,8 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       );
 
       final InspectorSelection selection = getInspectorState().selection as InspectorSelection;
-      expect(selection.current, isNull);
+      // The selection is static, so it may be initialized from previous tests.
+      selection?.clear();
 
       await tester.tap(find.text('Child 1'));
       await tester.pump();

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -543,7 +543,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
       final RenderObject childRenderObject = childKey.currentContext.findRenderObject();
 
-      // The tranform of the child with respect to the whole widget should be the sam
+      // The tranform of the child with respect to the whole widget should be the same
       // matrix applied to the widget inspector inspector.
       expect(childRenderObject.getTransformTo(null), mainTransform);
     });
@@ -568,7 +568,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       }
 
       // State type is private, hence using dynamic.
-      // The inspector state is static, so it's enough with reading one of them
+      // The inspector state is static, so it's enough with reading one of them.
       dynamic getInspectorState() => inspector1Key.currentState;
       String paragraphText(RenderParagraph paragraph) {
         final TextSpan textSpan = paragraph.text as TextSpan;


### PR DESCRIPTION
## Description

When placing a Transform that modifies the scale above a Material App, the `WidgetInspector` overlay does not match the new dimensions on the screen. Here is an example with the current behavior and with the PR.

### Old
![old](https://user-images.githubusercontent.com/22084723/86797969-93659680-c070-11ea-9500-deeca22fdb3f.png)

### New
![new](https://user-images.githubusercontent.com/22084723/86797980-95c7f080-c070-11ea-9816-3b4c2c41185a.png)


This was because the transform used when painting the overlay was obtained as `object.getTransformTo(null)`. When there is a Transform applied above the inspector, that transform will not be correct. What I did was to specify the correct ancestor in the `getTransformTo` method. The ancestor would be the `WidgetInspector` render object itself, which can be obtained via the parent property of the `_RenderInspectorOverlay`.
 
## Related Issues

Fixes #59566

## Tests

I added a test that compares the transform used inside the Widget Inspector with the one placed above the Widget Inspector. I don't know if there is a better way to test this fix, I haven't found tests covering the overlay placement itself. 

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

### New golden file (inspector.overlay_positioning_with_transform.png)
![inspector overlay_positioning_with_transform](https://user-images.githubusercontent.com/22084723/87678061-c7307280-c77a-11ea-88ca-a0043735adf1.png)


<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
