### PR TITLE
Re-land "Tweaking Material Chip a11y semantics to match buttons (#60141)"

### DIFF
--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -1944,9 +1944,10 @@ class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip
       ),
     );
     return Semantics(
+      button: widget.tapEnabled,
       container: true,
       selected: widget.selected,
-      enabled: canTap ? widget.isEnabled : null,
+      enabled: widget.tapEnabled ? canTap : null,
       child: result,
     );
   }

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -1624,6 +1624,10 @@ void main() {
                           TestSemantics(
                             label: 'test',
                             textDirection: TextDirection.ltr,
+                            flags: <SemanticsFlag>[
+                              SemanticsFlag.hasEnabledState,
+                              SemanticsFlag.isButton,
+                            ],
                           ),
                         ],
                       ),
@@ -1662,6 +1666,10 @@ void main() {
                           TestSemantics(
                             label: 'test',
                             textDirection: TextDirection.ltr,
+                            flags: <SemanticsFlag>[
+                              SemanticsFlag.hasEnabledState,
+                              SemanticsFlag.isButton,
+                            ],
                             children: <TestSemantics>[
                               TestSemantics(
                                 label: 'Delete',
@@ -1712,6 +1720,7 @@ void main() {
                             textDirection: TextDirection.ltr,
                             flags: <SemanticsFlag>[
                               SemanticsFlag.hasEnabledState,
+                              SemanticsFlag.isButton,
                               SemanticsFlag.isEnabled,
                               SemanticsFlag.isFocusable,
                             ],
@@ -1763,6 +1772,7 @@ void main() {
                             textDirection: TextDirection.ltr,
                             flags: <SemanticsFlag>[
                               SemanticsFlag.hasEnabledState,
+                              SemanticsFlag.isButton,
                               SemanticsFlag.isEnabled,
                               SemanticsFlag.isFocusable,
                             ],
@@ -1808,6 +1818,7 @@ void main() {
                             textDirection: TextDirection.ltr,
                             flags: <SemanticsFlag>[
                               SemanticsFlag.hasEnabledState,
+                              SemanticsFlag.isButton,
                               SemanticsFlag.isEnabled,
                               SemanticsFlag.isFocusable,
                               SemanticsFlag.isSelected,
@@ -1853,8 +1864,145 @@ void main() {
                           TestSemantics(
                             label: 'test',
                             textDirection: TextDirection.ltr,
-                            flags: <SemanticsFlag>[],
+                            flags: <SemanticsFlag>[
+                              SemanticsFlag.hasEnabledState,
+                              SemanticsFlag.isButton,
+                            ],
                             actions: <SemanticsAction>[],
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ],
+          ), ignoreTransform: true, ignoreId: true, ignoreRect: true));
+
+      semanticsTester.dispose();
+    });
+
+    testWidgets('tapEnabled explicitly false', (WidgetTester tester) async {
+      final SemanticsTester semanticsTester = SemanticsTester(tester);
+
+      await tester.pumpWidget(const MaterialApp(
+        home: Material(
+          child: RawChip(
+            tapEnabled: false,
+            label: Text('test'),
+          ),
+        ),
+      ));
+
+      expect(semanticsTester, hasSemantics(
+          TestSemantics.root(
+            children: <TestSemantics>[
+              TestSemantics(
+                textDirection: TextDirection.ltr,
+                children: <TestSemantics>[
+                  TestSemantics(
+                    children: <TestSemantics>[
+                      TestSemantics(
+                        flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
+                        children: <TestSemantics>[
+                          TestSemantics(
+                            label: 'test',
+                            textDirection: TextDirection.ltr,
+                            flags: <SemanticsFlag>[], // Must not be a button when tapping is disabled.
+                            actions: <SemanticsAction>[],
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ],
+          ), ignoreTransform: true, ignoreId: true, ignoreRect: true));
+
+      semanticsTester.dispose();
+    });
+
+    testWidgets('enabled when tapEnabled and canTap', (WidgetTester tester) async {
+      final SemanticsTester semanticsTester = SemanticsTester(tester);
+
+      // These settings make a Chip which can be tapped, both in general and at this moment.
+      await tester.pumpWidget(MaterialApp(
+        home: Material(
+          child: RawChip(
+            isEnabled: true,
+            tapEnabled: true,
+            onPressed: () {},
+            label: const Text('test'),
+          ),
+        ),
+      ));
+
+      expect(semanticsTester, hasSemantics(
+          TestSemantics.root(
+            children: <TestSemantics>[
+              TestSemantics(
+                textDirection: TextDirection.ltr,
+                children: <TestSemantics>[
+                  TestSemantics(
+                    children: <TestSemantics>[
+                      TestSemantics(
+                        flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
+                        children: <TestSemantics>[
+                          TestSemantics(
+                            label: 'test',
+                            textDirection: TextDirection.ltr,
+                            flags: <SemanticsFlag>[
+                              SemanticsFlag.hasEnabledState,
+                              SemanticsFlag.isButton,
+                              SemanticsFlag.isEnabled,
+                              SemanticsFlag.isFocusable,
+                            ],
+                            actions: <SemanticsAction>[SemanticsAction.tap],
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ],
+          ), ignoreTransform: true, ignoreId: true, ignoreRect: true));
+
+      semanticsTester.dispose();
+    });
+
+    testWidgets('disabled when tapEnabled but not canTap', (WidgetTester tester) async {
+      final SemanticsTester semanticsTester = SemanticsTester(tester);
+        // These settings make a Chip which _could_ be tapped, but not currently (ensures `canTap == false`).
+        await tester.pumpWidget(const MaterialApp(
+        home: Material(
+          child: RawChip(
+            isEnabled: true,
+            tapEnabled: true,
+            label: Text('test'),
+          ),
+        ),
+      ));
+
+      expect(semanticsTester, hasSemantics(
+          TestSemantics.root(
+            children: <TestSemantics>[
+              TestSemantics(
+                textDirection: TextDirection.ltr,
+                children: <TestSemantics>[
+                  TestSemantics(
+                    children: <TestSemantics>[
+                      TestSemantics(
+                        flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
+                        children: <TestSemantics>[
+                          TestSemantics(
+                            label: 'test',
+                            textDirection: TextDirection.ltr,
+                            flags: <SemanticsFlag>[
+                              SemanticsFlag.hasEnabledState,
+                              SemanticsFlag.isButton,
+                            ],
                           ),
                         ],
                       ),


### PR DESCRIPTION
## Description

Re-lands flutter/flutter#60141, which was reverted by flutter/flutter#60645 due to an unexpected edge case which broke some internal tests.

PR for breaking change doc: flutter/website#4312
Published breaking change doc: https://flutter.dev/docs/release/breaking-changes/material-chip-button-semantics

## Related Issues

- Fixes #58010

## Tests

See flutter/flutter#60141 for details.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [x] I wrote a migration guide: see [PR](flutter/website#4312) or [published document](https://flutter.dev/docs/release/breaking-changes/material-chip-button-semantics).

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes