### PR TITLE
WIP: TextInputTheme support step 1 of 3.

### DIFF
--- a/packages/flutter/lib/material.dart
+++ b/packages/flutter/lib/material.dart
@@ -127,6 +127,7 @@ export 'src/material/text_button.dart';
 export 'src/material/text_button_theme.dart';
 export 'src/material/text_field.dart';
 export 'src/material/text_form_field.dart';
+export 'src/material/text_input_theme.dart';
 export 'src/material/text_selection.dart';
 export 'src/material/text_theme.dart';
 export 'src/material/theme.dart';

--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -12,6 +12,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 
 import 'feedback.dart';
+import 'text_input_theme.dart';
 import 'text_selection.dart';
 import 'theme.dart';
 
@@ -560,7 +561,8 @@ class _SelectableTextState extends State<SelectableText> with AutomaticKeepAlive
       'inherit false style must supply fontSize and textBaseline',
     );
 
-    final ThemeData themeData = Theme.of(context);
+    final ThemeData theme = Theme.of(context);
+    final TextInputThemeData textInputTheme = TextInputTheme.of(context);
     final FocusNode focusNode = _effectiveFocusNode;
 
     TextSelectionControls textSelectionControls;
@@ -570,7 +572,7 @@ class _SelectableTextState extends State<SelectableText> with AutomaticKeepAlive
     Color cursorColor = widget.cursorColor;
     Radius cursorRadius = widget.cursorRadius;
 
-    switch (themeData.platform) {
+    switch (theme.platform) {
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         forcePressEnabled = true;
@@ -590,7 +592,11 @@ class _SelectableTextState extends State<SelectableText> with AutomaticKeepAlive
         textSelectionControls = materialTextSelectionControls;
         paintCursorAboveText = false;
         cursorOpacityAnimates = false;
-        cursorColor ??= themeData.cursorColor;
+        if (theme.useTextInputTheme) {
+          cursorColor ??= textInputTheme.cursorColor ?? theme.colorScheme.primary;
+        } else {
+          cursorColor ??= theme.cursorColor;
+        }
         break;
     }
 
@@ -620,7 +626,7 @@ class _SelectableTextState extends State<SelectableText> with AutomaticKeepAlive
         toolbarOptions: widget.toolbarOptions,
         minLines: widget.minLines,
         maxLines: widget.maxLines ?? defaultTextStyle.maxLines,
-        selectionColor: themeData.textSelectionColor,
+        selectionColor: theme.textSelectionColor,
         selectionControls: widget.selectionEnabled ? textSelectionControls : null,
         onSelectionChanged: _handleSelectionChanged,
         onSelectionHandleTapped: _handleSelectionHandleTapped,

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -21,6 +21,7 @@ import 'material.dart';
 import 'material_localizations.dart';
 import 'material_state.dart';
 import 'selectable_text.dart' show iOSHorizontalOffset;
+import 'text_input_theme.dart';
 import 'text_selection.dart';
 import 'theme.dart';
 
@@ -1021,9 +1022,10 @@ class _TextFieldState extends State<TextField> implements TextSelectionGestureDe
       'inherit false style must supply fontSize and textBaseline',
     );
 
-    final ThemeData themeData = Theme.of(context);
-    final TextStyle style = themeData.textTheme.subtitle1.merge(widget.style);
-    final Brightness keyboardAppearance = widget.keyboardAppearance ?? themeData.primaryColorBrightness;
+    final ThemeData theme = Theme.of(context);
+    final TextInputThemeData textInputTheme = TextInputTheme.of(context);
+    final TextStyle style = theme.textTheme.subtitle1.merge(widget.style);
+    final Brightness keyboardAppearance = widget.keyboardAppearance ?? theme.primaryColorBrightness;
     final TextEditingController controller = _effectiveController;
     final FocusNode focusNode = _effectiveFocusNode;
     final List<TextInputFormatter> formatters = widget.inputFormatters ?? <TextInputFormatter>[];
@@ -1038,7 +1040,7 @@ class _TextFieldState extends State<TextField> implements TextSelectionGestureDe
     Color autocorrectionTextRectColor;
     Radius cursorRadius = widget.cursorRadius;
 
