### PR TITLE
[flutter_tools] copy flutter_texture_registrar.h header for Windows shell

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/windows.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/windows.dart
@@ -22,6 +22,7 @@ const List<String> _kWindowsArtifacts = <String>[
   'flutter_export.h',
   'flutter_messenger.h',
   'flutter_plugin_registrar.h',
+  'flutter_texture_registrar.h',
   'flutter_windows.h',
 ];
 

--- a/packages/flutter_tools/templates/app/windows.tmpl/flutter/CMakeLists.txt
+++ b/packages/flutter_tools/templates/app/windows.tmpl/flutter/CMakeLists.txt
@@ -23,6 +23,7 @@ list(APPEND FLUTTER_LIBRARY_HEADERS
   "flutter_windows.h"
   "flutter_messenger.h"
   "flutter_plugin_registrar.h"
+  "flutter_texture_registrar.h"
 )
 list(TRANSFORM FLUTTER_LIBRARY_HEADERS PREPEND "${EPHEMERAL_DIR}/")
 add_library(flutter INTERFACE)

--- a/packages/flutter_tools/test/general.shard/build_system/targets/windows_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/windows_test.dart
@@ -56,6 +56,7 @@ void main() {
       '$windowsDesktopPath\\flutter_windows.dll.lib',
       '$windowsDesktopPath\\flutter_windows.dll.pdb',
       '$windowsDesktopPath\\flutter_plugin_registrar.h',
+      '$windowsDesktopPath\\flutter_texture_registrar.h',
       '$windowsDesktopPath\\flutter_windows.h',
       icuData,
       '$windowsCppClientWrapper\\foo',
@@ -79,6 +80,7 @@ void main() {
     expect(fileSystem.file(r'C:\windows\flutter\ephemeral\flutter_export.h'), exists);
     expect(fileSystem.file(r'C:\windows\flutter\ephemeral\flutter_messenger.h'), exists);
     expect(fileSystem.file(r'C:\windows\flutter\ephemeral\flutter_plugin_registrar.h'), exists);
+    expect(fileSystem.file(r'C:\windows\flutter\ephemeral\flutter_texture_registrar.h'), exists);
     expect(fileSystem.file(r'C:\windows\flutter\ephemeral\flutter_windows.h'), exists);
     expect(fileSystem.file('C:\\windows\\flutter\\ephemeral\\$icuData'), exists);
     expect(fileSystem.file('C:\\windows\\flutter\\ephemeral\\$windowsCppClientWrapper\\foo'), exists);
@@ -103,6 +105,7 @@ void main() {
       '$windowsDesktopPath\\flutter_windows.dll.lib',
       '$windowsDesktopPath\\flutter_windows.dll.pdb',
       '$windowsDesktopPath\\flutter_plugin_registrar.h',
+      '$windowsDesktopPath\\flutter_texture_registrar.h',
       '$windowsDesktopPath\\flutter_windows.h',
       icuData,
       '$windowsCppClientWrapper\\foo',
@@ -115,6 +118,7 @@ void main() {
       r'C:\windows\flutter\ephemeral\flutter_windows.dll.lib',
       r'C:\windows\flutter\ephemeral\flutter_windows.dll.pdb',
       r'C:\windows\flutter\ephemeral\flutter_plugin_registrar.h',
+      r'C:\windows\flutter\ephemeral\flutter_texture_registrar.h',
       r'C:\windows\flutter\ephemeral\flutter_windows.h',
       'C:\\windows\\flutter\\ephemeral\\$icuData',
       'C:\\windows\\flutter\\ephemeral\\$windowsCppClientWrapper\\foo',


### PR DESCRIPTION
## Description

Once flutter/engine#19405 has landed we need to ensure that the newly introduced header `flutter_texture_registrar.h` gets copied on Windows.

## Related Issues

#38601
flutter/engine#19405 

## Tests

I added the following tests:

I created a new plugin with Windows platform support and verified that the respective header file gets copied as expected.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
