### PR TITLE
[flutter_tools] ensure AppRunLogger is injected for run/attach machine

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -66,9 +66,9 @@ Future<void> main(List<String> args) async {
       (args.isNotEmpty && args.first == 'help') || (args.length == 1 && verbose);
   final bool muteCommandLogging = help || doctor;
   final bool verboseHelp = help && verbose;
-  final bool daemon = args.contains('daemon') ||
-    (args.contains('--machine') && args.contains('run')) ||
-    (args.contains('--machine') && args.contains('attach'));
+  final bool daemon = args.contains('daemon');
+  final bool runMachine = (args.contains('--machine') && args.contains('run')) ||
+                          (args.contains('--machine') && args.contains('attach'));
 
   await runner.run(args, () => <FlutterCommand>[
     AnalyzeCommand(
@@ -146,6 +146,13 @@ Future<void> main(List<String> args) async {
         ))
        else if (verbose && !muteCommandLogging)
         Logger: () => VerboseLogger(StdoutLogger(
+          timeoutConfiguration: timeoutConfiguration,
+          stdio: globals.stdio,
+          terminal: globals.terminal,
+          outputPreferences: globals.outputPreferences,
+        ))
+      else if (runMachine)
+        Logger: () => AppRunLogger(parent: StdoutLogger(
           timeoutConfiguration: timeoutConfiguration,
           stdio: globals.stdio,
           terminal: globals.terminal,

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -304,6 +304,7 @@ class AttachCommand extends FlutterCommand {
             true,
             globals.fs.currentDirectory,
             LaunchMode.attach,
+            globals.logger as AppRunLogger,
           );
         } on Exception catch (error) {
           throwToolExit(error.toString());

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -1039,6 +1039,7 @@ class AppInstance {
 
   Future<T> _runInZone<T>(AppDomain domain, FutureOr<T> method()) async {
     final AppRunLogger logger = globals.logger as AppRunLogger;
+    _logger = logger;
     logger.domain = domain;
     logger.app = this;
     return method();

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -139,7 +139,6 @@ abstract class ChromiumDevice extends Device {
         debugPort: debuggingOptions.webBrowserDebugPort,
       );
     }
-
     _logger.sendEvent('app.webLaunchUrl', <String, dynamic>{'url': url, 'launched': launchChrome});
     return LaunchResult.succeeded(observatoryUri: url != null ? Uri.parse(url): null);
   }

--- a/packages/flutter_tools/test/integration.shard/command_output_test.dart
+++ b/packages/flutter_tools/test/integration.shard/command_output_test.dart
@@ -41,26 +41,28 @@ void main() {
     expect(result.stdout, isNot(contains('exiting with code 0')));
   });
 
-  test('flutter run --machine uses NotifyingLogger', () async {
+  test('flutter run --machine uses AppRunLogger', () async {
     final String flutterBin = globals.fs.path.join(getFlutterRoot(), 'bin', 'flutter');
     final ProcessResult result = await const LocalProcessManager().run(<String>[
       flutterBin,
       'run',
       '--machine',
+      '-v',
     ]);
 
-    expect(result.stdout, isEmpty);
+    expect(result.stdout, isNotEmpty);
   });
 
-  test('flutter attach --machine uses NotifyingLogger', () async {
+  test('flutter attach --machine uses AppRunLogger', () async {
     final String flutterBin = globals.fs.path.join(getFlutterRoot(), 'bin', 'flutter');
     final ProcessResult result = await const LocalProcessManager().run(<String>[
       flutterBin,
       'attach',
       '--machine',
+      '-v',
     ]);
 
-    expect(result.stdout, isEmpty);
+    expect(result.stdout, isNotEmpty);
   });
 
   test('flutter build aot is deprecated', () async {


### PR DESCRIPTION
## Description

run/attach --machine requires a different logger than daemon, which uses the NotifyingLogger. We have too many loggers!

Fixes https://github.com/flutter/flutter/issues/59463