-    switch (themeData.platform) {
+    switch (theme.platform) {
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         forcePressEnabled = true;
@@ -1048,7 +1050,7 @@ class _TextFieldState extends State<TextField> implements TextSelectionGestureDe
         cursorColor ??= CupertinoTheme.of(context).primaryColor;
         cursorRadius ??= const Radius.circular(2.0);
         cursorOffset = Offset(iOSHorizontalOffset / MediaQuery.of(context).devicePixelRatio, 0);
-        autocorrectionTextRectColor = themeData.textSelectionColor;
+        autocorrectionTextRectColor = theme.textSelectionColor;
         break;
 
       case TargetPlatform.android:
@@ -1059,7 +1061,11 @@ class _TextFieldState extends State<TextField> implements TextSelectionGestureDe
         textSelectionControls = materialTextSelectionControls;
         paintCursorAboveText = false;
         cursorOpacityAnimates = false;
-        cursorColor ??= themeData.cursorColor;
+        if (theme.useTextInputTheme) {
+          cursorColor ??= textInputTheme.cursorColor ?? theme.colorScheme.primary;
+        } else {
+          cursorColor ??= theme.cursorColor;
+        }
         break;
     }
 
@@ -1089,7 +1095,7 @@ class _TextFieldState extends State<TextField> implements TextSelectionGestureDe
         maxLines: widget.maxLines,
         minLines: widget.minLines,
         expands: widget.expands,
-        selectionColor: themeData.textSelectionColor,
+        selectionColor: theme.textSelectionColor,
         selectionControls: widget.selectionEnabled ? textSelectionControls : null,
         onChanged: widget.onChanged,
         onSelectionChanged: _handleSelectionChanged,

--- a/packages/flutter/lib/src/material/text_input_theme.dart
+++ b/packages/flutter/lib/src/material/text_input_theme.dart
@@ -1,0 +1,156 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+import 'theme.dart';
+
+/// Defines the visual properties of [TextField], and [SelectableText] widgets.
+///
+/// Used by [TextInputTheme] to control the visual properties of text fields in
+/// a widget subtree.
+///
+/// Use [TextInputTheme.of] to access the closest ancestor [TextInputTheme] of
+/// the current [BuildContext].
+///
+/// See also:
+///
+///  * [TextInputTheme], an [InheritedWidget] that propagates the theme down its
+///    subtree.
+///  * [InputDecorationTheme], which defines most other visual properties of
+///    text fields.
+@immutable
+class TextInputThemeData with Diagnosticable {
+  /// Creates the set of properties used to configure [TextField]s.
+  const TextInputThemeData({
+    this.cursorColor,
+    this.selectionHandleColor,
+  });
+
+  /// The color used to paint the cursor in the text field.
+  ///
+  /// The cursor indicates the current location of text input in the field.
+  final Color cursorColor;
+
+  /// The color used to paint the selection handles on the text field.
+  ///
+  /// Selection handles are used to indicate the bounds of the selected text,
+  /// or as a handle to drag the cursor to a new location in the text.
+  final Color selectionHandleColor;
+
+  /// Creates a copy of this object with the given fields replaced with the
+  /// specified values.
+  TextInputThemeData copyWith({
+    Color cursorColor,
+    Color selectionHandleColor,
+  }) {
+    return TextInputThemeData(
+      cursorColor: cursorColor ?? this.cursorColor,
+      selectionHandleColor: selectionHandleColor ?? this.selectionHandleColor,
+    );
+  }
+
+  /// Linearly interpolate between two text field themes.
+  ///
+  /// If both arguments are null, then null is returned.
+  ///
+  /// {@macro dart.ui.shadow.lerp}
+  static TextInputThemeData lerp(TextInputThemeData a, TextInputThemeData b, double t) {
+    if (a == null && b == null)
+      return null;
+    assert(t != null);
+    return TextInputThemeData(
+      cursorColor: Color.lerp(a?.cursorColor, b?.cursorColor, t),
+      selectionHandleColor: Color.lerp(a?.selectionHandleColor, b?.selectionHandleColor, t),
+    );
+  }
+
+  @override
+  int get hashCode {
+    return hashValues(
+      cursorColor,
+      selectionHandleColor,
+    );
+  }
+
+  @override
+  bool operator==(Object other) {
+    if (identical(this, other))
+      return true;
+    if (other.runtimeType != runtimeType)
+      return false;
+    return other is TextInputThemeData
+      && other.cursorColor == cursorColor
+      && other.selectionHandleColor == selectionHandleColor;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(ColorProperty('cursorColor', cursorColor, defaultValue: null));
+    properties.add(ColorProperty('selectionHandleColor', selectionHandleColor, defaultValue: null));
+  }
+}
+
+/// An inherited widget that defines the configuration for
+/// [TextField]s in this widget's subtree.
+///
+/// Values specified here are used for [TextField] properties that are not
+/// given an explicit non-null value.
+///
+/// {@tool snippet}
+///
+/// Here is an example of a text input theme that applies a blue cursor color
+/// with light blue selection handles to the child text field.
+///
+/// ```dart
+/// TextInputTheme(
+///   data: TextInputThemeData(
+///     cursorColor: Colors.blue,
+///     selectionHandleColor: Colors.lightBlue,
+///   ),
+///   child: TextField(),
+/// ),
+/// ```
+/// {@end-tool}
+class TextInputTheme extends InheritedTheme {
+  /// Creates a text field theme that controls the configurations for
+  /// [TextField].
+  ///
+  /// The data argument must not be null.
+  const TextInputTheme({
+    Key key,
+    @required this.data,
+    Widget child,
+  }) : assert(data != null), super(key: key, child: child);
+
+  /// The properties for descendant [TextField] widgets.
+  final TextInputThemeData data;
+
+  /// Returns the [data] from the closest [TextInputTheme] ancestor. If there is
+  /// no ancestor, it returns [ThemeData.textInputTheme]. Applications can assume
+  /// that the returned value will not be null.
+  ///
+  /// Typical usage is as follows:
+  ///
+  /// ```dart
+  /// TextInputThemeData theme = TextInputTheme.of(context);
+  /// ```
+  static TextInputThemeData of(BuildContext context) {
+    final TextInputTheme textInputTheme = context.dependOnInheritedWidgetOfExactType<TextInputTheme>();
+    return textInputTheme?.data ?? Theme.of(context).textInputTheme;
+  }
+
+  @override
+  Widget wrap(BuildContext context, Widget child) {
+    final TextInputTheme ancestorTheme = context.findAncestorWidgetOfExactType<TextInputTheme>();
+    return identical(this, ancestorTheme) ? child : TextInputTheme(data: data, child: child);
+  }
+
+  @override
+  bool updateShouldNotify(TextInputTheme oldWidget) => data != oldWidget.data;
+}

--- a/packages/flutter/lib/src/material/text_selection.dart
+++ b/packages/flutter/lib/src/material/text_selection.dart
@@ -20,6 +20,7 @@ import 'icon_button.dart';
 import 'icons.dart';
 import 'material.dart';
 import 'material_localizations.dart';
+import 'text_input_theme.dart';
 import 'theme.dart';
 
 const double _kHandleSize = 22.0;
@@ -795,12 +796,16 @@ class _MaterialTextSelectionControls extends TextSelectionControls {
   /// Builder for material-style text selection handles.
   @override
   Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textHeight) {
+    final ThemeData theme = Theme.of(context);
+    final Color handleColor = theme.useTextInputTheme ?
+      TextInputTheme.of(context).selectionHandleColor ?? theme.colorScheme.primary :
+      theme.textSelectionHandleColor;
     final Widget handle = SizedBox(
       width: _kHandleSize,
       height: _kHandleSize,
       child: CustomPaint(
         painter: _TextSelectionHandlePainter(
-          color: Theme.of(context).textSelectionHandleColor,
+          color: handleColor,
         ),
       ),
     );

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -37,6 +37,7 @@ import 'slider_theme.dart';
 import 'snack_bar_theme.dart';
 import 'tab_bar_theme.dart';
 import 'text_button_theme.dart';
+import 'text_input_theme.dart';
 import 'text_theme.dart';
 import 'time_picker_theme.dart';
 import 'toggle_buttons_theme.dart';
@@ -278,7 +279,9 @@ class ThemeData with Diagnosticable {
     TextButtonThemeData textButtonTheme,
     ContainedButtonThemeData containedButtonTheme,
     OutlinedButtonThemeData outlinedButtonTheme,
+    TextInputThemeData textInputTheme,
     bool fixTextFieldOutlineLabel,
+    bool useTextInputTheme,
   }) {
     assert(colorScheme?.brightness == null || brightness == null || colorScheme.brightness == brightness);
     final Brightness _brightness = brightness ?? colorScheme?.brightness ?? Brightness.light;
@@ -319,7 +322,6 @@ class ThemeData with Diagnosticable {
     // Spec doesn't specify a dark theme secondaryHeaderColor, this is a guess.
     secondaryHeaderColor ??= isDark ? Colors.grey[700] : primarySwatch[50];
     textSelectionColor ??= isDark ? accentColor : primarySwatch[200];
-    // TODO(hansmuller): We need a TextFieldTheme to handle this instead, https://github.com/flutter/flutter/issues/56082
     cursorColor = cursorColor ?? const Color.fromRGBO(66, 133, 244, 1.0);
     textSelectionHandleColor ??= isDark ? Colors.tealAccent[400] : primarySwatch[300];
     backgroundColor ??= isDark ? Colors.grey[700] : primarySwatch[200];
@@ -394,7 +396,10 @@ class ThemeData with Diagnosticable {
     textButtonTheme ??= const TextButtonThemeData();
     containedButtonTheme ??= const ContainedButtonThemeData();
     outlinedButtonTheme ??= const OutlinedButtonThemeData();
+    textInputTheme ??= const TextInputThemeData();
+
     fixTextFieldOutlineLabel ??= false;
+    useTextInputTheme ??= false;
 
     return ThemeData.raw(
       visualDensity: visualDensity,
@@ -466,7 +471,9 @@ class ThemeData with Diagnosticable {
       textButtonTheme: textButtonTheme,
       containedButtonTheme: containedButtonTheme,
       outlinedButtonTheme: outlinedButtonTheme,
+      textInputTheme: textInputTheme,
       fixTextFieldOutlineLabel: fixTextFieldOutlineLabel,
+      useTextInputTheme: useTextInputTheme,
     );
   }
 
@@ -550,7 +557,9 @@ class ThemeData with Diagnosticable {
     @required this.textButtonTheme,
     @required this.containedButtonTheme,
     @required this.outlinedButtonTheme,
+    @required this.textInputTheme,
     @required this.fixTextFieldOutlineLabel,
+    @required this.useTextInputTheme,
   }) : assert(visualDensity != null),
        assert(primaryColor != null),
        assert(primaryColorBrightness != null),
@@ -617,7 +626,10 @@ class ThemeData with Diagnosticable {
        assert(textButtonTheme != null),
        assert(containedButtonTheme != null),
        assert(outlinedButtonTheme != null),
-       assert(fixTextFieldOutlineLabel != null);
+       assert(fixTextFieldOutlineLabel != null),
+       assert(textInputTheme != null),
+       assert(fixTextFieldOutlineLabel != null),
+       assert(useTextInputTheme != null);
 
   /// Create a [ThemeData] based on the colors in the given [colorScheme] and
   /// text styles of the optional [textTheme].
@@ -1093,6 +1105,9 @@ class ThemeData with Diagnosticable {
   /// [OutlinedButton]s.
   final OutlinedButtonThemeData outlinedButtonTheme;
 
+  /// A theme for customizing the appearance and layout of [TextField] widgets.
+  final TextInputThemeData textInputTheme;
+
   /// A temporary flag to allow apps to opt-in to a
   /// [small fix](https://github.com/flutter/flutter/issues/54028) for the Y
   /// coordinate of the floating label in a [TextField] [OutlineInputBorder].
@@ -1104,6 +1119,23 @@ class ThemeData with Diagnosticable {
   /// deprecated before the next beta release (1.18), and removed before the next
   /// stable release (1.19).
   final bool fixTextFieldOutlineLabel;
+
+  /// A temporary flag to allow apps to opt-in to the new [TextInputTheme], with
+  /// its new defaults for the [cursorColor] and [textSelectionHandleColor].
+  ///
+  /// Setting this flag to true will cause the [textInputTheme] to be used
+  /// instead of the [cursorColor] and [textSelectionHandleColor] by [TextField]
+  /// and [SelectableText] widgets. In addition, the default values of these
+  /// colors have changed to [colorScheme.primary].
+  ///
+  /// The flag is currently false by default. It will be removed after migration
+  /// to the [TextInputTheme] has been completed.
+  @Deprecated(
+    'Set useTextInputTheme to `true`. This parameter will be removed after '
+    'the migration TextInputTheme is complete. '
+    'This feature was deprecated after v1.20.0-3.0.pre.'
+  )
+  final bool useTextInputTheme;
 
   /// Creates a copy of this theme but with the given fields replaced with the new values.
   ///
@@ -1179,7 +1211,9 @@ class ThemeData with Diagnosticable {
     TextButtonThemeData textButtonTheme,
     ContainedButtonThemeData containedButtonTheme,
     OutlinedButtonThemeData outlinedButtonTheme,
+    TextInputThemeData textInputTheme,
     bool fixTextFieldOutlineLabel,
+    bool useTextInputTheme,
   }) {
     cupertinoOverrideTheme = cupertinoOverrideTheme?.noDefault();
     return ThemeData.raw(
@@ -1252,7 +1286,9 @@ class ThemeData with Diagnosticable {
       textButtonTheme: textButtonTheme ?? this.textButtonTheme,
       containedButtonTheme: containedButtonTheme ?? this.containedButtonTheme,
       outlinedButtonTheme: outlinedButtonTheme ?? this.outlinedButtonTheme,
+      textInputTheme: textInputTheme ?? this.textInputTheme,
       fixTextFieldOutlineLabel: fixTextFieldOutlineLabel ?? this.fixTextFieldOutlineLabel,
+      useTextInputTheme: useTextInputTheme ?? this.useTextInputTheme,
     );
   }
 
@@ -1403,7 +1439,9 @@ class ThemeData with Diagnosticable {
       textButtonTheme: TextButtonThemeData.lerp(a.textButtonTheme, b.textButtonTheme, t),
       containedButtonTheme: ContainedButtonThemeData.lerp(a.containedButtonTheme, b.containedButtonTheme, t),
       outlinedButtonTheme: OutlinedButtonThemeData.lerp(a.outlinedButtonTheme, b.outlinedButtonTheme, t),
+      textInputTheme: TextInputThemeData .lerp(a.textInputTheme, b.textInputTheme, t),
       fixTextFieldOutlineLabel: t < 0.5 ? a.fixTextFieldOutlineLabel : b.fixTextFieldOutlineLabel,
+      useTextInputTheme: t < 0.5 ? a.useTextInputTheme : b.useTextInputTheme,
     );
   }
 
@@ -1482,7 +1520,9 @@ class ThemeData with Diagnosticable {
         && other.textButtonTheme == textButtonTheme
         && other.containedButtonTheme == containedButtonTheme
         && other.outlinedButtonTheme == outlinedButtonTheme
-        && other.fixTextFieldOutlineLabel == fixTextFieldOutlineLabel;
+        && other.textInputTheme == textInputTheme
+        && other.fixTextFieldOutlineLabel == fixTextFieldOutlineLabel
+        && other.useTextInputTheme == useTextInputTheme;
   }
 
   @override
@@ -1560,7 +1600,9 @@ class ThemeData with Diagnosticable {
       textButtonTheme,
       containedButtonTheme,
       outlinedButtonTheme,
+      textInputTheme,
       fixTextFieldOutlineLabel,
+      useTextInputTheme,
     ];
     return hashList(values);
   }
@@ -1631,6 +1673,8 @@ class ThemeData with Diagnosticable {
     properties.add(DiagnosticsProperty<DividerThemeData>('dividerTheme', dividerTheme, defaultValue: defaultData.dividerTheme, level: DiagnosticLevel.debug));
     properties.add(DiagnosticsProperty<ButtonBarThemeData>('buttonBarTheme', buttonBarTheme, defaultValue: defaultData.buttonBarTheme, level: DiagnosticLevel.debug));
     properties.add(DiagnosticsProperty<TimePickerThemeData>('timePickerTheme', timePickerTheme, defaultValue: defaultData.timePickerTheme, level: DiagnosticLevel.debug));
+    properties.add(DiagnosticsProperty<TextInputThemeData>('textInputTheme', textInputTheme, defaultValue: defaultData.textInputTheme, level: DiagnosticLevel.debug));
+    properties.add(DiagnosticsProperty<TextInputThemeData>('textInputTheme', textInputTheme, defaultValue: defaultData.textInputTheme, level: DiagnosticLevel.debug));
     properties.add(DiagnosticsProperty<BottomNavigationBarThemeData>('bottomNavigationBarTheme', bottomNavigationBarTheme, defaultValue: defaultData.bottomNavigationBarTheme, level: DiagnosticLevel.debug));
     properties.add(DiagnosticsProperty<TextButtonThemeData>('textButtonTheme', textButtonTheme, defaultValue: defaultData.textButtonTheme, level: DiagnosticLevel.debug));
     properties.add(DiagnosticsProperty<ContainedButtonThemeData>('containedButtonTheme', containedButtonTheme, defaultValue: defaultData.containedButtonTheme, level: DiagnosticLevel.debug));

--- a/packages/flutter/test/material/text_input_theme_test.dart
+++ b/packages/flutter/test/material/text_input_theme_test.dart
@@ -1,0 +1,276 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/src/material/selectable_text.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../rendering/mock_canvas.dart';
+
+void main() {
+  test('TextInputThemeData copyWith, ==, hashCode basics', () {
+    expect(const TextInputThemeData(), const TextInputThemeData().copyWith());
+    expect(const TextInputThemeData().hashCode, const TextInputThemeData().copyWith().hashCode);
+  });
+
+  test('TextInputThemeData null fields by default', () {
+    const TextInputThemeData theme = TextInputThemeData();
+    expect(theme.cursorColor, null);
+    expect(theme.selectionHandleColor, null);
+  });
+
+  testWidgets('Default TextInputThemeData debugFillProperties', (WidgetTester tester) async {
+    final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
+    const TextInputThemeData().debugFillProperties(builder);
+
+    final List<String> description = builder.properties
+        .where((DiagnosticsNode node) => !node.isFiltered(DiagnosticLevel.info))
+        .map((DiagnosticsNode node) => node.toString())
+        .toList();
+
+    expect(description, <String>[]);
+  });
+
+  testWidgets('TextInputThemeData implements debugFillProperties', (WidgetTester tester) async {
+    final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
+    const TextInputThemeData(
+      cursorColor: Color(0xffeeffaa),
+      selectionHandleColor: Color(0xaabbccdd),
+    ).debugFillProperties(builder);
+
+    final List<String> description = builder.properties
+        .where((DiagnosticsNode node) => !node.isFiltered(DiagnosticLevel.info))
+        .map((DiagnosticsNode node) => node.toString())
+        .toList();
+
+    expect(description, <String>[
+      'cursorColor: Color(0xffeeffaa)',
+      'selectionHandleColor: Color(0xaabbccdd)',
+    ]);
+  });
+
+  testWidgets('Empty textInputTheme will use defaults', (WidgetTester tester) async {
+    // Test TextField's cursor color
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(
+          child: TextField(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+    final RenderEditable renderEditable = editableTextState.renderEditable;
+    expect(renderEditable.cursorColor, const Color(0x004285f4));
+
+    // Test the selection handle color
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return materialTextSelectionControls.buildHandle(
+                  context, TextSelectionHandleType.left, 10.0
+              );
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final RenderBox handle = tester.firstRenderObject<RenderBox>(find.byType(CustomPaint));
+    expect(handle, paints..path(color: Colors.blue[300]));
+
+  });
+
+  testWidgets('Empty textInputTheme, with useTextInputTheme set will use new defaults', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData.fallback().copyWith(useTextInputTheme: true);
+    final Color primaryColor = Color(theme.colorScheme.primary.value);
+
+    // Test TextField's cursor color
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: const Material(
+          child: TextField(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+    final RenderEditable renderEditable = editableTextState.renderEditable;
+    expect(renderEditable.cursorColor, primaryColor.withAlpha(0));
+
+    // Test the selection handle color
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return materialTextSelectionControls.buildHandle(
+                context, TextSelectionHandleType.left, 10.0
+              );
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final RenderBox handle = tester.firstRenderObject<RenderBox>(find.byType(CustomPaint));
+    expect(handle, paints..path(color: primaryColor));
+  });
+
+  testWidgets('ThemeDate.textInputTheme will used if provided', (WidgetTester tester) async {
+    const TextInputThemeData textInputTheme = TextInputThemeData(
+      cursorColor: Color(0xffaabbcc),
+      selectionHandleColor: Color(0x00ccbbaa),
+    );
+    final ThemeData theme = ThemeData.fallback().copyWith(
+      useTextInputTheme: true,
+      textInputTheme: textInputTheme,
+    );
+
+    // Test TextField's cursor color
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: const Material(
+          child: TextField(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+    final RenderEditable renderEditable = editableTextState.renderEditable;
+    expect(renderEditable.cursorColor, textInputTheme.cursorColor.withAlpha(0));
+
+    // Test the selection handle color
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return materialTextSelectionControls.buildHandle(
+                  context, TextSelectionHandleType.left, 10.0
+              );
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final RenderBox handle = tester.firstRenderObject<RenderBox>(find.byType(CustomPaint));
+    expect(handle, paints..path(color: textInputTheme.selectionHandleColor));
+  });
+
+  testWidgets('TextInputTheme widget will override ThemeDate.textInputTheme', (WidgetTester tester) async {
+    const TextInputThemeData defaultTextInputTheme = TextInputThemeData(
+      cursorColor: Color(0xffaabbcc),
+      selectionHandleColor: Color(0x00ccbbaa),
+    );
+    final ThemeData theme = ThemeData.fallback().copyWith(
+      useTextInputTheme: true,
+      textInputTheme: defaultTextInputTheme,
+    );
+    const TextInputThemeData widgetTextInputTheme = TextInputThemeData(
+      cursorColor: Color(0xffddeeff),
+      selectionHandleColor: Color(0x00ffeedd),
+    );
+
+    // Test TextField's cursor color
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: const Material(
+          child: TextInputTheme(
+            data: widgetTextInputTheme,
+            child: TextField(),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+    final RenderEditable renderEditable = editableTextState.renderEditable;
+    expect(renderEditable.cursorColor, widgetTextInputTheme.cursorColor.withAlpha(0));
+
+    // Test the selection handle color
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: Material(
+          child: TextInputTheme(
+            data: widgetTextInputTheme,
+            child: Builder(
+              builder: (BuildContext context) {
+                return materialTextSelectionControls.buildHandle(
+                    context, TextSelectionHandleType.left, 10.0
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final RenderBox handle = tester.firstRenderObject<RenderBox>(find.byType(CustomPaint));
+    expect(handle, paints..path(color: widgetTextInputTheme.selectionHandleColor));
+  });
+
+  testWidgets('TextField parameters will override theme settings', (WidgetTester tester) async {
+    const TextInputThemeData defaultTextInputTheme = TextInputThemeData(
+      cursorColor: Color(0xffaabbcc),
+      selectionHandleColor: Color(0x00ccbbaa),
+    );
+    final ThemeData theme = ThemeData.fallback().copyWith(
+      useTextInputTheme: true,
+      textInputTheme: defaultTextInputTheme,
+    );
+    const TextInputThemeData widgetTextInputTheme = TextInputThemeData(
+      cursorColor: Color(0xffddeeff),
+      selectionHandleColor: Color(0x00ffeedd),
+    );
+    const Color cursorColor = Color(0x88888888);
+
+    // Test TextField's cursor color
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: const Material(
+          child: TextInputTheme(
+            data: widgetTextInputTheme,
+            child: TextField(cursorColor: cursorColor),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+    final RenderEditable renderEditable = editableTextState.renderEditable;
+    expect(renderEditable.cursorColor, cursorColor.withAlpha(0));
+
+    // Test SelectableText's cursor color
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: const Material(
+          child: TextInputTheme(
+            data: widgetTextInputTheme,
+            child: SelectableText('foobar', cursorColor: cursorColor),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final EditableTextState selectableTextState = tester.firstState(find.byType(EditableText));
+    final RenderEditable renderSelectable = selectableTextState.renderEditable;
+    expect(renderSelectable.cursorColor, cursorColor.withAlpha(0));
+  });
+}

--- a/packages/flutter/test/material/theme_data_test.dart
+++ b/packages/flutter/test/material/theme_data_test.dart
@@ -287,7 +287,9 @@ void main() {
       textButtonTheme: TextButtonThemeData(style: TextButton.styleFrom(primary: Colors.red)),
       containedButtonTheme: ContainedButtonThemeData(style: ContainedButton.styleFrom(primary: Colors.green)),
       outlinedButtonTheme: OutlinedButtonThemeData(style: OutlinedButton.styleFrom(primary: Colors.blue)),
+      textInputTheme: const TextInputThemeData(cursorColor: Colors.black),
       fixTextFieldOutlineLabel: false,
+      useTextInputTheme: false,
     );
 
     final SliderThemeData otherSliderTheme = SliderThemeData.fromPrimaryColors(
@@ -373,7 +375,9 @@ void main() {
       textButtonTheme: const TextButtonThemeData(),
       containedButtonTheme: const ContainedButtonThemeData(),
       outlinedButtonTheme: const OutlinedButtonThemeData(),
+      textInputTheme: const TextInputThemeData(cursorColor: Colors.white),
       fixTextFieldOutlineLabel: true,
+      useTextInputTheme: true,
     );
 
     final ThemeData themeDataCopy = theme.copyWith(
@@ -445,7 +449,9 @@ void main() {
       textButtonTheme: otherTheme.textButtonTheme,
       containedButtonTheme: otherTheme.containedButtonTheme,
       outlinedButtonTheme: otherTheme.outlinedButtonTheme,
+      textInputTheme: otherTheme.textInputTheme,
       fixTextFieldOutlineLabel: otherTheme.fixTextFieldOutlineLabel,
+      useTextInputTheme: otherTheme.useTextInputTheme,
     );
 
     expect(themeDataCopy.brightness, equals(otherTheme.brightness));
@@ -516,7 +522,9 @@ void main() {
     expect(themeDataCopy.textButtonTheme, equals(otherTheme.textButtonTheme));
     expect(themeDataCopy.containedButtonTheme, equals(otherTheme.containedButtonTheme));
     expect(themeDataCopy.outlinedButtonTheme, equals(otherTheme.outlinedButtonTheme));
+    expect(themeDataCopy.textInputTheme, equals(otherTheme.textInputTheme));
     expect(themeDataCopy.fixTextFieldOutlineLabel, equals(otherTheme.fixTextFieldOutlineLabel));
+    expect(themeDataCopy.useTextInputTheme, equals(otherTheme.useTextInputTheme));
   });
 
   testWidgets('ThemeData.toString has less than 200 characters output', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

As part of the larger [theme system update](https://flutter.dev/go/material-theme-system-updates), this PR provides a new `TextFieldTheme` that configures the properties of `TextField`s. The initial supported properties are the `cursorColor` and `selectionHandleColor`, with more to come in future PRs.

As we are updating the default values for each of these properties this will eventually be a breaking change. However, for this first step this is all turned off by default. To turn on the text field theme support you can set the new temporary `ThemeData.useTextFieldTheme` flag to true.

_TBD: description of new defaults and breaking change migration docs_

## Related Issues

https://github.com/flutter/flutter/issues/17635
https://github.com/flutter/flutter/issues/56082

## Tests

I added tests for the new theme as well as updating the overall `ThemeData` tests.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them?

This PR specifically won't break any tests, as it is a soft migration. Overall however, after all stages of this are complete it will be a breaking change.

- [x] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

_TBD: breaking change docs._
