### PR TITLE
Issue with comparison operator in generated service worker

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -526,11 +526,11 @@ self.addEventListener("fetch", (event) => {
 self.addEventListener('message', (event) => {
   // SkipWaiting can be used to immediately activate a waiting service worker.
   // This will also require a page refresh triggered by the main worker.
-  if (event.data == 'skipWaiting') {
+  if (event.data === 'skipWaiting') {
     return self.skipWaiting();
   }
 
-  if (event.message = 'downloadOffline') {
+  if (event.message === 'downloadOffline') {
     downloadOffline();
   }
 });


### PR DESCRIPTION
## Description

There is an bug I believe with the comparison operator in the generated service worker for Flutter web. When the service worker registration receives a message event, it always triggers the `downloadOffline` case due to the assignment operator being used in place of the comparison operator.

I really appreciate the detailed guidance on contributing guidelines, however, I apologize in advance that I might not have the bandwidth to look into much follow-ups on this. The motivation of putting in this PR is to highlight the issue :)

Please feel free to merge if this is a bug, or create a separate contribution if there are any legal issues, many thanks!
