### PR TITLE
Mark new test as not flaky

### DIFF
--- a/dev/devicelab/manifest.yaml
+++ b/dev/devicelab/manifest.yaml
@@ -809,7 +809,6 @@ tasks:
       usage widgets.
     stage: devicelab
     required_agent_capabilities: ["linux/android"]
-    flaky: true
 
   animated_placeholder_perf:
     description: >


### PR DESCRIPTION
This is passing in devicelab, flag not needed anymore.