### PR TITLE
prevents sliver app bar from changing semantics tree when it is not n…

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
@@ -258,27 +258,10 @@ abstract class RenderSliverPersistentHeader extends RenderSliver with RenderObje
     }
   }
 
-  /// Whether the [SemanticsNode]s associated with this [RenderSliver] should
-  /// be excluded from the semantic scrolling area.
-  ///
-  /// [RenderSliver]s that stay on the screen even though the user has scrolled
-  /// past them (e.g. a pinned app bar) should set this to true.
-  @protected
-  bool get excludeFromSemanticsScrolling => _excludeFromSemanticsScrolling;
-  bool _excludeFromSemanticsScrolling = false;
-  set excludeFromSemanticsScrolling(bool value) {
-    if (_excludeFromSemanticsScrolling == value)
-      return;
-    _excludeFromSemanticsScrolling = value;
-    markNeedsSemanticsUpdate();
-  }
-
   @override
   void describeSemanticsConfiguration(SemanticsConfiguration config) {
     super.describeSemanticsConfiguration(config);
-
-    if (_excludeFromSemanticsScrolling)
-      config.addTagForChildren(RenderViewport.excludeFromScrolling);
+    config.addTagForChildren(RenderViewport.excludeFromScrolling);
   }
 
   @override
@@ -375,7 +358,6 @@ abstract class RenderSliverPinnedPersistentHeader extends RenderSliverPersistent
     final SliverConstraints constraints = this.constraints;
     final double maxExtent = this.maxExtent;
     final bool overlapsContent = constraints.overlap > 0.0;
-    excludeFromSemanticsScrolling = overlapsContent || (constraints.scrollOffset > maxExtent - minExtent);
     layoutChild(constraints.scrollOffset, maxExtent, overlapsContent: overlapsContent);
     final double effectiveRemainingPaintExtent = math.max(0, constraints.remainingPaintExtent - constraints.overlap);
     final double layoutExtent = (maxExtent - constraints.scrollOffset).clamp(0.0, effectiveRemainingPaintExtent) as double;
@@ -575,7 +557,6 @@ abstract class RenderSliverFloatingPersistentHeader extends RenderSliverPersiste
     } else {
       _effectiveScrollOffset = constraints.scrollOffset;
     }
-    excludeFromSemanticsScrolling = _effectiveScrollOffset <= constraints.scrollOffset;
     final bool overlapsContent = _effectiveScrollOffset < constraints.scrollOffset;
 
     layoutChild(

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -1604,21 +1604,19 @@ void main() {
                       TestSemantics(
                         children: <TestSemantics>[
                           TestSemantics(
-                            flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
                             children: <TestSemantics>[
                               TestSemantics(
-                                children: <TestSemantics>[
-                                  TestSemantics(
-                                    label: 'Leading',
-                                    textDirection: TextDirection.ltr,
-                                  ),
-                                  TestSemantics(
-                                    label: 'Action 1',
-                                    textDirection: TextDirection.ltr,
-                                  ),
-                                ],
+                                label: 'Leading',
+                                textDirection: TextDirection.ltr,
+                              ),
+                              TestSemantics(
+                                label: 'Action 1',
+                                textDirection: TextDirection.ltr,
                               ),
                             ],
+                          ),
+                          TestSemantics(
+                            flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
                           ),
                         ],
                       ),

--- a/packages/flutter/test/widgets/sliver_semantics_test.dart
+++ b/packages/flutter/test/widgets/sliver_semantics_test.dart
@@ -80,26 +80,26 @@ void _tests() {
                 id: 2,
                 children: <TestSemantics>[
                   TestSemantics(
+                    id: 7,
+                    children: <TestSemantics>[
+                      TestSemantics(
+                        id: 8,
+                        flags: <SemanticsFlag>[
+                          SemanticsFlag.namesRoute,
+                          SemanticsFlag.isHeader,
+                        ],
+                        label: 'Semantics Test with Slivers',
+                        textDirection: TextDirection.ltr,
+                      ),
+                    ],
+                  ),
+                  TestSemantics(
                     id: 9,
                     flags: <SemanticsFlag>[
                       SemanticsFlag.hasImplicitScrolling,
                     ],
                     actions: <SemanticsAction>[SemanticsAction.scrollUp],
                     children: <TestSemantics>[
-                      TestSemantics(
-                        id: 7,
-                        children: <TestSemantics>[
-                          TestSemantics(
-                            id: 8,
-                            flags: <SemanticsFlag>[
-                              SemanticsFlag.namesRoute,
-                              SemanticsFlag.isHeader,
-                            ],
-                            label: 'Semantics Test with Slivers',
-                            textDirection: TextDirection.ltr,
-                          ),
-                        ],
-                      ),
                       TestSemantics(
                         id: 3,
                         label: 'Item 0',
@@ -227,6 +227,20 @@ void _tests() {
                 id: 2,
                 children: <TestSemantics>[
                   TestSemantics(
+                    id: 7,
+                    children: <TestSemantics>[
+                      TestSemantics(
+                        id: 8,
+                        flags: <SemanticsFlag>[
+                          SemanticsFlag.namesRoute,
+                          SemanticsFlag.isHeader,
+                        ],
+                        label: 'Semantics Test with Slivers',
+                        textDirection: TextDirection.ltr,
+                      ),
+                    ],
+                  ),
+                  TestSemantics(
                     id: 9,
                     flags: <SemanticsFlag>[
                       SemanticsFlag.hasImplicitScrolling,
@@ -236,20 +250,6 @@ void _tests() {
                       SemanticsAction.scrollDown,
                     ],
                     children: <TestSemantics>[
-                      TestSemantics(
-                        id: 7,
-                        children: <TestSemantics>[
-                          TestSemantics(
-                            id: 8,
-                            flags: <SemanticsFlag>[
-                              SemanticsFlag.namesRoute,
-                              SemanticsFlag.isHeader,
-                            ],
-                            label: 'Semantics Test with Slivers',
-                            textDirection: TextDirection.ltr,
-                          ),
-                        ],
-                      ),
                       TestSemantics(
                         id: 3,
                         label: 'Item 0',


### PR DESCRIPTION
…ecesaary

## Description

When ios swipe up to focus a collapsed sliver app bar, the semantics tree suddenly change its shape and ios accessibility api can not handle it. The root cause is in the native ios side. This pr is a workaround to prevent this situation by not changing the shape of semantics tree when it is not necessary.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/60331

## Tests

I added the following tests:

existing test coverage

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
