### PR TITLE
Remove shouldCapTextScaleForTitle from AppBarTheme

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -584,19 +584,16 @@ class _AppBarState extends State<AppBar> {
       // sizes. To opt out, wrap the [title] widget in a [MediaQuery] widget
       // with [MediaQueryData.textScaleFactor] set to
       // `MediaQuery.textScaleFactorOf(context)`.
-      // ignore: deprecated_member_use_from_same_package
-      if (appBarTheme?.shouldCapTextScaleForTitle == true) {
-        final MediaQueryData mediaQueryData = MediaQuery.of(context);
-        title = MediaQuery(
-          data: mediaQueryData.copyWith(
-            textScaleFactor: math.min(
-              mediaQueryData.textScaleFactor,
-              _kMaxTitleTextScaleFactor,
-            ),
+      final MediaQueryData mediaQueryData = MediaQuery.of(context);
+      title = MediaQuery(
+        data: mediaQueryData.copyWith(
+          textScaleFactor: math.min(
+            mediaQueryData.textScaleFactor,
+            _kMaxTitleTextScaleFactor,
           ),
-          child: title,
-        );
-      }
+        ),
+        child: title,
+      );
     }
 
     Widget actions;

--- a/packages/flutter/lib/src/material/app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/app_bar_theme.dart
@@ -41,12 +41,6 @@ class AppBarTheme with Diagnosticable {
     this.actionsIconTheme,
     this.textTheme,
     this.centerTitle,
-    @Deprecated(
-      'Deprecated property to cap text scaling for title. '
-      'This feature was deprecated after v1.19.0.'
-    )
-    // ignore: deprecated_member_use_from_same_package
-    this.shouldCapTextScaleForTitle = true,
   });
 
   /// Default value for [AppBar.brightness].
@@ -89,19 +83,6 @@ class AppBarTheme with Diagnosticable {
   /// If null, the value is adapted to current [TargetPlatform].
   final bool centerTitle;
 
-  /// Cap text scale to a maximum for [AppBar.title].
-  ///
-  /// This flag is deprecated and caps the text scaling to a maximum for
-  /// [AppBar.title], to keep the visual hierarchy in an app with large font
-  /// sizes. It exists to provide backwards compatibility to ease migrations,
-  /// and will eventually be removed as the maximum text scale will be enabled
-  /// by default.
-  @Deprecated(
-    'Deprecated property to cap text scaling for title. '
-    'This feature was deprecated after v1.19.0.'
-  )
-  final bool shouldCapTextScaleForTitle;
-
   /// Creates a copy of this object with the given fields replaced with the
   /// new values.
   AppBarTheme copyWith({
@@ -113,12 +94,6 @@ class AppBarTheme with Diagnosticable {
     IconThemeData iconTheme,
     TextTheme textTheme,
     bool centerTitle,
-    @Deprecated(
-      'Deprecated property to cap text scaling for title. '
-      'This feature was deprecated after v1.19.0.'
-    )
-    // ignore: deprecated_member_use_from_same_package
-    bool shouldCapTextScaleForTitle,
   }) {
     return AppBarTheme(
       brightness: brightness ?? this.brightness,
@@ -129,8 +104,6 @@ class AppBarTheme with Diagnosticable {
       actionsIconTheme: actionsIconTheme ?? this.actionsIconTheme,
       textTheme: textTheme ?? this.textTheme,
       centerTitle: centerTitle ?? this.centerTitle,
-      // ignore: deprecated_member_use_from_same_package
-      shouldCapTextScaleForTitle: shouldCapTextScaleForTitle ?? this.shouldCapTextScaleForTitle,
     );
   }
 
@@ -155,8 +128,6 @@ class AppBarTheme with Diagnosticable {
       actionsIconTheme: IconThemeData.lerp(a?.actionsIconTheme, b?.actionsIconTheme, t),
       textTheme: TextTheme.lerp(a?.textTheme, b?.textTheme, t),
       centerTitle: t < 0.5 ? a?.centerTitle : b?.centerTitle,
-      // ignore: deprecated_member_use_from_same_package
-      shouldCapTextScaleForTitle: a?.shouldCapTextScaleForTitle == true || b?.shouldCapTextScaleForTitle == true,
     );
   }
 
@@ -188,9 +159,7 @@ class AppBarTheme with Diagnosticable {
         && other.iconTheme == iconTheme
         && other.actionsIconTheme == actionsIconTheme
         && other.textTheme == textTheme
-        && other.centerTitle == centerTitle
-        // ignore: deprecated_member_use_from_same_package
-        && other.shouldCapTextScaleForTitle == shouldCapTextScaleForTitle;
+        && other.centerTitle == centerTitle;
   }
 
   @override
@@ -204,7 +173,5 @@ class AppBarTheme with Diagnosticable {
     properties.add(DiagnosticsProperty<IconThemeData>('actionsIconTheme', actionsIconTheme, defaultValue: null));
     properties.add(DiagnosticsProperty<TextTheme>('textTheme', textTheme, defaultValue: null));
     properties.add(DiagnosticsProperty<bool>('centerTitle', centerTitle, defaultValue: null));
-    // ignore: deprecated_member_use_from_same_package
-    properties.add(DiagnosticsProperty<bool>('shouldCapTextScaleForTitle', shouldCapTextScaleForTitle, defaultValue: null));
   }
 }


### PR DESCRIPTION
## Description

The deprecated property `shouldCapTextScaleForTitle` existed for backwards compatibility with internal tests, when the change https://github.com/flutter/flutter/pull/58094 was being rolled through. Removing the flag now that is enabled by default.

## Related Issues

Relates to #58093

## Tests

I added the following tests:

No tests needed as I am just removing a deprecated property, that existed to help roll through a change. The tests were modified here: https://github.com/flutter/flutter/pull/60684

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
